### PR TITLE
Fix errors from the printers + catch potential error in repl

### DIFF
--- a/phel
+++ b/phel
@@ -33,6 +33,6 @@ $commandFacade = new CommandFacade(
 try {
     $facade = new PhelFacade($commandFacade);
     $facade->runCommand($argv[1], array_slice($argv, 2));
-} catch (Exception $e) {
+} catch (Throwable $e) {
     print $e->getMessage() . PHP_EOL;
 }

--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -66,7 +66,7 @@ final class ReplCommand
                     break;
                 }
             } catch (Throwable $e) {
-                $this->io->output($e->getMessage() . PHP_EOL);
+                $this->io->output($e->getTraceAsString() . PHP_EOL);
             }
         }
 

--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -58,7 +58,12 @@ final class ReplCommand
             $this->io->output("\e[?2004h"); // Enable bracketed paste
             $input = $this->io->readline('>>> ');
             $this->io->output("\e[?2004l"); // Disable bracketed paste
-            $this->checkInputAndAnalyze($input);
+
+            try {
+                $this->checkInputAndAnalyze($input);
+            } catch (Throwable $e) {
+                $this->io->output($e->getMessage());
+            }
         }
     }
 

--- a/src/php/Exceptions/HtmlExceptionPrinter.php
+++ b/src/php/Exceptions/HtmlExceptionPrinter.php
@@ -91,7 +91,7 @@ final class HtmlExceptionPrinter implements ExceptionPrinterInterface
                 $rf = new ReflectionClass($class);
                 if ($rf->implementsInterface(FnInterface::class)) {
                     $fnName = $this->munge->decodeNs($rf->getConstant('BOUND_TO'));
-                    $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args']);
+                    $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
                     echo "<li>#$i $file($line): ($fnName$argString)</li>";
 
                     continue;

--- a/src/php/Exceptions/TextExceptionPrinter.php
+++ b/src/php/Exceptions/TextExceptionPrinter.php
@@ -101,7 +101,7 @@ final class TextExceptionPrinter implements ExceptionPrinterInterface
                 $rf = new ReflectionClass($class);
                 if ($rf->implementsInterface(FnInterface::class)) {
                     $fnName = $this->munge->decodeNs($rf->getConstant('BOUND_TO'));
-                    $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args']);
+                    $argString = $this->exceptionArgsPrinter->parseArgsAsString($frame['args'] ?? []);
                     $pos = $this->filePositionExtractor->getOriginal($file, $line);
                     echo "#$i {$pos->filename()}:{$pos->line()} (gen: $file:$line) : ($fnName$argString)\n";
 
@@ -112,7 +112,7 @@ final class TextExceptionPrinter implements ExceptionPrinterInterface
             $class = $class ?? '';
             $type = $frame['type'] ?? '';
             $fn = $frame['function'];
-            $argString = $this->exceptionArgsPrinter->buildPhpArgsString($frame['args']);
+            $argString = $this->exceptionArgsPrinter->buildPhpArgsString($frame['args'] ?? []);
             echo "#$i $file($line): $class$type$fn($argString)\n";
         }
     }


### PR DESCRIPTION
## 📚 Description

https://github.com/jenshaase/phel-lang/issues/187 Prevent REPL from being closed on Exception

## 🔖 Changes

- Add a global try-catch block in the REPL loop to ensure it won't be close by any error. Instead, it will output the error message.
- Fix the ExceptionPrinters; the `$frame['args']` aren't present always, so using the `?? []` would be sufficient to avoid triggering a new error while rendering the actual "current error" ;)

## 🖼️  Screenshots

<img width="1598" alt="Screenshot 2021-01-22 at 17 10 17" src="https://user-images.githubusercontent.com/5256287/105515216-b71ec000-5cd4-11eb-8abf-6004713831be.png">

## QA
Before this was exiting the REPL:
```clojure
(print (\readline_info "library_version"))
```
With this PR it doesn't exit the REPL anymore.