### PR TITLE
Basic colors to repl printers

### DIFF
--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -1,7 +1,8 @@
 (ns phel\repl
   (:use Phel\Lang\Symbol)
   (:use Phel\Runtime\RuntimeFactory)
-  (:use Phel\Compiler\Analyzer\Environment\NodeEnvironment))
+  (:use Phel\Compiler\Analyzer\Environment\NodeEnvironment)
+  (:use Phel\Printer\Printer))
 
 (defn- get-runtime []
   (php/:: RuntimeFactory (getInstance)))
@@ -81,3 +82,31 @@
   (let [options (apply table args)
         alias (extract-alias sym options)]
     `(use-namespace ',sym ',alias)))
+
+(defn- print-colorful-str
+  "Same as print-str from core, but with color."
+  [& xs]
+  (let [len (count xs)
+        printer (php/:: Printer (nonReadableWithColor))
+        pp |(php/-> printer (print $))]
+    (case (count xs)
+      0 ""
+      1 (pp (first xs))
+      (loop [res (pp (first xs))
+             seq (next xs)]
+        (if seq
+          (recur (str res " " (pp (first seq))) (next seq))
+          res)))))
+
+(defn print-colorful
+  "Colored print."
+  [& xs]
+  (php/print (apply print-colorful-str xs))
+  nil)
+
+(defn println-colorful
+  "Colored println."
+  [& xs]
+  (apply print-colorful xs)
+  (php/print "\n")
+  nil)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -10,10 +10,10 @@
 # ------
 
 (def- stats @{:failed []
-             :counts @{:failed 0
-                       :error 0
-                       :pass 0
-                       :total 0}})
+              :counts @{:failed 0
+                        :error 0
+                        :pass 0
+                        :total 0}})
 
 (defn report [data]
   (let [@{:state state :type type} data

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -44,7 +44,7 @@ final class CommandFactory implements CommandFactoryInterface
             $this->compilerFactory->createEvalCompiler($runtime->getEnv()),
             TextExceptionPrinter::create(),
             ColorStyle::withStyles(),
-            Printer::nonReadable()->withColor()
+            Printer::nonReadableWithColor()
         );
     }
 

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -44,7 +44,7 @@ final class CommandFactory implements CommandFactoryInterface
             $this->compilerFactory->createEvalCompiler($runtime->getEnv()),
             TextExceptionPrinter::create(),
             ColorStyle::withStyles(),
-            Printer::nonReadable()
+            Printer::nonReadable()->withColor()
         );
     }
 

--- a/src/php/Command/Repl/startup.phel
+++ b/src/php/Command/Repl/startup.phel
@@ -1,3 +1,3 @@
 # This is the startup script that is launch in the REPL.
 (ns user
-  (:require phel\repl :refer [doc require use]))
+  (:require phel\repl :refer [doc require use print-colorful println-colorful]))

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -25,6 +25,7 @@ use Phel\Compiler\Reader\ExpressionReaderFactory;
 use Phel\Compiler\Reader\QuasiquoteTransformer;
 use Phel\Compiler\Reader\Reader;
 use Phel\Compiler\Reader\ReaderInterface;
+use Phel\Printer\Printer;
 
 final class CompilerFactory implements CompilerFactoryInterface
 {
@@ -89,7 +90,8 @@ final class CompilerFactory implements CompilerFactoryInterface
             $enableSourceMaps,
             new SourceMapGenerator(),
             new NodeEmitterFactory(),
-            new Munge()
+            new Munge(),
+            Printer::readable()
         );
     }
 

--- a/src/php/Compiler/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter.php
@@ -7,19 +7,21 @@ namespace Phel\Compiler\Emitter;
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Emitter\OutputEmitter\LiteralEmitter;
-use Phel\Compiler\Emitter\OutputEmitter\Munge;
+use Phel\Compiler\Emitter\OutputEmitter\MungeInterface;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Printer\PrinterInterface;
 
 final class OutputEmitter implements OutputEmitterInterface
 {
     private bool $enableSourceMaps;
     private SourceMapGenerator $sourceMapGenerator;
     private NodeEmitterFactory $nodeEmitterFactory;
-    private Munge $munge;
+    private MungeInterface $munge;
+    private PrinterInterface $printer;
 
     private int $indentLevel = 0;
     private int $generatedLines = 0;
@@ -30,12 +32,14 @@ final class OutputEmitter implements OutputEmitterInterface
         bool $enableSourceMaps,
         SourceMapGenerator $sourceMapGenerator,
         NodeEmitterFactory $nodeEmitterFactory,
-        Munge $munge
+        MungeInterface $munge,
+        PrinterInterface $printer
     ) {
         $this->enableSourceMaps = $enableSourceMaps;
         $this->sourceMapGenerator = $sourceMapGenerator;
         $this->nodeEmitterFactory = $nodeEmitterFactory;
         $this->munge = $munge;
+        $this->printer = $printer;
     }
 
     public function emitNodeAsString(AbstractNode $node): string
@@ -214,7 +218,7 @@ final class OutputEmitter implements OutputEmitterInterface
      */
     public function emitLiteral($value): void
     {
-        (new LiteralEmitter($this))->emitLiteral($value);
+        (new LiteralEmitter($this, $this->printer))->emitLiteral($value);
     }
 
     public function increaseIndentLevel(): void

--- a/src/php/Compiler/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/LiteralEmitter.php
@@ -11,16 +11,20 @@ use Phel\Lang\PhelArray;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 use RuntimeException;
 
 final class LiteralEmitter
 {
     private OutputEmitterInterface $outputEmitter;
+    private PrinterInterface $printer;
 
-    public function __construct(OutputEmitterInterface $outputEmitter)
-    {
+    public function __construct(
+        OutputEmitterInterface $outputEmitter,
+        PrinterInterface $printer
+    ) {
         $this->outputEmitter = $outputEmitter;
+        $this->printer = $printer;
     }
 
     /**
@@ -71,7 +75,7 @@ final class LiteralEmitter
 
     private function emitStr(string $x): void
     {
-        $this->outputEmitter->emitStr(Printer::readable()->print($x));
+        $this->outputEmitter->emitStr($this->printer->print($x));
     }
 
     private function emitNull(): void

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -31,7 +31,7 @@ use RuntimeException;
 final class Printer implements PrinterInterface
 {
     private bool $readable;
-    private bool $withColor = false;
+    private bool $withColor;
 
     public static function readable(): self
     {
@@ -43,16 +43,15 @@ final class Printer implements PrinterInterface
         return new self(false);
     }
 
-    private function __construct(bool $readable)
+    public static function nonReadableWithColor(): self
     {
-        $this->readable = $readable;
+        return new self(false, true);
     }
 
-    public function withColor(): self
+    private function __construct(bool $readable, bool $withColor = false)
     {
-        $this->withColor = true;
-
-        return $this;
+        $this->readable = $readable;
+        $this->withColor = $withColor;
     }
 
     /**

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -35,17 +35,17 @@ final class Printer implements PrinterInterface
 
     public static function readable(): self
     {
-        return new self(true);
+        return new self($readable = true);
     }
 
     public static function nonReadable(): self
     {
-        return new self(false);
+        return new self($readable= false);
     }
 
     public static function nonReadableWithColor(): self
     {
-        return new self(false, true);
+        return new self($readable=false, $withColor = true);
     }
 
     private function __construct(bool $readable, bool $withColor = false)

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -31,6 +31,7 @@ use RuntimeException;
 final class Printer implements PrinterInterface
 {
     private bool $readable;
+    private bool $withColor = false;
 
     public static function readable(): self
     {
@@ -45,6 +46,13 @@ final class Printer implements PrinterInterface
     private function __construct(bool $readable)
     {
         $this->readable = $readable;
+    }
+
+    public function withColor(): self
+    {
+        $this->withColor = true;
+
+        return $this;
     }
 
     /**
@@ -80,10 +88,10 @@ final class Printer implements PrinterInterface
             return new TuplePrinter($this);
         }
         if ($form instanceof Keyword) {
-            return new KeywordPrinter();
+            return new KeywordPrinter($this->withColor);
         }
         if ($form instanceof Symbol) {
-            return new SymbolPrinter();
+            return new SymbolPrinter($this->withColor);
         }
         if ($form instanceof Set) {
             return new SetPrinter($this);
@@ -109,16 +117,16 @@ final class Printer implements PrinterInterface
         $printerName = gettype($form);
 
         if ('string' === $printerName) {
-            return new StringPrinter($this->readable);
+            return new StringPrinter($this->readable, $this->withColor);
         }
         if ('integer' === $printerName || 'double' === $printerName) {
-            return new NumberPrinter();
+            return new NumberPrinter($this->withColor);
         }
         if ('boolean' === $printerName) {
-            return new BooleanPrinter();
+            return new BooleanPrinter($this->withColor);
         }
         if ('NULL' === $printerName) {
-            return new NullPrinter();
+            return new NullPrinter($this->withColor);
         }
         if ('array' === $printerName && !$this->readable) {
             return new ArrayPrinter();

--- a/src/php/Printer/TypePrinter/BooleanPrinter.php
+++ b/src/php/Printer/TypePrinter/BooleanPrinter.php
@@ -9,13 +9,29 @@ namespace Phel\Printer\TypePrinter;
  */
 final class BooleanPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
      * @param bool $form
      */
     public function print($form): string
     {
-        return $form === true
-            ? 'true'
-            : 'false';
+        $str = ($form === true) ? 'true' : 'false';
+
+        return $this->color($str);
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;94m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Printer/TypePrinter/KeywordPrinter.php
@@ -11,11 +11,27 @@ use Phel\Lang\Keyword;
  */
 final class KeywordPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
      * @param Keyword $form
      */
     public function print($form): string
     {
-        return ':' . $form->getName();
+        return $this->color(':' . $form->getName());
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;93m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/NullPrinter.php
+++ b/src/php/Printer/TypePrinter/NullPrinter.php
@@ -6,11 +6,27 @@ namespace Phel\Printer\TypePrinter;
 
 final class NullPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
      * @param mixed $form
      */
     public function print($form): string
     {
-        return 'nil';
+        return $this->color('nil');
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;96m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Printer/TypePrinter/NumberPrinter.php
@@ -9,11 +9,27 @@ namespace Phel\Printer\TypePrinter;
  */
 final class NumberPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
      * @param int|float $form
      */
     public function print($form): string
     {
-        return (string)$form;
+        return $this->color((string)$form);
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;92m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/PhelArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/PhelArrayPrinter.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\PhelArray;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 
 /**
  * @implements TypePrinterInterface<PhelArray>
  */
 final class PhelArrayPrinter implements TypePrinterInterface
 {
-    private Printer $printer;
+    private PrinterInterface $printer;
 
-    public function __construct(Printer $printer)
+    public function __construct(PrinterInterface $printer)
     {
         $this->printer = $printer;
     }

--- a/src/php/Printer/TypePrinter/SetPrinter.php
+++ b/src/php/Printer/TypePrinter/SetPrinter.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Set;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 
 /**
  * @implements TypePrinterInterface<Set>
  */
 final class SetPrinter implements TypePrinterInterface
 {
-    private Printer $printer;
+    private PrinterInterface $printer;
 
-    public function __construct(Printer $printer)
+    public function __construct(PrinterInterface $printer)
     {
         $this->printer = $printer;
     }

--- a/src/php/Printer/TypePrinter/StringPrinter.php
+++ b/src/php/Printer/TypePrinter/StringPrinter.php
@@ -22,16 +22,25 @@ final class StringPrinter implements TypePrinterInterface
     ];
 
     private bool $readable;
+    private bool $withColor;
 
-    public function __construct(bool $readable)
+    public function __construct(bool $readable, bool $withColor = false)
     {
         $this->readable = $readable;
+        $this->withColor = $withColor;
     }
 
     /**
      * @param string $str
      */
     public function print($str): string
+    {
+        $str = $this->parseString($str);
+
+        return $this->color($str);
+    }
+
+    private function parseString(string $str): string
     {
         if (!$this->readable) {
             return $str;
@@ -134,5 +143,14 @@ final class StringPrinter implements TypePrinterInterface
         }
 
         return (string) $a;
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;95m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/StructPrinter.php
+++ b/src/php/Printer/TypePrinter/StructPrinter.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\AbstractStruct;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 
 /**
  * @implements TypePrinterInterface<AbstractStruct>
  */
 final class StructPrinter implements TypePrinterInterface
 {
-    private Printer $printer;
+    private PrinterInterface $printer;
 
-    public function __construct(Printer $printer)
+    public function __construct(PrinterInterface $printer)
     {
         $this->printer = $printer;
     }

--- a/src/php/Printer/TypePrinter/SymbolPrinter.php
+++ b/src/php/Printer/TypePrinter/SymbolPrinter.php
@@ -11,11 +11,27 @@ use Phel\Lang\Symbol;
  */
 final class SymbolPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
      * @param Symbol $form
      */
     public function print($form): string
     {
-        return $form->getName();
+        return $this->color($form->getName());
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;91m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/TablePrinter.php
+++ b/src/php/Printer/TypePrinter/TablePrinter.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Table;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 
 /**
  * @implements TypePrinterInterface<Table>
  */
 final class TablePrinter implements TypePrinterInterface
 {
-    private Printer $printer;
+    private PrinterInterface $printer;
 
-    public function __construct(Printer $printer)
+    public function __construct(PrinterInterface $printer)
     {
         $this->printer = $printer;
     }

--- a/src/php/Printer/TypePrinter/TuplePrinter.php
+++ b/src/php/Printer/TypePrinter/TuplePrinter.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Tuple;
-use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
 
 /**
  * @implements TypePrinterInterface<Tuple>
  */
 final class TuplePrinter implements TypePrinterInterface
 {
-    private Printer $printer;
+    private PrinterInterface $printer;
 
-    public function __construct(Printer $printer)
+    public function __construct(PrinterInterface $printer)
     {
         $this->printer = $printer;
     }


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/phel-lang/phel-lang/issues/197
Pass a printer with colors to the REPL printer, so it can handle the colors for each individual type printer.

## 🔖 Changes

- Add colors to REPL printer
- By default, all TypePrinters are without color
- Added `print-colorful` to `core/repl.phel`, because `println` wont render any color.

## 🖼️  Screenshot

<img width="636" alt="Screenshot 2021-01-27 at 18 32 48" src="https://user-images.githubusercontent.com/5256287/106030067-0fd3cb80-60ce-11eb-87ec-b587381f44ca.png">

When using `(print ...)` function doesn't render the colors because print uses print-str, and there we are using a nonReadable printer without colors:  ```printer (php/:: Printer (nonReadable))```. The problem here is that `print-str`  is the "same as print. But instead of writing it to an output stream. The resulting string is returned."

```clojure
# see phel/core/print-operation:15
(defn print-str
  "Same as print. But instead of writing it to an output stream,
  The resulting string is returned."
  [& xs]
  (let [len (count xs)
        printer (php/:: Printer (nonReadable))
        pp |(php/-> printer (print $))]
    (case (count xs)
...
```
<img width="623" alt="Screenshot 2021-01-27 at 18 41 29" src="https://user-images.githubusercontent.com/5256287/106031188-46f6ac80-60cf-11eb-94be-2c2380b11a1f.png">

For this reason, I created a new function `print-colorful` which will be loaded only for the REPL and it does the same as `println` but with color.
<img width="623" alt="Screenshot 2021-01-27 at 19 47 08" src="https://user-images.githubusercontent.com/5256287/106038611-73fb8d00-60d8-11eb-80a4-45e350cbe4cd.png">
