### PR TITLE
Fix repl cannot print all values

### DIFF
--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -138,7 +138,7 @@ final class Printer implements PrinterInterface
             return new NullPrinter($this->withColor);
         }
         if ('array' === $printerName && !$this->readable) {
-            return new ArrayPrinter($this->withColor);
+            return new ArrayPrinter($this, $this->withColor);
         }
         if ('resource' === $printerName && !$this->readable) {
             return new ResourcePrinter();

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -128,7 +128,7 @@ final class Printer implements PrinterInterface
             return new NullPrinter($this->withColor);
         }
         if ('array' === $printerName && !$this->readable) {
-            return new ArrayPrinter();
+            return new ArrayPrinter($this->withColor);
         }
         if ('resource' === $printerName && !$this->readable) {
             return new ResourcePrinter();

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -15,6 +15,7 @@ use Phel\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use Phel\Printer\TypePrinter\BooleanPrinter;
 use Phel\Printer\TypePrinter\KeywordPrinter;
+use Phel\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Printer\TypePrinter\NullPrinter;
 use Phel\Printer\TypePrinter\NumberPrinter;
 use Phel\Printer\TypePrinter\ObjectPrinter;
@@ -25,6 +26,7 @@ use Phel\Printer\TypePrinter\StringPrinter;
 use Phel\Printer\TypePrinter\StructPrinter;
 use Phel\Printer\TypePrinter\SymbolPrinter;
 use Phel\Printer\TypePrinter\TablePrinter;
+use Phel\Printer\TypePrinter\ToStringPrinter;
 use Phel\Printer\TypePrinter\TuplePrinter;
 use Phel\Printer\TypePrinter\TypePrinterInterface;
 use ReflectionClass;
@@ -106,11 +108,14 @@ final class Printer implements PrinterInterface
         if ($form instanceof AbstractStruct) {
             return new StructPrinter($this);
         }
+        if (method_exists($form, '__toString')) {
+            return new ToStringPrinter();
+        }
         if ((new ReflectionClass($form))->isAnonymous()) {
             return new AnonymousClassPrinter();
         }
 
-        throw new RuntimeException('Printer can not print this type: ' . get_class($form));
+        return new NonPrintableClassPrinter($this->withColor);
     }
 
     /**

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -11,6 +11,7 @@ use Phel\Lang\Set;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
+use Phel\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use Phel\Printer\TypePrinter\BooleanPrinter;
 use Phel\Printer\TypePrinter\KeywordPrinter;
@@ -26,6 +27,7 @@ use Phel\Printer\TypePrinter\SymbolPrinter;
 use Phel\Printer\TypePrinter\TablePrinter;
 use Phel\Printer\TypePrinter\TuplePrinter;
 use Phel\Printer\TypePrinter\TypePrinterInterface;
+use ReflectionClass;
 use RuntimeException;
 
 final class Printer implements PrinterInterface
@@ -103,6 +105,9 @@ final class Printer implements PrinterInterface
         }
         if ($form instanceof AbstractStruct) {
             return new StructPrinter($this);
+        }
+        if ((new ReflectionClass($form))->isAnonymous()) {
+            return new AnonymousClassPrinter();
         }
 
         throw new RuntimeException('Printer can not print this type: ' . get_class($form));

--- a/src/php/Printer/TypePrinter/AnonymousClassPrinter.php
+++ b/src/php/Printer/TypePrinter/AnonymousClassPrinter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Printer\TypePrinter;
+
+/**
+ * @implements TypePrinterInterface<callable>
+ */
+final class AnonymousClassPrinter implements TypePrinterInterface
+{
+    /**
+     * @param callable $form
+     */
+    public function print($form): string
+    {
+        return '<PHP-AnonymousClass>';
+    }
+}

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Printer\TypePrinter;
 
+use Phel\Printer\PrinterInterface;
+
 /**
  * @implements TypePrinterInterface<array>
  */
 final class ArrayPrinter implements TypePrinterInterface
 {
-    use WithColorTrait;
+    private PrinterInterface $printer;
+    private bool $withColor;
+
+    public function __construct(PrinterInterface $printer, bool $withColor = false)
+    {
+        $this->printer = $printer;
+        $this->withColor = $withColor;
+    }
 
     /**
      * @param array $form
@@ -54,7 +63,7 @@ final class ArrayPrinter implements TypePrinterInterface
             return sprintf('"%s"', $v);
         }
 
-        return (string)$v;
+        return $this->printer->print($v);
     }
 
     private function color(string $str): string

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -9,12 +9,7 @@ namespace Phel\Printer\TypePrinter;
  */
 final class ArrayPrinter implements TypePrinterInterface
 {
-    private bool $withColor;
-
-    public function __construct(bool $withColor = false)
-    {
-        $this->withColor = $withColor;
-    }
+    use WithColorTrait;
 
     /**
      * @param array $form

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -4,13 +4,70 @@ declare(strict_types=1);
 
 namespace Phel\Printer\TypePrinter;
 
+/**
+ * @implements TypePrinterInterface<array>
+ */
 final class ArrayPrinter implements TypePrinterInterface
 {
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+
     /**
-     * @param mixed $form
+     * @param array $form
      */
     public function print($form): string
     {
-        return '<PHP-Array>';
+        $arr = $this->isList($form)
+            ? $this->formatValuesFromList($form)
+            : $this->formatKeyValuesFromDict($form);
+
+        return sprintf('<PHP-Array [%s]>', $this->color(implode(', ', $arr)));
+    }
+
+    private function isList(array $form): bool
+    {
+        return array_keys($form) === range(0, count($form) - 1);
+    }
+
+    private function formatValuesFromList(array $form): array
+    {
+        return array_map(
+            fn ($v) => $this->formatValue($v),
+            $form
+        );
+    }
+
+    private function formatKeyValuesFromDict(array $form): array
+    {
+        return array_map(
+            fn ($k, $v) => sprintf('%s:%s', $this->formatValue($k), $this->formatValue($v)),
+            array_keys($form),
+            $form
+        );
+    }
+
+    /**
+     * @param mixed $v
+     */
+    private function formatValue($v): string
+    {
+        if (is_string($v)) {
+            return sprintf('"%s"', $v);
+        }
+
+        return (string)$v;
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;37m%s\033[0m", $str);
+        }
+
+        return $str;
     }
 }

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -40,7 +40,7 @@ final class ArrayPrinter implements TypePrinterInterface
     private function formatValuesFromList(array $form): array
     {
         return array_map(
-            fn ($v) => $this->formatValue($v),
+            fn ($v) => $this->printer->print($v),
             $form
         );
     }
@@ -48,22 +48,10 @@ final class ArrayPrinter implements TypePrinterInterface
     private function formatKeyValuesFromDict(array $form): array
     {
         return array_map(
-            fn ($k, $v) => sprintf('%s:%s', $this->formatValue($k), $this->formatValue($v)),
+            fn ($k, $v) => sprintf('%s:%s', $this->printer->print($k), $this->printer->print($v)),
             array_keys($form),
             $form
         );
-    }
-
-    /**
-     * @param mixed $v
-     */
-    private function formatValue($v): string
-    {
-        if (is_string($v)) {
-            return sprintf('"%s"', $v);
-        }
-
-        return $this->printer->print($v);
     }
 
     private function color(string $str): string

--- a/src/php/Printer/TypePrinter/BooleanPrinter.php
+++ b/src/php/Printer/TypePrinter/BooleanPrinter.php
@@ -9,12 +9,7 @@ namespace Phel\Printer\TypePrinter;
  */
 final class BooleanPrinter implements TypePrinterInterface
 {
-    private bool $withColor;
-
-    public function __construct(bool $withColor = false)
-    {
-        $this->withColor = $withColor;
-    }
+    use WithColorTrait;
 
     /**
      * @param bool $form

--- a/src/php/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Printer/TypePrinter/KeywordPrinter.php
@@ -11,12 +11,7 @@ use Phel\Lang\Keyword;
  */
 final class KeywordPrinter implements TypePrinterInterface
 {
-    private bool $withColor;
-
-    public function __construct(bool $withColor = false)
-    {
-        $this->withColor = $withColor;
-    }
+    use WithColorTrait;
 
     /**
      * @param Keyword $form

--- a/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
+++ b/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace Phel\Printer\TypePrinter;
 
-final class NullPrinter implements TypePrinterInterface
+/**
+ * @implements TypePrinterInterface<object>
+ */
+final class NonPrintableClassPrinter implements TypePrinterInterface
 {
     use WithColorTrait;
 
     /**
-     * @param mixed $form
+     * @param object $form
      */
     public function print($form): string
     {
-        return $this->color('nil');
+        return 'Printer can not print this type: ' . $this->color(get_class($form));
     }
 
     private function color(string $str): string
     {
         if ($this->withColor) {
-            return sprintf("\033[0;96m%s\033[0m", $str);
+            return sprintf("\033[1;35m%s\033[0m", $str);
         }
 
         return $str;

--- a/src/php/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Printer/TypePrinter/NumberPrinter.php
@@ -9,12 +9,7 @@ namespace Phel\Printer\TypePrinter;
  */
 final class NumberPrinter implements TypePrinterInterface
 {
-    private bool $withColor;
-
-    public function __construct(bool $withColor = false)
-    {
-        $this->withColor = $withColor;
-    }
+    use WithColorTrait;
 
     /**
      * @param int|float $form

--- a/src/php/Printer/TypePrinter/SymbolPrinter.php
+++ b/src/php/Printer/TypePrinter/SymbolPrinter.php
@@ -11,12 +11,7 @@ use Phel\Lang\Symbol;
  */
 final class SymbolPrinter implements TypePrinterInterface
 {
-    private bool $withColor;
-
-    public function __construct(bool $withColor = false)
-    {
-        $this->withColor = $withColor;
-    }
+    use WithColorTrait;
 
     /**
      * @param Symbol $form

--- a/src/php/Printer/TypePrinter/ToStringPrinter.php
+++ b/src/php/Printer/TypePrinter/ToStringPrinter.php
@@ -7,15 +7,13 @@ namespace Phel\Printer\TypePrinter;
 /**
  * @implements TypePrinterInterface<object>
  */
-final class AnonymousClassPrinter implements TypePrinterInterface
+final class ToStringPrinter implements TypePrinterInterface
 {
-    use WithColorTrait;
-
     /**
      * @param object $form
      */
     public function print($form): string
     {
-        return '<PHP-AnonymousClass>';
+        return $form->__toString();
     }
 }

--- a/src/php/Printer/TypePrinter/WithColorTrait.php
+++ b/src/php/Printer/TypePrinter/WithColorTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Printer\TypePrinter;
+
+trait WithColorTrait
+{
+    private bool $withColor;
+
+    public function __construct(bool $withColor = false)
+    {
+        $this->withColor = $withColor;
+    }
+}

--- a/tests/php/Unit/Printer/PrinterTest.php
+++ b/tests/php/Unit/Printer/PrinterTest.php
@@ -66,6 +66,18 @@ final class PrinterTest extends TestCase
         );
     }
 
+    public function testPrintToStringFromObject(): void
+    {
+        $class = new class() {
+            public function __toString(): string
+            {
+                return 'toString method';
+            }
+        };
+
+        self::assertSame('toString method', $this->print($class));
+    }
+
     private function print($x): string
     {
         return Printer::readable()->print($x);

--- a/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Phel\Printer\TypePrinter\AnonymousClassPrinter;
+use PHPUnit\Framework\TestCase;
+
+final class AnonymousClassPrinterTest extends TestCase
+{
+    public function testPrint(): void
+    {
+        $class = new class() {
+        };
+
+        self::assertSame(
+            '<PHP-AnonymousClass>',
+            (new AnonymousClassPrinter())->print($class)
+        );
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
@@ -40,17 +40,17 @@ final class ArrayPrinterTest extends TestCase
 
         yield 'simple string list' => [
             'form' => ['s1', 's2', 's3'],
-            'expected ' => '<PHP-Array ["s1", "s2", "s3"]>',
+            'expected ' => '<PHP-Array [s1, s2, s3]>',
         ];
 
         yield 'key-value dictionary with numbers' => [
             'form' => ['k1' => 1, 'k2' => 2],
-            'expected ' => '<PHP-Array ["k1":1, "k2":2]>',
+            'expected ' => '<PHP-Array [k1:1, k2:2]>',
         ];
 
         yield 'key-value dictionary with strings' => [
             'form' => ['k1' => 'v1', 'k2' => 'v2'],
-            'expected ' => '<PHP-Array ["k1":"v1", "k2":"v2"]>',
+            'expected ' => '<PHP-Array [k1:v1, k2:v2]>',
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
+use Phel\Printer\PrinterInterface;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,14 @@ final class ArrayPrinterTest extends TestCase
      */
     public function testPrint(array $form, string $expected): void
     {
-        self::assertSame($expected, (new ArrayPrinter())->print($form));
+        $printer = new class() implements PrinterInterface {
+            public function print($form): string
+            {
+                return (string)$form;
+            }
+        };
+
+        self::assertSame($expected, (new ArrayPrinter($printer))->print($form));
     }
 
     public function providerPrint(): Generator

--- a/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
@@ -4,13 +4,45 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Printer\TypePrinter;
 
+use Generator;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use PHPUnit\Framework\TestCase;
 
 final class ArrayPrinterTest extends TestCase
 {
-    public function testPrint(): void
+    /**
+     * @dataProvider providerPrint
+     */
+    public function testPrint(array $form, string $expected): void
     {
-        self::assertSame('<PHP-Array>', (new ArrayPrinter())->print([]));
+        self::assertSame($expected, (new ArrayPrinter())->print($form));
+    }
+
+    public function providerPrint(): Generator
+    {
+        yield 'Empty array' => [
+            'form' => [],
+            'expected ' => '<PHP-Array []>',
+        ];
+
+        yield 'simple numeric list' => [
+            'form' => [1, 2, 3],
+            'expected ' => '<PHP-Array [1, 2, 3]>',
+        ];
+
+        yield 'simple string list' => [
+            'form' => ['s1', 's2', 's3'],
+            'expected ' => '<PHP-Array ["s1", "s2", "s3"]>',
+        ];
+
+        yield 'key-value dictionary with numbers' => [
+            'form' => ['k1' => 1, 'k2' => 2],
+            'expected ' => '<PHP-Array ["k1":1, "k2":2]>',
+        ];
+
+        yield 'key-value dictionary with strings' => [
+            'form' => ['k1' => 'v1', 'k2' => 'v2'],
+            'expected ' => '<PHP-Array ["k1":"v1", "k2":"v2"]>',
+        ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use DateTime;
+use Generator;
+use Phel\Printer\TypePrinter\NonPrintableClassPrinter;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class NonPrintableClassPrinterTest extends TestCase
+{
+    /**
+     * @dataProvider providerPrint
+     *
+     * @param mixed $form
+     */
+    public function testPrint($form, string $expected): void
+    {
+        self::assertSame($expected, (new NonPrintableClassPrinter())->print($form));
+    }
+
+    public function providerPrint(): Generator
+    {
+        yield 'Empty array' => [
+            'form' => new DateTime(),
+            'expected ' => 'Printer can not print this type: DateTime',
+        ];
+
+        yield 'simple numeric list' => [
+            'form' => new stdClass(),
+            'expected ' => 'Printer can not print this type: stdClass',
+        ];
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/ToStringPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ToStringPrinterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Phel\Printer\TypePrinter\ToStringPrinter;
+use PHPUnit\Framework\TestCase;
+
+final class ToStringPrinterTest extends TestCase
+{
+    public function testPrint(): void
+    {
+        $class = new class() {
+            public function __toString(): string
+            {
+                return 'toString method';
+            }
+        };
+
+        self::assertSame('toString method', (new ToStringPrinter())->print($class));
+    }
+}


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/phel-lang/phel-lang/issues/204
In order to avoid exceptions when printing anything from the REPL, I created 3 new printers.

## 🔖 Changes

- Created `WithColorTrait` for the Printers.

- Print one level of data from the `ArrayPrinter` instead of displaying only `<PHP-Array>`. 
- Created new printers:
  - `ToStringPrinter`: it calls the `__toString()` in case the object has it.
  - `AnonymousClassPrinter`: it notifies you that that class is an anon class, that's all.
  - `NonPrintableClassPrinter`: it tells you that the class that you are trying to print is not printable.

## 🖼️ Screenshots

<img width="614" alt="Screenshot 2021-01-28 at 17 32 18" src="https://user-images.githubusercontent.com/5256287/106168615-c8614400-618e-11eb-9b2b-954f8171be7e.png">
