### PR TITLE
Save in history incorrect REPL expressions

### DIFF
--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -105,9 +105,9 @@ final class ReplCommand
         }
     }
 
-    private function addHistory(?string $input): void
+    private function addHistory(string $input): void
     {
-        if (!empty($input)) {
+        if ('' !== $input) {
             $this->io->addHistory($input);
         }
     }

--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -101,14 +101,6 @@ final class ReplCommand
             $this->io->writeln();
         } else {
             $this->inputBuffer[] = $input;
-            $this->addHistory($input);
-        }
-    }
-
-    private function addHistory(string $input): void
-    {
-        if ('' !== $input) {
-            $this->io->addHistory($input);
         }
     }
 
@@ -132,6 +124,8 @@ final class ReplCommand
 
         $fullInput = implode(PHP_EOL, $this->inputBuffer);
 
+        $this->addHistory($fullInput);
+
         try {
             $result = $this->compiler->eval($fullInput, $this->lineNumber - count($this->inputBuffer));
             $this->io->writeln($this->printer->print($result));
@@ -150,6 +144,13 @@ final class ReplCommand
         } catch (Throwable $e) {
             $this->io->writeln($this->exceptionPrinter->getStackTraceString($e));
             $this->inputBuffer = [];
+        }
+    }
+
+    private function addHistory(string $input): void
+    {
+        if ('' !== $input) {
+            $this->io->addHistory($input);
         }
     }
 }

--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -101,6 +101,14 @@ final class ReplCommand
             $this->io->writeln();
         } else {
             $this->inputBuffer[] = $input;
+            $this->addHistory($input);
+        }
+    }
+
+    private function addHistory(?string $input): void
+    {
+        if (!empty($input)) {
+            $this->io->addHistory($input);
         }
     }
 
@@ -126,9 +134,7 @@ final class ReplCommand
 
         try {
             $result = $this->compiler->eval($fullInput, $this->lineNumber - count($this->inputBuffer));
-
             $this->io->writeln($this->printer->print($result));
-            $this->io->addHistory($fullInput);
 
             $this->inputBuffer = [];
         } catch (UnfinishedParserException $e) {

--- a/src/php/Command/ReplCommand.php
+++ b/src/php/Command/ReplCommand.php
@@ -124,10 +124,9 @@ final class ReplCommand
 
         $fullInput = implode(PHP_EOL, $this->inputBuffer);
 
-        $this->addHistory($fullInput);
-
         try {
             $result = $this->compiler->eval($fullInput, $this->lineNumber - count($this->inputBuffer));
+            $this->addHistory($fullInput);
             $this->io->writeln($this->printer->print($result));
 
             $this->inputBuffer = [];
@@ -140,9 +139,11 @@ final class ReplCommand
                     $e->getCodeSnippet()
                 )
             );
+            $this->addHistory($fullInput);
             $this->inputBuffer = [];
         } catch (Throwable $e) {
             $this->io->writeln($this->exceptionPrinter->getStackTraceString($e));
+            $this->addHistory($fullInput);
             $this->inputBuffer = [];
         }
     }


### PR DESCRIPTION
## 📚 Description

Closes https://github.com/phel-lang/phel-lang/issues/205

When you press `<ENTER>` in the REPL, even if the statement is incorrect, it will be saved inside the `phel-repl-history` file.

## 🖼️  Screenshot

![image](https://user-images.githubusercontent.com/6381924/106172338-02344980-6193-11eb-97bc-6f994177e2af.png)
