### PR TITLE
Use ExceptionPrinter in FormatCommand

### DIFF
--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -37,6 +37,9 @@ final class CommandFacade implements CommandFacadeInterface
             ->run($fileOrPath);
     }
 
+    /**
+     * @param list<string> $paths
+     */
     public function executeTestCommand(array $paths): void
     {
         $result = $this->commandFactory
@@ -48,6 +51,9 @@ final class CommandFacade implements CommandFacadeInterface
             : exit(self::FAILED_CODE);
     }
 
+    /**
+     * @param list<string> $paths
+     */
     public function executeFormatCommand(array $paths): void
     {
         $this->commandFactory

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -10,7 +10,13 @@ interface CommandFacadeInterface
 
     public function executeRunCommand(string $fileOrPath): void;
 
+    /**
+     * @param list<string> $paths
+     */
     public function executeTestCommand(array $paths): void;
 
+    /**
+     * @param list<string> $paths
+     */
     public function executeFormatCommand(array $paths): void;
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -71,7 +71,8 @@ final class CommandFactory implements CommandFactoryInterface
         return new FormatCommand(
             $this->formatterFactory->createFormatter(),
             $this->createCommandIo(),
-            $this->createPathFilter()
+            $this->createPathFilter(),
+            TextExceptionPrinter::create()
         );
     }
 

--- a/src/php/Command/FormatCommand.php
+++ b/src/php/Command/FormatCommand.php
@@ -39,27 +39,14 @@ final class FormatCommand
      */
     public function run(array $paths): void
     {
-        try {
-            $this->formatPaths($paths);
-        } catch (ParserException $e) {
-            $this->io->writeln(
-                $this->exceptionPrinter->getExceptionString($e, $e->getCodeSnippet())
-            );
-        }
-    }
-
-    /**
-     * @param list<string> $paths
-     *
-     * @throws ParserException
-     */
-    private function formatPaths(array $paths): void
-    {
         foreach ($this->pathFilter->filterPaths($paths) as $path) {
-            $wasFormatted = $this->formatter->formatFile($path);
-
-            if ($wasFormatted) {
-                $this->successfulFormattedFilePaths[] = $path;
+            try {
+                $wasFormatted = $this->formatter->formatFile($path);
+                if ($wasFormatted) {
+                    $this->successfulFormattedFilePaths[] = $path;
+                }
+            } catch (ParserException $e) {
+                $this->printParParserException($e);
             }
         }
 
@@ -77,5 +64,15 @@ final class FormatCommand
                 $this->io->writeln(sprintf('  %d) %s', $k + 1, $filePath));
             }
         }
+    }
+
+    private function printParParserException(ParserException $e): void
+    {
+        $this->io->writeln(
+            $this->exceptionPrinter->getExceptionString(
+                $e,
+                $e->getCodeSnippet()
+            )
+        );
     }
 }

--- a/src/php/Command/Shared/CommandIoInterface.php
+++ b/src/php/Command/Shared/CommandIoInterface.php
@@ -8,5 +8,5 @@ interface CommandIoInterface
 {
     public function fileGetContents(string $path): string;
 
-    public function output(string $string): void;
+    public function writeln(string $string): void;
 }

--- a/src/php/Command/Shared/CommandSystemIo.php
+++ b/src/php/Command/Shared/CommandSystemIo.php
@@ -11,8 +11,8 @@ final class CommandSystemIo implements CommandIoInterface
         return file_get_contents($string);
     }
 
-    public function output(string $string): void
+    public function writeln(string $string = ''): void
     {
-        print $string;
+        print $string . PHP_EOL;
     }
 }

--- a/src/php/Compiler/Parser/Parser.php
+++ b/src/php/Compiler/Parser/Parser.php
@@ -51,6 +51,11 @@ final class Parser implements ParserInterface
         return $this->readExpression($tokenStream);
     }
 
+    /**
+     * @throws ParserException
+     * @throws UnexpectedParserException
+     * @throws UnfinishedParserException
+     */
     public function parseAll(TokenStream $tokenStream): FileNode
     {
         $result = [];

--- a/src/php/Compiler/Parser/ParserInterface.php
+++ b/src/php/Compiler/Parser/ParserInterface.php
@@ -20,5 +20,10 @@ interface ParserInterface
      */
     public function parseNext(TokenStream $tokenStream): ?NodeInterface;
 
+    /**
+     * @throws ParserException
+     * @throws UnexpectedParserException
+     * @throws UnfinishedParserException
+     */
     public function parseAll(TokenStream $tokenStream): FileNode;
 }

--- a/src/php/Formatter/Formatter.php
+++ b/src/php/Formatter/Formatter.php
@@ -7,6 +7,7 @@ namespace Phel\Formatter;
 use Phel\Compiler\Lexer\LexerInterface;
 use Phel\Compiler\Parser\ParserInterface;
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
+use Phel\Exceptions\ParserException;
 use Phel\Formatter\Rules\RuleInterface;
 
 final class Formatter implements FormatterInterface
@@ -31,6 +32,9 @@ final class Formatter implements FormatterInterface
         $this->rules = $rules;
     }
 
+    /**
+     * @throws ParserException
+     */
     public function formatFile(string $filename): bool
     {
         $code = file_get_contents($filename);
@@ -40,6 +44,9 @@ final class Formatter implements FormatterInterface
         return (bool)strcmp($formattedCode, $code);
     }
 
+    /**
+     * @throws ParserException
+     */
     private function formatString(string $string, string $source = self::DEFAULT_SOURCE): string
     {
         $tokenStream = $this->lexer->lexString($string, $source);

--- a/src/php/Formatter/FormatterInterface.php
+++ b/src/php/Formatter/FormatterInterface.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Formatter;
 
+use Phel\Exceptions\ParserException;
+
 interface FormatterInterface
 {
     /**
+     * @throws ParserException
+     *
      * @return bool True if the file was formatted. False if the file wasn't altered because it was already formatted.
      */
     public function formatFile(string $filename): bool;

--- a/tests/php/Integration/Command/FormatCommandTest.php
+++ b/tests/php/Integration/Command/FormatCommandTest.php
@@ -36,7 +36,8 @@ final class FormatCommandTest extends TestCase
 
         $this->expectOutputString(<<<TXT
 Formatted files:
-  1) $path \n
+  1) $path
+
 TXT);
         $command->run([$path]);
 


### PR DESCRIPTION
## 📚 Description
Issue: https://github.com/phel-lang/phel-lang/issues/216
When running the "phel fmt" command, in case the phel file has any parsing error we didn't show much feedback.

## 🔖 Changes

- Include the ExceptionPrinter to the FormatCommand, so in case the formatted encounters any error, it will render the file and exact location where the error was found.

## 🖼️  Screenshots
Here you can see an example of the output when the phel code is malformed (I added the `]` for testing purpose):
<img width="1071" alt="Screenshot 2021-01-30 at 19 26 17" src="https://user-images.githubusercontent.com/5256287/106364663-08602c80-6331-11eb-83a1-f6918b1ebf9c.png">
