### PR TITLE
Improve exceptions triggered from EvalEmitter

### DIFF
--- a/src/php/Compiler/Analyzer/Analyzer.php
+++ b/src/php/Compiler/Analyzer/Analyzer.php
@@ -72,6 +72,8 @@ final class Analyzer implements AnalyzerInterface
 
     /**
      * @param AbstractType|string|float|int|bool|null $x
+     *
+     * @throws AnalyzerException
      */
     public function analyzeMacro($x, NodeEnvironmentInterface $env): AbstractNode
     {
@@ -84,6 +86,8 @@ final class Analyzer implements AnalyzerInterface
 
     /**
      * @param AbstractType|string|float|int|bool|null $x
+     *
+     * @throws AnalyzerException
      */
     public function analyze($x, NodeEnvironmentInterface $env): AbstractNode
     {

--- a/src/php/Compiler/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Analyzer/AnalyzerInterface.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Analyzer;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
@@ -14,6 +15,8 @@ interface AnalyzerInterface
 {
     /**
      * @param AbstractType|string|float|int|bool|null $x
+     *
+     * @throws AnalyzerException
      */
     public function analyze($x, NodeEnvironmentInterface $env): AbstractNode;
 

--- a/src/php/Compiler/Emitter/Emitter.php
+++ b/src/php/Compiler/Emitter/Emitter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Compiler\Emitter;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Exceptions\FileException;
 
 final class Emitter implements EmitterInterface
 {
@@ -19,6 +21,15 @@ final class Emitter implements EmitterInterface
         $this->evalEmitter = $evalEmitter;
     }
 
+    public function emitNodeAsString(AbstractNode $node): string
+    {
+        return $this->outputEmitter->emitNodeAsString($node);
+    }
+
+    /**
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     public function emitNodeAndEval(AbstractNode $node): string
     {
         $code = $this->emitNodeAsString($node);
@@ -27,12 +38,10 @@ final class Emitter implements EmitterInterface
         return $code;
     }
 
-    public function emitNodeAsString(AbstractNode $node): string
-    {
-        return $this->outputEmitter->emitNodeAsString($node);
-    }
-
     /**
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     *
      * @return mixed
      */
     public function evalCode(string $code)

--- a/src/php/Compiler/Emitter/EmitterInterface.php
+++ b/src/php/Compiler/Emitter/EmitterInterface.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace Phel\Compiler\Emitter;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Exceptions\FileException;
 
 interface EmitterInterface
 {
-    public function emitNodeAndEval(AbstractNode $node): string;
-
     public function emitNodeAsString(AbstractNode $node): string;
+
+    /**
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
+    public function emitNodeAndEval(AbstractNode $node): string;
 
     /**
      * @return mixed

--- a/src/php/Compiler/Emitter/EvalEmitter.php
+++ b/src/php/Compiler/Emitter/EvalEmitter.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Emitter;
 
-use RuntimeException;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Exceptions\FileException;
 use Throwable;
 
 final class EvalEmitter implements EvalEmitterInterface
@@ -12,7 +13,8 @@ final class EvalEmitter implements EvalEmitterInterface
     /**
      * Evaluates the code and returns the evaluated value.
      *
-     * @throws RuntimeException|Throwable
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
      *
      * @return mixed
      */
@@ -20,7 +22,7 @@ final class EvalEmitter implements EvalEmitterInterface
     {
         $filename = tempnam(sys_get_temp_dir(), '__phel');
         if (!$filename) {
-            throw new RuntimeException('can not create temp file.');
+            throw FileException::canNotCreateTempFile();
         }
 
         try {
@@ -29,9 +31,9 @@ final class EvalEmitter implements EvalEmitterInterface
                 return require $filename;
             }
 
-            throw new RuntimeException('Can not require file: ' . $filename);
+            throw FileException::canNotCreateFile($filename);
         } catch (Throwable $e) {
-            throw $e;
+            throw CompiledCodeIsMalformedException::fromThrowable($e);
         }
     }
 }

--- a/src/php/Compiler/Emitter/EvalEmitterInterface.php
+++ b/src/php/Compiler/Emitter/EvalEmitterInterface.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Emitter;
 
-use RuntimeException;
-use Throwable;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Exceptions\FileException;
 
 interface EvalEmitterInterface
 {
     /**
      * Evaluates the code and returns the evaluated value.
      *
-     * @throws RuntimeException|Throwable
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
      *
      * @return mixed
      */

--- a/src/php/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/EvalCompiler.php
@@ -14,7 +14,9 @@ use Phel\Compiler\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Reader\ReaderInterface;
 use Phel\Exceptions\AnalyzerException;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Exceptions\CompilerException;
+use Phel\Exceptions\FileException;
 use Phel\Exceptions\Parser\UnfinishedParserException;
 use Phel\Exceptions\ParserException;
 use Phel\Exceptions\ReaderException;
@@ -44,7 +46,10 @@ final class EvalCompiler implements EvalCompilerInterface
     /**
      * Evaluates a provided Phel code.
      *
-     * @throws CompilerException|UnfinishedParserException
+     * @throws CompiledCodeIsMalformedException
+     * @throws CompilerException
+     * @throws FileException
+     * @throws UnfinishedParserException
      *
      * @return mixed The result of the executed code
      */
@@ -69,7 +74,9 @@ final class EvalCompiler implements EvalCompilerInterface
     }
 
     /**
+     * @throws CompiledCodeIsMalformedException
      * @throws CompilerException
+     * @throws FileException
      *
      * @return mixed
      */

--- a/src/php/Compiler/FileCompiler.php
+++ b/src/php/Compiler/FileCompiler.php
@@ -13,7 +13,9 @@ use Phel\Compiler\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Reader\ReaderInterface;
 use Phel\Exceptions\AnalyzerException;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Exceptions\CompilerException;
+use Phel\Exceptions\FileException;
 use Phel\Exceptions\ParserException;
 use Phel\Exceptions\ReaderException;
 
@@ -39,6 +41,11 @@ final class FileCompiler implements FileCompilerInterface
         $this->emitter = $emitter;
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     public function compile(string $filename): string
     {
         $code = file_get_contents($filename);
@@ -66,6 +73,11 @@ final class FileCompiler implements FileCompilerInterface
         return $code;
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     private function analyzeAndEvalNode(ReaderResult $readerResult): string
     {
         try {

--- a/src/php/Compiler/FileCompilerInterface.php
+++ b/src/php/Compiler/FileCompilerInterface.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Compiler;
 
+use Phel\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Exceptions\CompilerException;
+use Phel\Exceptions\FileException;
+
 interface FileCompilerInterface
 {
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     public function compile(string $filename): string;
 }

--- a/src/php/Compiler/Reader/ReaderInterface.php
+++ b/src/php/Compiler/Reader/ReaderInterface.php
@@ -6,8 +6,12 @@ namespace Phel\Compiler\Reader;
 
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Parser\ReadModel\ReaderResult;
+use Phel\Exceptions\ReaderException;
 
 interface ReaderInterface
 {
+    /**
+     * @throws ReaderException
+     */
     public function read(NodeInterface $parseTree): ReaderResult;
 }

--- a/src/php/Exceptions/CompiledCodeIsMalformedException.php
+++ b/src/php/Exceptions/CompiledCodeIsMalformedException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class CompiledCodeIsMalformedException extends RuntimeException
+{
+    public static function fromThrowable(Throwable $e): self
+    {
+        return new self($e->getMessage(), 0, $e);
+    }
+}

--- a/src/php/Exceptions/FileException.php
+++ b/src/php/Exceptions/FileException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Exceptions;
+
+use RuntimeException;
+
+final class FileException extends RuntimeException
+{
+    public static function canNotCreateTempFile(): self
+    {
+        return new self('Can not create temp file.');
+    }
+
+    public static function canNotCreateFile(string $filename): self
+    {
+        return new self('Can not require file: ' . $filename);
+    }
+}

--- a/src/php/Runtime/Runtime.php
+++ b/src/php/Runtime/Runtime.php
@@ -7,8 +7,10 @@ namespace Phel\Runtime;
 use InvalidArgumentException;
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\CompilerFactoryInterface;
+use Phel\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Exceptions\CompilerException;
 use Phel\Exceptions\ExceptionPrinterInterface;
+use Phel\Exceptions\FileException;
 use Phel\Lang\Keyword;
 use Phel\Lang\MetaInterface;
 use Phel\Lang\Symbol;
@@ -78,6 +80,11 @@ class Runtime implements RuntimeInterface
         }
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     public function loadNs(string $ns): bool
     {
         if (in_array($ns, $this->loadedNs, true)) {
@@ -101,6 +108,11 @@ class Runtime implements RuntimeInterface
         return true;
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     public function loadFileIntoNamespace(string $ns, string $file): void
     {
         $this->loadFile($file, $ns);
@@ -186,6 +198,11 @@ class Runtime implements RuntimeInterface
         return true;
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     protected function loadFile(string $filename, string $ns): void
     {
         $code = $this->compilerFactory


### PR DESCRIPTION
## 📚 Description

It helps us to recognize the potential Exceptions that you can encounter in those specific contexts.

## 🔖 Changes

- Created `CompiledCodeIsMalformedException` & `FileException` that will be triggered from the `EvalEmitter` instead of the native `\RuntimeException`
- Added `@throws Exceptions...` in PHPDoc for the EvalEmitter context
