### PR TITLE
Add rule void_return to php_cs

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -47,4 +47,5 @@ return PhpCsFixer\Config::create()
     'single_quote' => true,
     'trailing_comma_in_multiline_array' => true,
     'trim_array_spaces' => true,
+    'void_return' => true,
   ]);

--- a/src/php/Compiler/Lexer/TokenStream.php
+++ b/src/php/Compiler/Lexer/TokenStream.php
@@ -34,7 +34,7 @@ final class TokenStream implements Iterator
         return $this->tokenGenerator->key();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->tokenGenerator->rewind();
     }

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefSymbolTest.php
@@ -112,7 +112,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testDocstring()
+    public function testDocstring(): void
     {
         $tuple = Tuple::create(
             Symbol::create(Symbol::NAME_DEF),
@@ -145,7 +145,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testMetaKeyword()
+    public function testMetaKeyword(): void
     {
         $tuple = Tuple::create(
             Symbol::create(Symbol::NAME_DEF),
@@ -178,7 +178,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testMetaTableKeyword()
+    public function testMetaTableKeyword(): void
     {
         $tuple = Tuple::create(
             Symbol::create(Symbol::NAME_DEF),
@@ -211,7 +211,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testInvalidMeta()
+    public function testInvalidMeta(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Metadata must be a String, Keyword or Table');

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/InvokeSymbolTest.php
@@ -36,7 +36,7 @@ final class InvokeSymbolTest extends TestCase
         };
 
         $env->addDefinition('user', Symbol::create('my-failed-macro'), Table::fromKVs(new Keyword('macro'), true));
-        $GLOBALS['__phel']['user']['my-failed-macro'] = function ($a) {
+        $GLOBALS['__phel']['user']['my-failed-macro'] = function ($a): void {
             throw new Exception('my-failed-macro message');
         };
 

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/LoopSymbolTest.php
@@ -135,7 +135,7 @@ final class LoopSymbolTest extends TestCase
         );
     }
 
-    public function testWithDestruction()
+    public function testWithDestruction(): void
     {
         Symbol::resetGen();
         $tuple = Tuple::create(Symbol::create('loop'), Tuple::create(Tuple::create(Symbol::create('a')), 1), 1);

--- a/tests/php/Unit/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Unit/Compiler/Reader/ReaderTest.php
@@ -634,7 +634,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testShortFnRestArgumentMultipleTimes()
+    public function testShortFnRestArgumentMultipleTimes(): void
     {
         $this->assertEquals(
             Tuple::create(

--- a/tests/php/Unit/Lang/SetTest.php
+++ b/tests/php/Unit/Lang/SetTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SetTest extends TestCase
 {
-    public function testCount()
+    public function testCount(): void
     {
         $set1 = new Set([]);
         $set2 = new Set(['a']);
@@ -22,13 +22,13 @@ final class SetTest extends TestCase
         $this->assertEquals(2, count($set4));
     }
 
-    public function testHash()
+    public function testHash(): void
     {
         $set = new Set(['a']);
         $this->assertEquals(spl_object_hash($set), $set->hash());
     }
 
-    public function testForeach()
+    public function testForeach(): void
     {
         $set = new Set(['a', 'b']);
         $result = [];
@@ -39,7 +39,7 @@ final class SetTest extends TestCase
         $this->assertEquals(['a', 'b'], $result);
     }
 
-    public function testCons()
+    public function testCons(): void
     {
         $set = new Set(['a']);
         $set->cons('b');
@@ -47,43 +47,43 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 'b']), $set);
     }
 
-    public function testFirst()
+    public function testFirst(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals('a', $set->first());
     }
 
-    public function testFirstEmpty()
+    public function testFirstEmpty(): void
     {
         $set = new Set([]);
         $this->assertNull($set->first());
     }
 
-    public function testCdr()
+    public function testCdr(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(new PhelArray(['b']), $set->cdr());
     }
 
-    public function testCdrEmpty()
+    public function testCdrEmpty(): void
     {
         $set = new Set([]);
         $this->assertEquals(null, $set->cdr());
     }
 
-    public function testRest()
+    public function testRest(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(new PhelArray(['b']), $set->rest());
     }
 
-    public function testRestEmpty()
+    public function testRestEmpty(): void
     {
         $set = new Set([]);
         $this->assertEquals(new PhelArray([]), $set->rest());
     }
 
-    public function testPush()
+    public function testPush(): void
     {
         $set = new Set(['a']);
         $set->push('b');
@@ -91,7 +91,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 'b']), $set);
     }
 
-    public function testPushDifferentTypes()
+    public function testPushDifferentTypes(): void
     {
         $set1 = new Set(['a']);
         $set2 = new Set(['b']);
@@ -103,7 +103,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 1, $set2, $date]), $set1);
     }
 
-    public function testConcat()
+    public function testConcat(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -113,7 +113,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testIntersection()
+    public function testIntersection(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -124,7 +124,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testDifference()
+    public function testDifference(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -135,7 +135,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['a', 'b']);
@@ -148,13 +148,13 @@ final class SetTest extends TestCase
         $this->assertFalse($set3->equals($set1));
     }
 
-    public function testToPhpArray()
+    public function testToPhpArray(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(['a', 'b'], $set->toPhpArray());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals('(set "a" "b")', $set->__toString());

--- a/tests/php/Unit/Lang/SourceLocationTest.php
+++ b/tests/php/Unit/Lang/SourceLocationTest.php
@@ -9,39 +9,39 @@ use PHPUnit\Framework\TestCase;
 
 final class SourceLocationTest extends TestCase
 {
-    public function testGetFile()
+    public function testGetFile(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals('/test', $s->getFile());
     }
 
-    public function testSetFile()
+    public function testSetFile(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setFile('/abc');
         $this->assertEquals('/abc', $s->getFile());
     }
 
-    public function testGetLine()
+    public function testGetLine(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals(1, $s->getLine());
     }
 
-    public function testSetLine()
+    public function testSetLine(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setLine(32);
         $this->assertEquals(32, $s->getLine());
     }
 
-    public function testGetColumn()
+    public function testGetColumn(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals(2, $s->getColumn());
     }
 
-    public function testSetColumn()
+    public function testSetColumn(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setColumn(32);

--- a/tests/php/Unit/Lang/SymbolTest.php
+++ b/tests/php/Unit/Lang/SymbolTest.php
@@ -41,26 +41,26 @@ final class SymbolTest extends TestCase
         $this->assertEquals('namespace/test', $s->getFullName());
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
         $this->assertEquals('test', $s->__toString());
     }
 
-    public function testGen()
+    public function testGen(): void
     {
         Symbol::resetGen();
         $this->assertEquals('__phel_1', Symbol::gen());
         $this->assertEquals('bla2', Symbol::gen('bla'));
     }
 
-    public function testHash()
+    public function testHash(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
         $this->assertEquals('test', $s->hash());
     }
 
-    public function testEquals()
+    public function testEquals(): void
     {
         $s1 = Symbol::createForNamespace('namespace', 'test');
         $s2 = Symbol::createForNamespace('namespace', 'test');
@@ -75,7 +75,7 @@ final class SymbolTest extends TestCase
         $this->assertFalse($s4->equals($s1));
     }
 
-    public function testIdentical()
+    public function testIdentical(): void
     {
         $s1 = Symbol::createForNamespace('namespace', 'test');
         $s2 = Symbol::createForNamespace('namespace', 'test');

--- a/tests/php/Unit/Lang/TruthyTest.php
+++ b/tests/php/Unit/Lang/TruthyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TruthyTest extends TestCase
 {
-    public function testFalse()
+    public function testFalse(): void
     {
         $this->assertFalse(Truthy::isTruthy(null));
         $this->assertFalse(Truthy::isTruthy(false));


### PR DESCRIPTION
## 📚 Description

I saw a lot of methods that don't have the `void` return.

## 🔖 Changes

- Add the rule (`'void_return' => true`) to the `.php_cs.dist` file
- Execute the command `composer csfix` and check tests are green 🍏 
