### PR TITLE
Minor exceptions clean-up

### DIFF
--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
+use Phel\Command\Shared\Exceptions\ExtractorException;
 use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
 use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Emitter\Exceptions\FileException;
@@ -77,6 +78,12 @@ final class CommandFacade implements CommandFacadeInterface
             ->run($paths);
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws ExtractorException
+     * @throws FileException
+     */
     public function executeExportCommand(): void
     {
         $this->commandFactory

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -4,14 +4,32 @@ declare(strict_types=1);
 
 namespace Phel\Command;
 
+use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
+use Phel\Command\Shared\Exceptions\ExtractorException;
+use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
+use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Emitter\Exceptions\FileException;
+use Phel\Compiler\Exceptions\CompilerException;
+
 interface CommandFacadeInterface
 {
     public function executeReplCommand(): void;
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     * @throws CannotLoadNamespaceException
+     */
     public function executeRunCommand(string $fileOrPath): void;
 
     /**
      * @param list<string> $paths
+     *
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     * @throws CannotFindAnyTestsException
      */
     public function executeTestCommand(array $paths): void;
 
@@ -20,5 +38,11 @@ interface CommandFacadeInterface
      */
     public function executeFormatCommand(array $paths): void;
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws ExtractorException
+     * @throws FileException
+     */
     public function executeExportCommand(): void;
 }

--- a/src/php/Command/Export/ExportCommand.php
+++ b/src/php/Command/Export/ExportCommand.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Phel\Command\Export;
 
 use Phel\Command\Shared\CommandIoInterface;
+use Phel\Command\Shared\Exceptions\ExtractorException;
+use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Emitter\Exceptions\FileException;
+use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Interop\Generator\WrapperGeneratorInterface;
 use Phel\Interop\ReadModel\Wrapper;
 
@@ -32,6 +36,12 @@ final class ExportCommand
         $this->destinationDir = $destinationDir;
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws ExtractorException
+     * @throws FileException
+     */
     public function run(): void
     {
         $wrappers = [];

--- a/src/php/Command/Export/FunctionsToExportFinderInterface.php
+++ b/src/php/Command/Export/FunctionsToExportFinderInterface.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace Phel\Command\Export;
 
+use Phel\Command\Shared\Exceptions\ExtractorException;
+use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Emitter\Exceptions\FileException;
+use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Interop\ReadModel\FunctionToExport;
 
 interface FunctionsToExportFinderInterface
 {
     /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws ExtractorException
+     * @throws FileException
+     *
      * @return array<string, list<FunctionToExport>>
      */
     public function findInPaths(): array;

--- a/src/php/Command/Format/FormatCommand.php
+++ b/src/php/Command/Format/FormatCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Command\Format;
 
 use Phel\Command\Shared\CommandIoInterface;
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
+use Phel\Formatter\Exceptions\ZipperException;
 use Phel\Formatter\FormatterInterface;
 use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
 
@@ -46,6 +47,8 @@ final class FormatCommand
                 }
             } catch (AbstractParserException $e) {
                 $this->printParserException($e);
+            } catch (ZipperException $e) {
+                $this->printZipperException($e);
             }
         }
 
@@ -73,5 +76,10 @@ final class FormatCommand
                 $e->getCodeSnippet()
             )
         );
+    }
+
+    private function printZipperException(ZipperException $e): void
+    {
+        $this->io->writeln($e->getMessage());
     }
 }

--- a/src/php/Command/Shared/NamespaceExtractor.php
+++ b/src/php/Command/Shared/NamespaceExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command\Shared;
 
 use Phel\Command\Shared\Exceptions\ExtractorException;
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Lexer\LexerInterface;
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Parser\ParserInterface;
@@ -39,6 +40,7 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
 
     /**
      * @throws ExtractorException
+     * @throws LexerValueException
      */
     public function getNamespaceFromFile(string $path): string
     {

--- a/src/php/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/EvalCompiler.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Emitter\EmitterInterface;
 use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Emitter\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Lexer\LexerInterface;
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Parser\Exceptions\UnfinishedParserException;
@@ -49,6 +50,7 @@ final class EvalCompiler implements EvalCompilerInterface
      * @throws CompiledCodeIsMalformedException
      * @throws CompilerException
      * @throws FileException
+     * @throws LexerValueException
      * @throws UnfinishedParserException
      *
      * @return mixed The result of the executed code

--- a/src/php/Compiler/FileCompiler.php
+++ b/src/php/Compiler/FileCompiler.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Emitter\EmitterInterface;
 use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Emitter\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Lexer\LexerInterface;
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Parser\ParserInterface;
@@ -45,6 +46,7 @@ final class FileCompiler implements FileCompilerInterface
      * @throws CompilerException
      * @throws CompiledCodeIsMalformedException
      * @throws FileException
+     * @throws LexerValueException
      */
     public function compile(string $filename): string
     {

--- a/src/php/Compiler/Lexer/Exceptions/LexerValueException.php
+++ b/src/php/Compiler/Lexer/Exceptions/LexerValueException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Lexer\Exceptions;
+
+use RuntimeException;
+
+final class LexerValueException extends RuntimeException
+{
+    public static function unexpectedLexerState(): self
+    {
+        return new self('Unexpected lexer state');
+    }
+}

--- a/src/php/Compiler/Lexer/Lexer.php
+++ b/src/php/Compiler/Lexer/Lexer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Lexer;
 
-use Exception;
 use Generator;
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
 use Phel\Lang\SourceLocation;
 
 final class Lexer implements LexerInterface
@@ -42,12 +42,17 @@ final class Lexer implements LexerInterface
         $this->combinedRegex = '/(?:' . implode('|', self::REGEXPS) . ')/mA';
     }
 
+    /**
+     * @throws LexerValueException
+     */
     public function lexString(string $code, string $source = self::DEFAULT_SOURCE, int $startingLine = 1): TokenStream
     {
         return new TokenStream($this->lexStringGenerator($code, $source, $startingLine));
     }
 
     /**
+     * @throws LexerValueException
+     *
      * @return Generator<Token>
      */
     private function lexStringGenerator(string $code, string $source = self::DEFAULT_SOURCE, int $startingLine = 1): Generator
@@ -68,7 +73,7 @@ final class Lexer implements LexerInterface
 
                 $startLocation = $endLocation;
             } else {
-                throw new Exception('Unexpected state');
+                throw LexerValueException::unexpectedLexerState();
             }
         }
 

--- a/src/php/Compiler/Lexer/LexerInterface.php
+++ b/src/php/Compiler/Lexer/LexerInterface.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Lexer;
 
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
+
 interface LexerInterface
 {
     public const DEFAULT_SOURCE = 'string';
 
+    /**
+     * @throws LexerValueException
+     */
     public function lexString(string $code, string $source = self::DEFAULT_SOURCE, int $startingLine = 1): TokenStream;
 }

--- a/src/php/Formatter/AbstractZipper.php
+++ b/src/php/Formatter/AbstractZipper.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Formatter;
 
-use Exception;
-use Phel\Formatter\Exceptions\CanNotRemoveAtTheTopException;
 use Phel\Formatter\Exceptions\ZipperException;
 
 /**
@@ -74,12 +72,14 @@ abstract class AbstractZipper
     abstract public function makeNode($node, $children);
 
     /**
+     * @throws ZipperException
+     *
      * @return static<T>
      */
     public function left(): AbstractZipper
     {
         if ($this->isTop()) {
-            throw new ZipperException('Can not go left on the root node');
+            throw ZipperException::cannotGoLeftOnRootNode();
         }
 
         if ($this->isFirst()) {
@@ -125,11 +125,11 @@ abstract class AbstractZipper
     public function right(): AbstractZipper
     {
         if ($this->isTop()) {
-            throw new ZipperException('Can not go right on the root node');
+            throw ZipperException::cannotGoRightOnRootNode();
         }
 
         if ($this->isLast()) {
-            throw new ZipperException('Can not go right on the rightmost node');
+            throw ZipperException::cannotGoRightOnLastNode();
         }
 
         $rightSiblings = $this->rightSiblings;
@@ -171,7 +171,7 @@ abstract class AbstractZipper
     public function up(): AbstractZipper
     {
         if ($this->isTop()) {
-            throw new ZipperException('Can not go up on the root node');
+            throw ZipperException::cannotGoUpOnRootNode();
         }
 
         if ($this->hasChanged) {
@@ -218,12 +218,12 @@ abstract class AbstractZipper
     public function down(): AbstractZipper
     {
         if (!$this->isBranch()) {
-            throw new ZipperException('Can not go down on a leaf node');
+            throw ZipperException::cannotGoDownOnLeafNode();
         }
 
         $children = $this->getChildren();
         if (count($children) == 0) {
-            throw new ZipperException('Can not go down on a node with zero children');
+            throw ZipperException::cannotGoDownOnNodeWithZeroChildren();
         }
 
         $leftChild = array_shift($children);
@@ -314,12 +314,14 @@ abstract class AbstractZipper
     /**
      * @param T $node
      *
+     * @throws ZipperException
+     *
      * @return static
      */
     public function insertLeft($node)
     {
         if ($this->isTop()) {
-            throw new Exception('Can not insert left at the top');
+            throw ZipperException::cannotInsertLeftOnRootNode();
         }
 
         $this->hasChanged = true;
@@ -331,12 +333,14 @@ abstract class AbstractZipper
     /**
      * @param T $node
      *
+     * @throws ZipperException
+     *
      * @return static
      */
     public function insertRight($node)
     {
         if ($this->isTop()) {
-            throw new Exception('Can not insert right at the top');
+            throw ZipperException::cannotInsertRightOnRootNode();
         }
 
         $this->hasChanged = true;
@@ -383,14 +387,14 @@ abstract class AbstractZipper
     }
 
     /**
-     * @throws CanNotRemoveAtTheTopException
+     * @throws ZipperException
      *
      * @return static<T>
      */
     public function remove(): AbstractZipper
     {
         if ($this->isTop()) {
-            throw new CanNotRemoveAtTheTopException();
+            throw ZipperException::cannotRemoveOnRootNode();
         }
 
         if (!$this->isFirst()) {

--- a/src/php/Formatter/Exceptions/ZipperException.php
+++ b/src/php/Formatter/Exceptions/ZipperException.php
@@ -10,11 +10,56 @@ final class ZipperException extends RuntimeException
 {
     public static function calledChildrenOnLeafNode(): self
     {
-        return new self('called children on leaf node');
+        return new self('Called children on a leaf node');
     }
 
-    public static function canReplaceChildrenOnLeafNode(): self
+    public static function cannotReplaceChildrenOnLeafNode(): self
     {
-        return new self('can replace children on leaf node');
+        return new self('Cannot replace children on a leaf node');
+    }
+
+    public static function cannotGoRightOnRootNode(): self
+    {
+        return new self('Cannot go right on the root node');
+    }
+
+    public static function cannotGoRightOnLastNode(): self
+    {
+        return new self('Cannot go right on the last node');
+    }
+
+    public static function cannotGoUpOnRootNode(): self
+    {
+        return new self('Cannot go up on the root node');
+    }
+
+    public static function cannotGoDownOnLeafNode(): self
+    {
+        return new self('Cannot go down on a leaf node');
+    }
+
+    public static function cannotGoDownOnNodeWithZeroChildren(): self
+    {
+        return new self('Cannot go down on a node with zero children');
+    }
+
+    public static function cannotInsertLeftOnRootNode(): self
+    {
+        return new self('Cannot insert left on the root node');
+    }
+
+    public static function cannotInsertRightOnRootNode(): self
+    {
+        return new self('Cannot insert right on the root node');
+    }
+
+    public static function cannotRemoveOnRootNode(): self
+    {
+        return new self('Cannot remove on the root node');
+    }
+
+    public static function cannotGoLeftOnRootNode(): self
+    {
+        return new self('Can not go left on the root node');
     }
 }

--- a/src/php/Formatter/Formatter.php
+++ b/src/php/Formatter/Formatter.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Formatter;
 
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Lexer\LexerInterface;
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Parser\ParserInterface;
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
+use Phel\Formatter\Exceptions\ZipperException;
 use Phel\Formatter\Rules\RuleInterface;
 
 final class Formatter implements FormatterInterface
@@ -34,6 +36,7 @@ final class Formatter implements FormatterInterface
 
     /**
      * @throws AbstractParserException
+     * @throws ZipperException
      */
     public function formatFile(string $filename): bool
     {
@@ -46,6 +49,8 @@ final class Formatter implements FormatterInterface
 
     /**
      * @throws AbstractParserException
+     * @throws LexerValueException
+     * @throws ZipperException
      */
     private function formatString(string $string, string $source = self::DEFAULT_SOURCE): string
     {
@@ -56,6 +61,9 @@ final class Formatter implements FormatterInterface
         return $formattedNode->getCode();
     }
 
+    /**
+     * @throws ZipperException
+     */
     private function formatNode(NodeInterface $node): NodeInterface
     {
         $formattedNode = $node;

--- a/src/php/Formatter/FormatterInterface.php
+++ b/src/php/Formatter/FormatterInterface.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Phel\Compiler\Parser\Exceptions\AbstractParserException;
+use Phel\Formatter\Exceptions\ZipperException;
 
 interface FormatterInterface
 {
     /**
      * @throws AbstractParserException
+     * @throws ZipperException
      *
      * @return bool True if the file was formatted. False if the file wasn't altered because it was already formatted.
      */

--- a/src/php/Formatter/ParseTreeZipper.php
+++ b/src/php/Formatter/ParseTreeZipper.php
@@ -35,7 +35,7 @@ final class ParseTreeZipper extends AbstractZipper
     public function makeNode($node, $children)
     {
         if (!$node instanceof InnerNodeInterface) {
-            throw ZipperException::canReplaceChildrenOnLeafNode();
+            throw ZipperException::cannotReplaceChildrenOnLeafNode();
         }
 
         /** @var InnerNodeInterface $node */

--- a/src/php/Formatter/Rules/RemoveSurroundingWhitespaceRule.php
+++ b/src/php/Formatter/Rules/RemoveSurroundingWhitespaceRule.php
@@ -5,18 +5,21 @@ declare(strict_types=1);
 namespace Phel\Formatter\Rules;
 
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
-use Phel\Formatter\Exceptions\CanNotRemoveAtTheTopException;
+use Phel\Formatter\Exceptions\ZipperException;
 use Phel\Formatter\ParseTreeZipper;
 
 final class RemoveSurroundingWhitespaceRule implements RuleInterface
 {
+    /**
+     * @throws ZipperException
+     */
     public function transform(NodeInterface $node): NodeInterface
     {
         return $this->removeSurroundingWhitespace(ParseTreeZipper::createRoot($node));
     }
 
     /**
-     * @throws CanNotRemoveAtTheTopException
+     * @throws ZipperException
      */
     private function removeSurroundingWhitespace(ParseTreeZipper $loc): NodeInterface
     {

--- a/src/php/Formatter/Rules/RuleInterface.php
+++ b/src/php/Formatter/Rules/RuleInterface.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Phel\Formatter\Rules;
 
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
+use Phel\Formatter\Exceptions\ZipperException;
 
 interface RuleInterface
 {
+    /**
+     * @throws ZipperException
+     */
     public function transform(NodeInterface $node): NodeInterface;
 }

--- a/src/php/PhelFacade.php
+++ b/src/php/PhelFacade.php
@@ -9,8 +9,14 @@ use Phel\Command\CommandFacadeInterface;
 use Phel\Command\Export\ExportCommand;
 use Phel\Command\Format\FormatCommand;
 use Phel\Command\Repl\ReplCommand;
+use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
 use Phel\Command\Run\RunCommand;
+use Phel\Command\Shared\Exceptions\ExtractorException;
+use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
 use Phel\Command\Test\TestCommand;
+use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Emitter\Exceptions\FileException;
+use Phel\Compiler\Exceptions\CompilerException;
 
 final class PhelFacade
 {
@@ -49,6 +55,10 @@ HELP;
     }
 
     /**
+     * @throws CannotLoadNamespaceException
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
      * @throws InvalidArgumentException
      */
     public function runCommand(string $commandName, array $arguments = []): void
@@ -79,6 +89,12 @@ HELP;
         $this->commandFacade->executeReplCommand();
     }
 
+    /**
+     * @throws CannotLoadNamespaceException
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     private function executeRunCommand(array $arguments): void
     {
         if (empty($arguments)) {
@@ -88,6 +104,12 @@ HELP;
         $this->commandFacade->executeRunCommand($arguments[0]);
     }
 
+    /**
+     * @throws CannotFindAnyTestsException
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
     private function executeTestCommand(array $arguments): void
     {
         $this->commandFacade->executeTestCommand($arguments);
@@ -102,6 +124,12 @@ HELP;
         $this->commandFacade->executeFormatCommand($arguments);
     }
 
+    /**
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws ExtractorException
+     * @throws FileException
+     */
     private function executeExportCommand(): void
     {
         $this->commandFacade->executeExportCommand();

--- a/tests/php/Unit/Formatter/ZipperTest.php
+++ b/tests/php/Unit/Formatter/ZipperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Formatter;
 
 use Exception;
-use Phel\Formatter\Exceptions\CanNotRemoveAtTheTopException;
 use Phel\Formatter\Exceptions\ZipperException;
 use PHPUnit\Framework\TestCase;
 
@@ -293,7 +292,7 @@ final class ZipperTest extends TestCase
 
     public function testRemoveOnRoot(): void
     {
-        $this->expectException(CanNotRemoveAtTheTopException::class);
+        $this->expectExceptionObject(ZipperException::cannotRemoveOnRootNode());
 
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);


### PR DESCRIPTION
## 📚 Description

Minor clean up to make the exception more explicit.

## 🔖 Changes

- Adding `@throws` PHPDoc blocks when necessary.
- Adding some name constructor exceptions to make them more domain specific.
