### PR TITLE
Handle exceptions inside commands

### DIFF
--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -4,20 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Command;
 
-use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
-use Phel\Command\Shared\Exceptions\ExtractorException;
-use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
-use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
-use Phel\Compiler\Emitter\Exceptions\FileException;
-use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Runtime\RuntimeInterface;
 use RuntimeException;
 
 final class CommandFacade implements CommandFacadeInterface
 {
-    private const SUCCESS_CODE = 0;
-    private const FAILED_CODE = 1;
-
     private string $projectRootDir;
     private CommandFactoryInterface $commandFactory;
 
@@ -36,12 +27,6 @@ final class CommandFacade implements CommandFacadeInterface
             ->run();
     }
 
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     * @throws CannotLoadNamespaceException
-     */
     public function executeRunCommand(string $fileOrPath): void
     {
         $this->commandFactory
@@ -51,21 +36,12 @@ final class CommandFacade implements CommandFacadeInterface
 
     /**
      * @param list<string> $paths
-     *
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     * @throws CannotFindAnyTestsException
      */
     public function executeTestCommand(array $paths): void
     {
-        $result = $this->commandFactory
+        $this->commandFactory
             ->createTestCommand($this->loadVendorPhelRuntime())
             ->run($paths);
-
-        ($result)
-            ? exit(self::SUCCESS_CODE)
-            : exit(self::FAILED_CODE);
     }
 
     /**
@@ -78,12 +54,6 @@ final class CommandFacade implements CommandFacadeInterface
             ->run($paths);
     }
 
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws ExtractorException
-     * @throws FileException
-     */
     public function executeExportCommand(): void
     {
         $this->commandFactory

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -9,6 +9,9 @@ use RuntimeException;
 
 final class CommandFacade implements CommandFacadeInterface
 {
+    private const SUCCESS_CODE = 0;
+    private const FAILED_CODE = 1;
+
     private string $projectRootDir;
     private CommandFactoryInterface $commandFactory;
 
@@ -39,9 +42,13 @@ final class CommandFacade implements CommandFacadeInterface
      */
     public function executeTestCommand(array $paths): void
     {
-        $this->commandFactory
+        $result = $this->commandFactory
             ->createTestCommand($this->loadVendorPhelRuntime())
             ->run($paths);
+
+        ($result)
+            ? exit(self::SUCCESS_CODE)
+            : exit(self::FAILED_CODE);
     }
 
     /**

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -4,32 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Command;
 
-use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
-use Phel\Command\Shared\Exceptions\ExtractorException;
-use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
-use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
-use Phel\Compiler\Emitter\Exceptions\FileException;
-use Phel\Compiler\Exceptions\CompilerException;
-
 interface CommandFacadeInterface
 {
     public function executeReplCommand(): void;
 
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     * @throws CannotLoadNamespaceException
-     */
     public function executeRunCommand(string $fileOrPath): void;
 
     /**
      * @param list<string> $paths
-     *
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     * @throws CannotFindAnyTestsException
      */
     public function executeTestCommand(array $paths): void;
 
@@ -38,11 +20,5 @@ interface CommandFacadeInterface
      */
     public function executeFormatCommand(array $paths): void;
 
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws ExtractorException
-     * @throws FileException
-     */
     public function executeExportCommand(): void;
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -78,6 +78,7 @@ final class CommandFactory implements CommandFactoryInterface
         return new TestCommand(
             $this->projectRootDir,
             $runtime,
+            $this->createCommandIo(),
             $this->createNamespaceExtractor($runtime->getEnv()),
             $this->compilerFactory->createEvalCompiler($runtime->getEnv()),
             $this->commandConfig->getDefaultTestDirectories()

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -69,6 +69,7 @@ final class CommandFactory implements CommandFactoryInterface
     {
         return new RunCommand(
             $runtime,
+            $this->createCommandIo(),
             $this->createNamespaceExtractor($runtime->getEnv())
         );
     }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -13,6 +13,7 @@ use Phel\Command\Format\FormatCommand;
 use Phel\Command\Format\PathFilterInterface;
 use Phel\Command\Format\PhelPathFilter;
 use Phel\Command\Repl\ColorStyle;
+use Phel\Command\Repl\ColorStyleInterface;
 use Phel\Command\Repl\ReplCommand;
 use Phel\Command\Repl\ReplCommandSystemIo;
 use Phel\Command\Run\RunCommand;
@@ -27,6 +28,8 @@ use Phel\Formatter\FormatterFactoryInterface;
 use Phel\Interop\Generator\WrapperGeneratorInterface;
 use Phel\Interop\InteropFactoryInterface;
 use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
+use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
 use Phel\Runtime\Exceptions\TextExceptionPrinter;
 use Phel\Runtime\RuntimeInterface;
 
@@ -59,9 +62,9 @@ final class CommandFactory implements CommandFactoryInterface
         return new ReplCommand(
             new ReplCommandSystemIo($this->projectRootDir . '.phel-repl-history'),
             $this->compilerFactory->createEvalCompiler($runtime->getEnv()),
-            TextExceptionPrinter::create(),
-            ColorStyle::withStyles(),
-            Printer::nonReadableWithColor()
+            $this->createExceptionPrinter(),
+            $this->createColorStyle(),
+            $this->createPrinter()
         );
     }
 
@@ -91,8 +94,7 @@ final class CommandFactory implements CommandFactoryInterface
         return new FormatCommand(
             $this->formatterFactory->createFormatter(),
             $this->createCommandIo(),
-            $this->createPathFilter(),
-            TextExceptionPrinter::create()
+            $this->createPathFilter()
         );
     }
 
@@ -109,7 +111,14 @@ final class CommandFactory implements CommandFactoryInterface
 
     private function createCommandIo(): CommandIoInterface
     {
-        return new CommandSystemIo();
+        return new CommandSystemIo(
+            $this->createExceptionPrinter()
+        );
+    }
+
+    private function createExceptionPrinter(): ExceptionPrinterInterface
+    {
+        return TextExceptionPrinter::create();
     }
 
     private function createPathFilter(): PathFilterInterface
@@ -145,5 +154,15 @@ final class CommandFactory implements CommandFactoryInterface
     private function createWrapperGenerator(): WrapperGeneratorInterface
     {
         return $this->interopFactory->createWrapperGenerator();
+    }
+
+    private function createColorStyle(): ColorStyleInterface
+    {
+        return ColorStyle::withStyles();
+    }
+
+    private function createPrinter(): PrinterInterface
+    {
+        return Printer::nonReadableWithColor();
     }
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -15,6 +15,7 @@ use Phel\Command\Format\PhelPathFilter;
 use Phel\Command\Repl\ColorStyle;
 use Phel\Command\Repl\ColorStyleInterface;
 use Phel\Command\Repl\ReplCommand;
+use Phel\Command\Repl\ReplCommandIoInterface;
 use Phel\Command\Repl\ReplCommandSystemIo;
 use Phel\Command\Run\RunCommand;
 use Phel\Command\Shared\CommandIoInterface;
@@ -60,9 +61,8 @@ final class CommandFactory implements CommandFactoryInterface
         $runtime->loadFileIntoNamespace('user', __DIR__ . '/Repl/startup.phel');
 
         return new ReplCommand(
-            new ReplCommandSystemIo($this->projectRootDir . '.phel-repl-history'),
+            $this->createReplCommandIo(),
             $this->compilerFactory->createEvalCompiler($runtime->getEnv()),
-            $this->createExceptionPrinter(),
             $this->createColorStyle(),
             $this->createPrinter()
         );
@@ -106,6 +106,14 @@ final class CommandFactory implements CommandFactoryInterface
             $this->createFunctionsToExportFinder($runtime),
             $this->createDirectoryRemover(),
             $this->commandConfig->getExportTargetDirectory()
+        );
+    }
+
+    private function createReplCommandIo(): ReplCommandIoInterface
+    {
+        return new ReplCommandSystemIo(
+            $this->projectRootDir . '.phel-repl-history',
+            $this->createExceptionPrinter()
         );
     }
 

--- a/src/php/Command/Export/ExportCommand.php
+++ b/src/php/Command/Export/ExportCommand.php
@@ -41,8 +41,10 @@ final class ExportCommand
             $wrappers = $this->generateWrappers();
             $this->directoryRemover->removeDir($this->destinationDir);
             $this->writeGeneratedWrappers($wrappers);
+        } catch (CompilerException $e) {
+            $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
         } catch (Throwable $e) {
-            $this->io->writeln($e->getMessage());
+            $this->io->writeStackTrace($e);
         }
     }
 

--- a/src/php/Command/Repl/ReplCommand.php
+++ b/src/php/Command/Repl/ReplCommand.php
@@ -9,7 +9,6 @@ use Phel\Compiler\EvalCompilerInterface;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Compiler\Parser\Exceptions\UnfinishedParserException;
 use Phel\Printer\PrinterInterface;
-use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
 use Throwable;
 
 final class ReplCommand
@@ -24,7 +23,6 @@ final class ReplCommand
 
     private ReplCommandIoInterface $io;
     private EvalCompilerInterface $compiler;
-    private ExceptionPrinterInterface $exceptionPrinter;
     private ColorStyleInterface $style;
     private PrinterInterface $printer;
 
@@ -35,13 +33,11 @@ final class ReplCommand
     public function __construct(
         ReplCommandIoInterface $io,
         EvalCompilerInterface $compiler,
-        ExceptionPrinterInterface $exceptionPrinter,
         ColorStyleInterface $style,
         PrinterInterface $printer
     ) {
         $this->io = $io;
         $this->compiler = $compiler;
-        $this->exceptionPrinter = $exceptionPrinter;
         $this->style = $style;
         $this->printer = $printer;
     }
@@ -131,16 +127,11 @@ final class ReplCommand
         } catch (UnfinishedParserException $e) {
             // The input is valid but more input is missing to finish the parsing.
         } catch (CompilerException $e) {
-            $this->io->write(
-                $this->exceptionPrinter->getExceptionString(
-                    $e->getNestedException(),
-                    $e->getCodeSnippet()
-                )
-            );
+            $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
             $this->addHistory($fullInput);
             $this->inputBuffer = [];
         } catch (Throwable $e) {
-            $this->io->writeln($this->exceptionPrinter->getStackTraceString($e));
+            $this->io->writeStackTrace($e);
             $this->addHistory($fullInput);
             $this->inputBuffer = [];
         }

--- a/src/php/Command/Repl/ReplCommandIoInterface.php
+++ b/src/php/Command/Repl/ReplCommandIoInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Command\Repl;
 
+use Phel\Compiler\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use Throwable;
+
 interface ReplCommandIoInterface
 {
     public function readHistory(): void;
@@ -11,6 +15,10 @@ interface ReplCommandIoInterface
     public function addHistory(string $line): void;
 
     public function readline(?string $prompt = null): ?string;
+
+    public function writeStackTrace(Throwable $e): void;
+
+    public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void;
 
     public function write(string $string = ''): void;
 

--- a/src/php/Command/Repl/ReplCommandSystemIo.php
+++ b/src/php/Command/Repl/ReplCommandSystemIo.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace Phel\Command\Repl;
 
+use Phel\Compiler\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
+use Throwable;
+
 final class ReplCommandSystemIo implements ReplCommandIoInterface
 {
     private string $historyFile;
+    private ExceptionPrinterInterface $exceptionPrinter;
 
-    public function __construct(string $historyFile)
-    {
+    public function __construct(
+        string $historyFile,
+        ExceptionPrinterInterface $exceptionPrinter
+    ) {
         $this->historyFile = $historyFile;
+        $this->exceptionPrinter = $exceptionPrinter;
     }
 
     public function readHistory(): void
@@ -35,6 +44,16 @@ final class ReplCommandSystemIo implements ReplCommandIoInterface
         }
 
         return $line;
+    }
+
+    public function writeStackTrace(Throwable $e): void
+    {
+        $this->writeln($this->exceptionPrinter->getStackTraceString($e));
+    }
+
+    public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void
+    {
+        $this->writeln($this->exceptionPrinter->getExceptionString($e, $codeSnippet));
     }
 
     public function write(string $string = ''): void

--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -36,7 +36,7 @@ final class RunCommand
         try {
             $this->loadNamespace($fileOrPath);
         } catch (Throwable $e) {
-            $this->io->writeln($e->getMessage());
+            $this->io->writeStackTrace($e);
         }
     }
 

--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -5,25 +5,39 @@ declare(strict_types=1);
 namespace Phel\Command\Run;
 
 use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
+use Phel\Command\Shared\CommandIoInterface;
 use Phel\Command\Shared\NamespaceExtractorInterface;
 use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Emitter\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Runtime\RuntimeInterface;
+use Throwable;
 
 final class RunCommand
 {
     public const COMMAND_NAME = 'run';
 
     private RuntimeInterface $runtime;
+    private CommandIoInterface $io;
     private NamespaceExtractorInterface $namespaceExtractor;
 
     public function __construct(
         RuntimeInterface $runtime,
+        CommandIoInterface $io,
         NamespaceExtractorInterface $namespaceExtractor
     ) {
         $this->runtime = $runtime;
+        $this->io = $io;
         $this->namespaceExtractor = $namespaceExtractor;
+    }
+
+    public function run(string $fileOrPath): void
+    {
+        try {
+            $this->loadNamespace($fileOrPath);
+        } catch (Throwable $e) {
+            $this->io->writeln($e->getMessage());
+        }
     }
 
     /**
@@ -32,7 +46,7 @@ final class RunCommand
      * @throws FileException
      * @throws CannotLoadNamespaceException
      */
-    public function run(string $fileOrPath): void
+    private function loadNamespace(string $fileOrPath): void
     {
         $ns = file_exists($fileOrPath)
             ? $this->namespaceExtractor->getNamespaceFromFile($fileOrPath)

--- a/src/php/Command/Shared/CommandIoInterface.php
+++ b/src/php/Command/Shared/CommandIoInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Command\Shared;
 
+use Phel\Compiler\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use Throwable;
+
 interface CommandIoInterface
 {
     public function createDirectory(string $directory): void;
@@ -11,6 +15,10 @@ interface CommandIoInterface
     public function fileGetContents(string $filename): string;
 
     public function filePutContents(string $filename, string $content): void;
+
+    public function writeStackTrace(Throwable $e): void;
+
+    public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void;
 
     public function writeln(string $string): void;
 }

--- a/src/php/Command/Shared/CommandSystemIo.php
+++ b/src/php/Command/Shared/CommandSystemIo.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Command\Shared;
 
+use Phel\Compiler\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
 use RuntimeException;
+use Throwable;
 
 final class CommandSystemIo implements CommandIoInterface
 {
+    private ExceptionPrinterInterface $exceptionPrinter;
+
+    public function __construct(ExceptionPrinterInterface $exceptionPrinter)
+    {
+        $this->exceptionPrinter = $exceptionPrinter;
+    }
+
     public function createDirectory(string $directory): void
     {
         if (!mkdir($directory, $permissions = 0777, $recursive = true) && !is_dir($directory)) {
@@ -17,12 +28,30 @@ final class CommandSystemIo implements CommandIoInterface
 
     public function fileGetContents(string $filename): string
     {
+        if (is_dir($filename)) {
+            throw new RuntimeException(sprintf('"%s" is a directory but needs to be a file path', $filename));
+        }
+
+        if (!is_file($filename)) {
+            throw new RuntimeException(sprintf('File path "%s" not found', $filename));
+        }
+
         return file_get_contents($filename);
     }
 
     public function filePutContents(string $filename, string $content): void
     {
         file_put_contents($filename, $content);
+    }
+
+    public function writeStackTrace(Throwable $e): void
+    {
+        $this->writeln($this->exceptionPrinter->getStackTraceString($e));
+    }
+
+    public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void
+    {
+        $this->writeln($this->exceptionPrinter->getExceptionString($e, $codeSnippet));
     }
 
     public function writeln(string $string = ''): void

--- a/src/php/Command/Test/Exceptions/CannotFindAnyTestsException.php
+++ b/src/php/Command/Test/Exceptions/CannotFindAnyTestsException.php
@@ -8,8 +8,8 @@ use RuntimeException;
 
 final class CannotFindAnyTestsException extends RuntimeException
 {
-    public function __construct()
+    public static function inPaths(array $paths): self
     {
-        parent::__construct('Cannot find any tests');
+        return new self('Cannot find any tests in : ' . implode(',', $paths));
     }
 }

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -49,8 +49,10 @@ final class TestCommand
     {
         try {
             $this->evalNamespaces($paths);
+        } catch (CompilerException $e) {
+            $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
         } catch (Throwable $e) {
-            $this->io->writeln($e->getMessage());
+            $this->io->writeStackTrace($e);
         }
     }
 

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -44,16 +44,20 @@ final class TestCommand
 
     /**
      * @param list<string> $paths
+     *
+     * @return bool true if all tests were successful. False otherwise.
      */
-    public function run(array $paths): void
+    public function run(array $paths): bool
     {
         try {
-            $this->evalNamespaces($paths);
+            return $this->evalNamespaces($paths);
         } catch (CompilerException $e) {
             $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
         } catch (Throwable $e) {
             $this->io->writeStackTrace($e);
         }
+
+        return false;
     }
 
     /**
@@ -63,8 +67,10 @@ final class TestCommand
      * @throws CompiledCodeIsMalformedException
      * @throws FileException
      * @throws CannotFindAnyTestsException
+     *
+     * @return bool true if all tests were successful. False otherwise.
      */
-    private function evalNamespaces(array $paths): void
+    private function evalNamespaces(array $paths): bool
     {
         $namespaces = $this->getNamespacesFromPaths($paths);
 
@@ -75,7 +81,7 @@ final class TestCommand
         $this->runtime->loadNs('phel\test');
         $nsString = $this->namespacesAsString($namespaces);
 
-        $this->evalCompiler->eval('(do (phel\test/run-tests ' . $nsString . ') (successful?))');
+        return $this->evalCompiler->eval('(do (phel\test/run-tests ' . $nsString . ') (successful?))');
     }
 
     private function getNamespacesFromPaths(array $paths): array

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -48,7 +48,7 @@ final class TestCommand
         $namespaces = $this->getNamespacesFromPaths($paths);
 
         if (empty($namespaces)) {
-            throw new CannotFindAnyTestsException();
+            throw CannotFindAnyTestsException::inPaths($paths);
         }
 
         $this->runtime->loadNs('phel\test');

--- a/src/php/Compiler/Exceptions/CompilerException.php
+++ b/src/php/Compiler/Exceptions/CompilerException.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Exceptions;
 
-use Exception;
 use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use RuntimeException;
 
-final class CompilerException extends Exception
+final class CompilerException extends RuntimeException
 {
     private CodeSnippet $codeSnippet;
 

--- a/src/php/PhelFacade.php
+++ b/src/php/PhelFacade.php
@@ -9,14 +9,8 @@ use Phel\Command\CommandFacadeInterface;
 use Phel\Command\Export\ExportCommand;
 use Phel\Command\Format\FormatCommand;
 use Phel\Command\Repl\ReplCommand;
-use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
 use Phel\Command\Run\RunCommand;
-use Phel\Command\Shared\Exceptions\ExtractorException;
-use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
 use Phel\Command\Test\TestCommand;
-use Phel\Compiler\Emitter\Exceptions\CompiledCodeIsMalformedException;
-use Phel\Compiler\Emitter\Exceptions\FileException;
-use Phel\Compiler\Exceptions\CompilerException;
 
 final class PhelFacade
 {
@@ -55,10 +49,6 @@ HELP;
     }
 
     /**
-     * @throws CannotLoadNamespaceException
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
      * @throws InvalidArgumentException
      */
     public function runCommand(string $commandName, array $arguments = []): void
@@ -89,12 +79,6 @@ HELP;
         $this->commandFacade->executeReplCommand();
     }
 
-    /**
-     * @throws CannotLoadNamespaceException
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     */
     private function executeRunCommand(array $arguments): void
     {
         if (empty($arguments)) {
@@ -104,12 +88,6 @@ HELP;
         $this->commandFacade->executeRunCommand($arguments[0]);
     }
 
-    /**
-     * @throws CannotFindAnyTestsException
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     */
     private function executeTestCommand(array $arguments): void
     {
         $this->commandFacade->executeTestCommand($arguments);
@@ -124,12 +102,6 @@ HELP;
         $this->commandFacade->executeFormatCommand($arguments);
     }
 
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws ExtractorException
-     * @throws FileException
-     */
     private function executeExportCommand(): void
     {
         $this->commandFacade->executeExportCommand();

--- a/tests/php/Integration/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Command/Repl/ReplCommandTest.php
@@ -28,11 +28,12 @@ final class ReplCommandTest extends TestCase
      */
     public function testIntegration(string $expectedOutput, InputLine ...$inputs): void
     {
-        $io = new ReplTestIo();
-        $repl = $this->createReplCommand($io);
-
+        $io = $this->createReplTestIo();
         $io->setInputs(...$inputs);
+
+        $repl = $this->createReplCommand($io);
         $repl->run();
+
         $replOutput = $io->getOutputString();
 
         self::assertEquals(trim($expectedOutput), trim($replOutput));
@@ -71,17 +72,9 @@ final class ReplCommandTest extends TestCase
         $rt = RuntimeFactory::initializeNew($globalEnv);
         $rt->addPath('phel\\', [__DIR__ . '/../../../../src/phel/']);
 
-        $exceptionPrinter = new TextExceptionPrinter(
-            new ExceptionArgsPrinter(Printer::readable()),
-            ColorStyle::noStyles(),
-            new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor())
-        );
-
         return new ReplCommand(
             $io,
             $compilerFactory->createEvalCompiler($globalEnv),
-            $exceptionPrinter,
             ColorStyle::noStyles(),
             Printer::nonReadable()
         );
@@ -104,5 +97,17 @@ final class ReplCommandTest extends TestCase
         }
 
         return $inputs;
+    }
+
+    private function createReplTestIo(): ReplTestIo
+    {
+        $exceptionPrinter = new TextExceptionPrinter(
+            new ExceptionArgsPrinter(Printer::readable()),
+            ColorStyle::noStyles(),
+            new Munge(),
+            new FilePositionExtractor(new SourceMapExtractor())
+        );
+
+        return new ReplTestIo($exceptionPrinter);
     }
 }

--- a/tests/php/Integration/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Command/Repl/ReplTestIo.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Command\Repl;
 
 use Phel\Command\Repl\ReplCommandIoInterface;
+use Phel\Compiler\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Parser\ReadModel\CodeSnippet;
+use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
+use Throwable;
 
 final class ReplTestIo implements ReplCommandIoInterface
 {
+    private ExceptionPrinterInterface $exceptionPrinter;
+
     /** @var array string[] */
     private array $outputs = [];
 
@@ -15,6 +21,12 @@ final class ReplTestIo implements ReplCommandIoInterface
     private array $inputs = [];
 
     private int $currentIndex = 0;
+
+
+    public function __construct(ExceptionPrinterInterface $exceptionPrinter)
+    {
+        $this->exceptionPrinter = $exceptionPrinter;
+    }
 
     public function readHistory(): void
     {
@@ -39,6 +51,16 @@ final class ReplTestIo implements ReplCommandIoInterface
         }
 
         return null;
+    }
+
+    public function writeStackTrace(Throwable $e): void
+    {
+        $this->write($this->exceptionPrinter->getStackTraceString($e));
+    }
+
+    public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void
+    {
+        $this->write($this->exceptionPrinter->getExceptionString($e, $codeSnippet));
     }
 
     public function write(string $string = ''): void

--- a/tests/php/Integration/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Command/Run/RunCommandTest.php
@@ -14,13 +14,12 @@ use Phel\Interop\InteropFactoryInterface;
 use Phel\Runtime\RuntimeFactory;
 use Phel\Runtime\RuntimeInterface;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 final class RunCommandTest extends TestCase
 {
     public function testRunByNamespace(): void
     {
-        $this->expectOutputString("hello world\n");
+        $this->expectOutputRegex('~hello world~');
 
         $runtime = $this->createRuntime();
         $runtime->addPath('test\\', [__DIR__ . '/Fixtures']);
@@ -32,7 +31,7 @@ final class RunCommandTest extends TestCase
 
     public function testRunByFilename(): void
     {
-        $this->expectOutputString("hello world\n");
+        $this->expectOutputRegex('~hello world~');
 
         $runtime = $this->createRuntime();
         $runtime->addPath('test\\', [__DIR__ . '/Fixtures']);
@@ -45,8 +44,7 @@ final class RunCommandTest extends TestCase
     public function testCannotParseFile(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-not-parsable.phel';
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot parse file: ' . $filename);
+        $this->expectOutputRegex(sprintf('~Cannot parse file: %s~', $filename));
 
         $this->createCommandFactory()
             ->createRunCommand($this->createRuntime())
@@ -56,8 +54,7 @@ final class RunCommandTest extends TestCase
     public function testCannotReadFile(): void
     {
         $filename = __DIR__ . '/Fixtures/this-file-does-not-exist.phel';
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot load namespace: ' . $filename);
+        $this->expectOutputRegex(sprintf('~Cannot load namespace: %s~', $filename));
 
         $this->createCommandFactory()
             ->createRunCommand($this->createRuntime())
@@ -67,8 +64,7 @@ final class RunCommandTest extends TestCase
     public function testFileWithoutNs(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-without-ns.phel';
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot extract namespace from file: ' . $filename);
+        $this->expectOutputRegex(sprintf('~Cannot extract namespace from file: %s~', $filename));
 
         $this->createCommandFactory()
             ->createRunCommand($this->createRuntime())

--- a/tests/php/Integration/Command/Test/TestCommandTest.php
+++ b/tests/php/Integration/Command/Test/TestCommandTest.php
@@ -31,7 +31,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputString("..\n\n\n\nPassed: 2\nFailed: 0\nError: 0\nTotal: 2\n");
-        self::assertTrue($testCommand->run([]));
+        $testCommand->run([]);
     }
 
     public function testOneFileInProject(): void
@@ -48,7 +48,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputString(".\n\n\n\nPassed: 1\nFailed: 0\nError: 0\nTotal: 1\n");
-        self::assertTrue($testCommand->run([$currentDir . 'tests/test1.phel']));
+        $testCommand->run([$currentDir . 'tests/test1.phel']);
     }
 
     public function testAllInFailedProject(): void
@@ -65,7 +65,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputRegex('/.*Failed\\: 1.*/');
-        self::assertFalse($testCommand->run([]));
+        $testCommand->run([]);
     }
 
     private function createRuntime(): RuntimeInterface


### PR DESCRIPTION
## 📚 Description

Don't throw up the logic exceptions from the commands, but handle them inside the commands themselves.

## 🔖 Changes

- Remove the `@throws ...` from the commands. They don't intentionally throw an exception up.
- Catch and handle the exceptions inside the `command->run()` logic.
