### PR TITLE
Add missig catch in run command

### DIFF
--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -35,6 +35,8 @@ final class RunCommand
     {
         try {
             $this->loadNamespace($fileOrPath);
+        } catch (CompilerException $e) {
+            $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
         } catch (Throwable $e) {
             $this->io->writeStackTrace($e);
         }

--- a/tests/php/Integration/Command/Test/TestCommandTest.php
+++ b/tests/php/Integration/Command/Test/TestCommandTest.php
@@ -31,7 +31,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputString("..\n\n\n\nPassed: 2\nFailed: 0\nError: 0\nTotal: 2\n");
-        $testCommand->run([]);
+        self::assertTrue($testCommand->run([]));
     }
 
     public function testOneFileInProject(): void
@@ -48,7 +48,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputString(".\n\n\n\nPassed: 1\nFailed: 0\nError: 0\nTotal: 1\n");
-        $testCommand->run([$currentDir . 'tests/test1.phel']);
+        self::assertTrue($testCommand->run([$currentDir . 'tests/test1.phel']));
     }
 
     public function testAllInFailedProject(): void
@@ -65,7 +65,7 @@ final class TestCommandTest extends TestCase
             ->createTestCommand($runtime);
 
         $this->expectOutputRegex('/.*Failed\\: 1.*/');
-        $testCommand->run([]);
+        self::assertFalse($testCommand->run([]));
     }
 
     private function createRuntime(): RuntimeInterface


### PR DESCRIPTION
## 📚 Description

Minor additions that I forgot while doing "Handle exceptions inside commands" https://github.com/phel-lang/phel-lang/pull/236

## 🔖 Changes

- Added `CompilerException` catch in `RunCommand`
- Added missing assertions to `TestCommandTest`
