### PR TITLE
Adding git pre-commit hook

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,10 @@ composer test-all      # csrun, psalm, compiler & core tests after each other
 > composer test-core
 ```
 
+### Git Hooks
+
+Enable the git hooks with `./tools/git-hooks/init.sh`
+
 ### Build the documentation
 
 The documentation is build with [Zola](https://www.getzola.org/).

--- a/tools/git-hooks/init.sh
+++ b/tools/git-hooks/init.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+function setup_git_hooks()
+{
+  echo "Initialising git hooks..."
+  ln -sf "$PWD/tools/scripts/git-hooks/pre-commit.sh" "$PWD/.git/hooks/pre-commit"
+  echo "Done"
+}
+
+setup_git_hooks

--- a/tools/git-hooks/init.sh
+++ b/tools/git-hooks/init.sh
@@ -5,7 +5,8 @@ set -e
 function setup_git_hooks()
 {
   echo "Initialising git hooks..."
-  ln -sf "$PWD/tools/scripts/git-hooks/pre-commit.sh" "$PWD/.git/hooks/pre-commit"
+  ln -sf "$PWD/tools/git-hooks/pre-commit.sh" "$PWD/.git/hooks/pre-commit"
+  chmod +x "$PWD/.git/hooks/pre-commit"
   echo "Done"
 }
 

--- a/tools/git-hooks/pre-commit.sh
+++ b/tools/git-hooks/pre-commit.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-echo 'composer test-all'
 composer test-all
 

--- a/tools/git-hooks/pre-commit.sh
+++ b/tools/git-hooks/pre-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+echo 'composer test-all'
+composer test-all
+


### PR DESCRIPTION
## 🔖 Changes

- Added `composer test-all` to the git "pre-commit" hook. 

This is optional, but I find it really useful as I run manually this command every time before I commit something. 
The whole check takes around 10 sec and ensures that every commit is fine with the CI.

I wrote in the `README` a command to easily enable this feature: `./tools/git-hooks/init.sh`