### PR TITLE
Fix some links on Documentation

### DIFF
--- a/doc/content/documentation/configuration.md
+++ b/doc/content/documentation/configuration.md
@@ -62,7 +62,7 @@ This configuration entry defines a list of folders where the test files of a pro
 
 ### `export`
 
-These configuration options are used for the Phel export command that is described in the [PHP Interop](php-interop/#calling-phel-functions-from-php) chapter. Currently, the export command requires three options:
+These configuration options are used for the Phel export command that is described in the [PHP Interop](/documentation/php-interop/#calling-phel-functions-from-php) chapter. Currently, the export command requires three options:
 
 - `directories`: Defines a list of directories in which the export command should search for export functions.
 - `namespace-prefix`: Defines a namespace prefix for all generated PHP classes.

--- a/doc/content/documentation/php-interop.md
+++ b/doc/content/documentation/php-interop.md
@@ -176,7 +176,7 @@ Before using the `export` command the required configuration options need to be 
 }
 ```
 
-A detailed description of the options can be found in the [Configuration](/configuration/#export) chapter.
+A detailed description of the options can be found in the [Configuration](/documentation/configuration/#export) chapter.
 
 To mark a function as exported the following meta data needs to be added to the function:
 


### PR DESCRIPTION
## 📚 Description

Fix some broken links on documentation:
1. [PHP-Interop (Using the export command)](https://phel-lang.org/documentation/php-interop/#using-the-export-command) ⇨ _Configuration_
2. [Configuration (Export)](https://phel-lang.org/documentation/configuration/#export) ⇨ _PHP Interop_

![image](https://user-images.githubusercontent.com/6381924/109434106-eb904500-7a13-11eb-8abf-332b8f06e24e.png)
