### PR TITLE
Rename fmt to format

### DIFF
--- a/src/php/Command/Format/FormatCommand.php
+++ b/src/php/Command/Format/FormatCommand.php
@@ -13,7 +13,7 @@ use Throwable;
 
 final class FormatCommand
 {
-    public const COMMAND_NAME = 'fmt';
+    public const COMMAND_NAME = 'format';
 
     private FormatterInterface $formatter;
     private CommandIoInterface $io;

--- a/src/php/PhelFacade.php
+++ b/src/php/PhelFacade.php
@@ -28,7 +28,7 @@ Commands:
         Tests the given files. If no filenames are provided all tests in the
         "tests" directory are executed.
 
-    fmt <filename-or-directory> ...
+    format <filename-or-directory> ...
         Formats the given files.
 
     export


### PR DESCRIPTION
## 📚 Description

Rename `fmt` to `format`:
```bash
➜  phel-lang git:(feature/rename-fmt-command) ./phel
Usage: phel [command]

Commands:
    repl
        Start a Repl.

    run <filename-or-namespace>
        Runs a script.

    test <filename> <filename> ...
        Tests the given files. If no filenames are provided all tests in the
        "tests" directory are executed.

    format <filename-or-directory> ...
        Formats the given files.

    export
        Export all definitions with the meta data `@{:export true}` as PHP classes.
        By default, it will search in the `src/` directory. All configuration
        options need to be set in composer.json.

    help
        Show this help message.

```