### PR TITLE
Allow print transients data structures

### DIFF
--- a/src/php/Lang/Collections/HashSet/TransientHashSet.php
+++ b/src/php/Lang/Collections/HashSet/TransientHashSet.php
@@ -60,4 +60,9 @@ class TransientHashSet implements TransientHashSetInterface
     {
         return new PersistentHashSet($this->hasher, null, $this->transientMap->persistent());
     }
+
+    public function toPhpArray(): array
+    {
+        return $this->persistent()->toPhpArray();
+    }
 }

--- a/src/php/Lang/Collections/HashSet/TransientHashSetInterface.php
+++ b/src/php/Lang/Collections/HashSet/TransientHashSetInterface.php
@@ -29,4 +29,6 @@ interface TransientHashSetInterface extends Countable
     public function remove($value): TransientHashSetInterface;
 
     public function persistent(): PersistentHashSetInterface;
+
+    public function toPhpArray(): array;
 }

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -7,6 +7,7 @@ namespace Phel\Lang\Collections\Map;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Traversable;
 
 /**
  * @template K
@@ -145,5 +146,10 @@ class TransientArrayMap implements TransientMapInterface
     public function persistent(): PersistentMapInterface
     {
         return new PersistentArrayMap($this->hasher, $this->equalizer, null, $this->array);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return $this->persistent()->getIterator();
     }
 }

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -7,6 +7,7 @@ namespace Phel\Lang\Collections\Map;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Traversable;
 
 /**
  * @template K
@@ -179,5 +180,10 @@ class TransientHashMap implements TransientMapInterface
     public function offsetUnset($offset): void
     {
         throw new MethodNotSupportedException('Method offsetUnset is not supported on TransientMap');
+    }
+
+    public function getIterator(): Traversable
+    {
+        return $this->persistent()->getIterator();
     }
 }

--- a/src/php/Lang/Collections/Map/TransientMapInterface.php
+++ b/src/php/Lang/Collections/Map/TransientMapInterface.php
@@ -6,12 +6,13 @@ namespace Phel\Lang\Collections\Map;
 
 use ArrayAccess;
 use Countable;
+use IteratorAggregate;
 
 /**
  * @template K
  * @template V
  */
-interface TransientMapInterface extends Countable, ArrayAccess
+interface TransientMapInterface extends Countable, ArrayAccess, IteratorAggregate
 {
     /**
      * @param K $key

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -8,6 +8,7 @@ use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Traversable;
 
 /**
  * @template T
@@ -302,5 +303,10 @@ class TransientVector implements TransientVectorInterface
     public function offsetUnset($offset): void
     {
         throw new MethodNotSupportedException('Method offsetUnset is not supported on VectorSequence');
+    }
+
+    public function getIterator(): Traversable
+    {
+        return $this->persistent()->getIterator();
     }
 }

--- a/src/php/Lang/Collections/Vector/TransientVectorInterface.php
+++ b/src/php/Lang/Collections/Vector/TransientVectorInterface.php
@@ -6,11 +6,13 @@ namespace Phel\Lang\Collections\Vector;
 
 use ArrayAccess;
 use Countable;
+use IteratorAggregate;
 
 /**
  * @template T
+ * @extends IteratorAggregate
  */
-interface TransientVectorInterface extends Countable, ArrayAccess
+interface TransientVectorInterface extends Countable, ArrayAccess, IteratorAggregate
 {
     public const BRANCH_FACTOR = 32;
     public const INDEX_MASK = self::BRANCH_FACTOR - 1;

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -26,7 +26,7 @@ use Phel\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Printer\TypePrinter\NullPrinter;
 use Phel\Printer\TypePrinter\NumberPrinter;
 use Phel\Printer\TypePrinter\ObjectPrinter;
-use Phel\Printer\TypePrinter\PersistentHashSetPrinter;
+use Phel\Printer\TypePrinter\HashSetPrinter;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
 use Phel\Printer\TypePrinter\PhelArrayPrinter;
@@ -106,7 +106,7 @@ final class Printer implements PrinterInterface
             return new MapPrinter($this);
         }
         if ($form instanceof PersistentHashSetInterface || $form instanceof TransientHashSetInterface) {
-            return new PersistentHashSetPrinter($this);
+            return new HashSetPrinter($this);
         }
         if ($form instanceof Keyword) {
             return new KeywordPrinter($this->withColor);

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Phel\Printer;
 
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
 use Phel\Lang\Collections\Struct\AbstractPersistentStruct;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\PhelArray;
 use Phel\Lang\Set;
@@ -50,12 +53,12 @@ final class Printer implements PrinterInterface
 
     public static function nonReadable(): self
     {
-        return new self($readable= false);
+        return new self($readable = false);
     }
 
     public static function nonReadableWithColor(): self
     {
-        return new self($readable=false, $withColor = true);
+        return new self($readable = false, $withColor = true);
     }
 
     private function __construct(bool $readable, bool $withColor = false)
@@ -96,13 +99,13 @@ final class Printer implements PrinterInterface
         if ($form instanceof PersistentListInterface) {
             return new PersistentListPrinter($this);
         }
-        if ($form instanceof PersistentVectorInterface) {
+        if ($form instanceof PersistentVectorInterface || $form instanceof TransientVectorInterface) {
             return new PersistentVectorPrinter($this);
         }
-        if ($form instanceof PersistentMapInterface) {
+        if ($form instanceof PersistentMapInterface || $form instanceof TransientMapInterface) {
             return new PersistentMapPrinter($this);
         }
-        if ($form instanceof PersistentHashSetInterface) {
+        if ($form instanceof PersistentHashSetInterface || $form instanceof TransientHashSetInterface) {
             return new PersistentHashSetPrinter($this);
         }
         if ($form instanceof Keyword) {

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -21,13 +21,13 @@ use Phel\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use Phel\Printer\TypePrinter\BooleanPrinter;
 use Phel\Printer\TypePrinter\KeywordPrinter;
+use Phel\Printer\TypePrinter\MapPrinter;
 use Phel\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Printer\TypePrinter\NullPrinter;
 use Phel\Printer\TypePrinter\NumberPrinter;
 use Phel\Printer\TypePrinter\ObjectPrinter;
 use Phel\Printer\TypePrinter\PersistentHashSetPrinter;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
-use Phel\Printer\TypePrinter\PersistentMapPrinter;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
 use Phel\Printer\TypePrinter\PhelArrayPrinter;
 use Phel\Printer\TypePrinter\ResourcePrinter;
@@ -103,7 +103,7 @@ final class Printer implements PrinterInterface
             return new PersistentVectorPrinter($this);
         }
         if ($form instanceof PersistentMapInterface || $form instanceof TransientMapInterface) {
-            return new PersistentMapPrinter($this);
+            return new MapPrinter($this);
         }
         if ($form instanceof PersistentHashSetInterface || $form instanceof TransientHashSetInterface) {
             return new PersistentHashSetPrinter($this);

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -20,15 +20,14 @@ use Phel\Lang\Table;
 use Phel\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use Phel\Printer\TypePrinter\BooleanPrinter;
+use Phel\Printer\TypePrinter\HashSetPrinter;
 use Phel\Printer\TypePrinter\KeywordPrinter;
 use Phel\Printer\TypePrinter\MapPrinter;
 use Phel\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Printer\TypePrinter\NullPrinter;
 use Phel\Printer\TypePrinter\NumberPrinter;
 use Phel\Printer\TypePrinter\ObjectPrinter;
-use Phel\Printer\TypePrinter\HashSetPrinter;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
-use Phel\Printer\TypePrinter\PersistentVectorPrinter;
 use Phel\Printer\TypePrinter\PhelArrayPrinter;
 use Phel\Printer\TypePrinter\ResourcePrinter;
 use Phel\Printer\TypePrinter\SetPrinter;
@@ -38,6 +37,7 @@ use Phel\Printer\TypePrinter\SymbolPrinter;
 use Phel\Printer\TypePrinter\TablePrinter;
 use Phel\Printer\TypePrinter\ToStringPrinter;
 use Phel\Printer\TypePrinter\TypePrinterInterface;
+use Phel\Printer\TypePrinter\VectorPrinter;
 use ReflectionClass;
 use RuntimeException;
 
@@ -100,7 +100,7 @@ final class Printer implements PrinterInterface
             return new PersistentListPrinter($this);
         }
         if ($form instanceof PersistentVectorInterface || $form instanceof TransientVectorInterface) {
-            return new PersistentVectorPrinter($this);
+            return new VectorPrinter($this);
         }
         if ($form instanceof PersistentMapInterface || $form instanceof TransientMapInterface) {
             return new MapPrinter($this);

--- a/src/php/Printer/TypePrinter/HashSetPrinter.php
+++ b/src/php/Printer/TypePrinter/HashSetPrinter.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
 use Phel\Printer\PrinterInterface;
 
 /**
- * @implements TypePrinterInterface<PersistentHashSetInterface>
+ * @implements TypePrinterInterface<PersistentHashSetInterface|TransientHashSetInterface>
  */
-final class PersistentHashSetPrinter implements TypePrinterInterface
+final class HashSetPrinter implements TypePrinterInterface
 {
     private PrinterInterface $printer;
 
@@ -20,7 +21,7 @@ final class PersistentHashSetPrinter implements TypePrinterInterface
     }
 
     /**
-     * @param PersistentHashSetInterface $form
+     * @param PersistentHashSetInterface|TransientHashSetInterface $form
      */
     public function print($form): string
     {

--- a/src/php/Printer/TypePrinter/MapPrinter.php
+++ b/src/php/Printer/TypePrinter/MapPrinter.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
 use Phel\Printer\PrinterInterface;
 
 /**
- * @implements TypePrinterInterface<PersistentMapInterface>
+ * @implements TypePrinterInterface<PersistentMapInterface|TransientMapInterface>
  */
-final class PersistentMapPrinter implements TypePrinterInterface
+final class MapPrinter implements TypePrinterInterface
 {
     private PrinterInterface $printer;
 
@@ -20,7 +21,7 @@ final class PersistentMapPrinter implements TypePrinterInterface
     }
 
     /**
-     * @param PersistentMapInterface $form
+     * @param PersistentMapInterface|TransientMapInterface $form
      */
     public function print($form): string
     {

--- a/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Printer\PrinterInterface;
 
 /**
@@ -20,7 +21,7 @@ final class PersistentVectorPrinter implements TypePrinterInterface
     }
 
     /**
-     * @param PersistentVectorInterface $form
+     * @param PersistentVectorInterface|TransientVectorInterface $form
      */
     public function print($form): string
     {

--- a/src/php/Printer/TypePrinter/VectorPrinter.php
+++ b/src/php/Printer/TypePrinter/VectorPrinter.php
@@ -9,9 +9,9 @@ use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Printer\PrinterInterface;
 
 /**
- * @implements TypePrinterInterface<PersistentVectorInterface>
+ * @implements TypePrinterInterface<PersistentVectorInterface|TransientVectorInterface>
  */
-final class PersistentVectorPrinter implements TypePrinterInterface
+final class VectorPrinter implements TypePrinterInterface
 {
     private PrinterInterface $printer;
 

--- a/tests/php/Unit/Printer/TypePrinter/HashSetPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/HashSetPrinterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Generator;
+use Phel\Lang\Collections\HashSet\PersistentHashSet;
+use Phel\Lang\TypeFactory;
+use Phel\Printer\Printer;
+use Phel\Printer\TypePrinter\PersistentHashSetPrinter;
+use PHPUnit\Framework\TestCase;
+
+final class HashSetPrinterTest extends TestCase
+{
+    /**
+     * @dataProvider printerDataProvider
+     */
+    public function testPrint(string $expected, PersistentHashSet $set): void
+    {
+        self::assertSame(
+            $expected,
+            (new PersistentHashSetPrinter(Printer::readable()))->print($set)
+        );
+    }
+
+    public function printerDataProvider(): Generator
+    {
+        $set = TypeFactory::getInstance()->emptyPersistentHashSet();
+
+        yield 'empty set' => [
+            'expected' => '(set)',
+            'set' => $set,
+        ];
+
+        yield 'set with one value' => [
+            'expected' => '(set "name")',
+            'set' => $set->add('name'),
+        ];
+
+        yield 'set with multiple values' => [
+            'expected' => '(set "key1" "key2")',
+            'set' => $set->add('key1')->add('key2'),
+        ];
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/HashSetPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/HashSetPrinterTest.php
@@ -5,26 +5,30 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
-use Phel\Lang\Collections\HashSet\PersistentHashSet;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
 use Phel\Lang\TypeFactory;
 use Phel\Printer\Printer;
-use Phel\Printer\TypePrinter\PersistentHashSetPrinter;
+use Phel\Printer\TypePrinter\HashSetPrinter;
 use PHPUnit\Framework\TestCase;
 
 final class HashSetPrinterTest extends TestCase
 {
     /**
-     * @dataProvider printerDataProvider
+     * @dataProvider providerPersistentHashSet
+     * @dataProvider providerTransientHashSet
+     *
+     * @param PersistentHashSetInterface|TransientHashSetInterface $hashSet
      */
-    public function testPrint(string $expected, PersistentHashSet $set): void
+    public function testPrintHashSet(string $expected, $hashSet): void
     {
         self::assertSame(
             $expected,
-            (new PersistentHashSetPrinter(Printer::readable()))->print($set)
+            (new HashSetPrinter(Printer::readable()))->print($hashSet)
         );
     }
 
-    public function printerDataProvider(): Generator
+    public function providerPersistentHashSet(): Generator
     {
         $set = TypeFactory::getInstance()->emptyPersistentHashSet();
 
@@ -41,6 +45,26 @@ final class HashSetPrinterTest extends TestCase
         yield 'set with multiple values' => [
             'expected' => '(set "key1" "key2")',
             'set' => $set->add('key1')->add('key2'),
+        ];
+    }
+
+    public function providerTransientHashSet(): Generator
+    {
+        $set = TypeFactory::getInstance()->emptyPersistentHashSet();
+
+        yield 'empty set' => [
+            'expected' => '(set)',
+            'set' => $set->asTransient(),
+        ];
+
+        yield 'set with one value' => [
+            'expected' => '(set "name")',
+            'set' => $set->add('name')->asTransient(),
+        ];
+
+        yield 'set with multiple values' => [
+            'expected' => '(set "key1" "key2")',
+            'set' => $set->add('key1')->add('key2')->asTransient(),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/MapPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/MapPrinterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Generator;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
+use Phel\Printer\Printer;
+use Phel\Printer\TypePrinter\PersistentMapPrinter;
+use PHPUnit\Framework\TestCase;
+
+final class MapPrinterTest extends TestCase
+{
+    /**
+     * @dataProvider providerPersistentMap
+     */
+    public function testPersistentMap(string $expected, PersistentMapInterface $map): void
+    {
+        self::assertSame(
+            $expected,
+            (new PersistentMapPrinter(Printer::readable()))->print($map)
+        );
+    }
+
+    public function providerPersistentMap(): Generator
+    {
+        $map = TypeFactory::getInstance()->emptyPersistentMap();
+
+        yield 'empty map' => [
+            'expected' => '{}',
+            'map' => $map,
+        ];
+
+        yield 'map with one key:value' => [
+            'expected' => '{:key "value"}',
+            'map' => $map->put(Keyword::create('key'), 'value'),
+        ];
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/MapPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/MapPrinterTest.php
@@ -6,22 +6,26 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
 use Phel\Printer\Printer;
-use Phel\Printer\TypePrinter\PersistentMapPrinter;
+use Phel\Printer\TypePrinter\MapPrinter;
 use PHPUnit\Framework\TestCase;
 
 final class MapPrinterTest extends TestCase
 {
     /**
      * @dataProvider providerPersistentMap
+     * @dataProvider providerTransientMap
+     *
+     * @param PersistentMapInterface|TransientMapInterface $map
      */
-    public function testPersistentMap(string $expected, PersistentMapInterface $map): void
+    public function testPrintMap(string $expected, $map): void
     {
         self::assertSame(
             $expected,
-            (new PersistentMapPrinter(Printer::readable()))->print($map)
+            (new MapPrinter(Printer::readable()))->print($map)
         );
     }
 
@@ -29,14 +33,59 @@ final class MapPrinterTest extends TestCase
     {
         $map = TypeFactory::getInstance()->emptyPersistentMap();
 
-        yield 'empty map' => [
+        yield 'empty persistent map' => [
             'expected' => '{}',
             'map' => $map,
         ];
 
-        yield 'map with one key:value' => [
+        yield 'persistent using a number as key' => [
+            'expected' => '{1 "value"}',
+            'map' => $map->put(1, 'value'),
+        ];
+
+        yield 'persistent using a string as key' => [
+            'expected' => '{"key" "value"}',
+            'map' => $map->put('key', 'value'),
+        ];
+
+        yield 'persistent using a keyword as key' => [
             'expected' => '{:key "value"}',
             'map' => $map->put(Keyword::create('key'), 'value'),
+        ];
+
+        yield 'persistent using multiple key-values' => [
+            'expected' => '{"k1" "v1" "k2" "v2"}',
+            'map' => $map->put('k1', 'v1')->put('k2', 'v2'),
+        ];
+    }
+
+    public function providerTransientMap(): Generator
+    {
+        $map = TypeFactory::getInstance()->emptyPersistentMap();
+
+        yield 'empty transient map' => [
+            'expected' => '{}',
+            'map' => $map->asTransient(),
+        ];
+
+        yield 'transient using a number as key' => [
+            'expected' => '{1 "value"}',
+            'map' => $map->put(1, 'value')->asTransient(),
+        ];
+
+        yield 'transient using a string as key' => [
+            'expected' => '{"key" "value"}',
+            'map' => $map->put('key', 'value')->asTransient(),
+        ];
+
+        yield 'transient using a keyword as key' => [
+            'expected' => '{:key "value"}',
+            'map' => $map->put(Keyword::create('key'), 'value')->asTransient(),
+        ];
+
+        yield 'transient using multiple key-values' => [
+            'expected' => '{"k1" "v1" "k2" "v2"}',
+            'map' => $map->put('k1', 'v1')->put('k2', 'v2')->asTransient(),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -9,55 +9,46 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Lang\TypeFactory;
 use Phel\Printer\Printer;
-use Phel\Printer\TypePrinter\PersistentVectorPrinter;
+use Phel\Printer\TypePrinter\VectorPrinter;
 use PHPUnit\Framework\TestCase;
 
 final class VectorPrinterTest extends TestCase
 {
     /**
-     * @dataProvider providerPersistentVector
+     * @dataProvider providerPrint
+     *
+     * @param PersistentVectorInterface|TransientVectorInterface $vector
      */
-    public function testPrintPersistent(string $expected, PersistentVectorInterface $vector): void
+    public function testPrint(string $expected, $vector): void
     {
         self::assertSame(
             $expected,
-            (new PersistentVectorPrinter(Printer::readable()))->print($vector)
+            (new VectorPrinter(Printer::readable()))->print($vector)
         );
     }
 
-    public function providerPersistentVector(): Generator
+    public function providerPrint(): Generator
     {
-        yield 'empty vector' => [
+        $vector = TypeFactory::getInstance()->emptyPersistentVector();
+
+        yield 'persistent empty vector' => [
             'expected' => '[]',
-            'vector' => TypeFactory::getInstance()->emptyPersistentVector(),
+            'vector' => $vector,
         ];
 
-        yield 'vector with values' => [
+        yield 'persistent vector with values' => [
             'expected' => '["a" 1]',
-            'vector' => TypeFactory::getInstance()->persistentVectorFromArray(['a', 1]),
+            'vector' => $vector->append('a')->append(1),
         ];
-    }
-    /**
-     * @dataProvider providerTransientVector
-     */
-    public function testPrintTransient(string $expected, TransientVectorInterface $vector): void
-    {
-        self::assertSame(
-            $expected,
-            (new PersistentVectorPrinter(Printer::readable()))->print($vector)
-        );
-    }
 
-    public function providerTransientVector(): Generator
-    {
-        yield 'empty vector' => [
+        yield 'transient empty vector' => [
             'expected' => '[]',
-            'vector' => TypeFactory::getInstance()->emptyPersistentVector()->asTransient(),
+            'vector' => $vector,
         ];
 
-        yield 'vector with values' => [
+        yield 'transient vector with values' => [
             'expected' => '["a" 1]',
-            'vector' => TypeFactory::getInstance()->persistentVectorFromArray(['a', 1])->asTransient(),
+            'vector' => $vector->append('a')->append(1),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Lang\TypeFactory;
 use Phel\Printer\Printer;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
@@ -14,9 +15,9 @@ use PHPUnit\Framework\TestCase;
 final class VectorPrinterTest extends TestCase
 {
     /**
-     * @dataProvider printerDataProvider
+     * @dataProvider providerPersistentVector
      */
-    public function testPrint(string $expected, PersistentVectorInterface $vector): void
+    public function testPrintPersistent(string $expected, PersistentVectorInterface $vector): void
     {
         self::assertSame(
             $expected,
@@ -24,7 +25,7 @@ final class VectorPrinterTest extends TestCase
         );
     }
 
-    public function printerDataProvider(): Generator
+    public function providerPersistentVector(): Generator
     {
         yield 'empty vector' => [
             'expected' => '[]',
@@ -34,6 +35,29 @@ final class VectorPrinterTest extends TestCase
         yield 'vector with values' => [
             'expected' => '["a" 1]',
             'vector' => TypeFactory::getInstance()->persistentVectorFromArray(['a', 1]),
+        ];
+    }
+    /**
+     * @dataProvider providerTransientVector
+     */
+    public function testPrintTransient(string $expected, TransientVectorInterface $vector): void
+    {
+        self::assertSame(
+            $expected,
+            (new PersistentVectorPrinter(Printer::readable()))->print($vector)
+        );
+    }
+
+    public function providerTransientVector(): Generator
+    {
+        yield 'empty vector' => [
+            'expected' => '[]',
+            'vector' => TypeFactory::getInstance()->emptyPersistentVector()->asTransient(),
+        ];
+
+        yield 'vector with values' => [
+            'expected' => '["a" 1]',
+            'vector' => TypeFactory::getInstance()->persistentVectorFromArray(['a', 1])->asTransient(),
         ];
     }
 }


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/phel-lang/phel-lang/issues/271 
Currently, it's not possible to print any transient data structures. 
In this PR I basically use the `transient->persistent()->getIterator()` logic to be able to iterate over the transient data and this way allows printing it in the easiest way I could think of.

## 🔖 Changes

- Make `TransientVector`, `TransientMap`, and `TransientHashSet` printable

#### Follow up

I will start thinking about a potential refactoring to simplify the transient/persistent interfaces, unifying the common functionality in another interface that will be shared between them both. I didn't want to apply such an idea in this PR to don't overcomplicate it already.
