### PR TITLE
Adding filter option to phel test command

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -173,7 +173,11 @@
   (let [loc (location form) e (gensym)]
     `(try ,(assert-expr form message)
           (catch Throwable ,e
-            (report @{:state :error :location ,loc :message ,message :form ',form :exception ,e})))))
+            (report @{:state :error
+                      :location ,loc
+                      :message ,message
+                      :form ',form
+                      :exception ,e})))))
 
 # --------------
 # Defining tests
@@ -298,19 +302,21 @@
           :when (get meta :test)]
       (get-in php/$GLOBALS ["__phel" munge-ns fn-name]))))
 
-(defn- run-test [ns]
+(defn- run-test [options ns]
   (let [rt (php/:: \Phel\Runtime\RuntimeSingleton (getInstance))
         _ (php/-> rt (loadNs ns))
-        tests (find-test-fns ns)]
-    (dofor [test :in tests]
+        tests (find-test-fns ns)
+        filter-option (get options :filter)]
+    (dofor [test :in tests :when (or (= filter-option nil)
+                                     (str-contains? (php/:: test BOUND_TO) filter-option))]
       (test))))
 
 (defn run-tests
   "Runs all test functions in the given namespaces"
-  [& namespaces]
+  [options & namespaces]
   (dofor [n :in namespaces
           :let [s (php/-> n (getName))]]
-    (run-test s))
+    (run-test options s))
   (print-summary))
 
 (defn successful?

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractFacade;
+use Phel\Command\Test\TestCommandOptions;
 
 /**
  * @method CommandFactory getFactory()
@@ -31,11 +32,11 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
     /**
      * @param list<string> $paths
      */
-    public function executeTestCommand(array $paths): void
+    public function executeTestCommand(array $paths, array $options = []): void
     {
         $result = $this->getFactory()
             ->createTestCommand()
-            ->run($paths);
+            ->run($paths, TestCommandOptions::fromArray($options));
 
         ($result)
             ? exit(self::SUCCESS_CODE)

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -13,7 +13,7 @@ interface CommandFacadeInterface
     /**
      * @param list<string> $paths
      */
-    public function executeTestCommand(array $paths): void;
+    public function executeTestCommand(array $paths, array $options = []): void;
 
     /**
      * @param list<string> $paths

--- a/src/php/Command/Test/TestCommandOptions.php
+++ b/src/php/Command/Test/TestCommandOptions.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command\Test;
+
+final class TestCommandOptions
+{
+    private const FILTER_OPTION = '--filter=';
+
+    private string $filter = '';
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public static function fromArray(array $options): self
+    {
+        $self = new self();
+
+        foreach ($options as $option) {
+            if (false !== strpos($option, self::FILTER_OPTION)) {
+                $self->filter = str_replace('-', '_', substr($option, strlen(self::FILTER_OPTION)));
+            }
+        }
+
+        return $self;
+    }
+
+    public function asPhelHashMap(): string
+    {
+        return sprintf(
+            '{:filter %s}',
+            $this->filter ? "\"{$this->filter}\"" : 'nil'
+        );
+    }
+}

--- a/src/php/PhelFacade.php
+++ b/src/php/PhelFacade.php
@@ -27,7 +27,7 @@ Commands:
     run <filename-or-namespace>
         Runs a script.
 
-    test <filename> <filename> ...
+    test <filename> <filename> ... [--filter=...]
         Tests the given files. If no filenames are provided all tests in the
         "tests" directory are executed.
 
@@ -49,20 +49,23 @@ HELP;
      */
     public function runCommand(string $commandName, array $arguments = []): void
     {
+        $inputs = $this->getInputs($arguments);
+        $options = $this->getOptions($arguments);
+
         switch ($commandName) {
             case ReplCommand::COMMAND_NAME:
                 $this->executeReplCommand();
                 break;
             case RunCommand::COMMAND_NAME:
-                $this->executeRunCommand($arguments);
+                $this->executeRunCommand($inputs);
                 break;
             case TestCommand::COMMAND_NAME:
-                $this->executeTestCommand($arguments);
+                $this->executeTestCommand($inputs, $options);
                 break;
             case FormatCommand::COMMAND_NAME:
-                $this->executeFormatCommand($arguments);
+                $this->executeFormatCommand($inputs);
                 break;
-           case ExportCommand::COMMAND_NAME:
+            case ExportCommand::COMMAND_NAME:
                 $this->executeExportCommand();
                 break;
             default:
@@ -77,33 +80,33 @@ HELP;
             ->executeReplCommand();
     }
 
-    private function executeRunCommand(array $arguments): void
+    private function executeRunCommand(array $inputs): void
     {
-        if (empty($arguments)) {
+        if (empty($inputs)) {
             throw new InvalidArgumentException('Please, provide a filename or namespace as argument!');
         }
 
         $this->getFactory()
             ->getCommandFacade()
-            ->executeRunCommand($arguments[0]);
+            ->executeRunCommand($inputs[0]);
     }
 
-    private function executeTestCommand(array $arguments): void
+    private function executeTestCommand(array $inputs, array $options = []): void
     {
         $this->getFactory()
             ->getCommandFacade()
-            ->executeTestCommand($arguments);
+            ->executeTestCommand($inputs, $options);
     }
 
-    private function executeFormatCommand(array $arguments): void
+    private function executeFormatCommand(array $inputs): void
     {
-        if (empty($arguments)) {
+        if (empty($inputs)) {
             throw new InvalidArgumentException('Please, provide a filename or a directory as arguments!');
         }
 
         $this->getFactory()
             ->getCommandFacade()
-            ->executeFormatCommand($arguments);
+            ->executeFormatCommand($inputs);
     }
 
     private function executeExportCommand(): void
@@ -111,5 +114,21 @@ HELP;
         $this->getFactory()
             ->getCommandFacade()
             ->executeExportCommand();
+    }
+
+    private function getInputs(array $arguments): array
+    {
+        return array_filter(
+            $arguments,
+            static fn (string $a): bool => 0 !== strpos($a, '--')
+        );
+    }
+
+    private function getOptions(array $arguments): array
+    {
+        return array_filter(
+            $arguments,
+            static fn (string $a): bool => 0 === strpos($a, '--')
+        );
     }
 }

--- a/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Test;
+
+use Generator;
+use Phel\Command\Test\TestCommandOptions;
+use PHPUnit\Framework\TestCase;
+
+final class TestCommandOptionsTest extends TestCase
+{
+    public function testEmptyFilter(): void
+    {
+        $options = TestCommandOptions::empty();
+
+        self::assertSame('{:filter nil}', $options->asPhelHashMap());
+    }
+
+    /**
+     * @dataProvider providerRandomFilter
+     */
+    public function testRandomFilter(array $options, string $expected): void
+    {
+        $options = TestCommandOptions::fromArray($options);
+
+        self::assertSame($expected, $options->asPhelHashMap());
+    }
+
+    public function providerRandomFilter(): Generator
+    {
+        yield 'simple filter' => [
+            'options' => ['--filter=example'],
+            'expected' => '{:filter "example"}',
+        ];
+
+        yield 'using underscore' => [
+            'options' => ['--filter=using_underscore'],
+            'expected' => '{:filter "using_underscore"}',
+        ];
+
+        yield 'using hyphen will use underscore instead' => [
+            'options' => ['--filter=using-hyphen'],
+            'expected' => '{:filter "using_hyphen"}',
+        ];
+    }
+}


### PR DESCRIPTION
## 📚 Description

Adding a new concept to the phel commands: "options". With this idea, we can extend the functionality of the different commands that we already have in a simple way.

The command arguments get divided by "inputs" and "options". The difference is basically that the options start with `--`

## 🔖 Changes

- Added an option `--filter=...` to the Test command
