### PR TITLE
Refactored Emitter and OutputEmitter

### DIFF
--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -90,6 +90,8 @@ final class CompilerFactory extends AbstractFactory
     public function createEmitter(bool $enableSourceMaps = true): EmitterInterface
     {
         return new Emitter(
+            $enableSourceMaps,
+            new SourceMapGenerator(),
             $this->createOutputEmitter($enableSourceMaps)
         );
     }
@@ -98,7 +100,6 @@ final class CompilerFactory extends AbstractFactory
     {
         return new OutputEmitter(
             $enableSourceMaps,
-            new SourceMapGenerator(),
             new NodeEmitterFactory(),
             new Munge(),
             Printer::readable()

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -17,6 +17,7 @@ use Phel\Compiler\Emitter\OutputEmitter;
 use Phel\Compiler\Emitter\OutputEmitter\Munge;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
+use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Compiler\Emitter\OutputEmitterInterface;
 use Phel\Compiler\Evaluator\EvaluatorInterface;
 use Phel\Compiler\Evaluator\RequireEvaluator;
@@ -102,7 +103,8 @@ final class CompilerFactory extends AbstractFactory
             $enableSourceMaps,
             new NodeEmitterFactory(),
             new Munge(),
-            Printer::readable()
+            Printer::readable(),
+            new SourceMapState()
         );
     }
 

--- a/src/php/Compiler/Emitter/Emitter.php
+++ b/src/php/Compiler/Emitter/Emitter.php
@@ -5,19 +5,50 @@ declare(strict_types=1);
 namespace Phel\Compiler\Emitter;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
 
 final class Emitter implements EmitterInterface
 {
+    private bool $enableSourceMaps;
+    private SourceMapGenerator $sourceMapGenerator;
     private OutputEmitterInterface $outputEmitter;
 
     public function __construct(
+        bool $enableSourceMaps,
+        SourceMapGenerator $sourceMapGenerator,
         OutputEmitterInterface $outputEmitter
     ) {
+        $this->enableSourceMaps = $enableSourceMaps;
+        $this->sourceMapGenerator = $sourceMapGenerator;
         $this->outputEmitter = $outputEmitter;
     }
 
     public function emitNode(AbstractNode $node): string
     {
-        return $this->outputEmitter->emitNodeAsString($node);
+        $this->outputEmitter->resetIndentLevel();
+        $this->outputEmitter->resetSourceMapState();
+
+        ob_start();
+        $this->outputEmitter->emitNode($node);
+        $code = ob_get_contents();
+        ob_end_clean();
+
+        if (!$this->enableSourceMaps) {
+            return $code;
+        }
+
+        $sourceMap = $this->sourceMapGenerator->encode(
+            $this->outputEmitter->getSourceMapState()->getMappings()
+        );
+        $sourceLocation = $node->getStartSourceLocation();
+        $file = $sourceLocation
+            ? $sourceLocation->getFile()
+            : 'string';
+
+        return (
+            '// ' . $file . "\n"
+            . '// ;;' . $sourceMap . "\n"
+            . $code
+        );
     }
 }

--- a/src/php/Compiler/Emitter/Emitter.php
+++ b/src/php/Compiler/Emitter/Emitter.php
@@ -30,8 +30,7 @@ final class Emitter implements EmitterInterface
 
         ob_start();
         $this->outputEmitter->emitNode($node);
-        $code = ob_get_contents();
-        ob_end_clean();
+        $code = ob_get_clean();
 
         if (!$this->enableSourceMaps) {
             return $code;

--- a/src/php/Compiler/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter.php
@@ -29,13 +29,14 @@ final class OutputEmitter implements OutputEmitterInterface
         bool $enableSourceMaps,
         NodeEmitterFactory $nodeEmitterFactory,
         MungeInterface $munge,
-        PrinterInterface $printer
+        PrinterInterface $printer,
+        SourceMapState $sourceMapState
     ) {
         $this->enableSourceMaps = $enableSourceMaps;
         $this->nodeEmitterFactory = $nodeEmitterFactory;
         $this->munge = $munge;
         $this->printer = $printer;
-        $this->sourceMapState = new SourceMapState();
+        $this->sourceMapState = $sourceMapState;
     }
 
     public function resetIndentLevel(): void

--- a/src/php/Compiler/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Emitter\OutputEmitter\LiteralEmitter;
 use Phel\Compiler\Emitter\OutputEmitter\MungeInterface;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterFactory;
-use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
+use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
@@ -18,57 +18,39 @@ use Phel\Printer\PrinterInterface;
 final class OutputEmitter implements OutputEmitterInterface
 {
     private bool $enableSourceMaps;
-    private SourceMapGenerator $sourceMapGenerator;
     private NodeEmitterFactory $nodeEmitterFactory;
     private MungeInterface $munge;
     private PrinterInterface $printer;
 
     private int $indentLevel = 0;
-    private int $generatedLines = 0;
-    private int $generatedColumns = 0;
-    private array $sourceMap = [];
+    private SourceMapState $sourceMapState;
 
     public function __construct(
         bool $enableSourceMaps,
-        SourceMapGenerator $sourceMapGenerator,
         NodeEmitterFactory $nodeEmitterFactory,
         MungeInterface $munge,
         PrinterInterface $printer
     ) {
         $this->enableSourceMaps = $enableSourceMaps;
-        $this->sourceMapGenerator = $sourceMapGenerator;
         $this->nodeEmitterFactory = $nodeEmitterFactory;
         $this->munge = $munge;
         $this->printer = $printer;
+        $this->sourceMapState = new SourceMapState();
     }
 
-    public function emitNodeAsString(AbstractNode $node): string
+    public function resetIndentLevel(): void
     {
-        $this->generatedLines = 0;
-        $this->generatedColumns = 0;
         $this->indentLevel = 0;
-        $this->sourceMap = [];
+    }
 
-        ob_start();
-        $this->emitNode($node);
-        $code = ob_get_contents();
-        ob_end_clean();
+    public function resetSourceMapState(): void
+    {
+        $this->sourceMapState->reset();
+    }
 
-        if (!$this->enableSourceMaps) {
-            return $code;
-        }
-
-        $sourceMap = $this->sourceMapGenerator->encode($this->sourceMap);
-        $sourceLocation = $node->getStartSourceLocation();
-        $file = $sourceLocation
-            ? $sourceLocation->getFile()
-            : 'string';
-
-        return (
-            '// ' . $file . "\n"
-            . '// ;;' . $sourceMap . "\n"
-            . $code
-        );
+    public function getSourceMapState(): SourceMapState
+    {
+        return $this->sourceMapState;
     }
 
     public function emitNode(AbstractNode $node): void
@@ -83,34 +65,36 @@ final class OutputEmitter implements OutputEmitterInterface
             $this->emitStr($str, $sl);
         }
 
-        $this->generatedLines++;
-        $this->generatedColumns = 0;
+        $this->sourceMapState->incGeneratedLines();
+        $this->sourceMapState->setGeneratedColumns(0);
 
         echo PHP_EOL;
     }
 
     public function emitStr(string $str, ?SourceLocation $sl = null): void
     {
-        if ($this->generatedColumns === 0) {
-            $this->generatedColumns += $this->indentLevel * 2;
+        if ($this->sourceMapState->getGeneratedColumns() === 0) {
+            $this->sourceMapState->incGeneratedColumns($this->indentLevel * 2);
             echo str_repeat(' ', $this->indentLevel * 2);
         }
 
         if ($this->enableSourceMaps && $sl) {
-            $this->sourceMap[] = [
-                'source' => $sl->getFile(),
-                'original' => [
-                    'line' => $sl->getLine() - 1,
-                    'column' => $sl->getColumn(),
-                ],
-                'generated' => [
-                    'line' => $this->generatedLines,
-                    'column' => $this->generatedColumns,
-                ],
-            ];
+            $this->sourceMapState->addMapping(
+                [
+                    'source' => $sl->getFile(),
+                    'original' => [
+                        'line' => $sl->getLine() - 1,
+                        'column' => $sl->getColumn(),
+                    ],
+                    'generated' => [
+                        'line' => $this->sourceMapState->getGeneratedLines(),
+                        'column' => $this->sourceMapState->getGeneratedColumns(),
+                    ],
+                ]
+            );
         }
 
-        $this->generatedColumns += strlen($str);
+        $this->sourceMapState->incGeneratedColumns(strlen($str));
 
         echo $str;
     }

--- a/src/php/Compiler/Emitter/OutputEmitter/SourceMap/SourceMapState.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/SourceMap/SourceMapState.php
@@ -21,13 +21,13 @@ final class SourceMapState
 
     public function incGeneratedLines(int $amount = 1): SourceMapState
     {
-        $this->generatedLines = $this->generatedLines + $amount;
+        $this->generatedLines += $amount;
         return $this;
     }
 
     public function incGeneratedColumns(int $amount = 1): SourceMapState
     {
-        $this->generatedColumns = $this->generatedColumns + $amount;
+        $this->generatedColumns += $amount;
         return $this;
     }
 
@@ -41,12 +41,6 @@ final class SourceMapState
         return $this->generatedColumns;
     }
 
-    public function setGeneratedLines(int $value): SourceMapState
-    {
-        $this->generatedLines = $value;
-        return $this;
-    }
-
     public function setGeneratedColumns(int $value): SourceMapState
     {
         $this->generatedColumns = $value;
@@ -56,12 +50,6 @@ final class SourceMapState
     public function getMappings(): array
     {
         return $this->mappings;
-    }
-
-    public function setMappings(array $mappings): SourceMapState
-    {
-        $this->mappings = $mappings;
-        return $this;
     }
 
     public function addMapping(array $mapping): SourceMapState

--- a/src/php/Compiler/Emitter/OutputEmitter/SourceMap/SourceMapState.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/SourceMap/SourceMapState.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Emitter\OutputEmitter\SourceMap;
+
+final class SourceMapState
+{
+    private int $generatedLines = 0;
+    private int $generatedColumns = 0;
+    private array $mappings = [];
+
+    public function reset(): SourceMapState
+    {
+        $this->generatedLines = 0;
+        $this->generatedColumns = 0;
+        $this->mappings = [];
+
+        return $this;
+    }
+
+    public function incGeneratedLines(int $amount = 1): SourceMapState
+    {
+        $this->generatedLines = $this->generatedLines + $amount;
+        return $this;
+    }
+
+    public function incGeneratedColumns(int $amount = 1): SourceMapState
+    {
+        $this->generatedColumns = $this->generatedColumns + $amount;
+        return $this;
+    }
+
+    public function getGeneratedLines(): int
+    {
+        return $this->generatedLines;
+    }
+
+    public function getGeneratedColumns(): int
+    {
+        return $this->generatedColumns;
+    }
+
+    public function setGeneratedLines(int $value): SourceMapState
+    {
+        $this->generatedLines = $value;
+        return $this;
+    }
+
+    public function setGeneratedColumns(int $value): SourceMapState
+    {
+        $this->generatedColumns = $value;
+        return $this;
+    }
+
+    public function getMappings(): array
+    {
+        return $this->mappings;
+    }
+
+    public function setMappings(array $mappings): SourceMapState
+    {
+        $this->mappings = $mappings;
+        return $this;
+    }
+
+    public function addMapping(array $mapping): SourceMapState
+    {
+        $this->mappings[] = $mapping;
+        return $this;
+    }
+}

--- a/src/php/Compiler/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Emitter/OutputEmitterInterface.php
@@ -6,13 +6,18 @@ namespace Phel\Compiler\Emitter;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
 interface OutputEmitterInterface
 {
-    public function emitNodeAsString(AbstractNode $node): string;
+    public function resetIndentLevel(): void;
+
+    public function resetSourceMapState(): void;
+
+    public function getSourceMapState(): SourceMapState;
 
     public function emitNode(AbstractNode $node): void;
 


### PR DESCRIPTION
## 📚 Description

Refactored some methods in Emitter and OutputEmitter. The target of the Pull Request is to decouple the generation of the source map and the generation of the source code.

## 🔖 Changes

- OutputEmitter::emitNodeAsString was moved to Emitter
- OutputEmiitter uses now a SourceMapState object.
- OutputEmiitter has methods to reset it's state
