### PR TITLE
Replace can not by cannot

### DIFF
--- a/src/phel/core/sequence-functions.phel
+++ b/src/phel/core/sequence-functions.phel
@@ -50,7 +50,7 @@ collection in map"))
   (cond
     (php-array? xs) (php/array_slice xs offset length)
     (php/instanceof xs SliceInterface) (php/-> xs (slice offset length))
-    (throw (php/new InvalidArgumentException "Can not slice"))))
+    (throw (php/new InvalidArgumentException "Cannot slice"))))
 
 (defn get-in
   "Access a value in a nested data structure. Looks into the data structure via a sequence of keys."

--- a/src/phel/core/sequence-operation.phel
+++ b/src/phel/core/sequence-operation.phel
@@ -14,7 +14,7 @@
     (or (set? xs) (php/instanceof xs TransientHashSetInterface)) (php/-> xs (add x))
     (php/instanceof xs PushInterface) (php/-> xs (push x))
     (throw (php/new InvalidArgumentException
-                    (str "Can not push on type " (type xs))))))
+                    (str "Cannot push on type " (type xs))))))
 
 (defn pop
   "Removes the last element of the array `xs`. If the array is empty
@@ -23,7 +23,7 @@
   (cond
     (php-array? xs) (php/array_pop xs)
     (php/instanceof xs PopInterface) (php/-> xs (pop))
-    (throw (php/new InvalidArgumentException "Can not pop"))))
+    (throw (php/new InvalidArgumentException "Cannot pop"))))
 
 (defn remove
   "Removes up to `n` element from array `xs` starting at index `offset`."
@@ -31,7 +31,7 @@
   (cond
     (php-array? xs) (if n (php/array_splice xs offset n) (php/array_splice xs offset))
     (php/instanceof xs RemoveInterface) (php/-> xs (remove offset n))
-    (throw (php/new InvalidArgumentException "Can not remove"))))
+    (throw (php/new InvalidArgumentException "Cannot remove"))))
 
 (defn get
   "Get the value mapped to `key` from the datastructure `ds`.
@@ -47,7 +47,7 @@
   [ds key value]
   (cond
     (php-array? ds)
-    (throw (php/new InvalidArgumentException "Can not call put on pure PHP
+    (throw (php/new InvalidArgumentException "Cannot call put on pure PHP
 arrays. Use (php/aset ds key value)"))
 
     (or (struct? ds) (hash-map? ds) (php/instanceof ds TransientMapInterface))
@@ -65,7 +65,7 @@ arrays. Use (php/aset ds key value)"))
   [ds key]
   (cond
     (php-array? ds)
-    (throw (php/new InvalidArgumentException "Can not call unset on pure PHP
+    (throw (php/new InvalidArgumentException "Cannot call unset on pure PHP
 arrays. Use (php/aunset ds key)"))
 
     (or (hash-map? ds) (php/instanceof ds TransientMapInterface))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -134,7 +134,7 @@
   (let [method (get (or server php/$_SERVER) "REQUEST_METHOD")]
     (if method
       method
-      (throw (php/new InvalidArgumentException "can not determine HTTP Method")))))
+      (throw (php/new InvalidArgumentException "cannot determine HTTP Method")))))
 
 (defn- post-global-valid [method headers]
   (let [content-type (get headers :content-type)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -13,7 +13,7 @@
 
 (defn resolve
   "Resolves the given symbol in the current environment and returns a
-   resolved Symbol with the absolute namespace or nil if it can not be resolved"
+   resolved Symbol with the absolute namespace or nil if it cannot be resolved"
   [sym]
   (-> (get-global-env)
       (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/AnalyzeSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/AnalyzeSymbol.php
@@ -46,7 +46,7 @@ final class AnalyzeSymbol
         $globalResolve = $this->analyzer->resolve($symbol, $env);
 
         if (!$globalResolve) {
-            throw AnalyzerException::withLocation("Can not resolve symbol '{$symbol->getFullName()}'", $symbol);
+            throw AnalyzerException::withLocation("Cannot resolve symbol '{$symbol->getFullName()}'", $symbol);
         }
 
         return $globalResolve;

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/Binding/BindingValidator.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/Binding/BindingValidator.php
@@ -33,10 +33,10 @@ final class BindingValidator implements BindingValidatorInterface
         $type = is_object($form) ? get_class($form) : gettype($form);
 
         if ($form instanceof TypeInterface) {
-            throw AnalyzerException::withLocation('Can not destructure ' . $type, $form);
+            throw AnalyzerException::withLocation('Cannot destructure ' . $type, $form);
         }
 
-        throw new AnalyzerException('Can not destructure ' . $type);
+        throw new AnalyzerException('Cannot destructure ' . $type);
     }
 
     /**

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -41,7 +41,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
         foreach ($parts as $part) {
             if ($this->isPHPKeyword($part)) {
                 throw AnalyzerException::withLocation(
-                    "The namespace is not valid. The part '{$part}' can not be used because it is a reserved keyword.",
+                    "The namespace is not valid. The part '{$part}' cannot be used because it is a reserved keyword.",
                     $list
                 );
             }
@@ -114,7 +114,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             return Symbol::create($parts[count($parts) - 1]);
         }
 
-        throw AnalyzerException::withLocation('Can not extract alias', $import);
+        throw AnalyzerException::withLocation('Cannot extract alias', $import);
     }
 
     /**

--- a/src/php/Compiler/Evaluator/Exceptions/FileException.php
+++ b/src/php/Compiler/Evaluator/Exceptions/FileException.php
@@ -10,11 +10,11 @@ final class FileException extends RuntimeException
 {
     public static function canNotCreateTempFile(): self
     {
-        return new self('Can not create temp file.');
+        return new self('Cannot create temp file.');
     }
 
     public static function canNotCreateFile(string $filename): self
     {
-        return new self('Can not require file: ' . $filename);
+        return new self('Cannot require file: ' . $filename);
     }
 }

--- a/src/php/Compiler/Parser/ParserNode/ListNode.php
+++ b/src/php/Compiler/Parser/ParserNode/ListNode.php
@@ -71,7 +71,7 @@ final class ListNode implements InnerNodeInterface
             case Token::T_TABLE:
                 return '@{';
             default:
-                throw new \RuntimeException('Can not find code prefix for token type: ' . $this->tokenType);
+                throw new \RuntimeException('Cannot find code prefix for token type: ' . $this->tokenType);
         }
     }
 
@@ -88,7 +88,7 @@ final class ListNode implements InnerNodeInterface
             case Token::T_TABLE:
                 return '}';
             default:
-                throw new \RuntimeException('Can not find code prefix for token type: ' . $this->tokenType);
+                throw new \RuntimeException('Cannot find code prefix for token type: ' . $this->tokenType);
         }
     }
 

--- a/src/php/Compiler/Parser/ParserNode/QuoteNode.php
+++ b/src/php/Compiler/Parser/ParserNode/QuoteNode.php
@@ -61,7 +61,7 @@ final class QuoteNode implements InnerNodeInterface
             case Token::T_QUASIQUOTE:
                 return '`';
             default:
-                throw new \RuntimeException('Can not find code prefix for token type: ' . $this->tokenType);
+                throw new \RuntimeException('Cannot find code prefix for token type: ' . $this->tokenType);
         }
     }
 

--- a/src/php/Compiler/Reader/Reader.php
+++ b/src/php/Compiler/Reader/Reader.php
@@ -48,7 +48,7 @@ final class Reader implements ReaderInterface
     public function read(NodeInterface $parseTree): ReaderResult
     {
         if ($parseTree instanceof TriviaNodeInterface) {
-            throw ReaderException::forNode($parseTree, $parseTree, 'Can not read from whitespace or comments');
+            throw ReaderException::forNode($parseTree, $parseTree, 'Cannot read from whitespace or comments');
         }
 
         return new ReaderResult(

--- a/src/php/Formatter/Exceptions/ZipperException.php
+++ b/src/php/Formatter/Exceptions/ZipperException.php
@@ -60,6 +60,6 @@ final class ZipperException extends RuntimeException
 
     public static function cannotGoLeftOnRootNode(): self
     {
-        return new self('Can not go left on the root node');
+        return new self('Cannot go left on the root node');
     }
 }

--- a/src/php/Formatter/Formatter/AbstractZipper.php
+++ b/src/php/Formatter/Formatter/AbstractZipper.php
@@ -90,7 +90,7 @@ abstract class AbstractZipper
         }
 
         if ($this->isFirst()) {
-            throw new ZipperException('Can not go left on the leftmost node');
+            throw new ZipperException('Cannot go left on the leftmost node');
         }
 
         $leftSiblings = $this->leftSiblings;

--- a/src/php/Lang/Collections/LinkedList/EmptyList.php
+++ b/src/php/Lang/Collections/LinkedList/EmptyList.php
@@ -53,7 +53,7 @@ class EmptyList extends AbstractType implements PersistentListInterface
 
     public function pop(): PersistentListInterface
     {
-        throw new RuntimeException('Can not pop empty list');
+        throw new RuntimeException('Cannot pop empty list');
     }
 
     public function count(): int

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -87,7 +87,7 @@ class SubVector extends AbstractPersistentVector
     {
         if ($this->start + $i > $this->end) {
             $count = $this->count();
-            throw new IndexOutOfBoundsException("Can not update index $i. Length of vector is $count");
+            throw new IndexOutOfBoundsException("Cannot update index $i. Length of vector is $count");
         }
 
         if ($this->start + $i === $this->end) {
@@ -106,7 +106,7 @@ class SubVector extends AbstractPersistentVector
             return $this->vector->get($i + $this->start);
         }
 
-        throw new IndexOutOfBoundsException("Can not access value at index $i.");
+        throw new IndexOutOfBoundsException("Cannot access value at index $i.");
     }
 
     public function pop(): PersistentVectorInterface

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -162,6 +162,6 @@ final class Printer implements PrinterInterface
             return new ObjectPrinter();
         }
 
-        throw new RuntimeException('Printer can not print this type: ' . $printerName);
+        throw new RuntimeException('Printer cannot print this type: ' . $printerName);
     }
 }

--- a/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
+++ b/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
@@ -16,7 +16,7 @@ final class NonPrintableClassPrinter implements TypePrinterInterface
      */
     public function print($form): string
     {
-        return 'Printer can not print this type: ' . $this->color(get_class($form));
+        return 'Printer cannot print this type: ' . $this->color(get_class($form));
     }
 
     private function color(string $str): string

--- a/src/php/Runtime/Runtime.php
+++ b/src/php/Runtime/Runtime.php
@@ -170,7 +170,7 @@ class Runtime implements RuntimeInterface
         $path = $this->getCachedFilePath($filename, $ns);
 
         if (!$path) {
-            throw new InvalidArgumentException("Can not load cached file: {$filename}");
+            throw new InvalidArgumentException("Cannot load cached file: {$filename}");
         }
 
         // Update global environment

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -246,9 +246,9 @@
 # Response
 # --------
 
-# TODO: Headers can not be tested at this point
+# TODO: Headers cannot be tested at this point
 # because the test script already has send some output
-# and new headers can not be send anymore.
+# and new headers cannot be send anymore.
 
 (deftest test-response
   (is (=

--- a/tests/php/Integration/Command/Repl/Fixtures/undefined-symbol.test
+++ b/tests/php/Integration/Command/Repl/Fixtures/undefined-symbol.test
@@ -1,6 +1,6 @@
 phel:1> (def my-fn (fn []
 ....:2>   (undefined-fn 1 2)))
-Can not resolve symbol 'undefined-fn'
+Cannot resolve symbol 'undefined-fn'
 in string:2
 
 1| (def my-fn (fn []

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -72,7 +72,7 @@ final class AnalyzeSymbolTest extends TestCase
     public function testUndefinedGlobalVar(): void
     {
         $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage("Can not resolve symbol 'a'");
+        $this->expectExceptionMessage("Cannot resolve symbol 'a'");
 
         $env = NodeEnvironment::empty();
         $this->symbolAnalyzer->analyze(Symbol::create('a'), $env);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -25,28 +25,28 @@ final class BindingValidatorTest extends TestCase
 
     public function testIntegerType(): void
     {
-        $this->expectExceptionMessage('Can not destructure integer');
+        $this->expectExceptionMessage('Cannot destructure integer');
 
         $this->validator->assertSupportedBinding(1);
     }
 
     public function testFloatType(): void
     {
-        $this->expectExceptionMessage('Can not destructure double');
+        $this->expectExceptionMessage('Cannot destructure double');
 
         $this->validator->assertSupportedBinding(1.99);
     }
 
     public function testStringType(): void
     {
-        $this->expectExceptionMessage('Can not destructure string');
+        $this->expectExceptionMessage('Cannot destructure string');
 
         $this->validator->assertSupportedBinding('');
     }
 
     public function testKeywordType(): void
     {
-        $this->expectExceptionMessage('Can not destructure Phel\Lang\Keyword');
+        $this->expectExceptionMessage('Cannot destructure Phel\Lang\Keyword');
 
         $this->validator->assertSupportedBinding(new Keyword('any'));
     }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -123,7 +123,7 @@ final class InvokeSymbolTest extends TestCase
     public function testMacroUndefinedMacro(): void
     {
         $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage('Can not resolve symbol \'user/my-undefined-macro\'');
+        $this->expectExceptionMessage('Cannot resolve symbol \'user/my-undefined-macro\'');
 
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::createForNamespace('user', 'my-undefined-macro'),

--- a/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
@@ -26,12 +26,12 @@ final class NonPrintableClassPrinterTest extends TestCase
     {
         yield 'Empty array' => [
             'form' => new DateTime(),
-            'expected ' => 'Printer can not print this type: DateTime',
+            'expected ' => 'Printer cannot print this type: DateTime',
         ];
 
         yield 'simple numeric list' => [
             'form' => new stdClass(),
-            'expected ' => 'Printer can not print this type: stdClass',
+            'expected ' => 'Printer cannot print this type: stdClass',
         ];
     }
 }


### PR DESCRIPTION
## 📚 Description

Replace `can not` by `cannot` in the message errors.

This word is correct only when it's written as a single word, you can check some information in this [link](https://www.grammarly.com/blog/cannot-or-can-not/). 😄 

- No logic was altered