### PR TITLE
Add execution time and resource usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=7.4",
         "phel-lang/phel-composer-plugin": "^0.2",
         "gacela-project/gacela": "^0.2.0",
-        "symfony/console": "^5.2"
+        "symfony/console": "^5.2",
+        "phpunit/php-timer": "^5.0"
     },
     "require-dev": {
         "ext-readline": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6da8e8dd527206388ddd68a9cfa2917e",
+    "content-hash": "c975e5f737203fdf0afffaf8a3e9dd3c",
     "packages": [
         {
             "name": "gacela-project/gacela",
@@ -123,6 +123,65 @@
                 "source": "https://github.com/phel-lang/phel-composer-plugin/tree/v0.2.0"
             },
             "time": "2021-05-12T18:25:31+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "psr/container",
@@ -3299,65 +3358,6 @@
                 }
             ],
             "time": "2020-10-26T05:33:50+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -10,9 +10,11 @@ use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Runtime\RuntimeFacadeInterface;
+use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -39,6 +41,11 @@ final class RunCommand extends Command
                 'path',
                 InputArgument::REQUIRED,
                 'The file path that you want to run.'
+            )->addOption(
+                'with-time',
+                't',
+                InputOption::VALUE_NONE,
+                'With time awareness'
             );
     }
 
@@ -55,6 +62,10 @@ final class RunCommand extends Command
             /** @var string $fileOrPath */
             $fileOrPath = $input->getArgument('path');
             $this->loadNamespace($fileOrPath);
+
+            if ($input->getOption('with-time')) {
+                $output->writeln((new ResourceUsageFormatter())->resourceUsageSinceStartOfRequest());
+            }
 
             return self::SUCCESS;
         } catch (CompilerException $e) {

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Runtime\RuntimeFacadeInterface;
+use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -64,6 +65,7 @@ final class TestCommand extends Command
             /** @var list<string> $paths */
             $paths = $input->getArgument('paths');
             $result = $this->evalNamespaces($paths);
+            $output->writeln((new ResourceUsageFormatter())->resourceUsageSinceStartOfRequest());
 
             return ($result) ? self::SUCCESS : self::FAILURE;
         } catch (CompilerException $e) {

--- a/tests/php/Integration/Command/Test/TestCommandTest.php
+++ b/tests/php/Integration/Command/Test/TestCommandTest.php
@@ -24,7 +24,11 @@ final class TestCommandTest extends AbstractCommandTest
             ->createTestCommand()
             ->addRuntimePath('test-cmd-project-success\\', [$currentDir]);
 
-        $this->expectOutputString("..\n\n\n\nPassed: 2\nFailed: 0\nError: 0\nTotal: 2\n");
+        $this->expectOutputRegex('/\.\..*/');
+        $this->expectOutputRegex('/.*Passed: 2.*/');
+        $this->expectOutputRegex('/.*Failed: 0.*/');
+        $this->expectOutputRegex('/.*Error: 0.*/');
+        $this->expectOutputRegex('/.*Total: 2.*/');
 
         $command->run($this->stubInput([]), $this->stubOutput());
     }
@@ -38,7 +42,11 @@ final class TestCommandTest extends AbstractCommandTest
             ->createTestCommand()
             ->addRuntimePath('test-cmd-project-success\\', [$currentDir]);
 
-        $this->expectOutputString(".\n\n\n\nPassed: 1\nFailed: 0\nError: 0\nTotal: 1\n");
+        $this->expectOutputRegex('/\..*/');
+        $this->expectOutputRegex('/.*Passed: 1.*/');
+        $this->expectOutputRegex('/.*Failed: 0.*/');
+        $this->expectOutputRegex('/.*Error: 0.*/');
+        $this->expectOutputRegex('/.*Total: 1.*/');
 
         $command->run(
             $this->stubInput([$currentDir . '/test1.phel']),
@@ -55,7 +63,11 @@ final class TestCommandTest extends AbstractCommandTest
             ->createTestCommand()
             ->addRuntimePath('test-cmd-project-failure\\', [$currentDir]);
 
-        $this->expectOutputRegex('/.*Failed\\: 1.*/');
+        $this->expectOutputRegex('/E.*/');
+        $this->expectOutputRegex('/.*Passed: 0.*/');
+        $this->expectOutputRegex('/.*Failed: 1.*/');
+        $this->expectOutputRegex('/.*Error: 0.*/');
+        $this->expectOutputRegex('/.*Total: 1.*/');
 
         $command->run($this->stubInput([]), $this->stubOutput());
     }


### PR DESCRIPTION
## 📚 Description

Add the total time that the "phel test" needs to complete. Similar as PHPUnit has. For example: 
```
......................................................................

Passed: 710
Failed: 0
Error: 0
Total: 710
Time: 00:21.911, Memory: 58.00 MB <------ 
```

## 🔖 Changes

- Require `phpunit/php-timer`, which has already this logic ready to be used 👌🏻
- Add execution time and resource usage always for `test` command and optional for `run` command.

## 🖼️  Screenshots

Some examples about how it looks like now:

<img width="1121" alt="Screenshot 2021-05-22 at 17 41 58" src="https://user-images.githubusercontent.com/5256287/119232302-03fc9100-bb25-11eb-9db4-79e0b09557ac.png">

