### PR TITLE
Add a filter option to test command

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -173,7 +173,11 @@
   (let [loc (location form) e (gensym)]
     `(try ,(assert-expr form message)
           (catch Throwable ,e
-            (report @{:state :error :location ,loc :message ,message :form ',form :exception ,e})))))
+            (report @{:state :error
+                      :location ,loc
+                      :message ,message
+                      :form ',form
+                      :exception ,e})))))
 
 # --------------
 # Defining tests
@@ -182,7 +186,7 @@
 (defmacro deftest
   "Defines a test function with no arguments"
   [name & body]
-  `(defn ,name {:test true} []
+  `(defn ,name {:test true :test-name ,name} []
      ,@body))
 
 # ---------------------
@@ -298,19 +302,22 @@
           :when (get meta :test)]
       (get-in php/$GLOBALS ["__phel" munge-ns fn-name]))))
 
-(defn- run-test [ns]
+(defn- run-test [options ns]
   (let [rt (php/:: \Phel\Runtime\RuntimeSingleton (getInstance))
         _ (php/-> rt (loadNs ns))
-        tests (find-test-fns ns)]
-    (dofor [test :in tests]
+        tests (find-test-fns ns)
+        filter-option (get options :filter)]
+    (for [test :in tests
+          :when (or (= filter-option nil)
+                    (str-contains? (php/:: test BOUND_TO) filter-option))]
       (test))))
 
 (defn run-tests
   "Runs all test functions in the given namespaces"
-  [& namespaces]
-  (dofor [n :in namespaces
-          :let [s (php/-> n (getName))]]
-    (run-test s))
+  [options & namespaces]
+  (dofor [namespace :in namespaces
+          :let [ns-name (php/-> namespace (getName))]]
+    (run-test options ns-name))
   (print-summary))
 
 (defn successful?

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -294,22 +294,19 @@
 # Running tests
 # -------------
 
-(defn- find-test-fns [ns]
+(defn- find-test-fns [ns {:filter filter}]
   (let [munge (php/new Munge)
         munge-ns (php/-> munge (encodeNs ns))]
     (for [fn-name :keys (get-in php/$GLOBALS ["__phel" munge-ns])
           :let [meta (get-in php/$GLOBALS ["__phel_meta" munge-ns fn-name])]
-          :when (get meta :test)]
+          :when (and (:test meta) (or (nil? filter) (str-contains? (:test-name meta) filter)))]
       (get-in php/$GLOBALS ["__phel" munge-ns fn-name]))))
 
 (defn- run-test [options ns]
   (let [rt (php/:: \Phel\Runtime\RuntimeSingleton (getInstance))
         _ (php/-> rt (loadNs ns))
-        tests (find-test-fns ns)
-        filter-option (get options :filter)]
-    (for [test :in tests
-          :when (or (= filter-option nil)
-                    (str-contains? (php/:: test BOUND_TO) filter-option))]
+        tests (find-test-fns ns options)]
+    (dofor [test :in tests]
       (test))))
 
 (defn run-tests

--- a/src/php/Command/Test/TestCommandOptions.php
+++ b/src/php/Command/Test/TestCommandOptions.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command\Test;
+
+use Phel\Lang\TypeFactory;
+use Phel\Printer\Printer;
+
+final class TestCommandOptions
+{
+    public const FILTER = 'filter';
+
+    private string $filter = '';
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public static function fromArray(array $options): self
+    {
+        $self = new self();
+        $self->filter = $options[self::FILTER] ?? '';
+
+        return $self;
+    }
+
+    public function asPhelHashMap(): string
+    {
+        $filter = empty($this->filter) ? 'nil' : sprintf('"%s"', $this->filter);
+
+        $optionsMap = TypeFactory::getInstance()
+            ->persistentMapFromKVs(':filter', $filter);
+
+        return Printer::nonReadable()->print($optionsMap);
+    }
+}

--- a/src/php/Command/Test/TestCommandOptions.php
+++ b/src/php/Command/Test/TestCommandOptions.php
@@ -28,11 +28,15 @@ final class TestCommandOptions
 
     public function asPhelHashMap(): string
     {
-        $filter = empty($this->filter) ? 'nil' : sprintf('"%s"', $this->filter);
+        $filter = empty($this->filter) ? null : $this->filter;
 
-        $optionsMap = TypeFactory::getInstance()
-            ->persistentMapFromKVs(':filter', $filter);
+        $typeFactory = TypeFactory::getInstance();
 
-        return Printer::nonReadable()->print($optionsMap);
+        $optionsMap = $typeFactory->persistentMapFromKVs(
+            $typeFactory->keyword(self::FILTER),
+            $filter
+        );
+
+        return Printer::readable()->print($optionsMap);
     }
 }

--- a/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Test;
+
+use Phel\Command\Test\TestCommandOptions;
+use PHPUnit\Framework\TestCase;
+
+final class TestCommandOptionsTest extends TestCase
+{
+    public function testEmptyFilter(): void
+    {
+        $options = TestCommandOptions::empty();
+
+        self::assertSame('{:filter nil}', $options->asPhelHashMap());
+    }
+
+    public function testRandomFilter(): void
+    {
+        $options = TestCommandOptions::fromArray(['filter' => 'example']);
+
+        self::assertSame('{:filter "example"}', $options->asPhelHashMap());
+    }
+}


### PR DESCRIPTION
## 📚 Description

Implementing a filter option for the test command, so you can run the tests by their name.
I applied some feedback from the other PR: https://github.com/phel-lang/phel-lang/pull/277/files

## 🔖 Changes

- Added: `:test-name` to the test macro
- Created `TestCommandOptions` to encapsulate all options for the `TestCommand`
