### PR TITLE
Move NamespaceExtractor from Compile module to its own module

### DIFF
--- a/src/php/Command/CommandDependencyProvider.php
+++ b/src/php/Command/CommandDependencyProvider.php
@@ -12,6 +12,8 @@ use Phel\Formatter\FormatterFacade;
 use Phel\Formatter\FormatterFacadeInterface;
 use Phel\Interop\InteropFacade;
 use Phel\Interop\InteropFacadeInterface;
+use Phel\NamespaceExtractor\NamespaceExtractorFacade;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 use Phel\Runtime\RuntimeFacadeInterface;
 
@@ -21,6 +23,7 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
     public const FACADE_FORMATTER = 'FACADE_FORMATTER';
     public const FACADE_INTEROP = 'FACADE_INTEROP';
     public const FACADE_RUNTIME = 'FACADE_RUNTIME';
+    public const FACADE_NAMESPACE_EXTRACTOR = 'FACADE_NAMESPACE_EXTRACTOR';
 
     public function provideModuleDependencies(Container $container): void
     {
@@ -28,6 +31,7 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
         $this->addFacadeFormatter($container);
         $this->addFacadeInterop($container);
         $this->addFacadeRuntime($container);
+        $this->addFacadeNamespaceExtractor($container);
     }
 
     private function addFacadeCompiler(Container $container): void
@@ -55,6 +59,13 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
     {
         $container->set(self::FACADE_RUNTIME, function (Container $container): RuntimeFacadeInterface {
             return $container->getLocator()->get(RuntimeFacade::class);
+        });
+    }
+
+    private function addFacadeNamespaceExtractor(Container $container): void
+    {
+        $container->set(self::FACADE_NAMESPACE_EXTRACTOR, function (Container $container): NamespaceExtractorFacadeInterface {
+            return $container->getLocator()->get(NamespaceExtractorFacade::class);
         });
     }
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -21,6 +21,7 @@ use Phel\Command\Test\TestCommand;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Formatter\FormatterFacadeInterface;
 use Phel\Interop\InteropFacadeInterface;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
 use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
@@ -52,7 +53,7 @@ final class CommandFactory extends AbstractFactory
         return new RunCommand(
             $this->createCommandExceptionWriter(),
             $this->getRuntimeFacade(),
-            $this->getCompilerFacade()
+            $this->getNamespaceExtractorFacade()
         );
     }
 
@@ -62,6 +63,7 @@ final class CommandFactory extends AbstractFactory
             $this->createCommandExceptionWriter(),
             $this->getRuntimeFacade(),
             $this->getCompilerFacade(),
+            $this->getNamespaceExtractorFacade(),
             $this->getConfig()->getTestDirectories()
         );
     }
@@ -137,5 +139,10 @@ final class CommandFactory extends AbstractFactory
     private function getRuntimeFacade(): RuntimeFacadeInterface
     {
         return $this->getProvidedDependency(CommandDependencyProvider::FACADE_RUNTIME);
+    }
+
+    private function getNamespaceExtractorFacade(): NamespaceExtractorFacadeInterface
+    {
+        return $this->getProvidedDependency(CommandDependencyProvider::FACADE_NAMESPACE_EXTRACTOR);
     }
 }

--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -6,10 +6,10 @@ namespace Phel\Command\Run;
 
 use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
 use Phel\Command\Shared\CommandExceptionWriterInterface;
-use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
@@ -25,17 +25,17 @@ final class RunCommand extends Command
 
     private CommandExceptionWriterInterface $exceptionWriter;
     private RuntimeFacadeInterface $runtimeFacade;
-    private CompilerFacadeInterface $compilerFacade;
+    private NamespaceExtractorFacadeInterface $namespaceExtractorFacade;
 
     public function __construct(
         CommandExceptionWriterInterface $exceptionWriter,
         RuntimeFacadeInterface $runtimeFacade,
-        CompilerFacadeInterface $compilerFacade
+        NamespaceExtractorFacadeInterface $namespaceExtractorFacade
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->exceptionWriter = $exceptionWriter;
         $this->runtimeFacade = $runtimeFacade;
-        $this->compilerFacade = $compilerFacade;
+        $this->namespaceExtractorFacade = $namespaceExtractorFacade;
     }
 
     protected function configure(): void
@@ -90,7 +90,7 @@ final class RunCommand extends Command
     private function loadNamespace(string $fileOrPath): void
     {
         $ns = file_exists($fileOrPath)
-            ? $this->compilerFacade->extractNamespaceFromFile($fileOrPath)->getNamespace()
+            ? $this->namespaceExtractorFacade->getNamespaceFromFile($fileOrPath)->getNamespace()
             : $fileOrPath;
 
         $result = $this->runtimeFacade->getRuntime()->loadNs($ns);

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -11,6 +11,7 @@ use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
@@ -27,6 +28,7 @@ final class TestCommand extends Command
     private CommandExceptionWriterInterface $exceptionWriter;
     private RuntimeFacadeInterface $runtimeFacade;
     private CompilerFacadeInterface $compilerFacade;
+    private NamespaceExtractorFacadeInterface $namespaceExtractor;
     /** @var list<string> */
     private array $defaultTestDirectories;
 
@@ -34,12 +36,14 @@ final class TestCommand extends Command
         CommandExceptionWriterInterface $exceptionWriter,
         RuntimeFacadeInterface $runtimeFacade,
         CompilerFacadeInterface $compilerFacade,
+        NamespaceExtractorFacadeInterface $namespaceExtractor,
         array $testDirectories
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->exceptionWriter = $exceptionWriter;
         $this->runtimeFacade = $runtimeFacade;
         $this->compilerFacade = $compilerFacade;
+        $this->namespaceExtractor = $namespaceExtractor;
         $this->defaultTestDirectories = $testDirectories;
     }
 
@@ -127,13 +131,13 @@ final class TestCommand extends Command
     {
         if (empty($paths)) {
             return array_map(
-                fn (NsNode $node): string => $node->getNamespace(),
-                $this->compilerFacade->extractNamespaceFromDirectories($this->defaultTestDirectories)
+                static fn (NsNode $node): string => $node->getNamespace(),
+                $this->namespaceExtractor->getNamespaceFromDirectories($this->defaultTestDirectories)
             );
         }
 
         return array_map(
-            fn (string $filename): string => $this->compilerFacade->extractNamespaceFromFile($filename)->getNamespace(),
+            fn (string $filename): string => $this->namespaceExtractor->getNamespaceFromFile($filename)->getNamespace(),
             $paths
         );
     }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Phel\Compiler;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\Compiler\Analyzer\Ast\NsNode;
+use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Compiler\CodeCompiler;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
@@ -19,12 +21,25 @@ use Phel\Compiler\Parser\ParserNode\FileNode;
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Reader\Exceptions\ReaderException;
+use Phel\Lang\TypeInterface;
 
 /**
  * @method CompilerFactory getFactory()
  */
 final class CompilerFacade extends AbstractFacade implements CompilerFacadeInterface
 {
+    /**
+     * @param TypeInterface|string|float|int|bool|null $x
+     *
+     * @throws AnalyzerException
+     */
+    public function analyze($x, NodeEnvironmentInterface $env): AbstractNode
+    {
+        return $this->getFactory()
+            ->createAnalyzer()
+            ->analyze($x, $env);
+    }
+
     /**
      * @throws CompilerException|UnfinishedParserException
      *
@@ -101,19 +116,5 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
         return $this->getFactory()
             ->createReader()
             ->read($parseTree);
-    }
-
-    public function extractNamespaceFromFile(string $filename): NsNode
-    {
-        return $this->getFactory()
-            ->createNamespaceExtractor()
-            ->getNamespaceFromFile($filename);
-    }
-
-    public function extractNamespaceFromDirectories(array $directories): array
-    {
-        return $this->getFactory()
-            ->createNamespaceExtractor()
-            ->getNamespacesFromDirectories($directories);
     }
 }

--- a/src/php/Compiler/CompilerFacadeInterface.php
+++ b/src/php/Compiler/CompilerFacadeInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Compiler;
 
-use Phel\Compiler\Analyzer\Ast\NsNode;
+use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Compiler\CodeCompiler;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
@@ -18,9 +20,17 @@ use Phel\Compiler\Parser\ParserNode\FileNode;
 use Phel\Compiler\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Reader\Exceptions\ReaderException;
+use Phel\Lang\TypeInterface;
 
 interface CompilerFacadeInterface
 {
+    /**
+     * @param TypeInterface|string|float|int|bool|null $x
+     *
+     * @throws AnalyzerException
+     */
+    public function analyze($x, NodeEnvironmentInterface $env): AbstractNode;
+
     /**
      * @throws CompilerException|UnfinishedParserException
      *
@@ -56,24 +66,4 @@ interface CompilerFacadeInterface
      * @throws UnfinishedParserException
      */
     public function parseAll(TokenStream $tokenStream): FileNode;
-
-    /**
-     * Extracts the namespace from a given file. It expects that the
-     * first statement in the file is the 'ns statement.
-     *
-     * @param string $filename The path to the file
-     *
-     * @return NsNode
-     */
-    public function extractNamespaceFromFile(string $filename): NsNode;
-
-    /**
-     * Extracts all namespaces from all Phel files in the given directories.
-     * It expects that the first statement in the file is the 'ns statement.
-     *
-     * @param string[] $directories The list of the directories
-     *
-     * @return NsNode[]
-     */
-    public function extractNamespaceFromDirectories(array $directories): array;
 }

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -11,7 +11,6 @@ use Phel\Compiler\Compiler\CodeCompiler;
 use Phel\Compiler\Compiler\CodeCompilerInterface;
 use Phel\Compiler\Compiler\EvalCompiler;
 use Phel\Compiler\Compiler\EvalCompilerInterface;
-use Phel\Compiler\Compiler\NamespaceExtractor;
 use Phel\Compiler\Emitter\Emitter;
 use Phel\Compiler\Emitter\EmitterInterface;
 use Phel\Compiler\Emitter\OutputEmitter;
@@ -57,16 +56,6 @@ final class CompilerFactory extends AbstractFactory
             $this->createAnalyzer(),
             $this->createEmitter($enableSourceMaps),
             $this->createEvaluator()
-        );
-    }
-
-    public function createNamespaceExtractor(): NamespaceExtractor
-    {
-        return new NamespaceExtractor(
-            $this->createLexer(),
-            $this->createParser(),
-            $this->createReader(),
-            $this->createAnalyzer()
         );
     }
 

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Interop\ExportFinder;
 
 use Phel\Compiler\Compiler\ExtractorException;
-use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
@@ -13,22 +12,23 @@ use Phel\Interop\ReadModel\FunctionToExport;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 
 final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 {
     private RuntimeFacadeInterface $runtimeFacade;
-    private CompilerFacadeInterface $compilerFacade;
+    private NamespaceExtractorFacadeInterface $namespaceExtractorFacade;
     /** @var list<string> */
     private array $exportDirectories;
 
     public function __construct(
         RuntimeFacadeInterface $runtimeFacade,
-        CompilerFacadeInterface $compilerFacade,
+        NamespaceExtractorFacadeInterface $namespaceExtractorFacade,
         array $exportDirectories
     ) {
         $this->runtimeFacade = $runtimeFacade;
-        $this->compilerFacade = $compilerFacade;
+        $this->namespaceExtractorFacade = $namespaceExtractorFacade;
         $this->exportDirectories = $exportDirectories;
     }
 
@@ -57,8 +57,8 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
     {
         $runtime = $this->runtimeFacade->getRuntime();
 
-        $namespaceFromDirectories = $this->compilerFacade
-            ->extractNamespaceFromDirectories($this->exportDirectories);
+        $namespaceFromDirectories = $this->namespaceExtractorFacade
+            ->getNamespaceFromDirectories($this->exportDirectories);
 
         foreach ($namespaceFromDirectories as $namespaceNode) {
             $runtime->loadNs($namespaceNode->getNamespace());

--- a/src/php/Interop/InteropDependencyProvider.php
+++ b/src/php/Interop/InteropDependencyProvider.php
@@ -6,20 +6,20 @@ namespace Phel\Interop;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
-use Phel\Compiler\CompilerFacade;
-use Phel\Compiler\CompilerFacadeInterface;
+use Phel\NamespaceExtractor\NamespaceExtractorFacade;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 use Phel\Runtime\RuntimeFacadeInterface;
 
 final class InteropDependencyProvider extends AbstractDependencyProvider
 {
     public const FACADE_RUNTIME = 'FACADE_RUNTIME';
-    public const FACADE_COMPILER = 'FACADE_COMPILER';
+    public const FACADE_NAMESPACE_EXTRACTOR = 'FACADE_NAMESPACE_EXTRACTOR';
 
     public function provideModuleDependencies(Container $container): void
     {
         $this->addFacadeRuntime($container);
-        $this->addFacadeCompiler($container);
+        $this->addFacadeNamespaceExtractor($container);
     }
 
     private function addFacadeRuntime(Container $container): void
@@ -29,10 +29,10 @@ final class InteropDependencyProvider extends AbstractDependencyProvider
         });
     }
 
-    private function addFacadeCompiler(Container $container): void
+    private function addFacadeNamespaceExtractor(Container $container): void
     {
-        $container->set(self::FACADE_COMPILER, function (Container $container): CompilerFacadeInterface {
-            return $container->getLocator()->get(CompilerFacade::class);
+        $container->set(self::FACADE_NAMESPACE_EXTRACTOR, function (Container $container): NamespaceExtractorFacadeInterface {
+            return $container->getLocator()->get(NamespaceExtractorFacade::class);
         });
     }
 }

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Interop;
 
 use Gacela\Framework\AbstractFactory;
-use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Interop\DirectoryRemover\DirectoryRemover;
 use Phel\Interop\DirectoryRemover\DirectoryRemoverInterface;
 use Phel\Interop\ExportFinder\FunctionsToExportFinder;
@@ -18,6 +17,7 @@ use Phel\Interop\Generator\Builder\CompiledPhpClassBuilder;
 use Phel\Interop\Generator\Builder\CompiledPhpMethodBuilder;
 use Phel\Interop\Generator\Builder\WrapperRelativeFilenamePathBuilder;
 use Phel\Interop\Generator\WrapperGenerator;
+use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 
 /**
@@ -37,7 +37,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new FunctionsToExportFinder(
             $this->getRuntimeFacade(),
-            $this->getCompilerFacade(),
+            $this->getNamespaceExtractorFacade(),
             $this->getConfig()->getExportDirectories()
         );
     }
@@ -75,8 +75,8 @@ final class InteropFactory extends AbstractFactory
         return $this->getProvidedDependency(InteropDependencyProvider::FACADE_RUNTIME);
     }
 
-    private function getCompilerFacade(): CompilerFacadeInterface
+    private function getNamespaceExtractorFacade(): NamespaceExtractorFacadeInterface
     {
-        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_COMPILER);
+        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_NAMESPACE_EXTRACTOR);
     }
 }

--- a/src/php/NamespaceExtractor/NamespaceExtractorDependencyProvider.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorDependencyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\NamespaceExtractor;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\CompilerFacadeInterface;
+
+final class NamespaceExtractorDependencyProvider extends AbstractDependencyProvider
+{
+    public const FACADE_COMPILER = 'FACADE_COMPILER';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $this->addFacadeRuntime($container);
+    }
+
+    private function addFacadeRuntime(Container $container): void
+    {
+        $container->set(self::FACADE_COMPILER, function (Container $container): CompilerFacadeInterface {
+            return $container->getLocator()->get(CompilerFacade::class);
+        });
+    }
+}

--- a/src/php/NamespaceExtractor/NamespaceExtractorFacade.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFacade.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\NamespaceExtractor;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Compiler\Analyzer\Ast\NsNode;
+
+/**
+ * @method NamespaceExtractorFactory getFactory()
+ */
+final class NamespaceExtractorFacade extends AbstractFacade implements NamespaceExtractorFacadeInterface
+{
+    /**
+     * Extracts the namespace from a given file. It expects that the
+     * first statement in the file is the 'ns statement.
+     *
+     * @param string $filename The path to the file
+     *
+     * @return NsNode
+     */
+    public function getNamespaceFromFile(string $filename): NsNode
+    {
+        return $this->getFactory()
+            ->createNamespaceExtractor()
+            ->getNamespaceFromFile($filename);
+    }
+
+    /**
+     * Extracts all namespaces from all Phel files in the given directories.
+     * It expects that the first statement in the file is the 'ns statement.
+     *
+     * @param string[] $directories The list of the directories
+     *
+     * @return NsNode[]
+     */
+    public function getNamespaceFromDirectories(array $directories): array
+    {
+        return $this->getFactory()
+            ->createNamespaceExtractor()
+            ->getNamespacesFromDirectories($directories);
+    }
+}

--- a/src/php/NamespaceExtractor/NamespaceExtractorFacadeInterface.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFacadeInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\NamespaceExtractor;
+
+use Phel\Compiler\Analyzer\Ast\NsNode;
+
+interface NamespaceExtractorFacadeInterface
+{
+    /**
+     * Extracts the namespace from a given file. It expects that the
+     * first statement in the file is the 'ns statement.
+     *
+     * @param string $filename The path to the file
+     *
+     * @return NsNode
+     */
+    public function getNamespaceFromFile(string $filename): NsNode;
+
+    /**
+     * Extracts all namespaces from all Phel files in the given directories.
+     * It expects that the first statement in the file is the 'ns statement.
+     *
+     * @param string[] $directories The list of the directories
+     *
+     * @return NsNode[]
+     */
+    public function getNamespaceFromDirectories(array $directories): array;
+}

--- a/src/php/NamespaceExtractor/NamespaceExtractorFactory.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\NamespaceExtractor;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Compiler\Compiler\NamespaceExtractor;
+use Phel\Compiler\CompilerFacadeInterface;
+
+final class NamespaceExtractorFactory extends AbstractFactory
+{
+    public function createNamespaceExtractor(): NamespaceExtractor
+    {
+        return new NamespaceExtractor(
+            $this->getCompilerFacade()
+        );
+    }
+
+    private function getCompilerFacade(): CompilerFacadeInterface
+    {
+        return $this->getProvidedDependency(NamespaceExtractorDependencyProvider::FACADE_COMPILER);
+    }
+}


### PR DESCRIPTION
## 📚 Description

In order to decrease the responsibilities of the Compiler module (its Facade interface shows how many things can that module do; aka its responsibilities), I would rather encapsulate these two new responsibilities in another module.

## 🔖 Changes

- Move `NamespaceExtractor` from Compile module to its own module 
