### PR TITLE
Minor clean-up on Code|EvalCompiler

### DIFF
--- a/src/php/Compiler/Compiler/EvalCompilerInterface.php
+++ b/src/php/Compiler/Compiler/EvalCompilerInterface.php
@@ -16,5 +16,5 @@ interface EvalCompilerInterface
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $code, int $startingLine = 1);
+    public function eval(string $phelCode, int $startingLine = 1);
 }


### PR DESCRIPTION
## 📚 Description

**CodeCompiler vs EvalCompiler**
- Does it makes sense to DRY the `EvalCompiler`?
- Can we use the `CodeCompiler` inside the `EvalCompiler` in order to avoid code duplication?

The answer is "nope". I think these two compilers have different responsibilities and they have different purposes and, actually, different logic and behavior inside. They look a bit similar (indeed; they share part of the namespace `Compiler`) but so far I wasn't able to find a way to combine them in a good way.

I like how it is for now. Maybe I will come back to this one in the future.

## 🔖 Changes

- Apply some minor clean-up on `CodeCompiler` & `EvalCompiler` in order to improve readability. 
