### PR TITLE
Add php_unit_method_casing rule to csfixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -30,6 +30,7 @@ return PhpCsFixer\Config::create()
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,
     'ordered_imports' => true,
+    'php_unit_method_casing' => ['case' => 'snake_case'],
     'phpdoc_add_missing_param_annotation' => true,
     'phpdoc_annotation_without_dot' => true,
     'phpdoc_indent' => true,

--- a/tests/php/Integration/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Command/Export/ExportCommandTest.php
@@ -16,7 +16,7 @@ final class ExportCommandTest extends AbstractCommandTest
         Config::setApplicationRootDir(__DIR__);
     }
 
-    public function testExportCommandMultiple(): void
+    public function test_export_command_multiple(): void
     {
         $command = $this
             ->createCommandFactory()

--- a/tests/php/Integration/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Command/Format/FormatCommandTest.php
@@ -17,7 +17,7 @@ final class FormatCommandTest extends AbstractCommandTest
         Config::setApplicationRootDir(__DIR__);
     }
 
-    public function testGoodFormat(): void
+    public function test_good_format(): void
     {
         $path = self::FIXTURES_DIR . 'good-format.phel';
         $oldContent = file_get_contents($path);
@@ -38,7 +38,7 @@ final class FormatCommandTest extends AbstractCommandTest
         }
     }
 
-    public function testBadFormat(): void
+    public function test_bad_format(): void
     {
         $path = self::FIXTURES_DIR . 'bad-format.phel';
         $oldContent = file_get_contents($path);

--- a/tests/php/Integration/Command/Repl/ColorStyleTest.php
+++ b/tests/php/Integration/Command/Repl/ColorStyleTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ColorStyleTest extends TestCase
 {
-    public function testCustomColor(): void
+    public function test_custom_color(): void
     {
         $color = 'custom';
         $format = 'begin %s end';
@@ -22,7 +22,7 @@ final class ColorStyleTest extends TestCase
         );
     }
 
-    public function testDefaultColors(): void
+    public function test_default_colors(): void
     {
         $style = ColorStyle::withStyles();
         $anyText = 'any text';

--- a/tests/php/Integration/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Command/Repl/ReplCommandTest.php
@@ -34,7 +34,7 @@ final class ReplCommandTest extends AbstractCommandTest
     /**
      * @dataProvider providerIntegration
      */
-    public function testIntegration(string $expectedOutput, InputLine ...$inputs): void
+    public function test_integration(string $expectedOutput, InputLine ...$inputs): void
     {
         $io = $this->createReplTestIo();
         $io->setInputs(...$inputs);

--- a/tests/php/Integration/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Command/Run/RunCommandTest.php
@@ -15,7 +15,7 @@ final class RunCommandTest extends AbstractCommandTest
         Config::setApplicationRootDir(__DIR__);
     }
 
-    public function testRunByNamespace(): void
+    public function test_run_by_namespace(): void
     {
         $this->expectOutputRegex('~hello world~');
 
@@ -28,7 +28,7 @@ final class RunCommandTest extends AbstractCommandTest
             );
     }
 
-    public function testRunByFilename(): void
+    public function test_run_by_filename(): void
     {
         $this->expectOutputRegex('~hello world~');
 
@@ -41,7 +41,7 @@ final class RunCommandTest extends AbstractCommandTest
             );
     }
 
-    public function testCannotParseFile(): void
+    public function test_cannot_parse_file(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-not-parsable.phel';
         $this->expectOutputRegex(sprintf('~Cannot parse file: %s~', $filename));
@@ -51,7 +51,7 @@ final class RunCommandTest extends AbstractCommandTest
             ->run($this->stubInput($filename), $this->stubOutput());
     }
 
-    public function testCannotReadFile(): void
+    public function test_cannot_read_file(): void
     {
         $filename = __DIR__ . '/Fixtures/this-file-does-not-exist.phel';
         $this->expectOutputRegex(sprintf('~Cannot load namespace: %s~', $filename));
@@ -61,7 +61,7 @@ final class RunCommandTest extends AbstractCommandTest
             ->run($this->stubInput($filename), $this->stubOutput());
     }
 
-    public function testFileWithoutNs(): void
+    public function test_file_without_ns(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-without-ns.phel';
         $this->expectOutputRegex(sprintf('~Cannot extract namespace from file: %s~', $filename));

--- a/tests/php/Integration/Command/Test/TestCommandTest.php
+++ b/tests/php/Integration/Command/Test/TestCommandTest.php
@@ -15,7 +15,7 @@ final class TestCommandTest extends AbstractCommandTest
         Config::setApplicationRootDir(__DIR__);
     }
 
-    public function testAllInProject(): void
+    public function test_all_in_project(): void
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-success/';
 
@@ -33,7 +33,7 @@ final class TestCommandTest extends AbstractCommandTest
         $command->run($this->stubInput([]), $this->stubOutput());
     }
 
-    public function testOneFileInProject(): void
+    public function test_one_file_in_project(): void
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-success/';
 
@@ -54,7 +54,7 @@ final class TestCommandTest extends AbstractCommandTest
         );
     }
 
-    public function testAllInFailedProject(): void
+    public function test_all_in_failed_project(): void
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-failure/';
 

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -42,7 +42,7 @@ final class ParserTest extends TestCase
         $this->compilerFacade = new CompilerFacade();
     }
 
-    public function testReadNumber(): void
+    public function test_read_number(): void
     {
         self::assertEquals(new NumberNode('1', $this->loc(1, 0), $this->loc(1, 1), 1), $this->parse('1'));
         self::assertEquals(new NumberNode('10', $this->loc(1, 0), $this->loc(1, 2), 10), $this->parse('10'));
@@ -65,7 +65,7 @@ final class ParserTest extends TestCase
         self::assertEquals(new NumberNode('7E-10', $this->loc(1, 0), $this->loc(1, 5), 7E-10), $this->parse('7E-10'));
     }
 
-    public function testReadKeyword(): void
+    public function test_read_keyword(): void
     {
         self::assertEquals(
             new KeywordNode(':test', $this->loc(1, 0), $this->loc(1, 5), new Keyword('test')),
@@ -73,7 +73,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadBoolean(): void
+    public function test_read_boolean(): void
     {
         self::assertEquals(
             new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true),
@@ -85,7 +85,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadNil(): void
+    public function test_read_nil(): void
     {
         self::assertEquals(
             new NilNode('nil', $this->loc(1, 0), $this->loc(1, 3), null),
@@ -93,7 +93,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadSymbol(): void
+    public function test_read_symbol(): void
     {
         self::assertEquals(
             new SymbolNode('test', $this->loc(1, 0), $this->loc(1, 4), Symbol::create('test')),
@@ -101,7 +101,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadList(): void
+    public function test_read_list(): void
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 2), []),
@@ -131,7 +131,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testRdlistBracket(): void
+    public function test_rdlist_bracket(): void
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 0), $this->loc(1, 2), []),
@@ -161,7 +161,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testQuote(): void
+    public function test_quote(): void
     {
         self::assertEquals(
             new QuoteNode(
@@ -174,7 +174,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testUnquote(): void
+    public function test_unquote(): void
     {
         self::assertEquals(
             new QuoteNode(
@@ -187,7 +187,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testUnquoteSplice(): void
+    public function test_unquote_splice(): void
     {
         self::assertEquals(
             new QuoteNode(
@@ -200,7 +200,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testQuasiquote1(): void
+    public function test_quasiquote1(): void
     {
         self::assertEquals(
             new QuoteNode(
@@ -213,7 +213,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testQuasiquote2(): void
+    public function test_quasiquote2(): void
     {
         self::assertEquals(
             new QuoteNode(
@@ -226,7 +226,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadString(): void
+    public function test_read_string(): void
     {
         self::assertEquals(
             new StringNode('"abc"', $this->loc(1, 0), $this->loc(1, 5), 'abc'),
@@ -279,7 +279,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadEmptyArray(): void
+    public function test_read_empty_array(): void
     {
         self::assertEquals(
             new ListNode(Token::T_ARRAY, $this->loc(1, 0), $this->loc(1, 3), []),
@@ -287,7 +287,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadArray1(): void
+    public function test_read_array1(): void
     {
         self::assertEquals(
             new ListNode(Token::T_ARRAY, $this->loc(1, 0), $this->loc(1, 4), [
@@ -297,7 +297,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadArray2(): void
+    public function test_read_array2(): void
     {
         self::assertEquals(
             new ListNode(Token::T_ARRAY, $this->loc(1, 0), $this->loc(1, 6), [
@@ -309,7 +309,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadEmptyMap(): void
+    public function test_read_empty_map(): void
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACE, $this->loc(1, 0), $this->loc(1, 2), []),
@@ -317,7 +317,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadMap1(): void
+    public function test_read_map1(): void
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACE, $this->loc(1, 0), $this->loc(1, 6), [
@@ -329,7 +329,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadMap2(): void
+    public function test_read_map2(): void
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACE, $this->loc(1, 0), $this->loc(1, 11), [
@@ -345,7 +345,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadEmptyTable(): void
+    public function test_read_empty_table(): void
     {
         self::assertEquals(
             new ListNode(Token::T_TABLE, $this->loc(1, 0), $this->loc(1, 3), []),
@@ -353,7 +353,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadTable1(): void
+    public function test_read_table1(): void
     {
         self::assertEquals(
             new ListNode(Token::T_TABLE, $this->loc(1, 0), $this->loc(1, 7), [
@@ -365,7 +365,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadTable2(): void
+    public function test_read_table2(): void
     {
         self::assertEquals(
             new ListNode(Token::T_TABLE, $this->loc(1, 0), $this->loc(1, 12), [
@@ -381,7 +381,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testMetaKeyword(): void
+    public function test_meta_keyword(): void
     {
         self::assertEquals(
             new MetaNode(
@@ -397,7 +397,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testMetaString(): void
+    public function test_meta_string(): void
     {
         self::assertEquals(
             new MetaNode(
@@ -413,7 +413,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testMetaSymbol(): void
+    public function test_meta_symbol(): void
     {
         self::assertEquals(
             new MetaNode(
@@ -429,7 +429,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testMetaTable(): void
+    public function test_meta_table(): void
     {
         self::assertEquals(
             new MetaNode(
@@ -453,7 +453,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testConcatMeta(): void
+    public function test_concat_meta(): void
     {
         self::assertEquals(
             new MetaNode(
@@ -477,7 +477,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadShortFnZeroArgs(): void
+    public function test_read_short_fn_zero_args(): void
     {
         self::assertEquals(
             new ListNode(Token::T_FN, $this->loc(1, 0), $this->loc(1, 6), [
@@ -487,7 +487,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadShortFnOneArg(): void
+    public function test_read_short_fn_one_arg(): void
     {
         self::assertEquals(
             new ListNode(Token::T_FN, $this->loc(1, 0), $this->loc(1, 8), [
@@ -499,35 +499,35 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadUnbalancedClosedParen(): void
+    public function test_read_unbalanced_closed_paren(): void
     {
         $this->expectException(AbstractParserException::class);
         $this->expectExceptionMessage('Unterminated list');
         $this->parse(')');
     }
 
-    public function testReadUnbalancedOpenParen(): void
+    public function test_read_unbalanced_open_paren(): void
     {
         $this->expectException(AbstractParserException::class);
         $this->expectExceptionMessage('Unterminated list');
         $this->parse('(');
     }
 
-    public function testReadUnbalancedOpenBrace(): void
+    public function test_read_unbalanced_open_brace(): void
     {
         $this->expectException(AbstractParserException::class);
         $this->expectExceptionMessage('Unterminated list');
         $this->parse('{');
     }
 
-    public function testEOF(): void
+    public function test_eof(): void
     {
         $tokenStream = $this->compilerFacade->lexString('');
 
         self::assertNull($this->compilerFacade->parseNext($tokenStream));
     }
 
-    public function testInvalidGenerator(): void
+    public function test_invalid_generator(): void
     {
         $tokenStream = $this->compilerFacade->lexString('');
 
@@ -535,7 +535,7 @@ final class ParserTest extends TestCase
         self::assertNull($this->compilerFacade->parseNext($tokenStream));
     }
 
-    public function testReadComment(): void
+    public function test_read_comment(): void
     {
         self::assertEquals(
             new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)),
@@ -543,7 +543,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadWhitespaceOnly(): void
+    public function test_read_whitespace_only(): void
     {
         self::assertEquals(
             new WhitespaceNode(" \t", $this->loc(1, 0), $this->loc(1, 2)),
@@ -551,7 +551,7 @@ final class ParserTest extends TestCase
         );
     }
 
-    public function testReadNewline(): void
+    public function test_read_newline(): void
     {
         self::assertEquals(
             new NewlineNode("\n", $this->loc(1, 0), $this->loc(2, 0)),

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -38,7 +38,7 @@ final class ReaderTest extends TestCase
         $this->compilerFacade = new CompilerFacade();
     }
 
-    public function testReadNumber(): void
+    public function test_read_number(): void
     {
         self::assertEquals(1, $this->read('1'));
         self::assertEquals(10, $this->read('10'));
@@ -61,7 +61,7 @@ final class ReaderTest extends TestCase
         self::assertEquals(7E-10, $this->read('7E-10'));
     }
 
-    public function testReadKeyword(): void
+    public function test_read_keyword(): void
     {
         self::assertEquals(
             $this->loc(new Keyword('test'), 1, 0, 1, 5),
@@ -69,20 +69,20 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadBoolean(): void
+    public function test_read_boolean(): void
     {
         self::assertEquals(true, $this->read('true'));
         self::assertEquals(false, $this->read('false'));
     }
 
-    public function testReadNil(): void
+    public function test_read_nil(): void
     {
         self::assertNull(
             $this->read('nil')
         );
     }
 
-    public function testReadSymbol(): void
+    public function test_read_symbol(): void
     {
         self::assertEquals(
             $this->loc(Symbol::create('test'), 1, 0, 1, 4),
@@ -90,7 +90,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadList(): void
+    public function test_read_list(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentList(), 1, 0, 1, 2),
@@ -119,7 +119,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadVector(): void
+    public function test_read_vector(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentVector(), 1, 0, 1, 2),
@@ -148,7 +148,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testQuote(): void
+    public function test_quote(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
@@ -159,7 +159,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testUnquote(): void
+    public function test_unquote(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
@@ -170,7 +170,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testUnquoteSplice(): void
+    public function test_unquote_splice(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
@@ -181,7 +181,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote1(): void
+    public function test_quasiquote1(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
@@ -192,7 +192,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote2(): void
+    public function test_quasiquote2(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
@@ -203,49 +203,49 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote3(): void
+    public function test_quasiquote3(): void
     {
         $l1 = $this->read('(apply list (concat (list (quote foo)) (list bar)))', true);
         $l2 = $this->read('`(foo ,bar)', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testQuasiquote4(): void
+    public function test_quasiquote4(): void
     {
         $l1 = $this->read('\'a', true);
         $l2 = $this->read('``,a', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testQuasiquote5(): void
+    public function test_quasiquote5(): void
     {
         $l1 = $this->read('(apply list (concat (list (quote foo)) bar))', true);
         $l2 = $this->read('`(foo ,@bar)', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testQuasiquote6(): void
+    public function test_quasiquote6(): void
     {
         $l1 = $this->read('(apply list (concat (list foo) bar))', true);
         $l2 = $this->read('`(,foo ,@bar)', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testQuasiquote7(): void
+    public function test_quasiquote7(): void
     {
         $l1 = $this->read('(apply list (concat foo bar))', true);
         $l2 = $this->read('`(,@foo ,@bar)', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testQuasiquote8(): void
+    public function test_quasiquote8(): void
     {
         $l1 = $this->read('(apply list (concat foo bar (list 1) (list "string") (list :keyword) (list true) (list nil)))', true);
         $l2 = $this->read('`(,@foo ,@bar 1 "string" :keyword true nil)', true);
         self::assertTrue($l1->equals($l2));
     }
 
-    public function testReadString(): void
+    public function test_read_string(): void
     {
         self::assertEquals(
             'abc',
@@ -298,7 +298,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadEmptyArray(): void
+    public function test_read_empty_array(): void
     {
         self::assertEquals(
             $this->loc(PhelArray::create(), 1, 0, 1, 3),
@@ -306,7 +306,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadArray1(): void
+    public function test_read_array1(): void
     {
         self::assertEquals(
             $this->loc(PhelArray::create(1), 1, 0, 1, 4),
@@ -314,7 +314,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadArray2(): void
+    public function test_read_array2(): void
     {
         self::assertEquals(
             $this->loc(PhelArray::create(1, 2), 1, 0, 1, 6),
@@ -322,7 +322,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadEmptyMap(): void
+    public function test_read_empty_map(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentMap(), 1, 0, 1, 2),
@@ -330,7 +330,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMapTable1(): void
+    public function test_map_table1(): void
     {
         self::assertEquals(
             $this->loc(
@@ -347,7 +347,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMapTable2(): void
+    public function test_map_table2(): void
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentMapFromKVs(
@@ -360,13 +360,13 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMapUneven(): void
+    public function test_map_uneven(): void
     {
         $this->expectException(ReaderException::class);
         $this->read('{:a}');
     }
 
-    public function testReadEmptyTable(): void
+    public function test_read_empty_table(): void
     {
         self::assertEquals(
             $this->loc(Table::fromKVs(), 1, 0, 1, 3),
@@ -374,7 +374,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadTable1(): void
+    public function test_read_table1(): void
     {
         self::assertEquals(
             $this->loc(Table::fromKVs($this->loc(new Keyword('a'), 1, 2, 1, 4), 1), 1, 0, 1, 7),
@@ -382,7 +382,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadTable2(): void
+    public function test_read_table2(): void
     {
         self::assertEquals(
             $this->loc(Table::fromKVs(
@@ -395,13 +395,13 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testTableUneven(): void
+    public function test_table_uneven(): void
     {
         $this->expectException(ReaderException::class);
         $this->read('@{:a}');
     }
 
-    public function testMetaKeyword(): void
+    public function test_meta_keyword(): void
     {
         self::assertEquals(
             $this->loc(
@@ -421,7 +421,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaString(): void
+    public function test_meta_string(): void
     {
         self::assertEquals(
             $this->loc(
@@ -441,7 +441,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaSymbol(): void
+    public function test_meta_symbol(): void
     {
         self::assertEquals(
             $this->loc(
@@ -461,7 +461,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaTable(): void
+    public function test_meta_table(): void
     {
         self::assertEquals(
             $this->loc(
@@ -483,7 +483,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testConcatMeta(): void
+    public function test_concat_meta(): void
     {
         self::assertEquals(
             $this->loc(
@@ -505,21 +505,21 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testVectorMeta(): void
+    public function test_vector_meta(): void
     {
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage('Metadata must be a Symbol, String, Keyword or Map');
         $this->read('^[:a] test');
     }
 
-    public function testMetaOnString(): void
+    public function test_meta_on_string(): void
     {
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage('Metadata can only applied to classes that implement MetaInterface');
         $this->read('^a "test"');
     }
 
-    public function testReadShortFnZeroArgs(): void
+    public function test_read_short_fn_zero_args(): void
     {
         self::assertEquals(
             $this->loc(
@@ -545,7 +545,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnOneArg(): void
+    public function test_read_short_fn_one_arg(): void
     {
         self::assertEquals(
             $this->loc(
@@ -574,7 +574,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnOneArgTwoTimes(): void
+    public function test_read_short_fn_one_arg_two_times(): void
     {
         self::assertEquals(
             $this->loc(
@@ -604,7 +604,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnTwoArguments(): void
+    public function test_read_short_fn_two_arguments(): void
     {
         self::assertEquals(
             $this->loc(
@@ -635,7 +635,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnArgumentsTwice(): void
+    public function test_read_short_fn_arguments_twice(): void
     {
         self::assertEquals(
             $this->loc(
@@ -665,7 +665,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnMissingArgument(): void
+    public function test_read_short_fn_missing_argument(): void
     {
         self::assertEquals(
             $this->loc(
@@ -697,7 +697,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnRestArguments(): void
+    public function test_read_short_fn_rest_arguments(): void
     {
         self::assertEquals(
             $this->loc(
@@ -729,7 +729,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function testShortFnRestArgumentMultipleTimes(): void
+    public function test_short_fn_rest_argument_multiple_times(): void
     {
         $this->assertEquals(
             $this->loc(

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -24,7 +24,7 @@ final class FormatterFacadeTest extends TestCase
      * @dataProvider providerReformatted
      * @dataProvider providerRemoveTrailingWhitespaceRule
      */
-    public function testFormat(array $actualLines, array $expectedLines): void
+    public function test_format(array $actualLines, array $expectedLines): void
     {
         $formatted = $this->formatterFacade->format(implode("\n", $actualLines));
 

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -38,7 +38,7 @@ final class IntegrationTest extends TestCase
     /**
      * @dataProvider providerIntegration
      */
-    public function testIntegration(
+    public function test_integration(
         string $filename,
         string $phelCode,
         string $expectedGeneratedCode

--- a/tests/php/Integration/Interop/CallPhelTest.php
+++ b/tests/php/Integration/Interop/CallPhelTest.php
@@ -19,13 +19,13 @@ final class CallPhelTest extends TestCase
         $this->wrapper = new ExampleWrapper();
     }
 
-    public function testCallOdd(): void
+    public function test_call_odd(): void
     {
         self::assertTrue($this->wrapper->isOdd(1));
         self::assertFalse($this->wrapper->isOdd(2));
     }
 
-    public function testCallPrintStr(): void
+    public function test_call_print_str(): void
     {
         self::assertSame('a b c', $this->wrapper->printStr('a', 'b', 'c'));
     }

--- a/tests/php/Integration/ParseAndPrintTest.php
+++ b/tests/php/Integration/ParseAndPrintTest.php
@@ -18,7 +18,7 @@ final class ParseAndPrintTest extends TestCase
         $this->compilerFactory = new CompilerFactory();
     }
 
-    public function testParseAndPrintCoreLibrary(): void
+    public function test_parse_and_print_core_library(): void
     {
         $coreLibCode = file_get_contents(__DIR__ . '/../../../src/phel/core.phel');
 

--- a/tests/php/Integration/Printer/PrinterTest.php
+++ b/tests/php/Integration/Printer/PrinterTest.php
@@ -26,7 +26,7 @@ final class PrinterTest extends TestCase
         $this->compilerFacade = new CompilerFacade();
     }
 
-    public function testPrintString(): void
+    public function test_print_string(): void
     {
         self::assertEquals(
             '"test"',
@@ -34,7 +34,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintEscapedStringChars(): void
+    public function test_print_escaped_string_chars(): void
     {
         self::assertEquals(
             '"\n\r\t\v\f\e\"\$\\\\"',
@@ -42,7 +42,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintDollarSignEscapedStringChars(): void
+    public function test_print_dollar_sign_escaped_string_chars(): void
     {
         self::assertEquals(
             '"\$ \$abc"',
@@ -50,7 +50,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintEscapedHexdecimalChars(): void
+    public function test_print_escaped_hexdecimal_chars(): void
     {
         self::assertEquals(
             '"\x07"',
@@ -58,7 +58,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintEscapedUnicodeChars(): void
+    public function test_print_escaped_unicode_chars(): void
     {
         self::assertEquals(
             '"\u{1000}"',
@@ -66,7 +66,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintZero(): void
+    public function test_print_zero(): void
     {
         self::assertEquals(
             '0',
@@ -74,7 +74,7 @@ final class PrinterTest extends TestCase
         );
     }
 
-    public function testPrintToStringFromObject(): void
+    public function test_print_to_string_from_object(): void
     {
         $class = new class() {
             public function __toString(): string

--- a/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Command/Test/TestCommandOptionsTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 final class TestCommandOptionsTest extends TestCase
 {
-    public function testEmptyFilter(): void
+    public function test_empty_filter(): void
     {
         $options = TestCommandOptions::empty();
 
         self::assertSame('{:filter nil}', $options->asPhelHashMap());
     }
 
-    public function testRandomFilter(): void
+    public function test_random_filter(): void
     {
         $options = TestCommandOptions::fromArray(['filter' => 'example']);
 

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeArrayTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeArrayTest.php
@@ -22,7 +22,7 @@ final class AnalyzeArrayTest extends TestCase
         $this->arrayAnalzyer = new AnalyzeArray(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testEmptyArray(): void
+    public function test_empty_array(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -31,7 +31,7 @@ final class AnalyzeArrayTest extends TestCase
         );
     }
 
-    public function testArray(): void
+    public function test_array(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
@@ -21,7 +21,7 @@ final class AnalyzeLiteralTest extends TestCase
         $this->literalAnalzyer = new AnalyzeLiteral(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testSymbolLiteral(): void
+    public function test_symbol_literal(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -30,7 +30,7 @@ final class AnalyzeLiteralTest extends TestCase
         );
     }
 
-    public function testNumberLiteral(): void
+    public function test_number_literal(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -42,7 +42,7 @@ final class AnalyzePersistentListTest extends TestCase
         $this->listAnalyzer = new AnalyzePersistentList(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testSymbolWithNameDef(): void
+    public function test_symbol_with_name_def(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
@@ -52,7 +52,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(DefNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameNs(): void
+    public function test_symbol_with_name_ns(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_NS),
@@ -61,7 +61,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(NsNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameFn(): void
+    public function test_symbol_with_name_fn(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
@@ -70,7 +70,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(FnNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameQuote(): void
+    public function test_symbol_with_name_quote(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_QUOTE),
@@ -79,7 +79,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(QuoteNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameDo(): void
+    public function test_symbol_with_name_do(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DO), 1,
@@ -87,7 +87,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(DoNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameIf(): void
+    public function test_symbol_with_name_if(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),
@@ -97,7 +97,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(IfNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameApply(): void
+    public function test_symbol_with_name_apply(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY), '+', TypeFactory::getInstance()->persistentVectorFromArray(['']),
@@ -105,7 +105,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(ApplyNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameLet(): void
+    public function test_symbol_with_name_let(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_LET),
@@ -115,7 +115,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNamePhpNew(): void
+    public function test_symbol_with_name_php_new(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_NEW), '',
@@ -123,7 +123,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNamePhpObjectCall(): void
+    public function test_symbol_with_name_php_object_call(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''),
@@ -134,7 +134,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNamePhpObjectStaticCall(): void
+    public function test_symbol_with_name_php_object_static_call(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''),
@@ -145,7 +145,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNamePhpArrayGet(): void
+    public function test_symbol_with_name_php_array_get(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
@@ -158,7 +158,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNamePhpArraySet(): void
+    public function test_symbol_with_name_php_array_set(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_SET),
@@ -172,7 +172,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNamePhpArrayPush(): void
+    public function test_symbol_with_name_php_array_push(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH),
@@ -185,7 +185,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNamePhpArrayUnset(): void
+    public function test_symbol_with_name_php_array_unset(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET),
@@ -198,7 +198,7 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
-    public function testSymbolWithNameRecur(): void
+    public function test_symbol_with_name_recur(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_RECUR), 1,
@@ -208,7 +208,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(RecurNode::class, $this->listAnalyzer->analyze($list, $nodeEnv));
     }
 
-    public function testSymbolWithNameTry(): void
+    public function test_symbol_with_name_try(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_TRY),
@@ -216,7 +216,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(TryNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameThrow(): void
+    public function test_symbol_with_name_throw(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_THROW), '',
@@ -224,7 +224,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(ThrowNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameLoop(): void
+    public function test_symbol_with_name_loop(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_LOOP),
@@ -234,7 +234,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameForeach(): void
+    public function test_symbol_with_name_foreach(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
@@ -246,7 +246,7 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(ForeachNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameDefStruct(): void
+    public function test_symbol_with_name_def_struct(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -22,7 +22,7 @@ final class AnalyzePersistentMapTest extends TestCase
         $this->mapAnalyzer = new AnalyzePersistentMap(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testEmptyMap(): void
+    public function test_empty_map(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -31,7 +31,7 @@ final class AnalyzePersistentMapTest extends TestCase
         );
     }
 
-    public function testMap(): void
+    public function test_map(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
@@ -22,7 +22,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         $this->vectorAnalzyer = new AnalyzePersistentVector(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testEmptyVector(): void
+    public function test_empty_vector(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -31,7 +31,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         );
     }
 
-    public function testVector(): void
+    public function test_vector(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -25,7 +25,7 @@ final class AnalyzeSymbolTest extends TestCase
         $this->symbolAnalyzer = new AnalyzeSymbol(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testPhpSymbol(): void
+    public function test_php_symbol(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -34,7 +34,7 @@ final class AnalyzeSymbolTest extends TestCase
         );
     }
 
-    public function testLocalVar(): void
+    public function test_local_var(): void
     {
         $env = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);
         self::assertEquals(
@@ -43,7 +43,7 @@ final class AnalyzeSymbolTest extends TestCase
         );
     }
 
-    public function testLocalShadowedVar(): void
+    public function test_local_shadowed_var(): void
     {
         $env = NodeEnvironment::empty()
             ->withLocals([Symbol::create('a')])
@@ -55,7 +55,7 @@ final class AnalyzeSymbolTest extends TestCase
         );
     }
 
-    public function testGlobalVar(): void
+    public function test_global_var(): void
     {
         $globalEnv = new GlobalEnvironment();
         $globalEnv->setNs('test');
@@ -69,7 +69,7 @@ final class AnalyzeSymbolTest extends TestCase
         );
     }
 
-    public function testUndefinedGlobalVar(): void
+    public function test_undefined_global_var(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Cannot resolve symbol 'a'");
@@ -78,7 +78,7 @@ final class AnalyzeSymbolTest extends TestCase
         $this->symbolAnalyzer->analyze(Symbol::create('a'), $env);
     }
 
-    public function testLocalVarWinsOverGlobalVar(): void
+    public function test_local_var_wins_over_global_var(): void
     {
         $globalEnv = new GlobalEnvironment();
         $globalEnv->setNs('test');

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeTableTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeTableTest.php
@@ -22,7 +22,7 @@ final class AnalyzeTableTest extends TestCase
         $this->tableAnalyzer = new AnalyzeTable(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function testEmptyTable(): void
+    public function test_empty_table(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(
@@ -31,7 +31,7 @@ final class AnalyzeTableTest extends TestCase
         );
     }
 
-    public function testTable(): void
+    public function test_table(): void
     {
         $env = NodeEnvironment::empty();
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
@@ -27,7 +27,7 @@ final class ApplySymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testLessThan3Arguments(): void
+    public function test_less_than3_arguments(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least three arguments are required for 'apply");
@@ -39,7 +39,7 @@ final class ApplySymbolTest extends TestCase
         (new ApplySymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testApplyNode(): void
+    public function test_apply_node(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -23,28 +23,28 @@ final class BindingValidatorTest extends TestCase
         $this->validator = new BindingValidator();
     }
 
-    public function testIntegerType(): void
+    public function test_integer_type(): void
     {
         $this->expectExceptionMessage('Cannot destructure integer');
 
         $this->validator->assertSupportedBinding(1);
     }
 
-    public function testFloatType(): void
+    public function test_float_type(): void
     {
         $this->expectExceptionMessage('Cannot destructure double');
 
         $this->validator->assertSupportedBinding(1.99);
     }
 
-    public function testStringType(): void
+    public function test_string_type(): void
     {
         $this->expectExceptionMessage('Cannot destructure string');
 
         $this->validator->assertSupportedBinding('');
     }
 
-    public function testKeywordType(): void
+    public function test_keyword_type(): void
     {
         $this->expectExceptionMessage('Cannot destructure Phel\Lang\Keyword');
 
@@ -56,7 +56,7 @@ final class BindingValidatorTest extends TestCase
      *
      * @param AbstractType $type
      */
-    public function testValidTypes($type): void
+    public function test_valid_types($type): void
     {
         $this->validator->assertSupportedBinding($type);
         self::assertTrue(true); // this assertion ensures that no exception was thrown

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/PhelArrayBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/PhelArrayBindingDeconstructorTest.php
@@ -27,7 +27,7 @@ final class PhelArrayBindingDeconstructorTest extends TestCase
         );
     }
 
-    public function testDeconstructSymbol(): void
+    public function test_deconstruct_symbol(): void
     {
         // Test for binding like this (let [@[0 a] x])
         // This will be destructured to this:
@@ -66,7 +66,7 @@ final class PhelArrayBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testDeconstructNestedVector(): void
+    public function test_deconstruct_nested_vector(): void
     {
         // Test for binding like this (let [@[0 [a]] x])
         // This will be destructured to this:

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/SymbolBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/SymbolBindingDeconstructorTest.php
@@ -21,7 +21,7 @@ final class SymbolBindingDeconstructorTest extends TestCase
         $this->deconstructor = new SymbolBindingDeconstructor();
     }
 
-    public function testDeconstruct(): void
+    public function test_deconstruct(): void
     {
         $bindings = [];
         $binding = Symbol::create('test');
@@ -33,7 +33,7 @@ final class SymbolBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testWithUnderscoreSymbol(): void
+    public function test_with_underscore_symbol(): void
     {
         $bindings = [];
         $binding = Symbol::create('_');

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/TableBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/TableBindingDeconstructorTest.php
@@ -28,7 +28,7 @@ final class TableBindingDeconstructorTest extends TestCase
         );
     }
 
-    public function testDeconstructTable(): void
+    public function test_deconstruct_table(): void
     {
         // Test for binding like this (let [@{:key a} x])
         // This will be destructured to this:
@@ -67,7 +67,7 @@ final class TableBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testDeconstructTableNestedVector(): void
+    public function test_deconstruct_table_nested_vector(): void
     {
         // Test for binding like this (let [@{:key [a]} x])
         // This will be destructured to this:

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
@@ -31,7 +31,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         );
     }
 
-    public function testEmptyVector(): void
+    public function test_empty_vector(): void
     {
         // Test for binding like this (let [[] x])
         // This will be destructured to this:
@@ -50,7 +50,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testVectorWithOneSymbol(): void
+    public function test_vector_with_one_symbol(): void
     {
         // Test for binding like this (let [[a] x])
         // This will be destructured to this:
@@ -92,7 +92,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testVectorWithSymbols(): void
+    public function test_vector_with_symbols(): void
     {
         // Test for binding like this (let [[a b] x])
         // This will be destructured to this:
@@ -156,7 +156,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testVectorWithOneSymbolWithRest(): void
+    public function test_vector_with_one_symbol_with_rest(): void
     {
         // Test for binding like this (let [[a & b] x])
         // This will be destructured to this:
@@ -213,7 +213,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testExceptionWhenMultipleRestSymbol(): void
+    public function test_exception_when_multiple_rest_symbol(): void
     {
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -30,7 +30,7 @@ final class DeconstructorTest extends TestCase
         );
     }
 
-    public function testEmptyVector(): void
+    public function test_empty_vector(): void
     {
         $bindings = $this->deconstructor->deconstruct(
             TypeFactory::getInstance()->persistentVectorFromArray([])
@@ -39,7 +39,7 @@ final class DeconstructorTest extends TestCase
         self::assertEquals([], $bindings);
     }
 
-    public function testVectorWithEmptyVectors(): void
+    public function test_vector_with_empty_vectors(): void
     {
         // Test for binding like this (let [[a] [10]
         //                                  [b] [20]])
@@ -109,7 +109,7 @@ final class DeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testTableBinding(): void
+    public function test_table_binding(): void
     {
         // Test for binding like this (let [@{:key a} x])
         // This will be destructured to this:
@@ -143,7 +143,7 @@ final class DeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testArrayBinding(): void
+    public function test_array_binding(): void
     {
         // Test for binding like this (let [@[0 a] x])
         // This will be destructured to this:
@@ -181,7 +181,7 @@ final class DeconstructorTest extends TestCase
         ], $bindings);
     }
 
-    public function testNilBinding(): void
+    public function test_nil_binding(): void
     {
         // Test for binding like this (let [nil x])
         // This will be destructured to this:

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -24,7 +24,7 @@ final class DefStructSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testWithWrongNumberOfArguments(): void
+    public function test_with_wrong_number_of_arguments(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly two arguments are required for 'defstruct. Got 1");
@@ -37,7 +37,7 @@ final class DefStructSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testFirstArgIsNotSymbol(): void
+    public function test_first_arg_is_not_symbol(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defstruct must be a Symbol.");
@@ -52,7 +52,7 @@ final class DefStructSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testSecondArgIsNotVector(): void
+    public function test_second_arg_is_not_vector(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'defstruct must be a vector.");
@@ -67,7 +67,7 @@ final class DefStructSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testVectorElemsAreNotSymbols(): void
+    public function test_vector_elems_are_not_symbols(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage('Defstruct field elements must be Symbols.');
@@ -82,7 +82,7 @@ final class DefStructSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testDefStructSymbol(): void
+    public function test_def_struct_symbol(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -27,7 +27,7 @@ final class DefSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testWithDefNotAllowed(): void
+    public function test_with_def_not_allowed(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("'def inside of a 'def is forbidden");
@@ -44,7 +44,7 @@ final class DefSymbolTest extends TestCase
         (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testWithWrongNumberOfArguments(): void
+    public function test_with_wrong_number_of_arguments(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
@@ -56,7 +56,7 @@ final class DefSymbolTest extends TestCase
         (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testFirstArgumentMustBeSymbol(): void
+    public function test_first_argument_must_be_symbol(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
@@ -69,7 +69,7 @@ final class DefSymbolTest extends TestCase
         (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testFalseInitValue(): void
+    public function test_false_init_value(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('$init must be TypeInterface|string|float|int|bool|null');
@@ -82,7 +82,7 @@ final class DefSymbolTest extends TestCase
         (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testInitValues(): void
+    public function test_init_values(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
@@ -111,7 +111,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testDocstring(): void
+    public function test_docstring(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
@@ -144,7 +144,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testMetaKeyword(): void
+    public function test_meta_keyword(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
@@ -177,7 +177,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testMetaTableKeyword(): void
+    public function test_meta_table_keyword(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
@@ -210,7 +210,7 @@ final class DefSymbolTest extends TestCase
         );
     }
 
-    public function testInvalidMeta(): void
+    public function test_invalid_meta(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Metadata must be a String, Keyword or Map');

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -24,7 +24,7 @@ final class DoSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testWrongSymbolName(): void
+    public function test_wrong_symbol_name(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'do.");
@@ -34,7 +34,7 @@ final class DoSymbolTest extends TestCase
         (new DoSymbol($this->analyzer))->analyze($list, $env);
     }
 
-    public function testEmptyList(): void
+    public function test_empty_list(): void
     {
         $env = NodeEnvironment::empty();
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -52,7 +52,7 @@ final class DoSymbolTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testWithOneScalarValue(): void
+    public function test_with_one_scalar_value(): void
     {
         $env = NodeEnvironment::empty();
 
@@ -72,7 +72,7 @@ final class DoSymbolTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testWithTwoScalarValue(): void
+    public function test_with_two_scalar_value(): void
     {
         $env = NodeEnvironment::empty();
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -31,7 +31,7 @@ final class FnSymbolTest extends TestCase
         $this->analyzer = new Analyzer($env);
     }
 
-    public function testRequiresAtLeastOneArg(): void
+    public function test_requires_at_least_one_arg(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("'fn requires at least one argument");
@@ -43,7 +43,7 @@ final class FnSymbolTest extends TestCase
         (new FnSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testSecondArgMustBeAVector(): void
+    public function test_second_arg_must_be_a_vector(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'fn must be a vector");
@@ -57,7 +57,7 @@ final class FnSymbolTest extends TestCase
         $this->analyze($list);
     }
 
-    public function testIsNotVariadic(): void
+    public function test_is_not_variadic(): void
     {
         // This is the same as: (fn [anything])
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -75,7 +75,7 @@ final class FnSymbolTest extends TestCase
     /**
      * @dataProvider providerVarNamesMustStartWithLetterOrUnderscore
      */
-    public function testVarNamesMustStartWithLetterOrUnderscore(string $paramName, bool $error): void
+    public function test_var_names_must_start_with_letter_or_underscore(string $paramName, bool $error): void
     {
         if ($error) {
             $this->expectException(AbstractLocatedException::class);
@@ -123,7 +123,7 @@ final class FnSymbolTest extends TestCase
         ];
     }
 
-    public function testOnlyOneSymbolCanFollowTheAmpersandParameter(): void
+    public function test_only_one_symbol_can_follow_the_ampersand_parameter(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage('Unsupported parameter form, only one symbol can follow the & parameter');
@@ -144,7 +144,7 @@ final class FnSymbolTest extends TestCase
     /**
      * @dataProvider providerGetParams
      */
-    public function testGetParams(PersistentListInterface $list, array $expectedParams): void
+    public function test_get_params(PersistentListInterface $list, array $expectedParams): void
     {
         $node = $this->analyze($list);
 
@@ -186,7 +186,7 @@ final class FnSymbolTest extends TestCase
     /**
      * @dataProvider providerGetBody
      */
-    public function testGetBody(PersistentListInterface $list, string $expectedBodyInstanceOf): void
+    public function test_get_body(PersistentListInterface $list, string $expectedBodyInstanceOf): void
     {
         $node = $this->analyze($list);
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ForeachSymbolTest extends TestCase
 {
-    public function testRequiresAtLeastTwoArg(): void
+    public function test_requires_at_least_two_arg(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'foreach");
@@ -36,7 +36,7 @@ final class ForeachSymbolTest extends TestCase
         $this->analyze($list);
     }
 
-    public function testFirstArgMustBeAVector(): void
+    public function test_first_arg_must_be_a_vector(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'foreach must be a vector.");
@@ -50,7 +50,7 @@ final class ForeachSymbolTest extends TestCase
         $this->analyze($list);
     }
 
-    public function testArgForVectorCanNotBe1(): void
+    public function test_arg_for_vector_can_not_be1(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
@@ -66,7 +66,7 @@ final class ForeachSymbolTest extends TestCase
         $this->analyze($list);
     }
 
-    public function testValueSymbolFromVectorWith2Args(): void
+    public function test_value_symbol_from_vector_with2_args(): void
     {
         // (foreach [x []])
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -95,7 +95,7 @@ final class ForeachSymbolTest extends TestCase
         );
     }
 
-    public function testDeconstrutionWithTwoArgs(): void
+    public function test_deconstrution_with_two_args(): void
     {
         // (foreach [[x] []])
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -111,7 +111,7 @@ final class ForeachSymbolTest extends TestCase
         self::assertInstanceOf(LetNode::class, $node->getBodyExpr());
     }
 
-    public function testValueSymbolVectorWith3Args(): void
+    public function test_value_symbol_vector_with3_args(): void
     {
         // (foreach [key value @{}])
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -142,7 +142,7 @@ final class ForeachSymbolTest extends TestCase
         );
     }
 
-    public function testDeconstrutionWithThreeArgs(): void
+    public function test_deconstrution_with_three_args(): void
     {
         // (foreach [[key] [value] []])
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -159,7 +159,7 @@ final class ForeachSymbolTest extends TestCase
         self::assertInstanceOf(LetNode::class, $node->getBodyExpr());
     }
 
-    public function testArgForVectorCanNotBe4(): void
+    public function test_arg_for_vector_can_not_be4(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
@@ -21,7 +21,7 @@ final class IfSymbolTest extends TestCase
     /**
      * @dataProvider providerRequiresAtLeastTwoOrThreeArgs
      */
-    public function testRequiresAtLeastTwoOrThreeArgs(PersistentListInterface $list): void
+    public function test_requires_at_least_two_or_three_args(PersistentListInterface $list): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("'if requires two or three arguments");
@@ -55,7 +55,7 @@ final class IfSymbolTest extends TestCase
         ];
     }
 
-    public function testAnalyze(): void
+    public function test_analyze(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -42,7 +42,7 @@ final class InvokeSymbolTest extends TestCase
         $this->analyzer = new Analyzer($env);
     }
 
-    public function testInvokeWithoutArguments(): void
+    public function test_invoke_without_arguments(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
@@ -60,7 +60,7 @@ final class InvokeSymbolTest extends TestCase
         );
     }
 
-    public function testInvokeWithOneArguments(): void
+    public function test_invoke_with_one_arguments(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
@@ -81,7 +81,7 @@ final class InvokeSymbolTest extends TestCase
         );
     }
 
-    public function testMacroExpand(): void
+    public function test_macro_expand(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::createForNamespace('user', 'my-macro'),
@@ -107,7 +107,7 @@ final class InvokeSymbolTest extends TestCase
         );
     }
 
-    public function testMacroExpandFailure(): void
+    public function test_macro_expand_failure(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Error in expanding macro "user\\my-failed-macro": my-failed-macro message');
@@ -120,7 +120,7 @@ final class InvokeSymbolTest extends TestCase
         $node = (new InvokeSymbol($this->analyzer))->analyze($list, $env);
     }
 
-    public function testMacroUndefinedMacro(): void
+    public function test_macro_undefined_macro(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Cannot resolve symbol \'user/my-undefined-macro\'');

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -28,7 +28,7 @@ final class LetSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testWrongSymbolName(): void
+    public function test_wrong_symbol_name(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'let.");
@@ -41,7 +41,7 @@ final class LetSymbolTest extends TestCase
         $analyzer->analyze($list, $env);
     }
 
-    public function testWrongArguments(): void
+    public function test_wrong_arguments(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'let");
@@ -52,7 +52,7 @@ final class LetSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testWrongSecondArgument(): void
+    public function test_wrong_second_argument(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
@@ -63,7 +63,7 @@ final class LetSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testUnevenBindings(): void
+    public function test_uneven_bindings(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
@@ -77,7 +77,7 @@ final class LetSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testWithNoBindings(): void
+    public function test_with_no_bindings(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create('let'),
@@ -91,7 +91,7 @@ final class LetSymbolTest extends TestCase
         );
     }
 
-    public function testWithOneBinding(): void
+    public function test_with_one_binding(): void
     {
         Symbol::resetGen();
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -130,7 +130,7 @@ final class LetSymbolTest extends TestCase
         );
     }
 
-    public function testWithOneBodyExpression(): void
+    public function test_with_one_body_expression(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create('let'),
@@ -154,7 +154,7 @@ final class LetSymbolTest extends TestCase
         );
     }
 
-    public function testWithTwoBodyExpression(): void
+    public function test_with_two_body_expression(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create('let'),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -32,7 +32,7 @@ final class LoopSymbolTest extends TestCase
         $this->analyzer = new Analyzer($env);
     }
 
-    public function testWrongSymbolName(): void
+    public function test_wrong_symbol_name(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'loop.");
@@ -43,7 +43,7 @@ final class LoopSymbolTest extends TestCase
         (new LoopSymbol($this->analyzer, new BindingValidator()))->analyze($list, $env);
     }
 
-    public function testWrongNumberOfArguments(): void
+    public function test_wrong_number_of_arguments(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'loop.");
@@ -54,7 +54,7 @@ final class LoopSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testWrongBindingParameter(): void
+    public function test_wrong_binding_parameter(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
@@ -65,7 +65,7 @@ final class LoopSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testUnevenBindings(): void
+    public function test_uneven_bindings(): void
     {
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
@@ -79,7 +79,7 @@ final class LoopSymbolTest extends TestCase
         $this->analyzer->analyze($list, $env);
     }
 
-    public function testBasicLoop(): void
+    public function test_basic_loop(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create('loop'),
@@ -102,7 +102,7 @@ final class LoopSymbolTest extends TestCase
         );
     }
 
-    public function testLoopWithBinding(): void
+    public function test_loop_with_binding(): void
     {
         Symbol::resetGen();
         $list = TypeFactory::getInstance()->persistentListFromArray([
@@ -146,7 +146,7 @@ final class LoopSymbolTest extends TestCase
         );
     }
 
-    public function testWithDestruction(): void
+    public function test_with_destruction(): void
     {
         Symbol::resetGen();
         $list = TypeFactory::getInstance()->persistentListFromArray([

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
@@ -26,7 +26,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function testListWithoutArgument(): void
+    public function test_list_without_argument(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly two arguments are expected for 'php/::");
@@ -40,7 +40,7 @@ final class PhpObjectCallSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testListWithWrongSymbol(): void
+    public function test_list_with_wrong_symbol(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'php/-> must be a List or a Symbol");
@@ -54,7 +54,7 @@ final class PhpObjectCallSymbolTest extends TestCase
             ->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testIsStatic(): void
+    public function test_is_static(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
@@ -68,7 +68,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
     }
 
-    public function testIsNotStatic(): void
+    public function test_is_not_static(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
@@ -84,7 +84,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
     }
 
-    public function testList2ndElemIsList(): void
+    public function test_list2nd_elem_is_list(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
@@ -100,7 +100,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         self::assertInstanceOf(MethodCallNode::class, $objCallNode->getCallExpr());
     }
 
-    public function testList2ndElemIsSymbol(): void
+    public function test_list2nd_elem_is_symbol(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 final class QuoteSymbolTest extends TestCase
 {
-    public function testListWithWrongSymbol(): void
+    public function test_list_with_wrong_symbol(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'quote.");
@@ -22,7 +22,7 @@ final class QuoteSymbolTest extends TestCase
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testListWithoutArgument(): void
+    public function test_list_without_argument(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
@@ -31,7 +31,7 @@ final class QuoteSymbolTest extends TestCase
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
-    public function testQuoteListWithAnyText(): void
+    public function test_quote_list_with_any_text(): void
     {
         $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
         $symbol = (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -28,7 +28,7 @@ final class ApplyEmitterTest extends TestCase
         $this->applyEmitter = new ApplyEmitter($outputEmitter);
     }
 
-    public function testPhpVarNodeAndFnNodeIsInfix(): void
+    public function test_php_var_node_and_fn_node_is_infix(): void
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), '+');
         $args = [
@@ -47,7 +47,7 @@ final class ApplyEmitterTest extends TestCase
         );
     }
 
-    public function testPhpVarNodeButNoInfix(): void
+    public function test_php_var_node_but_no_infix(): void
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), 'str');
         $args = [
@@ -63,7 +63,7 @@ final class ApplyEmitterTest extends TestCase
         $this->expectOutputString('str("abc", ...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray(["def"])) ?? []));');
     }
 
-    public function testNoPhpVarNode(): void
+    public function test_no_php_var_node(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -24,7 +24,7 @@ final class FnAsClassEmitterTest extends TestCase
         $this->fnAsClassEmitter = new FnAsClassEmitter($outputEmitter);
     }
 
-    public function testIdentityFn(): void
+    public function test_identity_fn(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
@@ -46,7 +46,7 @@ final class FnAsClassEmitterTest extends TestCase
 };');
     }
 
-    public function testWithoutParameters(): void
+    public function test_without_parameters(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
@@ -68,7 +68,7 @@ final class FnAsClassEmitterTest extends TestCase
 };');
     }
 
-    public function testWithUses(): void
+    public function test_with_uses(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
@@ -99,7 +99,7 @@ final class FnAsClassEmitterTest extends TestCase
 };');
     }
 
-    public function testIsVariadic(): void
+    public function test_is_variadic(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
@@ -122,7 +122,7 @@ final class FnAsClassEmitterTest extends TestCase
 };');
     }
 
-    public function testIsRecurs(): void
+    public function test_is_recurs(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
@@ -146,7 +146,7 @@ final class FnAsClassEmitterTest extends TestCase
 };');
     }
 
-    public function testVariadicAndRecurs(): void
+    public function test_variadic_and_recurs(): void
     {
         $fnNode = new FnNode(
             NodeEnvironment::empty(),

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/SourceMap/VLQTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/SourceMap/VLQTest.php
@@ -9,52 +9,52 @@ use PHPUnit\Framework\TestCase;
 
 final class VLQTest extends TestCase
 {
-    public function testEncode1(): void
+    public function test_encode1(): void
     {
         self::assertEquals('AAAA', $this->encode([0, 0, 0, 0]));
     }
 
-    public function testEncode2(): void
+    public function test_encode2(): void
     {
         self::assertEquals('AAgBC', $this->encode([0, 0, 16, 1]));
     }
 
-    public function testEncode3(): void
+    public function test_encode3(): void
     {
         self::assertEquals('D', $this->encode([-1]));
     }
 
-    public function testEncode4(): void
+    public function test_encode4(): void
     {
         self::assertEquals('B', $this->encode([-2147483648]));
     }
 
-    public function testEncode5(): void
+    public function test_encode5(): void
     {
         self::assertEquals('+/////D', $this->encode([2147483647]));
     }
 
-    public function testDecode1(): void
+    public function test_decode1(): void
     {
         self::assertEquals([0, 0, 0, 0], $this->decode('AAAA'));
     }
 
-    public function testDecode2(): void
+    public function test_decode2(): void
     {
         self::assertEquals([0, 0, 16, 1], $this->decode('AAgBC'));
     }
 
-    public function testDecode3(): void
+    public function test_decode3(): void
     {
         self::assertEquals([-1], $this->decode('D'));
     }
 
-    public function testDecode4(): void
+    public function test_decode4(): void
     {
         self::assertEquals([-2147483648], $this->decode('B'));
     }
 
-    public function testDecode5(): void
+    public function test_decode5(): void
     {
         self::assertEquals([2147483647], $this->decode('+/////D'));
     }

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -18,7 +18,7 @@ final class LexerTest extends TestCase
         $this->compilerFactory = new CompilerFactory();
     }
 
-    public function testWhitespaceWithNewline(): void
+    public function test_whitespace_with_newline(): void
     {
         self::assertEquals(
             [
@@ -32,7 +32,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadCommentWithoutText(): void
+    public function test_read_comment_without_text(): void
     {
         self::assertEquals(
             [
@@ -43,7 +43,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadCommentWithoutNewLine(): void
+    public function test_read_comment_without_new_line(): void
     {
         self::assertEquals(
             [
@@ -54,7 +54,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadCommentWithNewLine(): void
+    public function test_read_comment_with_new_line(): void
     {
         self::assertEquals(
             [
@@ -66,7 +66,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadSingleSyntaxChar(): void
+    public function test_read_single_syntax_char(): void
     {
         self::assertEquals(
             [
@@ -77,7 +77,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadEmptyList(): void
+    public function test_read_empty_list(): void
     {
         self::assertEquals(
             [
@@ -89,7 +89,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadWord(): void
+    public function test_read_word(): void
     {
         self::assertEquals(
             [
@@ -100,7 +100,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadNumber(): void
+    public function test_read_number(): void
     {
         self::assertEquals(
             [
@@ -111,7 +111,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadEmptyString(): void
+    public function test_read_empty_string(): void
     {
         self::assertEquals(
             [
@@ -122,7 +122,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadString(): void
+    public function test_read_string(): void
     {
         self::assertEquals(
             [
@@ -133,7 +133,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadEscapedString(): void
+    public function test_read_escaped_string(): void
     {
         self::assertEquals(
             [
@@ -144,7 +144,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testReadVector(): void
+    public function test_read_vector(): void
     {
         self::assertEquals(
             [
@@ -159,7 +159,7 @@ final class LexerTest extends TestCase
         );
     }
 
-    public function testUnexpectedState(): void
+    public function test_unexpected_state(): void
     {
         $this->expectException(\Exception::class);
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/BooleanNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/BooleanNodeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class BooleanNodeTest extends TestCase
 {
-    public function testGetCode(): void
+    public function test_get_code(): void
     {
         self::assertEquals(
             'true',
@@ -18,7 +18,7 @@ final class BooleanNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -26,7 +26,7 @@ final class BooleanNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 4),
@@ -34,7 +34,7 @@ final class BooleanNodeTest extends TestCase
         );
     }
 
-    public function testValue(): void
+    public function test_value(): void
     {
         self::assertTrue(
             (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getValue()

--- a/tests/php/Unit/Compiler/Parser/ParserNode/CommentNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/CommentNodeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class CommentNodeTest extends TestCase
 {
-    public function testGetCode(): void
+    public function test_get_code(): void
     {
         self::assertEquals(
             '# Test',
@@ -18,7 +18,7 @@ final class CommentNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -26,7 +26,7 @@ final class CommentNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 6),

--- a/tests/php/Unit/Compiler/Parser/ParserNode/ListNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/ListNodeTest.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 final class ListNodeTest extends TestCase
 {
-    public function testGetCodeList(): void
+    public function test_get_code_list(): void
     {
         self::assertEquals(
             '(1)',
@@ -23,7 +23,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeBracket(): void
+    public function test_get_code_bracket(): void
     {
         self::assertEquals(
             '[1]',
@@ -33,7 +33,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeBrace(): void
+    public function test_get_code_brace(): void
     {
         self::assertEquals(
             '{1}',
@@ -43,7 +43,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeFn(): void
+    public function test_get_code_fn(): void
     {
         self::assertEquals(
             '|(1)',
@@ -53,7 +53,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeTable(): void
+    public function test_get_code_table(): void
     {
         self::assertEquals(
             '@{1}',
@@ -63,7 +63,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeArray(): void
+    public function test_get_code_array(): void
     {
         self::assertEquals(
             '@[1]',
@@ -73,7 +73,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testUndefinedToken(): void
+    public function test_undefined_token(): void
     {
         $this->expectException(RuntimeException::class);
         (new ListNode(300, $this->loc(1, 0), $this->loc(1, 4), [
@@ -81,7 +81,7 @@ final class ListNodeTest extends TestCase
         ]))->getCode();
     }
 
-    public function testGetChildren(): void
+    public function test_get_children(): void
     {
         self::assertEquals(
             [new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1)],
@@ -91,7 +91,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -101,7 +101,7 @@ final class ListNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 3),

--- a/tests/php/Unit/Compiler/Parser/ParserNode/MetaNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/MetaNodeTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MetaNodeTest extends TestCase
 {
-    public function testGetCode(): void
+    public function test_get_code(): void
     {
         self::assertEquals(
             '^:test test',
@@ -31,7 +31,7 @@ final class MetaNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -47,7 +47,7 @@ final class MetaNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 11),
@@ -63,7 +63,7 @@ final class MetaNodeTest extends TestCase
         );
     }
 
-    public function testGetChildren(): void
+    public function test_get_children(): void
     {
         self::assertEquals(
             [

--- a/tests/php/Unit/Compiler/Parser/ParserNode/NewlineNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/NewlineNodeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class NewlineNodeTest extends TestCase
 {
-    public function testGetCode(): void
+    public function test_get_code(): void
     {
         self::assertEquals(
             '\n',
@@ -18,7 +18,7 @@ final class NewlineNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -26,7 +26,7 @@ final class NewlineNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(2, 0),

--- a/tests/php/Unit/Compiler/Parser/ParserNode/QuoteNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/QuoteNodeTest.php
@@ -14,7 +14,7 @@ use RuntimeException;
 
 final class QuoteNodeTest extends TestCase
 {
-    public function testGetCodeQuote(): void
+    public function test_get_code_quote(): void
     {
         self::assertEquals(
             "'a",
@@ -27,7 +27,7 @@ final class QuoteNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeUnquote(): void
+    public function test_get_code_unquote(): void
     {
         self::assertEquals(
             ',a',
@@ -40,7 +40,7 @@ final class QuoteNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeUnquoteSplicing(): void
+    public function test_get_code_unquote_splicing(): void
     {
         self::assertEquals(
             ',@a',
@@ -53,7 +53,7 @@ final class QuoteNodeTest extends TestCase
         );
     }
 
-    public function testGetCodeQuasiquote(): void
+    public function test_get_code_quasiquote(): void
     {
         self::assertEquals(
             '`a',
@@ -68,7 +68,7 @@ final class QuoteNodeTest extends TestCase
 
 
 
-    public function testUndefinedToken(): void
+    public function test_undefined_token(): void
     {
         $this->expectException(RuntimeException::class);
         (new QuoteNode(
@@ -79,7 +79,7 @@ final class QuoteNodeTest extends TestCase
         ))->getCode();
     }
 
-    public function testGetChildren(): void
+    public function test_get_children(): void
     {
         self::assertEquals(
             [new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))],
@@ -92,7 +92,7 @@ final class QuoteNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -105,7 +105,7 @@ final class QuoteNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 2),

--- a/tests/php/Unit/Compiler/Parser/ParserNode/WhitespaceNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/WhitespaceNodeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class WhitespaceNodeTest extends TestCase
 {
-    public function testGetCode(): void
+    public function test_get_code(): void
     {
         self::assertEquals(
             ' ',
@@ -18,7 +18,7 @@ final class WhitespaceNodeTest extends TestCase
         );
     }
 
-    public function testGetStartLocation(): void
+    public function test_get_start_location(): void
     {
         self::assertEquals(
             $this->loc(1, 0),
@@ -26,7 +26,7 @@ final class WhitespaceNodeTest extends TestCase
         );
     }
 
-    public function testGetEndLocation(): void
+    public function test_get_end_location(): void
     {
         self::assertEquals(
             $this->loc(1, 1),

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -16,7 +16,7 @@ use RuntimeException;
 
 final class QuasiquoteTest extends TestCase
 {
-    public function testTransformUnquote(): void
+    public function test_transform_unquote(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -25,14 +25,14 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformUnquoteSplicing(): void
+    public function test_transform_unquote_splicing(): void
     {
         $this->expectException(RuntimeException::class);
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         $q->transform(TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
     }
 
-    public function testTransformCreateList(): void
+    public function test_transform_create_list(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -49,7 +49,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreateListWithUnquoteSplicing(): void
+    public function test_transform_create_list_with_unquote_splicing(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -72,7 +72,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreateListWithUnquote(): void
+    public function test_transform_create_list_with_unquote(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -95,7 +95,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreateVector(): void
+    public function test_transform_create_vector(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -112,7 +112,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreateMap(): void
+    public function test_transform_create_map(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -131,7 +131,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreateTable(): void
+    public function test_transform_create_table(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -150,7 +150,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformCreatePhelArray(): void
+    public function test_transform_create_phel_array(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -167,7 +167,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformInt(): void
+    public function test_transform_int(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -176,7 +176,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformString(): void
+    public function test_transform_string(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -185,7 +185,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformFloat(): void
+    public function test_transform_float(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -194,7 +194,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformBoolean(): void
+    public function test_transform_boolean(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -203,7 +203,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformNull(): void
+    public function test_transform_null(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -212,7 +212,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformKeyword(): void
+    public function test_transform_keyword(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -221,7 +221,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformUnknownSymbol(): void
+    public function test_transform_unknown_symbol(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
@@ -233,7 +233,7 @@ final class QuasiquoteTest extends TestCase
         );
     }
 
-    public function testTransformGlobalSymbol(): void
+    public function test_transform_global_symbol(): void
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('test', Symbol::create('abc'), TypeFactory::getInstance()->emptyPersistentMap());

--- a/tests/php/Unit/Exceptions/Extractor/FilePositionExtractorTest.php
+++ b/tests/php/Unit/Exceptions/Extractor/FilePositionExtractorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class FilePositionExtractorTest extends TestCase
 {
-    public function testGetOriginal(): void
+    public function test_get_original(): void
     {
         $extractor = new FilePositionExtractor(
             $this->stubSourceMapExtractor()
@@ -27,7 +27,7 @@ final class FilePositionExtractorTest extends TestCase
         );
     }
 
-    public function testGetOriginalWithFileNameComment(): void
+    public function test_get_original_with_file_name_comment(): void
     {
         $extractor = new FilePositionExtractor(
             $this->stubSourceMapExtractor(

--- a/tests/php/Unit/Exceptions/Printer/ExceptionArgsPrinterTest.php
+++ b/tests/php/Unit/Exceptions/Printer/ExceptionArgsPrinterTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ExceptionArgsPrinterTest extends TestCase
 {
-    public function testParseArgsAsString(): void
+    public function test_parse_args_as_string(): void
     {
         $argsPrinter = $this->createExceptionArgsPrinter();
         $actual = $argsPrinter->parseArgsAsString(['1', '2']);
@@ -21,7 +21,7 @@ final class ExceptionArgsPrinterTest extends TestCase
     /**
      * @dataProvider providerBuildPhpArgsString
      */
-    public function testBuildPhpArgsString(array $args, string $expected): void
+    public function test_build_php_args_string(array $args, string $expected): void
     {
         $argsPrinter = $this->createExceptionArgsPrinter();
         $actual = $argsPrinter->buildPhpArgsString($args);

--- a/tests/php/Unit/Exceptions/TextExceptionPrinterTest.php
+++ b/tests/php/Unit/Exceptions/TextExceptionPrinterTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TextExceptionPrinterTest extends TestCase
 {
-    public function testPrintException(): void
+    public function test_print_exception(): void
     {
         $file = 'example-file.phel';
 

--- a/tests/php/Unit/Formatter/ZipperTest.php
+++ b/tests/php/Unit/Formatter/ZipperTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ZipperTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -21,7 +21,7 @@ final class ZipperTest extends TestCase
         $this->assertTrue($zipper->isTop());
     }
 
-    public function testDownChild(): void
+    public function test_down_child(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -32,7 +32,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([1, 2], $down->getNode());
     }
 
-    public function testDownLeaf(): void
+    public function test_down_leaf(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -43,7 +43,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals(1, $down->getNode());
     }
 
-    public function testDownNoChild(): void
+    public function test_down_no_child(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -53,7 +53,7 @@ final class ZipperTest extends TestCase
         $zipper->down()->down();
     }
 
-    public function testDownOnLeaf(): void
+    public function test_down_on_leaf(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -63,7 +63,7 @@ final class ZipperTest extends TestCase
         $zipper->down()->down()->down();
     }
 
-    public function testUp(): void
+    public function test_up(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -74,7 +74,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([1, 2], $down->getNode());
     }
 
-    public function testUpOnRoot(): void
+    public function test_up_on_root(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -84,7 +84,7 @@ final class ZipperTest extends TestCase
         $down = $zipper->up();
     }
 
-    public function testLeftOnRoot(): void
+    public function test_left_on_root(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -93,7 +93,7 @@ final class ZipperTest extends TestCase
         $zipper->left();
     }
 
-    public function testLeftOnLeftmost(): void
+    public function test_left_on_leftmost(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -102,7 +102,7 @@ final class ZipperTest extends TestCase
         $zipper->down()->left();
     }
 
-    public function testLeftMost(): void
+    public function test_left_most(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -112,7 +112,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([1, 2], $leftMost->getNode());
     }
 
-    public function testRightOnRoot(): void
+    public function test_right_on_root(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -121,7 +121,7 @@ final class ZipperTest extends TestCase
         $zipper->right();
     }
 
-    public function testRightOnRightMost(): void
+    public function test_right_on_right_most(): void
     {
         $this->expectException(ZipperException::class);
 
@@ -130,7 +130,7 @@ final class ZipperTest extends TestCase
         $zipper->down()->right()->right()->right();
     }
 
-    public function testRightMost(): void
+    public function test_right_most(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -140,7 +140,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([4, 5], $rightMost->getNode());
     }
 
-    public function testNext(): void
+    public function test_next(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -166,7 +166,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([[1, 2], 3, [4, 5]], $next->getNode());
     }
 
-    public function testPrev(): void
+    public function test_prev(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -195,7 +195,7 @@ final class ZipperTest extends TestCase
         $this->assertEquals([[1, 2], 3, [4, 5]], $prev->getNode());
     }
 
-    public function testInsertLeft(): void
+    public function test_insert_left(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -206,7 +206,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testInsertLeftOnTop(): void
+    public function test_insert_left_on_top(): void
     {
         $this->expectException(Exception::class);
 
@@ -215,7 +215,7 @@ final class ZipperTest extends TestCase
         $zipper->insertLeft(0);
     }
 
-    public function testInsertRight(): void
+    public function test_insert_right(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -226,7 +226,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testInsertRightOnTop(): void
+    public function test_insert_right_on_top(): void
     {
         $this->expectException(Exception::class);
 
@@ -235,7 +235,7 @@ final class ZipperTest extends TestCase
         $zipper->insertRight(0);
     }
 
-    public function testReplace(): void
+    public function test_replace(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -246,7 +246,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testInsertChild(): void
+    public function test_insert_child(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -257,7 +257,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testAppendChild(): void
+    public function test_append_child(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -268,7 +268,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testRemoveInner(): void
+    public function test_remove_inner(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -279,7 +279,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testRemoveLeftMost(): void
+    public function test_remove_left_most(): void
     {
         $tree = [[1, 2], 3, [4, 5]];
         $zipper = ArrayZipper::createRoot($tree);
@@ -290,7 +290,7 @@ final class ZipperTest extends TestCase
         );
     }
 
-    public function testRemoveOnRoot(): void
+    public function test_remove_on_root(): void
     {
         $this->expectExceptionObject(ZipperException::cannotRemoveOnRootNode());
 

--- a/tests/php/Unit/Interop/Generator/Builder/WrapperRelativeFilenamePathBuilderTest.php
+++ b/tests/php/Unit/Interop/Generator/Builder/WrapperRelativeFilenamePathBuilderTest.php
@@ -13,7 +13,7 @@ final class WrapperRelativeFilenamePathBuilderTest extends TestCase
     /**
      * @dataProvider providerBuild
      */
-    public function testBuild(string $phelNs, string $expected): void
+    public function test_build(string $phelNs, string $expected): void
     {
         $builder = new WrapperRelativeFilenamePathBuilder();
 

--- a/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
+++ b/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 final class WrapperGeneratorTest extends TestCase
 {
-    public function testGenerateCompiledPhp(): void
+    public function test_generate_compiled_php(): void
     {
         $generator = $this->createWrapperGenerator();
         $phelNs = 'custom_namespace\\file_name_example';

--- a/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 final class EmptyListTest extends TestCase
 {
-    public function testPrependOnEmptyList(): void
+    public function test_prepend_on_empty_list(): void
     {
         $list = (new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null))->prepend('foo');
 
@@ -24,7 +24,7 @@ final class EmptyListTest extends TestCase
         $this->assertEquals('foo', $list->get(0));
     }
 
-    public function testCanNotPopOnEmtpyList(): void
+    public function test_can_not_pop_on_emtpy_list(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -32,13 +32,13 @@ final class EmptyListTest extends TestCase
         $list->pop();
     }
 
-    public function testCount(): void
+    public function test_count(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals(0, $list->count());
     }
 
-    public function testCanGetOnEmtpyList(): void
+    public function test_can_get_on_emtpy_list(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
 
@@ -46,25 +46,25 @@ final class EmptyListTest extends TestCase
         $list->get(0);
     }
 
-    public function testEqualsDifferentType(): void
+    public function test_equals_different_type(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertFalse($list->equals([]));
     }
 
-    public function testEqualsSameType(): void
+    public function test_equals_same_type(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertTrue($list->equals(new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null)));
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals(1, $list->hash());
     }
 
-    public function testIterator(): void
+    public function test_iterator(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
 
@@ -75,43 +75,43 @@ final class EmptyListTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testFirst(): void
+    public function test_first(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertNull($list->first());
     }
 
-    public function testRest(): void
+    public function test_rest(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals($list, $list->rest());
     }
 
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertNull($list->cdr());
     }
 
-    public function testToArray(): void
+    public function test_to_array(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals([], $list->toArray());
     }
 
-    public function testConcatEmptyArray(): void
+    public function test_concat_empty_array(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals([], $list->concat([])->toArray());
     }
 
-    public function testConcatSingleEntryArray(): void
+    public function test_concat_single_entry_array(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertEquals([1], $list->concat([1])->toArray());
     }
 
-    public function testConsOnEmptyList(): void
+    public function test_cons_on_empty_list(): void
     {
         $list = (new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null))->cons('foo');
 
@@ -120,19 +120,19 @@ final class EmptyListTest extends TestCase
         $this->assertEquals('foo', $list->get(0));
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertFalse(isset($list[0]));
     }
 
-    public function testContains(): void
+    public function test_contains(): void
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertFalse($list->contains(0));
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
 
@@ -140,7 +140,7 @@ final class EmptyListTest extends TestCase
         $list[0];
     }
 
-    public function testAddMetaData(): void
+    public function test_add_meta_data(): void
     {
         $meta = TypeFactory::getInstance()->emptyPersistentMap();
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 final class PersistentListTest extends TestCase
 {
-    public function testConsOnEmptyList(): void
+    public function test_cons_on_empty_list(): void
     {
         $list = PersistentList::empty(new ModuloHasher(), new SimpleEqualizer())->cons('foo');
 
@@ -23,7 +23,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals('foo', $list->get(0));
     }
 
-    public function testConsOnList(): void
+    public function test_cons_on_list(): void
     {
         $list = PersistentList::empty(new ModuloHasher(), new SimpleEqualizer())
             ->cons('foo')
@@ -35,7 +35,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals('foo', $list->get(1));
     }
 
-    public function testFromEmptyArray(): void
+    public function test_from_empty_array(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), []);
 
@@ -43,7 +43,7 @@ final class PersistentListTest extends TestCase
         $this->assertTrue($list instanceof EmptyList);
     }
 
-    public function testFromArray(): void
+    public function test_from_array(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
 
@@ -52,7 +52,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals('bar', $list->get(1));
     }
 
-    public function testPopWithRest(): void
+    public function test_pop_with_rest(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar'])
             ->pop();
@@ -61,7 +61,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals('bar', $list->get(0));
     }
 
-    public function testPopWithoutRest(): void
+    public function test_pop_without_rest(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo'])
             ->pop();
@@ -70,14 +70,14 @@ final class PersistentListTest extends TestCase
         $this->assertEquals(0, $list->count());
     }
 
-    public function testGet(): void
+    public function test_get(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
 
         $this->assertEquals('bar', $list->get(1));
     }
 
-    public function testGetNegativeNumber(): void
+    public function test_get_negative_number(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
 
@@ -85,7 +85,7 @@ final class PersistentListTest extends TestCase
         $list->get(-1);
     }
 
-    public function testGetOutOfBound(): void
+    public function test_get_out_of_bound(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
 
@@ -93,14 +93,14 @@ final class PersistentListTest extends TestCase
         $list->get(3);
     }
 
-    public function testEqualsOtherType(): void
+    public function test_equals_other_type(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
 
         $this->assertFalse($list->equals(['foo', 'bar', 'foobar']));
     }
 
-    public function testEqualsDifferentLength(): void
+    public function test_equals_different_length(): void
     {
         $a = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
         $b = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
@@ -109,7 +109,7 @@ final class PersistentListTest extends TestCase
         $this->assertFalse($b->equals($a));
     }
 
-    public function testEqualsDifferentValues(): void
+    public function test_equals_different_values(): void
     {
         $a = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
         $b = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'foobar', 'bar']);
@@ -118,7 +118,7 @@ final class PersistentListTest extends TestCase
         $this->assertFalse($b->equals($a));
     }
 
-    public function testEqualsSameValues(): void
+    public function test_equals_same_values(): void
     {
         $a = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
         $b = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
@@ -127,14 +127,14 @@ final class PersistentListTest extends TestCase
         $this->assertTrue($b->equals($a));
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [2]);
 
         $this->assertEquals(33, $list->hash());
     }
 
-    public function testIterator(): void
+    public function test_iterator(): void
     {
         $xs = ['foo', 'bar', 'foobar'];
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), $xs);
@@ -147,35 +147,35 @@ final class PersistentListTest extends TestCase
         $this->assertEquals($xs, $result);
     }
 
-    public function testFirst(): void
+    public function test_first(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo']);
 
         $this->assertEquals('foo', $list->first());
     }
 
-    public function testRest(): void
+    public function test_rest(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo']);
 
         $this->assertEquals(PersistentList::empty(new ModuloHasher(), new SimpleEqualizer()), $list->rest());
     }
 
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo']);
 
         $this->assertNull($list->cdr());
     }
 
-    public function testCdr2(): void
+    public function test_cdr2(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
 
         $this->assertEquals(PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['bar']), $list->cdr());
     }
 
-    public function testAddMetaData(): void
+    public function test_add_meta_data(): void
     {
         $meta = TypeFactory::getInstance()->emptyPersistentMap();
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
@@ -185,7 +185,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals($meta, $listWithMeta->getMeta());
     }
 
-    public function testConcat(): void
+    public function test_concat(): void
     {
         $list1 = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
         $list2 = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foobar']);
@@ -194,7 +194,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'foobar'], $list->toArray());
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
 
@@ -204,7 +204,7 @@ final class PersistentListTest extends TestCase
         $this->assertFalse(isset($list[2]));
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
 
@@ -212,7 +212,7 @@ final class PersistentListTest extends TestCase
         $this->assertEquals('bar', $list[1]);
     }
 
-    public function testContains(): void
+    public function test_contains(): void
     {
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
 

--- a/tests/php/Unit/Lang/Collections/Map/ArrayNodeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/ArrayNodeIteratorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class ArrayNodeIteratorTest extends TestCase
 {
-    public function testIterateOnEmptyNode(): void
+    public function test_iterate_on_empty_node(): void
     {
         $node = ArrayNode::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -24,7 +24,7 @@ class ArrayNodeIteratorTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testIterateOnSingleEntryNode(): void
+    public function test_iterate_on_single_entry_node(): void
     {
         $node = ArrayNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false));
@@ -37,7 +37,7 @@ class ArrayNodeIteratorTest extends TestCase
         $this->assertEquals([1 => 'foo'], $result);
     }
 
-    public function testIterateOnTwoEntryNode(): void
+    public function test_iterate_on_two_entry_node(): void
     {
         $node = ArrayNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false))

--- a/tests/php/Unit/Lang/Collections/Map/ArrayNodeTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/ArrayNodeTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ArrayNodeTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer());
@@ -21,7 +21,7 @@ class ArrayNodeTest extends TestCase
         self::assertNull($node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutNonExistingKey(): void
+    public function test_put_non_existing_key(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer())
@@ -31,7 +31,7 @@ class ArrayNodeTest extends TestCase
         self::assertEquals('test', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutSameKeyTwice(): void
+    public function test_put_same_key_twice(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer())
@@ -42,7 +42,7 @@ class ArrayNodeTest extends TestCase
         self::assertEquals('bar', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutSameKeyValueTwice(): void
+    public function test_put_same_key_value_twice(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer())
@@ -53,7 +53,7 @@ class ArrayNodeTest extends TestCase
         self::assertEquals('foo', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer())
@@ -62,7 +62,7 @@ class ArrayNodeTest extends TestCase
         self::assertInstanceOf(ArrayNode::class, $node);
     }
 
-    public function testPackToIndexNode(): void
+    public function test_pack_to_index_node(): void
     {
         $hasher = new ModuloHasher();
         /** @var IndexedNode $node */
@@ -79,7 +79,7 @@ class ArrayNodeTest extends TestCase
         self::assertNull($node->find(0, $hasher->hash(33), 33, null));
     }
 
-    public function testRemoveKeyNoPacking(): void
+    public function test_remove_key_no_packing(): void
     {
         $hasher = new ModuloHasher();
         $node = ArrayNode::empty($hasher, new SimpleEqualizer())

--- a/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeIteratorTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class HashCollisionNodeIteratorTest extends TestCase
 {
-    public function testIterateOnEmptyNode(): void
+    public function test_iterate_on_empty_node(): void
     {
         $node = new HashCollisionNode(new ModuloHasher(), new SimpleEqualizer(), 1, 0, []);
 
@@ -23,7 +23,7 @@ class HashCollisionNodeIteratorTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testIterateOnSingleEntryNode(): void
+    public function test_iterate_on_single_entry_node(): void
     {
         $node = new HashCollisionNode(new ModuloHasher(), new SimpleEqualizer(), 1, 1, [1, 'foo']);
 
@@ -35,7 +35,7 @@ class HashCollisionNodeIteratorTest extends TestCase
         $this->assertEquals([1 => 'foo'], $result);
     }
 
-    public function testIterateOnTwoEntryNode(): void
+    public function test_iterate_on_two_entry_node(): void
     {
         $node = new HashCollisionNode(new ModuloHasher(), new SimpleEqualizer(), 1, 2, [1, 'foo', 3, 'bar']);
 

--- a/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class HashCollisionNodeTest extends TestCase
 {
-    public function testFindOnSingleCollisionNode(): void
+    public function test_find_on_single_collision_node(): void
     {
         $hasher = new ModuloHasher();
         $node = new HashCollisionNode($hasher, new SimpleEqualizer(), $hasher->hash(1), 1, [1, 'test']);
@@ -22,7 +22,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testFindWithMultipleEntries(): void
+    public function test_find_with_multiple_entries(): void
     {
         $hasher = new ModuloHasher(2);
         $node = new HashCollisionNode(
@@ -38,7 +38,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testPutAnotherKeyWithSameHash(): void
+    public function test_put_another_key_with_same_hash(): void
     {
         $hasher = new ModuloHasher(2);
         $box = new Box(null);
@@ -51,7 +51,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testUpdateExistingKey(): void
+    public function test_update_existing_key(): void
     {
         $hasher = new ModuloHasher(2);
         $box = new Box(null);
@@ -63,7 +63,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testUpdateExistingKeyWithSameValue(): void
+    public function test_update_existing_key_with_same_value(): void
     {
         $hasher = new ModuloHasher(2);
         $box = new Box(false);
@@ -75,7 +75,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testPutAnotherHash(): void
+    public function test_put_another_hash(): void
     {
         $hasher = new ModuloHasher(2);
         $box = new Box(null);
@@ -89,7 +89,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertEquals(null, $node->find(0, $hasher->hash(3), 3, null));
     }
 
-    public function testRemoveOnlyInsertedKey(): void
+    public function test_remove_only_inserted_key(): void
     {
         $hasher = new ModuloHasher(2);
         $node = (new HashCollisionNode($hasher, new SimpleEqualizer(), $hasher->hash(1), 1, [1, 'foo']))
@@ -98,7 +98,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertNull($node);
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $hasher = new ModuloHasher(2);
         $node = (new HashCollisionNode($hasher, new SimpleEqualizer(), $hasher->hash(1), 1, [1, 'foo']))
@@ -108,7 +108,7 @@ class HashCollisionNodeTest extends TestCase
         $this->assertNull($node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testRemoveOneCollisionKey(): void
+    public function test_remove_one_collision_key(): void
     {
         $hasher = new ModuloHasher(2);
         $node = (new HashCollisionNode(

--- a/tests/php/Unit/Lang/Collections/Map/IndexedNodeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/IndexedNodeIteratorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class IndexedNodeIteratorTest extends TestCase
 {
-    public function testIterateOnEmptyNode(): void
+    public function test_iterate_on_empty_node(): void
     {
         $node = IndexedNode::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -24,7 +24,7 @@ class IndexedNodeIteratorTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testIterateOnSingleEntryNode(): void
+    public function test_iterate_on_single_entry_node(): void
     {
         $node = IndexedNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false));
@@ -37,7 +37,7 @@ class IndexedNodeIteratorTest extends TestCase
         $this->assertEquals([1 => 'foo'], $result);
     }
 
-    public function testIterateOnTwoEntryNode(): void
+    public function test_iterate_on_two_entry_node(): void
     {
         $node = IndexedNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false))
@@ -51,7 +51,7 @@ class IndexedNodeIteratorTest extends TestCase
         $this->assertEquals([1 => 'foo', 2 => 'bar'], $result);
     }
 
-    public function testIterateOnThreeEntryNodeWithHashCollision(): void
+    public function test_iterate_on_three_entry_node_with_hash_collision(): void
     {
         $node = IndexedNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false))
@@ -66,7 +66,7 @@ class IndexedNodeIteratorTest extends TestCase
         $this->assertEquals([1 => 'foo', 2 => 'bar', 3 => 'foobar'], $result);
     }
 
-    public function testIterateOnMultipleChildNodes(): void
+    public function test_iterate_on_multiple_child_nodes(): void
     {
         $node = IndexedNode::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(0, 1, 1, 'foo', new Box(false))

--- a/tests/php/Unit/Lang/Collections/Map/IndexedNodeTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/IndexedNodeTest.php
@@ -13,14 +13,14 @@ use PHPUnit\Framework\TestCase;
 
 class IndexedNodeTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $hasher = new ModuloHasher();
         $h = IndexedNode::empty($hasher, new SimpleEqualizer());
         self::assertNull($h->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutKey(): void
+    public function test_put_key(): void
     {
         $hasher = new ModuloHasher();
         $box = new Box(null);
@@ -31,7 +31,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('test', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testSplitNode(): void
+    public function test_split_node(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer());
@@ -43,7 +43,7 @@ class IndexedNodeTest extends TestCase
         self::assertInstanceOf(ArrayNode::class, $node);
     }
 
-    public function testPutSameKeyValuePairTwice(): void
+    public function test_put_same_key_value_pair_twice(): void
     {
         $hasher = new ModuloHasher();
         $box = new Box(null);
@@ -55,7 +55,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('test', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutSameKeyWithDifferentValue(): void
+    public function test_put_same_key_with_different_value(): void
     {
         $hasher = new ModuloHasher();
         $box = new Box(null);
@@ -67,7 +67,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('bar', $node->find(0, $hasher->hash(1), 1, null));
     }
 
-    public function testPutSameHash(): void
+    public function test_put_same_hash(): void
     {
         $hasher = new ModuloHasher(2);
         $box = new Box(null);
@@ -80,7 +80,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('bar', $node->find(0, $hasher->hash(3), 3, null));
     }
 
-    public function testPutSameIndex(): void
+    public function test_put_same_index(): void
     {
         $hasher = new ModuloHasher();
         $box = new Box(null);
@@ -93,7 +93,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('bar', $node->find(0, $hasher->hash(33), 33, null));
     }
 
-    public function testAddToChild(): void
+    public function test_add_to_child(): void
     {
         $hasher = new ModuloHasher(64);
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -106,7 +106,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('foobar', $node->find(0, $hasher->hash(33), 33, null));
     }
 
-    public function testAddExistingKeyValuePairToChild(): void
+    public function test_add_existing_key_value_pair_to_child(): void
     {
         $hasher = new ModuloHasher(64);
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -118,7 +118,7 @@ class IndexedNodeTest extends TestCase
         self::assertEquals('bar', $node->find(0, $hasher->hash(65), 65, null));
     }
 
-    public function testRemoveAllExistingKeys(): void
+    public function test_remove_all_existing_keys(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -128,7 +128,7 @@ class IndexedNodeTest extends TestCase
         self::assertNull($node);
     }
 
-    public function testRemoveExistingKey(): void
+    public function test_remove_existing_key(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -140,7 +140,7 @@ class IndexedNodeTest extends TestCase
         self::assertNull($node->find(0, $hasher->hash(2), 2, null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $hasher = new ModuloHasher();
         $node1 = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -151,7 +151,7 @@ class IndexedNodeTest extends TestCase
         self::assertTrue($node1 === $node2);
     }
 
-    public function testRemoveNonExistingKeyOnSameIndex(): void
+    public function test_remove_non_existing_key_on_same_index(): void
     {
         $hasher = new ModuloHasher();
         $node1 = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -162,7 +162,7 @@ class IndexedNodeTest extends TestCase
         self::assertTrue($node1 === $node2);
     }
 
-    public function testRemoveExistingKeyOnChildNode(): void
+    public function test_remove_existing_key_on_child_node(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -174,7 +174,7 @@ class IndexedNodeTest extends TestCase
         self::assertNull($node->find(0, $hasher->hash(33), 33, null));
     }
 
-    public function testRemoveAllExistingKeysWithChildNodes(): void
+    public function test_remove_all_existing_keys_with_child_nodes(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -186,7 +186,7 @@ class IndexedNodeTest extends TestCase
         self::assertNull($node);
     }
 
-    public function testRemoveAllExistingKeysOnChildNode(): void
+    public function test_remove_all_existing_keys_on_child_node(): void
     {
         $hasher = new ModuloHasher();
         $node = IndexedNode::empty($hasher, new SimpleEqualizer())
@@ -200,7 +200,7 @@ class IndexedNodeTest extends TestCase
         self::assertNull($node->find(0, $hasher->hash(33), 33, null));
     }
 
-    public function testRemoveNonExistingKeysOnChildNode(): void
+    public function test_remove_non_existing_keys_on_child_node(): void
     {
         $hasher = new ModuloHasher();
         $node1 = IndexedNode::empty($hasher, new SimpleEqualizer())

--- a/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentArrayMapTest.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 class PersistentArrayMapTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -23,13 +23,13 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find('test'));
     }
 
-    public function testCanNotCreateFromArrayWithUnevenValues(): void
+    public function test_can_not_create_from_array_with_uneven_values(): void
     {
         $this->expectException(RuntimeException::class);
         PersistentArrayMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['test']);
     }
 
-    public function testAddNullKey(): void
+    public function test_add_null_key(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $h2 = $h->put(null, 'test');
@@ -42,7 +42,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertTrue($h2->contains(null));
     }
 
-    public function testPutKeyValue(): void
+    public function test_put_key_value(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -52,7 +52,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyValueTwice(): void
+    public function test_put_same_key_value_twice(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -63,7 +63,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyDifferentValue(): void
+    public function test_put_same_key_different_value(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -74,7 +74,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertEquals('foo', $h->find(1));
     }
 
-    public function testPutNullTwice(): void
+    public function test_put_null_twice(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -85,7 +85,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(null));
     }
 
-    public function testMerge(): void
+    public function test_merge(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -100,7 +100,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertEquals($expected, $h1->merge($h2));
     }
 
-    public function testConvertToPersistentHashMap(): void
+    public function test_convert_to_persistent_hash_map(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
         for ($i = 0; $i < PersistentArrayMap::MAX_SIZE + 1; $i++) {
@@ -110,7 +110,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertInstanceOf(PersistentHashMap::class, $h);
     }
 
-    public function testRemoveExistingNullKey(): void
+    public function test_remove_existing_null_key(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -121,7 +121,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingNullKey(): void
+    public function test_remove_non_existing_null_key(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(null);
@@ -131,7 +131,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(1);
@@ -141,7 +141,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveNonExistingKeyInChild(): void
+    public function test_remove_non_existing_key_in_child(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(2, 'test')
@@ -154,7 +154,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveExistingKey(): void
+    public function test_remove_existing_key(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -165,7 +165,7 @@ class PersistentArrayMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -179,7 +179,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertTrue($h2->equals($h1));
     }
 
-    public function testEqualsDifferentKeys(): void
+    public function test_equals_different_keys(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -193,7 +193,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentLength(): void
+    public function test_equals_different_length(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -208,7 +208,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentValues(): void
+    public function test_equals_different_values(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -222,7 +222,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentType(): void
+    public function test_equals_different_type(): void
     {
         $h1 = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -231,7 +231,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertFalse($h1->equals([1 => 'foo', 2 => 'bar']));
     }
 
-    public function testIteratable(): void
+    public function test_iteratable(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -246,7 +246,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertEquals([1 => 'foo', 2 => 'bar', 3 => 'foobar'], $result);
     }
 
-    public function testIteratableOnEmpty(): void
+    public function test_iteratable_on_empty(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -258,14 +258,14 @@ class PersistentArrayMapTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testHashOnEmptyMap(): void
+    public function test_hash_on_empty_map(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
         $this->assertEquals(1, $h->hash());
     }
 
-    public function testHashOnSingleEntryyMap(): void
+    public function test_hash_on_single_entryy_map(): void
     {
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 10);
@@ -273,7 +273,7 @@ class PersistentArrayMapTest extends TestCase
         $this->assertEquals(1 + (1 ^ 10), $h->hash());
     }
 
-    public function testAddMetaData(): void
+    public function test_add_meta_data(): void
     {
         $meta = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $h = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())

--- a/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/PersistentHashMapTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersistentHashMapTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -21,7 +21,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find('test'));
     }
 
-    public function testAddNullKey(): void
+    public function test_add_null_key(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $h2 = $h->put(null, 'test');
@@ -34,7 +34,7 @@ class PersistentHashMapTest extends TestCase
         self::assertTrue($h2->contains(null));
     }
 
-    public function testPutKeyValue(): void
+    public function test_put_key_value(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -44,7 +44,7 @@ class PersistentHashMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyValueTwice(): void
+    public function test_put_same_key_value_twice(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -55,7 +55,7 @@ class PersistentHashMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutNullTwice(): void
+    public function test_put_null_twice(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -67,7 +67,7 @@ class PersistentHashMapTest extends TestCase
     }
 
 
-    public function testMerge(): void
+    public function test_merge(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -82,7 +82,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertEquals($expected, $h1->merge($h2));
     }
 
-    public function testRemoveExistingNullKey(): void
+    public function test_remove_existing_null_key(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -93,7 +93,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingNullKey(): void
+    public function test_remove_non_existing_null_key(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(null);
@@ -103,7 +103,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(1);
@@ -113,7 +113,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveNonExistingKeyInChild(): void
+    public function test_remove_non_existing_key_in_child(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(2, 'test')
@@ -126,7 +126,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveExistingKey(): void
+    public function test_remove_existing_key(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -137,7 +137,7 @@ class PersistentHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -151,7 +151,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertTrue($h2->equals($h1));
     }
 
-    public function testEqualsDifferentKeys(): void
+    public function test_equals_different_keys(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -165,7 +165,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentLength(): void
+    public function test_equals_different_length(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -180,7 +180,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentValues(): void
+    public function test_equals_different_values(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -194,7 +194,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertFalse($h2->equals($h1));
     }
 
-    public function testEqualsDifferentType(): void
+    public function test_equals_different_type(): void
     {
         $h1 = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -203,7 +203,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertFalse($h1->equals([1 => 'foo', 2 => 'bar']));
     }
 
-    public function testIteratable(): void
+    public function test_iteratable(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'foo')
@@ -218,7 +218,7 @@ class PersistentHashMapTest extends TestCase
         $this->assertEquals([1 => 'foo', 2 => 'bar', 3 => 'foobar'], $result);
     }
 
-    public function testIteratableOnEmpty(): void
+    public function test_iteratable_on_empty(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -230,14 +230,14 @@ class PersistentHashMapTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testHashOnEmptyMap(): void
+    public function test_hash_on_empty_map(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
         $this->assertEquals(1, $h->hash());
     }
 
-    public function testHashOnSingleEntryyMap(): void
+    public function test_hash_on_single_entryy_map(): void
     {
         $h = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 10);

--- a/tests/php/Unit/Lang/Collections/Map/TransientArrayMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/TransientArrayMapTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class TransientArrayMapTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -23,7 +23,7 @@ class TransientArrayMapTest extends TestCase
         self::assertNull($h->find('test'));
     }
 
-    public function testAddNullKey(): void
+    public function test_add_null_key(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $h2 = $h->put(null, 'test');
@@ -36,7 +36,7 @@ class TransientArrayMapTest extends TestCase
         self::assertTrue($h2->contains(null));
     }
 
-    public function testPutKeyValue(): void
+    public function test_put_key_value(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -46,7 +46,7 @@ class TransientArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyValueTwice(): void
+    public function test_put_same_key_value_twice(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -57,7 +57,7 @@ class TransientArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyDifferentValueTwice(): void
+    public function test_put_same_key_different_value_twice(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -68,7 +68,7 @@ class TransientArrayMapTest extends TestCase
         self::assertEquals('foo', $h->find(1));
     }
 
-    public function testPutNullTwice(): void
+    public function test_put_null_twice(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -79,7 +79,7 @@ class TransientArrayMapTest extends TestCase
         self::assertEquals('test', $h->find(null));
     }
 
-    public function testConvertToTransientHashMap(): void
+    public function test_convert_to_transient_hash_map(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
         for ($i = 0; $i < PersistentArrayMap::MAX_SIZE + 1; $i++) {
@@ -89,7 +89,7 @@ class TransientArrayMapTest extends TestCase
         $this->assertInstanceOf(TransientHashMap::class, $h);
     }
 
-    public function testRemoveExistingNullKey(): void
+    public function test_remove_existing_null_key(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -100,7 +100,7 @@ class TransientArrayMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingNullKey(): void
+    public function test_remove_non_existing_null_key(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(null);
@@ -110,7 +110,7 @@ class TransientArrayMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(1);
@@ -120,7 +120,7 @@ class TransientArrayMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveNonExistingKeyInChild(): void
+    public function test_remove_non_existing_key_in_child(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(2, 'test')
@@ -133,7 +133,7 @@ class TransientArrayMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveExistingKey(): void
+    public function test_remove_existing_key(): void
     {
         $h = TransientArrayMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')

--- a/tests/php/Unit/Lang/Collections/Map/TransientHashMapTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/TransientHashMapTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class TransientHashMapTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
 
@@ -21,7 +21,7 @@ class TransientHashMapTest extends TestCase
         self::assertNull($h->find('test'));
     }
 
-    public function testAddNullKey(): void
+    public function test_add_null_key(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $h2 = $h->put(null, 'test');
@@ -34,7 +34,7 @@ class TransientHashMapTest extends TestCase
         self::assertTrue($h2->contains(null));
     }
 
-    public function testPutKeyValue(): void
+    public function test_put_key_value(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test');
@@ -44,7 +44,7 @@ class TransientHashMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutSameKeyValueTwice(): void
+    public function test_put_same_key_value_twice(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')
@@ -55,7 +55,7 @@ class TransientHashMapTest extends TestCase
         self::assertEquals('test', $h->find(1));
     }
 
-    public function testPutNullTwice(): void
+    public function test_put_null_twice(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -66,7 +66,7 @@ class TransientHashMapTest extends TestCase
         self::assertEquals('test', $h->find(null));
     }
 
-    public function testRemoveExistingNullKey(): void
+    public function test_remove_existing_null_key(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(null, 'test')
@@ -77,7 +77,7 @@ class TransientHashMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingNullKey(): void
+    public function test_remove_non_existing_null_key(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(null);
@@ -87,7 +87,7 @@ class TransientHashMapTest extends TestCase
         self::assertNull($h->find(null));
     }
 
-    public function testRemoveNonExistingKey(): void
+    public function test_remove_non_existing_key(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->remove(1);
@@ -97,7 +97,7 @@ class TransientHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveNonExistingKeyInChild(): void
+    public function test_remove_non_existing_key_in_child(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(2, 'test')
@@ -110,7 +110,7 @@ class TransientHashMapTest extends TestCase
         self::assertNull($h->find(1));
     }
 
-    public function testRemoveExistingKey(): void
+    public function test_remove_existing_key(): void
     {
         $h = TransientHashMap::empty(new ModuloHasher(), new SimpleEqualizer())
             ->put(1, 'test')

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -12,66 +12,66 @@ use PHPUnit\Framework\TestCase;
 
 final class StructTest extends TestCase
 {
-    public function testPut(): void
+    public function test_put(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s = $s->put(new Keyword('a'), 3);
         self::assertEquals([new Keyword('a'), 3, new Keyword('b'), 2], $this->toKeyValueList($s));
     }
 
-    public function testPutInvalidKey(): void
+    public function test_put_invalid_key(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s = $s->put(new Keyword('c'), 2);
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         self::assertTrue(isset($s[new Keyword('a')]));
     }
 
-    public function testOffsetExistsInvalidKey(): void
+    public function test_offset_exists_invalid_key(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         self::assertFalse(isset($s[new Keyword('c')]));
     }
 
-    public function testRemove(): void
+    public function test_remove(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s = $s->remove(new Keyword('a'));
         self::assertEquals(FakeStruct::fromKVs(new Keyword('b'), 2), $s);
     }
 
-    public function testRemoveInvalidKey(): void
+    public function test_remove_invalid_key(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s->remove(new Keyword('c'));
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         self::assertEquals(1, $s[new Keyword('a')]);
     }
 
-    public function testOffsetGetInvalidKey(): void
+    public function test_offset_get_invalid_key(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s[new Keyword('c')];
     }
 
-    public function testCount(): void
+    public function test_count(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         self::assertEquals(2, count($s));
     }
 
-    public function testEqualsOtherType(): void
+    public function test_equals_other_type(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $map = PersistentHashMap::fromArray(
@@ -83,7 +83,7 @@ final class StructTest extends TestCase
         self::assertFalse($s->equals($map));
     }
 
-    public function testEqualsDifferentValues(): void
+    public function test_equals_different_values(): void
     {
         $s1 = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s2 = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 3);
@@ -92,7 +92,7 @@ final class StructTest extends TestCase
         self::assertFalse($s2->equals($s1));
     }
 
-    public function testEqualsSameValues(): void
+    public function test_equals_same_values(): void
     {
         $s1 = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
         $s2 = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
@@ -101,14 +101,14 @@ final class StructTest extends TestCase
         self::assertTrue($s2->equals($s1));
     }
 
-    public function testAllowedKeys(): void
+    public function test_allowed_keys(): void
     {
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);
 
         self::assertEquals([new Keyword('a'), new Keyword('b')], $s->getAllowedKeys());
     }
 
-    public function testWithMeta(): void
+    public function test_with_meta(): void
     {
         $meta = TypeFactory::getInstance()->emptyPersistentMap();
         $s = FakeStruct::fromKVs(new Keyword('a'), 1, new Keyword('b'), 2);

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -17,7 +17,7 @@ use RuntimeException;
 
 final class PersistentVectorTest extends TestCase
 {
-    public function testAppendToTail(): void
+    public function test_append_to_tail(): void
     {
         $vEmpty = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $v1 = $vEmpty->append('a');
@@ -27,7 +27,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals('a', $v1->get(0));
     }
 
-    public function testAppendTailIsFull(): void
+    public function test_append_tail_is_full(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 31));
         $v2 = $v1->append(32);
@@ -37,7 +37,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(32, $v2->get(32));
     }
 
-    public function testAppendOverflowRoot(): void
+    public function test_append_overflow_root(): void
     {
         $initialLength = 32 + (32 * 32) - 1;
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -48,7 +48,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(1056, $v2->get(1056));
     }
 
-    public function testAppendTailIsFullSecondLevel(): void
+    public function test_append_tail_is_full_second_level(): void
     {
         $initialLength = 32 + (32 * 32) + 32 - 1;
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -59,7 +59,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($initialLength + 1, $v2->get($initialLength + 1));
     }
 
-    public function testAppendTailIsFullThirdLevel(): void
+    public function test_append_tail_is_full_third_level(): void
     {
         $initialLength = 32 + (32 * 32) + (32 * 32 * 32) - 1;
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -70,7 +70,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($initialLength + 1, $v2->get($initialLength + 1));
     }
 
-    public function testUpdateOutOfRange(): void
+    public function test_update_out_of_range(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $v = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -78,7 +78,7 @@ final class PersistentVectorTest extends TestCase
         $v->update(1, 10);
     }
 
-    public function testUpdateAppend(): void
+    public function test_update_append(): void
     {
         $vEmpty = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $v1 = $vEmpty->update(0, 10);
@@ -88,7 +88,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(10, $v1->get(0));
     }
 
-    public function testUpdateInTail(): void
+    public function test_update_in_tail(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [10]);
         $v2 = $v1->update(0, 20);
@@ -99,7 +99,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(20, $v2->get(0));
     }
 
-    public function testUpdateInLevelTree(): void
+    public function test_update_in_level_tree(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 32));
         $v2 = $v1->update(0, 20);
@@ -110,7 +110,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(20, $v2->get(0));
     }
 
-    public function testGetOutOfRange(): void
+    public function test_get_out_of_range(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $vEmpty = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -118,7 +118,7 @@ final class PersistentVectorTest extends TestCase
         $vEmpty->get(0);
     }
 
-    public function testPopOnEmptyVector(): void
+    public function test_pop_on_empty_vector(): void
     {
         $this->expectException(RuntimeException::class);
         $vEmpty = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -126,7 +126,7 @@ final class PersistentVectorTest extends TestCase
         $vEmpty->pop();
     }
 
-    public function testPopOnOneElementVector(): void
+    public function test_pop_on_one_element_vector(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $vEmpty = $v1->pop();
@@ -135,7 +135,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(0, $vEmpty->count());
     }
 
-    public function testPopFromTail(): void
+    public function test_pop_from_tail(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $v2 = $v1->pop();
@@ -145,7 +145,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(1, $v2->get(0));
     }
 
-    public function testPopFromTreeLevelOne(): void
+    public function test_pop_from_tree_level_one(): void
     {
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 32));
         $v2 = $v1->pop();
@@ -154,7 +154,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(32, $v2->count());
     }
 
-    public function testPopFromTreeLevelTwo(): void
+    public function test_pop_from_tree_level_two(): void
     {
         $length = 32 + (32 * 32);
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));
@@ -164,7 +164,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($length, $v2->count());
     }
 
-    public function testPopFromTreeLevelTwo2(): void
+    public function test_pop_from_tree_level_two2(): void
     {
         $length = (32 * 32);
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));
@@ -174,7 +174,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($length, $v2->count());
     }
 
-    public function testPopFromTreeLevelThree(): void
+    public function test_pop_from_tree_level_three(): void
     {
         $length = (32 * 32) + (32 * 32 * 31) + 32;
         $v1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));
@@ -184,19 +184,19 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($length, $v2->count());
     }
 
-    public function testToArrayTail(): void
+    public function test_to_array_tail(): void
     {
         $arr = [1, 2, 3];
         $this->assertEquals($arr, PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $arr)->toArray());
     }
 
-    public function testToArrayLevelOne(): void
+    public function test_to_array_level_one(): void
     {
         $arr = range(0, 32);
         $this->assertEquals($arr, PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), $arr)->toArray());
     }
 
-    public function testGetIteratorOnEmptyVector(): void
+    public function test_get_iterator_on_empty_vector(): void
     {
         $v = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $result = [];
@@ -207,7 +207,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testGetIteratorOnTailOnlyVector(): void
+    public function test_get_iterator_on_tail_only_vector(): void
     {
         $v = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $result = [];
@@ -218,7 +218,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals([1, 2], $result);
     }
 
-    public function testGetIteratorOnTreeVector(): void
+    public function test_get_iterator_on_tree_vector(): void
     {
         $v = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 32));
         $result = [];
@@ -232,12 +232,12 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(range(0, 32), $indices);
     }
 
-    public function testGetRangeIterator(): void
+    public function test_get_range_iterator(): void
     {
         $this->assertInstanceOf(RangeIterator::class, PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3])->getRangeIterator(0, 2));
     }
 
-    public function testAddMetaData(): void
+    public function test_add_meta_data(): void
     {
         $meta = TypeFactory::getInstance()->emptyPersistentMap();
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -247,19 +247,19 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals($meta, $vectorWithMeta->getMeta());
     }
 
-    public function testCdrOnEmptyVector(): void
+    public function test_cdr_on_empty_vector(): void
     {
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $this->assertNull($vector->cdr());
     }
 
-    public function testCdrOnOneElementVector(): void
+    public function test_cdr_on_one_element_vector(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $this->assertNull($vector->cdr());
     }
 
-    public function testCdrOnTwoElementVector(): void
+    public function test_cdr_on_two_element_vector(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 
@@ -270,7 +270,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals([2], $result);
     }
 
-    public function testSlice(): void
+    public function test_slice(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -279,7 +279,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(2, count($vector));
     }
 
-    public function testSliceToEmpty(): void
+    public function test_slice_to_empty(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 0);
@@ -288,7 +288,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(0, count($vector));
     }
 
-    public function testSliceWithoutLength(): void
+    public function test_slice_without_length(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1);
@@ -297,7 +297,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(3, count($vector));
     }
 
-    public function testAsTransient(): void
+    public function test_as_transient(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->asTransient();
@@ -306,26 +306,26 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(4, count($vector));
     }
 
-    public function testFirstOnEmpty(): void
+    public function test_first_on_empty(): void
     {
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $this->assertNull($vector->first());
     }
 
-    public function testFirstSingleElementVector(): void
+    public function test_first_single_element_vector(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $this->assertEquals(1, $vector->first());
     }
 
-    public function testInvoke(): void
+    public function test_invoke(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4]);
 
         $this->assertEquals(2, $vector(1));
     }
 
-    public function testRestOnEmptyVector(): void
+    public function test_rest_on_empty_vector(): void
     {
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $this->assertEquals(
@@ -334,7 +334,7 @@ final class PersistentVectorTest extends TestCase
         );
     }
 
-    public function testRestOnOneElementVector(): void
+    public function test_rest_on_one_element_vector(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $this->assertEquals(
@@ -343,7 +343,7 @@ final class PersistentVectorTest extends TestCase
         );
     }
 
-    public function testRestOnTwoElementVector(): void
+    public function test_rest_on_two_element_vector(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 
@@ -354,20 +354,20 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals([2], $result);
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $this->assertEquals(994, $vector->hash());
     }
 
-    public function testEqualsOtherType(): void
+    public function test_equals_other_type(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 
         $this->assertFalse($vector->equals([1, 2]));
     }
 
-    public function testEqualsDifferentLength(): void
+    public function test_equals_different_length(): void
     {
         $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
@@ -376,7 +376,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertFalse($vector2->equals($vector1));
     }
 
-    public function testEqualsDifferentValues(): void
+    public function test_equals_different_values(): void
     {
         $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 3]);
@@ -385,7 +385,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertFalse($vector2->equals($vector1));
     }
 
-    public function testEqualsSameValues(): void
+    public function test_equals_same_values(): void
     {
         $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $vector2 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
@@ -394,7 +394,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertTrue($vector2->equals($vector1));
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 
@@ -402,7 +402,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(2, $vector[1]);
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 
@@ -411,7 +411,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertFalse(isset($vector[2]));
     }
 
-    public function testPush(): void
+    public function test_push(): void
     {
         $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $vector2 = $vector1->push(3);
@@ -421,7 +421,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(3, $vector2->get(2));
     }
 
-    public function testConcat(): void
+    public function test_concat(): void
     {
         $vector1 = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $vector2 = $vector1->concat([3, 4]);
@@ -432,7 +432,7 @@ final class PersistentVectorTest extends TestCase
         $this->assertEquals(4, $vector2->get(3));
     }
 
-    public function testContains(): void
+    public function test_contains(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
 

--- a/tests/php/Unit/Lang/Collections/Vector/SubVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/SubVectorTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SubVectorTest extends TestCase
 {
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -22,7 +22,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals([3], $subVector->cdr()->toArray());
     }
 
-    public function testToArray(): void
+    public function test_to_array(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -30,7 +30,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals([2, 3], $subVector->toArray());
     }
 
-    public function testWithMeta(): void
+    public function test_with_meta(): void
     {
         $meta = PersistentHashMap::empty(new ModuloHasher(), new SimpleEqualizer());
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
@@ -41,7 +41,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals($meta, $subVectorWithMeta->getMeta());
     }
 
-    public function testGetIterator(): void
+    public function test_get_iterator(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -54,7 +54,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals([2, 3], $result);
     }
 
-    public function testAppend(): void
+    public function test_append(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -66,7 +66,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals(10, $subVectorAppended->get(2));
     }
 
-    public function testUpdateOutOfRange(): void
+    public function test_update_out_of_range(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
@@ -75,7 +75,7 @@ final class SubVectorTest extends TestCase
         $subVector->update(3, 10);
     }
 
-    public function testUpdateAsAppend(): void
+    public function test_update_as_append(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -86,7 +86,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals(10, $subVectorAppended->get(2));
     }
 
-    public function testUpdate(): void
+    public function test_update(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -97,7 +97,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals(10, $subVectorUpdated->get(0));
     }
 
-    public function testGet(): void
+    public function test_get(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -106,7 +106,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals(3, $subVector->get(1));
     }
 
-    public function testGetOutOfBound(): void
+    public function test_get_out_of_bound(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
@@ -115,7 +115,7 @@ final class SubVectorTest extends TestCase
         $subVector->get(2);
     }
 
-    public function testPopOnEmptySubVector(): void
+    public function test_pop_on_empty_sub_vector(): void
     {
         $subVector = new SubVector(
             new ModuloHasher(),
@@ -132,7 +132,7 @@ final class SubVectorTest extends TestCase
         );
     }
 
-    public function testPop(): void
+    public function test_pop(): void
     {
         $subVector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2);
@@ -142,7 +142,7 @@ final class SubVectorTest extends TestCase
         $this->assertEquals(1, count($subVectorPopped));
     }
 
-    public function testSlice(): void
+    public function test_slice(): void
     {
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4])
             ->slice(1, 2)

--- a/tests/php/Unit/Lang/Collections/Vector/TransientVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/TransientVectorTest.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 final class TransientVectorTest extends TestCase
 {
-    public function testAppendToTail(): void
+    public function test_append_to_tail(): void
     {
         $vEmpty = TransientVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $v1 = $vEmpty->append('a');
@@ -23,7 +23,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals('a', $v1->get(0));
     }
 
-    public function testAppendTailIsFull(): void
+    public function test_append_tail_is_full(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 31));
         $v2 = $v1->append(32);
@@ -33,7 +33,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(32, $v2->get(32));
     }
 
-    public function testAppendOverflowRoot(): void
+    public function test_append_overflow_root(): void
     {
         $initialLength = 32 + (32 * 32) - 1;
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -44,7 +44,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(1056, $v2->get(1056));
     }
 
-    public function testAppendTailIsFullSecondLevel(): void
+    public function test_append_tail_is_full_second_level(): void
     {
         $initialLength = 32 + (32 * 32) + 32 - 1;
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -55,7 +55,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals($initialLength + 1, $v2->get($initialLength + 1));
     }
 
-    public function testAppendTailIsFullThirdLevel(): void
+    public function test_append_tail_is_full_third_level(): void
     {
         $initialLength = 32 + (32 * 32) + (32 * 32 * 32) - 1;
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $initialLength));
@@ -66,7 +66,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals($initialLength + 1, $v2->get($initialLength + 1));
     }
 
-    public function testUpdateOutOfRange(): void
+    public function test_update_out_of_range(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $v = TransientVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -74,7 +74,7 @@ final class TransientVectorTest extends TestCase
         $v->update(1, 10);
     }
 
-    public function testUpdateAppend(): void
+    public function test_update_append(): void
     {
         $vEmpty = TransientVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $v1 = $vEmpty->update(0, 10);
@@ -85,7 +85,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(10, $v1->get(0));
     }
 
-    public function testUpdateInTail(): void
+    public function test_update_in_tail(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [10]);
         $v2 = $v1->update(0, 20);
@@ -96,7 +96,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(20, $v2->get(0));
     }
 
-    public function testUpdateInLevelTree(): void
+    public function test_update_in_level_tree(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 32));
         $v2 = $v1->update(0, 20);
@@ -107,7 +107,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(20, $v2->get(0));
     }
 
-    public function testGetOutOfRange(): void
+    public function test_get_out_of_range(): void
     {
         $this->expectException(IndexOutOfBoundsException::class);
         $vEmpty = TransientVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -115,7 +115,7 @@ final class TransientVectorTest extends TestCase
         $vEmpty->get(0);
     }
 
-    public function testPopOnEmptyVector(): void
+    public function test_pop_on_empty_vector(): void
     {
         $this->expectException(RuntimeException::class);
         $vEmpty = TransientVector::empty(new ModuloHasher(), new SimpleEqualizer());
@@ -123,7 +123,7 @@ final class TransientVectorTest extends TestCase
         $vEmpty->pop();
     }
 
-    public function testPopOnOneElementVector(): void
+    public function test_pop_on_one_element_vector(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $vEmpty = $v1->pop();
@@ -132,7 +132,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(0, $vEmpty->count());
     }
 
-    public function testPopFromTail(): void
+    public function test_pop_from_tail(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
         $v2 = $v1->pop();
@@ -142,7 +142,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(1, $v2->get(0));
     }
 
-    public function testPopFromTreeLevelOne(): void
+    public function test_pop_from_tree_level_one(): void
     {
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, 32));
         $v2 = $v1->pop();
@@ -151,7 +151,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals(32, $v2->count());
     }
 
-    public function testPopFromTreeLevelTwo(): void
+    public function test_pop_from_tree_level_two(): void
     {
         $length = 32 + (32 * 32);
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));
@@ -161,7 +161,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals($length, $v2->count());
     }
 
-    public function testPopFromTreeLevelTwo2(): void
+    public function test_pop_from_tree_level_two2(): void
     {
         $length = (32 * 32);
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));
@@ -171,7 +171,7 @@ final class TransientVectorTest extends TestCase
         $this->assertEquals($length, $v2->count());
     }
 
-    public function testPopFromTreeLevelThree(): void
+    public function test_pop_from_tree_level_three(): void
     {
         $length = (32 * 32) + (32 * 32 * 31) + 32;
         $v1 = TransientVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), range(0, $length));

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -10,19 +10,19 @@ use PHPUnit\Framework\TestCase;
 
 final class KeywordTest extends TestCase
 {
-    public function testGetName(): void
+    public function test_get_name(): void
     {
         $keyword = new Keyword('test');
         $this->assertEquals('test', $keyword->getName());
     }
 
-    public function testGetHash(): void
+    public function test_get_hash(): void
     {
         $keyword = new Keyword('test');
         $this->assertEquals(crc32(':test'), $keyword->hash());
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $keyword1 = new Keyword('test');
         $keyword2 = new Keyword('test');
@@ -31,7 +31,7 @@ final class KeywordTest extends TestCase
         $this->assertTrue($keyword2->equals($keyword1));
     }
 
-    public function testNotEquals(): void
+    public function test_not_equals(): void
     {
         $keyword1 = new Keyword('test');
         $keyword2 = new Keyword('test1');
@@ -41,7 +41,7 @@ final class KeywordTest extends TestCase
         $this->assertFalse($keyword1->equals(':test'));
     }
 
-    public function testIdentical(): void
+    public function test_identical(): void
     {
         $keyword1 = new Keyword('test');
         $keyword2 = new Keyword('test');
@@ -50,13 +50,13 @@ final class KeywordTest extends TestCase
         $this->assertTrue($keyword2->identical($keyword1));
     }
 
-    public function testToString(): void
+    public function test_to_string(): void
     {
         $keyword = new Keyword('test');
         $this->assertEquals(':test', $keyword->__toString());
     }
 
-    public function testInvoke(): void
+    public function test_invoke(): void
     {
         $keyword1 = new Keyword('test1');
         $keyword2 = new Keyword('test2');

--- a/tests/php/Unit/Lang/PhelArrayTest.php
+++ b/tests/php/Unit/Lang/PhelArrayTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 
 final class PhelArrayTest extends TestCase
 {
-    public function testOffsetSet(): void
+    public function test_offset_set(): void
     {
         $arr = new PhelArray([1]);
         $arr[0] = 10;
         $this->assertEquals(10, $arr[0]);
     }
 
-    public function testOffsetSetEnd(): void
+    public function test_offset_set_end(): void
     {
         $arr = new PhelArray([]);
         $arr[2] = 10;
@@ -27,14 +27,14 @@ final class PhelArrayTest extends TestCase
     }
 
 
-    public function testOffsetSetSmallerZero(): void
+    public function test_offset_set_smaller_zero(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $arr = new PhelArray([]);
         $arr[-1] = 10;
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $arr = new PhelArray([1]);
 
@@ -42,7 +42,7 @@ final class PhelArrayTest extends TestCase
         $this->assertFalse(isset($arr[1]));
     }
 
-    public function testOffsetUnset(): void
+    public function test_offset_unset(): void
     {
         $arr = new PhelArray([1, 2, 3]);
 
@@ -50,34 +50,34 @@ final class PhelArrayTest extends TestCase
         $this->assertEquals([1, 3], $arr->toPhpArray());
     }
 
-    public function testOffsetUnsetOutOfBound1(): void
+    public function test_offset_unset_out_of_bound1(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $arr = new PhelArray([1, 2, 3]);
         unset($arr[-1]);
     }
 
-    public function testOffsetUnsetOutOfBound2(): void
+    public function test_offset_unset_out_of_bound2(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $arr = new PhelArray([1, 2, 3]);
         unset($arr[3]);
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $arr = new PhelArray([1]);
         $this->assertEquals(1, $arr[0]);
         $this->assertNull($arr[1]);
     }
 
-    public function testCount(): void
+    public function test_count(): void
     {
         $arr = new PhelArray([1]);
         $this->assertEquals(1, count($arr));
     }
 
-    public function testForeach(): void
+    public function test_foreach(): void
     {
         $arr = new PhelArray([1, 2, 3]);
 
@@ -89,7 +89,7 @@ final class PhelArrayTest extends TestCase
         $this->assertEquals([1, 2, 3], $result);
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $arr1 = new PhelArray([1, 2, 3]);
         $arr2 = new PhelArray([1, 2, 3]);
@@ -99,7 +99,7 @@ final class PhelArrayTest extends TestCase
         $this->assertTrue($arr2->equals($arr1));
     }
 
-    public function testNotEquals(): void
+    public function test_not_equals(): void
     {
         $arr1 = new PhelArray([1, 2, 3]);
         $arr2 = new PhelArray([]);
@@ -108,7 +108,7 @@ final class PhelArrayTest extends TestCase
         $this->assertFalse($arr2->equals($arr1));
     }
 
-    public function testNotEqualsWhenOtherInstanceIsBeingCompared(): void
+    public function test_not_equals_when_other_instance_is_being_compared(): void
     {
         $class = new class() {
             public array $data = [1,2,3];
@@ -119,49 +119,49 @@ final class PhelArrayTest extends TestCase
         self::assertFalse($arr1->equals($class));
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $arr = new PhelArray([1, 2, 3]);
         $this->assertEquals(crc32(spl_object_hash($arr)), $arr->hash());
     }
 
-    public function testSlice(): void
+    public function test_slice(): void
     {
         $arr = new PhelArray([1, 2, 3]);
         $this->assertEquals(new PhelArray([2, 3]), $arr->slice(1));
         $this->assertEquals(new PhelArray([2]), $arr->slice(1, 1));
     }
 
-    public function testCons(): void
+    public function test_cons(): void
     {
         $arr = new PhelArray([1, 2, 3]);
         $this->assertEquals(new PhelArray([0, 1, 2, 3]), $arr->cons(0));
     }
 
-    public function testToPhpArray(): void
+    public function test_to_php_array(): void
     {
         $this->assertEquals([1, 2, 3], (new PhelArray([1, 2, 3]))->toPhpArray());
     }
 
-    public function testFirst(): void
+    public function test_first(): void
     {
         $this->assertEquals(1, (new PhelArray([1, 2, 3]))->first());
         $this->assertNull((new PhelArray([]))->first());
     }
 
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $this->assertEquals(new PhelArray([2, 3]), (new PhelArray([1, 2, 3]))->cdr());
         $this->assertNull((new PhelArray([]))->cdr());
     }
 
-    public function testRest(): void
+    public function test_rest(): void
     {
         $this->assertEquals(new PhelArray([2, 3]), (new PhelArray([1, 2, 3]))->rest());
         $this->assertEquals(new PhelArray([]), (new PhelArray([]))->rest());
     }
 
-    public function testPop(): void
+    public function test_pop(): void
     {
         $arr = new PhelArray([1, 2, 3]);
         $x = $arr->pop();
@@ -169,20 +169,20 @@ final class PhelArrayTest extends TestCase
         $this->assertEquals(new PhelArray([1, 2]), $arr);
     }
 
-    public function testRemove(): void
+    public function test_remove(): void
     {
         $arr = new PhelArray([1, 2, 3]);
         $this->assertEquals(new PhelArray([2]), $arr->remove(1, 1));
         $this->assertEquals(new PhelArray([3]), $arr->remove(1));
     }
 
-    public function testPush(): void
+    public function test_push(): void
     {
         $arr = new PhelArray([]);
         $this->assertEquals(new PhelArray([1]), $arr->push(1));
     }
 
-    public function testConcat(): void
+    public function test_concat(): void
     {
         $arr1 = new PhelArray([1, 2]);
         $arr2 = new PhelArray([3, 4]);
@@ -193,7 +193,7 @@ final class PhelArrayTest extends TestCase
         $this->assertEquals(new PhelArray([3, 4]), $arr2);
     }
 
-    public function testToString(): void
+    public function test_to_string(): void
     {
         $this->assertEquals('@[1 2 3]', (new PhelArray([1, 2, 3]))->__toString());
     }

--- a/tests/php/Unit/Lang/SetTest.php
+++ b/tests/php/Unit/Lang/SetTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SetTest extends TestCase
 {
-    public function testCount(): void
+    public function test_count(): void
     {
         $set1 = new Set([]);
         $set2 = new Set(['a']);
@@ -22,13 +22,13 @@ final class SetTest extends TestCase
         $this->assertEquals(2, count($set4));
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $set = new Set(['a']);
         $this->assertEquals(crc32(spl_object_hash($set)), $set->hash());
     }
 
-    public function testForeach(): void
+    public function test_foreach(): void
     {
         $set = new Set(['a', 'b']);
         $result = [];
@@ -39,7 +39,7 @@ final class SetTest extends TestCase
         $this->assertEquals(['a', 'b'], $result);
     }
 
-    public function testCons(): void
+    public function test_cons(): void
     {
         $set = new Set(['a']);
         $set->cons('b');
@@ -47,43 +47,43 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 'b']), $set);
     }
 
-    public function testFirst(): void
+    public function test_first(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals('a', $set->first());
     }
 
-    public function testFirstEmpty(): void
+    public function test_first_empty(): void
     {
         $set = new Set([]);
         $this->assertNull($set->first());
     }
 
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(new PhelArray(['b']), $set->cdr());
     }
 
-    public function testCdrEmpty(): void
+    public function test_cdr_empty(): void
     {
         $set = new Set([]);
         $this->assertEquals(null, $set->cdr());
     }
 
-    public function testRest(): void
+    public function test_rest(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(new PhelArray(['b']), $set->rest());
     }
 
-    public function testRestEmpty(): void
+    public function test_rest_empty(): void
     {
         $set = new Set([]);
         $this->assertEquals(new PhelArray([]), $set->rest());
     }
 
-    public function testPush(): void
+    public function test_push(): void
     {
         $set = new Set(['a']);
         $set->push('b');
@@ -91,7 +91,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 'b']), $set);
     }
 
-    public function testPushDifferentTypes(): void
+    public function test_push_different_types(): void
     {
         $set1 = new Set(['a']);
         $set2 = new Set(['b']);
@@ -103,7 +103,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['a', 1, $set2, $date]), $set1);
     }
 
-    public function testConcat(): void
+    public function test_concat(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -113,7 +113,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testIntersection(): void
+    public function test_intersection(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -124,7 +124,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testDifference(): void
+    public function test_difference(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['b', 'c']);
@@ -135,7 +135,7 @@ final class SetTest extends TestCase
         $this->assertEquals(new Set(['b', 'c']), $set2);
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $set1 = new Set(['a', 'b']);
         $set2 = new Set(['a', 'b']);
@@ -148,13 +148,13 @@ final class SetTest extends TestCase
         $this->assertFalse($set3->equals($set1));
     }
 
-    public function testToPhpArray(): void
+    public function test_to_php_array(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals(['a', 'b'], $set->toPhpArray());
     }
 
-    public function testToString(): void
+    public function test_to_string(): void
     {
         $set = new Set(['a', 'b']);
         $this->assertEquals('(set "a" "b")', $set->__toString());

--- a/tests/php/Unit/Lang/SourceLocationTest.php
+++ b/tests/php/Unit/Lang/SourceLocationTest.php
@@ -9,39 +9,39 @@ use PHPUnit\Framework\TestCase;
 
 final class SourceLocationTest extends TestCase
 {
-    public function testGetFile(): void
+    public function test_get_file(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals('/test', $s->getFile());
     }
 
-    public function testSetFile(): void
+    public function test_set_file(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setFile('/abc');
         $this->assertEquals('/abc', $s->getFile());
     }
 
-    public function testGetLine(): void
+    public function test_get_line(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals(1, $s->getLine());
     }
 
-    public function testSetLine(): void
+    public function test_set_line(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setLine(32);
         $this->assertEquals(32, $s->getLine());
     }
 
-    public function testGetColumn(): void
+    public function test_get_column(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $this->assertEquals(2, $s->getColumn());
     }
 
-    public function testSetColumn(): void
+    public function test_set_column(): void
     {
         $s = new SourceLocation('/test', 1, 2);
         $s->setColumn(32);

--- a/tests/php/Unit/Lang/SymbolTest.php
+++ b/tests/php/Unit/Lang/SymbolTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SymbolTest extends TestCase
 {
-    public function testCreateWithoutNs(): void
+    public function test_create_without_ns(): void
     {
         $s = Symbol::create('test');
         $this->assertEquals('test', $s->getName());
@@ -17,7 +17,7 @@ final class SymbolTest extends TestCase
         $this->assertEquals('test', $s->getFullName());
     }
 
-    public function testCreateWithNs(): void
+    public function test_create_with_ns(): void
     {
         $s = Symbol::create('namespace/test');
         $this->assertEquals('test', $s->getName());
@@ -25,7 +25,7 @@ final class SymbolTest extends TestCase
         $this->assertEquals('namespace/test', $s->getFullName());
     }
 
-    public function testCreateForNamespaceWithoutNs(): void
+    public function test_create_for_namespace_without_ns(): void
     {
         $s = Symbol::createForNamespace(null, 'test');
         $this->assertEquals('test', $s->getName());
@@ -33,7 +33,7 @@ final class SymbolTest extends TestCase
         $this->assertEquals('test', $s->getFullName());
     }
 
-    public function testCreateForNamespaceWithNs(): void
+    public function test_create_for_namespace_with_ns(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
         $this->assertEquals('test', $s->getName());
@@ -41,26 +41,26 @@ final class SymbolTest extends TestCase
         $this->assertEquals('namespace/test', $s->getFullName());
     }
 
-    public function testToString(): void
+    public function test_to_string(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
         $this->assertEquals('test', $s->__toString());
     }
 
-    public function testGen(): void
+    public function test_gen(): void
     {
         Symbol::resetGen();
         $this->assertEquals('__phel_1', Symbol::gen());
         $this->assertEquals('bla2', Symbol::gen('bla'));
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
         $this->assertEquals(crc32('test'), $s->hash());
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $s1 = Symbol::createForNamespace('namespace', 'test');
         $s2 = Symbol::createForNamespace('namespace', 'test');
@@ -75,7 +75,7 @@ final class SymbolTest extends TestCase
         $this->assertFalse($s4->equals($s1));
     }
 
-    public function testIdentical(): void
+    public function test_identical(): void
     {
         $s1 = Symbol::createForNamespace('namespace', 'test');
         $s2 = Symbol::createForNamespace('namespace', 'test');

--- a/tests/php/Unit/Lang/TableTest.php
+++ b/tests/php/Unit/Lang/TableTest.php
@@ -11,40 +11,40 @@ use PHPUnit\Framework\TestCase;
 
 final class TableTest extends TestCase
 {
-    public function testEmpty(): void
+    public function test_empty(): void
     {
         $table = Table::empty('a', 1, 'b', 2);
         self::assertEquals(0, $table->count());
     }
 
-    public function testFromKv(): void
+    public function test_from_kv(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2);
         self::assertEquals(1, $table['a']);
         self::assertEquals(2, $table['b']);
     }
 
-    public function testFromKvUneven(): void
+    public function test_from_kv_uneven(): void
     {
         $this->expectException(\Exception::class);
         $table = Table::fromKVs('a', 1, 'b');
     }
 
-    public function testFromKVArray(): void
+    public function test_from_kv_array(): void
     {
         $table = Table::fromKVArray(['a', 1, 'b', 2]);
         self::assertEquals(1, $table['a']);
         self::assertEquals(2, $table['b']);
     }
 
-    public function testOffsetSetExistingValue(): void
+    public function test_offset_set_existing_value(): void
     {
         $table = Table::fromKVs('a', 1);
         $table['a'] = 2;
         self::assertEquals(2, $table['a']);
     }
 
-    public function testOffsetSetNewValue(): void
+    public function test_offset_set_new_value(): void
     {
         $table = Table::fromKVs('a', 1);
         $table['b'] = 2;
@@ -52,7 +52,7 @@ final class TableTest extends TestCase
         self::assertEquals(2, $table['b']);
     }
 
-    public function testOffsetExists(): void
+    public function test_offset_exists(): void
     {
         $table = Table::fromKVs('a', 1);
 
@@ -60,7 +60,7 @@ final class TableTest extends TestCase
         self::assertFalse(isset($table['b']));
     }
 
-    public function testOffestUnset(): void
+    public function test_offest_unset(): void
     {
         $table = Table::fromKVs('a', 1);
         unset($table['a']);
@@ -69,19 +69,19 @@ final class TableTest extends TestCase
         self::assertNull($table['a']);
     }
 
-    public function testOffsetGet(): void
+    public function test_offset_get(): void
     {
         $table = Table::fromKVs('a', 1);
         self::assertEquals(1, $table['a']);
     }
 
-    public function testCount(): void
+    public function test_count(): void
     {
         $table = Table::fromKVs('a', 1);
         $this->assertEquals(1, count($table));
     }
 
-    public function testForeach(): void
+    public function test_foreach(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2);
         $result = [];
@@ -92,7 +92,7 @@ final class TableTest extends TestCase
         $this->assertEquals(['a' => 1, 'b' => 2], $result);
     }
 
-    public function testFirst(): void
+    public function test_first(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2);
         $this->assertEquals(
@@ -101,7 +101,7 @@ final class TableTest extends TestCase
         );
     }
 
-    public function testCdr(): void
+    public function test_cdr(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2, 'c', 3);
         $this->assertEquals(
@@ -113,13 +113,13 @@ final class TableTest extends TestCase
         );
     }
 
-    public function testCdrEmpty(): void
+    public function test_cdr_empty(): void
     {
         $table = Table::empty();
         $this->assertNull($table->cdr());
     }
 
-    public function testRest(): void
+    public function test_rest(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2, 'c', 3);
         $this->assertEquals(
@@ -131,19 +131,19 @@ final class TableTest extends TestCase
         );
     }
 
-    public function testRestEmpty(): void
+    public function test_rest_empty(): void
     {
         $table = Table::empty();
         $this->assertEquals(PhelArray::create(), $table->rest());
     }
 
-    public function testHash(): void
+    public function test_hash(): void
     {
         $table = Table::fromKVs('a', 1);
         $this->assertEquals(crc32(spl_object_hash($table)), $table->hash());
     }
 
-    public function testEquals(): void
+    public function test_equals(): void
     {
         $table1 = Table::fromKVs('a', 1, 'b', 2);
         $table2 = Table::fromKVs('a', 1, 'b', 2);
@@ -156,7 +156,7 @@ final class TableTest extends TestCase
         $this->assertFalse($table3->equals($table1));
     }
 
-    public function testToKeyValueList(): void
+    public function test_to_key_value_list(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2);
         $this->assertEquals(
@@ -165,7 +165,7 @@ final class TableTest extends TestCase
         );
     }
 
-    public function testToString(): void
+    public function test_to_string(): void
     {
         $table = Table::fromKVs('a', 1, 'b', 2);
         $this->assertEquals(
@@ -174,7 +174,7 @@ final class TableTest extends TestCase
         );
     }
 
-    public function testObjectKey(): void
+    public function test_object_key(): void
     {
         $date = new \DateTime();
         $table = Table::fromKVs($date, 1, 'b', 2);
@@ -182,7 +182,7 @@ final class TableTest extends TestCase
         $this->assertEquals(1, $table[$date]);
     }
 
-    public function testNumberZeroAsValue(): void
+    public function test_number_zero_as_value(): void
     {
         $table = Table::fromKVs('a', 0);
         self::assertEquals(0, $table['a']);

--- a/tests/php/Unit/Lang/TruthyTest.php
+++ b/tests/php/Unit/Lang/TruthyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TruthyTest extends TestCase
 {
-    public function testFalse(): void
+    public function test_false(): void
     {
         $this->assertFalse(Truthy::isTruthy(null));
         $this->assertFalse(Truthy::isTruthy(false));

--- a/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AnonymousClassPrinterTest extends TestCase
 {
-    public function testPrint(): void
+    public function test_print(): void
     {
         $class = new class() {
         };

--- a/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
@@ -14,7 +14,7 @@ final class ArrayPrinterTest extends TestCase
     /**
      * @dataProvider providerPrint
      */
-    public function testPrint(array $form, string $expected): void
+    public function test_print(array $form, string $expected): void
     {
         $printer = new class() implements PrinterInterface {
             public function print($form): string

--- a/tests/php/Unit/Printer/TypePrinter/BooleanPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/BooleanPrinterTest.php
@@ -13,7 +13,7 @@ final class BooleanPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, bool $boolean): void
+    public function test_print(string $expected, bool $boolean): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
@@ -14,7 +14,7 @@ final class KeywordPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, Keyword $keyword): void
+    public function test_print(string $expected, Keyword $keyword): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
@@ -16,7 +16,7 @@ final class ListPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, PersistentListInterface $list): void
+    public function test_print(string $expected, PersistentListInterface $list): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NonPrintableClassPrinterTest.php
@@ -17,7 +17,7 @@ final class NonPrintableClassPrinterTest extends TestCase
      *
      * @param mixed $form
      */
-    public function testPrint($form, string $expected): void
+    public function test_print($form, string $expected): void
     {
         self::assertSame($expected, (new NonPrintableClassPrinter())->print($form));
     }

--- a/tests/php/Unit/Printer/TypePrinter/NullPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NullPrinterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class NullPrinterTest extends TestCase
 {
-    public function testPrint(): void
+    public function test_print(): void
     {
         self::assertSame('nil', (new NullPrinter())->print(null));
     }

--- a/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
@@ -15,7 +15,7 @@ final class NumberPrinterTest extends TestCase
      *
      * @param int|float $number
      */
-    public function testPrint(string $expected, $number): void
+    public function test_print(string $expected, $number): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
@@ -13,7 +13,7 @@ final class ObjectPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, object $object): void
+    public function test_print(string $expected, object $object): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/PhelArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/PhelArrayPrinterTest.php
@@ -15,7 +15,7 @@ final class PhelArrayPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, PhelArray $phelArray): void
+    public function test_print(string $expected, PhelArray $phelArray): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/ResourcePrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ResourcePrinterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ResourcePrinterTest extends TestCase
 {
-    public function testPrint(): void
+    public function test_print(): void
     {
         self::assertMatchesRegularExpression(
             '<PHP Resource id #Resource id #\d+>',

--- a/tests/php/Unit/Printer/TypePrinter/SetPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/SetPrinterTest.php
@@ -15,7 +15,7 @@ final class SetPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, Set $set): void
+    public function test_print(string $expected, Set $set): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class StringPrinterTest extends TestCase
 {
-    public function testPrintNoReadable(): void
+    public function test_print_no_readable(): void
     {
         self::assertSame('str', (new StringPrinter(false))->print('str'));
     }
@@ -18,7 +18,7 @@ final class StringPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrintReadable(string $expected, string $string): void
+    public function test_print_readable(string $expected, string $string): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/StructPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/StructPrinterTest.php
@@ -16,7 +16,7 @@ final class StructPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $actual, AbstractPersistentStruct $struct): void
+    public function test_print(string $actual, AbstractPersistentStruct $struct): void
     {
         self::assertSame(
             $actual,

--- a/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
@@ -14,7 +14,7 @@ final class SymbolPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, Symbol $symbol): void
+    public function test_print(string $expected, Symbol $symbol): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/TablePrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/TablePrinterTest.php
@@ -15,7 +15,7 @@ final class TablePrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, Table $table): void
+    public function test_print(string $expected, Table $table): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Printer/TypePrinter/ToStringPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ToStringPrinterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ToStringPrinterTest extends TestCase
 {
-    public function testPrint(): void
+    public function test_print(): void
     {
         $class = new class() {
             public function __toString(): string

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -16,7 +16,7 @@ final class VectorPrinterTest extends TestCase
     /**
      * @dataProvider printerDataProvider
      */
-    public function testPrint(string $expected, PersistentVectorInterface $vector): void
+    public function test_print(string $expected, PersistentVectorInterface $vector): void
     {
         self::assertSame(
             $expected,

--- a/tests/php/Unit/Runtime/RuntimeTest.php
+++ b/tests/php/Unit/Runtime/RuntimeTest.php
@@ -28,7 +28,7 @@ final class RuntimeTest extends TestCase
         $this->runtime->addPath('Foo\\Bar\\Baz\\Dib\\Zim\\Gir\\', ['/vendor/foo.bar.baz.dib.zim.gir/src']);
     }
 
-    public function testExistingFile(): void
+    public function test_existing_file(): void
     {
         $this->runtime->loadNs('Foo\Bar\Core');
         self::assertEquals(
@@ -43,12 +43,12 @@ final class RuntimeTest extends TestCase
         );
     }
 
-    public function testMissing(): void
+    public function test_missing(): void
     {
         self::assertFalse($this->runtime->loadNs('No_Vendor\No_Package\NoClass'));
     }
 
-    public function testDeepFile(): void
+    public function test_deep_file(): void
     {
         $this->runtime->loadNs('Foo\Bar\Baz\Dib\Zim\Gir\Core');
         self::assertEquals(
@@ -57,7 +57,7 @@ final class RuntimeTest extends TestCase
         );
     }
 
-    public function testConfusion(): void
+    public function test_confusion(): void
     {
         $this->runtime->loadNs('Foo\Bar\Doom');
         self::assertEquals(


### PR DESCRIPTION
## 📚 Description

Change the test-names from camelCase to snake_case (clarity purposes).

```php
public function testMethodName(): void
{
    self::assertEquals(...);
}

// TO

public function test_method_name(): void
{
    self::assertEquals(...);
}
```

## 🔖 Changes

- Add `php_unit_method_casing` rule to PHP cs fix
- Execute `composer csfix`
