### PR TITLE
Make NamespaceExtractor more independent

### DIFF
--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -6,11 +6,11 @@ namespace Phel\Command\Test;
 
 use Phel\Command\Shared\CommandExceptionWriterInterface;
 use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
-use Phel\Compiler\Analyzer\Ast\NsNode;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
 use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
@@ -131,7 +131,7 @@ final class TestCommand extends Command
     {
         if (empty($paths)) {
             return array_map(
-                static fn (NsNode $node): string => $node->getNamespace(),
+                static fn (NamespaceInformation $info): string => $info->getNamespace(),
                 $this->namespaceExtractor->getNamespaceFromDirectories($this->defaultTestDirectories)
             );
         }

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Interop\ExportFinder;
 
-use Phel\Compiler\Compiler\ExtractorException;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
@@ -12,6 +11,7 @@ use Phel\Interop\ReadModel\FunctionToExport;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
+use Phel\NamespaceExtractor\Extractor\ExtractorException;
 use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinderInterface.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinderInterface.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Interop\ExportFinder;
 
-use Phel\Compiler\Compiler\ExtractorException;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Interop\ReadModel\FunctionToExport;
+use Phel\NamespaceExtractor\Extractor\ExtractorException;
 
 interface FunctionsToExportFinderInterface
 {

--- a/src/php/NamespaceExtractor/Extractor/ExtractorException.php
+++ b/src/php/NamespaceExtractor/Extractor/ExtractorException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Compiler\Compiler;
+namespace Phel\NamespaceExtractor\Extractor;
 
 use RuntimeException;
 

--- a/src/php/NamespaceExtractor/Extractor/NamespaceExtractorInterface.php
+++ b/src/php/NamespaceExtractor/Extractor/NamespaceExtractorInterface.php
@@ -2,18 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Phel\Compiler\Compiler;
-
-use Phel\Compiler\Analyzer\Ast\NsNode;
+namespace Phel\NamespaceExtractor\Extractor;
 
 interface NamespaceExtractorInterface
 {
-    public function getNamespaceFromFile(string $path): NsNode;
+    public function getNamespaceFromFile(string $path): NamespaceInformation;
 
     /**
      * @param list<string> $directories
      *
-     * @return NsNode[]
+     * @return NamespaceInformation[]
      */
     public function getNamespacesFromDirectories(array $directories): array;
 }

--- a/src/php/NamespaceExtractor/Extractor/NamespaceInformation.php
+++ b/src/php/NamespaceExtractor/Extractor/NamespaceInformation.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\NamespaceExtractor\Extractor;
 
-class NamespaceInformation
+final class NamespaceInformation
 {
     private string $file;
     private string $namespace;

--- a/src/php/NamespaceExtractor/Extractor/NamespaceInformation.php
+++ b/src/php/NamespaceExtractor/Extractor/NamespaceInformation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\NamespaceExtractor\Extractor;
+
+class NamespaceInformation
+{
+    private string $file;
+    private string $namespace;
+    /** @var string[] */
+    private array $dependencies;
+
+    public function __construct(string $file, string $namespace, array $dependencies)
+    {
+        $this->file = $file;
+        $this->namespace = $namespace;
+        $this->dependencies = $dependencies;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getDependencies(): array
+    {
+        return $this->dependencies;
+    }
+}

--- a/src/php/NamespaceExtractor/NamespaceExtractorFacade.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFacade.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\NamespaceExtractor;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\Compiler\Analyzer\Ast\NsNode;
+use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
 
 /**
  * @method NamespaceExtractorFactory getFactory()
@@ -18,9 +18,9 @@ final class NamespaceExtractorFacade extends AbstractFacade implements Namespace
      *
      * @param string $filename The path to the file
      *
-     * @return NsNode
+     * @return NamespaceInformation
      */
-    public function getNamespaceFromFile(string $filename): NsNode
+    public function getNamespaceFromFile(string $filename): NamespaceInformation
     {
         return $this->getFactory()
             ->createNamespaceExtractor()
@@ -33,7 +33,7 @@ final class NamespaceExtractorFacade extends AbstractFacade implements Namespace
      *
      * @param string[] $directories The list of the directories
      *
-     * @return NsNode[]
+     * @return NamespaceInformation[]
      */
     public function getNamespaceFromDirectories(array $directories): array
     {

--- a/src/php/NamespaceExtractor/NamespaceExtractorFacadeInterface.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFacadeInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\NamespaceExtractor;
 
-use Phel\Compiler\Analyzer\Ast\NsNode;
+use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
 
 interface NamespaceExtractorFacadeInterface
 {
@@ -14,9 +14,9 @@ interface NamespaceExtractorFacadeInterface
      *
      * @param string $filename The path to the file
      *
-     * @return NsNode
+     * @return NamespaceInformation
      */
-    public function getNamespaceFromFile(string $filename): NsNode;
+    public function getNamespaceFromFile(string $filename): NamespaceInformation;
 
     /**
      * Extracts all namespaces from all Phel files in the given directories.
@@ -24,7 +24,7 @@ interface NamespaceExtractorFacadeInterface
      *
      * @param string[] $directories The list of the directories
      *
-     * @return NsNode[]
+     * @return NamespaceInformation[]
      */
     public function getNamespaceFromDirectories(array $directories): array;
 }

--- a/src/php/NamespaceExtractor/NamespaceExtractorFactory.php
+++ b/src/php/NamespaceExtractor/NamespaceExtractorFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Phel\NamespaceExtractor;
 
 use Gacela\Framework\AbstractFactory;
-use Phel\Compiler\Compiler\NamespaceExtractor;
 use Phel\Compiler\CompilerFacadeInterface;
+use Phel\NamespaceExtractor\Extractor\NamespaceExtractor;
 
 final class NamespaceExtractorFactory extends AbstractFactory
 {


### PR DESCRIPTION
## 📚 Description

This Refactoring makes the NamespaceExtractor more independent from the compiler module.

## 🔖 Changes

- Return a `NamespaceInformation` object instead of the `NsNode`
- Move NamespaceExtractor classes from the compiler module to the NamespaceExtractor module.
