### PR TITLE
Remove passing by ref the array to the push function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Removed `load` function in `phel\core`
+* Pass by value the array (1st argument) to `push` (#306)
 
 ## 0.3.3 (2021-06-04)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -724,6 +724,7 @@ Calling the and function without arguments returns true."
   "Inserts `x` at the end of the sequence `xs`."
   [xs x]
   (cond
+    (php-array? xs) (do (php/apush xs x) xs)
     (or (vector? xs) (php/instanceof xs TransientVectorInterface)) (php/-> xs (append x))
     (or (set? xs) (php/instanceof xs TransientHashSetInterface)) (php/-> xs (add x))
     (php/instanceof xs PushInterface) (php/-> xs (push x))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -722,9 +722,8 @@ Calling the and function without arguments returns true."
 
 (defn push
   "Inserts `x` at the end of the sequence `xs`."
-  [^:reference xs x]
+  [xs x]
   (cond
-    (php-array? xs) (do (php/apush xs x) xs)
     (or (vector? xs) (php/instanceof xs TransientVectorInterface)) (php/-> xs (append x))
     (or (set? xs) (php/instanceof xs TransientHashSetInterface)) (php/-> xs (add x))
     (php/instanceof xs PushInterface) (php/-> xs (push x))
@@ -791,8 +790,7 @@ arrays. Use (php/aunset ds key)"))
 
     (let [x ds]
       (php/aunset x key)
-      x)
-    ))
+      x)))
 
 # --------
 # For loop

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -18,6 +18,13 @@
     (php/apush x 1)
     (is (= (php/array 1) x) "native push on PHP array"))
 
+  (let [x (php/array)]
+    (is (= (php/array 1) (push x 1)) "push on PHP array"))
+
+  (let [x (php/array)]
+    (push x 1)
+    (is (= (php/array) x) "push on PHP array, keeps initial state because it's immutable"))
+
   (let [x []]
     (push x 1)
     (is (= [] x) "push on existing vector, keeps initial state because it's immutable"))

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -15,8 +15,20 @@
     (is (= @[1] x) "push on array"))
 
   (let [x (php/array)]
+    (php/apush x 1)
+    (is (= (php/array 1) x) "native push on PHP array"))
+
+  (let [x []]
     (push x 1)
-    (is (= (php/array 1) x) "push on PHP array")))
+    (is (= [] x) "push on existing vector, keeps initial state because it's immutable"))
+
+  (is (= [1] (push [] 1)) "push on vector")
+
+  (let [x (set)]
+    (push x 1)
+    (is (= (set) x) "push on existing set, keeps initial state because it's immutable"))
+
+  (is (= (set 1) (push (set) 1)) "push on set"))
 
 (deftest test-pop
   (let [x @[1 2]


### PR DESCRIPTION
## 📚 Description

Related to https://github.com/phel-lang/phel-lang/issues/305 

You are currently not able to exec push with a non-variable as 1st argument. Well, you get a really annoying NOTICE 
`(push [] 1)`. The reason was that the `push` function was using the iterable argument as a reference.

## 🔖 Changes

- Remove passing by reference the 1st argument in the phel `push` function.

## 🖼️  Screenshots

<img width="603" alt="Screenshot 2021-06-06 at 00 28 15" src="https://user-images.githubusercontent.com/5256287/120906989-16ff7d00-c65e-11eb-9731-014773f59bb6.png">

