### PR TITLE
Use `$_` to get latest result from the REPL

### DIFF
--- a/src/php/Command/Repl/InputResult.php
+++ b/src/php/Command/Repl/InputResult.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command\Repl;
+
+final class InputResult
+{
+    private const NO_VALUE = 'no_value';
+    private const LAST_RESULT_PLACEHOLDER = '__';
+
+    /** @var ?mixed */
+    private $lastResult;
+
+    /**
+     * @param ?mixed $result
+     */
+    public static function fromAny($result): self
+    {
+        return new self($result);
+    }
+
+    public static function empty(): self
+    {
+        return new self(self::NO_VALUE);
+    }
+
+    /**
+     * @param ?mixed $result
+     */
+    private function __construct($result)
+    {
+        $this->lastResult = $result;
+    }
+
+    public function readBuffer(array $buffer): string
+    {
+        $fullInput = implode(PHP_EOL, $buffer);
+
+        if (self::NO_VALUE === $this->lastResult
+            || false === strpos($fullInput, self::LAST_RESULT_PLACEHOLDER)
+        ) {
+            return $fullInput;
+        }
+
+        return preg_replace(
+            '#".*?"(*SKIP)(*FAIL)|\b' . self::LAST_RESULT_PLACEHOLDER . '\b#s',
+            $this->formattedLastResult(),
+            $fullInput
+        );
+    }
+
+    private function formattedLastResult(): string
+    {
+        if (is_string($this->lastResult)) {
+            return sprintf('"%s"', $this->lastResult);
+        }
+
+        if (is_bool($this->lastResult)) {
+            return $this->lastResult ? 'true' : 'false';
+        }
+
+        if (is_null($this->lastResult)) {
+            return 'nil';
+        }
+
+        return (string)$this->lastResult;
+    }
+}

--- a/src/php/Command/Repl/InputResult.php
+++ b/src/php/Command/Repl/InputResult.php
@@ -7,7 +7,7 @@ namespace Phel\Command\Repl;
 final class InputResult
 {
     private const NO_VALUE = 'no_value';
-    private const LAST_RESULT_PLACEHOLDER = '__';
+    private const LAST_RESULT_PLACEHOLDER = '$_';
 
     /** @var ?mixed */
     private $lastResult;
@@ -44,7 +44,7 @@ final class InputResult
         }
 
         return preg_replace(
-            '#".*?"(*SKIP)(*FAIL)|\b' . self::LAST_RESULT_PLACEHOLDER . '\b#s',
+            '/"[^\\"]*(?:\\.|[^\\"]*)*"(*SKIP)(*F)|' . preg_quote(self::LAST_RESULT_PLACEHOLDER, '/') . '/',
             $this->formattedLastResult(),
             $fullInput
         );

--- a/src/php/Command/Repl/ReplCommand.php
+++ b/src/php/Command/Repl/ReplCommand.php
@@ -34,6 +34,7 @@ final class ReplCommand extends Command
     /** @var string[] */
     private array $inputBuffer = [];
     private int $lineNumber = 1;
+    private InputResult $previousResult;
 
     public function __construct(
         RuntimeFacadeInterface $runtimeFacade,
@@ -48,6 +49,7 @@ final class ReplCommand extends Command
         $this->compilerFacade = $compilerFacade;
         $this->style = $style;
         $this->printer = $printer;
+        $this->previousResult = InputResult::empty();
     }
 
     protected function configure(): void
@@ -138,10 +140,12 @@ final class ReplCommand extends Command
             return;
         }
 
-        $fullInput = implode(PHP_EOL, $this->inputBuffer);
+        $fullInput = $this->previousResult->readBuffer($this->inputBuffer);
 
         try {
             $result = $this->compilerFacade->eval($fullInput, $this->lineNumber - count($this->inputBuffer));
+            $this->previousResult = InputResult::fromAny($result);
+
             $this->addHistory($fullInput);
             $this->io->writeln($this->printer->print($result));
 

--- a/tests/php/Unit/Command/Repl/InputResultTest.php
+++ b/tests/php/Unit/Command/Repl/InputResultTest.php
@@ -12,15 +12,15 @@ final class InputResultTest extends TestCase
     public function test_empty(): void
     {
         $result = InputResult::empty();
-        $actual = $result->readBuffer(['__']);
+        $actual = $result->readBuffer(['$_']);
 
-        self::assertSame('__', $actual);
+        self::assertSame('$_', $actual);
     }
 
     public function test_buffer_boolean(): void
     {
         $result = InputResult::fromAny(true);
-        $actual = $result->readBuffer(['__']);
+        $actual = $result->readBuffer(['$_']);
 
         self::assertSame('true', $actual);
     }
@@ -28,7 +28,7 @@ final class InputResultTest extends TestCase
     public function test_buffer_null(): void
     {
         $result = InputResult::fromAny(null);
-        $actual = $result->readBuffer(['__']);
+        $actual = $result->readBuffer(['$_']);
 
         self::assertSame('nil', $actual);
     }
@@ -36,7 +36,7 @@ final class InputResultTest extends TestCase
     public function test_buffer_numerical(): void
     {
         $result = InputResult::fromAny(2.3);
-        $actual = $result->readBuffer(['(+ 1 __)']);
+        $actual = $result->readBuffer(['(+ 1 $_)']);
 
         self::assertSame('(+ 1 2.3)', $actual);
     }
@@ -44,7 +44,7 @@ final class InputResultTest extends TestCase
     public function test_buffer_string(): void
     {
         $result = InputResult::fromAny('hello');
-        $actual = $result->readBuffer(['(concat __ __)']);
+        $actual = $result->readBuffer(['(concat $_ $_)']);
 
         self::assertSame('(concat "hello" "hello")', $actual);
     }
@@ -52,7 +52,7 @@ final class InputResultTest extends TestCase
     public function test_buffer_multiline(): void
     {
         $result = InputResult::fromAny('str');
-        $actual = $result->readBuffer(['(concat', '__', '__)']);
+        $actual = $result->readBuffer(['(concat', '$_', '$_)']);
         $expected = <<<TXT
 (concat
 "str"
@@ -64,7 +64,7 @@ TXT;
     public function test_buffer_with_normal_underscore(): void
     {
         $result = InputResult::fromAny(true);
-        $actual = $result->readBuffer(['(let [a __ _ 20] a)']);
+        $actual = $result->readBuffer(['(let [a $_ _ 20] a)']);
 
         self::assertSame('(let [a true _ 20] a)', $actual);
     }
@@ -72,8 +72,8 @@ TXT;
     public function test_buffer_inside_string(): void
     {
         $result = InputResult::fromAny(1);
-        $actual = $result->readBuffer(['"__" __']);
+        $actual = $result->readBuffer(['"$_" $_']);
 
-        self::assertSame('"__" 1', $actual);
+        self::assertSame('"$_" 1', $actual);
     }
 }

--- a/tests/php/Unit/Command/Repl/InputResultTest.php
+++ b/tests/php/Unit/Command/Repl/InputResultTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Repl;
+
+use Phel\Command\Repl\InputResult;
+use PHPUnit\Framework\TestCase;
+
+final class InputResultTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $result = InputResult::empty();
+        $actual = $result->readBuffer(['__']);
+
+        self::assertSame('__', $actual);
+    }
+
+    public function test_buffer_boolean(): void
+    {
+        $result = InputResult::fromAny(true);
+        $actual = $result->readBuffer(['__']);
+
+        self::assertSame('true', $actual);
+    }
+
+    public function test_buffer_null(): void
+    {
+        $result = InputResult::fromAny(null);
+        $actual = $result->readBuffer(['__']);
+
+        self::assertSame('nil', $actual);
+    }
+
+    public function test_buffer_numerical(): void
+    {
+        $result = InputResult::fromAny(2.3);
+        $actual = $result->readBuffer(['(+ 1 __)']);
+
+        self::assertSame('(+ 1 2.3)', $actual);
+    }
+
+    public function test_buffer_string(): void
+    {
+        $result = InputResult::fromAny('hello');
+        $actual = $result->readBuffer(['(concat __ __)']);
+
+        self::assertSame('(concat "hello" "hello")', $actual);
+    }
+
+    public function test_buffer_multiline(): void
+    {
+        $result = InputResult::fromAny('str');
+        $actual = $result->readBuffer(['(concat', '__', '__)']);
+        $expected = <<<TXT
+(concat
+"str"
+"str")
+TXT;
+        self::assertSame($expected, $actual);
+    }
+
+    public function test_buffer_with_normal_underscore(): void
+    {
+        $result = InputResult::fromAny(true);
+        $actual = $result->readBuffer(['(let [a __ _ 20] a)']);
+
+        self::assertSame('(let [a true _ 20] a)', $actual);
+    }
+
+    public function test_buffer_inside_string(): void
+    {
+        $result = InputResult::fromAny(1);
+        $actual = $result->readBuffer(['"__" __']);
+
+        self::assertSame('"__" 1', $actual);
+    }
+}


### PR DESCRIPTION
## 📚 Description

If the last result from the REPL is a scalar value, you will be able to use it in your terminal by using `$_`.

## 🔖 Changes

- Add an `InputResult` class that is able to read the input buffer from the terminal and replace the placeholder (dollar sign + underscores)`$_` to the previous result.

## 🖼️ Screenshots

Some examples using simple math operations.
As you can see, `println` function returns `nil`, so that's the latest produced value. 
Some other examples using string and bool types:

![image](https://user-images.githubusercontent.com/6381924/127007362-aafcc10d-fd0b-4a90-b00a-e177de0ffe84.png)

To be considered: you cannot use `$_` to use a function, only scalar values.

![image](https://user-images.githubusercontent.com/6381924/127007561-743e9c7c-ba09-46ee-a6f1-d0272be131f4.png)

Edge case: avoid replacing the value inside double quotes (string)

![image](https://user-images.githubusercontent.com/6381924/127007907-879a46c6-1141-415b-8061-3c0b3d804e7f.png)
