### PR TITLE
Add spaceship operator function

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -486,6 +486,16 @@ Calling the and function without arguments returns true."
       (recur (first more) (next more))
       false)))
 
+(defn <=>
+  "Alias for the spaceship PHP operator in ascending order. Returns an int."
+  [a b]
+  (php/<=> a b))
+
+(defn >=<
+  "Alias for the spaceship PHP operator in descending order. Returns an int."
+  [a b]
+  (php/<=> b a))
+
 (defn all?
   "Returns true if `(pred x)` is logical true for every `x` in `xs`, else false."
   [pred xs]

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -162,7 +162,8 @@
 
 (deftest test-sort
   (is (= @[1 2 3] (sort @[3 2 1])) "sort")
-  (is (= @[3 3 2 2 1] (sort @[3 2 1 2 3] <)) "sort descending order")
+  (is (= @[1 2 2 3 3] (sort @[3 2 1 2 3] <=>)) "sort ascending order")
+  (is (= @[3 3 2 2 1] (sort @[3 2 1 2 3] >=<)) "sort descending order")
   (is (= @[1 2 3] (sort-by identity @[3 2 1])) "sort-by identity")
   (is (= @[3 2 1] (sort-by - @[3 2 1])) "sort-by reversed"))
 


### PR DESCRIPTION
## 📚 Description

All native PHP sorting functions should return an int and not a bool value.

```
usort(): Returning bool from comparison function is deprecated, 
return an integer less than, equal to, or greater than zero. 
Aka: the spaceship operator instead.
```

Source: https://wiki.php.net/rfc/stable_sorting

Therefore, currently, when running the tests from the core using PHP 8.0+ you can see this warning notice:

<img width="1253" alt="Screenshot 2021-07-24 at 14 15 09" src="https://user-images.githubusercontent.com/5256287/126868101-ed4603a9-480a-458c-bb4b-7f31f7c6dcfe.png">

And this was the result of using the function `<` as a sorting function in one test -> `(sort @[3 2 1 2 3] <)`

## 🔖 Changes

- Add a new core function as an alias for the new PHP spaceship operator `<=>`
- Use this new function in that previous "sorting test" with that warning
- Add another function `>=<` for the inversing sorting operation like `<=>`
