### PR TITLE
Create CommandFacade and use it as entry point instead of CommandFactory

### DIFF
--- a/phel
+++ b/phel
@@ -1,26 +1,26 @@
 #!/usr/bin/env php
 <?php
 
-$slash = DIRECTORY_SEPARATOR;
+declare(strict_types=1);
 
-use Phel\Command\CommandFactory;
+use Phel\Command\CommandFacade;
 use Symfony\Component\Console\Application;
 
-$projectRootDir = getcwd() . $slash;
-$autoloadPath = $projectRootDir . 'vendor' . $slash . 'autoload.php';
+$projectRootDir = getcwd() . DIRECTORY_SEPARATOR;
+$autoloadPath = $projectRootDir . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
 if (!file_exists($autoloadPath)) {
-    exit("Cannot load composer's autoload file: " . $autoloadPath);
+    exit("Cannot load composer's autoload file: $autoloadPath\n");
 }
 
 require $autoloadPath;
 
-$commandFactory = new CommandFactory();
+$commandFacade = new CommandFacade();
 
 $application = new Application();
-$application->add($commandFactory->createExportCommand());
-$application->add($commandFactory->createFormatCommand());
-$application->add($commandFactory->createReplCommand());
-$application->add($commandFactory->createRunCommand());
-$application->add($commandFactory->createTestCommand());
+$application->add($commandFacade->getExportCommand());
+$application->add($commandFacade->getFormatCommand());
+$application->add($commandFacade->getReplCommand());
+$application->add($commandFacade->getRunCommand());
+$application->add($commandFacade->getTestCommand());
 $application->run();

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Command\Export\ExportCommand;
+use Phel\Command\Format\FormatCommand;
+use Phel\Command\Repl\ReplCommand;
+use Phel\Command\Run\RunCommand;
+use Phel\Command\Test\TestCommand;
+
+/**
+ * @method CommandFactory getFactory()
+ */
+final class CommandFacade extends AbstractFacade
+{
+    public function getReplCommand(): ReplCommand
+    {
+        return $this->getFactory()->createReplCommand();
+    }
+
+    public function getRunCommand(): RunCommand
+    {
+        return $this->getFactory()->createRunCommand();
+    }
+
+    public function getTestCommand(): TestCommand
+    {
+        return $this->getFactory()->createTestCommand();
+    }
+
+    public function getFormatCommand(): FormatCommand
+    {
+        return $this->getFactory()->createFormatCommand();
+    }
+
+    public function getExportCommand(): ExportCommand
+    {
+        return $this->getFactory()->createExportCommand();
+    }
+}

--- a/tests/php/Integration/Command/AbstractCommandTest.php
+++ b/tests/php/Integration/Command/AbstractCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Command;
 
-use Phel\Command\CommandFactory;
+use Phel\Command\CommandFacade;
 use Phel\Runtime\RuntimeSingleton;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,9 +16,9 @@ abstract class AbstractCommandTest extends TestCase
         RuntimeSingleton::reset();
     }
 
-    protected function createCommandFactory(): CommandFactory
+    protected function createCommandFacade(): CommandFacade
     {
-        return new CommandFactory();
+        return new CommandFacade();
     }
 
     protected function stubOutput(): OutputInterface

--- a/tests/php/Integration/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Command/Export/ExportCommandTest.php
@@ -19,8 +19,8 @@ final class ExportCommandTest extends AbstractCommandTest
     public function test_export_command_multiple(): void
     {
         $command = $this
-            ->createCommandFactory()
-            ->createExportCommand()
+            ->createCommandFacade()
+            ->getExportCommand()
             ->addRuntimePath('test-cmd-export-multiple\\', [__DIR__ . '/src/test-cmd-export-multiple/']);
 
         $this->expectOutputRegex('~Exported namespaces:~');

--- a/tests/php/Integration/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Command/Format/FormatCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Command\Format;
 
 use Gacela\Framework\Config;
+use Phel\Command\Format\FormatCommand;
 use PhelTest\Integration\Command\AbstractCommandTest;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -22,9 +23,7 @@ final class FormatCommandTest extends AbstractCommandTest
         $path = self::FIXTURES_DIR . 'good-format.phel';
         $oldContent = file_get_contents($path);
 
-        $command = $this
-            ->createCommandFactory()
-            ->createFormatCommand();
+        $command = $this->getFormatCommand();
 
         $this->expectOutputRegex('/No files were formatted+/s');
 
@@ -43,9 +42,7 @@ final class FormatCommandTest extends AbstractCommandTest
         $path = self::FIXTURES_DIR . 'bad-format.phel';
         $oldContent = file_get_contents($path);
 
-        $command = $this
-            ->createCommandFactory()
-            ->createFormatCommand();
+        $command = $this->getFormatCommand();
 
         $this->expectOutputString(<<<TXT
 Formatted files:
@@ -60,6 +57,11 @@ TXT);
         } finally {
             file_put_contents($path, $oldContent);
         }
+    }
+
+    private function getFormatCommand(): FormatCommand
+    {
+        return $this->createCommandFacade()->getFormatCommand();
     }
 
     private function stubInput(array $paths): InputInterface

--- a/tests/php/Integration/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Command/Run/RunCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Command\Run;
 
 use Gacela\Framework\Config;
+use Phel\Command\Run\RunCommand;
 use PhelTest\Integration\Command\AbstractCommandTest;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -19,8 +20,7 @@ final class RunCommandTest extends AbstractCommandTest
     {
         $this->expectOutputRegex('~hello world~');
 
-        $this->createCommandFactory()
-            ->createRunCommand()
+        $this->getRunCommand()
             ->addRuntimePath('test\\', [__DIR__ . '/Fixtures'])
             ->run(
                 $this->stubInput('test\\test-script'),
@@ -32,8 +32,7 @@ final class RunCommandTest extends AbstractCommandTest
     {
         $this->expectOutputRegex('~hello world~');
 
-        $this->createCommandFactory()
-            ->createRunCommand()
+        $this->getRunCommand()
             ->addRuntimePath('test\\', [__DIR__ . '/Fixtures'])
             ->run(
                 $this->stubInput(__DIR__ . '/Fixtures/test-script.phel'),
@@ -46,8 +45,7 @@ final class RunCommandTest extends AbstractCommandTest
         $filename = __DIR__ . '/Fixtures/test-script-not-parsable.phel';
         $this->expectOutputRegex(sprintf('~Cannot parse file: %s~', $filename));
 
-        $this->createCommandFactory()
-            ->createRunCommand()
+        $this->getRunCommand()
             ->run($this->stubInput($filename), $this->stubOutput());
     }
 
@@ -56,8 +54,7 @@ final class RunCommandTest extends AbstractCommandTest
         $filename = __DIR__ . '/Fixtures/this-file-does-not-exist.phel';
         $this->expectOutputRegex(sprintf('~Cannot load namespace: %s~', $filename));
 
-        $this->createCommandFactory()
-            ->createRunCommand()
+        $this->getRunCommand()
             ->run($this->stubInput($filename), $this->stubOutput());
     }
 
@@ -66,9 +63,13 @@ final class RunCommandTest extends AbstractCommandTest
         $filename = __DIR__ . '/Fixtures/test-script-without-ns.phel';
         $this->expectOutputRegex(sprintf('~Cannot extract namespace from file: %s~', $filename));
 
-        $this->createCommandFactory()
-            ->createRunCommand()
+        $this->getRunCommand()
             ->run($this->stubInput($filename), $this->stubOutput());
+    }
+
+    private function getRunCommand(): RunCommand
+    {
+        return $this->createCommandFacade()->getRunCommand();
     }
 
     private function stubInput(string $path): InputInterface

--- a/tests/php/Integration/Command/Test/TestCommandTest.php
+++ b/tests/php/Integration/Command/Test/TestCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Command\Test;
 
 use Gacela\Framework\Config;
+use Phel\Command\Test\TestCommand;
 use PhelTest\Integration\Command\AbstractCommandTest;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -19,9 +20,7 @@ final class TestCommandTest extends AbstractCommandTest
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-success/';
 
-        $command = $this
-            ->createCommandFactory()
-            ->createTestCommand()
+        $command = $this->getTestCommand()
             ->addRuntimePath('test-cmd-project-success\\', [$currentDir]);
 
         $this->expectOutputRegex('/\.\..*/');
@@ -37,9 +36,7 @@ final class TestCommandTest extends AbstractCommandTest
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-success/';
 
-        $command = $this
-            ->createCommandFactory()
-            ->createTestCommand()
+        $command = $this->getTestCommand()
             ->addRuntimePath('test-cmd-project-success\\', [$currentDir]);
 
         $this->expectOutputRegex('/\..*/');
@@ -58,9 +55,7 @@ final class TestCommandTest extends AbstractCommandTest
     {
         $currentDir = __DIR__ . '/Fixtures/test-cmd-project-failure/';
 
-        $command = $this
-            ->createCommandFactory()
-            ->createTestCommand()
+        $command = $this->getTestCommand()
             ->addRuntimePath('test-cmd-project-failure\\', [$currentDir]);
 
         $this->expectOutputRegex('/E.*/');
@@ -70,6 +65,11 @@ final class TestCommandTest extends AbstractCommandTest
         $this->expectOutputRegex('/.*Total: 1.*/');
 
         $command->run($this->stubInput([]), $this->stubOutput());
+    }
+
+    private function getTestCommand(): TestCommand
+    {
+        return $this->createCommandFacade()->getTestCommand();
     }
 
     private function stubInput(array $paths): InputInterface


### PR DESCRIPTION
## 📚 Description

The Command module doesn't have a Facade, so we are using the Factory directly in the `phel` script 
(and in the integration tests).

## 🔖 Changes

- Add CommandFacade to make clear what are the entry points from the Command module.
