### PR TITLE
Add matrix OS and PHP version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,13 @@ jobs:
         run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats
 
   tests:
-    name: Tests
-
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        php: [ '7.4', '8.0' ]
+    name: Tests on PHP ${{ matrix.php }} - ${{ matrix.operating-system }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## 📚 Description

We can ensure that phel is compatible with PHP 7.4 and 8 and other OS.

## 🔖 Changes

- Add a matrix strategy to CI tests
