### PR TITLE
Allow optional argv in RunCommand

### DIFF
--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -45,6 +45,11 @@ final class RunCommand extends Command
                 'path',
                 InputArgument::REQUIRED,
                 'The file path that you want to run.'
+            )->addArgument(
+                'argv',
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                'Optional arguments',
+                []
             )->addOption(
                 'with-time',
                 't',


### PR DESCRIPTION
## 📚 Description

Before we could access the `argv` global values from PHP using the function:
```clojure
(def argv
  "Array of arguments passed to script."
  (php/aget php/$GLOBALS "argv"))
  ```

But, since we are using the Symfony console command, we don't allow using additional arguments when running phel scripts. 

<img width="1016" alt="Screenshot 2021-08-23 at 00 04 57" src="https://user-images.githubusercontent.com/5256287/130371432-f2f52912-0230-4c81-95c9-38937ca7d16e.png">

## 🔖 Changes

- Add to the `RunCommand` one more argument as `InputArgument::IS_ARRAY` and `OPTIONAL` ([source](https://symfony.com/doc/2.3/components/console/introduction.html#using-command-arguments)).