### PR TITLE
Renamed NamespaceExtractorFacade to BuildFacade

### DIFF
--- a/src/php/Build/BuildDependencyProvider.php
+++ b/src/php/Build/BuildDependencyProvider.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor;
+namespace Phel\Build;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\CompilerFacadeInterface;
 
-final class NamespaceExtractorDependencyProvider extends AbstractDependencyProvider
+final class BuildDependencyProvider extends AbstractDependencyProvider
 {
     public const FACADE_COMPILER = 'FACADE_COMPILER';
 

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor;
+namespace Phel\Build;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
+use Phel\Build\Extractor\NamespaceInformation;
 
 /**
- * @method NamespaceExtractorFactory getFactory()
+ * @method BuildFactory getFactory()
  */
-final class NamespaceExtractorFacade extends AbstractFacade implements NamespaceExtractorFacadeInterface
+final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
 {
     /**
      * Extracts the namespace from a given file. It expects that the

--- a/src/php/Build/BuildFacadeInterface.php
+++ b/src/php/Build/BuildFacadeInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor;
+namespace Phel\Build;
 
-use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
+use Phel\Build\Extractor\NamespaceInformation;
 
-interface NamespaceExtractorFacadeInterface
+interface BuildFacadeInterface
 {
     /**
      * Extracts the namespace from a given file. It expects that the

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor;
+namespace Phel\Build;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Build\Extractor\NamespaceExtractor;
 use Phel\Compiler\CompilerFacadeInterface;
-use Phel\NamespaceExtractor\Extractor\NamespaceExtractor;
 
-final class NamespaceExtractorFactory extends AbstractFactory
+final class BuildFactory extends AbstractFactory
 {
     public function createNamespaceExtractor(): NamespaceExtractor
     {
@@ -19,6 +19,6 @@ final class NamespaceExtractorFactory extends AbstractFactory
 
     private function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(NamespaceExtractorDependencyProvider::FACADE_COMPILER);
+        return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMPILER);
     }
 }

--- a/src/php/Build/Extractor/ExtractorException.php
+++ b/src/php/Build/Extractor/ExtractorException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor\Extractor;
+namespace Phel\Build\Extractor;
 
 use RuntimeException;
 

--- a/src/php/Build/Extractor/NamespaceExtractor.php
+++ b/src/php/Build/Extractor/NamespaceExtractor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor\Extractor;
+namespace Phel\Build\Extractor;
 
 use Phel\Compiler\Analyzer\Ast\NsNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironment;

--- a/src/php/Build/Extractor/NamespaceExtractorInterface.php
+++ b/src/php/Build/Extractor/NamespaceExtractorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor\Extractor;
+namespace Phel\Build\Extractor;
 
 interface NamespaceExtractorInterface
 {

--- a/src/php/Build/Extractor/NamespaceInformation.php
+++ b/src/php/Build/Extractor/NamespaceInformation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\NamespaceExtractor\Extractor;
+namespace Phel\Build\Extractor;
 
 final class NamespaceInformation
 {

--- a/src/php/Command/CommandDependencyProvider.php
+++ b/src/php/Command/CommandDependencyProvider.php
@@ -6,14 +6,14 @@ namespace Phel\Command;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
+use Phel\Build\BuildFacade;
+use Phel\Build\BuildFacadeInterface;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Formatter\FormatterFacade;
 use Phel\Formatter\FormatterFacadeInterface;
 use Phel\Interop\InteropFacade;
 use Phel\Interop\InteropFacadeInterface;
-use Phel\NamespaceExtractor\NamespaceExtractorFacade;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 use Phel\Runtime\RuntimeFacadeInterface;
 
@@ -23,7 +23,7 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
     public const FACADE_FORMATTER = 'FACADE_FORMATTER';
     public const FACADE_INTEROP = 'FACADE_INTEROP';
     public const FACADE_RUNTIME = 'FACADE_RUNTIME';
-    public const FACADE_NAMESPACE_EXTRACTOR = 'FACADE_NAMESPACE_EXTRACTOR';
+    public const FACADE_BUILD = 'FACADE_BUILD';
 
     public function provideModuleDependencies(Container $container): void
     {
@@ -31,7 +31,7 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
         $this->addFacadeFormatter($container);
         $this->addFacadeInterop($container);
         $this->addFacadeRuntime($container);
-        $this->addFacadeNamespaceExtractor($container);
+        $this->addFacadeBuild($container);
     }
 
     private function addFacadeCompiler(Container $container): void
@@ -62,10 +62,10 @@ final class CommandDependencyProvider extends AbstractDependencyProvider
         });
     }
 
-    private function addFacadeNamespaceExtractor(Container $container): void
+    private function addFacadeBuild(Container $container): void
     {
-        $container->set(self::FACADE_NAMESPACE_EXTRACTOR, function (Container $container): NamespaceExtractorFacadeInterface {
-            return $container->getLocator()->get(NamespaceExtractorFacade::class);
+        $container->set(self::FACADE_BUILD, function (Container $container): BuildFacadeInterface {
+            return $container->getLocator()->get(BuildFacade::class);
         });
     }
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Build\BuildFacadeInterface;
 use Phel\Command\Export\ExportCommand;
 use Phel\Command\Format\FormatCommand;
 use Phel\Command\Format\PathFilterInterface;
@@ -21,7 +22,6 @@ use Phel\Command\Test\TestCommand;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Formatter\FormatterFacadeInterface;
 use Phel\Interop\InteropFacadeInterface;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
 use Phel\Runtime\Exceptions\ExceptionPrinterInterface;
@@ -53,7 +53,7 @@ final class CommandFactory extends AbstractFactory
         return new RunCommand(
             $this->createCommandExceptionWriter(),
             $this->getRuntimeFacade(),
-            $this->getNamespaceExtractorFacade()
+            $this->getBuildFacade()
         );
     }
 
@@ -63,7 +63,7 @@ final class CommandFactory extends AbstractFactory
             $this->createCommandExceptionWriter(),
             $this->getRuntimeFacade(),
             $this->getCompilerFacade(),
-            $this->getNamespaceExtractorFacade(),
+            $this->getBuildFacade(),
             $this->getConfig()->getTestDirectories()
         );
     }
@@ -141,8 +141,8 @@ final class CommandFactory extends AbstractFactory
         return $this->getProvidedDependency(CommandDependencyProvider::FACADE_RUNTIME);
     }
 
-    private function getNamespaceExtractorFacade(): NamespaceExtractorFacadeInterface
+    private function getBuildFacade(): BuildFacadeInterface
     {
-        return $this->getProvidedDependency(CommandDependencyProvider::FACADE_NAMESPACE_EXTRACTOR);
+        return $this->getProvidedDependency(CommandDependencyProvider::FACADE_BUILD);
     }
 }

--- a/src/php/Command/Run/RunCommand.php
+++ b/src/php/Command/Run/RunCommand.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Command\Run;
 
+use Phel\Build\BuildFacadeInterface;
 use Phel\Command\Run\Exceptions\CannotLoadNamespaceException;
 use Phel\Command\Shared\CommandExceptionWriterInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
@@ -25,17 +25,17 @@ final class RunCommand extends Command
 
     private CommandExceptionWriterInterface $exceptionWriter;
     private RuntimeFacadeInterface $runtimeFacade;
-    private NamespaceExtractorFacadeInterface $namespaceExtractorFacade;
+    private BuildFacadeInterface $buildFacade;
 
     public function __construct(
         CommandExceptionWriterInterface $exceptionWriter,
         RuntimeFacadeInterface $runtimeFacade,
-        NamespaceExtractorFacadeInterface $namespaceExtractorFacade
+        BuildFacadeInterface $buildFacade
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->exceptionWriter = $exceptionWriter;
         $this->runtimeFacade = $runtimeFacade;
-        $this->namespaceExtractorFacade = $namespaceExtractorFacade;
+        $this->buildFacade = $buildFacade;
     }
 
     protected function configure(): void
@@ -95,7 +95,7 @@ final class RunCommand extends Command
     private function loadNamespace(string $fileOrPath): void
     {
         $ns = file_exists($fileOrPath)
-            ? $this->namespaceExtractorFacade->getNamespaceFromFile($fileOrPath)->getNamespace()
+            ? $this->buildFacade->getNamespaceFromFile($fileOrPath)->getNamespace()
             : $fileOrPath;
 
         $result = $this->runtimeFacade->getRuntime()->loadNs($ns);

--- a/src/php/Command/Test/TestCommand.php
+++ b/src/php/Command/Test/TestCommand.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Command\Test;
 
+use Phel\Build\BuildFacadeInterface;
+use Phel\Build\Extractor\NamespaceInformation;
 use Phel\Command\Shared\CommandExceptionWriterInterface;
 use Phel\Command\Test\Exceptions\CannotFindAnyTestsException;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
-use Phel\NamespaceExtractor\Extractor\NamespaceInformation;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
@@ -28,7 +28,7 @@ final class TestCommand extends Command
     private CommandExceptionWriterInterface $exceptionWriter;
     private RuntimeFacadeInterface $runtimeFacade;
     private CompilerFacadeInterface $compilerFacade;
-    private NamespaceExtractorFacadeInterface $namespaceExtractor;
+    private BuildFacadeInterface $buildFacade;
     /** @var list<string> */
     private array $defaultTestDirectories;
 
@@ -36,14 +36,14 @@ final class TestCommand extends Command
         CommandExceptionWriterInterface $exceptionWriter,
         RuntimeFacadeInterface $runtimeFacade,
         CompilerFacadeInterface $compilerFacade,
-        NamespaceExtractorFacadeInterface $namespaceExtractor,
+        BuildFacadeInterface $buildFacade,
         array $testDirectories
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->exceptionWriter = $exceptionWriter;
         $this->runtimeFacade = $runtimeFacade;
         $this->compilerFacade = $compilerFacade;
-        $this->namespaceExtractor = $namespaceExtractor;
+        $this->buildFacade = $buildFacade;
         $this->defaultTestDirectories = $testDirectories;
     }
 
@@ -132,12 +132,12 @@ final class TestCommand extends Command
         if (empty($paths)) {
             return array_map(
                 static fn (NamespaceInformation $info): string => $info->getNamespace(),
-                $this->namespaceExtractor->getNamespaceFromDirectories($this->defaultTestDirectories)
+                $this->buildFacade->getNamespaceFromDirectories($this->defaultTestDirectories)
             );
         }
 
         return array_map(
-            fn (string $filename): string => $this->namespaceExtractor->getNamespaceFromFile($filename)->getNamespace(),
+            fn (string $filename): string => $this->buildFacade->getNamespaceFromFile($filename)->getNamespace(),
             $paths
         );
     }

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Interop\ExportFinder;
 
+use Phel\Build\BuildFacadeInterface;
+use Phel\Build\Extractor\ExtractorException;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
@@ -11,24 +13,22 @@ use Phel\Interop\ReadModel\FunctionToExport;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
-use Phel\NamespaceExtractor\Extractor\ExtractorException;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacadeInterface;
 
 final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 {
     private RuntimeFacadeInterface $runtimeFacade;
-    private NamespaceExtractorFacadeInterface $namespaceExtractorFacade;
+    private BuildFacadeInterface $buildFacade;
     /** @var list<string> */
     private array $exportDirectories;
 
     public function __construct(
         RuntimeFacadeInterface $runtimeFacade,
-        NamespaceExtractorFacadeInterface $namespaceExtractorFacade,
+        BuildFacadeInterface $buildFacade,
         array $exportDirectories
     ) {
         $this->runtimeFacade = $runtimeFacade;
-        $this->namespaceExtractorFacade = $namespaceExtractorFacade;
+        $this->buildFacade = $buildFacade;
         $this->exportDirectories = $exportDirectories;
     }
 
@@ -57,7 +57,7 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
     {
         $runtime = $this->runtimeFacade->getRuntime();
 
-        $namespaceFromDirectories = $this->namespaceExtractorFacade
+        $namespaceFromDirectories = $this->buildFacade
             ->getNamespaceFromDirectories($this->exportDirectories);
 
         foreach ($namespaceFromDirectories as $namespaceNode) {

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinderInterface.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinderInterface.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Interop\ExportFinder;
 
+use Phel\Build\Extractor\ExtractorException;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Interop\ReadModel\FunctionToExport;
-use Phel\NamespaceExtractor\Extractor\ExtractorException;
 
 interface FunctionsToExportFinderInterface
 {

--- a/src/php/Interop/InteropDependencyProvider.php
+++ b/src/php/Interop/InteropDependencyProvider.php
@@ -6,20 +6,20 @@ namespace Phel\Interop;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
-use Phel\NamespaceExtractor\NamespaceExtractorFacade;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
+use Phel\Build\BuildFacade;
+use Phel\Build\BuildFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 use Phel\Runtime\RuntimeFacadeInterface;
 
 final class InteropDependencyProvider extends AbstractDependencyProvider
 {
     public const FACADE_RUNTIME = 'FACADE_RUNTIME';
-    public const FACADE_NAMESPACE_EXTRACTOR = 'FACADE_NAMESPACE_EXTRACTOR';
+    public const FACADE_BUILD = 'FACADE_BUILD';
 
     public function provideModuleDependencies(Container $container): void
     {
         $this->addFacadeRuntime($container);
-        $this->addFacadeNamespaceExtractor($container);
+        $this->addFacadeBuild($container);
     }
 
     private function addFacadeRuntime(Container $container): void
@@ -29,10 +29,10 @@ final class InteropDependencyProvider extends AbstractDependencyProvider
         });
     }
 
-    private function addFacadeNamespaceExtractor(Container $container): void
+    private function addFacadeBuild(Container $container): void
     {
-        $container->set(self::FACADE_NAMESPACE_EXTRACTOR, function (Container $container): NamespaceExtractorFacadeInterface {
-            return $container->getLocator()->get(NamespaceExtractorFacade::class);
+        $container->set(self::FACADE_BUILD, function (Container $container): BuildFacadeInterface {
+            return $container->getLocator()->get(BuildFacade::class);
         });
     }
 }

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Interop;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Build\BuildFacadeInterface;
 use Phel\Interop\DirectoryRemover\DirectoryRemover;
 use Phel\Interop\DirectoryRemover\DirectoryRemoverInterface;
 use Phel\Interop\ExportFinder\FunctionsToExportFinder;
@@ -17,7 +18,6 @@ use Phel\Interop\Generator\Builder\CompiledPhpClassBuilder;
 use Phel\Interop\Generator\Builder\CompiledPhpMethodBuilder;
 use Phel\Interop\Generator\Builder\WrapperRelativeFilenamePathBuilder;
 use Phel\Interop\Generator\WrapperGenerator;
-use Phel\NamespaceExtractor\NamespaceExtractorFacadeInterface;
 use Phel\Runtime\RuntimeFacade;
 
 /**
@@ -37,7 +37,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new FunctionsToExportFinder(
             $this->getRuntimeFacade(),
-            $this->getNamespaceExtractorFacade(),
+            $this->getBuildFacade(),
             $this->getConfig()->getExportDirectories()
         );
     }
@@ -75,8 +75,8 @@ final class InteropFactory extends AbstractFactory
         return $this->getProvidedDependency(InteropDependencyProvider::FACADE_RUNTIME);
     }
 
-    private function getNamespaceExtractorFacade(): NamespaceExtractorFacadeInterface
+    private function getBuildFacade(): BuildFacadeInterface
     {
-        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_NAMESPACE_EXTRACTOR);
+        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_BUILD);
     }
 }


### PR DESCRIPTION
## 📚 Description

I renamed the `NamespaceExtractorFacade` to `BuildFacade`. The new BuildFacade should later contain more method to build and compile a complete project. Additional work will be done in the following PRs.

## 🔖 Changes

- Renamed namespace Phel\NamespaceExtractor to Phel\Build
- Renamed NamespaceExtractorFacade to BuildFacade
- Renamed all other module classes accordingly.
