### PR TITLE
Extracted namespaces are now sorted based on their dependecies

### DIFF
--- a/src/php/Build/BuildFacadeInterface.php
+++ b/src/php/Build/BuildFacadeInterface.php
@@ -22,6 +22,9 @@ interface BuildFacadeInterface
      * Extracts all namespaces from all Phel files in the given directories.
      * It expects that the first statement in the file is the 'ns statement.
      *
+     * The result is topologically sorted. That means that file that have dependencies
+     * to other files are sorted behind the files that have no dependecies.
+     *
      * @param string[] $directories The list of the directories
      *
      * @return NamespaceInformation[]

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -6,7 +6,8 @@ namespace Phel\Build;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Build\Extractor\NamespaceExtractor;
-use Phel\Build\Extractor\TopologicalSorting;
+use Phel\Build\Extractor\NamespaceSorterInterface;
+use Phel\Build\Extractor\TopologicalNamespaceSorter;
 use Phel\Compiler\CompilerFacadeInterface;
 
 final class BuildFactory extends AbstractFactory
@@ -15,12 +16,17 @@ final class BuildFactory extends AbstractFactory
     {
         return new NamespaceExtractor(
             $this->getCompilerFacade(),
-            new TopologicalSorting()
+            $this->createNamespaceSorter()
         );
     }
 
     private function getCompilerFacade(): CompilerFacadeInterface
     {
         return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMPILER);
+    }
+
+    private function createNamespaceSorter(): NamespaceSorterInterface
+    {
+        return new TopologicalNamespaceSorter();
     }
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -6,6 +6,7 @@ namespace Phel\Build;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Build\Extractor\NamespaceExtractor;
+use Phel\Build\Extractor\TopologicalSorting;
 use Phel\Compiler\CompilerFacadeInterface;
 
 final class BuildFactory extends AbstractFactory
@@ -13,7 +14,8 @@ final class BuildFactory extends AbstractFactory
     public function createNamespaceExtractor(): NamespaceExtractor
     {
         return new NamespaceExtractor(
-            $this->getCompilerFacade()
+            $this->getCompilerFacade(),
+            new TopologicalSorting()
         );
     }
 

--- a/src/php/Build/Extractor/NamespaceSorterInterface.php
+++ b/src/php/Build/Extractor/NamespaceSorterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Extractor;
+
+interface NamespaceSorterInterface
+{
+    /**
+     * @param list<string> $data the data array that should be sorted
+     * @param array<string, list<string>> $dependencies a map of dependencies for each data node
+     *
+     * @return list<string> The sorted array
+     */
+    public function sort(array $data, array $dependencies): array;
+}

--- a/src/php/Build/Extractor/TopologicalNamespaceSorter.php
+++ b/src/php/Build/Extractor/TopologicalNamespaceSorter.php
@@ -6,19 +6,19 @@ namespace Phel\Build\Extractor;
 
 use RuntimeException;
 
-class TopologicalSorting
+final class TopologicalNamespaceSorter implements NamespaceSorterInterface
 {
     /**
      * @param list<string> $data the data array that should be sorted
-     * @param array<string, string[]> $dependencies a map of dependencies for each data node
+     * @param array<string, list<string>> $dependencies a map of dependencies for each data node
      *
-     * @return list<string> The storted array
+     * @return list<string> The sorted array
      */
     public function sort(array $data, array $dependencies): array
     {
-        /** @var string[] $order */
+        /** @var list<string> $order */
         $order = [];
-        /** @var string[] $seen */
+        /** @var list<string> $seen */
         $seen = [];
         foreach ($data as $item) {
             $this->process($item, $dependencies, $order, $seen);
@@ -29,7 +29,7 @@ class TopologicalSorting
 
     /**
      * @param string $item
-     * @param array<string, string[]> $dependencies
+     * @param array<string, list<string>> $dependencies
      * @param string[] $order
      * @param array<int, string> $seen
      */
@@ -46,22 +46,22 @@ class TopologicalSorting
                     $this->process($master, $dependencies, $order, $seen);
                 }
 
-                if (!in_array($master, $order)) {
+                if (!in_array($master, $order, true)) {
                     $order[] = $master;
                 }
 
-                $index = array_search($master, $seen);
+                $index = array_search($master, $seen, true);
                 if ($index !== false) {
                     unset($seen[$index]);
                 }
             }
         }
 
-        if (!in_array($item, $order)) {
+        if (!in_array($item, $order, true)) {
             $order[] = $item;
         }
 
-        $index = array_search($item, $seen);
+        $index = array_search($item, $seen, true);
         if ($index !== false) {
             unset($seen[$index]);
         }

--- a/src/php/Build/Extractor/TopologicalSorting.php
+++ b/src/php/Build/Extractor/TopologicalSorting.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Extractor;
+
+use RuntimeException;
+
+class TopologicalSorting
+{
+    /**
+     * @param list<string> $data the data array that should be sorted
+     * @param array<string, string[]> $dependencies a map of dependencies for each data node
+     *
+     * @return list<string> The storted array
+     */
+    public function sort(array $data, array $dependencies): array
+    {
+        /** @var string[] $order */
+        $order = [];
+        /** @var string[] $seen */
+        $seen = [];
+        foreach ($data as $item) {
+            $this->process($item, $dependencies, $order, $seen);
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param string $item
+     * @param array<string, string[]> $dependencies
+     * @param string[] $order
+     * @param array<int, string> $seen
+     */
+    private function process(string $item, array &$dependencies, array &$order, array &$seen): void
+    {
+        if (in_array($item, $seen)) {
+            throw new RuntimeException('Circular dependency detected, ' . implode(' -> ', [...$seen, $item]));
+        }
+
+        $seen[] = $item;
+        if (isset($dependencies[$item])) {
+            foreach ($dependencies[$item] as $master) {
+                if (isset($dependencies[$master])) {
+                    $this->process($master, $dependencies, $order, $seen);
+                }
+
+                if (!in_array($master, $order)) {
+                    $order[] = $master;
+                }
+
+                $index = array_search($master, $seen);
+                if ($index !== false) {
+                    unset($seen[$index]);
+                }
+            }
+        }
+
+        if (!in_array($item, $order)) {
+            $order[] = $item;
+        }
+
+        $index = array_search($item, $seen);
+        if ($index !== false) {
+            unset($seen[$index]);
+        }
+    }
+}

--- a/tests/php/Integration/Command/Test/Fixtures/test-cmd-project-success/test2.phel
+++ b/tests/php/Integration/Command/Test/Fixtures/test-cmd-project-success/test2.phel
@@ -1,5 +1,5 @@
-(ns test-cmd-project-success\test1
-  (:require phel\test :only [deftest is]))
+(ns test-cmd-project-success\test2
+  (:require phel\test :refer [deftest is]))
 
 (deftest my-test
   (is (true? true)))

--- a/tests/php/Unit/Build/Extractor/TopologicalSortingTest.php
+++ b/tests/php/Unit/Build/Extractor/TopologicalSortingTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Extractor;
+
+use Phel\Build\Extractor\TopologicalSorting;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class TopologicalSortingTest extends TestCase
+{
+    public function test_circular_exception(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $data = ['car', 'owner'];
+        $dependencies = [
+            'car' => ['owner'],
+            'owner' => ['car'],
+        ];
+        $sorter = new TopologicalSorting();
+        $sorter->sort($data, $dependencies);
+    }
+
+    public function test_simplesort(): void
+    {
+        $data = ['car', 'owner'];
+        $dependencies = [
+            'car' => ['owner'],
+            'owner' => [],
+        ];
+        $sorter = new TopologicalSorting();
+        $sorted = $sorter->sort($data, $dependencies);
+
+        $this->assertEquals(['owner', 'car'], $sorted);
+    }
+
+    public function test_multiple_dependencies(): void
+    {
+        $data = ['car', 'owner', 'brand'];
+        $dependencies = [
+            'car' => ['owner', 'brand'],
+            'owner' => ['brand'],
+        ];
+        $sorter = new TopologicalSorting();
+        $sorted = $sorter->sort($data, $dependencies);
+
+        $this->assertEquals(['brand', 'owner', 'car'], $sorted);
+    }
+
+    public function test_duplicated_data_entries(): void
+    {
+        $data = ['car', 'owner', 'brand', 'owner'];
+        $dependencies = [
+            'car' => ['owner', 'brand'],
+            'owner' => ['brand'],
+        ];
+        $sorter = new TopologicalSorting();
+        $sorted = $sorter->sort($data, $dependencies);
+
+        $this->assertEquals(['brand', 'owner', 'car'], $sorted);
+    }
+}

--- a/tests/php/Unit/Build/Extractor/TopologicalSortingTest.php
+++ b/tests/php/Unit/Build/Extractor/TopologicalSortingTest.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Build\Extractor;
 
-use Phel\Build\Extractor\TopologicalSorting;
+use Phel\Build\Extractor\TopologicalNamespaceSorter;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 final class TopologicalSortingTest extends TestCase
 {
+    private TopologicalNamespaceSorter $sorter;
+
+    public function setUp(): void
+    {
+        $this->sorter = new TopologicalNamespaceSorter();
+    }
+
     public function test_circular_exception(): void
     {
         $this->expectException(RuntimeException::class);
@@ -19,8 +26,8 @@ final class TopologicalSortingTest extends TestCase
             'car' => ['owner'],
             'owner' => ['car'],
         ];
-        $sorter = new TopologicalSorting();
-        $sorter->sort($data, $dependencies);
+
+        $this->sorter->sort($data, $dependencies);
     }
 
     public function test_simplesort(): void
@@ -30,10 +37,10 @@ final class TopologicalSortingTest extends TestCase
             'car' => ['owner'],
             'owner' => [],
         ];
-        $sorter = new TopologicalSorting();
-        $sorted = $sorter->sort($data, $dependencies);
 
-        $this->assertEquals(['owner', 'car'], $sorted);
+        $sorted = $this->sorter->sort($data, $dependencies);
+
+        self::assertEquals(['owner', 'car'], $sorted);
     }
 
     public function test_multiple_dependencies(): void
@@ -43,10 +50,10 @@ final class TopologicalSortingTest extends TestCase
             'car' => ['owner', 'brand'],
             'owner' => ['brand'],
         ];
-        $sorter = new TopologicalSorting();
-        $sorted = $sorter->sort($data, $dependencies);
 
-        $this->assertEquals(['brand', 'owner', 'car'], $sorted);
+        $sorted = $this->sorter->sort($data, $dependencies);
+
+        self::assertEquals(['brand', 'owner', 'car'], $sorted);
     }
 
     public function test_duplicated_data_entries(): void
@@ -56,9 +63,9 @@ final class TopologicalSortingTest extends TestCase
             'car' => ['owner', 'brand'],
             'owner' => ['brand'],
         ];
-        $sorter = new TopologicalSorting();
-        $sorted = $sorter->sort($data, $dependencies);
 
-        $this->assertEquals(['brand', 'owner', 'car'], $sorted);
+        $sorted = $this->sorter->sort($data, $dependencies);
+
+        self::assertEquals(['brand', 'owner', 'car'], $sorted);
     }
 }


### PR DESCRIPTION
## 📚 Description

The method `NamespaceExtractor::getNamespacesFromDirectories` returns now a sorted list of namespace information. They are sorted based on their dependencies. File that depend on other files will be sorted at the end and files with no dependencies will be sorted at the beginning.

This is useful for the upcoming compile command. The compile command can use this order to compile files in the correct order.
