### PR TITLE
Load replStartupFile on ReplCommand->execute()

### DIFF
--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -27,7 +27,7 @@ final class CommandConfig extends AbstractPhelConfig
         return $this->getApplicationRootDir() . '/.phel-repl-history';
     }
 
-    public function getReplStartupPhel(): string
+    public function getReplStartupFile(): string
     {
         return __DIR__ . '/Repl/startup.phel';
     }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -35,16 +35,13 @@ final class CommandFactory extends AbstractFactory
 {
     public function createReplCommand(): ReplCommand
     {
-        $this->getRuntimeFacade()
-            ->getRuntime()
-            ->loadFileIntoNamespace('user', $this->getConfig()->getReplStartupPhel());
-
         return new ReplCommand(
             $this->getRuntimeFacade(),
             $this->createReplCommandIo(),
             $this->getCompilerFacade(),
             $this->createColorStyle(),
-            $this->createPrinter()
+            $this->createPrinter(),
+            $this->getConfig()->getReplStartupFile()
         );
     }
 

--- a/src/php/Command/Repl/ReplCommand.php
+++ b/src/php/Command/Repl/ReplCommand.php
@@ -30,6 +30,7 @@ final class ReplCommand extends Command
     private CompilerFacadeInterface $compilerFacade;
     private ColorStyleInterface $style;
     private PrinterInterface $printer;
+    private string $replStartupFile;
 
     /** @var string[] */
     private array $inputBuffer = [];
@@ -41,7 +42,8 @@ final class ReplCommand extends Command
         ReplCommandIoInterface $io,
         CompilerFacadeInterface $compilerFacade,
         ColorStyleInterface $style,
-        PrinterInterface $printer
+        PrinterInterface $printer,
+        string $replStartupFile = ''
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->runtimeFacade = $runtimeFacade;
@@ -49,6 +51,7 @@ final class ReplCommand extends Command
         $this->compilerFacade = $compilerFacade;
         $this->style = $style;
         $this->printer = $printer;
+        $this->replStartupFile = $replStartupFile;
         $this->previousResult = InputResult::empty();
     }
 
@@ -69,6 +72,11 @@ final class ReplCommand extends Command
         $this->io->readHistory();
         $this->io->writeln($this->style->yellow('Welcome to the Phel Repl'));
         $this->io->writeln('Type "exit" or press Ctrl-D to exit.');
+
+        if ($this->replStartupFile) {
+            $this->runtimeFacade->getRuntime()
+                ->loadFileIntoNamespace('user', $this->replStartupFile);
+        }
 
         $this->loopReadLineAndAnalyze();
 


### PR DESCRIPTION
Issue: https://github.com/phel-lang/phel-lang/issues/341

## 📚 Description

The REPL startup script (`startup.phel`) is loaded when any command is executed and not ONLY when the REPL command is executed.

## 🔖 Changes

Move the `loadFileIntoNamespace()` from the `CommandFactory` (which was being called for every command when creating all commands in the phel entry point script) to the `ReplCommand::execute()` function
