### PR TITLE
Using arg unpacking in config dirs setters

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -10,6 +10,6 @@ return (new ProjectConfiguration())
     ->setTestConfiguration((new TestConfiguration())
         ->setDirectories('tests/phel/'))
     ->setExportConfiguration((new ExportConfiguration())
-        ->setDirectories(['src/phel'])
+        ->setDirectories('src/phel')
         ->setNamespacePrefix('PhelGenerated')
         ->setTargetDirectory('src/PhelGenerated'));

--- a/src/php/Config/ExportConfiguration.php
+++ b/src/php/Config/ExportConfiguration.php
@@ -6,8 +6,11 @@ namespace Phel\Config;
 
 final class ExportConfiguration
 {
+    /** @var list<string> */
     private array $directories = [];
+
     private string $namespacePrefix = '';
+
     private string $targetDirectory = '';
 
     public static function empty(): self
@@ -15,20 +18,16 @@ final class ExportConfiguration
         return new self();
     }
 
+    /**
+     * @return list<string>
+     */
     public function getDirectories(): array
     {
         return $this->directories;
     }
 
-    /**
-     * @param string|array $directories
-     */
-    public function setDirectories($directories): self
+    public function setDirectories(string ...$directories): self
     {
-        if (is_string($directories)) {
-            $directories = [$directories];
-        }
-
         $this->directories = $directories;
 
         return $this;

--- a/src/php/Config/TestConfiguration.php
+++ b/src/php/Config/TestConfiguration.php
@@ -6,6 +6,7 @@ namespace Phel\Config;
 
 final class TestConfiguration
 {
+    /** @var list<string> */
     private array $directories = [];
 
     public static function empty(): self
@@ -14,21 +15,17 @@ final class TestConfiguration
     }
 
     /**
-     * @param string|array $directories
+     * @return list<string>
      */
-    public function setDirectories($directories): self
-    {
-        if (is_string($directories)) {
-            $directories = [$directories];
-        }
-
-        $this->directories = $directories;
-
-        return $this;
-    }
-
     public function getDirectories(): array
     {
         return $this->directories;
+    }
+
+    public function setDirectories(string ...$directories): self
+    {
+        $this->directories = $directories;
+
+        return $this;
     }
 }


### PR DESCRIPTION
## 📚 Description

Right now you can pass either a string or an array of strings. I think it is simpler to just allow `string ...$dirs` using the variadics function (native PHP). I wrote last year a post about this: [Typed arrays in PHP
](https://chemaclass.es/blog/typed-arrays-php/)

## 🔖 Changes

It unifies the argument to `setDirectories(string ...$directories)`. There is no need to pass an array itself when calling that method, but it will be received as an array of strings. For example:

```php
return (new ProjectConfiguration())
    ->setTestConfiguration((new TestConfiguration())
        ->setDirectories('path-1/'))
    ->setExportConfiguration((new ExportConfiguration())
        ->setDirectories('path-1/', 'path-2/', 'path-3/'));
```
