### PR TITLE
Refactor BuildFacade; extract to classes the logic from the facade

### DIFF
--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -34,7 +34,7 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      *
      * @param string[] $directories The list of the directories
      *
-     * @return NamespaceInformation[]
+     * @return list<NamespaceInformation>
      */
     public function getNamespaceFromDirectories(array $directories): array
     {
@@ -46,45 +46,18 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
     /**
      * Gets a list of all dependencies for a given list of namespaces. It first extracts all
      * namespaces from all Phel files in the give directories and then return a
-     * topoloigcal sorted subset of these namespace information.
+     * topological sorted subset of this namespace information.
      *
      * @param string[] $directories The list of the directories
      * @param string[] $ns A list of namespace for which we should find the subset
      *
-     * @return NamespaceInformation[]
+     * @return list<NamespaceInformation>
      */
     public function getDependenciesForNamespace(array $directories, array $ns): array
     {
-        $namespaceInformation = $this->getNamespaceFromDirectories($directories);
-
-        $index = [];
-        $queue = [];
-        foreach ($namespaceInformation as $info) {
-            $index[$info->getNamespace()] = $info;
-            if (in_array($info->getNamespace(), $ns)) {
-                $queue[] = $info->getNamespace();
-            }
-        }
-
-        $requiredNamespaces = [];
-        while (count($queue) > 0) {
-            $currentNs = array_shift($queue);
-            if (!isset($requiredNamespaces[$currentNs])) {
-                foreach ($index[$currentNs]->getDependencies() as $depNs) {
-                    $queue[] = $depNs;
-                }
-            }
-            $requiredNamespaces[$currentNs] = true;
-        }
-
-        $result = [];
-        foreach ($namespaceInformation as $info) {
-            if (isset($requiredNamespaces[$info->getNamespace()])) {
-                $result[] = $info;
-            }
-        }
-
-        return $result;
+        return $this->getFactory()
+            ->createDependenciesForNamespace()
+            ->getDependenciesForNamespace($directories, $ns);
     }
 
     /**
@@ -97,19 +70,9 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      */
     public function compileFile(string $src, string $dest): CompiledFile
     {
-        $compiledCode = $this->getFactory()->getCompilerFacade()->compile(
-            file_get_contents($src),
-            $src,
-            true
-        );
-
-        file_put_contents($dest, "<?php\n" . $compiledCode);
-
-        return new CompiledFile(
-            $src,
-            $dest,
-            $this->getNamespaceFromFile($src)->getNamespace()
-        );
+        return $this->getFactory()
+            ->createFileCompiler()
+            ->compileFile($src, $dest);
     }
 
     /**
@@ -121,17 +84,9 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      */
     public function evalFile(string $src): CompiledFile
     {
-        $this->getFactory()->getCompilerFacade()->compile(
-            file_get_contents($src),
-            $src,
-            true
-        );
-
-        return new CompiledFile(
-            $src,
-            '',
-            $this->getNamespaceFromFile($src)->getNamespace()
-        );
+        return $this->getFactory()
+            ->createFileEvaluator()
+            ->evalFile($src);
     }
 
     /**
@@ -141,28 +96,12 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      * @param string[] $srcDirectories The list of source directories
      * @param string $dest the target dir that should contain the generated code
      *
-     * @return CompiledFile[] A list of compiled files
+     * @return list<CompiledFile>
      */
     public function compileProject(array $srcDirectories, string $dest): array
     {
-        $namespaceInformation = $this->getNamespaceFromDirectories($srcDirectories);
-
-        $result = [];
-        foreach ($namespaceInformation as $info) {
-            $targetFile = $dest . '/' . $this->getTargetFileFromNamespace($info->getNamespace());
-            $targetDir = dirname($targetFile);
-            if (!file_exists($targetDir)) {
-                mkdir($targetDir, 0777, true);
-            }
-
-            $result[] = $this->compileFile($info->getFile(), $targetFile);
-        }
-
-        return $result;
-    }
-
-    private function getTargetFileFromNamespace(string $namespace): string
-    {
-        return implode(DIRECTORY_SEPARATOR, explode('\\', $namespace)) . '.php';
+        return $this->getFactory()
+            ->createProjectCompiler()
+            ->compileProject($srcDirectories, $dest);
     }
 }

--- a/src/php/Build/BuildFacadeInterface.php
+++ b/src/php/Build/BuildFacadeInterface.php
@@ -28,19 +28,19 @@ interface BuildFacadeInterface
      *
      * @param string[] $directories The list of the directories
      *
-     * @return NamespaceInformation[]
+     * @return list<NamespaceInformation>
      */
     public function getNamespaceFromDirectories(array $directories): array;
 
     /**
      * Gets a list of all dependencies for a given list of namespaces. It first extracts all
      * namespaces from all Phel files in the give directories and then return a
-     * topoloigcal sorted subset of these namespace information.
+     * topological sorted subset of these namespace information.
      *
      * @param string[] $directories The list of the directories
      * @param string[] $ns A list of namespace for which we should find the subset
      *
-     * @return NamespaceInformation[]
+     * @return list<NamespaceInformation>
      */
     public function getDependenciesForNamespace(array $directories, array $ns): array;
 
@@ -70,7 +70,7 @@ interface BuildFacadeInterface
      * @param string[] $srcDirectories The list of source directories
      * @param string $dest the target dir that should contain the generated code
      *
-     * @return CompiledFile[] A list of compiled files
+     * @return list<CompiledFile>
      */
     public function compileProject(array $srcDirectories, string $dest): array;
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Phel\Build;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Build\Compile\DependenciesForNamespace;
+use Phel\Build\Compile\FileCompiler;
+use Phel\Build\Compile\FileEvaluator;
+use Phel\Build\Compile\ProjectCompiler;
 use Phel\Build\Extractor\NamespaceExtractor;
 use Phel\Build\Extractor\NamespaceSorterInterface;
 use Phel\Build\Extractor\TopologicalNamespaceSorter;
@@ -12,6 +16,37 @@ use Phel\Compiler\CompilerFacadeInterface;
 
 final class BuildFactory extends AbstractFactory
 {
+    public function createProjectCompiler(): ProjectCompiler
+    {
+        return new ProjectCompiler(
+            $this->createNamespaceExtractor(),
+            $this->createFileCompiler()
+        );
+    }
+
+    public function createDependenciesForNamespace(): DependenciesForNamespace
+    {
+        return new DependenciesForNamespace(
+            $this->createNamespaceExtractor()
+        );
+    }
+
+    public function createFileCompiler(): FileCompiler
+    {
+        return new FileCompiler(
+            $this->getCompilerFacade(),
+            $this->createNamespaceExtractor()
+        );
+    }
+
+    public function createFileEvaluator(): FileEvaluator
+    {
+        return new FileEvaluator(
+            $this->getCompilerFacade(),
+            $this->createNamespaceExtractor()
+        );
+    }
+
     public function createNamespaceExtractor(): NamespaceExtractor
     {
         return new NamespaceExtractor(
@@ -20,13 +55,13 @@ final class BuildFactory extends AbstractFactory
         );
     }
 
-    public function getCompilerFacade(): CompilerFacadeInterface
-    {
-        return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMPILER);
-    }
-
     private function createNamespaceSorter(): NamespaceSorterInterface
     {
         return new TopologicalNamespaceSorter();
+    }
+
+    public function getCompilerFacade(): CompilerFacadeInterface
+    {
+        return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMPILER);
     }
 }

--- a/src/php/Build/Compile/CompiledFile.php
+++ b/src/php/Build/Compile/CompiledFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Compile;
 
-class CompiledFile
+final class CompiledFile
 {
     private string $sourceFile;
     private string $targetFile;

--- a/src/php/Build/Compile/DependenciesForNamespace.php
+++ b/src/php/Build/Compile/DependenciesForNamespace.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Compile;
+
+use Phel\Build\Extractor\NamespaceExtractor;
+use Phel\Build\Extractor\NamespaceInformation;
+
+final class DependenciesForNamespace
+{
+    private NamespaceExtractor $namespaceExtractor;
+
+    public function __construct(NamespaceExtractor $namespaceExtractor)
+    {
+        $this->namespaceExtractor = $namespaceExtractor;
+    }
+
+    /**
+     * @return list<NamespaceInformation>
+     */
+    public function getDependenciesForNamespace(array $directories, array $ns): array
+    {
+        $namespaceInformation = $this->namespaceExtractor->getNamespacesFromDirectories($directories);
+
+        $index = [];
+        $queue = [];
+        foreach ($namespaceInformation as $info) {
+            $index[$info->getNamespace()] = $info;
+            if (in_array($info->getNamespace(), $ns)) {
+                $queue[] = $info->getNamespace();
+            }
+        }
+
+        $requiredNamespaces = [];
+        while (count($queue) > 0) {
+            $currentNs = array_shift($queue);
+            if (!isset($requiredNamespaces[$currentNs])) {
+                foreach ($index[$currentNs]->getDependencies() as $depNs) {
+                    $queue[] = $depNs;
+                }
+            }
+            $requiredNamespaces[$currentNs] = true;
+        }
+
+        $result = [];
+        foreach ($namespaceInformation as $info) {
+            if (isset($requiredNamespaces[$info->getNamespace()])) {
+                $result[] = $info;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Build/Compile/FileCompiler.php
+++ b/src/php/Build/Compile/FileCompiler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Compile;
+
+use Phel\Build\Extractor\NamespaceExtractor;
+use Phel\Compiler\CompilerFacadeInterface;
+
+final class FileCompiler
+{
+    private CompilerFacadeInterface $compilerFacade;
+
+    private NamespaceExtractor $namespaceExtractor;
+
+    public function __construct(
+        CompilerFacadeInterface $compilerFacade,
+        NamespaceExtractor $namespaceExtractor
+    ) {
+        $this->compilerFacade = $compilerFacade;
+        $this->namespaceExtractor = $namespaceExtractor;
+    }
+
+    public function compileFile(string $src, string $dest): CompiledFile
+    {
+        $this->compilerFacade->compile(
+            file_get_contents($src),
+            $src,
+            true
+        );
+
+        $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
+
+        return new CompiledFile(
+            $src,
+            $dest,
+            $namespaceInfo->getNamespace()
+        );
+    }
+}

--- a/src/php/Build/Compile/FileEvaluator.php
+++ b/src/php/Build/Compile/FileEvaluator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Compile;
+
+use Phel\Build\Extractor\NamespaceExtractor;
+use Phel\Compiler\CompilerFacadeInterface;
+
+final class FileEvaluator
+{
+    private CompilerFacadeInterface $compilerFacade;
+
+    private NamespaceExtractor $namespaceExtractor;
+
+    public function __construct(
+        CompilerFacadeInterface $compilerFacade,
+        NamespaceExtractor $namespaceExtractor
+    ) {
+        $this->compilerFacade = $compilerFacade;
+        $this->namespaceExtractor = $namespaceExtractor;
+    }
+
+    public function evalFile(string $src): CompiledFile
+    {
+        $this->compilerFacade->compile(
+            file_get_contents($src),
+            $src,
+            true
+        );
+
+        $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
+
+        return new CompiledFile(
+            $src,
+            '',
+            $namespaceInfo->getNamespace()
+        );
+    }
+}

--- a/src/php/Build/Compile/ProjectCompiler.php
+++ b/src/php/Build/Compile/ProjectCompiler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Compile;
+
+use Phel\Build\Extractor\NamespaceExtractorInterface;
+
+final class ProjectCompiler
+{
+    private NamespaceExtractorInterface $namespaceExtractor;
+
+    private FileCompiler $fileCompiler;
+
+    public function __construct(
+        NamespaceExtractorInterface $namespaceExtractor,
+        FileCompiler $fileCompiler
+    ) {
+        $this->namespaceExtractor = $namespaceExtractor;
+        $this->fileCompiler = $fileCompiler;
+    }
+
+    /**
+     * @return list<CompiledFile>
+     */
+    public function compileProject(array $srcDirectories, string $dest): array
+    {
+        $namespaceInformation = $this->namespaceExtractor->getNamespacesFromDirectories($srcDirectories);
+
+        $result = [];
+        foreach ($namespaceInformation as $info) {
+            $targetFile = $dest . '/' . $this->getTargetFileFromNamespace($info->getNamespace());
+            $targetDir = dirname($targetFile);
+            if (!file_exists($targetDir)) {
+                mkdir($targetDir, 0777, true);
+            }
+
+            $result[] = $this->fileCompiler->compileFile($info->getFile(), $targetFile);
+        }
+
+        return $result;
+    }
+
+    private function getTargetFileFromNamespace(string $namespace): string
+    {
+        return implode(DIRECTORY_SEPARATOR, explode('\\', $namespace)) . '.php';
+    }
+}

--- a/src/php/Build/Extractor/NamespaceExtractor.php
+++ b/src/php/Build/Extractor/NamespaceExtractor.php
@@ -74,7 +74,7 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
      *
      * @throws ExtractorException
      *
-     * @return NamespaceInformation[]
+     * @return list<NamespaceInformation>
      */
     public function getNamespacesFromDirectories(array $directories): array
     {


### PR DESCRIPTION
## 📚 Description

We don't want to have any logic in the Facade. The Facade should be like a "proxy" delegating all logic to domain classes that the Factory creates for it.

The main reason is that you cannot easily write tests for the Facade. Actually, you cannot write unit tests for the Facade because it is part of the infrastructure layer (like the Factory or Config, for example). That said, of course, it's always a good idea to have integration tests that test the Facade methods (at least with the happy paths), because these are the endpoints/usages of a module, from beginning to end.

For this reason, you want to have isolated classes with the logic of your domain, and using the Factory to create your domain classes injecting all collaborators/dependencies that your domain classes need. 

☝️ This way allows you to create independent classes with logic that is really easy to test.

## 🔖 Changes

- Apply "extract class refactoring" to extract the logic from the Facade to its own classes.
