### PR TITLE
Remove Runtime::loadNs function

### DIFF
--- a/src/php/Command/Runtime/RuntimeFileGenerator.php
+++ b/src/php/Command/Runtime/RuntimeFileGenerator.php
@@ -20,7 +20,6 @@ use Phel\Runtime\RuntimeSingleton;
 require __DIR__ .'/autoload.php';
 
 $rt = RuntimeSingleton::initialize();
-$rt->loadNs("phel\\core");
 
 EOF;
 

--- a/src/php/Runtime/Runtime.php
+++ b/src/php/Runtime/Runtime.php
@@ -72,9 +72,4 @@ class Runtime implements RuntimeInterface
     {
         return array_merge(...array_values($this->paths));
     }
-
-    public function loadNs(string $ns): bool
-    {
-        return true;
-    }
 }

--- a/src/php/Runtime/RuntimeInterface.php
+++ b/src/php/Runtime/RuntimeInterface.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Phel\Runtime;
 
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironmentInterface;
-use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
-use Phel\Compiler\Evaluator\Exceptions\FileException;
-use Phel\Compiler\Exceptions\CompilerException;
 
 interface RuntimeInterface
 {
@@ -23,15 +20,4 @@ interface RuntimeInterface
      * @return list<string>
      */
     public function getSourceDirectories(): array;
-
-    /**
-     * @throws CompilerException
-     * @throws CompiledCodeIsMalformedException
-     * @throws FileException
-     *
-     * @return bool true if the namespace was successfully loaded; false otherwise
-     *
-     * @deprecated this function only exists because the phel composer plugin is using it
-     */
-    public function loadNs(string $ns): bool;
 }

--- a/tests/php/Integration/Command/Export/vendor/PhelRuntime.php
+++ b/tests/php/Integration/Command/Export/vendor/PhelRuntime.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
 use Phel\Runtime\RuntimeSingleton;
 
 $runtime = RuntimeSingleton::initializeNew(new GlobalEnvironment());
 $runtime->addPath('phel\\', [__DIR__ . '/../../../../../../src/phel']);
-$runtime->loadNs('phel\core');
 
 return $runtime;

--- a/tests/php/Integration/Command/Test/vendor/PhelRuntime.php
+++ b/tests/php/Integration/Command/Test/vendor/PhelRuntime.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
 use Phel\Runtime\RuntimeSingleton;
 
 $runtime = RuntimeSingleton::initializeNew(new GlobalEnvironment());
 $runtime->addPath('phel\\', [__DIR__ . '/../../../../../../src/phel']);
-$runtime->loadNs('phel\core');
 
 return $runtime;

--- a/tests/php/Integration/Printer/vendor/PhelRuntime.php
+++ b/tests/php/Integration/Printer/vendor/PhelRuntime.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
 use Phel\Runtime\RuntimeSingleton;
 
 $runtime = RuntimeSingleton::initializeNew(new GlobalEnvironment());
 $runtime->addPath('phel\\', [__DIR__ . '/../../../../../../src/phel']);
-$runtime->loadNs('phel\core');
 
 return $runtime;

--- a/tests/php/Unit/Command/Runtime/RuntimeFileGeneratorTest.php
+++ b/tests/php/Unit/Command/Runtime/RuntimeFileGeneratorTest.php
@@ -29,7 +29,6 @@ use Phel\Runtime\RuntimeSingleton;
 require __DIR__ .'/autoload.php';
 
 $rt = RuntimeSingleton::initialize();
-$rt->loadNs("phel\\core");
 $rt->addPath("my-namespace\\", [__DIR__ . '/src/']);
 $rt->addPath("my-other-namespace\\", [__DIR__ . '/lib/', __DIR__ . '/other/']);
 $rt->addPath("my-test-namespace\\", [__DIR__ . '/tests/']);


### PR DESCRIPTION
## 📚 Description

This function removes the `Runtime::loadNs` function. It is not needed anymore.
