### PR TITLE
Use phel-test as a prefix for tests/phel directory

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -8,7 +8,7 @@ return [
         'phel\\' => 'src/phel/',
     ],
     'loader-dev' => [
-        'phel\\' => 'tests/phel/',
+        'phel-test\\' => 'tests/phel/',
         'tests-phpbench\\' => 'tests/php/Benchmark/',
     ],
     'tests' => [

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core
+(ns phel-test\test\core
   (:require phel\test :refer [deftest is]))
 
 # -------------

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\basic-constructors
+(ns phel-test\test\core\basic-constructors
   (:require phel\test :refer [deftest is]))
 
 (deftest create-list

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\basic-sequence-operation
+(ns phel-test\test\core\basic-sequence-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-cons

--- a/tests/phel/test/core/bitwise-operation.phel
+++ b/tests/phel/test/core/bitwise-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\bitwise-operation
+(ns phel-test\test\core\bitwise-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-bit-and

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\boolean-operation
+(ns phel-test\test\core\boolean-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-or

--- a/tests/phel/test/core/control-structures.phel
+++ b/tests/phel/test/core/control-structures.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\control-structures
+(ns phel-test\test\core\control-structures
   (:require phel\test :refer [deftest is]))
 
 (deftest test-if-not

--- a/tests/phel/test/core/for-loop.phel
+++ b/tests/phel/test/core/for-loop.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\for-loop
+(ns phel-test\test\core\for-loop
   (:require phel\test :refer [deftest is]))
 
 (deftest test-range

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\function-operation
+(ns phel-test\test\core\function-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-identity

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\math-operation
+(ns phel-test\test\core\math-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-+

--- a/tests/phel/test/core/more-sequence-operation.phel
+++ b/tests/phel/test/core/more-sequence-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\more-sequence-operation
+(ns phel-test\test\core\more-sequence-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-tree-seq

--- a/tests/phel/test/core/print-operation.phel
+++ b/tests/phel/test/core/print-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\print-operation
+(ns phel-test\test\core\print-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-str

--- a/tests/phel/test/core/regex-functions.phel
+++ b/tests/phel/test/core/regex-functions.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\regex-functions
+(ns phel-test\test\core\regex-functions
   (:require phel\test :refer [deftest is]))
 
 (deftest test-re-seq

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\sequence-functions
+(ns phel-test\test\core\sequence-functions
   (:require phel\test :refer [deftest is]))
 
 (deftest test-map

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\sequence-operation
+(ns phel-test\test\core\sequence-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-peek

--- a/tests/phel/test/core/set-operation.phel
+++ b/tests/phel/test/core/set-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\set-operation
+(ns phel-test\test\core\set-operation
   (:require phel\test :refer [deftest is]))
 
 (deftest test-set-union

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\threading-macros
+(ns phel-test\test\core\threading-macros
   (:require phel\test :refer [deftest is]))
 
 (deftest test->

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -1,4 +1,4 @@
-(ns phel\test\core\type-operation
+(ns phel-test\test\core\type-operation
   (:use DateTime)
   (:require phel\test :refer [deftest is]))
 

--- a/tests/phel/test/html.phel
+++ b/tests/phel/test/html.phel
@@ -1,4 +1,4 @@
-(ns phel\test\html
+(ns phel-test\test\html
   (:require phel\html :refer [html raw-string doctype])
   (:require phel\test :refer [deftest is]))
 

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -1,4 +1,4 @@
-(ns phel\test\http
+(ns phel-test\test\http
   (:require phel\http :as h)
   (:require phel\test :refer [deftest is]))
 

--- a/tests/phel/test/special-forms.phel
+++ b/tests/phel/test/special-forms.phel
@@ -1,4 +1,4 @@
-(ns phel\test\special-forms
+(ns phel-test\test\special-forms
   (:require phel\test :refer [deftest is]))
 
 (deftest test-set-object-property


### PR DESCRIPTION

## 📚 Description

Use phel-test as a prefix for tests/phel directory, because just "phel" is already in use for the production phel library itself.

Also, I think we can end up with some collision of naming when unifying all src and test keys when doing ns extraction per file. But anyhow, I think we get some benefits already by having diff namespaces for different contexts. And in this case, for test context, it makes totally sense.

## 🔖 Changes

- Change `phel\\` to `phel-test\\` the `loader-dev` phel test namespace

