### PR TITLE
Wrong pathPrefix on ComposerVendorDirectoriesFinder

### DIFF
--- a/src/php/Run/Finder/ComposerVendorDirectoriesFinder.php
+++ b/src/php/Run/Finder/ComposerVendorDirectoriesFinder.php
@@ -28,8 +28,7 @@ final class ComposerVendorDirectoriesFinder implements VendorDirectoriesFinderIn
         $result = [];
 
         foreach (glob($pattern) as $phelConfigPath) {
-            $relativeVendorConfigPath = substr($phelConfigPath, strlen($vendorDir) - strlen($phelConfigPath));
-            $pathPrefix = dirname($relativeVendorConfigPath);
+            $pathPrefix = dirname($phelConfigPath);
             /** @psalm-suppress UnresolvableInclude */
             $sourceDirectories = (require $phelConfigPath)[RunConfig::SRC_DIRS] ?? [];
 


### PR DESCRIPTION
## 📚 Description

I discovered this bug when I was updating the phel-scaffolding repo. The "vendor/" was missing from the `pathPrefix`, and therefore the dependency was not found.
I actually don't remember why I did that `substr()` but without that, I think it makes sense. And everything seems to be working.

I think we should write an integration test for this. It will be complex due to the real files with I/O stuff (`glob()` & `require`), but I think it is worth trying this in order to avoid this bug in the future.


Anyway, I think we can postpone that as "tech debt" for the next release.