### PR TITLE
Move the src Finder from the Run to the Command module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data/
 PhelGenerated/
 var/
 .phpbench/
+!PhelGenerated/.gitkeep
 .php-cs-fixer.cache
 .phel-repl-history
 .phpunit.*

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="src/PhelGenerated" />
         </ignoreFiles>
     </projectFiles>
 

--- a/src/php/Build/BuildFacadeInterface.php
+++ b/src/php/Build/BuildFacadeInterface.php
@@ -35,7 +35,7 @@ interface BuildFacadeInterface
     /**
      * Gets a list of all dependencies for a given list of namespaces. It first extracts all
      * namespaces from all Phel files in the give directories and then return a
-     * topological sorted subset of these namespace information.
+     * topological sorted subset of these namespaces' information.
      *
      * @param string[] $directories The list of the directories
      * @param string[] $ns A list of namespace for which we should find the subset

--- a/src/php/Build/Extractor/NamespaceExtractor.php
+++ b/src/php/Build/Extractor/NamespaceExtractor.php
@@ -16,6 +16,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
+use RuntimeException;
 
 final class NamespaceExtractor implements NamespaceExtractorInterface
 {
@@ -138,7 +139,11 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
      */
     private function findAllNs(string $directory): array
     {
-        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
+        $realpath = realpath($directory);
+        if (!$realpath) {
+            throw new RuntimeException("Directory '$directory' not found");
+        }
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($realpath));
         $phelIterator = new RegexIterator($iterator, '/^.+\.phel$/i', RecursiveRegexIterator::GET_MATCH);
 
         return array_map(

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Command;
+
+use Gacela\Framework\AbstractConfig;
+use Gacela\Framework\Config;
+use Phel\Command\Domain\CodeDirectories;
+
+final class CommandConfig extends AbstractConfig
+{
+    public const SRC_DIRS = 'src-dirs';
+    public const TEST_DIRS = 'test-dirs';
+    public const VENDOR_DIR = 'vendor-dir';
+
+    public function getPhelReplHistory(): string
+    {
+        return $this->getApplicationRootDir() . '.phel-repl-history';
+    }
+
+    public function getReplStartupFile(): string
+    {
+        return __DIR__ . '/Command/Repl/startup.phel';
+    }
+
+    public function getApplicationRootDir(): string
+    {
+        return Config::getInstance()->getApplicationRootDir();
+    }
+
+    public function getConfigDirectories(): CodeDirectories
+    {
+        return new CodeDirectories(
+            (array)$this->get(self::SRC_DIRS),
+            (array)$this->get(self::TEST_DIRS)
+        );
+    }
+
+    public function getVendorDir(): string
+    {
+        return (string)$this->get(self::VENDOR_DIR);
+    }
+}

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -59,4 +59,25 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
             }
         });
     }
+
+    public function getSourceDirectories(): array
+    {
+        return $this->getFactory()
+            ->createDirectoryFinder()
+            ->getSourceDirectories();
+    }
+
+    public function getTestDirectories(): array
+    {
+        return $this->getFactory()
+            ->createDirectoryFinder()
+            ->getTestDirectories();
+    }
+
+    public function getVendorSourceDirectories(): array
+    {
+        return $this->getFactory()
+            ->createDirectoryFinder()
+            ->getVendorSourceDirectories();
+    }
 }

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -24,4 +24,19 @@ interface CommandFacadeInterface
     public function getStackTraceString(Throwable $e): string;
 
     public function registerExceptionHandler(): void;
+
+    /**
+     * @return list<string>
+     */
+    public function getSourceDirectories(): array;
+
+    /**
+     * @return list<string>
+     */
+    public function getTestDirectories(): array;
+
+    /**
+     * @return list<string>
+     */
+    public function getVendorSourceDirectories(): array;
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Command\Finder\ComposerVendorDirectoriesFinder;
+use Phel\Command\Finder\DirectoryFinder;
+use Phel\Command\Finder\DirectoryFinderInterface;
+use Phel\Command\Finder\VendorDirectoriesFinderInterface;
 use Phel\Command\Shared\CommandExceptionWriter;
 use Phel\Command\Shared\CommandExceptionWriterInterface;
 use Phel\Command\Shared\Exceptions\ExceptionPrinterInterface;
 use Phel\Command\Shared\Exceptions\TextExceptionPrinter;
 
+/**
+ * @method CommandConfig getConfig()
+ */
 final class CommandFactory extends AbstractFactory
 {
     public function createCommandExceptionWriter(): CommandExceptionWriterInterface
@@ -22,5 +29,21 @@ final class CommandFactory extends AbstractFactory
     public function createExceptionPrinter(): ExceptionPrinterInterface
     {
         return TextExceptionPrinter::create();
+    }
+
+    public function createDirectoryFinder(): DirectoryFinderInterface
+    {
+        return new DirectoryFinder(
+            $this->getConfig()->getApplicationRootDir(),
+            $this->getConfig()->getConfigDirectories(),
+            $this->createComposerVendorDirectoriesFinder()
+        );
+    }
+
+    private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface
+    {
+        return new ComposerVendorDirectoriesFinder(
+            $this->getConfig()->getVendorDir()
+        );
     }
 }

--- a/src/php/Command/Domain/CodeDirectories.php
+++ b/src/php/Command/Domain/CodeDirectories.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Domain;
+namespace Phel\Command\Domain;
 
 final class CodeDirectories
 {

--- a/src/php/Command/Finder/ComposerVendorDirectoriesFinder.php
+++ b/src/php/Command/Finder/ComposerVendorDirectoriesFinder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
-use Phel\Run\RunConfig;
+use Phel\Command\CommandConfig;
 
 final class ComposerVendorDirectoriesFinder implements VendorDirectoriesFinderInterface
 {
@@ -30,7 +30,7 @@ final class ComposerVendorDirectoriesFinder implements VendorDirectoriesFinderIn
         foreach (glob($pattern) as $phelConfigPath) {
             $pathPrefix = dirname($phelConfigPath);
             /** @psalm-suppress UnresolvableInclude */
-            $sourceDirectories = (require $phelConfigPath)[RunConfig::SRC_DIRS] ?? [];
+            $sourceDirectories = (require $phelConfigPath)[CommandConfig::SRC_DIRS] ?? [];
 
             foreach ($sourceDirectories as $directory) {
                 $result[] = $pathPrefix . '/' . $directory;

--- a/src/php/Command/Finder/DirectoryFinder.php
+++ b/src/php/Command/Finder/DirectoryFinder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
-use Phel\Run\Domain\CodeDirectories;
+use Phel\Command\Domain\CodeDirectories;
 
 final class DirectoryFinder implements DirectoryFinderInterface
 {

--- a/src/php/Command/Finder/DirectoryFinderInterface.php
+++ b/src/php/Command/Finder/DirectoryFinderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
 interface DirectoryFinderInterface
 {

--- a/src/php/Command/Finder/PhelFileFinder.php
+++ b/src/php/Command/Finder/PhelFileFinder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
 use AppendIterator;
 use Iterator;

--- a/src/php/Command/Finder/PhelFileFinderInterface.php
+++ b/src/php/Command/Finder/PhelFileFinderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
 use Iterator;
 

--- a/src/php/Command/Finder/VendorDirectoriesFinderInterface.php
+++ b/src/php/Command/Finder/VendorDirectoriesFinderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Finder;
+namespace Phel\Command\Finder;
 
 interface VendorDirectoriesFinderInterface
 {

--- a/src/php/Interop/Command/ExportCommand.php
+++ b/src/php/Interop/Command/ExportCommand.php
@@ -87,8 +87,10 @@ final class ExportCommand extends Command
      */
     public function generateWrappers(): array
     {
+        $allFunctionsToExport = $this->functionsToExportFinder->findInPaths();
         $wrappers = [];
-        foreach ($this->functionsToExportFinder->findInPaths() as $ns => $functionsToExport) {
+
+        foreach ($allFunctionsToExport as $ns => $functionsToExport) {
             $wrappers[] = $this->wrapperGenerator->generateCompiledPhp($ns, $functionsToExport);
         }
 

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
@@ -65,20 +65,16 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
             $namespaceFromDirectories
         ));
 
-        $dependenciesForNamespace = [];
-        foreach ($namespaces as $namespace) {
-            $dependenciesForNamespace[] = $this->buildFacade->getDependenciesForNamespace(
-                [
-                    ...$this->commandFacade->getSourceDirectories(),
-                    ...$this->commandFacade->getVendorSourceDirectories(),
-                ],
-                [$namespace, 'phel\\core']
-            );
-        }
-        $allNamespaces = array_merge(...$dependenciesForNamespace);
+        $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
+            [
+                ...$this->commandFacade->getSourceDirectories(),
+                ...$this->commandFacade->getVendorSourceDirectories(),
+            ],
+            [...$namespaces, 'phel\\core']
+        );
 
-        foreach ($allNamespaces as $ns) {
-            $this->buildFacade->evalFile($ns->getFile());
+        foreach ($namespaceInformation as $info) {
+            $this->buildFacade->evalFile($info->getFile());
         }
     }
 

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -74,7 +74,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new FunctionsToExportFinder(
             $this->getBuildFacade(),
-            $this->getConfig()->getSourceDirectories(),
+            $this->getCommandFacade(),
             $this->getConfig()->getExportDirectories()
         );
     }

--- a/src/php/Run/Command/Repl/ReplCommand.php
+++ b/src/php/Run/Command/Repl/ReplCommand.php
@@ -11,7 +11,6 @@ use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Compiler\Parser\Exceptions\UnfinishedParserException;
 use Phel\Printer\PrinterInterface;
 use Phel\Run\Command\Repl\Exceptions\ExitException;
-use Phel\Run\Finder\DirectoryFinderInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,9 +31,8 @@ final class ReplCommand extends Command
     private ColorStyleInterface $style;
     private PrinterInterface $printer;
     private BuildFacadeInterface $buildFacade;
-    private string $replStartupFile;
-    private DirectoryFinderInterface $directoryFinder;
     private CommandFacadeInterface $commandFacade;
+    private string $replStartupFile;
 
     /** @var string[] */
     private array $inputBuffer = [];
@@ -47,7 +45,6 @@ final class ReplCommand extends Command
         ColorStyleInterface $style,
         PrinterInterface $printer,
         BuildFacadeInterface $buildFacade,
-        DirectoryFinderInterface $directoryFinder,
         CommandFacadeInterface $commandFacade,
         string $replStartupFile = ''
     ) {
@@ -57,9 +54,8 @@ final class ReplCommand extends Command
         $this->style = $style;
         $this->printer = $printer;
         $this->buildFacade = $buildFacade;
-        $this->directoryFinder = $directoryFinder;
-        $this->replStartupFile = $replStartupFile;
         $this->commandFacade = $commandFacade;
+        $this->replStartupFile = $replStartupFile;
         $this->previousResult = InputResult::empty();
     }
 
@@ -77,12 +73,15 @@ final class ReplCommand extends Command
         $this->commandFacade->registerExceptionHandler();
 
         if ($this->replStartupFile && file_exists($this->replStartupFile)) {
-            $namespace = $this->buildFacade->getNamespaceFromFile($this->replStartupFile)->getNamespace();
+            $namespace = $this->buildFacade
+                ->getNamespaceFromFile($this->replStartupFile)
+                ->getNamespace();
+
             $srcDirectories = [
                 dirname($this->replStartupFile),
-                ...$this->directoryFinder->getSourceDirectories(),
-                ...$this->directoryFinder->getTestDirectories(),
-                ...$this->directoryFinder->getVendorSourceDirectories(),
+                ...$this->commandFacade->getSourceDirectories(),
+                ...$this->commandFacade->getTestDirectories(),
+                ...$this->commandFacade->getVendorSourceDirectories(),
             ];
             $namespaceInformation = $this->buildFacade->getDependenciesForNamespace($srcDirectories, [$namespace, 'phel\\core']);
 

--- a/src/php/Run/Command/Test/TestCommand.php
+++ b/src/php/Run/Command/Test/TestCommand.php
@@ -10,7 +10,6 @@ use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Run\Command\Test\Exceptions\CannotFindAnyTestsException;
-use Phel\Run\Finder\DirectoryFinder;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -26,19 +25,16 @@ final class TestCommand extends Command
     private CommandFacadeInterface $commandFacade;
     private CompilerFacadeInterface $compilerFacade;
     private BuildFacadeInterface $buildFacade;
-    private DirectoryFinder $directoryFinder;
 
     public function __construct(
         CommandFacadeInterface $commandFacade,
         CompilerFacadeInterface $compilerFacade,
-        BuildFacadeInterface $buildFacade,
-        DirectoryFinder $directoryFinder
+        BuildFacadeInterface $buildFacade
     ) {
         parent::__construct(self::COMMAND_NAME);
         $this->commandFacade = $commandFacade;
         $this->compilerFacade = $compilerFacade;
         $this->buildFacade = $buildFacade;
-        $this->directoryFinder = $directoryFinder;
     }
 
     protected function configure(): void
@@ -71,9 +67,9 @@ final class TestCommand extends Command
 
             $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
                 [
-                    ...$this->directoryFinder->getSourceDirectories(),
-                    ...$this->directoryFinder->getTestDirectories(),
-                    ...$this->directoryFinder->getVendorSourceDirectories(),
+                    ...$this->commandFacade->getSourceDirectories(),
+                    ...$this->commandFacade->getTestDirectories(),
+                    ...$this->commandFacade->getVendorSourceDirectories(),
                 ],
                 $namespaces
             );
@@ -115,7 +111,7 @@ final class TestCommand extends Command
     {
         if (empty($paths)) {
             $namespaces = $this->buildFacade->getNamespaceFromDirectories(
-                $this->directoryFinder->getTestDirectories()
+                $this->commandFacade->getTestDirectories()
             );
 
             return array_map(

--- a/src/php/Run/RunConfig.php
+++ b/src/php/Run/RunConfig.php
@@ -6,17 +6,12 @@ namespace Phel\Run;
 
 use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\Config;
-use Phel\Run\Domain\CodeDirectories;
 
 final class RunConfig extends AbstractConfig
 {
-    public const SRC_DIRS = 'src-dirs';
-    public const TEST_DIRS = 'test-dirs';
-    public const VENDOR_DIR = 'vendor-dir';
-
     public function getPhelReplHistory(): string
     {
-        return $this->getApplicationRootDir() . '/.phel-repl-history';
+        return $this->getApplicationRootDir() . '.phel-repl-history';
     }
 
     public function getReplStartupFile(): string
@@ -24,21 +19,8 @@ final class RunConfig extends AbstractConfig
         return __DIR__ . '/Command/Repl/startup.phel';
     }
 
-    public function getApplicationRootDir(): string
+    private function getApplicationRootDir(): string
     {
         return Config::getInstance()->getApplicationRootDir();
-    }
-
-    public function getConfigDirectories(): CodeDirectories
-    {
-        return new CodeDirectories(
-            (array)$this->get(self::SRC_DIRS),
-            (array)$this->get(self::TEST_DIRS)
-        );
-    }
-
-    public function getVendorDir(): string
-    {
-        return (string)$this->get(self::VENDOR_DIR);
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -17,9 +17,6 @@ use Phel\Run\Command\Repl\ReplCommandIoInterface;
 use Phel\Run\Command\Repl\ReplCommandSystemIo;
 use Phel\Run\Command\Run\RunCommand;
 use Phel\Run\Command\Test\TestCommand;
-use Phel\Run\Finder\ComposerVendorDirectoriesFinder;
-use Phel\Run\Finder\DirectoryFinder;
-use Phel\Run\Finder\VendorDirectoriesFinderInterface;
 use Phel\Run\Runner\NamespaceRunner;
 use Phel\Run\Runner\NamespaceRunnerInterface;
 
@@ -36,7 +33,6 @@ final class RunFactory extends AbstractFactory
             $this->createColorStyle(),
             $this->createPrinter(),
             $this->getBuildFacade(),
-            $this->createDirectoryFinder(),
             $this->getCommandFacade(),
             $this->getConfig()->getReplStartupFile()
         );
@@ -56,8 +52,7 @@ final class RunFactory extends AbstractFactory
         return new TestCommand(
             $this->getCommandFacade(),
             $this->getCompilerFacade(),
-            $this->getBuildFacade(),
-            $this->createDirectoryFinder()
+            $this->getBuildFacade()
         );
     }
 
@@ -65,8 +60,7 @@ final class RunFactory extends AbstractFactory
     {
         return new NamespaceRunner(
             $this->getCommandFacade(),
-            $this->getBuildFacade(),
-            $this->createDirectoryFinder()
+            $this->getBuildFacade()
         );
     }
 
@@ -86,22 +80,6 @@ final class RunFactory extends AbstractFactory
     private function createPrinter(): PrinterInterface
     {
         return Printer::nonReadableWithColor();
-    }
-
-    private function createDirectoryFinder(): DirectoryFinder
-    {
-        return new DirectoryFinder(
-            $this->getConfig()->getApplicationRootDir(),
-            $this->getConfig()->getConfigDirectories(),
-            $this->createComposerVendorDirectoriesFinder()
-        );
-    }
-
-    private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface
-    {
-        return new ComposerVendorDirectoriesFinder(
-            $this->getConfig()->getVendorDir()
-        );
     }
 
     private function getCompilerFacade(): CompilerFacadeInterface

--- a/src/php/Run/Runner/NamespaceRunner.php
+++ b/src/php/Run/Runner/NamespaceRunner.php
@@ -6,22 +6,18 @@ namespace Phel\Run\Runner;
 
 use Phel\Build\BuildFacadeInterface;
 use Phel\Command\CommandFacadeInterface;
-use Phel\Run\Finder\DirectoryFinder;
 
 class NamespaceRunner implements NamespaceRunnerInterface
 {
     private CommandFacadeInterface $commandFacade;
     private BuildFacadeInterface $buildFacade;
-    private DirectoryFinder $directoryFinder;
 
     public function __construct(
         CommandFacadeInterface $commandFacade,
-        BuildFacadeInterface $buildFacade,
-        DirectoryFinder $directoryFinder
+        BuildFacadeInterface $buildFacade
     ) {
         $this->commandFacade = $commandFacade;
         $this->buildFacade = $buildFacade;
-        $this->directoryFinder = $directoryFinder;
     }
 
     public function run(string $namespace): void
@@ -30,8 +26,8 @@ class NamespaceRunner implements NamespaceRunnerInterface
 
         $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
             [
-                ...$this->directoryFinder->getSourceDirectories(),
-                ...$this->directoryFinder->getVendorSourceDirectories(),
+                ...$this->commandFacade->getSourceDirectories(),
+                ...$this->commandFacade->getVendorSourceDirectories(),
             ],
             [$namespace, 'phel\\core']
         );

--- a/tests/php/Integration/Interop/Command/Export/config/phel-config.php
+++ b/tests/php/Integration/Interop/Command/Export/config/phel-config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'src-dirs' => [
-        '/../../../../../../src/phel/',
+        '../../../../../../src/phel/',
         'src',
     ],
     'test-dirs' => [],

--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
@@ -17,7 +17,6 @@ use Phel\Compiler\Emitter\OutputEmitter\Munge;
 use Phel\Printer\Printer;
 use Phel\Run\Command\Repl\ColorStyle;
 use Phel\Run\Command\Repl\ReplCommand;
-use Phel\Run\Finder\DirectoryFinderInterface;
 use PhelTest\Integration\Run\Command\AbstractCommandTest;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -53,7 +52,7 @@ final class ReplCommandTest extends AbstractCommandTest
 
     /**
      * This is doing the same as the test above except that it will load the core lib before.
-     * We splitted it because it takes some time to load the core lib before every test.
+     * We split it because it takes some time to load the core lib before every test.
      *
      * @dataProvider providerIntegrationWithCoreLib
      */
@@ -108,28 +107,19 @@ final class ReplCommandTest extends AbstractCommandTest
 
     private function createReplCommand(ReplTestIo $io): ReplCommand
     {
-        $directoryFinder = $this->createMock(DirectoryFinderInterface::class);
-        $directoryFinder->method('getSourceDirectories')->willReturn([__DIR__ . '/../../../../src/phel/']);
-        $directoryFinder->method('getTestDirectories')->willReturn([]);
-        $directoryFinder->method('getVendorSourceDirectories')->willReturn([]);
-
         return new ReplCommand(
             $io,
             new CompilerFacade(),
             ColorStyle::noStyles(),
             Printer::nonReadable(),
             new BuildFacade(),
-            $directoryFinder,
             new CommandFacade()
         );
     }
 
     private function createReplCommandWithCoreLib(ReplTestIo $io): ReplCommand
     {
-        $directoryFinder = $this->createMock(DirectoryFinderInterface::class);
-        $directoryFinder->method('getSourceDirectories')->willReturn([__DIR__ . '/../../../../../../src/phel/']);
-        $directoryFinder->method('getTestDirectories')->willReturn([]);
-        $directoryFinder->method('getVendorSourceDirectories')->willReturn([]);
+        $replStartupFile =  __DIR__ . '/../../../../../../src/php/Run/Command/Repl/startup.phel';
 
         return new ReplCommand(
             $io,
@@ -137,9 +127,8 @@ final class ReplCommandTest extends AbstractCommandTest
             ColorStyle::noStyles(),
             Printer::nonReadable(),
             new BuildFacade(),
-            $directoryFinder,
             new CommandFacade(),
-            __DIR__ . '/../../../../../../src/php/Run/Command/Repl/startup.phel'
+            $replStartupFile
         );
     }
 

--- a/tests/php/Integration/Run/Command/Repl/config/phel-config.php
+++ b/tests/php/Integration/Run/Command/Repl/config/phel-config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'src-dirs' => [
+        '../../../../../../src/phel/',
+    ],
+    'test-dirs' => [],
+    'vendor-dir' => 'vendor',
+];


### PR DESCRIPTION
## 📚 Description

This way we can access `src-dirs` + `vendor` dependencies from other modules (like Interop, so we can use it in the `ExportCommand` as well).

I think the `src-dirs`, `test-dirs`, and vendor would be interesting information for all general commands. For example, the `ExportCommand` (from the Interop module) needs to know about the `src-dirs` in order to compile the export code properly.

## 🔖 Changes

- Move the Finder folder from the `Run` to the `Command` module.

## 🖼️ Screenshots

Some screenshots from the phel-scaffolding project.

#### BEFORE (current master)
<img width="1693" alt="Screenshot 2021-10-03 at 11 43 08" src="https://user-images.githubusercontent.com/5256287/135748227-68f8080a-8874-4d9a-9725-597fc2de10a7.png">

#### AFTER (using this branch)
<img width="685" alt="Screenshot 2021-10-03 at 11 43 37" src="https://user-images.githubusercontent.com/5256287/135748243-e61459b3-cecf-46bf-9590-06fca98d2423.png">


