### PR TITLE
Enable config default values

### DIFF
--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -14,6 +14,10 @@ final class CommandConfig extends AbstractConfig
     public const TEST_DIRS = 'test-dirs';
     public const VENDOR_DIR = 'vendor-dir';
 
+    private const DEFAULT_VENDOR_DIR = 'vendor';
+    private const DEFAULT_SRC_DIRS = ['src'];
+    private const DEFAULT_TEST_DIRS = ['tests'];
+
     public function getPhelReplHistory(): string
     {
         return $this->getApplicationRootDir() . '.phel-repl-history';
@@ -32,13 +36,13 @@ final class CommandConfig extends AbstractConfig
     public function getConfigDirectories(): CodeDirectories
     {
         return new CodeDirectories(
-            (array)$this->get(self::SRC_DIRS),
-            (array)$this->get(self::TEST_DIRS)
+            (array)$this->get(self::SRC_DIRS, self::DEFAULT_SRC_DIRS),
+            (array)$this->get(self::TEST_DIRS, self::DEFAULT_TEST_DIRS)
         );
     }
 
     public function getVendorDir(): string
     {
-        return (string)$this->get(self::VENDOR_DIR);
+        return (string)$this->get(self::VENDOR_DIR, self::DEFAULT_VENDOR_DIR);
     }
 }

--- a/src/php/Interop/InteropConfig.php
+++ b/src/php/Interop/InteropConfig.php
@@ -11,44 +11,48 @@ final class InteropConfig extends AbstractConfig
 {
     public const EXPORT = 'export';
 
-    public const EXPORT_NAMESPACE_PREFIX = 'namespace-prefix';
-    public const EXPORT_TARGET_DIRECTORY = 'target-directory';
-    public const EXPORT_DIRECTORIES = 'directories';
+    private const EXPORT_DIRECTORIES = 'directories';
+    private const EXPORT_NAMESPACE_PREFIX = 'namespace-prefix';
+    private const EXPORT_TARGET_DIRECTORY = 'target-directory';
+
+    private const DEFAULT_EXPORT_DIRECTORIES = ['src'];
+    private const DEFAULT_EXPORT_NAMESPACE_PREFIX = 'PhelGenerated';
+    private const DEFAULT_EXPORT_TARGET_DIRECTORY = 'src/PhelGenerated';
+
+    private const DEFAULT_EXPORT = [
+        self::EXPORT_DIRECTORIES => self::DEFAULT_EXPORT_DIRECTORIES,
+        self::EXPORT_NAMESPACE_PREFIX => self::DEFAULT_EXPORT_NAMESPACE_PREFIX,
+        self::EXPORT_TARGET_DIRECTORY => self::DEFAULT_EXPORT_TARGET_DIRECTORY,
+    ];
 
     public function prefixNamespace(): string
     {
-        return (string)$this->get(self::EXPORT)[self::EXPORT_NAMESPACE_PREFIX];
+        return (string)($this->getExport()[self::EXPORT_NAMESPACE_PREFIX] ?? self::DEFAULT_EXPORT_NAMESPACE_PREFIX);
     }
 
     public function getExportTargetDirectory(): string
     {
-        return (string)($this->get(self::EXPORT)[self::EXPORT_TARGET_DIRECTORY] ?? 'PhelGenerated');
+        return (string)($this->getExport()[self::EXPORT_TARGET_DIRECTORY] ?? self::DEFAULT_EXPORT_TARGET_DIRECTORY);
     }
 
     /**
-     * @return string[]
-     */
-    public function getSourceDirectories(): array
-    {
-        return array_map(
-            fn (string $dir): string => $this->getApplicationRootDir() . '/' . $dir,
-            $this->get('src-dirs') ?? []
-        );
-    }
-
-    /**
-     * @return string[]
+     * @return list<string>
      */
     public function getExportDirectories(): array
     {
         return array_map(
             fn (string $dir): string => $this->getApplicationRootDir() . '/' . $dir,
-            $this->get('export')[self::EXPORT_DIRECTORIES] ?? []
+            $this->getExport()[self::EXPORT_DIRECTORIES] ?? self::DEFAULT_EXPORT_DIRECTORIES
         );
     }
 
     public function getApplicationRootDir(): string
     {
         return Config::getInstance()->getApplicationRootDir();
+    }
+
+    private function getExport(): array
+    {
+        return $this->get(self::EXPORT, self::DEFAULT_EXPORT);
     }
 }


### PR DESCRIPTION
## 📚 Description

Issues: 
https://github.com/phel-lang/phel-lang/issues/369: Could not find config key "export" in "Gacela\Framework\Config"
https://github.com/phel-lang/phel-lang/issues/370: Could not find config key "vendor-dir" in "Gacela\Framework\Config"

## 🔖 Changes

- Add default values for all current keys in `phel-config.php` file
