### PR TITLE
Added internal compile mode definition

### DIFF
--- a/src/php/Build/Compile/FileCompiler.php
+++ b/src/php/Build/Compile/FileCompiler.php
@@ -30,7 +30,9 @@ final class FileCompiler implements FileCompilerInterface
             ->setSource($src)
             ->setIsEnabledSourceMaps($enableSourceMaps);
 
+        $GLOBALS['__phel']['phel\core']['*compile-mode*'] = true;
         $result = $this->compilerFacade->compile($phelCode, $options);
+        $GLOBALS['__phel']['phel\core']['*compile-mode*'] = false;
 
         file_put_contents($dest, "<?php\n" . $result->getCode());
         file_put_contents(str_replace('.php', '.phel', $dest), $phelCode);

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
@@ -36,7 +36,6 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function __construct()
     {
-        // Add internal definition
         $this->addInternalDefinition('phel\core', Symbol::create('*compile-mode*'), false);
     }
 

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
@@ -12,6 +12,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
 use RuntimeException;
 
 final class GlobalEnvironment implements GlobalEnvironmentInterface
@@ -31,6 +32,12 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private array $useAliases = [];
 
     private bool $allowPrivateAccess = false;
+
+    public function __construct()
+    {
+        // Add internal definition
+        $this->addInternalDefinition('phel\core', Symbol::create('*compile-mode*'), false);
+    }
 
     public function getNs(): string
     {
@@ -241,5 +248,17 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     public function setAllowPrivateAccess(bool $allowPrivateAccess): void
     {
         $this->allowPrivateAccess = $allowPrivateAccess;
+    }
+
+    /**
+     * @param TypeInterface|string|float|int|bool|null $value The inital value
+     */
+    private function addInternalDefinition(string $namespace, Symbol $symbol, $value): void
+    {
+        $GLOBALS['__phel'][$namespace][$symbol->getName()] = $value;
+        $this->addDefinition($namespace, $symbol, TypeFactory::getInstance()->persistentMapFromKVs(
+            new Keyword('doc'),
+            'Set to true when a file is compiled, false otherwise',
+        ));
     }
 }

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
@@ -13,6 +13,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
+use Phel\Lang\TypeInterface;
 use RuntimeException;
 
 final class GlobalEnvironment implements GlobalEnvironmentInterface

--- a/tests/php/Integration/Build/Command/CompileCommandTest.php
+++ b/tests/php/Integration/Build/Command/CompileCommandTest.php
@@ -26,6 +26,8 @@ final class CompileCommandTest extends TestCase
     {
         $command = $this->createBuildFacade()->getCompileCommand();
 
+        $this->expectOutputString("This is printed\n");
+
         $command->run(
             new ArrayInput([
                 '--no-source-map' => true,

--- a/tests/php/Integration/Build/Command/src/hello.phel
+++ b/tests/php/Integration/Build/Command/src/hello.phel
@@ -3,3 +3,8 @@
 
 (defn hello-world []
   (h/html [:div "hello-world"]))
+
+(println "This is printed")
+
+(when-not *compile-mode*
+  (println "This is not printed"))


### PR DESCRIPTION
## 📚 Description

This adds a `*compile-mode*` variable to Phel that will be set to true if a file is compiled. This flag can be used to prevent that side effects (like `print`) are executed while running the compile command.

## 🔖 Changes

- Added internal `*compile-mode*` definition
- Initial value is `false`
- Set the value to `true` in the `FileCompiler` class before the `compile` function is executed.
- Reset to `false` after the `compile` function is done.
