### PR TITLE
Support for variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Support for variables
+
 ## 0.4.0 (2021-10-05)
 
 * Removed `load` function in `phel\core`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -28,6 +28,7 @@
   (:use Phel\Lang\Collections\Map\TransientMapInterface)
   (:use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
   (:use Phel\Lang\Collections\HashSet\TransientHashSetInterface)
+  (:use Phel\Lang\Variable)
   (:use Phel\Compiler\Emitter\OutputEmitter\Munge)
   (:use Phel\Printer\Printer)
   (:use Countable)
@@ -565,6 +566,7 @@ Calling the and function without arguments returns true."
 * `:table`
 * `:keyword`
 * `:symbol`
+* `:var`
 * `:int`
 * `:float`
 * `:string`
@@ -586,6 +588,7 @@ Calling the and function without arguments returns true."
     (php/instanceof x Table)                      :table
     (php/instanceof x Keyword)                    :keyword
     (php/instanceof x Symbol)                     :symbol
+    (php/instanceof x Variable)                   :var
     (php/is_int x)                                :int
     (php/is_float x)                              :float
     (php/is_string x)                             :string
@@ -1690,3 +1693,31 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
           ,@body
           (finally
             ,@(map bind-value resets))))))
+
+(defn var
+  "Creates a new variable with the give value"
+  [value]
+  (php/-> (php/:: TypeFactory (getInstance)) (variable value)))
+
+(defn var?
+  "Checks if the given value is a variable"
+  [x]
+  (php/instanceof x Variable))
+
+(defn set!
+  "Sets a new value to the given variable"
+  [variable value]
+  (php/-> variable (set value)))
+
+(defn deref
+  "Return the value inside the variable"
+  [variable]
+  (php/-> variable (deref)))
+
+(defn swap!
+  "Swaps the value of the variable to (apply f current-value args). Returns the values that is swapped in."
+  [variable f & args]
+  (let [current (deref variable)
+        next (apply f current args)]
+    (set! variable next)
+    next))

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -94,6 +94,18 @@ class TypeFactory
         return PersistentVector::fromArray($this->hasher, $this->equalizer, $values);
     }
 
+    /**
+     * @template T
+     *
+     * @param T $value The initial value of the variable
+     *
+     * @return Variable<T>
+     */
+    public function variable($value): Variable
+    {
+        return new Variable(null, $value);
+    }
+
     public function symbol(string $name): Symbol
     {
         return Symbol::create($name);

--- a/src/php/Lang/Variable.php
+++ b/src/php/Lang/Variable.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+
+/**
+ * @template T
+ */
+final class Variable extends AbstractType
+{
+    use MetaTrait;
+
+    /** @var T */
+    private $value;
+
+    /**
+     * @param T $value
+     */
+    public function __construct(?PersistentMapInterface $meta, $value)
+    {
+        $this->meta = $meta;
+        $this->value = $value;
+    }
+
+    /**
+     * @param T $value
+     */
+    public function set($value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return T
+     */
+    public function deref()
+    {
+        return $this->value;
+    }
+
+    public function equals($other): bool
+    {
+        return $this === $other;
+    }
+
+    public function hash(): int
+    {
+        return crc32(spl_object_hash($this));
+    }
+}

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -72,3 +72,12 @@
 
 (deftest test-__DIR__
   (is (true? (and (false? (php/strpos __DIR__ "tests/phel/test/core.phel")) (>= (php/strpos __DIR__ "tests/phel/test") 0))) "__DIR__"))
+
+
+(deftest test-var
+  (is (= :var (type (var 10))) "type of var is :var")
+  (is (= 10 (deref (var 10))) "deref variable")
+  (is (true? (var? (var 10))) "var? return true if x is a variable")
+  (is (false? (var? 10)) "var? return false if x is a number")
+  (is (= 20 (let [x (var 10)] (set! x 20) (deref x))) "set new value to variable")
+  (is (= 11 (let [x (var 10)] (swap! x + 1) (deref x))) "swap a value by incrementing the number"))

--- a/tests/php/Unit/Lang/VariableTest.php
+++ b/tests/php/Unit/Lang/VariableTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Phel\Lang\Variable;
+use PHPUnit\Framework\TestCase;
+
+final class VariableTest extends TestCase
+{
+    public function test_deref(): void
+    {
+        $v = new Variable(null, 10);
+        $this->assertEquals(10, $v->deref());
+    }
+
+    public function test_set(): void
+    {
+        $v = new Variable(null, 10);
+        $v->set(20);
+        $this->assertEquals(20, $v->deref());
+    }
+
+    public function test_equals(): void
+    {
+        $v1 = new Variable(null, 10);
+        $v2 = new Variable(null, 10);
+
+        $this->assertTrue($v1->equals($v1));
+        $this->assertFalse($v1->equals($v2));
+        $this->assertFalse($v2->equals($v1));
+    }
+
+    public function test_hash(): void
+    {
+        $v1 = new Variable(null, 10);
+
+        $this->assertEquals(crc32(spl_object_hash($v1)), $v1->hash());
+    }
+}


### PR DESCRIPTION
## 📚 Description

This PR add a new language feature: Variables.

Sometime it is necessary to store a central value that is changing. Currently there was no support for this in Phel. Now you can define a variable to store a changing value. Example:

```
(def foo (var 10))

(deref foo) # Evaluates to 10
(set! foo 20) # Set foo to 20
(deref foo) # Evaluates to 20

(swap! foo + 2) # Evaluates to 22
(deref foo) # Evaluates to 22
```
