### PR TITLE
Add deprecated note to old collection data structures

### DIFF
--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -11,6 +11,7 @@ use Iterator;
 use Phel\Printer\Printer;
 
 /**
+ * @deprecated in favor of PersistentList|PersistentVector
  * @template T
  * @template-implements ArrayAccess<int, T>
  * @template-implements Iterator<int, T>

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -9,6 +9,7 @@ use Iterator;
 use Phel\Printer\Printer;
 
 /**
+ * @deprecated in favor of PersistentHashSet
  * @template T
  * @template-implements SeqInterface<T, PhelArray>
  */

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -12,6 +12,7 @@ use Phel\Printer\Printer;
 use RuntimeException;
 
 /**
+ * @deprecated in favor of PersistentHashMap
  * @template-implements SeqInterface<\Phel\Lang\Collections\Vector\PersistentVectorInterface, PhelArray>
  */
 class Table extends AbstractType implements ArrayAccess, Countable, Iterator, SeqInterface


### PR DESCRIPTION
## 🔖 Changes

- Added `@deprected` to PhelArray, Set & Table classes in favor of the new persistent data structures (that were introduced here: https://github.com/phel-lang/phel-lang/pull/244)

### 🤔  Follow up

What are the next step we should do to get rid of these deprecated classes? I guess we should check that the core tests are using the persistent data structures, and the old ones aren't used anywhere else. Is there something else we need to keep in mind to do this, @jenshaase?