### PR TITLE
Define interface and let struct implement them

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1743,7 +1743,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                `(defn ,fn-name {:doc ,doc} ,args
                   (if (php/is_a ,(first args) ,class-name-str)
                     (php/-> ,(first args) (,munged-fn-symbol ,@(rest args)))
-                    (php/throw (php/new \InvalidArgumentException ,(str "Value doesn't implement interface " name)))
+                    (throw (php/new \InvalidArgumentException ,(str "Value doesn't implement interface " name)))
                     )))]
   `(do
      (definterface* ,name ,@fns)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1694,6 +1694,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
           (finally
             ,@(map bind-value resets))))))
 
+# --------
+# Variable
+# --------
+
 (defn var
   "Creates a new variable with the give value"
   [value]
@@ -1721,3 +1725,26 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
         next (apply f current args)]
     (set! variable next)
     next))
+
+# ----------
+# Interfaces
+# ----------
+
+(defmacro definterface
+  "Defines a interface"
+  [name & fns]
+  (let [name-str (php/-> name (getName))
+        munge (php/new Munge)
+        class-name-str (php/. *ns* "\\" (php/-> munge (encode name-str)))
+        defs (for [[fn-name args doc] :in fns
+                   :let [fn-name-str (php/-> fn-name (getName))
+                         munged-fn-name (php/-> munge (encode fn-name-str))
+                         munged-fn-symbol (php/:: Symbol (create munged-fn-name))]]
+               `(defn ,fn-name {:doc ,doc} ,args
+                  (if (php/is_a ,(first args) ,class-name-str)
+                    (php/-> ,(first args) (,munged-fn-symbol ,@(rest args)))
+                    (php/throw (php/new \InvalidArgumentException ,(str "Value doesn't implement interface " name)))
+                    )))]
+  `(do
+     (definterface* ,name ,@fns)
+     ,@defs)))

--- a/src/php/Compiler/Analyzer/Analyzer.php
+++ b/src/php/Compiler/Analyzer/Analyzer.php
@@ -73,6 +73,11 @@ final class Analyzer implements AnalyzerInterface
         $this->globalEnvironment->addDefinition($ns, $symbol, $meta);
     }
 
+    public function addInterface(string $ns, Symbol $name): void
+    {
+        $this->globalEnvironment->addInterface($ns, $name);
+    }
+
     /**
      * @param TypeInterface|string|float|int|bool|null $x
      *

--- a/src/php/Compiler/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Analyzer/AnalyzerInterface.php
@@ -41,4 +41,6 @@ interface AnalyzerInterface
     public function addRefers(string $ns, array $referSymbols, Symbol $nsSymbol): void;
 
     public function addDefinition(string $ns, Symbol $symbol, PersistentMapInterface $meta): void;
+
+    public function addInterface(string $ns, Symbol $name): void;
 }

--- a/src/php/Compiler/Analyzer/Ast/DefInterfaceMethod.php
+++ b/src/php/Compiler/Analyzer/Ast/DefInterfaceMethod.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Analyzer\Ast;
+
+use Phel\Lang\Symbol;
+
+final class DefInterfaceMethod
+{
+    private Symbol $name;
+    /** @var list<string> */
+    private array $arguments;
+    private ?string $comment;
+
+    public function __construct(Symbol $name, array $arguments, ?string $comment = null)
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+        $this->comment = $comment;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function getArgumentCount(): int
+    {
+        return count($this->arguments);
+    }
+
+    public function getArgumentsWithoutFirst(): array
+    {
+        return array_slice($this->arguments, 1);
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+}

--- a/src/php/Compiler/Analyzer/Ast/DefInterfaceMethod.php
+++ b/src/php/Compiler/Analyzer/Ast/DefInterfaceMethod.php
@@ -32,12 +32,12 @@ final class DefInterfaceMethod
 
     public function getArgumentCount(): int
     {
-        return count($this->arguments);
+        return count($this->getArguments());
     }
 
     public function getArgumentsWithoutFirst(): array
     {
-        return array_slice($this->arguments, 1);
+        return array_slice($this->getArguments(), 1);
     }
 
     public function getComment(): ?string

--- a/src/php/Compiler/Analyzer/Ast/DefInterfaceNode.php
+++ b/src/php/Compiler/Analyzer/Ast/DefInterfaceNode.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Analyzer\Ast;
+
+use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+final class DefInterfaceNode extends AbstractNode
+{
+    private string $namespace;
+    private Symbol $name;
+    /** @var list<DefInterfaceMethod> */
+    private array $methods;
+
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        string $namespace,
+        Symbol $name,
+        array $methods,
+        ?SourceLocation $startSourceLocation = null
+    ) {
+        parent::__construct($env, $startSourceLocation);
+        $this->namespace = $namespace;
+        $this->name = $name;
+        $this->methods = $methods;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return list<DefInterfaceMethod>
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+}

--- a/src/php/Compiler/Analyzer/Ast/DefStructInterface.php
+++ b/src/php/Compiler/Analyzer/Ast/DefStructInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Analyzer\Ast;
+
+final class DefStructInterface
+{
+    private string $absoluteInterfaceName;
+    /** @var list<DefStructMethod> */
+    private array $methods;
+
+    /**
+     * @param list<DefStructMethod> $methods;
+     */
+    public function __construct(string $absoluteInterfaceName, array $methods)
+    {
+        $this->absoluteInterfaceName = $absoluteInterfaceName;
+        $this->methods = $methods;
+    }
+
+    public function getAbsoluteInterfaceName(): string
+    {
+        return $this->absoluteInterfaceName;
+    }
+
+    /**
+     * @return list<DefStructMethod>
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+}

--- a/src/php/Compiler/Analyzer/Ast/DefStructMethod.php
+++ b/src/php/Compiler/Analyzer/Ast/DefStructMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Analyzer\Ast;
+
+use Phel\Lang\Symbol;
+
+final class DefStructMethod
+{
+    private Symbol $name;
+    private FnNode $fnNode;
+
+    public function __construct(Symbol $name, FnNode $fnNode)
+    {
+        $this->name = $name;
+        $this->fnNode = $fnNode;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->name;
+    }
+
+    public function getFnNode(): FnNode
+    {
+        return $this->fnNode;
+    }
+}

--- a/src/php/Compiler/Analyzer/Ast/DefStructNode.php
+++ b/src/php/Compiler/Analyzer/Ast/DefStructNode.php
@@ -18,20 +18,26 @@ final class DefStructNode extends AbstractNode
     /** @var Symbol[] */
     private array $params;
 
+    /** @var list<DefStructInterface> */
+    private array $interfaces;
+
     /**
      * @param Symbol[] $params
+     * @param list<DefStructInterface> $interfaces
      */
     public function __construct(
         NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $name,
         array $params,
+        array $interfaces,
         ?SourceLocation $sourceLocation = null
     ) {
         parent::__construct($env, $sourceLocation);
         $this->namespace = $namespace;
         $this->name = $name;
         $this->params = $params;
+        $this->interfaces = $interfaces;
     }
 
     public function getNamespace(): string
@@ -59,5 +65,13 @@ final class DefStructNode extends AbstractNode
         }
 
         return $result;
+    }
+
+    /**
+     * @return list<DefStructInterface>
+     */
+    public function getInterfaces(): array
+    {
+        return $this->interfaces;
     }
 }

--- a/src/php/Compiler/Analyzer/Ast/DefStructNode.php
+++ b/src/php/Compiler/Analyzer/Ast/DefStructNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer\Ast;
 
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
-use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -53,18 +52,6 @@ final class DefStructNode extends AbstractNode
     public function getParams(): array
     {
         return $this->params;
-    }
-
-    public function getParamsAsKeywords(): array
-    {
-        $result = [];
-        foreach ($this->params as $param) {
-            $keyword = Keyword::create($param->getName());
-            $keyword->setStartLocation($this->getStartSourceLocation());
-            $result[] = $keyword;
-        }
-
-        return $result;
     }
 
     /**

--- a/src/php/Compiler/Analyzer/Ast/PhpClassNameNode.php
+++ b/src/php/Compiler/Analyzer/Ast/PhpClassNameNode.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Analyzer\Ast;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use ReflectionClass;
 
 final class PhpClassNameNode extends AbstractNode
 {
@@ -21,5 +22,20 @@ final class PhpClassNameNode extends AbstractNode
     public function getName(): Symbol
     {
         return $this->name;
+    }
+
+    /**
+     * @psalm-return class-string
+     */
+    public function getAbsolutePhpName(): string
+    {
+        /** @psalm-var class-string $classString */
+        $classString = '\\' . $this->name->getNamespace() . '\\' . $this->name->getName();
+        return $classString;
+    }
+
+    public function getReflectionClass(): ReflectionClass
+    {
+        return new ReflectionClass($this->getAbsolutePhpName());
     }
 }

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -36,5 +36,7 @@ interface GlobalEnvironmentInterface
 
     public function resolveAsSymbol(Symbol $name, NodeEnvironment $env): ?Symbol;
 
+    public function addInterface(string $namespace, Symbol $name): void;
+
     public function setAllowPrivateAccess(bool $allowPrivateAccess): void;
 }

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
+use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\DefInterfaceSymbol;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\DefSymbol;
 use Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm\DoSymbol;
@@ -111,6 +112,8 @@ final class AnalyzePersistentList
                 return new PhpOSetSymbol($this->analyzer);
             case Symbol::NAME_SET_VAR:
                 return new SetVarSymbol($this->analyzer);
+            case Symbol::NAME_DEF_INTERFACE:
+                return new DefInterfaceSymbol($this->analyzer);
             default:
                 return new InvokeSymbol($this->analyzer);
         }

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Analyzer\Ast\DefInterfaceMethod;
+use Phel\Compiler\Analyzer\Ast\DefInterfaceNode;
+use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+
+final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
+{
+    use WithAnalyzerTrait;
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefInterfaceNode
+    {
+        $interfaceSymbol = $list->get(1);
+        if (!($interfaceSymbol instanceof Symbol)) {
+            throw AnalyzerException::withLocation("First argument of 'definterace must be a Symbol.", $list);
+        }
+        $this->analyzer->addUseAlias($this->analyzer->getNamespace(), $interfaceSymbol, $interfaceSymbol);
+
+        $result = new DefInterfaceNode(
+            $env,
+            $this->analyzer->getNamespace(),
+            $interfaceSymbol,
+            $this->methods($list->rest()->cdr()),
+            $list->getStartLocation()
+        );
+
+        return $result;
+    }
+
+    /**
+     * @return list<DefInterfaceMethod>
+     */
+    private function methods(?PersistentListInterface $list): array
+    {
+        if ($list === null) {
+            return [];
+        }
+
+        $methods = [];
+        for ($forms = $list; $forms != null; $forms = $forms->cdr()) {
+            $method = $forms->first();
+
+            if (!$method instanceof PersistentListInterface) {
+                throw AnalyzerException::withLocation('Methods in definterface must be lists', $list);
+            }
+
+            $name = $method->get(0);
+            if (!$name instanceof Symbol) {
+                throw AnalyzerException::withLocation('Method names must be symbols', $method);
+            }
+
+            $arguments = $method->get(1);
+            if (!$arguments instanceof PersistentVectorInterface) {
+                throw AnalyzerException::withLocation('Method arguments must be vectors', $method);
+            }
+
+            foreach ($arguments as $argument) {
+                if (!$argument instanceof Symbol) {
+                    throw AnalyzerException::withLocation('A method argument must be symbol', $arguments);
+                }
+            }
+
+            $comment = null;
+            if (count($method) > 2) {
+                $comment = $method->get(2);
+                if (!is_string($comment)) {
+                    throw AnalyzerException::withLocation('Method comments must be strings', $method);
+                }
+            }
+
+            $methods[] = new DefInterfaceMethod(
+                $name,
+                $arguments->toArray(),
+                $comment
+            );
+        }
+
+        return $methods;
+    }
+}

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
@@ -23,7 +23,7 @@ final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
         if (!($interfaceSymbol instanceof Symbol)) {
             throw AnalyzerException::withLocation("First argument of 'definterace must be a Symbol.", $list);
         }
-        $this->analyzer->addUseAlias($this->analyzer->getNamespace(), $interfaceSymbol, $interfaceSymbol);
+        $this->analyzer->addInterface($this->analyzer->getNamespace(), $interfaceSymbol);
 
         $result = new DefInterfaceNode(
             $env,

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -183,9 +183,4 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
             $fnNode
         );
     }
-
-    private function getExpectedMethodsForInterface(): int
-    {
-        return 0;
-    }
 }

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm;
 
+use Phel\Compiler\Analyzer\Ast\DefStructInterface;
+use Phel\Compiler\Analyzer\Ast\DefStructMethod;
 use Phel\Compiler\Analyzer\Ast\DefStructNode;
+use Phel\Compiler\Analyzer\Ast\FnNode;
+use Phel\Compiler\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
 
 final class DefStructSymbol implements SpecialFormAnalyzerInterface
 {
@@ -18,9 +23,9 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefStructNode
     {
-        if (count($list) !== 3) {
+        if (count($list) < 3) {
             throw AnalyzerException::withLocation(
-                "Exactly two arguments are required for 'defstruct. Got " . count($list),
+                "At least two arguments are required for 'defstruct. Got " . count($list),
                 $list
             );
         }
@@ -35,17 +40,26 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation("Second argument of 'defstruct must be a vector.", $list);
         }
 
+        $params = $this->params($structParams);
+
         return new DefStructNode(
             $env,
             $this->analyzer->getNamespace(),
             $structSymbol,
-            $this->params($structParams),
+            $params,
+            $this->interfaces(
+                $list->rest()->rest()->rest(),
+                $env->withMergedLocals($params),
+                $params
+            ),
             $list->getStartLocation()
         );
     }
 
     /**
      * @param PersistentVectorInterface<mixed> $vector
+     *
+     * @return list<Symbol>
      */
     private function params(PersistentVectorInterface $vector): array
     {
@@ -58,5 +72,120 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $params;
+    }
+
+    /**
+     * @param list<Symbol> $structParams
+     *
+     * @return list<DefStructInterface>
+     */
+    private function interfaces(PersistentListInterface $list, NodeEnvironmentInterface $env, array $structParams): array
+    {
+        if ($list->count() === 0) {
+            return [];
+        }
+
+        $interfaces = [];
+        for ($forms = $list; $forms != null; $forms = $forms->cdr()) {
+            $first = $forms->first();
+
+            if (!$first instanceof Symbol) {
+                throw AnalyzerException::withLocation('Expected a interface name in defstruct', $list);
+            }
+
+            $classNode = $this->analyzer->resolve($first, $env);
+            if (!$classNode instanceof PhpClassNameNode) {
+                throw AnalyzerException::withLocation('Can not resolve interface ' . $first->getFullName(), $list);
+            }
+
+            $reflectionClass = $classNode->getReflectionClass();
+            if (!$reflectionClass->isInterface()) {
+                throw AnalyzerException::withLocation('Given interface ' . $first->getFullName() . ' is not an interface', $list);
+            }
+
+            $absoluteInterfaceName = $classNode->getAbsolutePhpName();
+            $expectedMethods = $reflectionClass->getMethods();
+            $expectedMethodIndex = [];
+            foreach ($expectedMethods as $method) {
+                $expectedMethodIndex[$method->getName()] = $method;
+            }
+
+            $methods = [];
+            for ($i = 0; $i < count($expectedMethods); $i++) {
+                $forms = $forms->cdr();
+                if ($forms === null) {
+                    throw AnalyzerException::withLocation('Missing method for interface ' . $absoluteInterfaceName . ' in defstruct', $list);
+                }
+
+                $method = $forms->first();
+                if (!$method instanceof PersistentListInterface) {
+                    throw AnalyzerException::withLocation('Missing method for interface ' . $absoluteInterfaceName . ' in defstruct', $list);
+                }
+
+                $methods[] = $this->analyzeInterfaceMethod($method, $env, $expectedMethodIndex, $structParams);
+            }
+
+            if (count($methods) !== count($expectedMethods)) {
+                throw AnalyzerException::withLocation('Missing method for interface ' . $absoluteInterfaceName . ' in defstruct', $list);
+            }
+
+            $interfaces[] = new DefStructInterface(
+                $absoluteInterfaceName,
+                $methods
+            );
+        }
+
+        return $interfaces;
+    }
+
+    /**
+     * @param array<string, \ReflectionMethod> $expectedMethodIndex
+     * @param list<Symbol> $structParams
+     */
+    private function analyzeInterfaceMethod(PersistentListInterface $list, NodeEnvironmentInterface $env, array $expectedMethodIndex, $structParams): DefStructMethod
+    {
+        $methodName = $list->get(0);
+        if (!$methodName instanceof Symbol) {
+            throw AnalyzerException::withLocation('Method name must be a Symbol', $list);
+        }
+
+        if (!isset($expectedMethodIndex[$methodName->getName()])) {
+            throw AnalyzerException::withLocation('The interface doesn\'t support this method: ' . $methodName->getName(), $list);
+        }
+
+        $arguments = $list->get(1);
+        if (!$arguments instanceof PersistentVectorInterface) {
+            throw AnalyzerException::withLocation('Method arguments must be a vector', $list);
+        }
+
+        // Analyze arguments and body as (fn arguments (do body))
+        $fnNode = $this->analyzer->analyze(
+            TypeFactory::getInstance()->persistentListFromArray([
+                Symbol::create('fn'),
+                $arguments->rest(), // remove the first argument. The first argument is bound to $this
+                TypeFactory::getInstance()->persistentListFromArray([
+                    Symbol::create('let'),
+                    TypeFactory::getInstance()->persistentVectorFromArray([
+                        $arguments->first(), Symbol::createForNamespace('php', '$this'),
+                    ]),
+                    ...($list->rest()->rest()->toArray()),
+                ]),
+            ]),
+            $env
+        );
+
+        if (!$fnNode instanceof FnNode) {
+            throw AnalyzerException::withLocation('Can not correctly analyse method body', $list);
+        }
+
+        return new DefStructMethod(
+            $methodName,
+            $fnNode
+        );
+    }
+
+    private function getExpectedMethodsForInterface(): int
+    {
+        return 0;
     }
 }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Analyzer\Ast\DefInterfaceMethod;
+use Phel\Compiler\Analyzer\Ast\DefInterfaceNode;
+use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterInterface;
+
+final class DefInterfaceEmitter implements NodeEmitterInterface
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof DefInterfaceNode);
+
+        $this->emitClassBegin($node);
+        $this->emitMethods($node);
+        $this->emitClassEnd($node);
+    }
+
+    private function emitClassBegin(DefInterfaceNode $node): void
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            $this->outputEmitter->emitLine(
+                'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
+                $node->getStartSourceLocation()
+            );
+        }
+        $this->outputEmitter->emitLine(
+            'interface ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' {',
+            $node->getStartSourceLocation()
+        );
+        $this->outputEmitter->increaseIndentLevel();
+    }
+
+    private function emitMethods(DefInterfaceNode $node): void
+    {
+        /** @var DefInterfaceMethod $method */
+        foreach ($node->getMethods() as $method) {
+            $this->outputEmitter->emitStr('public function ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr(
+                $this->outputEmitter->mungeEncode($method->getName()->getName()),
+                $node->getStartSourceLocation()
+            );
+            $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+
+            foreach ($method->getArgumentsWithoutFirst() as $i => $argument) {
+                $this->outputEmitter->emitPhpVariable($argument, $node->getStartSourceLocation());
+
+                if ($i < $method->getArgumentCount() - 2) {
+                    $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+                }
+            }
+
+            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+            $this->outputEmitter->emitLine(';');
+        }
+    }
+
+    private function emitClassEnd(DefInterfaceNode $node): void
+    {
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -38,7 +38,6 @@ final class DefStructEmitter implements NodeEmitterInterface
         foreach ($node->getInterfaces() as $interface) {
             $this->emitInterfaceImplementation($interface);
         }
-        //$this->emitGetAllowedKeysFunction($node);
         $this->emitClassEnd($node);
     }
 
@@ -128,28 +127,6 @@ final class DefStructEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitPhpVariable(Symbol::create('meta'));
         $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-        $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
-    }
-
-    private function emitGetAllowedKeysFunction(DefStructNode $node): void
-    {
-        $paramCount = count($node->getParams());
-
-        $this->outputEmitter->emitStr('public function getAllowedKeys(', $node->getStartSourceLocation());
-        $this->outputEmitter->emitLine('): array {', $node->getStartSourceLocation());
-        $this->outputEmitter->increaseIndentLevel();
-        $this->outputEmitter->emitStr('return [', $node->getStartSourceLocation());
-
-        foreach ($node->getParamsAsKeywords() as $i => $keyword) {
-            $this->outputEmitter->emitLiteral($keyword);
-
-            if ($i < $paramCount - 1) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-            }
-        }
-
-        $this->outputEmitter->emitLine('];', $node->getStartSourceLocation());
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
     }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -5,14 +5,24 @@ declare(strict_types=1);
 namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Analyzer\Ast\DefStructInterface;
+use Phel\Compiler\Analyzer\Ast\DefStructMethod;
 use Phel\Compiler\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Emitter\OutputEmitterInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 final class DefStructEmitter implements NodeEmitterInterface
 {
-    use WithOutputEmitterTrait;
+    private OutputEmitterInterface $outputEmitter;
+    private MethodEmitter $methodEmitter;
+
+    public function __construct(OutputEmitterInterface $emitter, MethodEmitter $methodEmitter)
+    {
+        $this->outputEmitter = $emitter;
+        $this->methodEmitter = $methodEmitter;
+    }
 
     public function emit(AbstractNode $node): void
     {
@@ -25,6 +35,9 @@ final class DefStructEmitter implements NodeEmitterInterface
         $this->emitProperties($node);
         $this->outputEmitter->emitLine();
         $this->emitConstructor($node);
+        foreach ($node->getInterfaces() as $interface) {
+            $this->emitInterfaceImplementation($interface);
+        }
         //$this->emitGetAllowedKeysFunction($node);
         $this->emitClassEnd($node);
     }
@@ -37,10 +50,25 @@ final class DefStructEmitter implements NodeEmitterInterface
                 $node->getStartSourceLocation()
             );
         }
-        $this->outputEmitter->emitLine(
-            'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {',
+        $this->outputEmitter->emitStr(
+            'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
             $node->getStartSourceLocation()
         );
+
+        if (count($node->getInterfaces()) > 0) {
+            $this->outputEmitter->emitStr(' implements ');
+        }
+
+        /** @var DefStructInterface $interface */
+        foreach ($node->getInterfaces() as $i => $interface) {
+            $this->outputEmitter->emitStr($interface->getAbsoluteInterfaceName());
+            if ($i < count($node->getInterfaces()) - 1) {
+                $this->outputEmitter->emitStr(', ');
+            }
+        }
+
+        $this->outputEmitter->emitLine(' {');
+
         $this->outputEmitter->increaseIndentLevel();
     }
 
@@ -124,6 +152,15 @@ final class DefStructEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('];', $node->getStartSourceLocation());
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitInterfaceImplementation(DefStructInterface $interface): void
+    {
+        /** @var DefStructMethod $method */
+        foreach ($interface->getMethods() as $method) {
+            $this->outputEmitter->emitLine();
+            $this->methodEmitter->emit($method->getName()->getName(), $method->getFnNode());
+        }
     }
 
     private function emitClassEnd(DefStructNode $node): void

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Analyzer\Ast\FnNode;
+use Phel\Lang\Keyword;
+
+final class MethodEmitter
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(string $methodName, FnNode $node): void
+    {
+        $this->emitInvokeFunctionBegin($methodName, $node);
+        $this->emitInvokeFunctionParameters($node);
+        $this->emitInvokeFunctionBody($node);
+        $this->emitInvokeFunctionEnd($node);
+    }
+
+    private function emitInvokeFunctionBegin(string $methodName, FnNode $node): void
+    {
+        $this->outputEmitter->emitStr('public function ' . $methodName . '(', $node->getStartSourceLocation());
+    }
+
+    private function emitInvokeFunctionParameters(FnNode $node): void
+    {
+        $paramsCount = count($node->getParams());
+
+        foreach ($node->getParams() as $i => $p) {
+            if ($i === $paramsCount - 1 && $node->isVariadic()) {
+                $this->outputEmitter->emitPhpVariable($p, null, false, true);
+            } else {
+                $meta = $p->getMeta();
+                $isReference = $meta && $meta->find(Keyword::create('reference')) === true;
+                $this->outputEmitter->emitPhpVariable($p, null, $isReference);
+            }
+
+            if ($i < $paramsCount - 1) {
+                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            }
+        }
+
+        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        // Use Parameter extraction
+        foreach ($node->getUses() as $i => $u) {
+            $shadowed = $node->getEnv()->getShadowed($u);
+            if ($shadowed) {
+                $u = $shadowed;
+            }
+
+            $varName = $this->outputEmitter->mungeEncode($u->getName());
+
+            $this->outputEmitter->emitLine(
+                '$' . $varName . ' = $this->' . $varName . ';',
+                $node->getStartSourceLocation()
+            );
+        }
+
+        // Variadic Parameter
+        if ($node->isVariadic()) {
+            $p = $node->getParams()[count($node->getParams()) - 1];
+
+            $this->outputEmitter->emitLine(
+                '$' . $this->outputEmitter->mungeEncode($p->getName())
+                . ' = new \Phel\Lang\PhelArray($' . $this->outputEmitter->mungeEncode($p->getName()) . ');',
+                $node->getStartSourceLocation()
+            );
+        }
+    }
+
+    private function emitInvokeFunctionBody(FnNode $node): void
+    {
+        if ($node->getRecurs()) {
+            $this->outputEmitter->emitLine('while (true) {', $node->getStartSourceLocation());
+            $this->outputEmitter->increaseIndentLevel();
+        }
+
+        $this->outputEmitter->emitNode($node->getBody());
+
+        if ($node->getRecurs()) {
+            $this->outputEmitter->emitLine('break;', $node->getStartSourceLocation());
+            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
+        }
+    }
+
+    private function emitInvokeFunctionEnd(FnNode $node): void
+    {
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -79,6 +79,8 @@ final class NodeEmitterFactory
                 return new NodeEmitter\MapEmitter($outputEmitter);
             case Ast\SetVarNode::class:
                 return new NodeEmitter\SetVarEmitter($outputEmitter);
+            case Ast\DefInterfaceNode::class:
+                return new NodeEmitter\DefInterfaceEmitter($outputEmitter);
             default:
                 throw NotSupportedAstException::withClassName($astNodeClassName);
         }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter;
 
 use Phel\Compiler\Analyzer\Ast;
 use Phel\Compiler\Emitter\Exceptions\NotSupportedAstException;
+use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter\MethodEmitter;
 use Phel\Compiler\Emitter\OutputEmitterInterface;
 
 final class NodeEmitterFactory
@@ -24,7 +25,7 @@ final class NodeEmitterFactory
             case Ast\QuoteNode::class:
                 return new NodeEmitter\QuoteEmitter($outputEmitter);
             case Ast\FnNode::class:
-                return new NodeEmitter\FnAsClassEmitter($outputEmitter);
+                return new NodeEmitter\FnAsClassEmitter($outputEmitter, new MethodEmitter($outputEmitter));
             case Ast\DoNode::class:
                 return new NodeEmitter\DoEmitter($outputEmitter);
             case Ast\LetNode::class:
@@ -72,7 +73,7 @@ final class NodeEmitterFactory
             case Ast\TableNode::class:
                 return new NodeEmitter\TableEmitter($outputEmitter);
             case Ast\DefStructNode::class:
-                return new NodeEmitter\DefStructEmitter($outputEmitter);
+                return new NodeEmitter\DefStructEmitter($outputEmitter, new MethodEmitter($outputEmitter));
             case Ast\PhpObjectSetNode::class:
                 return new NodeEmitter\PhpObjectSetEmitter($outputEmitter);
             case Ast\MapNode::class:

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -41,6 +41,7 @@ final class Symbol extends AbstractType implements IdenticalInterface
     public const NAME_VECTOR = 'vector';
     public const NAME_MAP = 'hash-map';
     public const NAME_SET_VAR = 'set-var';
+    public const NAME_DEF_INTERFACE = 'definterface*';
 
     private static int $symGenCounter = 1;
 

--- a/tests/php/Integration/Fixtures/Def/definterface-with-methods.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-with-methods.test
@@ -1,0 +1,11 @@
+--PHEL--
+(ns user)
+
+(definterface IFoo)
+--PHP--
+namespace user;
+require_once __DIR__ . '/../phel/core.php';
+\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("user");
+$GLOBALS["__phel"]["phel\\core"]["*ns*"] = "user";
+interface IFoo {
+}

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -24,7 +24,7 @@ $GLOBALS["__phel"]["user"]["choose"] = new class() extends \Phel\Lang\AbstractFn
         return $target_1->choose();
       })();
     } else {
-      return throw((new \InvalidArgumentException("Value doesn't implement interface IPlayer")));
+      throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
     }
 
   }
@@ -53,7 +53,7 @@ $GLOBALS["__phel"]["user"]["update-strategy"] = new class() extends \Phel\Lang\A
         return $target_2->update_strategy($me, $you);
       })();
     } else {
-      return throw((new \InvalidArgumentException("Value doesn't implement interface IPlayer")));
+      throw (new \InvalidArgumentException("Value doesn't implement interface IPlayer"));
     }
 
   }

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -1,0 +1,73 @@
+--PHEL--
+(ns user)
+
+(definterface IPlayer
+  (choose [p] "Choose docs")
+  (update-strategy [p me you]))
+--PHP--
+namespace user;
+require_once __DIR__ . '/../phel/core.php';
+\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("user");
+$GLOBALS["__phel"]["phel\\core"]["*ns*"] = "user";
+interface IPlayer {
+  public function choose();
+  public function update_strategy($me, $you);
+}
+
+$GLOBALS["__phel"]["user"]["choose"] = new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "user\\choose";
+
+  public function __invoke($p) {
+    if (\Phel\Lang\Truthy::isTruthy(is_a($p, "user\\IPlayer"))) {
+      return (function() use($p) {
+        $target_1 = $p;
+        return $target_1->choose();
+      })();
+    } else {
+      return throw((new \InvalidArgumentException("Value doesn't implement interface IPlayer")));
+    }
+
+  }
+};
+$GLOBALS["__phel_meta"]["user"]["choose"] = \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
+  \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
+    \Phel\Lang\Keyword::create("line"), 3,
+    \Phel\Lang\Keyword::create("column"), 0
+  ),
+  \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
+    \Phel\Lang\Keyword::create("line"), 5,
+    \Phel\Lang\Keyword::create("column"), 31
+  )
+);
+
+$GLOBALS["__phel"]["user"]["update-strategy"] = new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "user\\update_strategy";
+
+  public function __invoke($p, $me, $you) {
+    if (\Phel\Lang\Truthy::isTruthy(is_a($p, "user\\IPlayer"))) {
+      return (function() use($p,$me,$you) {
+        $target_2 = $p;
+        return $target_2->update_strategy($me, $you);
+      })();
+    } else {
+      return throw((new \InvalidArgumentException("Value doesn't implement interface IPlayer")));
+    }
+
+  }
+};
+$GLOBALS["__phel_meta"]["user"]["update-strategy"] = \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
+  \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
+    \Phel\Lang\Keyword::create("line"), 3,
+    \Phel\Lang\Keyword::create("column"), 0
+  ),
+  \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
+    \Phel\Lang\Keyword::create("line"), 5,
+    \Phel\Lang\Keyword::create("column"), 31
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/defstruct-interface-without-methods.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-interface-without-methods.test
@@ -1,0 +1,20 @@
+--PHEL--
+(definterface* MyInterfaceWithoutMethods)
+
+(defstruct* my-type-with-one-interface-without-methods [v]
+  MyInterfaceWithoutMethods)
+--PHP--
+interface MyInterfaceWithoutMethods {
+}
+class my_type_with_one_interface_without_methods extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterfaceWithoutMethods {
+
+  protected const ALLOWED_KEYS = ['v'];
+
+  protected $v;
+
+  public function __construct($v, $meta = null) {
+    parent::__construct();
+    $this->v = $v;
+    $this->meta = $meta;
+  }
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-one-interface.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-one-interface.test
@@ -1,0 +1,38 @@
+--PHEL--
+(definterface* MyInterface
+  (foo [this])
+  (bar [this a b]))
+
+(defstruct* my-type-with-one-interface [v]
+  MyInterface
+  (foo [this] v)
+  (bar [this a b] (+ a b v)))
+--PHP--
+interface MyInterface {
+  public function foo();
+  public function bar($a, $b);
+}
+class my_type_with_one_interface extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterface {
+
+  protected const ALLOWED_KEYS = ['v'];
+
+  protected $v;
+
+  public function __construct($v, $meta = null) {
+    parent::__construct();
+    $this->v = $v;
+    $this->meta = $meta;
+  }
+
+  public function foo() {
+    $v = $this->v;
+    $this_1 = $this;
+    return $v;
+  }
+
+  public function bar($a, $b) {
+    $v = $this->v;
+    $this_2 = $this;
+    return ($GLOBALS["__phel"]["phel\\core"]["+"])($a, $b, $v);
+  }
+}

--- a/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
@@ -1,0 +1,55 @@
+--PHEL--
+(definterface* MyFirstInterface
+  (foo [this])
+  (bar [this a b]))
+
+(definterface* MySecondInterface
+  (foobar [this]))
+
+(defstruct* my-type-with-two-interfaces [v]
+  MyFirstInterface
+  (foo [this] v)
+  (bar [this a b] (+ a b v))
+  MySecondInterface
+  (foobar [this] (php/-> this (foo))))
+--PHP--
+interface MyFirstInterface {
+  public function foo();
+  public function bar($a, $b);
+}
+interface MySecondInterface {
+  public function foobar();
+}
+class my_type_with_two_interfaces extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyFirstInterface, \user\MySecondInterface {
+
+  protected const ALLOWED_KEYS = ['v'];
+
+  protected $v;
+
+  public function __construct($v, $meta = null) {
+    parent::__construct();
+    $this->v = $v;
+    $this->meta = $meta;
+  }
+
+  public function foo() {
+    $v = $this->v;
+    $this_1 = $this;
+    return $v;
+  }
+
+  public function bar($a, $b) {
+    $v = $this->v;
+    $this_2 = $this;
+    return ($GLOBALS["__phel"]["phel\\core"]["+"])($a, $b, $v);
+  }
+
+  public function foobar() {
+    $v = $this->v;
+    $this_3 = $this;
+    return (function() use($v,$this_3) {
+      $target_4 = $this_3;
+      return $target_4->foo();
+    })();
+  }
+}

--- a/tests/php/Integration/Fixtures/Fn/fn-this-parameter.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-this-parameter.test
@@ -1,0 +1,10 @@
+--PHEL--
+(fn [this] 1)
+--PHP--
+new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "";
+
+  public function __invoke($__phel_this) {
+    return 1;
+  }
+};

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel\Compiler\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Analyzer\Environment\NodeEnvironment;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class GlobalEnvironmentTest extends TestCase
+{
+    public function test_set_ns(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('foo');
+
+        $this->assertEquals('foo', $env->getNs());
+    }
+
+    public function test_add_definition(): void
+    {
+        $env = new GlobalEnvironment();
+        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $env->addDefinition('foo', Symbol::create('bar'), $meta);
+
+        $this->assertTrue($env->hasDefinition('foo', Symbol::create('bar')));
+        $this->assertFalse($env->hasDefinition('bar', Symbol::create('bar')));
+        $this->assertEquals($meta, $env->getDefinition('foo', Symbol::create('bar')));
+        $this->assertNull($env->getDefinition('bar', Symbol::create('bar')));
+    }
+
+    public function test_require_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+
+        $this->assertTrue($env->hasRequireAlias('foo', Symbol::create('b')));
+        $this->assertFalse($env->hasRequireAlias('foo', Symbol::create('c')));
+        $this->assertFalse($env->hasRequireAlias('foobar', Symbol::create('b')));
+    }
+
+    public function test_use_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addUseAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+
+        $this->assertTrue($env->hasUseAlias('foo', Symbol::create('b')));
+        $this->assertFalse($env->hasUseAlias('foo', Symbol::create('c')));
+        $this->assertFalse($env->hasUseAlias('foobar', Symbol::create('b')));
+    }
+
+    public function test_resolve_dir(): void
+    {
+        $env = new GlobalEnvironment();
+        $nodeEnv = NodeEnvironment::empty();
+        $sym = Symbol::create('__DIR__');
+        $sym->setStartLocation(new SourceLocation(__FILE__, 0, 0));
+
+        $this->assertEquals(
+            new LiteralNode($nodeEnv, __DIR__),
+            $env->resolve($sym, $nodeEnv)
+        );
+    }
+
+    public function test_resolve_file(): void
+    {
+        $env = new GlobalEnvironment();
+        $nodeEnv = NodeEnvironment::empty();
+        $sym = Symbol::create('__FILE__');
+        $sym->setStartLocation(new SourceLocation(__FILE__, 0, 0));
+
+        $this->assertEquals(
+            new LiteralNode($nodeEnv, __FILE__),
+            $env->resolve($sym, $nodeEnv)
+        );
+    }
+
+    public function test_resolve_absolute_php_class(): void
+    {
+        $env = new GlobalEnvironment();
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::create('\\Exception'),
+                null
+            ),
+            $env->resolve(Symbol::create('\\Exception'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('foo');
+        $env->addUseAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::create('bar'),
+                null
+            ),
+            $env->resolve(Symbol::create('b'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_refer_definition(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('foo', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->setNs('bar');
+        $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'foo',
+                Symbol::create('x'),
+                TypeFactory::getInstance()->emptyPersistentMap()
+            ),
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_definition_in_same_ns(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('bar');
+        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'bar',
+                Symbol::create('x'),
+                TypeFactory::getInstance()->emptyPersistentMap()
+            ),
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_interface_in_same_ns(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('bar');
+        $env->addInterface('bar', Symbol::create('x'));
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::createForNamespace('bar', 'x')
+            ),
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_definition_in_phel_core(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('phel\\core', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->setNs('bar');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'phel\\core',
+                Symbol::create('x'),
+                TypeFactory::getInstance()->emptyPersistentMap()
+            ),
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_private_definition_in_phel_core(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('phel\\core', Symbol::create('x'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        $env->setNs('bar');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertNull(
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_interface_in_phel_core(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addInterface('phel\\core', Symbol::create('x'));
+        $env->setNs('bar');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::createForNamespace('phel\\core', 'x')
+            ),
+            $env->resolve(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_can_not_resolve_symbol_without_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $this->assertNull(
+            $env->resolve(Symbol::create('foo'), NodeEnvironment::empty())
+        );
+    }
+
+
+    // ========================================
+
+    public function test_resolve_absolute_definition_name(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->setNs('foo');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'bar',
+                Symbol::create('x'),
+                TypeFactory::getInstance()->emptyPersistentMap()
+            ),
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_absolute_definition_from_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->setNs('foo');
+        $env->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'bar',
+                Symbol::create('x'),
+                TypeFactory::getInstance()->emptyPersistentMap()
+            ),
+            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_private_absolute_definition_name(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        $env->setNs('foo');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertNull(
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_absolute_interface_name(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addInterface('bar', Symbol::create('x'));
+        $env->setNs('foo');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::createForNamespace('bar', 'x')
+            ),
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_interface_from_alias(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addInterface('bar', Symbol::create('x'));
+        $env->setNs('foo');
+        $env->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            new PhpClassNameNode(
+                $nodeEnv,
+                Symbol::createForNamespace('bar', 'x')
+            ),
+            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_as_symbol(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('bar');
+        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertEquals(
+            Symbol::createForNamespace('bar', 'x'),
+            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv)
+        );
+    }
+
+    public function test_resolve_as_symbol_not_existing(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->setNs('bar');
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertNull(
+            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv)
+        );
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -27,7 +27,7 @@ final class DefStructSymbolTest extends TestCase
     public function test_with_wrong_number_of_arguments(): void
     {
         $this->expectException(AbstractLocatedException::class);
-        $this->expectExceptionMessage("Exactly two arguments are required for 'defstruct. Got 1");
+        $this->expectExceptionMessage("At least two arguments are required for 'defstruct. Got 1");
 
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
@@ -101,7 +101,8 @@ final class DefStructSymbolTest extends TestCase
                 [
                     Symbol::create('method'),
                     Symbol::create('uri'),
-                ]
+                ],
+                []
             ),
             $defStructNode
         );

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter\FnAsClassEmitter;
+use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter\MethodEmitter;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
@@ -21,7 +22,7 @@ final class FnAsClassEmitterTest extends TestCase
         $outputEmitter = (new CompilerFactory())
             ->createOutputEmitter();
 
-        $this->fnAsClassEmitter = new FnAsClassEmitter($outputEmitter);
+        $this->fnAsClassEmitter = new FnAsClassEmitter($outputEmitter, new MethodEmitter($outputEmitter));
     }
 
     public function test_identity_fn(): void


### PR DESCRIPTION
## 📚 Description

This PR add a new language feature: interfaces.

It is now possible to define interfaces with `definterface`. It is possible to add zero or more function to a interface. Each function must have a least one parameter. This parameter is bound to `$this` in PHP. Examples:

```
(definterface MyInterfaceWithoutFunctions)

(definterface MyInterfaceWithOneFunction
  (foo [this]))

(definterface MyInterfaceWithTwoFunction
  (foo [this])
  (bar [this a b]))

(definterface MyInterfaceWithDocComments
  (foo [this] "my optional comment")
  (bar [this a b] "my other optional comment"))
```

Furthermore it is now possible to use these interface in structs. Structs can implement zero or more interfaces. Examples:

```
(definterface MyInterfaceWithoutMethods)

(defstruct* my-type-with-one-interface-without-methods [v]
  MyInterfaceWithoutMethods)
```

```
(definterface MyInterface
  (foo [this])
  (bar [this a b]))

(defstruct my-type-with-one-interface [v]
  MyInterface
  (foo [this] v)
  (bar [this a b] (+ a b v)))


(let [x (my-type-with-one-interface 1)]
  (foo)
  (bar 1 2))
```

```
(definterface MyFirstInterface
  (foo [this])
  (bar [this a b]))

(definterface MySecondInterface
  (foobar [this]))

(defstruct my-type-with-two-interfaces [v]
  MyFirstInterface
  (foo [this] v)
  (bar [this a b] (+ a b v))
  MySecondInterface
  (foobar [this] (php/-> this (foo))))

(let [x (my-type-with-two-interfaces 1)]
  (foo)
  (bar 1 2)
  (foobar))
```
