### PR TITLE
Move contributing section from Readme.md to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,19 @@ We look forward to your contributions! Here are some examples how you can contri
 * [Propose a new feature](https://github.com/phel-lang/phel/issues/new?labels=enhancement&template=FEATURE_REQUEST.md)
 * [Send a pull request](https://github.com/phel-lang/phel/pulls)
 
+### Substantial changes
+
+Substantial changes are architecture decisions, documentation restructuring, breaking changes, etc.
+But not Bug Reports, Bug Fixes, Unit Tests, etc.
+
+#### How to contribute a substantial change
+
+In order to make a substantial change it is a good practice to discuss the idea before implementing it.
+
+- An Architecture Decision Record (ADR) or Request for Comments (RFC) can be proposed with an issue.
+- The issue is the place to discuss everything.
+- The result of the issue can be an ADR file (under the [adrs](../adrs) directory), but also just as CS Fixer rule to check then during CI.
+
 ## We have a Code of Conduct
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
@@ -62,11 +75,17 @@ $ ./vendor/bin/php-cs-fixer fix
 
 Please understand that we will not accept a pull request when its changes violate this project's coding guidelines.
 
-## Running Phel's test suites
+## Development
+
+### Requirements
+
+Phel requires PHP 7.4 or higher and Composer.
+
+### Running Phel's test suites
 
 Phel has two test suites. The first test suite runs PHPUnit to test the compiler itself. The second test suite runs tests against Phel's core library.
 
-### Testing the PHP compiler
+#### Testing the PHP compiler
 
 Phel uses PHPUnit to test its compiler.
 
@@ -75,7 +94,7 @@ $ vendor/bin/phpunit --testsuite unit
 $ vendor/bin/phpunit --testsuite integration
 ```
 
-### Testing the core library
+#### Testing the core library
 
 Phel has its own [testing framework](https://phel-lang.org/documentation/testing/).
 
@@ -83,7 +102,7 @@ Phel has its own [testing framework](https://phel-lang.org/documentation/testing
 ./phel test
 ```
 
-## Coding Guidelines and Tests
+### Coding Guidelines and Tests
 
 These are the composer scripts that might help you to run the all test suites:
 
@@ -104,3 +123,7 @@ composer test-all      # csrun, psalm, compiler & core tests after each other
 > composer test-compiler
 > composer test-core
 ```
+
+### Git Hooks
+
+Enable the git hooks with `./tools/git-hooks/init.sh`

--- a/Readme.md
+++ b/Readme.md
@@ -22,15 +22,13 @@
   </a>
 </p>
 
-#
+---
 
 Phel is a functional programming language that compiles to PHP. It is a dialect of Lisp inspired by [Clojure](https://clojure.org/) and [Janet](https://janet-lang.org/).
 
 ## Documentation
 
-The documentation for Phel can be found on Phel's website
-
-[Read the documentation](https://phel-lang.org)
+The documentation for Phel can be found on the Phel's website: [https://phel-lang.org](https://phel-lang.org).
 
 ## Community
 
@@ -38,55 +36,4 @@ Feel free to ask questions and join discussions on the [Phel Gitter channel](htt
 
 ## Contribute
 
-You are more than welcome to contribute to Phel. You can do so by either:
-
-* reporting bugs
-* contributing changes
-* enrich the documentation
-
-### Substantial changes
-
-Substantial changes are architecture decisions, documentation restructuring, breaking changes, etc.
-But not Bug Reports, Bug Fixes, Unit Tests, etc.
-
-#### How to contribute a substantial change
-
-In order to make a substantial change it is a good practice to discuss the idea before implementing it.
-
-- An Architecture Decision Record (ADR) or Request for Comments (RFC) can be proposed with an issue.
-- The issue is the place to discuss everything.
-- The result of the issue can be an ADR file (under the [adrs](./adrs) directory), but also just as CS Fixer rule to check then during CI.
-
-## Development
-
-### Requirements
-
-Phel requires PHP 7.4 or higher and Composer.
-
-### Testing
-
-Phel has two test suites. The first test suite runs PHPUnit to test the compiler itself. The second test suite runs tests against Phel's core library.
-
-These are the composer scripts that might help you to run the all test suites:
-
-```bash
-composer psalm         # Run Psalm
-> vendor/bin/psalm
-
-composer test-compiler # test the compiler
-> vendor/bin/phpunit --testsuite unit
-> vendor/bin/phpunit --testsuite integration
-
-composer test-core     # test core library
-> ./phel test
-
-composer test-all      # csrun, psalm, compiler & core tests after each other
-> composer csrun
-> composer psalm
-> composer test-compiler
-> composer test-core
-```
-
-### Git Hooks
-
-Enable the git hooks with `./tools/git-hooks/init.sh`
+Please refer to [CONTRIBUTING.md](https://github.com/phel-lang/phel-lang/blob/master/.github/CONTRIBUTING.md) for information on how to contribute to Phel.


### PR DESCRIPTION
### 🤔 Background

We have currently duplicated some "contributing" guides on the `Readme.md` and on the new `CONTRIBUTING.md`.

### 💡 Goal

Unify the contributing section in one single place.

### 🔖 Changes

- Move the `Contributing` section from the `Readme.md` to `.github/CONTRIBUTING.md`
