### PR TITLE
Expose ExceptionPrinter from CommandFacade

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1,7 +1,7 @@
 (ns phel\test
   (:use Phel\Lang\Symbol)
   (:use Phel\Compiler\Emitter\OutputEmitter\Munge)
-  (:use Phel\Command\Shared\Exceptions\TextExceptionPrinter)
+  (:use Phel\Command\CommandFacade)
   (:use Throwable))
 
 # ------
@@ -214,7 +214,8 @@
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception :form form} data
-        printer (php/:: TextExceptionPrinter (create))]
+        command-facade (php/new CommandFacade)
+        printer (php/-> command-facade (getExceptionPrinter))]
     (println "              Test:" form)
     (println "   threw exception:" (php/get_class exception))
     (println)

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractFacade;
+use Phel\Command\Shared\Exceptions\ExceptionPrinterInterface;
 use Phel\Compiler\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Compiler\Parser\ReadModel\CodeSnippet;
@@ -49,7 +50,7 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
 
     public function registerExceptionHandler(): void
     {
-        $exceptionPrinter = $this->getFactory()->createExceptionPrinter();
+        $exceptionPrinter = $this->getExceptionPrinter();
 
         set_exception_handler(function (Throwable $exception) use ($exceptionPrinter): void {
             if ($exception instanceof CompilerException) {
@@ -58,6 +59,14 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
                 $exceptionPrinter->printStackTrace($exception);
             }
         });
+    }
+
+    /**
+     * We want to expose the ExceptionPrinter to `src/phel/test.phel` to be able to print the stack trace.
+     */
+    public function getExceptionPrinter(): ExceptionPrinterInterface
+    {
+        return $this->getFactory()->createExceptionPrinter();
     }
 
     public function getSourceDirectories(): array


### PR DESCRIPTION
### 🤔 Background

TextExceptionPrinter::create method is not available anymore #397

### 💡 Goal

Get rid of the PHP exception when the test has an exception on runtime

### 🔖 Changes

Use the CommandFacade to get the ExceptionPrinter in the `print-error` function.

I intentionally didn't add the `public function getExceptionPrinter(): ExceptionPrinterInterface` to the `CommandFacadeInterface` because I considered that we don't really want to expose that method to other modules, and the FacadeInterface is the contract that modules has between each other. If we end-up needing this function, we could add it, but till then I think it's ok keeping it like this.

## 🖼️  Screenshots

### BEFORE
There is a PHP runtime exception due to calling an non-existing method.
<img width="1618" alt="Screenshot 2021-12-11 at 19 56 34" src="https://user-images.githubusercontent.com/5256287/145688291-d50769fd-55aa-481b-b3e6-c519d177ae22.png">


### AFTER
The Exception is being rendered properly.
<img width="1729" alt="Screenshot 2021-12-11 at 20 01 43" src="https://user-images.githubusercontent.com/5256287/145688451-812ae3d7-536f-4bf7-81ac-fa632cf76622.png">

