### PR TITLE
Keep Munge creation inside its module

### DIFF
--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -16,7 +16,6 @@ use Phel\Build\Extractor\NamespaceSorterInterface;
 use Phel\Build\Extractor\TopologicalNamespaceSorter;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacadeInterface;
-use Phel\Compiler\Emitter\OutputEmitter\Munge;
 
 final class BuildFactory extends AbstractFactory
 {
@@ -25,7 +24,7 @@ final class BuildFactory extends AbstractFactory
         return new ProjectCompiler(
             $this->createNamespaceExtractor(),
             $this->createFileCompiler(),
-            new Munge()
+            $this->getCompilerFacade(),
         );
     }
 

--- a/src/php/Build/Compile/ProjectCompiler.php
+++ b/src/php/Build/Compile/ProjectCompiler.php
@@ -5,24 +5,26 @@ declare(strict_types=1);
 namespace Phel\Build\Compile;
 
 use Phel\Build\Extractor\NamespaceExtractorInterface;
-use Phel\Compiler\Emitter\OutputEmitter\MungeInterface;
+use Phel\Compiler\CompilerFacadeInterface;
 
 final class ProjectCompiler
 {
+    private const TARGET_FILE_EXTENSION = '.php';
+
     private NamespaceExtractorInterface $namespaceExtractor;
 
     private FileCompilerInterface $fileCompiler;
 
-    private MungeInterface $munge;
+    private CompilerFacadeInterface $compilerFacade;
 
     public function __construct(
         NamespaceExtractorInterface $namespaceExtractor,
         FileCompilerInterface $fileCompiler,
-        MungeInterface $munge
+        CompilerFacadeInterface $compilerFacade
     ) {
         $this->namespaceExtractor = $namespaceExtractor;
         $this->fileCompiler = $fileCompiler;
-        $this->munge = $munge;
+        $this->compilerFacade = $compilerFacade;
     }
 
     /**
@@ -61,7 +63,8 @@ final class ProjectCompiler
 
     private function getTargetFileFromNamespace(string $namespace): string
     {
-        $mungedNamespace = $this->munge->encodeNs($namespace);
-        return implode(DIRECTORY_SEPARATOR, explode('\\', $mungedNamespace)) . '.php';
+        $mungedNamespace = $this->compilerFacade->encodeNs($namespace);
+
+        return implode(DIRECTORY_SEPARATOR, explode('\\', $mungedNamespace)) . self::TARGET_FILE_EXTENSION;
     }
 }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -115,4 +115,11 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
             ->createReader()
             ->read($parseTree);
     }
+
+    public function encodeNs(string $namespace): string
+    {
+        return $this->getFactory()
+            ->createMunge()
+            ->encodeNs($namespace);
+    }
 }

--- a/src/php/Compiler/CompilerFacadeInterface.php
+++ b/src/php/Compiler/CompilerFacadeInterface.php
@@ -78,4 +78,6 @@ interface CompilerFacadeInterface
      * @throws UnfinishedParserException
      */
     public function parseAll(TokenStream $tokenStream): FileNode;
+
+    public function encodeNs(string $namespace): string;
 }

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -18,6 +18,7 @@ use Phel\Compiler\Emitter\FileEmitter;
 use Phel\Compiler\Emitter\FileEmitterInterface;
 use Phel\Compiler\Emitter\OutputEmitter;
 use Phel\Compiler\Emitter\OutputEmitter\Munge;
+use Phel\Compiler\Emitter\OutputEmitter\MungeInterface;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Emitter\OutputEmitter\OutputEmitterOptions;
 use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
@@ -106,7 +107,7 @@ final class CompilerFactory extends AbstractFactory
             new OutputEmitter(
                 $enableSourceMaps,
                 new NodeEmitterFactory(),
-                new Munge(),
+                $this->createMunge(),
                 Printer::readable(),
                 new SourceMapState(),
                 new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_FILE)
@@ -119,7 +120,7 @@ final class CompilerFactory extends AbstractFactory
         return new OutputEmitter(
             $enableSourceMaps,
             new NodeEmitterFactory(),
-            new Munge(),
+            $this->createMunge(),
             Printer::readable(),
             new SourceMapState(),
             new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_STATEMENT)
@@ -129,6 +130,11 @@ final class CompilerFactory extends AbstractFactory
     public function createEvaluator(): EvaluatorInterface
     {
         return new RequireEvaluator();
+    }
+
+    public function createMunge(): MungeInterface
+    {
+        return new Munge();
     }
 
     private function getGlobalEnvironment(): GlobalEnvironmentInterface


### PR DESCRIPTION
### 🤔 Background

In the `Build` module, instead of creating a new instance of an object from the `Compiler` module, we should delegate that communication to the `CompilerFacade`.

### 💡 Goal

Don't create object from external modules directly inside a module.

### 🔖 Changes

- Add `encodeNs()` to the `CompilerFacade`
- Inject the `CompilerFacade` into the `ProjectCompiler`
