### PR TITLE
Move format() inside FormatCommand

### DIFF
--- a/src/php/Formatter/Command/FormatCommand.php
+++ b/src/php/Formatter/Command/FormatCommand.php
@@ -39,6 +39,14 @@ final class FormatCommand extends Command
         $this->pathFilter = $pathFilter;
     }
 
+    /**
+     * @internal Public method for test purposes
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        return $this->formatter;
+    }
+
     protected function configure(): void
     {
         $this->setDescription('Formats the given files.')

--- a/src/php/Formatter/FormatterFacade.php
+++ b/src/php/Formatter/FormatterFacade.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\Compiler\Lexer\Exceptions\LexerValueException;
-use Phel\Compiler\Parser\Exceptions\AbstractParserException;
 use Phel\Formatter\Command\FormatCommand;
-use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
 
 /**
  * @method FormatterFactory getFactory()
@@ -18,19 +15,5 @@ final class FormatterFacade extends AbstractFacade implements FormatterFacadeInt
     public function getFormatCommand(): FormatCommand
     {
         return $this->getFactory()->createFormatCommand();
-    }
-
-    /**
-     * @throws AbstractParserException
-     * @throws LexerValueException
-     * @throws ZipperException
-     *
-     * @return string The formatted file result
-     */
-    public function format(string $string, string $source = 'string'): string
-    {
-        return $this->getFactory()
-            ->createFormatter()
-            ->format($string, $source);
     }
 }

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -30,7 +30,7 @@ final class FormatterFactory extends AbstractFactory
         );
     }
 
-    public function createFormatter(): FormatterInterface
+    private function createFormatter(): FormatterInterface
     {
         return new Formatter(
             $this->getFacadeCompiler(),

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -26,7 +26,10 @@ final class FormatterFacadeTest extends TestCase
      */
     public function test_format(array $actualLines, array $expectedLines): void
     {
-        $formatted = $this->formatterFacade->format(implode("\n", $actualLines));
+        $formatted = $this->formatterFacade
+            ->getFormatCommand()
+            ->getFormatter()
+            ->format(implode("\n", $actualLines));
 
         self::assertEquals($expectedLines, explode("\n", $formatted));
     }


### PR DESCRIPTION
## 📚 Description

We were exposing in the facade a `format()` method which is used only on feature tests.
The idea of this PR is to move deeper this method to make it less exposure to the exterior, and to make it more difficult someone from outside can use it.

Also, I have marked the `getFormatter()` method as `@internal` to make it more explicit.