### PR TITLE
Added feature to require php files in ns statement.

### DIFF
--- a/src/php/Compiler/Analyzer/Ast/NsNode.php
+++ b/src/php/Compiler/Analyzer/Ast/NsNode.php
@@ -13,24 +13,29 @@ final class NsNode extends AbstractNode
     /** @var Symbol[] */
     private array $requireNs;
 
+    /** @var string[] */
+    private array $requireFiles;
+
     private string $namespace;
 
     /**
-     * @param Symbol[] $requireNs
+     * @param list<Symbol> $requireNs
+     * @param list<string> $requireFiles
      */
-    public function __construct(string $namespace, array $requireNs, ?SourceLocation $sourceLocation = null)
+    public function __construct(string $namespace, array $requireNs, array $requireFiles, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct(NodeEnvironment::empty(), $sourceLocation);
         $this->requireNs = $requireNs;
         if ($namespace !== 'phel\\core') {
             // All other files implicitly depend on phel\core
-            $this->requireNs[] = Symbol::create('phel\\core');
+            $this->requireNs = [Symbol::create('phel\\core'), ...$requireNs];
         }
+        $this->requireFiles = $requireFiles;
         $this->namespace = $namespace;
     }
 
     /**
-     * @return Symbol[]
+     * @return list<Symbol>
      */
     public function getRequireNs(): array
     {
@@ -40,5 +45,13 @@ final class NsNode extends AbstractNode
     public function getNamespace(): string
     {
         return $this->namespace;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRequireFiles(): array
+    {
+        return $this->requireFiles;
     }
 }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -19,6 +19,7 @@ final class NsEmitter implements NodeEmitterInterface
         assert($node instanceof NsNode);
 
         $this->emitNamespace($node);
+        $this->emitRequireFiles($node);
         $this->emitRequiredNamespaces($node);
         $this->emitCurrentNamespace($node);
     }
@@ -29,6 +30,17 @@ final class NsEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitStr('namespace ', $node->getStartSourceLocation());
             $this->outputEmitter->emitStr($this->outputEmitter->mungeEncodeNs($node->getNamespace()), $node->getStartSourceLocation());
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+        }
+    }
+
+    private function emitRequireFiles(NsNode $node): void
+    {
+        if ($this->outputEmitter->getOptions()->isFileEmitMode()) {
+            foreach ($node->getRequireFiles() as $path) {
+                $this->outputEmitter->emitStr('require_once ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitLiteral($path);
+                $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+            }
         }
     }
 

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -7,8 +7,8 @@
 (def d :xyz\foo/bar)
 --PHP--
 namespace test;
-require_once __DIR__ . '/xyz/foo.php';
 require_once __DIR__ . '/phel/core.php';
+require_once __DIR__ . '/xyz/foo.php';
 \Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";
 $GLOBALS["__phel"]["test"]["a"] = \Phel\Lang\Keyword::create("bar");

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -8,8 +8,8 @@
 (defstruct abc [a])
 --PHP--
 namespace hello_world;
-require_once __DIR__ . '/my_namespace/core.php';
 require_once __DIR__ . '/phel/core.php';
+require_once __DIR__ . '/my_namespace/core.php';
 \Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("hello-world");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "hello_world";
 $GLOBALS["__phel"]["hello_world"]["x"] = 10;

--- a/tests/php/Integration/Fixtures/Ns/require-file.test
+++ b/tests/php/Integration/Fixtures/Ns/require-file.test
@@ -1,11 +1,11 @@
 --PHEL--
 (ns test
-  (:require xzy\core)
-  (:require xyz\foo :as f))
+  (:require-file "vendor/autoload.php")
+  (:require xzy\core))
 --PHP--
 namespace test;
+require_once "vendor/autoload.php";
 require_once __DIR__ . '/phel/core.php';
 require_once __DIR__ . '/xzy/core.php';
-require_once __DIR__ . '/xyz/foo.php';
 \Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";

--- a/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
@@ -28,7 +28,7 @@ final class NamespaceExtractorTest extends TestCase
         $result = $this->extractNamespace($fileContent);
 
         $this->assertEquals('get\\ns\\from\\file', $result->getNamespace());
-        $this->assertEquals(['phel\html', 'phel\core'], $result->getDependencies());
+        $this->assertEquals(['phel\core', 'phel\html'], $result->getDependencies());
     }
 
     public function test_get_namespace_from_file_not_parsable(): void


### PR DESCRIPTION
This commit adds a new feature to load php files in the ns statement. This
can, for example, be used to load the composer autoload file. Example

```
(ns myapp
  (:require-file "vendor/autload.php"))
```

The :require-file import ins transformed into a require_once statement in PHP.
The file is loaded before any other :require import.

Fixes: #409