### PR TITLE
Fixes #408: Remove calls to GlobalEnvironmentSingleton in compiled code

### DIFF
--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -63,10 +63,12 @@ final class NsEmitter implements NodeEmitterInterface
 
     private function emitCurrentNamespace(NsNode $node): void
     {
-        $this->outputEmitter->emitLine(
-            '\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");',
-            $node->getStartSourceLocation()
-        );
+        if (!$this->outputEmitter->getOptions()->isFileEmitMode()) {
+            $this->outputEmitter->emitLine(
+                '\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");',
+                $node->getStartSourceLocation()
+            );
+        }
 
         $nsSym = Symbol::create('*ns*');
         $nsSym->setStartLocation($node->getStartSourceLocation());

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -9,7 +9,6 @@
 --PHP--
 namespace interface_instance;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("interface-instance");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "interface_instance";
 interface IPlayer {
   public function choose();

--- a/tests/php/Integration/Fixtures/Def/definterface-with-methods.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-with-methods.test
@@ -5,7 +5,6 @@
 --PHP--
 namespace user;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("user");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "user";
 interface IFoo {
 }

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -7,7 +7,6 @@
 --PHP--
 namespace user;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("user");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "user";
 interface IPlayer {
   public function choose();

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -5,7 +5,6 @@
 --PHP--
 namespace my\ns;
 require_once __DIR__ . '/../phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("my\\ns");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "my\\ns";
 $GLOBALS["__phel"]["my\\ns"]["x"] = 1;
 $GLOBALS["__phel_meta"]["my\\ns"]["x"] = \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -9,7 +9,6 @@
 namespace test;
 require_once __DIR__ . '/phel/core.php';
 require_once __DIR__ . '/xyz/foo.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";
 $GLOBALS["__phel"]["test"]["a"] = \Phel\Lang\Keyword::create("bar");
 $GLOBALS["__phel_meta"]["test"]["a"] = \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -9,7 +9,6 @@
 --PHP--
 namespace test;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";
 $__phel_1_2 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3, 4]);
 $sum_3 = 0;

--- a/tests/php/Integration/Fixtures/New/new-from-alias.test
+++ b/tests/php/Integration/Fixtures/New/new-from-alias.test
@@ -6,6 +6,5 @@
 --PHP--
 namespace test\abc;
 require_once __DIR__ . '/../phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test\\abc");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test\\abc";
 (new \DateTimeImmutable("2020-03-22"));

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -10,7 +10,6 @@
 namespace hello_world;
 require_once __DIR__ . '/phel/core.php';
 require_once __DIR__ . '/my_namespace/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("hello-world");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "hello_world";
 $GLOBALS["__phel"]["hello_world"]["x"] = 10;
 $GLOBALS["__phel_meta"]["hello_world"]["x"] = \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(

--- a/tests/php/Integration/Fixtures/Ns/require-file.test
+++ b/tests/php/Integration/Fixtures/Ns/require-file.test
@@ -7,5 +7,4 @@ namespace test;
 require_once "vendor/autoload.php";
 require_once __DIR__ . '/phel/core.php';
 require_once __DIR__ . '/xzy/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";

--- a/tests/php/Integration/Fixtures/Ns/require.test
+++ b/tests/php/Integration/Fixtures/Ns/require.test
@@ -7,5 +7,4 @@ namespace test;
 require_once __DIR__ . '/phel/core.php';
 require_once __DIR__ . '/xzy/core.php';
 require_once __DIR__ . '/xyz/foo.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";

--- a/tests/php/Integration/Fixtures/Ns/use.test
+++ b/tests/php/Integration/Fixtures/Ns/use.test
@@ -8,6 +8,5 @@
 --PHP--
 namespace test;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "test";
 (new \DateTimeImmutable());(new \DateTime());

--- a/tests/php/Integration/Fixtures/Try/catch-from-ns-use.test
+++ b/tests/php/Integration/Fixtures/Try/catch-from-ns-use.test
@@ -5,7 +5,6 @@
 --PHP--
 namespace catch_from_ns_use;
 require_once __DIR__ . '/phel/core.php';
-\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("catch-from-ns-use");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "catch_from_ns_use";
 try {
   (1 + 1);


### PR DESCRIPTION
### 🤔 Background

Currently the compiled code contains lines like this:

```php
\Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton::getInstance()->setNs("hello-world\\boot");
```

### 💡 Goal

Remove this line from the compiled code because it is not needed.
