### PR TITLE
Override method getDefintionMetadata by getDefinitionMetadata

### DIFF
--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -37,7 +37,7 @@
 
 (defn- find-doc [namespace name]
   (let [registry (php/:: Registry (getInstance))
-        meta (php/-> registry (getDefintionMetaData namespace name))]
+        meta (php/-> registry (getDefinitionMetaData namespace name))]
     (when meta
       (clean-doc (get meta :doc)))))
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -304,7 +304,7 @@
         munge-ns (php/-> munge (encodeNs ns))
         registry (php/:: Registry (getInstance))]
     (for [fn-name :keys (php/-> registry (getDefinitionInNamespace munge-ns))
-          :let [meta (php/-> registry (getDefintionMetaData munge-ns fn-name))]
+          :let [meta (php/-> registry (getDefinitionMetaData munge-ns fn-name))]
           :when (and (:test meta) (or (nil? filter) (str-contains? (:test-name meta) filter)))]
       (php/-> registry (getDefinition munge-ns fn-name)))))
 

--- a/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/ExportFinder/FunctionsToExportFinder.php
@@ -101,7 +101,7 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
     private function isExport(string $ns, string $fnName): bool
     {
         /** @var PersistentMapInterface $meta */
-        $meta = Registry::getInstance()->getDefintionMetaData($ns, $fnName)
+        $meta = Registry::getInstance()->getDefinitionMetaData($ns, $fnName)
             ?? TypeFactory::getInstance()->emptyPersistentList();
 
         return (bool)($meta[Keyword::create('export')] ?? false);

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -50,7 +50,7 @@ final class Registry
         return $this->definitions[$ns][$name] ?? null;
     }
 
-    public function getDefintionMetaData(string $ns, string $name): ?PersistentMapInterface
+    public function getDefinitionMetaData(string $ns, string $name): ?PersistentMapInterface
     {
         return $this->definitionsMetaData[$ns][$name] ?? null;
     }


### PR DESCRIPTION
### 📚 Description

Replace the string method name `getDefintionMetadata` to `getDefinitionMetadata` from PHP and Phel code.
(Notice the missing `i` on `Definition` word) 😄 