### PR TITLE
Evaluate meta data in the special form def

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -190,7 +190,7 @@
 (defmacro deftest
   "Defines a test function with no arguments"
   [name & body]
-  `(defn ,name {:test true :test-name ,name} []
+  `(defn ,name {:test true :test-name ,(php/-> name (getName))} []
      ,@body))
 
 # ---------------------

--- a/src/php/Compiler/Analyzer/Analyzer.php
+++ b/src/php/Compiler/Analyzer/Analyzer.php
@@ -64,9 +64,9 @@ final class Analyzer implements AnalyzerInterface
         }
     }
 
-    public function addDefinition(string $ns, Symbol $symbol, PersistentMapInterface $meta): void
+    public function addDefinition(string $ns, Symbol $symbol): void
     {
-        $this->globalEnvironment->addDefinition($ns, $symbol, $meta);
+        $this->globalEnvironment->addDefinition($ns, $symbol);
     }
 
     public function addInterface(string $ns, Symbol $name): void

--- a/src/php/Compiler/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Analyzer/AnalyzerInterface.php
@@ -7,7 +7,6 @@ namespace Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
@@ -40,7 +39,7 @@ interface AnalyzerInterface
      */
     public function addRefers(string $ns, array $referSymbols, Symbol $nsSymbol): void;
 
-    public function addDefinition(string $ns, Symbol $symbol, PersistentMapInterface $meta): void;
+    public function addDefinition(string $ns, Symbol $symbol): void;
 
     public function addInterface(string $ns, Symbol $name): void;
 }

--- a/src/php/Compiler/Analyzer/Ast/DefNode.php
+++ b/src/php/Compiler/Analyzer/Ast/DefNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer\Ast;
 
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -13,14 +12,14 @@ final class DefNode extends AbstractNode
 {
     private string $namespace;
     private Symbol $name;
-    private PersistentMapInterface $meta;
+    private MapNode $meta;
     private AbstractNode $init;
 
     public function __construct(
         NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $name,
-        PersistentMapInterface $meta,
+        MapNode $meta,
         AbstractNode $init,
         ?SourceLocation $sourceLocation = null
     ) {
@@ -41,7 +40,7 @@ final class DefNode extends AbstractNode
         return $this->name;
     }
 
-    public function getMeta(): PersistentMapInterface
+    public function getMeta(): MapNode
     {
         return $this->meta;
     }

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
@@ -22,7 +22,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     private string $ns = 'user';
 
-    /** @var array<string, array<string, PersistentMapInterface>> */
+    /** @var array<string, array<string, bool>> */
     private array $definitions = [];
 
     /** @var array<string, array<string, Symbol>> */
@@ -52,7 +52,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             'Set to true when a file is compiled, false otherwise',
         );
         Registry::getInstance()->addDefinition(self::PHEL_CORE_NAMESPACE, $symbol->getName(), false, $meta);
-        $this->addDefinition(self::PHEL_CORE_NAMESPACE, $symbol, $meta);
+        $this->addDefinition(self::PHEL_CORE_NAMESPACE, $symbol);
     }
 
     public function getNs(): string
@@ -65,13 +65,13 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->ns = $ns;
     }
 
-    public function addDefinition(string $namespace, Symbol $name, PersistentMapInterface $meta): void
+    public function addDefinition(string $namespace, Symbol $name): void
     {
         if (!array_key_exists($namespace, $this->definitions)) {
             $this->definitions[$namespace] = [];
         }
 
-        $this->definitions[$namespace][$name->getName()] = $meta;
+        $this->definitions[$namespace][$name->getName()] = true;
     }
 
     public function hasDefinition(string $namespace, Symbol $name): bool
@@ -82,7 +82,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     public function getDefinition(string $namespace, Symbol $name): ?PersistentMapInterface
     {
         if ($this->hasDefinition($namespace, $name)) {
-            return $this->definitions[$namespace][$name->getName()];
+            return Registry::getInstance()->getDefinitionMetaData($namespace, $name->getName()) ?? TypeFactory::getInstance()->emptyPersistentMap();
         }
 
         return null;

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -14,7 +14,7 @@ interface GlobalEnvironmentInterface
 
     public function setNs(string $ns): void;
 
-    public function addDefinition(string $namespace, Symbol $name, PersistentMapInterface $meta): void;
+    public function addDefinition(string $namespace, Symbol $name): void;
 
     public function hasDefinition(string $namespace, Symbol $name): bool;
 

--- a/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Analyzer\Ast\DefNode;
+use Phel\Compiler\Analyzer\Ast\MapNode;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
@@ -38,15 +39,17 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $namespace = $this->analyzer->getNamespace();
 
-        [$metaMap, $init] = $this->createMetaMapAndInit($list);
+        $this->analyzer->addDefinition($namespace, $nameSymbol);
 
-        $this->analyzer->addDefinition($namespace, $nameSymbol, $metaMap);
+        [$metaMap, $init] = $this->createMetaMapAndInit($list);
+        $meta = $this->analyzer->analyze($metaMap, $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION));
+        assert($meta instanceof MapNode);
 
         return new DefNode(
             $env,
             $namespace,
             $nameSymbol,
-            $metaMap,
+            $meta,
             $this->analyzeInit($init, $env, $namespace, $nameSymbol),
             $list->getStartLocation()
         );

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -25,9 +25,9 @@ final class DefEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr(addslashes($node->getName()->getName()));
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitNode($node->getInit());
-        if (count($node->getMeta()) > 0) {
+        if (count($node->getMeta()->getKeyValues()) > 0) {
             $this->outputEmitter->emitLine(',');
-            $this->outputEmitter->emitLiteral($node->getMeta());
+            $this->outputEmitter->emitNode($node->getMeta());
         }
         $this->outputEmitter->emitLine();
         $this->outputEmitter->decreaseIndentLevel();

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -16,9 +16,39 @@ final class MapEmitter implements NodeEmitterInterface
     {
         assert($node instanceof MapNode);
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        /*$this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(', $node->getStartSourceLocation());
         $this->outputEmitter->emitArgList($node->getKeyValues(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());*/
+
+        $keyValues = $node->getKeyValues();
+        $countKeyValues = count($keyValues);
+
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(', $node->getStartSourceLocation());
+        if ($countKeyValues > 0) {
+            $this->outputEmitter->increaseIndentLevel();
+            $this->outputEmitter->emitLine();
+        }
+
+        $i = 0;
+        for ($i = 0; $i < $countKeyValues; $i+=2) {
+            $key = $keyValues[$i];
+            $value = $keyValues[$i+1];
+
+            $this->outputEmitter->emitNode($key);
+            $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($value);
+            if ($i < $countKeyValues - 2) {
+                $this->outputEmitter->emitStr(',', $node->getStartSourceLocation());
+            }
+            $this->outputEmitter->emitLine();
+        }
+
+        if ($countKeyValues > 0) {
+            $this->outputEmitter->decreaseIndentLevel();
+        }
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -52,7 +52,11 @@ final class Registry
 
     public function getDefinitionMetaData(string $ns, string $name): ?PersistentMapInterface
     {
-        return $this->definitionsMetaData[$ns][$name] ?? null;
+        if (array_key_exists($ns, $this->definitions) && array_key_exists($name, $this->definitions[$ns])) {
+            return $this->definitionsMetaData[$ns][$name] ?? TypeFactory::getInstance()->emptyPersistentMap();
+        }
+
+        return null;
     }
 
     /**

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironment;
 use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
@@ -17,6 +18,11 @@ use PHPUnit\Framework\TestCase;
 
 final class GlobalEnvironmentTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Registry::getInstance()->clear();
+    }
+
     public function test_set_ns(): void
     {
         $env = new GlobalEnvironment();
@@ -29,7 +35,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $meta = TypeFactory::getInstance()->emptyPersistentMap();
-        $env->addDefinition('foo', Symbol::create('bar'), $meta);
+        $env->addDefinition('foo', Symbol::create('bar'));
 
         $this->assertTrue($env->hasDefinition('foo', Symbol::create('bar')));
         $this->assertFalse($env->hasDefinition('bar', Symbol::create('bar')));
@@ -118,7 +124,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_refer_definition(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('foo', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('foo', Symbol::create('x'));
         $env->setNs('bar');
         $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
         $nodeEnv = NodeEnvironment::empty();
@@ -138,7 +144,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->setNs('bar');
-        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('bar', Symbol::create('x'));
         $nodeEnv = NodeEnvironment::empty();
 
         $this->assertEquals(
@@ -171,7 +177,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_definition_in_phel_core(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('phel\\core', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('phel\\core', Symbol::create('x'));
         $env->setNs('bar');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -189,7 +195,8 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_private_definition_in_phel_core(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('phel\\core', Symbol::create('x'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        $env->addDefinition('phel\\core', Symbol::create('x'));
+        Registry::getInstance()->addDefinition('phel\\core', 'x', null, TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('bar');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -228,7 +235,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_absolute_definition_name(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('bar', Symbol::create('x'));
         $env->setNs('foo');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -246,7 +253,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_absolute_definition_from_alias(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('bar', Symbol::create('x'));
         $env->setNs('foo');
         $env->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
         $nodeEnv = NodeEnvironment::empty();
@@ -265,7 +272,8 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_resolve_private_absolute_definition_name(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        $env->addDefinition('bar', Symbol::create('x'));
+        Registry::getInstance()->addDefinition('bar', 'x', null, TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('foo');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -311,7 +319,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->setNs('bar');
-        $env->addDefinition('bar', Symbol::create('x'), TypeFactory::getInstance()->emptyPersistentMap());
+        $env->addDefinition('bar', Symbol::create('x'));
         $nodeEnv = NodeEnvironment::empty();
 
         $this->assertEquals(

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Analyzer\Analyzer;
 use Phel\Compiler\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Analyzer\Ast\DefNode;
 use Phel\Compiler\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Analyzer\Ast\MapNode;
 use Phel\Compiler\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Analyzer\Exceptions\AnalyzerException;
@@ -97,7 +98,10 @@ final class DefSymbolTest extends TestCase
                 $env,
                 'user',
                 Symbol::create('name'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                new MapNode(
+                    $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                    []
+                ),
                 new LiteralNode(
                     $env
                         ->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
@@ -127,9 +131,18 @@ final class DefSymbolTest extends TestCase
                 $env,
                 'user',
                 Symbol::create('name'),
-                TypeFactory::getInstance()->persistentMapFromKVs(
-                    Keyword::create('doc'),
-                    'my docstring'
+                new MapNode(
+                    $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                    [
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            Keyword::create('doc')
+                        ),
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            'my docstring'
+                        ),
+                    ]
                 ),
                 new LiteralNode(
                     $env
@@ -160,9 +173,18 @@ final class DefSymbolTest extends TestCase
                 $env,
                 'user',
                 Symbol::create('name'),
-                TypeFactory::getInstance()->persistentMapFromKVs(
-                    Keyword::create('private'),
-                    true
+                new MapNode(
+                    $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                    [
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            Keyword::create('private')
+                        ),
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            true
+                        ),
+                    ]
                 ),
                 new LiteralNode(
                     $env
@@ -193,9 +215,20 @@ final class DefSymbolTest extends TestCase
                 $env,
                 'user',
                 Symbol::create('name'),
-                TypeFactory::getInstance()->persistentMapFromKVs(
-                    Keyword::create('private'),
-                    true
+                new MapNode(
+                    $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                    [
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            Keyword::create('private'),
+                            null
+                        ),
+                        new LiteralNode(
+                            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
+                            true,
+                            null
+                        ),
+                    ]
                 ),
                 new LiteralNode(
                     $env

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -28,11 +28,21 @@ final class InvokeSymbolTest extends TestCase
     public function setUp(): void
     {
         $env = new GlobalEnvironment();
-        $env->addDefinition('user', Symbol::create('my-macro'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true));
-        Registry::getInstance()->addDefinition('user', 'my-macro', fn ($a) => $a);
+        $env->addDefinition('user', Symbol::create('my-macro'));
+        Registry::getInstance()->addDefinition(
+            'user',
+            'my-macro',
+            fn ($a) => $a,
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true)
+        );
 
-        $env->addDefinition('user', Symbol::create('my-failed-macro'), TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true));
-        Registry::getInstance()->addDefinition('user', 'my-failed-macro', fn ($a) => throw new Exception('my-failed-macro message'));
+        $env->addDefinition('user', Symbol::create('my-failed-macro'));
+        Registry::getInstance()->addDefinition(
+            'user',
+            'my-failed-macro',
+            fn ($a) => throw new Exception('my-failed-macro message'),
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true)
+        );
 
         $this->analyzer = new Analyzer($env);
     }


### PR DESCRIPTION
This commit evaluates the meta data that can be provided in def. This was
currently not a problem because all data stored in the map was literal data
that evaluates to itself.

Before this commit the code
```
(def x {:foo (+ 1 1)} 10)
```
was evaluated to
```
(def x {:foo '(+ 1 1)} 10) # The + operation is not evaluated
```
With the commit the code evaluates to
```
(def x {:foo 2} 10)
```
This required some changes to the GlobalEnvironment. The meta data
of a definition is now loaded from the Registry and is not stored in the
GlobalEnvironment itself. This has the drawback that the meta data
is only available after the definition was evaluated and not while analysing the
initial value of the definition. However, this only happens in recursive function
calls. In this case the meta data will be a empty persistent map.
