### PR TITLE
Fixes the compile command when it rebuild using a cache.

### DIFF
--- a/src/php/Build/Compile/ProjectCompiler.php
+++ b/src/php/Build/Compile/ProjectCompiler.php
@@ -46,6 +46,7 @@ final class ProjectCompiler
                 && file_exists($targetFile)
                 && filemtime($targetFile) === filemtime($info->getFile())
             ) {
+                /** @psalm-suppress UnresolvableInclude */
                 require_once $targetFile;
                 continue;
             }

--- a/src/php/Build/Compile/ProjectCompiler.php
+++ b/src/php/Build/Compile/ProjectCompiler.php
@@ -46,6 +46,7 @@ final class ProjectCompiler
                 && file_exists($targetFile)
                 && filemtime($targetFile) === filemtime($info->getFile())
             ) {
+                require_once $targetFile;
                 continue;
             }
 

--- a/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Analyzer/Environment/GlobalEnvironment.php
@@ -76,7 +76,10 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function hasDefinition(string $namespace, Symbol $name): bool
     {
-        return (isset($this->definitions[$namespace][$name->getName()]));
+        return (
+            isset($this->definitions[$namespace][$name->getName()])
+            || Registry::getInstance()->hasDefinition($namespace, $name->getName())
+        );
     }
 
     public function getDefinition(string $namespace, Symbol $name): ?PersistentMapInterface

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -45,6 +45,11 @@ final class Registry
         $this->definitionsMetaData[$ns][$name] = $metaData;
     }
 
+    public function hasDefinition(string $ns, string $name): bool
+    {
+        return isset($this->definitions[$ns][$name]);
+    }
+
     public function getDefinition(string $ns, string $name): mixed
     {
         return $this->definitions[$ns][$name] ?? null;

--- a/tests/php/Integration/Build/Command/CompileCommandTest.php
+++ b/tests/php/Integration/Build/Command/CompileCommandTest.php
@@ -42,6 +42,33 @@ final class CompileCommandTest extends TestCase
         self::assertFileExists(__DIR__ . '/out/hello.php');
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @depends test_compile_project
+     */
+    public function test_compile_project_cached(): void
+    {
+        // Mark file cache invalid by setting the modification time to 0
+        touch(__DIR__ . '/out/hello.php', 1);
+
+        $command = $this->createBuildFacade()->getCompileCommand();
+
+        $this->expectOutputString("This is printed\n");
+
+        $command->run(
+            new ArrayInput([
+                '--no-source-map' => true,
+            ]),
+            $this->stubOutput()
+        );
+
+        self::assertFileExists(__DIR__ . '/out/phel/core.phel');
+        self::assertFileExists(__DIR__ . '/out/phel/core.php');
+        self::assertFileExists(__DIR__ . '/out/hello.phel');
+        self::assertFileExists(__DIR__ . '/out/hello.php');
+    }
+
     private function createBuildFacade(): BuildFacadeInterface
     {
         return new BuildFacade();


### PR DESCRIPTION
The compile command had the problem that the cached version was not really working. After executing the command the first time everything went fine, because the was not cached files. In the second run the command mostly fails because of undefined functions. The problem here is that the `GlobalEnvironment` didn't know of functions in the cached files.

This PR fixes the problem by importing the already compiled files.