### PR TITLE
Use str_starts_with & str_contains instead of strpos

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -535,7 +535,7 @@ Calling the and function without arguments returns true."
 (defn str-contains?
   "True if str contains s."
   [str s]
-  (not (false? (php/strpos str s))))
+  (php/str_contains str s))
 
 (defn contains?
   "Returns true if key is present in the given collection, otherwise returns false."

--- a/src/php/Command/Shared/Exceptions/Extractor/FilePositionExtractor.php
+++ b/src/php/Command/Shared/Exceptions/Extractor/FilePositionExtractor.php
@@ -29,7 +29,7 @@ final class FilePositionExtractor implements FilePositionExtractorInterface
 
     private function extractOriginalFilename(SourceMapInformation $sourceMapInfo, string $filename): string
     {
-        if (false === strpos($sourceMapInfo->filename(), '// ')) {
+        if (!str_contains($sourceMapInfo->filename(), '// ')) {
             return $filename;
         }
 
@@ -38,8 +38,8 @@ final class FilePositionExtractor implements FilePositionExtractorInterface
 
     private function extractOriginalLine(SourceMapInformation $sourceMapInfo, int $line): int
     {
-        if (false === strpos($sourceMapInfo->filename(), '// ')
-            || false === strpos($sourceMapInfo->sourceMap(), '// ')
+        if (!str_contains($sourceMapInfo->filename(), '// ')
+            || !str_contains($sourceMapInfo->sourceMap(), '// ')
         ) {
             return $line;
         }

--- a/src/php/Compiler/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Parser/ExpressionParser/AtomParser.php
@@ -43,7 +43,7 @@ final class AtomParser
             return new NilNode($word, $token->getStartLocation(), $token->getEndLocation(), null);
         }
 
-        if (strpos($word, ':') === 0) {
+        if (str_starts_with($word, ':')) {
             return $this->parseKeyword($token);
         }
 

--- a/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/LineIndenter.php
@@ -24,7 +24,7 @@ final class LineIndenter implements IndenterInterface
                 $s = $loc->getNode()->getCode();
                 $str = $s . $str;
 
-                if (strpos($s, "\n") !== false) {
+                if (str_contains($s, "\n")) {
                     return $str;
                 }
             } else {

--- a/src/php/Run/Domain/Repl/InputResult.php
+++ b/src/php/Run/Domain/Repl/InputResult.php
@@ -38,7 +38,7 @@ final class InputResult
         $fullInput = implode(PHP_EOL, $buffer);
 
         if (self::NO_VALUE === $this->lastResult
-            || false === strpos($fullInput, self::LAST_RESULT_PLACEHOLDER)
+            || !str_contains($fullInput, self::LAST_RESULT_PLACEHOLDER)
         ) {
             return $fullInput;
         }


### PR DESCRIPTION
### 💡 Goal

Use new PHP 8.0 functions to improve readability. 

### 🔖 Changes

- Use `str_starts_with()` & `str_contains()` instead of `strpos()`
