### PR TITLE
Docker quickstart container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Publish docker images
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  repl:
+    name: Docker quickstart repl
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: docker login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+    - name: Build the Docker image
+      run: cd docker/repl && docker build . --file Dockerfile --tag phellang/repl:${{github.ref_name}} && docker tag phellang/repl:${{github.ref_name}} phellang/repl:latest
+
+    - name: Docker Push
+      run: docker push phellang/repl

--- a/docker/repl/Dockerfile
+++ b/docker/repl/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:8.1-cli
+
+# Install composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Install zip extension
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libzip-dev \
+        zip \
+  && rm -rf /var/lib/apt/lists/* \
+  && docker-php-ext-install zip
+
+# Create project
+RUN mkdir /usr/src/repl
+RUN mkdir /usr/src/repl/src
+RUN mkdir /usr/src/repl/tests
+COPY ./composer.json /usr/src/repl
+RUN cd /usr/src/repl && composer update
+WORKDIR /usr/src/repl
+
+# Execute repl
+CMD ["./vendor/bin/phel", "repl"]

--- a/docker/repl/composer.json
+++ b/docker/repl/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "phel-lang/repl",
+    "homepage": "https://phel-lang.org/",
+    "license": "MIT",
+    "require": {
+      "phel-lang/phel-lang": "dev-master"
+    }
+  }


### PR DESCRIPTION
### 🤔 Background

I want to give new user a very easy way got try out the REPL.

### 💡 Goal

This PR adds a Dockerfile to build a Docker image that starts the REPL. A GitHub actions workflow is added to automatically publish a version to docker hub. 

New user can use this image to try out Phel simply by running
```
docker run -it --rm phellang/repl
```

I already a push a image to Docker Hub. So you can try it out yourself.

### 🔖 Changes

* Added a Dockerfile
* Added a new GitHub Actions workflow.

---
Next: Update the website with this command