### PR TITLE
Added two new merge function: merge-with and deep-merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Added: `merge-with` function
+* Added: `deep-merge` function
+
 ## 0.6.0 (2022-02-02)
 
 * Drop support for PHP 7.4. (#403)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1395,6 +1395,43 @@ collection in map"))
    (complement indexed?)
    (rest (tree-seq indexed? identity xs))))
 
+(defn- merge-with-2 [f left right]
+  (for [[k v] :pairs right
+        :reduce [acc left]]
+    (if (contains? acc k)
+      (put acc k (f (get acc k) v))
+      (put acc k v))))
+
+(defn merge-with
+  "Merges multiple maps into one new map. If a key appears in more than one
+   collection, the result of `(f current-val next-val)` is used."
+  [f & hash-maps]
+  (case (count hash-maps)
+    0 {}
+    1 (first hash-maps)
+    2 (merge-with-2 f (first hash-maps) (second hash-maps))
+      (reduce (partial merge-with f) (first hash-maps) (rest hash-maps))))
+
+(declare deep-merge)
+
+(defn- deep-merge-2 [left right]
+  (cond
+    (nil? left) right
+    (nil? right) left
+    (and (hash-map? left) (hash-map? right)) (merge-with deep-merge left right)
+    (and (set? left) (set? right)) (union left right)
+    (and (vector? left) (vector? right)) (concat left right)
+    right))
+
+(defn deep-merge
+  "Recursivly merges data structures."
+  [& args]
+  (case (count args)
+    0 {}
+    1 (first args)
+    2 (deep-merge-2 (first args) (second args))
+      (reduce deep-merge (first args) (rest args))))
+
 # -----------------
 # Bitwise operation
 # -----------------

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -167,6 +167,45 @@
 (deftest test-merge
   (is (= {:a -1 :b 2 :c 3 :d 4} (merge {:a 1 :b 2} {:a -1 :c 3} {:d 4})) "merge"))
 
+(deftest test-merge-with-zero-args
+  (is (= {} (merge-with identity))))
+
+(deftest test-merge-with-one-args
+  (is (= {:a 1} (merge-with identity {:a 1}))))
+
+(deftest test-merge-with-sum
+  (is (= {:a 1 :b 5 :c 4} (merge-with + {:a 1 :b 2} {:b 3 :c 4}))))
+
+(deftest test-merge-with-mulitple-maps
+  (is (= {:a 3 :b 2 :c 3} (merge-with + {:a 1} {:a 1 :b 2} {:a 1 :c 3}))))
+
+(deftest test-simple-deep-merge
+  (is (= {:a 1 :b 3 :c 4} (deep-merge {:a 1 :b 2} {:b 3 :c 4}))))
+
+(deftest test-inner-map-deep-merge
+  (is (= {:a {:b 1 :c 3}} (deep-merge {:a {:b 1 :c 2}} {:a {:c 3}}))))
+
+(deftest test-inner-set-deep-merge
+  (is (= {:a (set :b :c :d)} (deep-merge {:a (set :b :c)} {:a (set :c :d)}))))
+
+(deftest test-inner-vector-deep-merge
+  (is (= {:a [:b :c :d]} (deep-merge {:a [:b :c]} {:a [:d]}))))
+
+(deftest test-deep-inner-merge
+  (is (= {:a {:b {:c [:d :e] :f :g}}} (deep-merge {:a {:b {:c [:d]}}} {:a {:b {:c [:e] :f :g}}}))))
+
+(deftest test-collection-stay-the-same-in-deep-merge
+  (is (hash-map? (deep-merge {:a :b} {:c :d})))
+  (is (vector? (deep-merge [:a :b] [:c])))
+  (is (set? (deep-merge (set :a :b) (set :c))))
+  (is (list? (deep-merge '(:a :b) '(:c)))))
+
+(deftest test-different-args-in-deep-merge
+  (is (= {} (deep-merge)))
+  (is (= {:a :b} (deep-merge {:a :b})))
+  (is (= {:a :d :x 1 :y 2} (deep-merge {:a :b :x 1} {:a :c :y 2} {:a :d})))
+  (is (= {:a :d :x 1 :y 4 :z 3} (deep-merge {:a :b :x 1} {:a :c :y 2} {:a :d} {:y 4 :z 3}))))
+
 (deftest test-invert
   (is (= {1 :a 2 :b} (invert {:a 1 :b 2})) "invert")
   (is (= {1 :a 2 :c} (invert {:a 1 :b 2 :c 2})) "invert duplicate values"))


### PR DESCRIPTION
### 🤔 Background

Merging maps or nested data structures is a common problem in programming. This PR will add new functions that may be very useful.

### 💡 Goal

The first function is call `merge-with`. `merge-with` takes a two-arity function `f` and a unlimited number of hash maps. It will merge these hash maps as in `merge` but in case two maps have the same key it will call `f` with the left and the right value. Example:

```
(merge-with + {:a 1 :b 2} {:b 3 :c 4}) # Evaluates to {:a 1 :b 5 :c 4}
```

The second function is called `deep-merge`. This function will recursively merge nested data structures. Hash maps will be merged as in `merge`, vectors will be concatenated, sets will be united. Example:

```
(deep-merge {:a {:b {:c [:d]}}} {:a {:b {:c [:e] :f :g}}} # Evaluates to {:a {:b {:c [:d :e] :f :g}}}
```

### 🔖 Changes

* Added: `merge-with` function
* Added: `deep-merge` function
