### PR TITLE
NamedInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 * Added: `merge-with` function
 * Added: `deep-merge` function
+* Added: `NamedInterface` interface for Symbol and Keyword
+* Added: `name` function
+* Added: `namespace` function
+* Added: `full-name` function
 
 ## 0.6.0 (2022-02-02)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1814,3 +1814,19 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   `(do
      (definterface* ,name ,@fns)
      ,@defs)))
+
+
+(defn name
+  "Returns the name string of a string, keyword or symbol."
+  [x]
+  (if (string? x) x (php/-> x (getName))))
+
+(defn namespace
+  "Return the namespace string of a symbol or keyword. Nil if not present."
+  [x]
+  (php/-> x (getNamespace)))
+
+(defn full-name
+  "Return the namespace and name string of a string, keyword or symbol."
+  [x]
+  (if (string? x) x (php/-> x (getFullName))))

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -11,7 +11,7 @@
 (defn- to-str [x]
   (cond
     (string? x)  x
-    (keyword? x) (php/-> x (getName))
+    (keyword? x) (name x)
     (nil? x)     ""
     (str x)))
 
@@ -126,7 +126,7 @@
 
 (defn- compile-form [form]
   (let [form-name (if (and (list? form) (symbol? (first form)))
-                    (php/-> (first form) (getName)))]
+                    (name (first form)))]
     (case form-name
       "for" (let [[_ bindings body] form]
               `(apply str (for ,bindings ,(compile-html body))))
@@ -138,7 +138,7 @@
   (for [element :in content]
     (cond
       (vector? element)         (compile-element element)
-      (keyword? element)        (escape-html (php/-> element (getName)))
+      (keyword? element)        (escape-html (name element))
       (raw-string? element)     (get element :s)
       (string? element)         (escape-html element)
       (indexed? element)        (compile-form element)

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -272,11 +272,10 @@
        true
        status))))
 
-(defn- normalize-header-name [name]
-  (when-not (or (keyword? name) (string? name))
-    (throw (php/new InvalidArgumentException (str "Header must be a keyword or string. Given: " name))))
-  (let [name (if (keyword? name) (php/-> name (getName)) name)]
-    (php/ucwords name "-")))
+(defn- normalize-header-name [header-name]
+  (when-not (or (keyword? header-name) (string? header-name))
+    (throw (php/new InvalidArgumentException (str "Header must be a keyword or string. Given: " header-name))))
+  (php/ucwords (name header-name) "-"))
 
 (defn- emit-headers [{:status status :headers headers}]
   (when-not (php/headers_sent)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -48,12 +48,12 @@
   [sym]
   (let [resolved-sym (resolve sym)]
     (when resolved-sym
-      `(println (find-doc ,(php/-> resolved-sym (getNamespace)) ,(php/-> resolved-sym (getName)))))))
+      `(println (find-doc ,(namespace resolved-sym) ,(name resolved-sym))))))
 
 (defn- extract-alias [sym options]
   (if (:as options)
     (:as options)
-    (let [parts (php/explode "\\" (php/-> sym (getName)))
+    (let [parts (php/explode "\\" (name sym))
           last (pop parts)]
       (php/:: Symbol (create last)))))
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -189,8 +189,8 @@
 
 (defmacro deftest
   "Defines a test function with no arguments."
-  [name & body]
-  `(defn ,name {:test true :test-name ,(php/-> name (getName))} []
+  [test-name & body]
+  `(defn ,test-name {:test true :test-name ,(name test-name)} []
      ,@body))
 
 # ---------------------
@@ -317,7 +317,7 @@
   "Runs all test functions in the given namespaces."
   [options & namespaces]
   (dofor [namespace :in namespaces
-          :let [ns-name (php/-> namespace (getName))]]
+          :let [ns-name (name namespace)]]
     (run-test options ns-name))
   (print-summary))
 

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -7,7 +7,7 @@ namespace Phel\Lang;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Printer\Printer;
 
-final class Keyword extends AbstractType implements IdenticalInterface, FnInterface
+final class Keyword extends AbstractType implements IdenticalInterface, FnInterface, NamedInterface
 {
     use MetaTrait;
 
@@ -56,6 +56,15 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
     public function getNamespace(): ?string
     {
         return $this->namespace;
+    }
+
+    public function getFullName(): string
+    {
+        if ($this->namespace) {
+            return $this->namespace . '/' . $this->name;
+        }
+
+        return $this->name;
     }
 
     public function hash(): int

--- a/src/php/Lang/NamedInterface.php
+++ b/src/php/Lang/NamedInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+interface NamedInterface
+{
+    /**
+     * Return the name of the object.
+     */
+    public function getName(): string;
+
+    /**
+     * Return the namespace of the object.
+     */
+    public function getNamespace(): ?string;
+
+    /**
+     * Return the namespace and name of the object.
+     */
+    public function getFullName(): string;
+}

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -6,7 +6,7 @@ namespace Phel\Lang;
 
 use Phel\Printer\Printer;
 
-final class Symbol extends AbstractType implements IdenticalInterface
+final class Symbol extends AbstractType implements IdenticalInterface, NamedInterface
 {
     use MetaTrait;
 

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -1,5 +1,6 @@
 (ns phel-test\test\core
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is])
+  (:use Phel\Lang\Symbol))
 
 # -------------
 # Destructuring
@@ -70,3 +71,22 @@
   (is (false? (var? 10)) "var? return false if x is a number")
   (is (= 20 (let [x (var 10)] (set! x 20) (deref x))) "set new value to variable")
   (is (= 11 (let [x (var 10)] (swap! x + 1) (deref x))) "swap a value by incrementing the number"))
+
+
+(deftest test-name
+  (is (= "string" (name "string")) "name on string")
+  (is (= "symbol" (name 'symbol)) "name on symbol")
+  (is (= "keyword" (name :keyword)) "name of keyword"))
+
+(deftest test-namespace
+  (is (= nil (namespace 'symbol)) "namespace on symbol without ns")
+  (is (= nil (namespace :keyword)) "namespace of keyword without ns")
+  (is (= "test" (namespace (php/:: Symbol (createForNamespace "test" "symbol")))) "namespace on symbol with ns")
+  (is (= "phel-test\\test\\core" (namespace ::keyword)) "namespace of keyword with ns"))
+
+(deftest test-full-name
+  (is (= "string" (name "string")) "full-name on string")
+  (is (= "symbol" (full-name 'symbol)) "full-name on symbol without ns")
+  (is (= "keyword" (full-name :keyword)) "full-name of keyword without ns")
+  (is (= "test/symbol" (full-name (php/:: Symbol (createForNamespace "test" "symbol")))) "full-name on symbol with ns")
+  (is (= "phel-test\\test\\core/keyword" (full-name ::keyword)) "full-name of keyword with ns"))


### PR DESCRIPTION
### 🤔 Background

`\Phel\Lang\Symbol` and `\Phel\Lang\Keyword` have both the methods `getName`, `getNamespace` and `getFullName`.

### 💡 Goal

Put the three methods into a unified Interface and let Symbol and Keyword implement these interface. Additionally, add functions in Phel's core library to call these methods. Use the new functions in the rest of the code.

The function `name` and `full-name` also support strings. This is quite useful to convert Hash Map to PHP arrays. Example:
```
(def data {:foo "value" "bar" "value2"})

(->> data
       (map-indexed (fn [k v] [(name k) v]))
       (flatten)
       (apply php-associative-array))
```

### 🔖 Changes

* Added: `NamedInterface` interface for Symbol and Keyword
* Added: `name` function
* Added: `namespace` function
* Added: `full-name` function
* Use the added function in the rest of the code.
