### PR TITLE
Improve phel\http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 * Added: `name` function
 * Added: `namespace` function
 * Added: `full-name` function
+* Added: `http/uri-from-string` function
+* Added: Uri structs implements `Stringable` interface
+* Added: `http/response-from-map` function
+* Deprecated: `http/create-response-from-map` in favor of `http/response-from-map`
+* Added: `http/response-from-string` function
+* Deprecated: `http/create-response-from-string` in favor of `http/response-from-string`
+* Added: `attributes` field to `request` struct. Allows developers to enrich the request with custom data
+* Added: `http/request-from-map` function
 
 ## 0.6.0 (2022-02-02)
 

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -182,6 +182,7 @@
                     server-params # Map with alle server parameters ($_SERVER)
                     uploaded-files # Array of normalized uploaded files ($_FILES)
                     version # HTTP Version
+                    attributes # consumer specific data to enrich the request
 ])
 
 
@@ -219,7 +220,8 @@
      (php-array-to-map cookies)
      (php-array-to-map server)
      (normalize-files files)
-     version)))
+     version
+     {})))
 
 (defn request-from-globals
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE` and `$_FILES`."

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -295,7 +295,7 @@
                         510 "Not Extended"
                         511 "Network Authentication Required"})
 
-(defn create-response-from-map
+(defn response-from-map
   "Creates a response struct from a map. The map can have the following keys:
   * `:status` The HTTP Status (default 200)
   * `:headers` A map of HTTP Headers (default: empty map)
@@ -310,10 +310,14 @@
         reason (or reason (get response-phrases status) "")]
     (response status headers body version reason)))
 
-(defn create-response-from-string
+(def create-response-from-map {:deprecated "Use response-from-map"} response-from-map)
+
+(defn response-from-string
   "Create a response from a string."
   [s]
   (create-response-from-map {:body s}))
+
+(def create-response-from-string {:deprecated "Use response-from-string"} response-from-string)
 
 (defn- emit-status-line [{:status status :reason reason :version version}]
   (when-not (php/headers_sent)

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -1,11 +1,36 @@
 (ns phel\http
-  (:use InvalidArgumentException))
+  (:use InvalidArgumentException)
+  (:use Stringable))
 
 # ---
 # URI
 # ---
 
-(defstruct uri [scheme userinfo host port path query fragment])
+(defstruct uri [scheme userinfo host port path query fragment]
+  Stringable
+  (__toString [this]
+    (let [authority (str host)
+          authority (if (and userinfo (not= userinfo ""))
+                      (str userinfo "@" authority)
+                      authority)
+          authority (if port
+                      (str authority ":" port)
+                      authority)
+          res ""
+          res (if (and scheme (not= scheme ""))
+                (str res scheme ":")
+                res)
+          res (if (or (not= authority "") (= scheme "file"))
+                (str res "//" authority)
+                res)
+          res (str res path)
+          res (if (and query (not= query ""))
+                (str res "?" query)
+                res)
+          res (if (and fragment (not= fragment ""))
+                (str res "#" fragment)
+                res)]
+      res)))
 
 (def- uri-host-port-regex "/^(.+)\:(\d+)$/")
 
@@ -38,6 +63,38 @@
         query  (get server "QUERY_STRING")
         [h p]  (host-and-port-from-globals server)]
     (uri scheme nil h p path query nil)))
+
+# See: https://www.php.net/manual/en/function.parse-url.php#114817
+(defn- encode-utf-8-url
+  "Prepares utf-8 urls form php/parse-url."
+  [url]
+  (php/preg_replace_callback
+   "%[^:/@?&=#]+%usD"
+   (fn [matches] (php/urlencode (php/aget matches 0)))
+   url))
+
+(defn uri-from-string
+  "Create a uri struct from a string"
+  [url]
+  (let [matches (php/array)
+        [prefix url] (if (one? (php/preg_match "%^(.*://\\[[0-9:a-f]+\\])(.*?)$%" url matches))
+                       [(php/aget matches 1) (php/aget matches 2)]
+                       ["" url])
+        encodedUrl (encode-utf-8-url url)
+        parts (php/parse_url (str prefix encodedUrl))
+        parts (php/array_map php/urldecode parts)]
+    (when-not parts
+      (throw (php/new InvalidArgumentException (str "This is not a valid uri: " url))))
+    (uri
+     (php/aget parts "scheme")
+     (if (php/aget parts "pass")
+       (str (php/aget parts "user") ":" (php/aget parts "pass"))
+       (php/aget parts "user"))
+     (php/aget parts "host")
+     (when (php/aget parts "port") (php/intval (php/aget parts "port")))
+     (php/aget parts "path")
+     (php/aget parts "query")
+     (php/aget parts "fragment"))))
 
 # -----
 # Files

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -185,7 +185,6 @@
                     attributes # consumer specific data to enrich the request
 ])
 
-
 (defn- get-method-from-globals
   "Extracts the request method from `$_SERVER`."
   [& [server]]
@@ -227,6 +226,33 @@
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE` and `$_FILES`."
   []
   (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES))
+
+(defn request-from-map
+  [{:method method
+    :uri uri
+    :headers headers
+    :parsed-body parsed-body
+    :query-params query-params
+    :cookie-params cookie-params
+    :server-params server-params
+    :uploded-files uploaded-files
+    :version version
+    :attributes attributes}]
+  (request
+   method
+   (cond
+     (string? uri) (uri-from-string uri)
+     (uri? uri) uri
+     (nil? uri) nil
+     (throw (php/new InvalidArgumentException "Invalid :uri provided. Must be nil, string or uri")))
+   (or headers {})
+   parsed-body
+   (or query-params {})
+   (or cookie-params {})
+   (or server-params {})
+   (or uploaded-files [])
+   (or version "1.1")
+   (or attributes {})))
 
 # --------
 # Response

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -286,31 +286,31 @@
 (deftest test-response
   (is (=
        (h/response 200 {} "" "1.1" "OK")
-       (h/create-response-from-map {})) "create-response-from-map empty")
+       (h/response-from-map {})) "response-from-map empty")
 
   (is (=
        (h/response 201 {} "" "1.1" "Created")
-       (h/create-response-from-map {:status 201})) "create-response-from-map status")
+       (h/response-from-map {:status 201})) "response-from-map status")
 
   (is (=
        (h/response 200 {:content-type "text/plain"} "" "1.1" "OK")
-       (h/create-response-from-map {:headers {:content-type "text/plain"}})) "create-response-from-map headers")
+       (h/response-from-map {:headers {:content-type "text/plain"}})) "response-from-map headers")
 
   (is (=
        (h/response 200 {} "hello" "1.1" "OK")
-       (h/create-response-from-map {:body "hello"})) "create-response-from-map body")
+       (h/response-from-map {:body "hello"})) "response-from-map body")
 
   (is (=
        (h/response 200 {} "" "2.0" "OK")
-       (h/create-response-from-map {:version "2.0"})) "create-response-from-map version")
+       (h/response-from-map {:version "2.0"})) "response-from-map version")
 
   (is (=
        (h/response 200 {} "" "1.1" "Yes!")
-       (h/create-response-from-map {:reason "Yes!"})) "create-response-from-map reason")
+       (h/response-from-map {:reason "Yes!"})) "response-from-map reason")
 
   (is (=
        (h/response 200 {} "test" "1.1" "OK")
-       (h/create-response-from-string "test")) "create-response-from-string"))
+       (h/response-from-string "test")) "response-from-string"))
 
 (def send-response-examples [["send body"
                               (h/response 200 {:content-type "text/plain"} "Content!" nil nil)

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -275,6 +275,34 @@
         :version))
       "server protocol 2.0"))
 
+(deftest request-from-map
+  (is (= (h/request nil nil {} nil {} {} {} [] "1.1" {})
+         (h/request-from-map {})))
+  (is (= (h/request nil (h/uri "http" nil "example.com" nil nil nil nil) {} nil {} {} {} [] "1.1" {})
+         (h/request-from-map {:uri "http://example.com"})))
+  (is (= (h/request
+          "GET"
+          (h/uri "http" nil "example.com" nil nil nil nil)
+          {:content-type "application/json"}
+          {:foo "bar"}
+          {:foobar "foobar"}
+          {:session "xyz"}
+          {:param "str"}
+          []
+          "1.0"
+          {:route "my-route"})
+        (h/request-from-map
+         {:method "GET"
+          :uri (h/uri "http" nil "example.com" nil nil nil nil)
+          :headers {:content-type "application/json"}
+          :parsed-body {:foo "bar"}
+          :query-params {:foobar "foobar"}
+          :cookie-params {:session "xyz"}
+          :server-params {:param "str"}
+          :uploded-files []
+          :version "1.0"
+          :attributes {:route "my-route"}}))))
+
 # --------
 # Response
 # --------

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -53,6 +53,39 @@
   (foreach [[name uri server] uri-examples]
     (is (= uri (h/uri-from-globals server)) name)))
 
+(deftest uri-to-string
+  (is (= "https://user:pass@example.com:8080/path/123?q=abc#test"
+         (str (h/uri "https" "user:pass" "example.com" 8080 "/path/123" "q=abc" "test")))))
+
+(deftest parse-uri-from-string
+  (is (= (h/uri "https" "user:pass" "example.com" 8080 "/path/123" "q=abc" "test")
+         (h/uri-from-string "https://user:pass@example.com:8080/path/123?q=abc#test"))
+      "basic url")
+  (is (= (h/uri "http" nil "[2a00:f48:1008::212:183:10]" 56 nil "foo=bar" nil)
+         (h/uri-from-string "http://[2a00:f48:1008::212:183:10]:56?foo=bar"))
+      "IPv6 uri")
+  (is (= (h/uri "https" nil "яндекс.рф" nil nil nil nil)
+         (h/uri-from-string "https://яндекс.рф"))
+      "internaltional domain names"))
+
+(deftest test-parse-and-stringify-urls
+  (foreach [url ["urn:path-rootless"
+                 "urn:path:with:colon"
+                 "urn:/path-absolute"
+                 "urn:/"
+                 "urn:"
+                 "/"
+                 "relative/"
+                 "0"
+                 ""
+                 "//example.org"
+                 "//example.org/"
+                 "//example.org?q#h"
+                 "?q"
+                 "?q=abc&foo=bar"
+                 "#fragment"
+                 "./foo/../bar"]]
+    (is (= url (str (h/uri-from-string url))) url)))
 
 # -----
 # FILES


### PR DESCRIPTION
### 💡 Goal

Improve `phel\http`

### 🔖 Changes

* Added: `http/uri-from-string` function
* Added: Uri structs implements `Stringable` interface
* Added: `http/response-from-map` function
* Deprecated: `http/create-response-from-map` in favor of `http/response-from-map`
* Added: `http/response-from-string` function
* Deprecated: `http/create-response-from-string` in favor of `http/response-from-string`
* Added: `attributes` field to `request` struct. Allows developers to enrich the request with custom data
* Added: `http/request-from-map` function
