### PR TITLE
Emit PHP array literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 * Added: `attributes` field to `request` struct. Allows developers to enrich the request with custom data
 * Added: `http/request-from-map` function
 * Bugfix: #443
+* Added: Support for PHP Array literals (#451)
 
 ## 0.6.0 (2022-02-02)
 

--- a/src/php/Compiler/Analyzer/Analyzer.php
+++ b/src/php/Compiler/Analyzer/Analyzer.php
@@ -119,7 +119,7 @@ final class Analyzer implements AnalyzerInterface
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $x
+     * @param TypeInterface|string|float|int|bool|null|array $x
      */
     private function isLiteral($x): bool
     {
@@ -128,6 +128,7 @@ final class Analyzer implements AnalyzerInterface
             || is_int($x)
             || is_bool($x)
             || $x === null
-            || $x instanceof Keyword;
+            || $x instanceof Keyword
+            || is_array($x);
     }
 }

--- a/src/php/Compiler/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/LiteralEmitter.php
@@ -28,7 +28,7 @@ final class LiteralEmitter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $x The value
+     * @param TypeInterface|string|float|int|bool|null|array $x The value
      */
     public function emitLiteral($x): void
     {
@@ -52,6 +52,8 @@ final class LiteralEmitter
             $this->emitVector($x);
         } elseif ($x instanceof PersistentListInterface) {
             $this->emitList($x);
+        } elseif (is_array($x)) {
+            $this->emitArray($x);
         } else {
             $typeName = gettype($x);
             if ($typeName === 'object') {
@@ -185,5 +187,23 @@ final class LiteralEmitter
             $this->outputEmitter->decreaseIndentLevel();
         }
         $this->outputEmitter->emitStr('])', $x->getStartLocation());
+    }
+
+    private function emitArray(array $x): void
+    {
+        $this->outputEmitter->emitStr('[');
+        $count = count($x);
+        $index = 0;
+        foreach ($x as $key => $value) {
+            $this->outputEmitter->emitLiteral($key);
+            $this->outputEmitter->emitStr(' => ');
+            $this->outputEmitter->emitLiteral($value);
+            if ($index < $count - 1) {
+                $this->outputEmitter->emitStr(', ');
+            }
+
+            $index++;
+        }
+        $this->outputEmitter->emitStr(']');
     }
 }

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -1,0 +1,46 @@
+--PHEL--
+(def x :macro (fn [x] (php/array 1 2 (php/array 3 4))))
+
+(def y (x 1))
+--PHP--
+\Phel\Lang\Registry::getInstance()->addDefinition(
+  "user",
+  "x",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\x";
+
+    public function __invoke($x) {
+      return array(1, 2, array(3, 4));
+    }
+  },
+  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
+      \Phel\Lang\Keyword::create("line"), 1,
+      \Phel\Lang\Keyword::create("column"), 0
+    ),
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
+      \Phel\Lang\Keyword::create("line"), 1,
+      \Phel\Lang\Keyword::create("column"), 55
+    )
+  )
+);
+\Phel\Lang\Registry::getInstance()->addDefinition(
+  "user",
+  "y",
+  [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
+  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
+      \Phel\Lang\Keyword::create("line"), 3,
+      \Phel\Lang\Keyword::create("column"), 0
+    ),
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
+      \Phel\Lang\Keyword::create("line"), 3,
+      \Phel\Lang\Keyword::create("column"), 13
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
@@ -38,4 +38,13 @@ final class AnalyzeLiteralTest extends TestCase
             $this->literalAnalzyer->analyze(2, $env)
         );
     }
+
+    public function test_array_literal(): void
+    {
+        $env = NodeEnvironment::empty();
+        self::assertEquals(
+            new LiteralNode($env, [1, 2], null),
+            $this->literalAnalzyer->analyze([1, 2], $env)
+        );
+    }
 }


### PR DESCRIPTION
With this commit it is possible to emit PHP array literals. This is useful if a macro wants to return a PHP array.

### 🤔 Background

Macros can currently only return Phel data structures. For some use cases it is useful to also allow PHP arrays as return type.

### 💡 Goal

This PR makes it possible to emit PHP array literals. Example:

```clojure
(defn build-some-php-array []
  (php/array 1 2))

(defmacro macro-returns-php-array []
  (build-some-php-array))
```
