### PR TITLE
Update gacela bootstrap in phel static helper

### DIFF
--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel;
 
+use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Gacela;
 use Phel\Run\RunFacade;
 
@@ -15,11 +16,9 @@ final class Phel
     public static function run(string $projectRootDir, string $namespace): void
     {
         Gacela::bootstrap($projectRootDir, [
-            'config' => [
-                'type' => 'php',
-                'path' => 'phel-config.php',
-                'path_local' => 'phel-config_local.php',
-            ],
+            'config' => static function (ConfigBuilder $configBuilder): void {
+                $configBuilder->add('phel-config.php', 'phel-config-local.php');
+            },
         ]);
 
         $runFacade = new RunFacade();

--- a/tests/php/Benchmark/Phel/PhelBench.php
+++ b/tests/php/Benchmark/Phel/PhelBench.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Phel;
+
+use Phel\Build\BuildFacade;
+use Phel\Compiler\Analyzer\Environment\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Phel;
+
+/**
+ * @BeforeMethods("setUp")
+ * @Revs(5)
+ * @Iterations(2)
+ */
+final class PhelBench
+{
+    public function setUp(): void
+    {
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        (new BuildFacade())->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core')
+        );
+    }
+
+    public function bench_phel_run(): void
+    {
+        Phel::run(__DIR__ . '/../../../../', 'phel\\core');
+    }
+}


### PR DESCRIPTION
### 🤔 Background

When updating to gacela 0.14 we forgot to update the `Phel::run()` method, on which we are actually using `Gacela::bootstrap()`. This happened mainly because we didn't have any tests covering/using this code.

### 🔖 Changes

- Update the `Phel::run()` internal method to use the new gacela version code.
- Add a Bench test which is executing the `Phel::run()` so we wont have this problem in the future anymore. 
