### PR TITLE
Printer module using php80

### DIFF
--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -62,20 +62,13 @@ final class Printer implements PrinterInterface
 
     /**
      * Converts a form to a printable string.
-     *
-     * @param mixed $form The form to print
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
-        $printer = $this->createTypePrinter($form);
-
-        return $printer->print($form);
+        return $this->createTypePrinter($form)->print($form);
     }
 
-    /**
-     * @param mixed $form The form to print
-     */
-    private function createTypePrinter($form): TypePrinterInterface
+    private function createTypePrinter(mixed $form): TypePrinterInterface
     {
         if (is_object($form)) {
             return $this->createObjectTypePrinter($form);
@@ -84,10 +77,7 @@ final class Printer implements PrinterInterface
         return $this->creatScalarTypePrinter($form);
     }
 
-    /**
-     * @param mixed $form The form to print
-     */
-    private function createObjectTypePrinter($form): TypePrinterInterface
+    private function createObjectTypePrinter(mixed $form): TypePrinterInterface
     {
         if ($form instanceof PersistentListInterface) {
             return new PersistentListPrinter($this);

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -79,6 +79,9 @@ final class Printer implements PrinterInterface
 
     private function createObjectTypePrinter(mixed $form): TypePrinterInterface
     {
+        if ($form instanceof AbstractPersistentStruct) {
+            return new StructPrinter($this);
+        }
         if ($form instanceof PersistentListInterface) {
             return new PersistentListPrinter($this);
         }
@@ -96,9 +99,6 @@ final class Printer implements PrinterInterface
         }
         if ($form instanceof Symbol) {
             return new SymbolPrinter($this->withColor);
-        }
-        if ($form instanceof AbstractPersistentStruct) {
-            return new StructPrinter($this);
         }
         if (method_exists($form, '__toString')) {
             return new ToStringPrinter();

--- a/src/php/Printer/PrinterInterface.php
+++ b/src/php/Printer/PrinterInterface.php
@@ -8,8 +8,6 @@ interface PrinterInterface
 {
     /**
      * Converts a form to a printable string.
-     *
-     * @param mixed $form The form to print
      */
-    public function print($form): string;
+    public function print(mixed $form): string;
 }

--- a/src/php/Printer/TypePrinter/AnonymousClassPrinter.php
+++ b/src/php/Printer/TypePrinter/AnonymousClassPrinter.php
@@ -12,7 +12,7 @@ final class AnonymousClassPrinter implements TypePrinterInterface
     /**
      * @param object $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return '<PHP-AnonymousClass>';
     }

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -6,6 +6,8 @@ namespace Phel\Printer\TypePrinter;
 
 use Phel\Printer\PrinterInterface;
 
+use function array_is_list;
+
 /**
  * @implements TypePrinterInterface<array>
  */
@@ -23,18 +25,13 @@ final class ArrayPrinter implements TypePrinterInterface
     /**
      * @param array $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
-        $arr = $this->isList($form)
+        $arr = array_is_list($form)
             ? $this->formatValuesFromList($form)
             : $this->formatKeyValuesFromDict($form);
 
         return sprintf('<PHP-Array [%s]>', $this->color(implode(', ', $arr)));
-    }
-
-    private function isList(array $form): bool
-    {
-        return array_keys($form) === range(0, count($form) - 1);
     }
 
     private function formatValuesFromList(array $form): array

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -6,8 +6,6 @@ namespace Phel\Printer\TypePrinter;
 
 use Phel\Printer\PrinterInterface;
 
-use function array_is_list;
-
 /**
  * @implements TypePrinterInterface<array>
  */
@@ -27,11 +25,16 @@ final class ArrayPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        $arr = array_is_list($form)
+        $arr = $this->isList($form)
             ? $this->formatValuesFromList($form)
             : $this->formatKeyValuesFromDict($form);
 
         return sprintf('<PHP-Array [%s]>', $this->color(implode(', ', $arr)));
+    }
+
+    private function isList(array $form): bool
+    {
+        return array_keys($form) === range(0, count($form) - 1);
     }
 
     private function formatValuesFromList(array $form): array

--- a/src/php/Printer/TypePrinter/BooleanPrinter.php
+++ b/src/php/Printer/TypePrinter/BooleanPrinter.php
@@ -14,7 +14,7 @@ final class BooleanPrinter implements TypePrinterInterface
     /**
      * @param bool $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $str = ($form === true) ? 'true' : 'false';
 

--- a/src/php/Printer/TypePrinter/FnPrinter.php
+++ b/src/php/Printer/TypePrinter/FnPrinter.php
@@ -12,7 +12,7 @@ final class FnPrinter implements TypePrinterInterface
     /**
      * @param object $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return '<function>';
     }

--- a/src/php/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Printer/TypePrinter/KeywordPrinter.php
@@ -16,7 +16,7 @@ final class KeywordPrinter implements TypePrinterInterface
     /**
      * @param Keyword $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         if ($form->getNamespace()) {
             return $this->color(':' . $form->getNamespace() . '/' . $form->getName());

--- a/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
+++ b/src/php/Printer/TypePrinter/NonPrintableClassPrinter.php
@@ -14,7 +14,7 @@ final class NonPrintableClassPrinter implements TypePrinterInterface
     /**
      * @param object $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return 'Printer cannot print this type: ' . $this->color(get_class($form));
     }

--- a/src/php/Printer/TypePrinter/NullPrinter.php
+++ b/src/php/Printer/TypePrinter/NullPrinter.php
@@ -8,10 +8,7 @@ final class NullPrinter implements TypePrinterInterface
 {
     use WithColorTrait;
 
-    /**
-     * @param mixed $form
-     */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return $this->color('nil');
     }

--- a/src/php/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Printer/TypePrinter/NumberPrinter.php
@@ -14,7 +14,7 @@ final class NumberPrinter implements TypePrinterInterface
     /**
      * @param int|float $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return $this->color((string)$form);
     }

--- a/src/php/Printer/TypePrinter/ObjectPrinter.php
+++ b/src/php/Printer/TypePrinter/ObjectPrinter.php
@@ -12,7 +12,7 @@ final class ObjectPrinter implements TypePrinterInterface
     /**
      * @param object $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return '<PHP-Object(' . get_class($form) . ')>';
     }

--- a/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
@@ -22,7 +22,7 @@ final class PersistentHashSetPrinter implements TypePrinterInterface
     /**
      * @param PersistentHashSetInterface $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $values = array_map(
             fn ($elem): string => $this->printer->print($elem),

--- a/src/php/Printer/TypePrinter/PersistentListPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentListPrinter.php
@@ -22,7 +22,7 @@ final class PersistentListPrinter implements TypePrinterInterface
     /**
      * @param PersistentListInterface $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $prefix = '(';
         $suffix = ')';

--- a/src/php/Printer/TypePrinter/PersistentMapPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentMapPrinter.php
@@ -22,7 +22,7 @@ final class PersistentMapPrinter implements TypePrinterInterface
     /**
      * @param PersistentMapInterface $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $prefix = '{';
         $suffix = '}';

--- a/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
@@ -22,7 +22,7 @@ final class PersistentVectorPrinter implements TypePrinterInterface
     /**
      * @param PersistentVectorInterface $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $prefix = '[';
         $suffix = ']';

--- a/src/php/Printer/TypePrinter/ResourcePrinter.php
+++ b/src/php/Printer/TypePrinter/ResourcePrinter.php
@@ -12,7 +12,7 @@ final class ResourcePrinter implements TypePrinterInterface
     /**
      * @param resource $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return '<PHP Resource id #' . (string)$form . '>';
     }

--- a/src/php/Printer/TypePrinter/StringPrinter.php
+++ b/src/php/Printer/TypePrinter/StringPrinter.php
@@ -30,11 +30,7 @@ final class StringPrinter implements TypePrinterInterface
         $this->withColor = $withColor;
     }
 
-    /**
-     * @param string $str
-     * @param mixed $form
-     */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $str = $this->parseString($form);
 

--- a/src/php/Printer/TypePrinter/StructPrinter.php
+++ b/src/php/Printer/TypePrinter/StructPrinter.php
@@ -22,7 +22,7 @@ final class StructPrinter implements TypePrinterInterface
     /**
      * @param AbstractPersistentStruct $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         $values = array_map(
             fn ($key): string => $this->printer->print($form[$key]),

--- a/src/php/Printer/TypePrinter/SymbolPrinter.php
+++ b/src/php/Printer/TypePrinter/SymbolPrinter.php
@@ -16,7 +16,7 @@ final class SymbolPrinter implements TypePrinterInterface
     /**
      * @param Symbol $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return $this->color($form->getName());
     }

--- a/src/php/Printer/TypePrinter/ToStringPrinter.php
+++ b/src/php/Printer/TypePrinter/ToStringPrinter.php
@@ -12,7 +12,7 @@ final class ToStringPrinter implements TypePrinterInterface
     /**
      * @param object $form
      */
-    public function print($form): string
+    public function print(mixed $form): string
     {
         return $form->__toString();
     }

--- a/src/php/Printer/TypePrinter/TypePrinterInterface.php
+++ b/src/php/Printer/TypePrinter/TypePrinterInterface.php
@@ -12,5 +12,5 @@ interface TypePrinterInterface
     /**
      * @param T $form
      */
-    public function print($form): string;
+    public function print(mixed $form): string;
 }


### PR DESCRIPTION
### 🔖 Changes

- Update Printer module to use some new PHP 8.0 features
  - use mixed keyword
  - use `array_is_list` function
- Fix a (really hidden) bug  inside the `createObjectTypePrinter()`
  - The condition checking the `AbstractPersistentStruct` was never reached
