### PR TITLE
Added read-string, eval and compile function to core library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 * Added: `http/request-from-map` function
 * Bugfix: #443
 * Added: Support for PHP Array literals (#451)
+* Added: `read-string` function
+* Added: `eval` function
+* Added: `compile` function
 
 ## 0.6.0 (2022-02-02)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -27,6 +27,8 @@
   (:use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
   (:use Phel\Lang\Collections\HashSet\TransientHashSetInterface)
   (:use Phel\Lang\Variable)
+  (:use Phel\Compiler\CompilerFacade)
+  (:use Phel\Compiler\Compiler\CompileOptions)
   (:use Phel\Compiler\Emitter\OutputEmitter\Munge)
   (:use Phel\Printer\Printer)
   (:use Countable)
@@ -1830,3 +1832,26 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Return the namespace and name string of a string, keyword or symbol."
   [x]
   (if (string? x) x (php/-> x (getFullName))))
+
+(defn read-string
+  "Reads the first phel expression from the string s."
+  [s]
+  (let [cf (php/new CompilerFacade)
+        token-stream (php/-> cf (lexString s))
+        node (php/-> cf (parseNext token-stream))]
+    (when node
+      (php/-> (php/-> cf (read node)) (getAst)))))
+
+(defn eval
+  "Evaluates a form and return the evaluated results."
+  [form]
+  (let [cf (php/new CompilerFacade)
+        opts (php/new CompileOptions)]
+    (php/-> cf (evalForm form opts))))
+
+(defn compile
+  "Returns the compiled PHP code string for the given form."
+  [form]
+  (let [cf (php/new CompilerFacade)
+        opts (php/new CompileOptions)]
+    (php/-> (php/-> cf (compileForm form opts)) (getCode))))

--- a/src/php/Compiler/Compiler/CodeCompiler.php
+++ b/src/php/Compiler/Compiler/CodeCompiler.php
@@ -58,7 +58,7 @@ final class CodeCompiler implements CodeCompilerInterface
      * @throws FileException
      * @throws LexerValueException
      */
-    public function compile(string $phelCode, CompileOptions $compileOptions): EmitterResult
+    public function compileString(string $phelCode, CompileOptions $compileOptions): EmitterResult
     {
         $tokenStream = $this->lexer->lexString($phelCode, $compileOptions->getSource(), $compileOptions->getStartingLine());
 
@@ -82,6 +82,14 @@ final class CodeCompiler implements CodeCompilerInterface
             }
         }
 
+        return $this->fileEmitter->endFile($compileOptions->isSourceMapsEnabled());
+    }
+
+    public function compileForm($form, CompileOptions $compileOptions): EmitterResult
+    {
+        $this->fileEmitter->startFile($compileOptions->getSource());
+        $node = $this->analyzer->analyze($form, NodeEnvironment::empty());
+        $this->emitNode($node, $compileOptions);
         return $this->fileEmitter->endFile($compileOptions->isSourceMapsEnabled());
     }
 

--- a/src/php/Compiler/Compiler/CodeCompilerInterface.php
+++ b/src/php/Compiler/Compiler/CodeCompilerInterface.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Emitter\EmitterResult;
 use Phel\Compiler\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Exceptions\CompilerException;
+use Phel\Lang\TypeInterface;
 
 interface CodeCompilerInterface
 {
@@ -16,5 +17,14 @@ interface CodeCompilerInterface
      * @throws CompiledCodeIsMalformedException
      * @throws FileException
      */
-    public function compile(string $phelCode, CompileOptions $compileOptions): EmitterResult;
+    public function compileString(string $phelCode, CompileOptions $compileOptions): EmitterResult;
+
+    /**
+     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
+     *
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
+    public function compileForm($form, CompileOptions $compileOptions): EmitterResult;
 }

--- a/src/php/Compiler/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/Compiler/EvalCompiler.php
@@ -60,7 +60,7 @@ final class EvalCompiler implements EvalCompilerInterface
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $phelCode, CompileOptions $compileOptions)
+    public function evalString(string $phelCode, CompileOptions $compileOptions): mixed
     {
         $tokenStream = $this->lexer->lexString($phelCode, $compileOptions->getSource(), $compileOptions->getStartingLine());
 
@@ -89,6 +89,11 @@ final class EvalCompiler implements EvalCompilerInterface
         return $result;
     }
 
+    public function evalForm($form, CompileOptions $compileOptions): mixed
+    {
+        $node = $this->analyzer->analyze($form, NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN));
+        return $this->evalNode($node, $compileOptions);
+    }
     /**
      * @throws CompilerException
      */

--- a/src/php/Compiler/Compiler/EvalCompilerInterface.php
+++ b/src/php/Compiler/Compiler/EvalCompilerInterface.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Compiler;
 
 use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Compiler\Parser\Exceptions\UnfinishedParserException;
+use Phel\Lang\TypeInterface;
 
 interface EvalCompilerInterface
 {
@@ -16,5 +17,16 @@ interface EvalCompilerInterface
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $phelCode, CompileOptions $compileOptions);
+    public function evalString(string $phelCode, CompileOptions $compileOptions): mixed;
+
+    /**
+     * Evaluates a provided Phel form.
+     *
+     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
+     *
+     * @throws CompilerException|UnfinishedParserException
+     *
+     * @return mixed The result of the executed code
+     */
+    public function evalForm($form, CompileOptions $compileOptions): mixed;
 }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -46,11 +46,18 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $phelCode, CompileOptions $compileOptions)
+    public function eval(string $phelCode, CompileOptions $compileOptions): mixed
     {
         return $this->getFactory()
             ->createEvalCompiler()
-            ->eval($phelCode, $compileOptions);
+            ->evalString($phelCode, $compileOptions);
+    }
+
+    public function evalForm($form, CompileOptions $compileOptions): mixed
+    {
+        return $this->getFactory()
+            ->createEvalCompiler()
+            ->evalForm($form, $compileOptions);
     }
 
     /**
@@ -62,7 +69,21 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
     {
         return $this->getFactory()
             ->createCodeCompiler($compileOptions)
-            ->compile($phelCode, $compileOptions);
+            ->compileString($phelCode, $compileOptions);
+    }
+
+    /**
+     * @param TypeInterface|string|float|int|bool|null $form
+     *
+     * @throws CompilerException
+     * @throws CompiledCodeIsMalformedException
+     * @throws FileException
+     */
+    public function compileForm($form, CompileOptions $compileOptions): EmitterResult
+    {
+        return $this->getFactory()
+            ->createCodeCompiler($compileOptions)
+            ->compileForm($form, $compileOptions);
     }
 
     /**

--- a/src/php/Compiler/CompilerFacadeInterface.php
+++ b/src/php/Compiler/CompilerFacadeInterface.php
@@ -43,7 +43,17 @@ interface CompilerFacadeInterface
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $phelCode, CompileOptions $compileOptions);
+    public function eval(string $phelCode, CompileOptions $compileOptions): mixed;
+
+    /**
+     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
+     * @param CompileOptions $evalOptions The evaluation options
+     *
+     * @throws CompilerException
+     *
+     * @return mixed The evaluated result
+     */
+    public function evalForm($form, CompileOptions $compileOptions): mixed;
 
     /**
      * Compiles the given phel code to PHP code.

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -90,3 +90,13 @@
   (is (= "keyword" (full-name :keyword)) "full-name of keyword without ns")
   (is (= "test/symbol" (full-name (php/:: Symbol (createForNamespace "test" "symbol")))) "full-name on symbol with ns")
   (is (= "phel-test\\test\\core/keyword" (full-name ::keyword)) "full-name of keyword with ns"))
+
+(deftest test-read-string
+  (is (= '(+ 1 1) (read-string "(+ 1 1)")) "read simple expression")
+  (is (= nil (read-string "")) "read empty string"))
+
+(deftest test-eval-form
+  (is (= 2 (eval '(+ 1 1))) "eval simple expression"))
+
+(deftest test-compile-form
+  (is (= "(1 + 1);" (compile '(+ 1 1))) "compile simple expression"))


### PR DESCRIPTION
### 🤔 Background

Add some more function to core library

### 💡 Goal / Changes

The following functions have been added:

* `read-string`: Takes a string and returns the parsed expression
* `eval`: Takes a Phel form and evaluates it
* `compile`: Takes a Phel form and return the compiled PHP code.
