### PR TITLE
Create a ConsoleBootstrap

### DIFF
--- a/phel
+++ b/phel
@@ -6,17 +6,13 @@ declare(strict_types=1);
 use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Setup\SetupGacela;
-use Phel\Build\BuildFacade;
-use Phel\Formatter\FormatterFacade;
-use Phel\Interop\InteropFacade;
-use Phel\Run\RunFacade;
-use Symfony\Component\Console\Application;
+use Phel\Console\Infrastructure\ConsoleBootstrap;
 
 $projectRootDir = getcwd() . DIRECTORY_SEPARATOR;
 $autoloadPath = $projectRootDir . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
 if (!file_exists($autoloadPath)) {
-    exit("Cannot load composer's autoload file: $autoloadPath\n");
+    exit("Cannot load composer's autoload file: {$autoloadPath}\n");
 }
 
 require $autoloadPath;
@@ -28,16 +24,5 @@ $setupGacela = (new SetupGacela())
 
 Gacela::bootstrap($projectRootDir, $setupGacela);
 
-$interopFacade = new InteropFacade();
-$formatterFacade = new FormatterFacade();
-$runFacade = new RunFacade();
-$buildFacade = new BuildFacade();
-
-$application = new Application();
-$application->add($interopFacade->getExportCommand());
-$application->add($formatterFacade->getFormatCommand());
-$application->add($runFacade->getReplCommand());
-$application->add($runFacade->getRunCommand());
-$application->add($runFacade->getTestCommand());
-$application->add($buildFacade->getCompileCommand());
-$application->run();
+$bootstrap = new ConsoleBootstrap();
+$bootstrap->run();

--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -15,59 +15,20 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
 {
     public const COMMANDS = 'COMMANDS';
 
-    private const FACADE_INTEROP = 'FACADE_INTEROP';
-    private const FACADE_FORMATTER = 'FACADE_FORMATTER';
-    private const FACADE_RUN = 'FACADE_RUN';
-    private const FACADE_BUILD = 'FACADE_BUILD';
-
     public function provideModuleDependencies(Container $container): void
     {
-        $this->addFacadeCompiler($container);
-        $this->addFacadeFormatter($container);
-        $this->addFacadeRun($container);
-        $this->addFacadeBuild($container);
+        $interopFacade = new InteropFacade();
+        $formatterFacade = new FormatterFacade();
+        $runFacade = new RunFacade();
+        $buildFacade = new BuildFacade();
 
-        $this->addCommands($container);
-    }
-
-
-    private function addFacadeCompiler(Container $container): void
-    {
-        $container->set(self::FACADE_INTEROP, static function (Container $container) {
-            return $container->getLocator()->get(InteropFacade::class);
-        });
-    }
-
-    private function addFacadeFormatter(Container $container): void
-    {
-        $container->set(self::FACADE_FORMATTER, static function (Container $container) {
-            return $container->getLocator()->get(FormatterFacade::class);
-        });
-    }
-
-    private function addFacadeRun(Container $container): void
-    {
-        $container->set(self::FACADE_RUN, static function (Container $container) {
-            return $container->getLocator()->get(RunFacade::class);
-        });
-    }
-
-    private function addFacadeBuild(Container $container): void
-    {
-        $container->set(self::FACADE_BUILD, static function (Container $container) {
-            return $container->getLocator()->get(BuildFacade::class);
-        });
-    }
-
-    private function addCommands(Container $container): void
-    {
         $container->set(self::COMMANDS, static fn () => [
-            $container->get(self::FACADE_INTEROP)->getExportCommand(),
-            $container->get(self::FACADE_FORMATTER)->getFormatCommand(),
-            $container->get(self::FACADE_RUN)->getReplCommand(),
-            $container->get(self::FACADE_RUN)->getRunCommand(),
-            $container->get(self::FACADE_RUN)->getTestCommand(),
-            $container->get(self::FACADE_BUILD)->getCompileCommand(),
+            $interopFacade->getExportCommand(),
+            $formatterFacade->getFormatCommand(),
+            $runFacade->getReplCommand(),
+            $runFacade->getRunCommand(),
+            $runFacade->getTestCommand(),
+            $buildFacade->getCompileCommand(),
         ]);
     }
 }

--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console;
+
+use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\Container\Container;
+use Phel\Build\BuildFacade;
+use Phel\Formatter\FormatterFacade;
+use Phel\Interop\InteropFacade;
+use Phel\Run\RunFacade;
+
+final class ConsoleDependencyProvider extends AbstractDependencyProvider
+{
+    public const COMMANDS = 'COMMANDS';
+
+    private const FACADE_INTEROP = 'FACADE_INTEROP';
+    private const FACADE_FORMATTER = 'FACADE_FORMATTER';
+    private const FACADE_RUN = 'FACADE_RUN';
+    private const FACADE_BUILD = 'FACADE_BUILD';
+
+    public function provideModuleDependencies(Container $container): void
+    {
+        $this->addFacadeCompiler($container);
+        $this->addFacadeFormatter($container);
+        $this->addFacadeRun($container);
+        $this->addFacadeBuild($container);
+
+        $this->addCommands($container);
+    }
+
+
+    private function addFacadeCompiler(Container $container): void
+    {
+        $container->set(self::FACADE_INTEROP, static function (Container $container) {
+            return $container->getLocator()->get(InteropFacade::class);
+        });
+    }
+
+    private function addFacadeFormatter(Container $container): void
+    {
+        $container->set(self::FACADE_FORMATTER, static function (Container $container) {
+            return $container->getLocator()->get(FormatterFacade::class);
+        });
+    }
+
+    private function addFacadeRun(Container $container): void
+    {
+        $container->set(self::FACADE_RUN, static function (Container $container) {
+            return $container->getLocator()->get(RunFacade::class);
+        });
+    }
+
+    private function addFacadeBuild(Container $container): void
+    {
+        $container->set(self::FACADE_BUILD, static function (Container $container) {
+            return $container->getLocator()->get(BuildFacade::class);
+        });
+    }
+
+    private function addCommands(Container $container): void
+    {
+        $container->set(self::COMMANDS, static fn () => [
+            $container->get(self::FACADE_INTEROP)->getExportCommand(),
+            $container->get(self::FACADE_FORMATTER)->getFormatCommand(),
+            $container->get(self::FACADE_RUN)->getReplCommand(),
+            $container->get(self::FACADE_RUN)->getRunCommand(),
+            $container->get(self::FACADE_RUN)->getTestCommand(),
+            $container->get(self::FACADE_BUILD)->getCompileCommand(),
+        ]);
+    }
+}

--- a/src/php/Console/ConsoleFactory.php
+++ b/src/php/Console/ConsoleFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console;
+
+use Gacela\Framework\AbstractFactory;
+
+final class ConsoleFactory extends AbstractFactory
+{
+    public function getConsoleCommands(): array
+    {
+        return $this->getProvidedDependency(ConsoleDependencyProvider::COMMANDS);
+    }
+}

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure;
+
+use Phel\Console\ConsoleFactory;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+final class ConsoleBootstrap extends Application
+{
+    /**
+     * @return array<string,Command>
+     */
+    protected function getDefaultCommands(): array
+    {
+        $commands = parent::getDefaultCommands();
+
+        $consoleFactory = new ConsoleFactory();
+
+        foreach ($consoleFactory->getConsoleCommands() as $command) {
+            $commands[$command->getName()] = $command;
+        }
+
+        return $commands;
+    }
+}


### PR DESCRIPTION
### 🤔 Background

Currently all console commands are created inside the `phel` file, the entry point of phel. I would delegate the responsibility of the command creation in another place like a Console module.

### 🔖 Changes

- Created a `ConsoleBootstrap` which extends Application Symfony Command.
- Define all phel commands inside the `ConsoleDependencyProvider`.
