### PR TITLE
Install PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,11 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-ansi --no-progress
 
-      - name: Run vimeo/psalm on internal code
+      - name: Run Psalm on internal code
         run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=${{ matrix.php }}
+
+      - name: Run PHPStan on internal code
+        run: ./vendor/bin/phpstan --memory-limit=516M --debug -vvv
 
   compiler-tests:
     name: Compiler tests on PHP ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "symfony/var-dumper": "^5.4",
         "friendsofphp/php-cs-fixer": "^3.8",
         "phpmetrics/phpmetrics": "^2.8",
-        "phpbench/phpbench": "^1.2"
+        "phpbench/phpbench": "^1.2",
+        "phpstan/phpstan": "^1.5"
     },
     "autoload": {
         "psr-4": {
@@ -45,12 +46,18 @@
         ],
         "test-quality": [
             "@csrun",
-            "@psalm"
+            "@psalm",
+            "@phpstan"
+        ],
+        "static-clear-cache": [
+            "vendor/bin/psalm --clear-cache",
+            "vendor/bin/phpstan clear-result-cache"
         ],
         "test-compiler": "./vendor/bin/phpunit --testsuite=integration,unit",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=integration,unit --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",
         "test-core": "./phel test",
         "psalm": "./vendor/bin/psalm --no-cache",
+        "phpstan": "./vendor/bin/phpstan --memory-limit=516M",
         "csfix": "./vendor/bin/php-cs-fixer fix",
         "csrun": "./vendor/bin/php-cs-fixer fix --dry-run",
         "phpbench": "./vendor/bin/phpbench run --report=aggregate --ansi",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6994a3c63e5482e0e934cd640e40ea94",
+    "content-hash": "f432e93b23df530da830ff78807bb29b",
     "packages": [
         {
             "name": "gacela-project/gacela",
@@ -2778,6 +2778,65 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "bbf68cae24f6dc023c607ea0f87da55dd9d55c2b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bbf68cae24f6dc023c607ea0f87da55dd9d55c2b",
+                "reference": "bbf68cae24f6dc023c607ea0f87da55dd9d55c2b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-03T12:39:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,27 @@
+parameters:
+    level: 1
+    parallel:
+        maximumNumberOfProcesses: 4
+        processTimeout: 3000.0
+    paths:
+        - %currentWorkingDirectory%/src/
+    excludePaths:
+        - '%currentWorkingDirectory%/src/php/Printer/Printer.php'
+        - '%currentWorkingDirectory%/src/php/Printer/TypePrinter/StructPrinter.php'
+        - '%currentWorkingDirectory%/src/php/Lang/TypeFactory.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/HashSet/PersistentHashSet.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/HashSet/TransientHashSet.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Map/AbstractPersistentMap.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Map/TransientHashMap.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Map/TransientArrayMap.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Map/PersistentHashMap.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Map/PersistentArrayMap.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Vector/TransientVector.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Vector/RangeIterator.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Vector/PersistentVector.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Vector/AbstractPersistentVector.php'
+        - '%currentWorkingDirectory%/src/php/Lang/Collections/Vector/SubVector.php'
+        - '%currentWorkingDirectory%/src/php/Compiler/Reader/QuasiquoteTransformer.php'
+        - '%currentWorkingDirectory%/src/php/Compiler/Emitter/OutputEmitter/LiteralEmitter.php'
+

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -45,9 +45,7 @@ class PersistentList extends AbstractType implements PersistentListInterface
     }
 
     /**
-     * @template TT
-     *
-     * @return EmptyList<TT>
+     * @return EmptyList<T>
      */
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): PersistentListInterface
     {


### PR DESCRIPTION
### 🤔 Background

Similar like Psalm, PHPStan is another static analysis tool for PHP which catches a lot of other things that Psalm doesn't. Currently it's not possible to install PHPStan at any higher level but the minimum (level 1; the highest level in PHPStan is 9|max).

### 💡 Goal

Use PHPStan to spot potential bugs in the project, and so improve the quality overall. Starting with the min level and upgrading it to higher levels step by step.

### 🔖 Changes

- Install PHPStan with level 1 - the lowest level (for now).
- In the `phpstan.neon` you can see that I'm excluding a lot of paths. The reason: `Child process error (exit code 255): PHP Fatal error:  Allowed memory size of 541065216 bytes exhausted (tried to allocate 262144 bytes) in [...]`, so I thought a quick way to get rid of those "memory size" exceptions could be just ignoring those clases, and we can still get the benefits of PHPStan for the rest of the project.

<img width="1515" alt="Screenshot 2022-04-08 at 23 45 40" src="https://user-images.githubusercontent.com/5256287/162536277-35132036-4356-49d5-adbc-4aa9dc731cda.png">


###  💡 Next steps

Change the [parameters.level from 1 to 2](https://github.com/phel-lang/phel-lang/compare/feature/install-phpstan?expand=1#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766R2) and run `composer phpstan`, you will get some feedback with ideas for potential bugs.
