### PR TITLE
Improve phpmetrics usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
             "@csrun",
             "@psalm"
         ],
-        "test-compiler": "./vendor/bin/phpunit --testsuite=integration,unit",
+        "test-compiler": "./vendor/bin/phpunit --testsuite=integration,unit --log-junit=data/log-junit.xml",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --testsuite=integration,unit --coverage-html=data/coverage-html --coverage-xml=data/coverage-xml --log-junit=data/coverage-xml/junit.xml",
         "test-core": "./phel test",
         "psalm": "./vendor/bin/psalm --no-cache",
@@ -56,7 +56,10 @@
         "phpbench": "./vendor/bin/phpbench run --report=aggregate --ansi",
         "phpbench-base": "./vendor/bin/phpbench run --tag=baseline --report=aggregate --progress=plain --ansi",
         "phpbench-ref": "./vendor/bin/phpbench run --ref=baseline --report=aggregate --progress=plain --ansi",
-        "metrics-report": "./vendor/bin/phpmetrics --report-html=data/metrics-report src/php"
+        "metrics-report": [
+            "@test-compiler",
+            "./vendor/bin/phpmetrics --config=phpmetrics-config.json --junit=data/log-junit.xml"
+        ]
     },
     "bin": [
         "phel"

--- a/phpmetrics-config.json
+++ b/phpmetrics-config.json
@@ -1,0 +1,17 @@
+{
+  "includes": [
+    "src/php"
+  ],
+  "excludes": [
+    "tests"
+  ],
+  "report": {
+    "html": "data/metrics-report",
+    "violations": "data/metrics-report/violations.xml"
+  },
+  "plugins": {
+    "git": {
+      "binary": "git"
+    }
+  }
+}


### PR DESCRIPTION
### 🤔 Background

As I did recently in Gacela, I thought it would be interesting to have a similar setup for Phel regarding this phpmetric setup.
See: https://github.com/gacela-project/gacela/pull/139

This is a cool alternative to have an overlook of the project structure, and look for potential spots for improvements.

### 💡 Goal

Optimize the usage for phpmetric dev tool.

### 🔖 Changes

- Define a `phpmetrics-config.json` and updates the composer script `metrics-report`

<img width="1602" alt="Screenshot 2022-04-09 at 23 10 47" src="https://user-images.githubusercontent.com/5256287/162591773-8c91e1b3-14e7-4189-b563-dfea754a3fe1.png">

