### PR TITLE
Remove constructor for TestCommand using RunFacade instead

### DIFF
--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Container\Container;
 use Phel\Build\Command\CompileCommand;
 use Phel\Formatter\FormatterFacade;
 use Phel\Interop\InteropFacade;
+use Phel\Run\Command\TestCommand;
 use Phel\Run\RunFacade;
 
 final class ConsoleDependencyProvider extends AbstractDependencyProvider
@@ -26,7 +27,7 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
             $formatterFacade->getFormatCommand(),
             $runFacade->getReplCommand(),
             $runFacade->getRunCommand(),
-            $runFacade->getTestCommand(),
+            new TestCommand(),
             new CompileCommand(),
         ]);
     }

--- a/src/php/Run/Command/TestCommand.php
+++ b/src/php/Run/Command/TestCommand.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Run\Command;
 
-use Phel\Build\BuildFacadeInterface;
+use Gacela\Framework\FacadeResolverAwareTrait;
 use Phel\Build\Extractor\NamespaceInformation;
-use Phel\Command\CommandFacadeInterface;
-use Phel\Compiler\Compiler\CompileOptions;
-use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Exceptions\CompilerException;
-use Phel\Run\Domain\Test\CannotFindAnyTestsException;
 use Phel\Run\Domain\Test\TestCommandOptions;
+use Phel\Run\RunFacade;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -20,77 +17,21 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+/**
+ * @method RunFacade getFacade()
+ */
 final class TestCommand extends Command
 {
+    use FacadeResolverAwareTrait;
+
     public const COMMAND_NAME = 'test';
-
-    private CommandFacadeInterface $commandFacade;
-    private CompilerFacadeInterface $compilerFacade;
-    private BuildFacadeInterface $buildFacade;
-
-    public function __construct(
-        CommandFacadeInterface $commandFacade,
-        CompilerFacadeInterface $compilerFacade,
-        BuildFacadeInterface $buildFacade
-    ) {
-        parent::__construct(self::COMMAND_NAME);
-        $this->commandFacade = $commandFacade;
-        $this->compilerFacade = $compilerFacade;
-        $this->buildFacade = $buildFacade;
-    }
-
-    public function execute(InputInterface $input, OutputInterface $output): int
-    {
-        try {
-            /** @var list<string> $paths */
-            $paths = (array)$input->getArgument('paths');
-
-            $namespaces = $this->getNamespacesFromPaths($paths);
-            if (empty($namespaces)) {
-                throw CannotFindAnyTestsException::inPaths($paths);
-            }
-            $namespaces[] = 'phel\\test';
-
-            $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
-                [
-                    ...$this->commandFacade->getSourceDirectories(),
-                    ...$this->commandFacade->getTestDirectories(),
-                    ...$this->commandFacade->getVendorSourceDirectories(),
-                ],
-                $namespaces
-            );
-
-            $this->commandFacade->registerExceptionHandler();
-
-            foreach ($namespaceInformation as $info) {
-                $this->buildFacade->evalFile($info->getFile());
-            }
-
-            $phelCode = sprintf(
-                '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
-                TestCommandOptions::fromArray([
-                    TestCommandOptions::FILTER => (string)$input->getOption('filter'),
-                ])->asPhelHashMap(),
-                $this->namespacesAsString($namespaces),
-            );
-
-            $result = $this->compilerFacade->eval($phelCode, new CompileOptions());
-
-            $output->writeln((new ResourceUsageFormatter())->resourceUsageSinceStartOfRequest());
-
-            return ($result) ? self::SUCCESS : self::FAILURE;
-        } catch (CompilerException $e) {
-            $this->commandFacade->writeLocatedException($output, $e->getNestedException(), $e->getCodeSnippet());
-        } catch (Throwable $e) {
-            $this->commandFacade->writeStackTrace($output, $e);
-        }
-
-        return self::FAILURE;
-    }
 
     protected function configure(): void
     {
-        $this->setDescription('Tests the given files. If no filenames are provided all tests in the "tests" directory are executed.')
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription(
+                'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed.'
+            )
             ->addArgument(
                 'paths',
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
@@ -104,35 +45,56 @@ final class TestCommand extends Command
             );
     }
 
-    /**
-     * @param string[] $paths
-     *
-     * @return string[]
-     */
-    private function getNamespacesFromPaths(array $paths): array
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (empty($paths)) {
-            $namespaces = $this->buildFacade->getNamespaceFromDirectories(
-                $this->commandFacade->getTestDirectories()
+        try {
+            $this->getFacade()->registerExceptionHandler();
+
+            /** @var list<string> $paths */
+            $paths = (array)$input->getArgument('paths');
+            $namespacesInformation = $this->getFacade()->getDependenciesFromPaths($paths);
+
+            foreach ($namespacesInformation as $info) {
+                $this->getFacade()->evalFile($info);
+            }
+
+            $phelCode = sprintf(
+                '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
+                TestCommandOptions::fromArray([
+                    TestCommandOptions::FILTER => (string)$input->getOption('filter'),
+                ])->asPhelHashMap(),
+                $this->namespacesAsString($namespacesInformation),
             );
 
-            return array_map(
-                static fn (NamespaceInformation $info): string => $info->getNamespace(),
-                $namespaces
-            );
+            $result = $this->getFacade()->eval($phelCode);
+
+            $output->writeln((new ResourceUsageFormatter())->resourceUsageSinceStartOfRequest());
+
+            return ($result) ? self::SUCCESS : self::FAILURE;
+        } catch (CompilerException $e) {
+            $this->getFacade()->writeLocatedException($output, $e);
+        } catch (Throwable $e) {
+            $this->getFacade()->writeStackTrace($output, $e);
         }
 
-        return array_map(
-            fn (string $filename): string => $this->buildFacade->getNamespaceFromFile($filename)->getNamespace(),
-            $paths
-        );
+        return self::FAILURE;
     }
 
-    private function namespacesAsString(array $namespaces): string
+    protected function facadeClass(): string
     {
-        return implode(' ', array_map(
-            static fn (string $ns): string => "'" . $ns,
-            $namespaces
-        ));
+        return RunFacade::class;
+    }
+
+    /**
+     * @param list<NamespaceInformation> $namespacesInfo
+     */
+    private function namespacesAsString(array $namespacesInfo): string
+    {
+        $namespaces = [];
+        foreach ($namespacesInfo as $info) {
+            $namespaces[] = "'{$info->getNamespace()}";
+        }
+
+        return implode(' ', $namespaces);
     }
 }

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -5,28 +5,33 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Gacela\Framework\AbstractFacade;
+use Phel\Build\Extractor\NamespaceInformation;
+use Phel\Compiler\Compiler\CompileOptions;
+use Phel\Compiler\Exceptions\CompilerException;
 use Phel\Run\Command\ReplCommand;
 use Phel\Run\Command\RunCommand;
-use Phel\Run\Command\TestCommand;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 /**
  * @method RunFactory getFactory()
  */
 final class RunFacade extends AbstractFacade implements RunFacadeInterface
 {
+    /**
+     * TODO: Refactor and make the ReplCommand instantiable.
+     */
     public function getReplCommand(): ReplCommand
     {
         return $this->getFactory()->createReplCommand();
     }
 
+    /**
+     * TODO: Refactor and make the RunCommand instantiable.
+     */
     public function getRunCommand(): RunCommand
     {
         return $this->getFactory()->createRunCommand();
-    }
-
-    public function getTestCommand(): TestCommand
-    {
-        return $this->getFactory()->createTestCommand();
     }
 
     public function runNamespace(string $namespace): void
@@ -34,5 +39,59 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
         $this->getFactory()
             ->createNamespaceRunner()
             ->run($namespace);
+    }
+
+    public function registerExceptionHandler(): void
+    {
+        $this->getFactory()
+            ->getCommandFacade()
+            ->registerExceptionHandler();
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<NamespaceInformation>
+     */
+    public function getDependenciesFromPaths(array $paths): array
+    {
+        return $this->getFactory()
+            ->createNamespaceCollector()
+            ->getDependenciesFromPaths($paths);
+    }
+
+    public function evalFile(NamespaceInformation $info): void
+    {
+        $this->getFactory()
+            ->getBuildFacade()
+            ->evalFile($info->getFile());
+    }
+
+    /**
+     * @return mixed The result of the executed code
+     */
+    public function eval(string $phelCode): mixed
+    {
+        return $this->getFactory()
+            ->getCompilerFacade()
+            ->eval($phelCode, new CompileOptions());
+    }
+
+    public function writeLocatedException(OutputInterface $output, CompilerException $e): void
+    {
+        $this->getFactory()
+            ->getCommandFacade()
+            ->writeLocatedException(
+                $output,
+                $e->getNestedException(),
+                $e->getCodeSnippet()
+            );
+    }
+
+    public function writeStackTrace(OutputInterface $output, Throwable $e): void
+    {
+        $this->getFactory()
+            ->getCommandFacade()
+            ->writeStackTrace($output, $e);
     }
 }

--- a/src/php/Run/RunFacadeInterface.php
+++ b/src/php/Run/RunFacadeInterface.php
@@ -6,15 +6,12 @@ namespace Phel\Run;
 
 use Phel\Run\Command\ReplCommand;
 use Phel\Run\Command\RunCommand;
-use Phel\Run\Command\TestCommand;
 
 interface RunFacadeInterface
 {
     public function getReplCommand(): ReplCommand;
 
     public function getRunCommand(): RunCommand;
-
-    public function getTestCommand(): TestCommand;
 
     public function runNamespace(string $namespace): void;
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -12,11 +12,11 @@ use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
 use Phel\Run\Command\ReplCommand;
 use Phel\Run\Command\RunCommand;
-use Phel\Run\Command\TestCommand;
 use Phel\Run\Domain\Repl\ColorStyle;
 use Phel\Run\Domain\Repl\ColorStyleInterface;
 use Phel\Run\Domain\Repl\ReplCommandIoInterface;
 use Phel\Run\Domain\Repl\ReplCommandSystemIo;
+use Phel\Run\Runner\NamespaceCollector;
 use Phel\Run\Runner\NamespaceRunner;
 use Phel\Run\Runner\NamespaceRunnerInterface;
 
@@ -47,20 +47,34 @@ final class RunFactory extends AbstractFactory
         );
     }
 
-    public function createTestCommand(): TestCommand
-    {
-        return new TestCommand(
-            $this->getCommandFacade(),
-            $this->getCompilerFacade(),
-            $this->getBuildFacade()
-        );
-    }
-
     public function createNamespaceRunner(): NamespaceRunnerInterface
     {
         return new NamespaceRunner(
             $this->getCommandFacade(),
             $this->getBuildFacade()
+        );
+    }
+
+    public function getCommandFacade(): CommandFacadeInterface
+    {
+        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMMAND);
+    }
+
+    public function getCompilerFacade(): CompilerFacadeInterface
+    {
+        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMPILER);
+    }
+
+    public function getBuildFacade(): BuildFacadeInterface
+    {
+        return $this->getProvidedDependency(RunDependencyProvider::FACADE_BUILD);
+    }
+
+    public function createNamespaceCollector(): NamespaceCollector
+    {
+        return new NamespaceCollector(
+            $this->getBuildFacade(),
+            $this->getCommandFacade()
         );
     }
 
@@ -80,20 +94,5 @@ final class RunFactory extends AbstractFactory
     private function createPrinter(): PrinterInterface
     {
         return Printer::nonReadableWithColor();
-    }
-
-    private function getCompilerFacade(): CompilerFacadeInterface
-    {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMPILER);
-    }
-
-    private function getBuildFacade(): BuildFacadeInterface
-    {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_BUILD);
-    }
-
-    private function getCommandFacade(): CommandFacadeInterface
-    {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMMAND);
     }
 }

--- a/src/php/Run/Runner/NamespaceCollector.php
+++ b/src/php/Run/Runner/NamespaceCollector.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Runner;
+
+use Phel\Build\BuildFacadeInterface;
+use Phel\Build\Extractor\NamespaceInformation;
+use Phel\Command\CommandFacadeInterface;
+use Phel\Run\Domain\Test\CannotFindAnyTestsException;
+
+final class NamespaceCollector
+{
+    private BuildFacadeInterface $buildFacade;
+
+    private CommandFacadeInterface $commandFacade;
+
+    public function __construct(
+        BuildFacadeInterface $buildFacade,
+        CommandFacadeInterface $commandFacade
+    ) {
+        $this->buildFacade = $buildFacade;
+        $this->commandFacade = $commandFacade;
+    }
+
+    /**
+     * @return list<NamespaceInformation>
+     */
+    public function getDependenciesFromPaths(array $paths): array
+    {
+        $namespaces = $this->getNamespacesFromPaths($paths);
+        if (empty($namespaces)) {
+            throw CannotFindAnyTestsException::inPaths($paths);
+        }
+        $namespaces[] = 'phel\\test';
+
+        return $this->buildFacade->getDependenciesForNamespace(
+            [
+                ...$this->commandFacade->getSourceDirectories(),
+                ...$this->commandFacade->getTestDirectories(),
+                ...$this->commandFacade->getVendorSourceDirectories(),
+            ],
+            $namespaces
+        );
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function getNamespacesFromPaths(array $paths): array
+    {
+        if (empty($paths)) {
+            $namespaces = $this->buildFacade->getNamespaceFromDirectories(
+                $this->commandFacade->getTestDirectories()
+            );
+
+            return array_map(
+                static fn (NamespaceInformation $info): string => $info->getNamespace(),
+                $namespaces
+            );
+        }
+
+        return array_map(
+            fn (string $filename): string => $this->buildFacade->getNamespaceFromFile($filename)->getNamespace(),
+            $paths
+        );
+    }
+}

--- a/tests/php/Benchmark/Command/CommandBench.php
+++ b/tests/php/Benchmark/Command/CommandBench.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Benchmark\Command;
 
+use Phel\Run\Command\TestCommand;
 use Phel\Run\RunFactory;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -35,8 +36,7 @@ final class CommandBench
     public function bench_test_command(): void
     {
         ob_start();
-        $this->commandFactory
-            ->createTestCommand()
+        (new TestCommand())
             ->run(
                 new StringInput(__DIR__ . '/fixtures/test-command.phel'),
                 new NullOutput()

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/TestCommandProjectFailureTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/TestCommandProjectFailureTest.php
@@ -43,6 +43,6 @@ final class TestCommandProjectFailureTest extends AbstractCommandTest
 
     private function getTestCommand(): TestCommand
     {
-        return $this->createRunFacade()->getTestCommand();
+        return new TestCommand();
     }
 }

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
@@ -22,7 +22,7 @@ final class TestCommandProjectSuccessTest extends AbstractCommandTest
      */
     public function test_all_in_project(): void
     {
-        $command = $this->getTestCommand();
+        $command = new TestCommand();
 
         $this->expectOutputRegex('/\.\..*/');
         $this->expectOutputRegex('/.*Passed: 2.*/');
@@ -39,7 +39,7 @@ final class TestCommandProjectSuccessTest extends AbstractCommandTest
      */
     public function test_one_file_in_project(): void
     {
-        $command = $this->getTestCommand();
+        $command = new TestCommand();
 
         $this->expectOutputRegex('/\..*/');
         $this->expectOutputRegex('/.*Passed: 1.*/');
@@ -59,10 +59,5 @@ final class TestCommandProjectSuccessTest extends AbstractCommandTest
         $input->method('getArgument')->willReturn($paths);
 
         return $input;
-    }
-
-    private function getTestCommand(): TestCommand
-    {
-        return $this->createRunFacade()->getTestCommand();
     }
 }


### PR DESCRIPTION
### 🤔 Background

Similar as it was done in https://github.com/phel-lang/phel-lang/pull/461 

### 💡 Goal

The goal is to allow the creation of the `TestCommand` directly, and for this we need to get rid of its dependencies.

### 🔖 Changes

Refactor the `TestCommand` using internally its RunFacade. This way, its communication will be via its facade; 
- accesible via `getFacade()`, a new feature of the latest version from Gacela with `use FacadeResolverAwareTrait;`
- see: https://gacela-project.com/docs/facade/#use-the-facade-from-your-infrastructure-layer