### PR TITLE
Refactor FormatCommand to use the Facade

### DIFF
--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -7,7 +7,7 @@ namespace Phel\Console;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Build\Command\CompileCommand;
-use Phel\Formatter\Command\FormatCommand;
+use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\InteropFacade;
 use Phel\Run\RunFacade;
 

--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -7,7 +7,7 @@ namespace Phel\Console;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Build\Command\CompileCommand;
-use Phel\Formatter\FormatterFacade;
+use Phel\Formatter\Command\FormatCommand;
 use Phel\Interop\InteropFacade;
 use Phel\Run\RunFacade;
 
@@ -18,12 +18,11 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
     public function provideModuleDependencies(Container $container): void
     {
         $interopFacade = new InteropFacade();
-        $formatterFacade = new FormatterFacade();
         $runFacade = new RunFacade();
 
         $container->set(self::COMMANDS, static fn () => [
             $interopFacade->getExportCommand(),
-            $formatterFacade->getFormatCommand(),
+            new FormatCommand(),
             $runFacade->getReplCommand(),
             $runFacade->getRunCommand(),
             $runFacade->getTestCommand(),

--- a/src/php/Formatter/Command/FormatCommand.php
+++ b/src/php/Formatter/Command/FormatCommand.php
@@ -4,52 +4,27 @@ declare(strict_types=1);
 
 namespace Phel\Formatter\Command;
 
-use Phel\Command\CommandFacadeInterface;
-use Phel\Compiler\Lexer\Exceptions\LexerValueException;
-use Phel\Compiler\Parser\Exceptions\AbstractParserException;
-use Phel\Formatter\Domain\FormatterInterface;
-use Phel\Formatter\Domain\PathFilterInterface;
-use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
-use RuntimeException;
+use Gacela\Framework\FacadeResolverAwareTrait;
+use Phel\Formatter\FormatterFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
+/**
+ * @method FormatterFacade getFacade()
+ */
 final class FormatCommand extends Command
 {
-    public const COMMAND_NAME = 'format';
-
-    private CommandFacadeInterface $commandFacade;
-    private FormatterInterface $formatter;
-    private PathFilterInterface $pathFilter;
+    use FacadeResolverAwareTrait;
 
     /** @var list<string> */
     private array $successfulFormattedFilePaths = [];
 
-    public function __construct(
-        CommandFacadeInterface $commandFacade,
-        FormatterInterface $formatter,
-        PathFilterInterface $pathFilter
-    ) {
-        parent::__construct(self::COMMAND_NAME);
-        $this->commandFacade = $commandFacade;
-        $this->formatter = $formatter;
-        $this->pathFilter = $pathFilter;
-    }
-
-    /**
-     * @internal Public method for test purposes
-     */
-    public function getFormatter(): FormatterInterface
-    {
-        return $this->formatter;
-    }
-
     protected function configure(): void
     {
-        $this->setDescription('Formats the given files.')
+        $this->setName('format')
+            ->setDescription('Formats the given files.')
             ->addArgument(
                 'paths',
                 InputArgument::IS_ARRAY|InputArgument::REQUIRED,
@@ -61,58 +36,24 @@ final class FormatCommand extends Command
     {
         /** @var list<string> $paths */
         $paths = $input->getArgument('paths');
-        foreach ($this->pathFilter->filterPaths($paths) as $path) {
-            try {
-                $wasFormatted = $this->formatFile($path);
-                if ($wasFormatted) {
-                    $this->successfulFormattedFilePaths[] = $path;
-                }
-            } catch (AbstractParserException $e) {
-                $this->commandFacade->writeLocatedException($output, $e, $e->getCodeSnippet());
-            } catch (Throwable $e) {
-                $this->commandFacade->writeStackTrace($output, $e);
-            }
-        }
 
-        $this->printResult($output);
+        $successfulFormattedFilePaths = $this->getFacade()->format($paths, $output);
 
-        return self::SUCCESS;
-    }
-
-    /**
-     * @throws AbstractParserException
-     * @throws LexerValueException
-     * @throws ZipperException
-     *
-     * @return bool True if the file was formatted. False if the file wasn't altered because it was already formatted.
-     */
-    private function formatFile(string $filename): bool
-    {
-        if (is_dir($filename)) {
-            throw new RuntimeException(sprintf('"%s" is a directory but needs to be a file path', $filename));
-        }
-
-        if (!is_file($filename)) {
-            throw new RuntimeException(sprintf('File path "%s" not found', $filename));
-        }
-
-        $code = file_get_contents($filename);
-        $formattedCode = $this->formatter->format($code, $filename);
-        file_put_contents($filename, $formattedCode);
-
-        return (bool)strcmp($formattedCode, $code);
-    }
-
-    private function printResult(OutputInterface $output): void
-    {
-        if (empty($this->successfulFormattedFilePaths)) {
+        if (empty($successfulFormattedFilePaths)) {
             $output->writeln('No files were formatted.');
         } else {
             $output->writeln('Formatted files:');
 
-            foreach ($this->successfulFormattedFilePaths as $k => $filePath) {
+            foreach ($successfulFormattedFilePaths as $k => $filePath) {
                 $output->writeln(sprintf('  %d) %s', $k + 1, $filePath));
             }
         }
+
+        return self::SUCCESS;
+    }
+
+    protected function facadeClass(): string
+    {
+        return FormatterFacade::class;
     }
 }

--- a/src/php/Formatter/Domain/Exception/FilePathException.php
+++ b/src/php/Formatter/Domain/Exception/FilePathException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain\Exception;
+
+use RuntimeException;
+
+final class FilePathException extends RuntimeException
+{
+    public static function directoryFound(string $filename): self
+    {
+        return new self("{$filename}' is a directory but needs to be a file path");
+    }
+
+    public static function notFound(string $filename): self
+    {
+        return new self("File path '{$filename}' not found");
+    }
+}

--- a/src/php/Formatter/Domain/PathsFormatter.php
+++ b/src/php/Formatter/Domain/PathsFormatter.php
@@ -68,6 +68,7 @@ final class PathsFormatter
             throw new RuntimeException(sprintf('File path "%s" not found', $filename));
         }
 
+        // TODO: Consider creating some `FileIoInterface` to do this IO actions
         $code = file_get_contents($filename);
         $formattedCode = $this->formatter->format($code, $filename);
         file_put_contents($filename, $formattedCode);

--- a/src/php/Formatter/Domain/PathsFormatter.php
+++ b/src/php/Formatter/Domain/PathsFormatter.php
@@ -56,6 +56,7 @@ final class PathsFormatter
     }
 
     /**
+     * @throws FilePathException
      * @throws LexerValueException
      * @throws ZipperException
      * @throws AbstractParserException
@@ -64,13 +65,7 @@ final class PathsFormatter
      */
     private function formatFile(string $filename): bool
     {
-        if (is_dir($filename)) {
-            throw FilePathException::directoryFound($filename);
-        }
-
-        if (!is_file($filename)) {
-            throw FilePathException::notFound($filename);
-        }
+        $this->fileIo->checkIfValid($filename);
 
         $code = $this->fileIo->getContents($filename);
         $formattedCode = $this->formatter->format($code, $filename);

--- a/src/php/Formatter/Domain/PathsFormatter.php
+++ b/src/php/Formatter/Domain/PathsFormatter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain;
+
+use Phel\Command\CommandFacadeInterface;
+use Phel\Compiler\Lexer\Exceptions\LexerValueException;
+use Phel\Compiler\Parser\Exceptions\AbstractParserException;
+use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class PathsFormatter
+{
+    private CommandFacadeInterface $commandFacade;
+    private FormatterInterface $formatter;
+    private PathFilterInterface $pathFilter;
+
+    public function __construct(
+        CommandFacadeInterface $commandFacade,
+        FormatterInterface $formatter,
+        PathFilterInterface $pathFilter
+    ) {
+        $this->commandFacade = $commandFacade;
+        $this->formatter = $formatter;
+        $this->pathFilter = $pathFilter;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function format(array $paths, OutputInterface $output): array
+    {
+        $successfulFormattedFilePaths = [];
+
+        foreach ($this->pathFilter->filterPaths($paths) as $path) {
+            try {
+                $wasFormatted = $this->formatFile($path);
+                if ($wasFormatted) {
+                    $successfulFormattedFilePaths[] = $path;
+                }
+            } catch (AbstractParserException $e) {
+                $this->commandFacade->writeLocatedException($output, $e, $e->getCodeSnippet());
+            } catch (Throwable $e) {
+                $this->commandFacade->writeStackTrace($output, $e);
+            }
+        }
+
+        return $successfulFormattedFilePaths;
+    }
+
+    /**
+     * @throws LexerValueException
+     * @throws ZipperException
+     * @throws AbstractParserException
+     *
+     * @return bool True if the file was formatted. False if the file wasn't altered because it was already formatted.
+     */
+    private function formatFile(string $filename): bool
+    {
+        if (is_dir($filename)) {
+            throw new RuntimeException(sprintf('"%s" is a directory but needs to be a file path', $filename));
+        }
+
+        if (!is_file($filename)) {
+            throw new RuntimeException(sprintf('File path "%s" not found', $filename));
+        }
+
+        $code = file_get_contents($filename);
+        $formattedCode = $this->formatter->format($code, $filename);
+        file_put_contents($filename, $formattedCode);
+
+        return (bool)strcmp($formattedCode, $code);
+    }
+}

--- a/src/php/Formatter/FormatterFacade.php
+++ b/src/php/Formatter/FormatterFacade.php
@@ -5,15 +5,20 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\Formatter\Command\FormatCommand;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @method FormatterFactory getFactory()
  */
 final class FormatterFacade extends AbstractFacade implements FormatterFacadeInterface
 {
-    public function getFormatCommand(): FormatCommand
+    /**
+     * @return list<string> successful formatted file paths
+     */
+    public function format(array $paths, OutputInterface $output): array
     {
-        return $this->getFactory()->createFormatCommand();
+        return $this->getFactory()
+            ->createPathsFormatter()
+            ->format($paths, $output);
     }
 }

--- a/src/php/Formatter/FormatterFacadeInterface.php
+++ b/src/php/Formatter/FormatterFacadeInterface.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Formatter;
 
-use Phel\Formatter\Command\FormatCommand;
+use Symfony\Component\Console\Output\OutputInterface;
 
 interface FormatterFacadeInterface
 {
-    public function getFormatCommand(): FormatCommand;
+    public function format(array $paths, OutputInterface $output): array;
 }

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -18,6 +18,8 @@ use Phel\Formatter\Domain\Rules\IndentRule;
 use Phel\Formatter\Domain\Rules\RemoveSurroundingWhitespaceRule;
 use Phel\Formatter\Domain\Rules\RemoveTrailingWhitespaceRule;
 use Phel\Formatter\Domain\Rules\UnindentRule;
+use Phel\Formatter\Infrastructure\IO\FileIoInterface;
+use Phel\Formatter\Infrastructure\IO\SystemFileIo;
 
 final class FormatterFactory extends AbstractFactory
 {
@@ -26,7 +28,8 @@ final class FormatterFactory extends AbstractFactory
         return new PathsFormatter(
             $this->getCommandFacade(),
             $this->createFormatter(),
-            $this->createPathFilter()
+            $this->createPathFilter(),
+            $this->createFileIo()
         );
     }
 
@@ -102,5 +105,10 @@ final class FormatterFactory extends AbstractFactory
     private function getCommandFacade(): CommandFacadeInterface
     {
         return $this->getProvidedDependency(FormatterDependencyProvider::FACADE_COMMAND);
+    }
+
+    private function createFileIo(): FileIoInterface
+    {
+        return new SystemFileIo();
     }
 }

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -7,10 +7,10 @@ namespace Phel\Formatter;
 use Gacela\Framework\AbstractFactory;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacade;
-use Phel\Formatter\Command\FormatCommand;
 use Phel\Formatter\Domain\Formatter;
 use Phel\Formatter\Domain\FormatterInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
+use Phel\Formatter\Domain\PathsFormatter;
 use Phel\Formatter\Domain\PhelPathFilter;
 use Phel\Formatter\Domain\Rules\Indenter\BlockIndenter;
 use Phel\Formatter\Domain\Rules\Indenter\InnerIndenter;
@@ -21,16 +21,16 @@ use Phel\Formatter\Domain\Rules\UnindentRule;
 
 final class FormatterFactory extends AbstractFactory
 {
-    public function createFormatCommand(): FormatCommand
+    public function createPathsFormatter(): PathsFormatter
     {
-        return new FormatCommand(
+        return new PathsFormatter(
             $this->getCommandFacade(),
             $this->createFormatter(),
             $this->createPathFilter()
         );
     }
 
-    private function createFormatter(): FormatterInterface
+    public function createFormatter(): FormatterInterface
     {
         return new Formatter(
             $this->getFacadeCompiler(),

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Formatter\Command;
+namespace Phel\Formatter\Infrastructure\Command;
 
 use Gacela\Framework\FacadeResolverAwareTrait;
 use Phel\Formatter\FormatterFacade;

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -18,16 +18,13 @@ final class FormatCommand extends Command
 {
     use FacadeResolverAwareTrait;
 
-    /** @var list<string> */
-    private array $successfulFormattedFilePaths = [];
-
     protected function configure(): void
     {
         $this->setName('format')
             ->setDescription('Formats the given files.')
             ->addArgument(
                 'paths',
-                InputArgument::IS_ARRAY|InputArgument::REQUIRED,
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
                 'The file paths that you want to format.'
             );
     }
@@ -37,16 +34,18 @@ final class FormatCommand extends Command
         /** @var list<string> $paths */
         $paths = $input->getArgument('paths');
 
-        $successfulFormattedFilePaths = $this->getFacade()->format($paths, $output);
+        $formattedFilePaths = $this->getFacade()->format($paths, $output);
 
-        if (empty($successfulFormattedFilePaths)) {
+        if (empty($formattedFilePaths)) {
             $output->writeln('No files were formatted.');
-        } else {
-            $output->writeln('Formatted files:');
 
-            foreach ($successfulFormattedFilePaths as $k => $filePath) {
-                $output->writeln(sprintf('  %d) %s', $k + 1, $filePath));
-            }
+            return self::SUCCESS;
+        }
+
+        $output->writeln('Formatted files:');
+
+        foreach ($formattedFilePaths as $k => $filePath) {
+            $output->writeln(sprintf('  %d) %s', $k + 1, $filePath));
         }
 
         return self::SUCCESS;

--- a/src/php/Formatter/Infrastructure/IO/FileIoInterface.php
+++ b/src/php/Formatter/Infrastructure/IO/FileIoInterface.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Phel\Formatter\Infrastructure\IO;
 
+use Phel\Formatter\Domain\Exception\FilePathException;
+
 interface FileIoInterface
 {
+    /**
+     * @throws FilePathException
+     */
+    public function checkIfValid(string $filename): void;
+
     public function getContents(string $filename): string;
 
     public function putContents(string $filename, string $data): void;

--- a/src/php/Formatter/Infrastructure/IO/FileIoInterface.php
+++ b/src/php/Formatter/Infrastructure/IO/FileIoInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Infrastructure\IO;
+
+interface FileIoInterface
+{
+    public function getContents(string $filename): string;
+
+    public function putContents(string $filename, string $data): void;
+}

--- a/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Infrastructure\IO;
+
+final class SystemFileIo implements FileIoInterface
+{
+    public function getContents(string $filename): string
+    {
+        return file_get_contents($filename);
+    }
+
+    public function putContents(string $filename, string $data): void
+    {
+        file_put_contents($filename, $data);
+    }
+}

--- a/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Formatter/Infrastructure/IO/SystemFileIo.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace Phel\Formatter\Infrastructure\IO;
 
+use Phel\Formatter\Domain\Exception\FilePathException;
+
 final class SystemFileIo implements FileIoInterface
 {
+    /**
+     * @throws FilePathException
+     */
+    public function checkIfValid(string $filename): void
+    {
+        if (is_dir($filename)) {
+            throw FilePathException::directoryFound($filename);
+        }
+
+        if (!is_file($filename)) {
+            throw FilePathException::notFound($filename);
+        }
+    }
+
     public function getContents(string $filename): string
     {
         return file_get_contents($filename);

--- a/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Formatter\Command\Format;
 
 use Gacela\Framework\Gacela;
-use Phel\Formatter\Command\FormatCommand;
+use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
@@ -6,8 +6,6 @@ namespace PhelTest\Integration\Formatter\Command\Format;
 
 use Gacela\Framework\Gacela;
 use Phel\Formatter\Command\FormatCommand;
-use Phel\Formatter\FormatterFacade;
-use Phel\Formatter\FormatterFacadeInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,7 +24,7 @@ final class FormatCommandTest extends TestCase
         $path = self::FIXTURES_DIR . 'good-format.phel';
         $oldContent = file_get_contents($path);
 
-        $command = $this->getFormatCommand();
+        $command = $this->createFormatCommand();
 
         $this->expectOutputRegex('/No files were formatted+/s');
 
@@ -45,7 +43,7 @@ final class FormatCommandTest extends TestCase
         $path = self::FIXTURES_DIR . 'bad-format.phel';
         $oldContent = file_get_contents($path);
 
-        $command = $this->getFormatCommand();
+        $command = $this->createFormatCommand();
 
         $this->expectOutputString(
             <<<TXT
@@ -64,14 +62,9 @@ TXT
         }
     }
 
-    private function getFormatCommand(): FormatCommand
+    private function createFormatCommand(): FormatCommand
     {
-        return $this->createFormatterFacade()->getFormatCommand();
-    }
-
-    private function createFormatterFacade(): FormatterFacadeInterface
-    {
-        return new FormatterFacade();
+        return new FormatCommand();
     }
 
     private function stubInput(array $paths): InputInterface

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Formatter;
 
 use Generator;
-use Phel\Formatter\FormatterFacade;
+use Phel\Formatter\FormatterFactory;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
 final class FormatterFacadeTest extends TestCase
 {
-    private FormatterFacade $formatterFacade;
+    private FormatterFactory $formatterFactory;
 
     public function setUp(): void
     {
         Symbol::resetGen();
-        $this->formatterFacade = new FormatterFacade();
+        $this->formatterFactory = new FormatterFactory();
     }
 
     /**
@@ -26,9 +26,8 @@ final class FormatterFacadeTest extends TestCase
      */
     public function test_format(array $actualLines, array $expectedLines): void
     {
-        $formatted = $this->formatterFacade
-            ->getFormatCommand()
-            ->getFormatter()
+        $formatted = $this->formatterFactory
+            ->createFormatter()
             ->format(implode("\n", $actualLines));
 
         self::assertEquals($expectedLines, explode("\n", $formatted));


### PR DESCRIPTION
### 🤔 Background

Similar as it was done in https://github.com/phel-lang/phel-lang/pull/461 & https://github.com/phel-lang/phel-lang/pull/465

### 💡 Goal

The goal is to allow the creation of the `FormatCommand` directly, and for this we need to get rid of its dependencies.

### 🔖 Changes

Refactor the `FormatCommand` using internally its `FormatterFacade`. This way, its communication will be via its facade;

- accesible via getFacade(), a new feature of the latest version from Gacela with use FacadeResolverAwareTrait;
- see: https://gacela-project.com/docs/facade/#use-the-facade-from-your-infrastructure-layer
