### PR TITLE
Fix ReplCommandSystemIo when internal library_version is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 * Added: `read-string` function
 * Added: `eval` function
 * Added: `compile` function
+* Bugfix: #467 Failed to run a REPL on Windows
 
 ## 0.6.0 (2022-02-02)
 

--- a/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
@@ -68,6 +68,8 @@ final class ReplCommandSystemIo implements ReplCommandIoInterface
 
     public function isBracketedPasteSupported(): bool
     {
-        return stripos(readline_info('library_version'), 'editline') === false;
+        $haystack = readline_info('library_version') ?? '';
+
+        return stripos($haystack, 'editline') === false;
     }
 }


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/467

There seems to be a bug when `readline_info('library_version')` return `null`. And this is an error because `stripos()` expect a non-nullable string as first argument.

### 🔖 Changes

- Use an empty string when `readline_info('library_version')` returns null
