### PR TITLE
Refactor RunCommand to use DocBlockResolverAwareTrait

### DIFF
--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -9,6 +9,7 @@ use Gacela\Framework\Container\Container;
 use Phel\Build\Infrastructure\Command\CompileCommand;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\InteropFacade;
+use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
 use Phel\Run\RunFacade;
 
@@ -25,7 +26,7 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
             $interopFacade->getExportCommand(),
             new FormatCommand(),
             $runFacade->getReplCommand(),
-            $runFacade->getRunCommand(),
+            new RunCommand(),
             new TestCommand(),
             new CompileCommand(),
         ]);

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -9,7 +9,6 @@ use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\Infrastructure\Command\RunCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -26,19 +25,18 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
         return $this->getFactory()->createReplCommand();
     }
 
-    /**
-     * TODO: Refactor and make the RunCommand instantiable.
-     */
-    public function getRunCommand(): RunCommand
-    {
-        return $this->getFactory()->createRunCommand();
-    }
-
     public function runNamespace(string $namespace): void
     {
         $this->getFactory()
             ->createNamespaceRunner()
             ->run($namespace);
+    }
+
+    public function getNamespaceFromFile(string $fileOrPath): NamespaceInformation
+    {
+        return $this->getFactory()
+            ->getBuildFacade()
+            ->getNamespaceFromFile($fileOrPath);
     }
 
     public function registerExceptionHandler(): void

--- a/src/php/Run/RunFacadeInterface.php
+++ b/src/php/Run/RunFacadeInterface.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\Infrastructure\Command\RunCommand;
 
 interface RunFacadeInterface
 {
     public function getReplCommand(): ReplCommand;
-
-    public function getRunCommand(): RunCommand;
 
     public function runNamespace(string $namespace): void;
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -18,7 +18,6 @@ use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Run\Domain\Runner\NamespaceRunner;
 use Phel\Run\Domain\Runner\NamespaceRunnerInterface;
 use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\Infrastructure\Command\RunCommand;
 
 /**
  * @method RunConfig getConfig()
@@ -35,15 +34,6 @@ final class RunFactory extends AbstractFactory
             $this->getBuildFacade(),
             $this->getCommandFacade(),
             $this->getConfig()->getReplStartupFile()
-        );
-    }
-
-    public function createRunCommand(): RunCommand
-    {
-        return new RunCommand(
-            $this->getCommandFacade(),
-            $this->createNamespaceRunner(),
-            $this->getBuildFacade(),
         );
     }
 

--- a/tests/php/Benchmark/Command/CommandBench.php
+++ b/tests/php/Benchmark/Command/CommandBench.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace PhelTest\Benchmark\Command;
 
+use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
-use Phel\Run\RunFactory;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 /**
- * @BeforeMethods("setUp")
  * @Iterations(3)
  * @Revs(1)
  */
 final class CommandBench
 {
-    private RunFactory $commandFactory;
-
-    public function setUp(): void
-    {
-        $this->commandFactory = new RunFactory();
-    }
-
     public function bench_run_command(): void
     {
-        $this->commandFactory
-            ->createRunCommand()
-            ->run(
-                new StringInput(__DIR__ . '/fixtures/run-command.phel'),
-                new NullOutput()
-            );
+        (new RunCommand())->run(
+            new StringInput(__DIR__ . '/fixtures/run-command.phel'),
+            new NullOutput()
+        );
     }
 
     public function bench_test_command(): void
     {
         ob_start();
-        (new TestCommand())
-            ->run(
-                new StringInput(__DIR__ . '/fixtures/test-command.phel'),
-                new NullOutput()
-            );
+        (new TestCommand())->run(
+            new StringInput(__DIR__ . '/fixtures/test-command.phel'),
+            new NullOutput()
+        );
         ob_clean();
     }
 }

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -24,7 +24,7 @@ final class RunCommandTest extends AbstractCommandTest
     {
         $this->expectOutputRegex('~hello world~');
 
-        $this->getRunCommand()->run(
+        $this->createRunCommand()->run(
             $this->stubInput('test\\test-script'),
             $this->stubOutput()
         );
@@ -34,15 +34,15 @@ final class RunCommandTest extends AbstractCommandTest
     {
         $this->expectOutputRegex('~hello world~');
 
-        $this->getRunCommand()->run(
+        $this->createRunCommand()->run(
             $this->stubInput(__DIR__ . '/Fixtures/test-script.phel'),
             $this->stubOutput()
         );
     }
 
-    private function getRunCommand(): RunCommand
+    private function createRunCommand(): RunCommand
     {
-        return $this->createRunFacade()->getRunCommand();
+        return new RunCommand();
     }
 
     private function stubInput(string $path): InputInterface


### PR DESCRIPTION
### 🤔 Background

Similar as it was done in:
- https://github.com/phel-lang/phel-lang/pull/466
- https://github.com/phel-lang/phel-lang/pull/461
- https://github.com/phel-lang/phel-lang/pull/465

### 💡 Goal

The goal is to allow the creation of the `RunCommand` directly, and for this we need to get rid of its dependencies.

### 🔖 Changes

Refactor the `RunCommand` using internally its `RunFacade`. This way, its communication will be via its facade;

- accesible via `getFacade()`, a new feature of the latest version from Gacela with `use DocBlockResolverAwareTrait;`
- see: https://gacela-project.com/docs/facade/#use-the-facade-from-your-infrastructure-layer
