### PR TITLE
Refactor ExportCommand to use DocBlockResolverAwareTrait 

### DIFF
--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -8,7 +8,7 @@ use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Build\Infrastructure\Command\CompileCommand;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
-use Phel\Interop\InteropFacade;
+use Phel\Interop\Infrastructure\Command\ExportCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
 use Phel\Run\RunFacade;
 
@@ -18,11 +18,10 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
 
     public function provideModuleDependencies(Container $container): void
     {
-        $interopFacade = new InteropFacade();
         $runFacade = new RunFacade();
 
         $container->set(self::COMMANDS, static fn () => [
-            $interopFacade->getExportCommand(),
+            new ExportCommand(),
             new FormatCommand(),
             $runFacade->getReplCommand(),
             $runFacade->getRunCommand(),

--- a/src/php/Interop/Domain/ExportCodeGenerator.php
+++ b/src/php/Interop/Domain/ExportCodeGenerator.php
@@ -11,7 +11,6 @@ use Phel\Interop\Domain\FileCreator\FileCreatorInterface;
 use Phel\Interop\Domain\Generator\WrapperGeneratorInterface;
 use Phel\Interop\Domain\ReadModel\Wrapper;
 use RuntimeException;
-use Symfony\Component\Console\Output\OutputInterface;
 
 final class ExportCodeGenerator
 {
@@ -35,21 +34,19 @@ final class ExportCodeGenerator
     /**
      * @throws CompilerException
      * @throws RuntimeException
+     *
+     * @return list<Wrapper>
      */
-    public function generateExportCode(OutputInterface $output): void
+    public function generateExportCode(): array
     {
         $this->directoryRemover->removeDir();
-        $output->writeln('Exported namespaces:');
         $wrappers = $this->generateWrappers();
 
-        if (empty($wrappers)) {
-            $output->writeln('No functions were found to be exported');
+        foreach ($wrappers as $wrapper) {
+            $this->fileCreator->createFromWrapper($wrapper);
         }
 
-        foreach ($wrappers as $i => $wrapper) {
-            $this->fileCreator->createFromWrapper($wrapper);
-            $output->writeln(sprintf('  %d) %s', $i + 1, $wrapper->relativeFilenamePath()));
-        }
+        return $wrappers;
     }
 
     /**

--- a/src/php/Interop/Domain/ExportCodeGenerator.php
+++ b/src/php/Interop/Domain/ExportCodeGenerator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Interop\Domain;
+
+use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Interop\Domain\DirectoryRemover\DirectoryRemoverInterface;
+use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinderInterface;
+use Phel\Interop\Domain\FileCreator\FileCreatorInterface;
+use Phel\Interop\Domain\Generator\WrapperGeneratorInterface;
+use Phel\Interop\Domain\ReadModel\Wrapper;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ExportCodeGenerator
+{
+    private DirectoryRemoverInterface $directoryRemover;
+    private WrapperGeneratorInterface $wrapperGenerator;
+    private FunctionsToExportFinderInterface $functionsToExportFinder;
+    private FileCreatorInterface $fileCreator;
+
+    public function __construct(
+        DirectoryRemoverInterface $directoryRemover,
+        WrapperGeneratorInterface $wrapperGenerator,
+        FunctionsToExportFinderInterface $functionsToExportFinder,
+        FileCreatorInterface $fileCreator,
+    ) {
+        $this->directoryRemover = $directoryRemover;
+        $this->wrapperGenerator = $wrapperGenerator;
+        $this->functionsToExportFinder = $functionsToExportFinder;
+        $this->fileCreator = $fileCreator;
+    }
+
+    /**
+     * @throws CompilerException
+     * @throws RuntimeException
+     */
+    public function generateExportCode(OutputInterface $output): void
+    {
+        $this->directoryRemover->removeDir();
+        $output->writeln('Exported namespaces:');
+        $wrappers = $this->generateWrappers();
+
+        if (empty($wrappers)) {
+            $output->writeln('No functions were found to be exported');
+        }
+
+        foreach ($wrappers as $i => $wrapper) {
+            $this->fileCreator->createFromWrapper($wrapper);
+            $output->writeln(sprintf('  %d) %s', $i + 1, $wrapper->relativeFilenamePath()));
+        }
+    }
+
+    /**
+     * @return list<Wrapper>
+     */
+    private function generateWrappers(): array
+    {
+        $allFunctionsToExport = $this->functionsToExportFinder->findInPaths();
+        $wrappers = [];
+
+        foreach ($allFunctionsToExport as $ns => $functionsToExport) {
+            $wrappers[] = $this->wrapperGenerator->generateCompiledPhp($ns, $functionsToExport);
+        }
+
+        return $wrappers;
+    }
+}

--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -28,7 +28,7 @@ final class ExportCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $this->getFacade()->generateExportCode($output);
+            $this->generateExportCode($output);
 
             return self::SUCCESS;
         } catch (CompilerException $e) {
@@ -38,5 +38,23 @@ final class ExportCommand extends Command
         }
 
         return self::FAILURE;
+    }
+
+    private function generateExportCode(OutputInterface $output): void
+    {
+        $output->writeln('Exported namespaces:');
+        $wrappers = $this->getFacade()->generateExportCode();
+
+        if (empty($wrappers)) {
+            $output->writeln('No functions were found to be exported');
+        }
+
+        foreach ($wrappers as $i => $wrapper) {
+            $output->writeln(sprintf(
+                '  %d) %s',
+                $i + 1,
+                $wrapper->relativeFilenamePath()
+            ));
+        }
     }
 }

--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -4,96 +4,39 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Infrastructure\Command;
 
-use Phel\Command\CommandFacadeInterface;
+use Gacela\Framework\DocBlockResolverAwareTrait;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
-use Phel\Interop\Domain\DirectoryRemover\DirectoryRemoverInterface;
-use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinderInterface;
-use Phel\Interop\Domain\FileCreator\FileCreatorInterface;
-use Phel\Interop\Domain\Generator\WrapperGeneratorInterface;
-use Phel\Interop\Domain\ReadModel\Wrapper;
-use RuntimeException;
+use Phel\Interop\InteropFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+/**
+ * @method InteropFacade getFacade()
+ */
 final class ExportCommand extends Command
 {
-    public const COMMAND_NAME = 'export';
-
-    private DirectoryRemoverInterface $directoryRemover;
-    private WrapperGeneratorInterface $wrapperGenerator;
-    private FunctionsToExportFinderInterface $functionsToExportFinder;
-    private FileCreatorInterface $fileCreator;
-    private CommandFacadeInterface $commandFacade;
-
-    public function __construct(
-        DirectoryRemoverInterface $directoryRemover,
-        WrapperGeneratorInterface $wrapperGenerator,
-        FunctionsToExportFinderInterface $functionsToExportFinder,
-        FileCreatorInterface $fileCreator,
-        CommandFacadeInterface $commandFacade
-    ) {
-        parent::__construct(self::COMMAND_NAME);
-        $this->directoryRemover = $directoryRemover;
-        $this->wrapperGenerator = $wrapperGenerator;
-        $this->functionsToExportFinder = $functionsToExportFinder;
-        $this->fileCreator = $fileCreator;
-        $this->commandFacade = $commandFacade;
-    }
-
-    /**
-     * @return list<Wrapper>
-     */
-    public function generateWrappers(): array
-    {
-        $allFunctionsToExport = $this->functionsToExportFinder->findInPaths();
-        $wrappers = [];
-
-        foreach ($allFunctionsToExport as $ns => $functionsToExport) {
-            $wrappers[] = $this->wrapperGenerator->generateCompiledPhp($ns, $functionsToExport);
-        }
-
-        return $wrappers;
-    }
+    use DocBlockResolverAwareTrait;
 
     protected function configure(): void
     {
-        $this->setDescription('Export all definitions with the meta data `@{:export true}` as PHP classes.');
+        $this->setName('export')
+            ->setDescription('Export all definitions with the meta data `@{:export true}` as PHP classes.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $this->createGeneratedWrappers($output);
+            $this->getFacade()->generateExportCode($output);
 
             return self::SUCCESS;
         } catch (CompilerException $e) {
-            $this->commandFacade->writeLocatedException($output, $e->getNestedException(), $e->getCodeSnippet());
+            $this->getFacade()->writeLocatedException($output, $e);
         } catch (Throwable $e) {
-            $this->commandFacade->writeStackTrace($output, $e);
+            $this->getFacade()->writeStackTrace($output, $e);
         }
 
         return self::FAILURE;
-    }
-
-    /**
-     * @throws CompilerException
-     * @throws RuntimeException
-     */
-    private function createGeneratedWrappers(OutputInterface $output): void
-    {
-        $this->directoryRemover->removeDir();
-        $output->writeln('Exported namespaces:');
-        $wrappers = $this->generateWrappers();
-
-        if (empty($wrappers)) {
-            $output->writeln('No functions were found to be exported');
-        }
-
-        foreach ($wrappers as $i => $wrapper) {
-            $this->fileCreator->createFromWrapper($wrapper);
-            $output->writeln(sprintf('  %d) %s', $i + 1, $wrapper->relativeFilenamePath()));
-        }
     }
 }

--- a/src/php/Interop/InteropFacade.php
+++ b/src/php/Interop/InteropFacade.php
@@ -6,6 +6,7 @@ namespace Phel\Interop;
 
 use Gacela\Framework\AbstractFacade;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Interop\Domain\ReadModel\Wrapper;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -14,6 +15,16 @@ use Throwable;
  */
 final class InteropFacade extends AbstractFacade implements InteropFacadeInterface
 {
+    /**
+     * @return list<Wrapper>
+     */
+    public function generateExportCode(): array
+    {
+        return $this->getFactory()
+            ->createExportCodeGenerator()
+            ->generateExportCode();
+    }
+
     public function writeLocatedException(OutputInterface $output, CompilerException $e): void
     {
         $this->getFactory()
@@ -30,12 +41,5 @@ final class InteropFacade extends AbstractFacade implements InteropFacadeInterfa
         $this->getFactory()
             ->getCommandFacade()
             ->writeStackTrace($output, $e);
-    }
-
-    public function generateExportCode(OutputInterface $output): void
-    {
-        $this->getFactory()
-            ->createExportCodeGenerator()
-            ->generateExportCode($output);
     }
 }

--- a/src/php/Interop/InteropFacade.php
+++ b/src/php/Interop/InteropFacade.php
@@ -5,15 +5,37 @@ declare(strict_types=1);
 namespace Phel\Interop;
 
 use Gacela\Framework\AbstractFacade;
-use Phel\Interop\Infrastructure\Command\ExportCommand;
+use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 /**
  * @method InteropFactory getFactory()
  */
 final class InteropFacade extends AbstractFacade implements InteropFacadeInterface
 {
-    public function getExportCommand(): ExportCommand
+    public function writeLocatedException(OutputInterface $output, CompilerException $e): void
     {
-        return $this->getFactory()->createExportCommand();
+        $this->getFactory()
+            ->getCommandFacade()
+            ->writeLocatedException(
+                $output,
+                $e->getNestedException(),
+                $e->getCodeSnippet()
+            );
+    }
+
+    public function writeStackTrace(OutputInterface $output, Throwable $e): void
+    {
+        $this->getFactory()
+            ->getCommandFacade()
+            ->writeStackTrace($output, $e);
+    }
+
+    public function generateExportCode(OutputInterface $output): void
+    {
+        $this->getFactory()
+            ->createExportCodeGenerator()
+            ->generateExportCode($output);
     }
 }

--- a/src/php/Interop/InteropFacadeInterface.php
+++ b/src/php/Interop/InteropFacadeInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Interop;
 
+use Phel\Interop\Domain\ReadModel\Wrapper;
+
 interface InteropFacadeInterface
 {
+    /**
+     * @return list<Wrapper>
+     */
+    public function generateExportCode(): array;
 }

--- a/src/php/Interop/InteropFacadeInterface.php
+++ b/src/php/Interop/InteropFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Interop;
 
-use Phel\Interop\Infrastructure\Command\ExportCommand;
-
 interface InteropFacadeInterface
 {
-    public function getExportCommand(): ExportCommand;
 }

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -9,6 +9,7 @@ use Phel\Build\BuildFacadeInterface;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Interop\Domain\DirectoryRemover\DirectoryRemover;
 use Phel\Interop\Domain\DirectoryRemover\DirectoryRemoverInterface;
+use Phel\Interop\Domain\ExportCodeGenerator;
 use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinder;
 use Phel\Interop\Domain\ExportFinder\FunctionsToExportFinderInterface;
 use Phel\Interop\Domain\FileCreator\FileCreator;
@@ -19,32 +20,35 @@ use Phel\Interop\Domain\Generator\Builder\CompiledPhpClassBuilder;
 use Phel\Interop\Domain\Generator\Builder\CompiledPhpMethodBuilder;
 use Phel\Interop\Domain\Generator\Builder\WrapperRelativeFilenamePathBuilder;
 use Phel\Interop\Domain\Generator\WrapperGenerator;
-use Phel\Interop\Infrastructure\Command\ExportCommand;
 
 /**
  * @method InteropConfig getConfig()
  */
 final class InteropFactory extends AbstractFactory
 {
-    public function createExportCommand(): ExportCommand
+    public function createExportCodeGenerator(): ExportCodeGenerator
     {
-        return new ExportCommand(
+        return new ExportCodeGenerator(
             $this->createDirectoryRemover(),
             $this->createWrapperGenerator(),
             $this->createFunctionsToExportFinder(),
             $this->createFileCreator(),
-            $this->getCommandFacade(),
         );
     }
 
-    public function createDirectoryRemover(): DirectoryRemoverInterface
+    public function getCommandFacade(): CommandFacadeInterface
+    {
+        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_COMMAND);
+    }
+
+    private function createDirectoryRemover(): DirectoryRemoverInterface
     {
         return new DirectoryRemover(
             $this->getConfig()->getExportTargetDirectory()
         );
     }
 
-    public function createFileCreator(): FileCreatorInterface
+    private function createFileCreator(): FileCreatorInterface
     {
         return new FileCreator(
             $this->getConfig()->getExportTargetDirectory(),
@@ -95,10 +99,5 @@ final class InteropFactory extends AbstractFactory
     private function createFileSystemIo(): FileIoInterface
     {
         return new FileSystemIo();
-    }
-
-    private function getCommandFacade(): CommandFacadeInterface
-    {
-        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_COMMAND);
     }
 }

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Interop\Command\Export;
 
 use Gacela\Framework\Gacela;
-use Phel\Interop\InteropFacade;
-use Phel\Interop\InteropFacadeInterface;
+use Phel\Interop\Infrastructure\Command\ExportCommand;
 use PhelTest\Integration\Util\DirectoryUtil;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,7 +24,7 @@ final class ExportCommandTest extends TestCase
      */
     public function test_export_command_multiple(): void
     {
-        $command = $this->createInteropFacade()->getExportCommand();
+        $command = new ExportCommand();
 
         $this->expectOutputRegex('~Exported namespaces:~');
         $this->expectOutputRegex('~TestCmdExportMultiple/Adder~');
@@ -40,11 +39,6 @@ final class ExportCommandTest extends TestCase
         self::assertFileExists(__DIR__ . '/PhelGenerated/TestCmdExportMultiple/Multiplier.php');
 
         DirectoryUtil::removeDir(__DIR__ . '/PhelGenerated/');
-    }
-
-    private function createInteropFacade(): InteropFacadeInterface
-    {
-        return new InteropFacade();
     }
 
     private function stubOutput(): OutputInterface


### PR DESCRIPTION
### 🤔 Background

Similar as it was done in:
- https://github.com/phel-lang/phel-lang/pull/466
- https://github.com/phel-lang/phel-lang/pull/461
- https://github.com/phel-lang/phel-lang/pull/465

### 💡 Goal

The goal is to allow the creation of the `ExportCommand` directly, and for this we need to get rid of its dependencies.

### 🔖 Changes

Refactor the `ExportCommand` using internally its `InteropFacade`. This way, its communication will be via its facade;

- accesible via `getFacade()`, a new feature of the latest version from Gacela with `use DocBlockResolverAwareTrait;`
- see: https://gacela-project.com/docs/facade/#use-the-facade-from-your-infrastructure-layer
