### PR TITLE
Update gacela 0.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "ext-json": "*",
         "php": ">=8.0",
-        "gacela-project/gacela": "^0.18",
+        "gacela-project/gacela": "^0.19",
         "symfony/console": "^5.4",
         "phpunit/php-timer": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "ext-json": "*",
         "php": ">=8.0",
-        "gacela-project/gacela": "^0.17",
+        "gacela-project/gacela": "^0.18",
         "symfony/console": "^5.4",
         "phpunit/php-timer": "^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b36c46a701b9676a84d968f3a7682b6",
+    "content-hash": "714958e83709119bcb8e947f1f5b0211",
     "packages": [
         {
             "name": "gacela-project/gacela",
-            "version": "0.18.1",
+            "version": "0.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "be53343aeac0bf1472551345c099309140f1af75"
+                "reference": "064724e428e7e5d3f9af6818711032d7eef273f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/be53343aeac0bf1472551345c099309140f1af75",
-                "reference": "be53343aeac0bf1472551345c099309140f1af75",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/064724e428e7e5d3f9af6818711032d7eef273f7",
+                "reference": "064724e428e7e5d3f9af6818711032d7eef273f7",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.4",
-                "symfony/console": "^5.4"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.8",
@@ -35,12 +34,10 @@
                 "vimeo/psalm": "^4.22"
             },
             "suggest": {
+                "gacela-project/gacela-cli": "Gacela cli util",
                 "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
                 "gacela-project/gacela-yaml-config-reader": "Allows to read yml/yaml config files"
             },
-            "bin": [
-                "gacela"
-            ],
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -70,9 +67,9 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/0.18.1"
+                "source": "https://github.com/gacela-project/gacela/tree/0.19.0"
             },
-            "time": "2022-05-14T20:27:40+00:00"
+            "time": "2022-05-19T19:46:21+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -5310,5 +5307,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd1eed8ae714b2bb352727e240b64a65",
+    "content-hash": "4b36c46a701b9676a84d968f3a7682b6",
     "packages": [
         {
             "name": "gacela-project/gacela",
-            "version": "0.17.0",
+            "version": "0.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "577ab3538db63da85cc3ebf315bbfe9c3492f62e"
+                "reference": "be53343aeac0bf1472551345c099309140f1af75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/577ab3538db63da85cc3ebf315bbfe9c3492f62e",
-                "reference": "577ab3538db63da85cc3ebf315bbfe9c3492f62e",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/be53343aeac0bf1472551345c099309140f1af75",
+                "reference": "be53343aeac0bf1472551345c099309140f1af75",
                 "shasum": ""
             },
             "require": {
@@ -70,9 +70,9 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/0.17.0"
+                "source": "https://github.com/gacela-project/gacela/tree/0.18.1"
             },
-            "time": "2022-04-29T10:41:54+00:00"
+            "time": "2022-05-14T20:27:40+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/phel
+++ b/phel
@@ -3,9 +3,8 @@
 
 declare(strict_types=1);
 
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
-use Gacela\Framework\Setup\SetupGacela;
 use Phel\Console\Infrastructure\ConsoleBootstrap;
 
 $projectRootDir = getcwd() . DIRECTORY_SEPARATOR;
@@ -17,12 +16,11 @@ if (!file_exists($autoloadPath)) {
 
 require $autoloadPath;
 
-$setupGacela = (new SetupGacela())
-    ->setConfig(static function (ConfigBuilder $configBuilder): void {
-        $configBuilder->add('phel-config.php', 'phel-config-local.php');
-    });
+$configFn = static function (GacelaConfig $config): void {
+    $config->addAppConfig('phel-config.php', 'phel-config-local.php');
+};
 
-Gacela::bootstrap($projectRootDir, $setupGacela);
+Gacela::bootstrap($projectRootDir, $configFn);
 
 $bootstrap = new ConsoleBootstrap();
 $bootstrap->run();

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Phel;
 
-use Gacela\Framework\Config\GacelaConfigBuilder\ConfigBuilder;
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
-use Gacela\Framework\Setup\SetupGacela;
 use Phel\Run\RunFacade;
 
 final class Phel
@@ -16,12 +15,11 @@ final class Phel
      */
     public static function run(string $projectRootDir, string $namespace): void
     {
-        $setupGacela = (new SetupGacela())
-            ->setConfig(static function (ConfigBuilder $configBuilder): void {
-                $configBuilder->add('phel-config.php', 'phel-config-local.php');
-            });
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('phel-config.php', 'phel-config-local.php');
+        };
 
-        Gacela::bootstrap($projectRootDir, $setupGacela);
+        Gacela::bootstrap($projectRootDir, $configFn);
 
         $runFacade = new RunFacade();
         $runFacade->runNamespace($namespace);

--- a/tests/php/Integration/Build/Command/CompileCommandTest.php
+++ b/tests/php/Integration/Build/Command/CompileCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Build\Command;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Build\Infrastructure\Command\CompileCommand;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,11 @@ final class CompileCommandTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     protected function setUp(): void

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Interop\Command\Export;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
 use PhelTest\Integration\Util\DirectoryUtil;
@@ -15,7 +16,11 @@ final class ExportCommandTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Repl;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Generator;
 use Phel\Build\BuildFacade;
@@ -28,7 +29,11 @@ final class ReplCommandTest extends AbstractCommandTest
 {
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Run;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use PhelTest\Integration\Run\Command\AbstractCommandTest;
@@ -13,7 +14,11 @@ final class RunCommandTest extends AbstractCommandTest
 {
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/TestCommandProjectFailureTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/TestCommandProjectFailureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Test\TestCommandProjectFailure;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Run\Infrastructure\Command\TestCommand;
 use PhelTest\Integration\Run\Command\AbstractCommandTest;
@@ -13,7 +14,11 @@ final class TestCommandProjectFailureTest extends AbstractCommandTest
 {
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Test\TestCommandProjectSuccess;
 
+use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Run\Infrastructure\Command\TestCommand;
 use PhelTest\Integration\Run\Command\AbstractCommandTest;
@@ -13,7 +14,11 @@ final class TestCommandProjectSuccessTest extends AbstractCommandTest
 {
     public static function setUpBeforeClass(): void
     {
-        Gacela::bootstrap(__DIR__);
+        $configFn = static function (GacelaConfig $config): void {
+            $config->addAppConfig('config/*.php');
+        };
+
+        Gacela::bootstrap(__DIR__, $configFn);
     }
 
     /**


### PR DESCRIPTION
### 🤔 Background

Now it's mandatory to define the appConfig path.

### 🔖 Changes

- Upgrade gacela from 0.17 to 0.19
- Define the appConfig for all feature tests who needs some config values
