### PR TITLE
Support strings in `empty?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Allow strings on `empty?` (#492)
+* Improved error message when using strings on `count` (#492)
+
 ## 0.7.0 (2022-05-05)
 
 * Added: `merge-with` function

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -316,9 +316,11 @@ implement the PHP Countable interface."
     (php/-> xs (count))
     (if (php/is_array xs)
       (php/count xs)
-      (if (php/=== xs nil)
-        0
-        (throw (php/new InvalidArgumentException (str "object is not countable: " xs)))))))
+      (if (php/is_string xs)
+        (throw (php/new InvalidArgumentException "strings are not supported. Consider using native PHP functions like `php/strlen` or `php/mb_strlen`."))
+        (if (php/=== xs nil)
+          0
+          (throw (php/new InvalidArgumentException (str "object is not countable: " xs))))))))
 
 # ------------------
 # Control structures
@@ -678,7 +680,9 @@ Calling the and function without arguments returns true."
 (defn empty?
   "Returns true if `(count x)` is zero, false otherwise."
   [x]
-  (= 0 (count x)))
+  (if (php/is_string x)
+    (true? (php/empty x))
+    (= 0 (count x))))
 
 (defn- indexed-php-array?
   [x]

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -43,4 +43,5 @@
   (is (= 0 (count {})) "count of empty hash map")
   (is (= 1 (count ["a"])) "count of one element vector")
   (is (= 1 (count (php/array "a"))) "count of one element php array")
-  (is (= 1 (count {:a 1})) "count of one element hash map"))
+  (is (= 1 (count {:a 1})) "count of one element hash map")
+  (is (thrown? \InvalidArgumentException (count "str")) "strings are not supported"))

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -90,9 +90,11 @@
   (is (true? (empty? [])) "empty? on empty vector")
   (is (true? (empty? (php/array))) "empty? on empty php array")
   (is (true? (empty? {})) "empty? on empty map")
+  (is (true? (empty? "")) "empty? on one empty string")
   (is (false? (empty? [1])) "empty? on one element vector")
   (is (false? (empty? (php/array 1))) "empty? on one element php array")
-  (is (false? (empty? {:a 1})) "empty? on one element map"))
+  (is (false? (empty? {:a 1})) "empty? on one element map")
+  (is (false? (empty? "a")) "empty? on one string"))
 
 (deftest test-indexed?
   (is (false? (indexed? {})) "indexed? on map")


### PR DESCRIPTION
### 🤔 Background

Currently, it's not possible to use the `count` function with strings. 
This is also affecting the `empty?` function, which uses the `count`, you get an error: `object is not countable`.

### 💡 Goal

Allow **checking emptiness** in strings.

### 🔖 Changes

- Allow `(empty? "")` and `(empty? "any string")`
- Display a more descriptive error when using an string with `(count "")` function