### PR TITLE
Add .editorconfig & .gitattributes files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+/.github                export-ignore
+/adrs                   export-ignore
+/docker                 export-ignore
+/tests                  export-ignore
+/tools                  export-ignore
+/.editorconfig          export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/infection.json.dist    export-ignore
+/phpbench.json          export-ignore
+/phpmetrics-config.json export-ignore
+/phpstan.neon           export-ignore
+/phpunit.xml.dist       export-ignore
+/psalm.xml              export-ignore


### PR DESCRIPTION
### 📚 Description

This PR adds two config files to the `phel` project which I consider they are very important.


- What is [editorconfig](https://editorconfig.org/)?

**EditorConfig** helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a **file format** for defining coding styles. EditorConfig files are easily readable and they work nicely with version control systems.

- What are [gitattributes](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes)?

You can tell Git not to export certain files or directories when generating an archive. If there is a subdirectory or file that you don’t want to include in your archive file but that you do want checked into your project, you can determine those files via the export-ignore attribute.

In other words, basically, when you require from `composer` the `phel` dependency, you won't download the folders that are ignored.

You can see an example of `PHPUnit` dependency in any project:

<img width="274" alt="image" src="https://user-images.githubusercontent.com/6381924/176550320-bc0f5ba0-2a4f-46e7-8578-1d5d8a097da1.png">

If you take a look at the `phpunit/phpunit`, you can realise there are more files and they are ignored because of this file 😄 

<img width="695" alt="image" src="https://user-images.githubusercontent.com/6381924/176550702-1fa0fdf4-2e3e-46bc-9771-e1ba4e4199de.png">
