### PR TITLE
Remove ext-json from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         }
     ],
     "require": {
-        "ext-json": "*",
         "php": ">=8.0",
         "gacela-project/gacela": "^0.23",
         "symfony/console": "^5.4",
@@ -23,7 +22,7 @@
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "^4.24",
         "symfony/var-dumper": "^5.4",
-        "friendsofphp/php-cs-fixer": "^3.8",
+        "friendsofphp/php-cs-fixer": "^3.9",
         "phpmetrics/phpmetrics": "^2.8",
         "phpbench/phpbench": "^1.2",
         "phpstan/phpstan": "^1.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a848b5f33ce3a1a9533ad1c24c767719",
+    "content-hash": "4dc610aa16fb3f86a9a9f76c9a025dff",
     "packages": [
         {
             "name": "gacela-project/gacela",
@@ -1513,16 +1513,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.2",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
                 "shasum": ""
             },
             "require": {
@@ -1534,9 +1534,10 @@
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2"
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
             "autoload": {
@@ -1579,9 +1580,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
             },
-            "time": "2021-08-05T19:00:23+00:00"
+            "time": "2022-07-02T10:48:51+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1832,16 +1833,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.8.0",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3"
+                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3",
-                "reference": "cbad1115aac4b5c3c5540e7210d3c9fba2f81fa3",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
+                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
                 "shasum": ""
             },
             "require": {
@@ -1909,7 +1910,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.8.0"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.3"
             },
             "funding": [
                 {
@@ -1917,7 +1918,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-18T17:20:59+00:00"
+            "time": "2022-07-13T09:53:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2788,16 +2789,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5"
+                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7648d4ee9321665acaf112e49da9fd93df8fbd5",
-                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8dbba631fa32f4b289404469c2afd6122fd61d67",
+                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67",
                 "shasum": ""
             },
             "require": {
@@ -2823,7 +2824,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.0"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.1"
             },
             "funding": [
                 {
@@ -2843,7 +2844,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-29T08:53:31+00:00"
+            "time": "2022-07-12T16:08:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5308,7 +5309,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*",
         "php": ">=8.0"
     },
     "platform-dev": {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -55,10 +55,10 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
                     break;
 
                 case 'done':
-                   throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
+                    throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
 
                 default:
-                   throw AnalyzerException::withLocation("Unexpected parser state in 'try", $list);
+                    throw AnalyzerException::withLocation("Unexpected parser state in 'try", $list);
             }
         }
 

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -11,6 +11,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Map/ArrayNodeIterator.php
+++ b/src/php/Lang/Collections/Map/ArrayNodeIterator.php
@@ -6,6 +6,7 @@ namespace Phel\Lang\Collections\Map;
 
 use Iterator;
 use RuntimeException;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Map/HashCollisionNode.php
+++ b/src/php/Lang/Collections/Map/HashCollisionNode.php
@@ -7,6 +7,7 @@ namespace Phel\Lang\Collections\Map;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
+
 use function array_slice;
 
 /**

--- a/src/php/Lang/Collections/Map/IndexedNodeIterator.php
+++ b/src/php/Lang/Collections/Map/IndexedNodeIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lang\Collections\Map;
 
 use Iterator;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -8,6 +8,7 @@ use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use RuntimeException;
 use Traversable;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -10,6 +10,7 @@ use Phel\Lang\HasherInterface;
 use RuntimeException;
 use stdclass;
 use Traversable;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -7,6 +7,7 @@ namespace Phel\Lang\Collections\Map;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+
 use function count;
 
 /**

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -10,6 +10,7 @@ use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use RuntimeException;
 use Traversable;
+
 use function array_slice;
 use function count;
 

--- a/src/php/Lang/Collections/Vector/RangeIterator.php
+++ b/src/php/Lang/Collections/Vector/RangeIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lang\Collections\Vector;
 
 use Iterator;
+
 use function assert;
 use function count;
 

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -11,6 +11,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use Traversable;
+
 use function array_slice;
 
 /**

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -9,6 +9,7 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use RuntimeException;
+
 use function count;
 
 /**

--- a/src/php/Lang/Hasher.php
+++ b/src/php/Lang/Hasher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lang;
 
 use RuntimeException;
+
 use function gettype;
 use function is_float;
 use function is_int;

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lang;
 
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+
 use function array_key_exists;
 
 final class Registry

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -14,6 +14,7 @@ use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
 use function count;
 
 class TypeFactory

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -33,6 +33,7 @@ use Phel\Printer\TypePrinter\ToStringPrinter;
 use Phel\Printer\TypePrinter\TypePrinterInterface;
 use ReflectionClass;
 use RuntimeException;
+
 use function gettype;
 use function is_object;
 

--- a/src/php/Printer/TypePrinter/StructPrinter.php
+++ b/src/php/Printer/TypePrinter/StructPrinter.php
@@ -6,6 +6,7 @@ namespace Phel\Printer\TypePrinter;
 
 use Phel\Lang\Collections\Struct\AbstractPersistentStruct;
 use Phel\Printer\PrinterInterface;
+
 use function get_class;
 
 /**

--- a/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Formatter\Domain\Rules\Zipper;
 
 use Phel\Formatter\Domain\Rules\Zipper\AbstractZipper;
 use Phel\Formatter\Domain\Rules\Zipper\ZipperException;
+
 use function is_array;
 
 /**

--- a/tests/php/Unit/Lang/Collections/Struct/FakeStruct.php
+++ b/tests/php/Unit/Lang/Collections/Struct/FakeStruct.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Struct;
 
 use Phel\Lang\Collections\Struct\AbstractPersistentStruct;
+
 use function count;
 
 final class FakeStruct extends AbstractPersistentStruct


### PR DESCRIPTION
## 📚 Description

Remove `ext-json`, as it is not necessary anymore [since PHP 8.0](https://php.watch/versions/8.0/ext-json), also, update dependencies 😃

**Edit**: Because of updating the dependencies, the CI pipeline was not working, I had to run `./vendor/bin/php-cs-fixer fix` command to make it green.