### PR TITLE
Update gacela@0.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "gacela-project/gacela": "^0.23",
+        "gacela-project/gacela": "^0.24",
         "symfony/console": "^5.4",
         "phpunit/php-timer": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
     "name": "phel-lang/phel-lang",
     "type": "library",
     "description": "Phel is a functional programming language that compiles to PHP",
-    "keywords": ["phel","lisp","functional","language"],
+    "keywords": [
+        "phel",
+        "lisp",
+        "functional",
+        "language"
+    ],
     "homepage": "https://phel-lang.org/",
     "license": "MIT",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4dc610aa16fb3f86a9a9f76c9a025dff",
+    "content-hash": "1613d5290103d8b1cbdc5c4d0a499cb8",
     "packages": [
         {
             "name": "gacela-project/gacela",
-            "version": "0.23.1",
+            "version": "0.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "65c0fbb9a70c3160a4e46dd10f4a2071129341b8"
+                "reference": "e69bbbba62205fd23bb54d543fe0ec721d220408"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/65c0fbb9a70c3160a4e46dd10f4a2071129341b8",
-                "reference": "65c0fbb9a70c3160a4e46dd10f4a2071129341b8",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/e69bbbba62205fd23bb54d543fe0ec721d220408",
+                "reference": "e69bbbba62205fd23bb54d543fe0ec721d220408",
                 "shasum": ""
             },
             "require": {
@@ -25,14 +25,15 @@
                 "php": ">=7.4"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.8",
+                "friendsofphp/php-cs-fixer": "^3.9",
                 "phpbench/phpbench": "^1.2",
                 "phpmetrics/phpmetrics": "^2.8",
-                "phpstan/phpstan": "^1.7",
+                "phpstan/phpstan": "^1.8",
                 "phpunit/phpunit": "^9.5",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "symfony/console": "^5.4",
                 "symfony/var-dumper": "^5.4",
-                "vimeo/psalm": "^4.23"
+                "vimeo/psalm": "^4.24"
             },
             "suggest": {
                 "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
@@ -71,7 +72,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/0.23.1"
+                "source": "https://github.com/gacela-project/gacela/tree/0.24.0"
             },
             "funding": [
                 {
@@ -79,7 +80,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-25T09:32:09+00:00"
+            "time": "2022-07-23T16:37:11+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -5317,5 +5318,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1834,16 +1834,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.9.3",
+            "version": "v3.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1"
+                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
-                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4465d70ba776806857a1ac2a6f877e582445ff36",
+                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36",
                 "shasum": ""
             },
             "require": {
@@ -1911,7 +1911,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.3"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.5"
             },
             "funding": [
                 {
@@ -1919,7 +1919,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-13T09:53:20+00:00"
+            "time": "2022-07-22T08:43:51+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2407,16 +2407,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "a38af132cf317fd13c199cf73501153b82c279b5"
+                "reference": "c30fac992e72b505a1f131790583647f4d3255c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/a38af132cf317fd13c199cf73501153b82c279b5",
-                "reference": "a38af132cf317fd13c199cf73501153b82c279b5",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/c30fac992e72b505a1f131790583647f4d3255c3",
+                "reference": "c30fac992e72b505a1f131790583647f4d3255c3",
                 "shasum": ""
             },
             "require": {
@@ -2483,7 +2483,7 @@
             "description": "PHP Benchmarking Framework",
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.2.5"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.6"
             },
             "funding": [
                 {
@@ -2491,7 +2491,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-06T17:10:14+00:00"
+            "time": "2022-07-19T19:52:39+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2790,16 +2790,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.1",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8dbba631fa32f4b289404469c2afd6122fd61d67",
-                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
@@ -2825,7 +2825,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.1"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -2845,7 +2845,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-12T16:08:06+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
### 🤔 Background

We released a new version of Gacela with some internal improvements.

### 🔖 Changes

- Update gacela to the latest 0.24 ([release notes](https://github.com/gacela-project/gacela/releases/tag/0.24.0))
- Update composer require-dev dependencies as well

```
phel-lang/ (feature/update-gacela-0-24) $  ~/.composer/vendor/bin/composer-lock-diff --from=/tmp/composer-dev.lock --to=composer.lock

+-----------------------+--------+--------+------------------------------------------------------------------+
| Production Changes    | From   | To     | Compare                                                          |
+-----------------------+--------+--------+------------------------------------------------------------------+
| gacela-project/gacela | 0.23.1 | 0.24.0 | https://github.com/gacela-project/gacela/compare/0.23.1...0.24.0 |
+-----------------------+--------+--------+------------------------------------------------------------------+

+---------------------------+--------+--------+----------------------------------------------------------------------+
| Dev Changes               | From   | To     | Compare                                                              |
+---------------------------+--------+--------+----------------------------------------------------------------------+
| friendsofphp/php-cs-fixer | v3.9.3 | v3.9.5 | https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v3.9.3...v3.9.5 |
| phpbench/phpbench         | 1.2.5  | 1.2.6  | https://github.com/phpbench/phpbench/compare/1.2.5...1.2.6           |
| phpstan/phpstan           | 1.8.1  | 1.8.2  | https://github.com/phpstan/phpstan/compare/1.8.1...1.8.2             |
+---------------------------+--------+--------+----------------------------------------------------------------------+

```
