### PR TITLE
Add trailing comma in multiline arrays, arguments and parameters

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -112,7 +112,11 @@ return (new Config())
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline' => [
-            'elements' => ['arrays'],
+            'elements' => [
+                'arrays',
+                'arguments',
+                'parameters',
+            ],
         ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -118,7 +118,7 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
             ->writeLocatedException(
                 $output,
                 $e->getNestedException(),
-                $e->getCodeSnippet()
+                $e->getCodeSnippet(),
             );
     }
 

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -24,14 +24,14 @@ final class BuildFactory extends AbstractFactory
             $this->createNamespaceExtractor(),
             $this->createFileCompiler(),
             $this->getCompilerFacade(),
-            $this->getCommandFacade()
+            $this->getCommandFacade(),
         );
     }
 
     public function createDependenciesForNamespace(): DependenciesForNamespace
     {
         return new DependenciesForNamespace(
-            $this->createNamespaceExtractor()
+            $this->createNamespaceExtractor(),
         );
     }
 
@@ -39,7 +39,7 @@ final class BuildFactory extends AbstractFactory
     {
         return new FileCompiler(
             $this->getCompilerFacade(),
-            $this->createNamespaceExtractor()
+            $this->createNamespaceExtractor(),
         );
     }
 
@@ -47,7 +47,7 @@ final class BuildFactory extends AbstractFactory
     {
         return new FileEvaluator(
             $this->getCompilerFacade(),
-            $this->createNamespaceExtractor()
+            $this->createNamespaceExtractor(),
         );
     }
 
@@ -55,7 +55,7 @@ final class BuildFactory extends AbstractFactory
     {
         return new NamespaceExtractor(
             $this->getCompilerFacade(),
-            $this->createNamespaceSorter()
+            $this->createNamespaceSorter(),
         );
     }
 

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -42,7 +42,7 @@ final class FileCompiler implements FileCompilerInterface
         return new CompiledFile(
             $src,
             $dest,
-            $namespaceInfo->getNamespace()
+            $namespaceInfo->getNamespace(),
         );
     }
 }

--- a/src/php/Build/Domain/Compile/FileEvaluator.php
+++ b/src/php/Build/Domain/Compile/FileEvaluator.php
@@ -29,7 +29,7 @@ final class FileEvaluator
         return new CompiledFile(
             $src,
             '',
-            $namespaceInfo->getNamespace()
+            $namespaceInfo->getNamespace(),
         );
     }
 }

--- a/src/php/Build/Domain/Compile/ProjectCompiler.php
+++ b/src/php/Build/Domain/Compile/ProjectCompiler.php
@@ -72,7 +72,7 @@ final class ProjectCompiler
             $result[] = $this->fileCompiler->compileFile(
                 $info->getFile(),
                 $targetFile,
-                $buildOptions->isSourceMapEnabled()
+                $buildOptions->isSourceMapEnabled(),
             );
 
             touch($targetFile, filemtime($info->getFile()));

--- a/src/php/Build/Domain/Extractor/NamespaceExtractor.php
+++ b/src/php/Build/Domain/Extractor/NamespaceExtractor.php
@@ -53,8 +53,8 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
                     $node->getNamespace(),
                     array_map(
                         static fn (Symbol $s) => $s->getFullName(),
-                        $node->getRequireNs()
-                    )
+                        $node->getRequireNs(),
+                    ),
                 );
             }
 
@@ -142,7 +142,7 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
 
         return array_map(
             fn ($file) => $this->getNamespaceFromFile($file[0]),
-            iterator_to_array($phelIterator)
+            iterator_to_array($phelIterator),
         );
     }
 }

--- a/src/php/Build/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Build/Infrastructure/Command/CompileCommand.php
@@ -53,7 +53,7 @@ final class CompileCommand extends Command
     {
         return new BuildOptions(
             $input->getOption(self::OPTION_CACHE) === true,
-            $input->getOption(self::OPTION_SOURCE_MAP) === true
+            $input->getOption(self::OPTION_SOURCE_MAP) === true,
         );
     }
 
@@ -67,7 +67,7 @@ final class CompileCommand extends Command
                     $compiledFile->getNamespace(),
                     $compiledFile->getSourceFile(),
                     $compiledFile->getTargetFile(),
-                )
+                ),
             );
         }
     }

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -24,7 +24,7 @@ final class CommandConfig extends AbstractConfig
         return new CodeDirectories(
             (array)$this->get(self::SRC_DIRS, self::DEFAULT_SRC_DIRS),
             (array)$this->get(self::TEST_DIRS, self::DEFAULT_TEST_DIRS),
-            (string)$this->get(self::OUTPUT_DIR, self::DEFAULT_OUT_DIR)
+            (string)$this->get(self::OUTPUT_DIR, self::DEFAULT_OUT_DIR),
         );
     }
 

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -20,7 +20,7 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $locatedException,
-        CodeSnippet $snippet
+        CodeSnippet $snippet,
     ): void {
         $this->getFactory()
             ->createCommandExceptionWriter()

--- a/src/php/Command/CommandFacadeInterface.php
+++ b/src/php/Command/CommandFacadeInterface.php
@@ -14,7 +14,7 @@ interface CommandFacadeInterface
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $locatedException,
-        CodeSnippet $snippet
+        CodeSnippet $snippet,
     ): void;
 
     public function writeStackTrace(OutputInterface $output, Throwable $e): void;

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -28,7 +28,7 @@ final class CommandFactory extends AbstractFactory
     public function createCommandExceptionWriter(): CommandExceptionWriterInterface
     {
         return new CommandExceptionWriter(
-            $this->createExceptionPrinter()
+            $this->createExceptionPrinter(),
         );
     }
 
@@ -38,7 +38,7 @@ final class CommandFactory extends AbstractFactory
             new ExceptionArgsPrinter(Printer::readable()),
             ColorStyle::withStyles(),
             new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor())
+            new FilePositionExtractor(new SourceMapExtractor()),
         );
     }
 
@@ -47,14 +47,14 @@ final class CommandFactory extends AbstractFactory
         return new DirectoryFinder(
             $this->getConfig()->getAppRootDir(),
             $this->getConfig()->getCodeDirs(),
-            $this->createComposerVendorDirectoriesFinder()
+            $this->createComposerVendorDirectoriesFinder(),
         );
     }
 
     private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface
     {
         return new ComposerVendorDirectoriesFinder(
-            $this->getConfig()->getAppRootDir() . '/' . $this->getConfig()->getVendorDir()
+            $this->getConfig()->getAppRootDir() . '/' . $this->getConfig()->getVendorDir(),
         );
     }
 }

--- a/src/php/Command/Domain/Finder/DirectoryFinder.php
+++ b/src/php/Command/Domain/Finder/DirectoryFinder.php
@@ -51,7 +51,7 @@ final class DirectoryFinder implements DirectoryFinderInterface
     {
         return array_map(
             fn (string $dir): string => $this->applicationRootDir . '/' . $dir,
-            $relativeDirectories
+            $relativeDirectories,
         );
     }
 }

--- a/src/php/Command/Domain/Finder/PhelFileFinder.php
+++ b/src/php/Command/Domain/Finder/PhelFileFinder.php
@@ -26,7 +26,7 @@ final class PhelFileFinder implements PhelFileFinderInterface
         $appendIterator = new AppendIterator();
         foreach ($directories as $directory) {
             $appendIterator->append(
-                new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory))
+                new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory)),
             );
         }
 

--- a/src/php/Command/Domain/Shared/CommandExceptionWriter.php
+++ b/src/php/Command/Domain/Shared/CommandExceptionWriter.php
@@ -18,7 +18,7 @@ final class CommandExceptionWriter implements CommandExceptionWriterInterface
 
     public function writeStackTrace(
         OutputInterface $output,
-        Throwable $e
+        Throwable $e,
     ): void {
         $output->writeln($this->exceptionPrinter->getStackTraceString($e));
 
@@ -32,7 +32,7 @@ final class CommandExceptionWriter implements CommandExceptionWriterInterface
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $e,
-        CodeSnippet $codeSnippet
+        CodeSnippet $codeSnippet,
     ): void {
         $output->writeln($this->exceptionPrinter->getExceptionString($e, $codeSnippet));
     }

--- a/src/php/Command/Domain/Shared/CommandExceptionWriterInterface.php
+++ b/src/php/Command/Domain/Shared/CommandExceptionWriterInterface.php
@@ -16,7 +16,7 @@ interface CommandExceptionWriterInterface
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $e,
-        CodeSnippet $codeSnippet
+        CodeSnippet $codeSnippet,
     ): void;
 
     public function getExceptionString(AbstractLocatedException $e, CodeSnippet $codeSnippet): string;

--- a/src/php/Command/Domain/Shared/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Shared/Exceptions/ExceptionArgsPrinter.php
@@ -25,7 +25,7 @@ final class ExceptionArgsPrinter implements ExceptionArgsPrinterInterface
     {
         $argParts = array_map(
             fn (mixed $arg) => $this->printer->print($arg),
-            $frameArgs
+            $frameArgs,
         );
 
         $argString = implode(' ', $argParts);
@@ -40,7 +40,7 @@ final class ExceptionArgsPrinter implements ExceptionArgsPrinterInterface
     {
         $result = array_map(
             fn ($arg) => $this->buildPhpArg($arg),
-            $args
+            $args,
         );
 
         return implode(', ', $result);

--- a/src/php/Command/Domain/Shared/Exceptions/Extractor/FilePositionExtractor.php
+++ b/src/php/Command/Domain/Shared/Exceptions/Extractor/FilePositionExtractor.php
@@ -20,7 +20,7 @@ final class FilePositionExtractor implements FilePositionExtractorInterface
 
         return new FilePosition(
             $this->extractOriginalFilename($sourceMapInfo, $filename),
-            $this->extractOriginalLine($sourceMapInfo, $line)
+            $this->extractOriginalLine($sourceMapInfo, $line),
         );
     }
 

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -89,7 +89,7 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
         string $code,
         string $source = Lexer::DEFAULT_SOURCE,
         bool $withLocation = true,
-        int $startingLine = 1
+        int $startingLine = 1,
     ): TokenStream {
         return $this->getFactory()
             ->createLexer($withLocation)

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -49,7 +49,7 @@ final class CompilerFactory extends AbstractFactory
             $this->createReader(),
             $this->createAnalyzer(),
             $this->createStatementEmitter(),
-            $this->createEvaluator()
+            $this->createEvaluator(),
         );
     }
 
@@ -62,7 +62,7 @@ final class CompilerFactory extends AbstractFactory
             $this->createAnalyzer(),
             $this->createStatementEmitter($compileOptions->isSourceMapsEnabled()),
             $this->createFileEmitter($compileOptions->isSourceMapsEnabled()),
-            $this->createEvaluator()
+            $this->createEvaluator(),
         );
     }
 
@@ -75,7 +75,7 @@ final class CompilerFactory extends AbstractFactory
     {
         return new Reader(
             new ExpressionReaderFactory(),
-            new QuasiquoteTransformer($this->getGlobalEnvironment())
+            new QuasiquoteTransformer($this->getGlobalEnvironment()),
         );
     }
 
@@ -83,7 +83,7 @@ final class CompilerFactory extends AbstractFactory
     {
         return new Parser(
             new ExpressionParserFactory(),
-            $this->getGlobalEnvironment()
+            $this->getGlobalEnvironment(),
         );
     }
 
@@ -96,7 +96,7 @@ final class CompilerFactory extends AbstractFactory
     {
         return new StatementEmitter(
             new SourceMapGenerator(),
-            $this->createOutputEmitter($enableSourceMaps)
+            $this->createOutputEmitter($enableSourceMaps),
         );
     }
 
@@ -110,8 +110,8 @@ final class CompilerFactory extends AbstractFactory
                 $this->createMunge(),
                 Printer::readable(),
                 new SourceMapState(),
-                new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_FILE)
-            )
+                new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_FILE),
+            ),
         );
     }
 
@@ -123,7 +123,7 @@ final class CompilerFactory extends AbstractFactory
             $this->createMunge(),
             Printer::readable(),
             new SourceMapState(),
-            new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_STATEMENT)
+            new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_STATEMENT),
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefStructInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefStructInterface.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Domain\Analyzer\Ast;
 final class DefStructInterface
 {
     /**
-     * @param list<DefStructMethod> $methods ;
+     * @param list<DefStructMethod> $methods
      */
     public function __construct(
         private string $absoluteInterfaceName,

--- a/src/php/Compiler/Domain/Analyzer/Ast/QuoteNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/QuoteNode.php
@@ -13,7 +13,7 @@ final class QuoteNode extends AbstractNode
     public function __construct(
         NodeEnvironmentInterface $env,
         private TypeInterface|array|string|float|int|bool|null $value,
-        ?SourceLocation $sourceLocation = null
+        ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }

--- a/src/php/Compiler/Domain/Analyzer/Ast/TryNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/TryNode.php
@@ -17,7 +17,7 @@ final class TryNode extends AbstractNode
         private AbstractNode $body,
         private array $catches,
         private ?AbstractNode $finally = null,
-        ?SourceLocation $sourceLocation = null
+        ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -143,14 +143,14 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         if ($strName === '__DIR__') {
             return new LiteralNode(
                 $env,
-                $this->resolveMagicDir($name->getStartLocation())
+                $this->resolveMagicDir($name->getStartLocation()),
             );
         }
 
         if ($strName === '__FILE__') {
             return new LiteralNode(
                 $env,
-                $this->resolveMagicFile($name->getStartLocation())
+                $this->resolveMagicFile($name->getStartLocation()),
             );
         }
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -80,8 +80,8 @@ final class NodeEnvironment implements NodeEnvironmentInterface
             $this->locals,
             array_map(
                 static fn (Symbol $s) => Symbol::create($s->getName()),
-                $locals
-            )
+                $locals,
+            ),
         );
 
         return $this

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -16,7 +16,7 @@ final class AnalyzerException extends AbstractLocatedException
             $message,
             $type->getStartLocation(),
             $type->getEndLocation(),
-            $nested
+            $nested,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ApplySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ApplySymbol.php
@@ -33,7 +33,7 @@ final class ApplySymbol implements SpecialFormAnalyzerInterface
             $env,
             $this->fnExpr($fnExpr, $env),
             $this->arguments($args, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -44,7 +44,7 @@ final class ApplySymbol implements SpecialFormAnalyzerInterface
     {
         return $this->analyzer->analyze(
             $x,
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -108,9 +108,9 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
         throw AnalyzerException::withLocation(
             sprintf(
                 'Unsupported binding form, only one symbol can follow the %s parameter',
-                self::REST_SYMBOL_NAME
+                self::REST_SYMBOL_NAME,
             ),
-            $binding
+            $binding,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefInterfaceSymbol.php
@@ -33,7 +33,7 @@ final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
             $this->analyzer->getNamespace(),
             $interfaceSymbol,
             $this->methods($list->rest()->cdr()),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -89,7 +89,7 @@ final class DefInterfaceSymbol implements SpecialFormAnalyzerInterface
         return new DefInterfaceMethod(
             $name,
             $arguments->toArray(),
-            $comment
+            $comment,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -34,7 +34,7 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
         if (count($list) < 3) {
             throw AnalyzerException::withLocation(
                 "At least two arguments are required for 'defstruct. Got " . count($list),
-                $list
+                $list,
             );
         }
 
@@ -57,9 +57,9 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
             $params,
             $this->interfaces(
                 $list->rest()->rest()->rest(),
-                $env->withMergedLocals($params)
+                $env->withMergedLocals($params),
             ),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -137,7 +137,7 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
 
             $interfaces[] = new DefStructInterface(
                 $absoluteInterfaceName,
-                $methods
+                $methods,
             );
         }
 
@@ -181,7 +181,7 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
                     ...($list->rest()->rest()->toArray()),
                 ]),
             ]),
-            $env
+            $env,
         );
 
         if (!$fnNode instanceof FnNode) {
@@ -190,7 +190,7 @@ final class DefStructSymbol implements SpecialFormAnalyzerInterface
 
         return new DefStructMethod(
             $methodName,
-            $fnNode
+            $fnNode,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -57,7 +57,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $nameSymbol,
             $meta,
             $this->analyzeInit($init, $env, $namespace, $nameSymbol),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -75,7 +75,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         if (!in_array($listSize, self::POSSIBLE_TUPLE_SIZES)) {
             throw AnalyzerException::withLocation(
                 "Two or three arguments are required for 'def. Got " . $listSize,
-                $list
+                $list,
             );
         }
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
@@ -53,7 +53,7 @@ final class DoSymbol implements SpecialFormAnalyzerInterface
             $env,
             array_slice($stmts, 0, -1),
             $stmts[count($stmts) - 1],
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -36,7 +36,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
             $this->buildUsesFromEnv($env, $fnSymbolTuple),
             $fnSymbolTuple->isVariadic(),
             $recurFrame->isActive(),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
@@ -30,7 +30,7 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
 
         $bodyExpr = $this->analyzer->analyze(
             $this->buildTupleBody($foreachSymbolTuple->lets(), $list),
-            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)
+            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT),
         );
 
         return new ForeachNode(
@@ -39,7 +39,7 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
             $foreachSymbolTuple->listExpr(),
             $foreachSymbolTuple->valueSymbol(),
             $foreachSymbolTuple->keySymbol(),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -83,7 +83,7 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
         $bodyEnv = $env->withMergedLocals([$valueSymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple->get(1),
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION),
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol);
@@ -112,7 +112,7 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
         $bodyEnv = $env->withMergedLocals([$valueSymbol, $keySymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple->get(2),
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION),
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol, $keySymbol);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/IfSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/IfSymbol.php
@@ -29,7 +29,7 @@ final class IfSymbol implements SpecialFormAnalyzerInterface
             $this->testExpression($list, $env),
             $this->thenExpression($list, $env),
             $this->elseExpression($list, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -27,7 +27,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
     {
         $f = $this->analyzer->analyze(
             $list->first(),
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
         );
 
         if ($f instanceof GlobalVarNode && $this->isInline($f, count($list) - 1)) {
@@ -42,7 +42,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             $env,
             $f,
             $this->arguments($list->rest(), $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -84,7 +84,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation(
                 'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName() . '": ' . $e->getMessage(),
                 $list,
-                $e
+                $e,
             );
         }
     }
@@ -101,7 +101,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation(
                 'Error in expanding macro "' . $macroNode->getNamespace() . '\\' . $nodeName . '": ' . $e->getMessage(),
                 $list,
-                $e
+                $e,
             );
         }
     }
@@ -138,7 +138,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         return $this->enrichLocationForAbstractType(
             TypeFactory::getInstance()->persistentListFromArray($result)->withMeta($list->getMeta()),
-            $parent
+            $parent,
         );
     }
 
@@ -161,7 +161,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         foreach ($argsList as $element) {
             $arguments[] = $this->analyzer->analyze(
                 $element,
-                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
             );
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -78,7 +78,7 @@ final class LetSymbol implements SpecialFormAnalyzerInterface
             ->withContext(
                 $env->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION
                     ? NodeEnvironmentInterface::CONTEXT_RETURN
-                    : $env->getContext()
+                    : $env->getContext(),
             );
 
         foreach ($bindings as $binding) {
@@ -91,7 +91,7 @@ final class LetSymbol implements SpecialFormAnalyzerInterface
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),
-            $bodyEnv
+            $bodyEnv,
         );
 
         return new LetNode(
@@ -99,7 +99,7 @@ final class LetSymbol implements SpecialFormAnalyzerInterface
             $bindings,
             $bodyExpr,
             $isLoop = false,
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -128,7 +128,7 @@ final class LetSymbol implements SpecialFormAnalyzerInterface
                 $sym,
                 $shadowSym,
                 $expr,
-                $sym->getStartLocation()
+                $sym->getStartLocation(),
             );
 
             $initEnv = $initEnv->withMergedLocals([$sym])->withShadowedLocal($sym, $shadowSym);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -114,7 +114,7 @@ final class LoopSymbol implements SpecialFormAnalyzerInterface
             ->withContext(
                 $env->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION
                     ? NodeEnvironmentInterface::CONTEXT_RETURN
-                    : $env->getContext()
+                    : $env->getContext(),
             );
 
         $bodyEnv = $bodyEnv->withAddedRecurFrame($recurFrame);
@@ -128,7 +128,7 @@ final class LoopSymbol implements SpecialFormAnalyzerInterface
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),
-            $bodyEnv
+            $bodyEnv,
         );
 
         return new LetNode(
@@ -136,7 +136,7 @@ final class LoopSymbol implements SpecialFormAnalyzerInterface
             $bindings,
             $bodyExpr,
             $recurFrame->isActive(),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -165,7 +165,7 @@ final class LoopSymbol implements SpecialFormAnalyzerInterface
                 $sym,
                 $shadowSym,
                 $expr,
-                $sym->getStartLocation()
+                $sym->getStartLocation(),
             );
 
             $initEnv = $initEnv->withMergedLocals([$sym])->withShadowedLocal($sym, $shadowSym);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -36,7 +36,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation(
                 'The namespace is not valid. A valid namespace name starts with a letter,
                 followed by any number of letters, numbers, or dashes. Elements are splitted by a backslash.',
-                $nsSymbol
+                $nsSymbol,
             );
         }
 
@@ -45,7 +45,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             if ($this->isPHPKeyword($part)) {
                 throw AnalyzerException::withLocation(
                     "The namespace is not valid. The part '{$part}' cannot be used because it is a reserved keyword.",
-                    $list
+                    $list,
                 );
             }
         }
@@ -73,7 +73,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             } elseif ($value instanceof Keyword) {
                 throw AnalyzerException::withLocation(
                     "Unexpected keyword {$value->getName()} encountered in 'ns. Expected :use or :require.",
-                    $value
+                    $value,
                 );
             }
         }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAGetSymbol.php
@@ -19,7 +19,7 @@ final class PhpAGetSymbol implements SpecialFormAnalyzerInterface
             $env,
             $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
@@ -19,7 +19,7 @@ final class PhpAPushSymbol implements SpecialFormAnalyzerInterface
             $env,
             $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
@@ -20,7 +20,7 @@ final class PhpASetSymbol implements SpecialFormAnalyzerInterface
             $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(3), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
@@ -24,7 +24,7 @@ final class PhpAUnsetSymbol implements SpecialFormAnalyzerInterface
             $env,
             $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
@@ -25,13 +25,13 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
 
         $classExpr = $this->analyzer->analyze(
             $list->get(1),
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
         );
         $args = [];
         for ($forms = $list->rest()->cdr(); $forms != null; $forms = $forms->cdr()) {
             $args[] = $this->analyzer->analyze(
                 $forms->first(),
-                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
             );
         }
 
@@ -39,7 +39,7 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
             $env,
             $classExpr,
             $args,
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpOSetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpOSetSymbol.php
@@ -32,7 +32,7 @@ final class PhpOSetSymbol implements SpecialFormAnalyzerInterface
             $env,
             $left,
             $right,
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -39,7 +39,7 @@ final class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
 
         $targetExpr = $this->analyzer->analyze(
             $list->get(1),
-            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
         );
 
         if ($list->get(2) instanceof PersistentListInterface) {
@@ -56,7 +56,7 @@ final class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
             $callExpr,
             $this->isStatic,
             $methodCall,
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -68,7 +68,7 @@ final class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
         for ($forms = $list2->cdr(); $forms != null; $forms = $forms->cdr()) {
             $args[] = $this->analyzer->analyze(
                 $forms->first(),
-                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
             );
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/QuoteSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/QuoteSymbol.php
@@ -27,7 +27,7 @@ final class QuoteSymbol implements SpecialFormAnalyzerInterface
         return new QuoteNode(
             $env,
             $list->get(1),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
@@ -63,7 +63,7 @@ final class FnSymbolTuple
     {
         return array_slice(
             $this->parentList->toArray(),
-            self::PARENT_TUPLE_BODY_OFFSET
+            self::PARENT_TUPLE_BODY_OFFSET,
         );
     }
 
@@ -80,7 +80,7 @@ final class FnSymbolTuple
             if (!preg_match("/^[a-zA-Z_\x80-\xff].*$/", $param->getName())) {
                 throw AnalyzerException::withLocation(
                     "Variable names must start with a letter or underscore: {$param->getName()}",
-                    $this->parentList
+                    $this->parentList,
                 );
             }
         }
@@ -145,7 +145,7 @@ final class FnSymbolTuple
     {
         throw AnalyzerException::withLocation(
             'Unsupported parameter form, only one symbol can follow the & parameter',
-            $this->parentList
+            $this->parentList,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/ForeachSymbolTuple.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/ForeachSymbolTuple.php
@@ -15,7 +15,7 @@ final class ForeachSymbolTuple
         private NodeEnvironmentInterface $bodyEnv,
         private AbstractNode $listExpr,
         private Symbol $valueSymbol,
-        private ?Symbol $keySymbol = null
+        private ?Symbol $keySymbol = null,
     ) {
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
@@ -34,7 +34,7 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation(
                 "Wrong number of arguments for 'recur. Expected: "
                 . count($currentFrame->getParams()) . ' args, got: ' . (count($list) - 1),
-                $list
+                $list,
             );
         }
 
@@ -44,7 +44,7 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
             $env,
             $currentFrame,
             $this->expressions($list, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 
@@ -54,7 +54,7 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
         for ($forms = $list->cdr(); $forms != null; $forms = $forms->cdr()) {
             $expressions[] = $this->analyzer->analyze(
                 $forms->first(),
-                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
             );
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/SetVarSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/SetVarSymbol.php
@@ -26,7 +26,7 @@ final class SetVarSymbol implements SpecialFormAnalyzerInterface
             $env,
             $this->analyzer->analyze($nameSymbol, $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ThrowSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ThrowSymbol.php
@@ -25,7 +25,7 @@ final class ThrowSymbol implements SpecialFormAnalyzerInterface
         return new ThrowNode(
             $env,
             $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -69,7 +69,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             ])->copyLocationFrom($finally);
             $finally = $this->analyzer->analyze(
                 $finally,
-                $env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)->withDisallowRecurFrame(),
             );
         }
 
@@ -100,7 +100,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
                 TypeFactory::getInstance()->persistentListFromArray($exprs),
                 $env->withContext($catchCtx)
                     ->withMergedLocals([$name])
-                    ->withDisallowRecurFrame()
+                    ->withDisallowRecurFrame(),
             );
 
             $catchNodes[] = new CatchNode(
@@ -108,14 +108,14 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
                 $resolvedType,
                 $name,
                 $catchBody,
-                $catch->getStartLocation()
+                $catch->getStartLocation(),
             );
         }
 
         $body = $this->analyzer->analyze(
             TypeFactory::getInstance()->persistentListFromArray(array_merge([Symbol::create(Symbol::NAME_DO)], $body)),
             $env->withContext(count($catchNodes) > 0 || $finally ? $catchCtx : $env->getContext())
-                ->withDisallowRecurFrame()
+                ->withDisallowRecurFrame(),
         );
 
         return new TryNode(
@@ -123,7 +123,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             $body,
             $catchNodes,
             $finally,
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Compiler/CodeCompiler.php
+++ b/src/php/Compiler/Domain/Compiler/CodeCompiler.php
@@ -35,7 +35,7 @@ final class CodeCompiler implements CodeCompilerInterface
         private AnalyzerInterface $analyzer,
         private StatementEmitterInterface $statementEmitter,
         private FileEmitterInterface $fileEmitter,
-        private EvaluatorInterface $evaluator
+        private EvaluatorInterface $evaluator,
     ) {
     }
 
@@ -88,7 +88,7 @@ final class CodeCompiler implements CodeCompilerInterface
         try {
             return $this->analyzer->analyze(
                 $readerResult->getAst(),
-                NodeEnvironment::empty()
+                NodeEnvironment::empty(),
             );
         } catch (AnalyzerException $e) {
             throw new CompilerException($e, $readerResult->getCodeSnippet());

--- a/src/php/Compiler/Domain/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/Domain/Compiler/EvalCompiler.php
@@ -34,7 +34,7 @@ final class EvalCompiler implements EvalCompilerInterface
         private ReaderInterface $reader,
         private AnalyzerInterface $analyzer,
         private StatementEmitterInterface $emitter,
-        private EvaluatorInterface $evaluator
+        private EvaluatorInterface $evaluator,
     ) {
     }
 
@@ -89,7 +89,7 @@ final class EvalCompiler implements EvalCompilerInterface
         try {
             return $this->analyzer->analyze(
                 $readerResult->getAst(),
-                NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN)
+                NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN),
             );
         } catch (AnalyzerException $e) {
             throw new CompilerException($e, $readerResult->getCodeSnippet());

--- a/src/php/Compiler/Domain/Emitter/FileEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/FileEmitter.php
@@ -36,14 +36,14 @@ final class FileEmitter implements FileEmitterInterface
     public function endFile(bool $enableSourceMaps): EmitterResult
     {
         $sourceMap = $this->sourceMapGenerator->encode(
-            $this->outputEmitter->getSourceMapState()->getMappings()
+            $this->outputEmitter->getSourceMapState()->getMappings(),
         );
 
         return new EmitterResult(
             $enableSourceMaps,
             $this->code,
             $sourceMap,
-            $this->source
+            $this->source,
         );
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -92,7 +92,7 @@ final class OutputEmitter implements OutputEmitterInterface
                         'line' => $this->sourceMapState->getGeneratedLines(),
                         'column' => $this->sourceMapState->getGeneratedColumns(),
                     ],
-                ]
+                ],
             );
         }
 
@@ -156,7 +156,7 @@ final class OutputEmitter implements OutputEmitterInterface
         Symbol $symbol,
         ?SourceLocation $loc = null,
         bool $asReference = false,
-        bool $isVariadic = false
+        bool $isVariadic = false,
     ): void {
         if (is_null($loc)) {
             $loc = $symbol->getStartLocation();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -100,12 +100,12 @@ final class LiteralEmitter
         if ($x->getNamespace()) {
             $this->outputEmitter->emitStr(
                 '\Phel\Lang\Keyword::createForNamespace("' . addslashes($x->getNamespace()) . '", "' . addslashes($x->getName()) . '")',
-                $x->getStartLocation()
+                $x->getStartLocation(),
             );
         } else {
             $this->outputEmitter->emitStr(
                 '\Phel\Lang\Keyword::create("' . addslashes($x->getName()) . '")',
-                $x->getStartLocation()
+                $x->getStartLocation(),
             );
         }
     }
@@ -114,7 +114,7 @@ final class LiteralEmitter
     {
         $this->outputEmitter->emitStr(
             '(\Phel\Lang\Symbol::create("' . addslashes($x->getFullName()) . '"))',
-            $x->getStartLocation()
+            $x->getStartLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -37,7 +37,7 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitArgList(
             $node->getArguments(),
             $node->getStartSourceLocation(),
-            ' ' . $fnNode->getName() . ' '
+            ' ' . $fnNode->getName() . ' ',
         );
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CatchEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CatchEmitter.php
@@ -22,7 +22,7 @@ final class CatchEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($node->getType());
         $this->outputEmitter->emitStr(
             ' $' . $this->outputEmitter->mungeEncode($node->getName()->getName()),
-            $node->getName()->getStartLocation()
+            $node->getName()->getStartLocation(),
         );
         $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -29,12 +29,12 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
         if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
             $this->outputEmitter->emitLine(
                 'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
         $this->outputEmitter->emitLine(
             'interface ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' {',
-            $node->getStartSourceLocation()
+            $node->getStartSourceLocation(),
         );
         $this->outputEmitter->increaseIndentLevel();
     }
@@ -51,7 +51,7 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('public function ', $node->getStartSourceLocation());
         $this->outputEmitter->emitStr(
             $this->outputEmitter->mungeEncode($method->getName()->getName()),
-            $node->getStartSourceLocation()
+            $node->getStartSourceLocation(),
         );
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -40,12 +40,12 @@ final class DefStructEmitter implements NodeEmitterInterface
         if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
             $this->outputEmitter->emitLine(
                 'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
         $this->outputEmitter->emitStr(
             'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
-            $node->getStartSourceLocation()
+            $node->getStartSourceLocation(),
         );
 
         if (count($node->getInterfaces()) > 0) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -61,7 +61,7 @@ final class FnAsClassEmitter implements NodeEmitterInterface
 
             $this->outputEmitter->emitLine(
                 'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
     }
@@ -95,7 +95,7 @@ final class FnAsClassEmitter implements NodeEmitterInterface
 
                 $this->outputEmitter->emitLine(
                     '$this->' . $varName . ' = $' . $varName . ';',
-                    $node->getStartSourceLocation()
+                    $node->getStartSourceLocation(),
                 );
             }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -60,7 +60,7 @@ final class MethodEmitter
 
             $this->outputEmitter->emitLine(
                 '$' . $varName . ' = $this->' . $varName . ';',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
     }
@@ -73,7 +73,7 @@ final class MethodEmitter
 
             $this->outputEmitter->emitLine(
                 '$' . $varName . ' = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($' . $varName . ');',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -57,7 +57,7 @@ final class NsEmitter implements NodeEmitterInterface
 
                 $this->outputEmitter->emitLine(
                     'require_once ' . $absolutePath . ';',
-                    $ns->getStartLocation()
+                    $ns->getStartLocation(),
                 );
             }
         }
@@ -68,7 +68,7 @@ final class NsEmitter implements NodeEmitterInterface
         if (!$this->outputEmitter->getOptions()->isFileEmitMode()) {
             $this->outputEmitter->emitLine(
                 '\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpClassNameEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpClassNameEmitter.php
@@ -20,7 +20,7 @@ final class PhpClassNameEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitStr(
             $node->getAbsolutePhpName(),
-            $node->getName()->getStartLocation()
+            $node->getName()->getStartLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpVarEmitter.php
@@ -23,7 +23,7 @@ final class PhpVarEmitter implements NodeEmitterInterface
         if ($node->isCallable()) {
             $this->outputEmitter->emitStr(
                 '(function(...$args) { return ' . $node->getName() . '(...$args);' . '})',
-                $node->getStartSourceLocation()
+                $node->getStartSourceLocation(),
             );
         } else {
             $this->outputEmitter->emitStr($node->getName(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -12,7 +12,7 @@ final class NodeEmitterFactory
 {
     public function createNodeEmitter(
         OutputEmitterInterface $outputEmitter,
-        string $astNodeClassName
+        string $astNodeClassName,
     ): NodeEmitterInterface {
         return match ($astNodeClassName) {
             Ast\NsNode::class => new NodeEmitter\NsEmitter($outputEmitter),

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -40,7 +40,7 @@ interface OutputEmitterInterface
         Symbol $symbol,
         ?SourceLocation $loc = null,
         bool $asReference = false,
-        bool $isVariadic = false
+        bool $isVariadic = false,
     ): void;
 
     public function mungeEncode(string $str): string;

--- a/src/php/Compiler/Domain/Emitter/StatementEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/StatementEmitter.php
@@ -14,7 +14,7 @@ final class StatementEmitter implements StatementEmitterInterface
 
     public function __construct(
         SourceMapGenerator $sourceMapGenerator,
-        OutputEmitterInterface $outputEmitter
+        OutputEmitterInterface $outputEmitter,
     ) {
         $this->sourceMapGenerator = $sourceMapGenerator;
         $this->outputEmitter = $outputEmitter;
@@ -39,19 +39,19 @@ final class StatementEmitter implements StatementEmitterInterface
                 $enableSourceMaps,
                 $code,
                 '',
-                $file
+                $file,
             );
         }
 
         $sourceMap = $this->sourceMapGenerator->encode(
-            $this->outputEmitter->getSourceMapState()->getMappings()
+            $this->outputEmitter->getSourceMapState()->getMappings(),
         );
 
         return new EmitterResult(
             $enableSourceMaps,
             $code,
             $sourceMap,
-            $file
+            $file,
         );
     }
 }

--- a/src/php/Compiler/Domain/Lexer/TokenStream.php
+++ b/src/php/Compiler/Domain/Lexer/TokenStream.php
@@ -69,7 +69,7 @@ final class TokenStream implements Iterator
         return new CodeSnippet(
             $tokens[0]->getStartLocation(),
             $tokens[count($tokens) - 1]->getEndLocation(),
-            $code
+            $code,
         );
     }
 
@@ -100,7 +100,7 @@ final class TokenStream implements Iterator
     {
         return implode(array_map(
             static fn (Token $t) => $t->getCode(),
-            $readTokens
+            $readTokens,
         ));
     }
 }

--- a/src/php/Compiler/Domain/Parser/Exceptions/UnexpectedParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/UnexpectedParserException.php
@@ -15,7 +15,7 @@ final class UnexpectedParserException extends AbstractParserException
             $message,
             $snippet,
             $token->getStartLocation(),
-            $token->getEndLocation()
+            $token->getEndLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Parser/Exceptions/UnfinishedParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/UnfinishedParserException.php
@@ -15,7 +15,7 @@ class UnfinishedParserException extends AbstractParserException
             $message,
             $snippet,
             $token->getStartLocation(),
-            $token->getEndLocation()
+            $token->getEndLocation(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -51,7 +51,7 @@ final class AtomParser
                 $word,
                 $token->getStartLocation(),
                 $token->getEndLocation(),
-                $sign * bindec(str_replace('_', '', $word))
+                $sign * bindec(str_replace('_', '', $word)),
             );
         }
 
@@ -62,7 +62,7 @@ final class AtomParser
                 $word,
                 $token->getStartLocation(),
                 $token->getEndLocation(),
-                $sign * hexdec(str_replace('_', '', $word))
+                $sign * hexdec(str_replace('_', '', $word)),
             );
         }
 
@@ -73,7 +73,7 @@ final class AtomParser
                 $word,
                 $token->getStartLocation(),
                 $token->getEndLocation(),
-                $sign * octdec(str_replace('_', '', $word))
+                $sign * octdec(str_replace('_', '', $word)),
             );
         }
 
@@ -123,7 +123,7 @@ final class AtomParser
             $word,
             $token->getStartLocation(),
             $token->getEndLocation(),
-            $keyword
+            $keyword,
         );
     }
 }

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -32,7 +32,7 @@ final class StringParser
             $token->getCode(),
             $token->getStartLocation(),
             $token->getEndLocation(),
-            $this->parseEscapedString(substr($token->getCode(), 1, -1))
+            $this->parseEscapedString(substr($token->getCode(), 1, -1)),
         );
     }
 
@@ -59,7 +59,7 @@ final class StringParser
         return preg_replace_callback(
             '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}|u\{([0-9a-fA-F]+)\})~',
             $callback,
-            str_replace('\\"', '"', $str)
+            str_replace('\\"', '"', $str),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/Parser.php
+++ b/src/php/Compiler/Domain/Parser/Parser.php
@@ -29,7 +29,7 @@ final class Parser implements ParserInterface
 
     public function __construct(
         ExpressionParserFactoryInterface $parserFactory,
-        GlobalEnvironmentInterface $globalEnvironment
+        GlobalEnvironmentInterface $globalEnvironment,
     ) {
         $this->parserFactory = $parserFactory;
         $this->globalEnvironment = $globalEnvironment;
@@ -137,7 +137,7 @@ final class Parser implements ParserInterface
             'Unterminated list',
             $snippet,
             $snippet->getStartLocation(),
-            $snippet->getEndLocation()
+            $snippet->getEndLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
@@ -24,7 +24,7 @@ abstract class AbstractAtomNode implements NodeInterface
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-        $value
+        $value,
     ) {
         $this->value = $value;
     }

--- a/src/php/Compiler/Domain/Parser/ParserNode/CommentNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/CommentNode.php
@@ -12,7 +12,7 @@ final class CommentNode implements TriviaNodeInterface
     public function __construct(
         private string $code,
         private SourceLocation $startLocation,
-        private SourceLocation $endLocation
+        private SourceLocation $endLocation,
     ) {
     }
 
@@ -21,7 +21,7 @@ final class CommentNode implements TriviaNodeInterface
         return new self(
             $token->getCode(),
             $token->getStartLocation(),
-            $token->getEndLocation()
+            $token->getEndLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/ParserNode/MetaNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/MetaNode.php
@@ -18,7 +18,7 @@ final class MetaNode implements InnerNodeInterface
         private NodeInterface $meta,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-        private array $children
+        private array $children,
     ) {
     }
 

--- a/src/php/Compiler/Domain/Parser/ParserNode/NewlineNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/NewlineNode.php
@@ -21,7 +21,7 @@ final class NewlineNode implements TriviaNodeInterface
         return new self(
             $token->getCode(),
             $token->getStartLocation(),
-            $token->getEndLocation()
+            $token->getEndLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/ParserNode/WhitespaceNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/WhitespaceNode.php
@@ -21,7 +21,7 @@ final class WhitespaceNode implements TriviaNodeInterface
         return new self(
             $token->getCode(),
             $token->getStartLocation(),
-            $token->getEndLocation()
+            $token->getEndLocation(),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/ReadModel/CodeSnippet.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/CodeSnippet.php
@@ -21,7 +21,7 @@ final class CodeSnippet
         return new self(
             $node->getStartLocation(),
             $node->getEndLocation(),
-            $node->getCode()
+            $node->getCode(),
         );
     }
 

--- a/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
@@ -10,7 +10,7 @@ final class ReaderResult
 {
     public function __construct(
         private float|bool|int|string|TypeInterface|null $ast,
-        private CodeSnippet $codeSnippet
+        private CodeSnippet $codeSnippet,
     ) {
     }
 

--- a/src/php/Compiler/Domain/Reader/Exceptions/ReaderException.php
+++ b/src/php/Compiler/Domain/Reader/Exceptions/ReaderException.php
@@ -28,7 +28,7 @@ final class ReaderException extends AbstractLocatedException
             $message,
             $node->getStartLocation(),
             $node->getEndLocation(),
-            $codeSnippet
+            $codeSnippet,
         );
     }
 

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
@@ -48,7 +48,7 @@ final class ExpressionReaderFactory implements ExpressionReaderFactoryInterface
 
     public function createQuoasiquoteReader(
         Reader $reader,
-        QuasiquoteTransformerInterface $quasiquoteTransformer
+        QuasiquoteTransformerInterface $quasiquoteTransformer,
     ): QuoasiquoteReader {
         return new QuoasiquoteReader($reader, $quasiquoteTransformer);
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
@@ -32,7 +32,7 @@ interface ExpressionReaderFactoryInterface
 
     public function createQuoasiquoteReader(
         Reader $reader,
-        QuasiquoteTransformerInterface $quasiquoteTransformer
+        QuasiquoteTransformerInterface $quasiquoteTransformer,
     ): QuoasiquoteReader;
 
     public function createMetaReader(Reader $reader): MetaReader;

--- a/src/php/Compiler/Domain/Reader/Reader.php
+++ b/src/php/Compiler/Domain/Reader/Reader.php
@@ -50,7 +50,7 @@ final class Reader implements ReaderInterface
 
         return new ReaderResult(
             $this->readExpression($parseTree, $parseTree),
-            CodeSnippet::fromNode($parseTree)
+            CodeSnippet::fromNode($parseTree),
         );
     }
 

--- a/src/php/Compiler/Infrastructure/Munge.php
+++ b/src/php/Compiler/Infrastructure/Munge.php
@@ -73,7 +73,7 @@ final class Munge implements MungeInterface
         return str_replace(
             array_keys($mapping),
             array_values($mapping),
-            $str
+            $str,
         );
     }
 }

--- a/src/php/Formatter/Domain/PhelPathFilter.php
+++ b/src/php/Formatter/Domain/PhelPathFilter.php
@@ -46,7 +46,7 @@ final class PhelPathFilter implements PathFilterInterface
     {
         return new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::LEAVES_ONLY
+            RecursiveIteratorIterator::LEAVES_ONLY,
         );
     }
 

--- a/src/php/Formatter/Domain/Rules/IndentRule.php
+++ b/src/php/Formatter/Domain/Rules/IndentRule.php
@@ -74,7 +74,7 @@ final class IndentRule implements RuleInterface
         $width = $this->indentAmount($form);
         if ($width && $width > 0) {
             return $form->insertRight(
-                new WhitespaceNode(str_repeat(' ', $width), new SourceLocation('', 0, 0), new SourceLocation('', 0, 0))
+                new WhitespaceNode(str_repeat(' ', $width), new SourceLocation('', 0, 0), new SourceLocation('', 0, 0)),
             );
         }
 

--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -71,7 +71,7 @@ abstract class AbstractZipper
             $leftSiblings,
             [$this->node, ...$this->rightSiblings],
             $this->hasChanged,
-            false
+            false,
         );
     }
 
@@ -117,7 +117,7 @@ abstract class AbstractZipper
             [...$this->leftSiblings, $this->node],
             $rightSiblings,
             $this->hasChanged,
-            false
+            false,
         );
     }
 
@@ -154,7 +154,7 @@ abstract class AbstractZipper
         if ($this->hasChanged) {
             $newParent = $this->makeNode(
                 $this->parent->getNode(),
-                [...$this->leftSiblings, $this->node, ...$this->rightSiblings]
+                [...$this->leftSiblings, $this->node, ...$this->rightSiblings],
             );
 
             return $this->createNewInstance(
@@ -163,7 +163,7 @@ abstract class AbstractZipper
                 $this->parent->lefts(),
                 $this->parent->rights(),
                 true,
-                $this->parent->isEnd()
+                $this->parent->isEnd(),
             );
         }
 
@@ -211,7 +211,7 @@ abstract class AbstractZipper
             [],
             $children,
             false,
-            false
+            false,
         );
     }
 
@@ -347,7 +347,7 @@ abstract class AbstractZipper
     public function insertChild($node)
     {
         return $this->replace(
-            $this->makeNode($this->node, [$node, ...$this->getChildren()])
+            $this->makeNode($this->node, [$node, ...$this->getChildren()]),
         );
     }
 
@@ -359,7 +359,7 @@ abstract class AbstractZipper
     public function appendChild($node)
     {
         return $this->replace(
-            $this->makeNode($this->node, [...$this->getChildren(), $node])
+            $this->makeNode($this->node, [...$this->getChildren(), $node]),
         );
     }
 
@@ -383,7 +383,7 @@ abstract class AbstractZipper
                 $leftSiblings,
                 $this->rightSiblings,
                 true,
-                false
+                false,
             );
             while ($loc->isBranch() && $loc->hasChildren() && ($child = $loc->down())) {
                 $loc = $child->rightMost();
@@ -399,7 +399,7 @@ abstract class AbstractZipper
             $this->parent->lefts(),
             $this->parent->rights(),
             true,
-            $this->parent->isEnd()
+            $this->parent->isEnd(),
         );
     }
 
@@ -448,6 +448,6 @@ abstract class AbstractZipper
         array $leftSiblings,
         array $rightSiblings,
         bool $hasChanged,
-        bool $isEnd
+        bool $isEnd,
     );
 }

--- a/src/php/Formatter/Domain/Rules/Zipper/ParseTreeZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/ParseTreeZipper.php
@@ -150,7 +150,7 @@ final class ParseTreeZipper extends AbstractZipper
         array $leftSiblings,
         array $rightSiblings,
         bool $hasChanged,
-        bool $isEnd
+        bool $isEnd,
     ): self {
         return new self($node, $parent, $leftSiblings, $rightSiblings, $hasChanged, $isEnd);
     }

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -29,7 +29,7 @@ final class FormatterFactory extends AbstractFactory
             $this->getCommandFacade(),
             $this->createFormatter(),
             $this->createPathFilter(),
-            $this->createFileIo()
+            $this->createFileIo(),
         );
     }
 
@@ -42,7 +42,7 @@ final class FormatterFactory extends AbstractFactory
                 $this->createUnindentRule(),
                 $this->createIndentRule(),
                 $this->createRemoveTrailingWhitespaceRule(),
-            ]
+            ],
         );
     }
 

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -25,7 +25,7 @@ final class FormatCommand extends Command
             ->addArgument(
                 'paths',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'The file paths that you want to format.'
+                'The file paths that you want to format.',
             );
     }
 

--- a/src/php/Interop/Domain/DirectoryRemover/DirectoryRemover.php
+++ b/src/php/Interop/Domain/DirectoryRemover/DirectoryRemover.php
@@ -23,7 +23,7 @@ final class DirectoryRemover implements DirectoryRemoverInterface
 
         $files = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($this->targetDir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         /** @var SplFileInfo $file */

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -56,7 +56,7 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 
         $namespaces = array_map(
             static fn (NamespaceInformation $info) => $info->getNamespace(),
-            $namespaceFromDirectories
+            $namespaceFromDirectories,
         );
 
         $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
@@ -64,7 +64,7 @@ final class FunctionsToExportFinder implements FunctionsToExportFinderInterface
                 ...$this->commandFacade->getSourceDirectories(),
                 ...$this->commandFacade->getVendorSourceDirectories(),
             ],
-            [...$namespaces, 'phel\\core']
+            [...$namespaces, 'phel\\core'],
         );
 
         foreach ($namespaceInformation as $info) {

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -53,7 +53,7 @@ final class CompiledPhpMethodBuilder
 
                 return $variadic . $param;
             },
-            $refInvoke->getParameters()
+            $refInvoke->getParameters(),
         );
 
 

--- a/src/php/Interop/Domain/Generator/WrapperGenerator.php
+++ b/src/php/Interop/Domain/Generator/WrapperGenerator.php
@@ -16,7 +16,7 @@ final class WrapperGenerator implements WrapperGeneratorInterface
 
     public function __construct(
         CompiledPhpClassBuilder $classBuilder,
-        WrapperRelativeFilenamePathBuilder $relativeFilenamePathBuilder
+        WrapperRelativeFilenamePathBuilder $relativeFilenamePathBuilder,
     ) {
         $this->classBuilder = $classBuilder;
         $this->relativeFilenamePathBuilder = $relativeFilenamePathBuilder;

--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -53,7 +53,7 @@ final class ExportCommand extends Command
             $output->writeln(sprintf(
                 '  %d) %s',
                 $i + 1,
-                $wrapper->relativeFilenamePath()
+                $wrapper->relativeFilenamePath(),
             ));
         }
     }

--- a/src/php/Interop/InteropConfig.php
+++ b/src/php/Interop/InteropConfig.php
@@ -41,7 +41,7 @@ final class InteropConfig extends AbstractConfig
     {
         return array_map(
             fn (string $dir): string => $this->getAppRootDir() . '/' . $dir,
-            $this->getExport()[self::EXPORT_DIRECTORIES] ?? self::DEFAULT_EXPORT_DIRECTORIES
+            $this->getExport()[self::EXPORT_DIRECTORIES] ?? self::DEFAULT_EXPORT_DIRECTORIES,
         );
     }
 

--- a/src/php/Interop/InteropFacade.php
+++ b/src/php/Interop/InteropFacade.php
@@ -32,7 +32,7 @@ final class InteropFacade extends AbstractFacade implements InteropFacadeInterfa
             ->writeLocatedException(
                 $output,
                 $e->getNestedException(),
-                $e->getCodeSnippet()
+                $e->getCodeSnippet(),
             );
     }
 

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -44,7 +44,7 @@ final class InteropFactory extends AbstractFactory
     private function createDirectoryRemover(): DirectoryRemoverInterface
     {
         return new DirectoryRemover(
-            $this->getConfig()->getExportTargetDirectory()
+            $this->getConfig()->getExportTargetDirectory(),
         );
     }
 
@@ -52,7 +52,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new FileCreator(
             $this->getConfig()->getExportTargetDirectory(),
-            $this->createFileSystemIo()
+            $this->createFileSystemIo(),
         );
     }
 
@@ -60,7 +60,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new WrapperGenerator(
             $this->createCompiledPhpClassBuilder(),
-            $this->createWrapperPathBuilder()
+            $this->createWrapperPathBuilder(),
         );
     }
 
@@ -68,7 +68,7 @@ final class InteropFactory extends AbstractFactory
     {
         return new CompiledPhpClassBuilder(
             $this->getConfig()->prefixNamespace(),
-            $this->createCompiledPhpMethodBuilder()
+            $this->createCompiledPhpMethodBuilder(),
         );
     }
 
@@ -87,7 +87,7 @@ final class InteropFactory extends AbstractFactory
         return new FunctionsToExportFinder(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
-            $this->getConfig()->getExportDirectories()
+            $this->getConfig()->getExportDirectories(),
         );
     }
 

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -26,7 +26,7 @@ class PersistentHashSet extends AbstractType implements PersistentHashSetInterfa
     public function __construct(
         private HasherInterface $hasher,
         private ?PersistentMapInterface $meta,
-        private PersistentMapInterface $map
+        private PersistentMapInterface $map,
     ) {
     }
 

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -59,7 +59,7 @@ class ArrayNode implements HashMapNodeInterface, Countable
                 $this->hasher,
                 $this->equalizer,
                 $this->count,
-                $this->cloneAndSet($index, $n)
+                $this->cloneAndSet($index, $n),
             );
         }
 
@@ -67,7 +67,7 @@ class ArrayNode implements HashMapNodeInterface, Countable
             $this->hasher,
             $this->equalizer,
             $this->count + 1,
-            $this->cloneAndSet($index, IndexedNode::empty($this->hasher, $this->equalizer)->put($shift + 5, $hash, $key, $value, $addedLeaf))
+            $this->cloneAndSet($index, IndexedNode::empty($this->hasher, $this->equalizer)->put($shift + 5, $hash, $key, $value, $addedLeaf)),
         );
     }
 

--- a/src/php/Lang/Collections/Map/PersistentArrayMap.php
+++ b/src/php/Lang/Collections/Map/PersistentArrayMap.php
@@ -128,8 +128,8 @@ class PersistentArrayMap extends AbstractPersistentMap
             new TransientArrayMap(
                 $this->hasher,
                 $this->equalizer,
-                $this->array
-            )
+                $this->array,
+            ),
         );
     }
 

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -171,8 +171,8 @@ class PersistentHashMap extends AbstractPersistentMap
                 $this->count,
                 $this->root,
                 $this->hasNull,
-                $this->nullValue
-            )
+                $this->nullValue,
+            ),
         );
     }
 }

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -32,7 +32,7 @@ class TransientHashMap implements TransientMapInterface
         private int $count,
         private ?HashMapNodeInterface $root,
         private bool $hasNull,
-        $nullValue
+        $nullValue,
     ) {
         $this->nullValue = $nullValue;
     }

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -34,7 +34,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
         parent::__construct(
             TypeFactory::getInstance()->getHasher(),
             TypeFactory::getInstance()->getEqualizer(),
-            null
+            null,
         );
         $this->munge = new Munge();
     }
@@ -108,7 +108,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     {
         return array_map(
             static fn (string $k): Keyword => TypeFactory::getInstance()->keyword($k),
-            static::ALLOWED_KEYS
+            static::ALLOWED_KEYS,
         );
     }
 

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -102,7 +102,7 @@ class PersistentVector extends AbstractPersistentVector
                 $this->count + 1,
                 $this->shift,
                 $this->root,
-                [...$this->tail, $value]
+                [...$this->tail, $value],
             );
         }
 
@@ -124,7 +124,7 @@ class PersistentVector extends AbstractPersistentVector
             $this->count + 1,
             $newShift,
             $newRoot,
-            [$value]
+            [$value],
         );
     }
 
@@ -155,7 +155,7 @@ class PersistentVector extends AbstractPersistentVector
                     $this->count,
                     $this->shift,
                     $this->root,
-                    $newTail
+                    $newTail,
                 );
             }
 
@@ -166,7 +166,7 @@ class PersistentVector extends AbstractPersistentVector
                 $this->count,
                 $this->shift,
                 $this->doUpdate($this->shift, $this->root, $i, $value),
-                $this->tail
+                $this->tail,
             );
         }
 
@@ -239,7 +239,7 @@ class PersistentVector extends AbstractPersistentVector
                 $this->count - 1,
                 $this->shift,
                 $this->root,
-                $newTail
+                $newTail,
             );
         }
 
@@ -263,7 +263,7 @@ class PersistentVector extends AbstractPersistentVector
             $this->count - 1,
             $newShift,
             $newRoot,
-            $newTail
+            $newTail,
         );
     }
 
@@ -310,7 +310,7 @@ class PersistentVector extends AbstractPersistentVector
             $this->count,
             $this->shift,
             $this->root,
-            $this->tail
+            $this->tail,
         );
     }
 

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -42,7 +42,7 @@ class TransientVector implements TransientVectorInterface
             0,
             self::SHIFT,
             [],
-            []
+            [],
         );
     }
 

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -40,7 +40,7 @@ final class ArrayPrinter implements TypePrinterInterface
     {
         return array_map(
             fn ($v) => $this->printer->print($v),
-            $form
+            $form,
         );
     }
 
@@ -49,7 +49,7 @@ final class ArrayPrinter implements TypePrinterInterface
         return array_map(
             fn ($k, $v) => sprintf('%s:%s', $this->printer->print($k), $this->printer->print($v)),
             array_keys($form),
-            $form
+            $form,
         );
     }
 

--- a/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
@@ -25,7 +25,7 @@ final class PersistentHashSetPrinter implements TypePrinterInterface
     {
         $values = array_map(
             fn ($elem): string => $this->printer->print($elem),
-            $form->toPhpArray()
+            $form->toPhpArray(),
         );
 
         return '(set' . (count($values) > 0 ? ' ' : '') . implode(' ', $values) . ')';

--- a/src/php/Printer/TypePrinter/StructPrinter.php
+++ b/src/php/Printer/TypePrinter/StructPrinter.php
@@ -25,7 +25,7 @@ final class StructPrinter implements TypePrinterInterface
     {
         $values = array_map(
             fn ($key): string => $this->printer->print($form[$key]),
-            $form->getAllowedKeys()
+            $form->getAllowedKeys(),
         );
 
         return '(' . get_class($form) . ' ' . implode(' ', $values) . ')';

--- a/src/php/Run/Domain/Repl/InputResult.php
+++ b/src/php/Run/Domain/Repl/InputResult.php
@@ -40,7 +40,7 @@ final class InputResult
         return preg_replace(
             '/"[^\\"]*(?:\\.|[^\\"]*)*"(*SKIP)(*F)|' . preg_quote(self::LAST_RESULT_PLACEHOLDER, '/') . '/',
             $this->formattedLastResult(),
-            $fullInput
+            $fullInput,
         );
     }
 

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -34,7 +34,7 @@ final class NamespaceCollector
                 ...$this->commandFacade->getTestDirectories(),
                 ...$this->commandFacade->getVendorSourceDirectories(),
             ],
-            $namespaces
+            $namespaces,
         );
     }
 
@@ -47,18 +47,18 @@ final class NamespaceCollector
     {
         if (empty($paths)) {
             $namespaces = $this->buildFacade->getNamespaceFromDirectories(
-                $this->commandFacade->getTestDirectories()
+                $this->commandFacade->getTestDirectories(),
             );
 
             return array_map(
                 static fn (NamespaceInformation $info): string => $info->getNamespace(),
-                $namespaces
+                $namespaces,
             );
         }
 
         return array_map(
             fn (string $filename): string => $this->buildFacade->getNamespaceFromFile($filename)->getNamespace(),
-            $paths
+            $paths,
         );
     }
 }

--- a/src/php/Run/Domain/Runner/NamespaceRunner.php
+++ b/src/php/Run/Domain/Runner/NamespaceRunner.php
@@ -24,7 +24,7 @@ class NamespaceRunner implements NamespaceRunnerInterface
                 ...$this->commandFacade->getSourceDirectories(),
                 ...$this->commandFacade->getVendorSourceDirectories(),
             ],
-            [$namespace, 'phel\\core']
+            [$namespace, 'phel\\core'],
         );
 
         foreach ($namespaceInformation as $info) {

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -34,7 +34,7 @@ final class TestCommandOptions
 
         $optionsMap = $typeFactory->persistentMapFromKVs(
             $typeFactory->keyword(self::FILTER),
-            $filter
+            $filter,
         );
 
         return Printer::readable()->print($optionsMap);

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -112,7 +112,7 @@ final class ReplCommand extends Command
         ];
         $namespaceInformation = $this->getFacade()->getDependenciesForNamespace(
             $srcDirectories,
-            [$namespace, 'phel\\core']
+            [$namespace, 'phel\\core'],
         );
 
         foreach ($namespaceInformation as $info) {

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -29,17 +29,17 @@ final class RunCommand extends Command
             ->addArgument(
                 'path',
                 InputArgument::REQUIRED,
-                'The file path that you want to run.'
+                'The file path that you want to run.',
             )->addArgument(
                 'argv',
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                 'Optional arguments',
-                []
+                [],
             )->addOption(
                 'with-time',
                 't',
                 InputOption::VALUE_NONE,
-                'With time awareness'
+                'With time awareness',
             );
     }
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -31,18 +31,18 @@ final class TestCommand extends Command
     {
         $this->setName(self::COMMAND_NAME)
             ->setDescription(
-                'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed.'
+                'Tests the given files. If no filenames are provided all tests in the "tests" directory are executed.',
             )
             ->addArgument(
                 'paths',
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                 'The file paths that you want to test.',
-                []
+                [],
             )->addOption(
                 'filter',
                 'f',
                 InputOption::VALUE_OPTIONAL,
-                'Filter by test names.'
+                'Filter by test names.',
             );
     }
 

--- a/src/php/Run/RunFacade.php
+++ b/src/php/Run/RunFacade.php
@@ -109,7 +109,7 @@ final class RunFacade extends AbstractFacade implements RunFacadeInterface
             ->writeLocatedException(
                 $output,
                 $e->getNestedException(),
-                $e->getCodeSnippet()
+                $e->getCodeSnippet(),
             );
     }
 

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -27,7 +27,7 @@ class RunFactory extends AbstractFactory
     {
         return new NamespaceRunner(
             $this->getCommandFacade(),
-            $this->getBuildFacade()
+            $this->getBuildFacade(),
         );
     }
 
@@ -55,7 +55,7 @@ class RunFactory extends AbstractFactory
     {
         return new NamespaceCollector(
             $this->getBuildFacade(),
-            $this->getCommandFacade()
+            $this->getCommandFacade(),
         );
     }
 
@@ -73,7 +73,7 @@ class RunFactory extends AbstractFactory
     {
         return new ReplCommandSystemIo(
             $this->getConfig()->getPhelReplHistory(),
-            $this->getCommandFacade()
+            $this->getCommandFacade(),
         );
     }
 }

--- a/tests/php/Benchmark/Command/CommandBench.php
+++ b/tests/php/Benchmark/Command/CommandBench.php
@@ -28,7 +28,7 @@ final class CommandBench
     {
         (new RunCommand())->run(
             new StringInput(__DIR__ . '/fixtures/run-command.phel'),
-            new NullOutput()
+            new NullOutput(),
         );
     }
 
@@ -37,7 +37,7 @@ final class CommandBench
         ob_start();
         (new TestCommand())->run(
             new StringInput(__DIR__ . '/fixtures/test-command.phel'),
-            new NullOutput()
+            new NullOutput(),
         );
         ob_clean();
     }

--- a/tests/php/Benchmark/Phel/PhelBench.php
+++ b/tests/php/Benchmark/Phel/PhelBench.php
@@ -23,7 +23,7 @@ final class PhelBench
 
         (new BuildFacade())->compileFile(
             __DIR__ . '/../../../../src/phel/core.phel',
-            tempnam(sys_get_temp_dir(), 'phel-core')
+            tempnam(sys_get_temp_dir(), 'phel-core'),
         );
     }
 

--- a/tests/php/Integration/Build/Command/CompileCommandTest.php
+++ b/tests/php/Integration/Build/Command/CompileCommandTest.php
@@ -38,7 +38,7 @@ final class CompileCommandTest extends TestCase
                 '--no-source-map' => true,
                 '--no-cache' => true,
             ]),
-            $this->createStub(OutputInterface::class)
+            $this->createStub(OutputInterface::class),
         );
 
         self::assertFileExists(__DIR__ . '/out/phel/core.phel');
@@ -63,7 +63,7 @@ final class CompileCommandTest extends TestCase
             new ArrayInput([
                 '--no-source-map' => true,
             ]),
-            $this->createStub(OutputInterface::class)
+            $this->createStub(OutputInterface::class),
         );
 
         self::assertFileExists(__DIR__ . '/out/phel/core.phel');

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -72,7 +72,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new KeywordNode(':test', $this->loc(1, 0), $this->loc(1, 5), Keyword::create('test')),
-            $this->parse(':test')
+            $this->parse(':test'),
         );
     }
 
@@ -80,11 +80,11 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true),
-            $this->parse('true')
+            $this->parse('true'),
         );
         self::assertEquals(
             new BooleanNode('false', $this->loc(1, 0), $this->loc(1, 5), false),
-            $this->parse('false')
+            $this->parse('false'),
         );
     }
 
@@ -92,7 +92,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new NilNode('nil', $this->loc(1, 0), $this->loc(1, 3), null),
-            $this->parse('nil')
+            $this->parse('nil'),
         );
     }
 
@@ -100,7 +100,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new SymbolNode('test', $this->loc(1, 0), $this->loc(1, 4), Symbol::create('test')),
-            $this->parse('test')
+            $this->parse('test'),
         );
     }
 
@@ -108,20 +108,20 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 2), []),
-            $this->parse('()')
+            $this->parse('()'),
         );
         self::assertEquals(
             new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 4), [
                 new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 1), $this->loc(1, 3), []),
             ]),
-            $this->parse('(())')
+            $this->parse('(())'),
         );
 
         self::assertEquals(
             new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 3), [
                 new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
             ]),
-            $this->parse('(a)')
+            $this->parse('(a)'),
         );
 
         self::assertEquals(
@@ -130,7 +130,7 @@ final class ParserTest extends TestCase
                 new WhitespaceNode(' ', $this->loc(1, 2), $this->loc(1, 3)),
                 new SymbolNode('b', $this->loc(1, 3), $this->loc(1, 4), Symbol::create('b')),
             ]),
-            $this->parse('(a b)')
+            $this->parse('(a b)'),
         );
     }
 
@@ -138,20 +138,20 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 0), $this->loc(1, 2), []),
-            $this->parse('[]')
+            $this->parse('[]'),
         );
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 0), $this->loc(1, 4), [
                 new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 1), $this->loc(1, 3), []),
             ]),
-            $this->parse('[[]]')
+            $this->parse('[[]]'),
         );
 
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 0), $this->loc(1, 3), [
                 new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
             ]),
-            $this->parse('[a]')
+            $this->parse('[a]'),
         );
 
         self::assertEquals(
@@ -160,7 +160,7 @@ final class ParserTest extends TestCase
                 new WhitespaceNode(' ', $this->loc(1, 2), $this->loc(1, 3)),
                 new SymbolNode('b', $this->loc(1, 3), $this->loc(1, 4), Symbol::create('b')),
             ]),
-            $this->parse('[a b]')
+            $this->parse('[a b]'),
         );
     }
 
@@ -171,9 +171,9 @@ final class ParserTest extends TestCase
                 Token::T_QUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
             ),
-            $this->parse('\'a')
+            $this->parse('\'a'),
         );
     }
 
@@ -184,9 +184,9 @@ final class ParserTest extends TestCase
                 Token::T_UNQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
             ),
-            $this->parse(',a')
+            $this->parse(',a'),
         );
     }
 
@@ -197,9 +197,9 @@ final class ParserTest extends TestCase
                 Token::T_UNQUOTE_SPLICING,
                 $this->loc(1, 0),
                 $this->loc(1, 3),
-                new SymbolNode('a', $this->loc(1, 2), $this->loc(1, 3), Symbol::create('a'))
+                new SymbolNode('a', $this->loc(1, 2), $this->loc(1, 3), Symbol::create('a')),
             ),
-            $this->parse(',@a')
+            $this->parse(',@a'),
         );
     }
 
@@ -210,9 +210,9 @@ final class ParserTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 8),
-                new SymbolNode('unquote', $this->loc(1, 1), $this->loc(1, 8), Symbol::create('unquote'))
+                new SymbolNode('unquote', $this->loc(1, 1), $this->loc(1, 8), Symbol::create('unquote')),
             ),
-            $this->parse(sprintf('`%s', Symbol::NAME_UNQUOTE))
+            $this->parse(sprintf('`%s', Symbol::NAME_UNQUOTE)),
         );
     }
 
@@ -223,9 +223,9 @@ final class ParserTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
             ),
-            $this->parse('`a')
+            $this->parse('`a'),
         );
     }
 
@@ -233,17 +233,17 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new StringNode('"abc"', $this->loc(1, 0), $this->loc(1, 5), 'abc'),
-            $this->parse('"abc"')
+            $this->parse('"abc"'),
         );
 
         self::assertEquals(
             new StringNode('"ab\"c"', $this->loc(1, 0), $this->loc(1, 7), 'ab"c'),
-            $this->parse('"ab\"c"')
+            $this->parse('"ab\"c"'),
         );
 
         self::assertEquals(
             new StringNode('"\\\\\r\n\t\f\v\e\$"', $this->loc(1, 0), $this->loc(1, 18), "\\\r\n\t\f\v\e\$"),
-            $this->parse('"\\\\\r\n\t\f\v\e\$"')
+            $this->parse('"\\\\\r\n\t\f\v\e\$"'),
         );
 
         self::assertEquals(
@@ -253,32 +253,32 @@ final class ParserTest extends TestCase
 
         self::assertEquals(
             new StringNode('"\x41"', $this->loc(1, 0), $this->loc(1, 6), "\x41"),
-            $this->parse('"\x41"')
+            $this->parse('"\x41"'),
         );
 
         self::assertEquals(
             new StringNode('"\u{65}"', $this->loc(1, 0), $this->loc(1, 8), "\u{65}"),
-            $this->parse('"\u{65}"')
+            $this->parse('"\u{65}"'),
         );
 
         self::assertEquals(
             new StringNode('"\u{129}"', $this->loc(1, 0), $this->loc(1, 9), "\u{129}"),
-            $this->parse('"\u{129}"')
+            $this->parse('"\u{129}"'),
         );
 
         self::assertEquals(
             new StringNode('"\u{1000}"', $this->loc(1, 0), $this->loc(1, 10), "\u{1000}"),
-            $this->parse('"\u{1000}"')
+            $this->parse('"\u{1000}"'),
         );
 
         self::assertEquals(
             new StringNode('"\u{10000}"', $this->loc(1, 0), $this->loc(1, 11), "\u{10000}"),
-            $this->parse('"\u{10000}"')
+            $this->parse('"\u{10000}"'),
         );
 
         self::assertEquals(
             new StringNode('"\77"', $this->loc(1, 0), $this->loc(1, 5), "\77"),
-            $this->parse('"\77"')
+            $this->parse('"\77"'),
         );
     }
 
@@ -286,7 +286,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new ListNode(Token::T_OPEN_BRACE, $this->loc(1, 0), $this->loc(1, 2), []),
-            $this->parse('{}')
+            $this->parse('{}'),
         );
     }
 
@@ -298,7 +298,7 @@ final class ParserTest extends TestCase
                 new WhitespaceNode(' ', $this->loc(1, 3), $this->loc(1, 4)),
                 new NumberNode('1', $this->loc(1, 4), $this->loc(1, 5), 1),
             ]),
-            $this->parse('{:a 1}')
+            $this->parse('{:a 1}'),
         );
     }
 
@@ -314,7 +314,7 @@ final class ParserTest extends TestCase
                 new WhitespaceNode(' ', $this->loc(1, 8), $this->loc(1, 9)),
                 new NumberNode('2', $this->loc(1, 9), $this->loc(1, 10), 2),
             ]),
-            $this->parse('{:a 1 :b 2}')
+            $this->parse('{:a 1 :b 2}'),
         );
     }
 
@@ -328,9 +328,9 @@ final class ParserTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 6), $this->loc(1, 7)),
                     new SymbolNode('test', $this->loc(1, 7), $this->loc(1, 11), Symbol::create('test')),
-                ]
+                ],
             ),
-            $this->parse('^:test test')
+            $this->parse('^:test test'),
         );
     }
 
@@ -344,9 +344,9 @@ final class ParserTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 7), $this->loc(1, 8)),
                     new SymbolNode('test', $this->loc(1, 8), $this->loc(1, 12), Symbol::create('test')),
-                ]
+                ],
             ),
-            $this->parse('^"test" test')
+            $this->parse('^"test" test'),
         );
     }
 
@@ -360,9 +360,9 @@ final class ParserTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 7), $this->loc(1, 8)),
                     new SymbolNode('test', $this->loc(1, 8), $this->loc(1, 12), Symbol::create('test')),
-                ]
+                ],
             ),
-            $this->parse('^String test')
+            $this->parse('^String test'),
         );
     }
 
@@ -384,9 +384,9 @@ final class ParserTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 12), $this->loc(1, 13)),
                     new SymbolNode('test', $this->loc(1, 13), $this->loc(1, 17), Symbol::create('test')),
-                ]
+                ],
             ),
-            $this->parse('^{:a 1 :b 2} test')
+            $this->parse('^{:a 1 :b 2} test'),
         );
     }
 
@@ -406,11 +406,11 @@ final class ParserTest extends TestCase
                         [
                             new WhitespaceNode(' ', $this->loc(1, 7), $this->loc(1, 8)),
                             new SymbolNode('test', $this->loc(1, 8), $this->loc(1, 12), Symbol::create('test')),
-                        ]
+                        ],
                     ),
-                ]
+                ],
             ),
-            $this->parse('^:a ^:b test')
+            $this->parse('^:a ^:b test'),
         );
     }
 
@@ -420,7 +420,7 @@ final class ParserTest extends TestCase
             new ListNode(Token::T_FN, $this->loc(1, 0), $this->loc(1, 6), [
                 new SymbolNode('add', $this->loc(1, 2), $this->loc(1, 5), Symbol::create('add')),
             ]),
-            $this->parse('|(add)')
+            $this->parse('|(add)'),
         );
     }
 
@@ -432,7 +432,7 @@ final class ParserTest extends TestCase
                 new WhitespaceNode(' ', $this->loc(1, 5), $this->loc(1, 6)),
                 new SymbolNode('$', $this->loc(1, 6), $this->loc(1, 7), Symbol::create('$')),
             ]),
-            $this->parse('|(add $)')
+            $this->parse('|(add $)'),
         );
     }
 
@@ -476,7 +476,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)),
-            $this->parse('# Test')
+            $this->parse('# Test'),
         );
     }
 
@@ -484,7 +484,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new WhitespaceNode(" \t", $this->loc(1, 0), $this->loc(1, 2)),
-            $this->parse(" \t")
+            $this->parse(" \t"),
         );
     }
 
@@ -492,7 +492,7 @@ final class ParserTest extends TestCase
     {
         self::assertEquals(
             new NewlineNode("\n", $this->loc(1, 0), $this->loc(2, 0)),
-            $this->parse("\n")
+            $this->parse("\n"),
         );
     }
 

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -68,7 +68,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(Keyword::create('test'), 1, 0, 1, 5),
-            $this->read(':test')
+            $this->read(':test'),
         );
     }
 
@@ -81,7 +81,7 @@ final class ReaderTest extends TestCase
     public function test_read_nil(): void
     {
         self::assertNull(
-            $this->read('nil')
+            $this->read('nil'),
         );
     }
 
@@ -89,7 +89,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(Symbol::create('test'), 1, 0, 1, 4),
-            $this->read('test')
+            $this->read('test'),
         );
     }
 
@@ -97,20 +97,20 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentList(), 1, 0, 1, 2),
-            $this->read('()')
+            $this->read('()'),
         );
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
                 $this->loc(TypeFactory::getInstance()->emptyPersistentList(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
-            $this->read('(())')
+            $this->read('(())'),
         );
 
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentListFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
-            $this->read('(a)')
+            $this->read('(a)'),
         );
 
         self::assertEquals(
@@ -118,7 +118,7 @@ final class ReaderTest extends TestCase
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
-            $this->read('(a b)')
+            $this->read('(a b)'),
         );
     }
 
@@ -126,20 +126,20 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentVector(), 1, 0, 1, 2),
-            $this->read('[]')
+            $this->read('[]'),
         );
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentVectorFromArray([
                 $this->loc(TypeFactory::getInstance()->emptyPersistentVector(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
-            $this->read('[[]]')
+            $this->read('[[]]'),
         );
 
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->persistentVectorFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
-            $this->read('[a]')
+            $this->read('[a]'),
         );
 
         self::assertEquals(
@@ -147,7 +147,7 @@ final class ReaderTest extends TestCase
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
-            $this->read('[a b]')
+            $this->read('[a b]'),
         );
     }
 
@@ -158,7 +158,7 @@ final class ReaderTest extends TestCase
                 Symbol::create(Symbol::NAME_QUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
-            $this->read('\'a')
+            $this->read('\'a'),
         );
     }
 
@@ -169,7 +169,7 @@ final class ReaderTest extends TestCase
                 Symbol::create(Symbol::NAME_UNQUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
-            $this->read(',a')
+            $this->read(',a'),
         );
     }
 
@@ -180,7 +180,7 @@ final class ReaderTest extends TestCase
                 Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                 $this->loc(Symbol::create('a'), 1, 2, 1, 3),
             ]), 1, 0, 1, 3),
-            $this->read(',@a')
+            $this->read(',@a'),
         );
     }
 
@@ -191,7 +191,7 @@ final class ReaderTest extends TestCase
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 8),
                 $this->loc(Symbol::create(Symbol::NAME_UNQUOTE), 1, 1, 1, 8),
             ]), 1, 0, 1, 8),
-            $this->read(sprintf('`%s', Symbol::NAME_UNQUOTE))
+            $this->read(sprintf('`%s', Symbol::NAME_UNQUOTE)),
         );
     }
 
@@ -202,7 +202,7 @@ final class ReaderTest extends TestCase
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 2),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
-            $this->read('`a')
+            $this->read('`a'),
         );
     }
 
@@ -252,52 +252,52 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             'abc',
-            $this->read('"abc"')
+            $this->read('"abc"'),
         );
 
         self::assertEquals(
             'ab"c',
-            $this->read('"ab\"c"')
+            $this->read('"ab\"c"'),
         );
 
         self::assertEquals(
             "\\\r\n\t\f\v\e\$",
-            $this->read('"\\\\\r\n\t\f\v\e\$"')
+            $this->read('"\\\\\r\n\t\f\v\e\$"'),
         );
 
         self::assertEquals(
             'read $abc sign',
-            $this->read('"read $abc sign"')
+            $this->read('"read $abc sign"'),
         );
 
         self::assertEquals(
             "\x41",
-            $this->read('"\x41"')
+            $this->read('"\x41"'),
         );
 
         self::assertEquals(
             "\u{65}",
-            $this->read('"\u{65}"')
+            $this->read('"\u{65}"'),
         );
 
         self::assertEquals(
             "\u{129}",
-            $this->read('"\u{129}"')
+            $this->read('"\u{129}"'),
         );
 
         self::assertEquals(
             "\u{1000}",
-            $this->read('"\u{1000}"')
+            $this->read('"\u{1000}"'),
         );
 
         self::assertEquals(
             "\u{10000}",
-            $this->read('"\u{10000}"')
+            $this->read('"\u{10000}"'),
         );
 
         self::assertEquals(
             "\77",
-            $this->read('"\77"')
+            $this->read('"\77"'),
         );
     }
 
@@ -305,7 +305,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(TypeFactory::getInstance()->emptyPersistentMap(), 1, 0, 1, 2),
-            $this->read('{}')
+            $this->read('{}'),
         );
     }
 
@@ -315,14 +315,14 @@ final class ReaderTest extends TestCase
             $this->loc(
                 TypeFactory::getInstance()->persistentMapFromKVs(
                     $this->loc(Keyword::create('a'), 1, 1, 1, 3),
-                    1
+                    1,
                 ),
                 1,
                 0,
                 1,
-                6
+                6,
             ),
-            $this->read('{:a 1}')
+            $this->read('{:a 1}'),
         );
     }
 
@@ -333,9 +333,9 @@ final class ReaderTest extends TestCase
                 $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                 1,
                 $this->loc(Keyword::create('b'), 1, 6, 1, 8),
-                2
+                2,
             ), 1, 0, 1, 11),
-            $this->read('{:a 1 :b 2}')
+            $this->read('{:a 1 :b 2}'),
         );
     }
 
@@ -353,15 +353,15 @@ final class ReaderTest extends TestCase
                     Symbol::create('test'),
                     TypeFactory::getInstance()->persistentMapFromKVs(
                         $this->loc(Keyword::create('test'), 1, 1, 1, 6),
-                        true
-                    )
+                        true,
+                    ),
                 ),
                 1,
                 7,
                 1,
-                11
+                11,
             ),
-            $this->read('^:test test')
+            $this->read('^:test test'),
         );
     }
 
@@ -373,15 +373,15 @@ final class ReaderTest extends TestCase
                     Symbol::create('test'),
                     TypeFactory::getInstance()->persistentMapFromKVs(
                         Keyword::create('tag'),
-                        'test'
-                    )
+                        'test',
+                    ),
                 ),
                 1,
                 8,
                 1,
-                12
+                12,
             ),
-            $this->read('^"test" test')
+            $this->read('^"test" test'),
         );
     }
 
@@ -393,15 +393,15 @@ final class ReaderTest extends TestCase
                     Symbol::create('test'),
                     TypeFactory::getInstance()->persistentMapFromKVs(
                         Keyword::create('tag'),
-                        $this->loc(Symbol::create('String'), 1, 1, 1, 7)
-                    )
+                        $this->loc(Symbol::create('String'), 1, 1, 1, 7),
+                    ),
                 ),
                 1,
                 8,
                 1,
-                12
+                12,
             ),
-            $this->read('^String test')
+            $this->read('^String test'),
         );
     }
 
@@ -415,15 +415,15 @@ final class ReaderTest extends TestCase
                         $this->loc(Keyword::create('a'), 1, 2, 1, 4),
                         1,
                         $this->loc(Keyword::create('b'), 1, 7, 1, 9),
-                        2
-                    )
+                        2,
+                    ),
                 ),
                 1,
                 13,
                 1,
-                17
+                17,
             ),
-            $this->read('^{:a 1 :b 2} test')
+            $this->read('^{:a 1 :b 2} test'),
         );
     }
 
@@ -437,15 +437,15 @@ final class ReaderTest extends TestCase
                         $this->loc(Keyword::create('b'), 1, 5, 1, 7),
                         true,
                         $this->loc(Keyword::create('a'), 1, 1, 1, 3),
-                        true
-                    )
+                        true,
+                    ),
                 ),
                 1,
                 8,
                 1,
-                12
+                12,
             ),
-            $this->read('^:a ^:b test')
+            $this->read('^:a ^:b test'),
         );
     }
 
@@ -477,15 +477,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        6
+                        6,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                6
+                6,
             ),
-            $this->read('|(add)')
+            $this->read('|(add)'),
         );
     }
 
@@ -506,15 +506,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        8
+                        8,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                8
+                8,
             ),
-            $this->read('|(add $)')
+            $this->read('|(add $)'),
         );
     }
 
@@ -536,15 +536,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        10
+                        10,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                10
+                10,
             ),
-            $this->read('|(add $ $)')
+            $this->read('|(add $ $)'),
         );
     }
 
@@ -567,15 +567,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        12
+                        12,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                12
+                12,
             ),
-            $this->read('|(add $1 $2)')
+            $this->read('|(add $1 $2)'),
         );
     }
 
@@ -597,15 +597,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        12
+                        12,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                12
+                12,
             ),
-            $this->read('|(add $1 $1)')
+            $this->read('|(add $1 $1)'),
         );
     }
 
@@ -629,15 +629,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        12
+                        12,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                12
+                12,
             ),
-            $this->read('|(add $1 $3)')
+            $this->read('|(add $1 $3)'),
         );
     }
 
@@ -661,15 +661,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        12
+                        12,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                12
+                12,
             ),
-            $this->read('|(add $1 $&)')
+            $this->read('|(add $1 $&)'),
         );
     }
 
@@ -692,15 +692,15 @@ final class ReaderTest extends TestCase
                         1,
                         0,
                         1,
-                        15
+                        15,
                     ),
                 ]),
                 1,
                 0,
                 1,
-                15
+                15,
             ),
-            $this->read('|(concat $& $&)')
+            $this->read('|(concat $& $&)'),
         );
     }
 

--- a/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
+++ b/tests/php/Integration/Formatter/Command/Format/FormatCommandTest.php
@@ -31,7 +31,7 @@ final class FormatCommandTest extends TestCase
         try {
             $command->run(
                 $this->stubInput([$path]),
-                $this->stubOutput()
+                $this->stubOutput(),
             );
         } finally {
             file_put_contents($path, $oldContent);
@@ -55,7 +55,7 @@ TXT
         try {
             $command->run(
                 $this->stubInput([$path]),
-                $this->stubOutput()
+                $this->stubOutput(),
             );
         } finally {
             file_put_contents($path, $oldContent);

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -28,7 +28,7 @@ final class IntegrationTest extends TestCase
         $globalEnv = GlobalEnvironmentSingleton::initializeNew();
         (new BuildFacade())->compileFile(
             __DIR__ . '/../../../src/phel/core.phel',
-            tempnam(sys_get_temp_dir(), 'phel-core')
+            tempnam(sys_get_temp_dir(), 'phel-core'),
         );
         self::$globalEnv = $globalEnv;
     }
@@ -44,7 +44,7 @@ final class IntegrationTest extends TestCase
     public function test_integration(
         string $filename,
         string $phelCode,
-        string $expectedGeneratedCode
+        string $expectedGeneratedCode,
     ): void {
         $globalEnv = self::$globalEnv;
         $globalEnv->setNs('user');
@@ -58,7 +58,7 @@ final class IntegrationTest extends TestCase
         self::assertSame(
             trim($expectedGeneratedCode),
             trim($compiledCode),
-            'in ' . $filename
+            'in ' . $filename,
         );
     }
 
@@ -68,7 +68,7 @@ final class IntegrationTest extends TestCase
 
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($fixturesDir),
-            RecursiveIteratorIterator::LEAVES_ONLY
+            RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         /** @var SplFileInfo $file */

--- a/tests/php/Integration/Interop/CallPhelTest.php
+++ b/tests/php/Integration/Interop/CallPhelTest.php
@@ -18,7 +18,7 @@ final class CallPhelTest extends TestCase
 
         (new BuildFacade())->compileFile(
             __DIR__ . '/../../../../src/phel/core.phel',
-            tempnam(sys_get_temp_dir(), 'phel-core')
+            tempnam(sys_get_temp_dir(), 'phel-core'),
         );
         $this->wrapper = new ExampleWrapper();
     }

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -33,7 +33,7 @@ final class ExportCommandTest extends TestCase
 
         $command->run(
             $this->createStub(InputInterface::class),
-            $this->stubOutput()
+            $this->stubOutput(),
         );
 
         self::assertFileExists(__DIR__ . '/PhelGenerated/TestCmdExportMultiple/Adder.php');

--- a/tests/php/Integration/ParseAndPrintTest.php
+++ b/tests/php/Integration/ParseAndPrintTest.php
@@ -54,7 +54,7 @@ final class ParseAndPrintTest extends TestCase
     {
         return implode(array_map(
             static fn (NodeInterface $t) => $t->getCode(),
-            $parseTrees
+            $parseTrees,
         ));
     }
 }

--- a/tests/php/Integration/Printer/PrinterTest.php
+++ b/tests/php/Integration/Printer/PrinterTest.php
@@ -30,7 +30,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '"test"',
-            $this->print('test')
+            $this->print('test'),
         );
     }
 
@@ -38,7 +38,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '"\n\r\t\v\f\e\"\$\\\\"',
-            $this->print("\n\r\t\v\f\e\"\$\\")
+            $this->print("\n\r\t\v\f\e\"\$\\"),
         );
     }
 
@@ -46,7 +46,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '"\$ \$abc"',
-            $this->print($this->read('"$ $abc"'))
+            $this->print($this->read('"$ $abc"')),
         );
     }
 
@@ -54,7 +54,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '"\x07"',
-            $this->print("\x07")
+            $this->print("\x07"),
         );
     }
 
@@ -62,7 +62,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '"\u{1000}"',
-            $this->print("\u{1000}")
+            $this->print("\u{1000}"),
         );
     }
 
@@ -70,7 +70,7 @@ final class PrinterTest extends TestCase
     {
         self::assertEquals(
             '0',
-            $this->print(0)
+            $this->print(0),
         );
     }
 

--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
@@ -50,7 +50,7 @@ final class ReplCommandTest extends AbstractCommandTest
         $repl = $this->createReplCommand();
         $repl->run(
             $this->createStub(InputInterface::class),
-            $this->createStub(OutputInterface::class)
+            $this->createStub(OutputInterface::class),
         );
 
         $replOutput = $io->getOutputString();
@@ -73,7 +73,7 @@ final class ReplCommandTest extends AbstractCommandTest
         $repl = $this->createReplCommandWithCoreLib();
         $repl->run(
             $this->createStub(InputInterface::class),
-            $this->createStub(OutputInterface::class)
+            $this->createStub(OutputInterface::class),
         );
 
         $replOutput = $io->getOutputString();
@@ -95,7 +95,7 @@ final class ReplCommandTest extends AbstractCommandTest
     {
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($fixturesDir),
-            RecursiveIteratorIterator::LEAVES_ONLY
+            RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         /** @var SplFileInfo $file */
@@ -151,7 +151,7 @@ final class ReplCommandTest extends AbstractCommandTest
             new ExceptionArgsPrinter(Printer::readable()),
             ColorStyle::noStyles(),
             new Munge(),
-            new FilePositionExtractor(new SourceMapExtractor())
+            new FilePositionExtractor(new SourceMapExtractor()),
         );
 
         return new ReplTestIo($exceptionPrinter);
@@ -183,7 +183,7 @@ final class ReplCommandTest extends AbstractCommandTest
                 {
                     return $this->io;
                 }
-            }
+            },
         );
     }
 }

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -27,7 +27,7 @@ final class RunCommandTest extends AbstractCommandTest
 
         $this->createRunCommand()->run(
             $this->stubInput('test\\test-script'),
-            $this->stubOutput()
+            $this->stubOutput(),
         );
     }
 
@@ -37,7 +37,7 @@ final class RunCommandTest extends AbstractCommandTest
 
         $this->createRunCommand()->run(
             $this->stubInput(__DIR__ . '/Fixtures/test-script.phel'),
-            $this->stubOutput()
+            $this->stubOutput(),
         );
     }
 

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/TestCommandProjectSuccessTest.php
@@ -50,7 +50,7 @@ final class TestCommandProjectSuccessTest extends AbstractCommandTest
 
         $command->run(
             $this->stubInput([__DIR__ . '/Fixtures/test1.phel']),
-            $this->stubOutput()
+            $this->stubOutput(),
         );
     }
 

--- a/tests/php/Integration/Util/DirectoryUtil.php
+++ b/tests/php/Integration/Util/DirectoryUtil.php
@@ -19,7 +19,7 @@ final class DirectoryUtil
 
         $files = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($target, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         /** @var SplFileInfo $file */

--- a/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
@@ -59,7 +59,7 @@ final class NamespaceExtractorTest extends TestCase
 
         $nsExtractor = new NamespaceExtractor(
             new CompilerFacade(),
-            new TopologicalNamespaceSorter()
+            new TopologicalNamespaceSorter(),
         );
 
         return $nsExtractor->getNamespaceFromFile($filePath);

--- a/tests/php/Unit/Command/Shared/Exceptions/Extractor/FilePositionExtractorTest.php
+++ b/tests/php/Unit/Command/Shared/Exceptions/Extractor/FilePositionExtractorTest.php
@@ -15,7 +15,7 @@ final class FilePositionExtractorTest extends TestCase
     public function test_get_original(): void
     {
         $extractor = new FilePositionExtractor(
-            $this->stubSourceMapExtractor()
+            $this->stubSourceMapExtractor(),
         );
 
         $filename = '/example-module-name/file-name.phel';
@@ -23,7 +23,7 @@ final class FilePositionExtractorTest extends TestCase
 
         self::assertEquals(
             new FilePosition($filename, $line),
-            $extractor->getOriginal($filename, $line)
+            $extractor->getOriginal($filename, $line),
         );
     }
 
@@ -31,8 +31,8 @@ final class FilePositionExtractorTest extends TestCase
     {
         $extractor = new FilePositionExtractor(
             $this->stubSourceMapExtractor(
-                '// file-name/comment'
-            )
+                '// file-name/comment',
+            ),
         );
 
         $filename = '/example-module-name/file-name.phel';
@@ -40,13 +40,13 @@ final class FilePositionExtractorTest extends TestCase
 
         self::assertEquals(
             new FilePosition('file-name/comment', $line),
-            $extractor->getOriginal($filename, $line)
+            $extractor->getOriginal($filename, $line),
         );
     }
 
     private function stubSourceMapExtractor(
         string $filename = '',
-        string $sourceMap = ''
+        string $sourceMap = '',
     ): SourceMapExtractorInterface {
         $sourceMapExtractor = $this->createMock(SourceMapExtractorInterface::class);
         $sourceMapExtractor

--- a/tests/php/Unit/Command/Shared/Exceptions/TextExceptionPrinterTest.php
+++ b/tests/php/Unit/Command/Shared/Exceptions/TextExceptionPrinterTest.php
@@ -24,7 +24,7 @@ final class TextExceptionPrinterTest extends TestCase
         $codeSnippet = new CodeSnippet(
             startLocation: new SourceLocation($file, line: 1, column: 1),
             endLocation: new SourceLocation($file, line: 1, column: 3),
-            code: '(+ 1 2 3 unknown-symbol)'
+            code: '(+ 1 2 3 unknown-symbol)',
         );
 
         $type = $this->createStub(AbstractType::class);
@@ -53,7 +53,7 @@ MSG
             $this->stubExceptionArgsPrinter(),
             $this->stubColorStyle(),
             $this->stubMunge(),
-            $this->stubFilePositionExtractor()
+            $this->stubFilePositionExtractor(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeLiteralTest.php
@@ -24,7 +24,7 @@ final class AnalyzeLiteralTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new LiteralNode($env, Symbol::create('test'), null),
-            $this->literalAnalyzer->analyze(Symbol::create('test'), $env)
+            $this->literalAnalyzer->analyze(Symbol::create('test'), $env),
         );
     }
 
@@ -33,7 +33,7 @@ final class AnalyzeLiteralTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new LiteralNode($env, 2, null),
-            $this->literalAnalyzer->analyze(2, $env)
+            $this->literalAnalyzer->analyze(2, $env),
         );
     }
 
@@ -42,7 +42,7 @@ final class AnalyzeLiteralTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new LiteralNode($env, [1, 2], null),
-            $this->literalAnalyzer->analyze([1, 2], $env)
+            $this->literalAnalyzer->analyze([1, 2], $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -130,7 +130,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 
@@ -141,7 +141,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 
@@ -154,7 +154,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpArrayGetNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 
@@ -168,7 +168,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpArraySetNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 
@@ -181,7 +181,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpArrayPushNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 
@@ -194,7 +194,7 @@ final class AnalyzePersistentListTest extends TestCase
         ]);
         self::assertInstanceOf(
             PhpArrayUnsetNode::class,
-            $this->listAnalyzer->analyze($list, NodeEnvironment::empty())
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -28,7 +28,7 @@ final class AnalyzePersistentMapTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new MapNode($env, [], null),
-            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->emptyPersistentMap(), $env)
+            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->emptyPersistentMap(), $env),
         );
     }
 
@@ -40,7 +40,7 @@ final class AnalyzePersistentMapTest extends TestCase
                 new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 'a', null),
                 new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 1, null),
             ], null),
-            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->persistentMapFromKVs('a', 1), $env)
+            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->persistentMapFromKVs('a', 1), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
@@ -28,7 +28,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new VectorNode($env, [], null),
-            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->emptyPersistentVector(), $env)
+            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->emptyPersistentVector(), $env),
         );
     }
 
@@ -39,7 +39,7 @@ final class AnalyzePersistentVectorTest extends TestCase
             new VectorNode($env, [
                 new LiteralNode($env->withDisallowRecurFrame()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 1, null),
             ], null),
-            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->persistentVectorFromArray([1]), $env)
+            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->persistentVectorFromArray([1]), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -32,7 +32,7 @@ final class AnalyzeSymbolTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new PhpVarNode($env, 'is_array', null),
-            $this->symbolAnalyzer->analyze(Symbol::createForNamespace('php', 'is_array'), $env)
+            $this->symbolAnalyzer->analyze(Symbol::createForNamespace('php', 'is_array'), $env),
         );
     }
 
@@ -41,7 +41,7 @@ final class AnalyzeSymbolTest extends TestCase
         $env = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);
         self::assertEquals(
             new LocalVarNode($env, Symbol::create('a'), null),
-            $this->symbolAnalyzer->analyze(Symbol::create('a'), $env)
+            $this->symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }
 
@@ -53,7 +53,7 @@ final class AnalyzeSymbolTest extends TestCase
 
         self::assertEquals(
             new LocalVarNode($env, Symbol::create('b'), null),
-            $this->symbolAnalyzer->analyze(Symbol::create('a'), $env)
+            $this->symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }
 
@@ -67,7 +67,7 @@ final class AnalyzeSymbolTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new GlobalVarNode($env, 'test', Symbol::create('a'), TypeFactory::getInstance()->emptyPersistentMap(), null),
-            $symbolAnalyzer->analyze(Symbol::create('a'), $env)
+            $symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }
 
@@ -90,7 +90,7 @@ final class AnalyzeSymbolTest extends TestCase
         $env = NodeEnvironment::empty()->withLocals([Symbol::create('a')]);
         self::assertEquals(
             new LocalVarNode($env, Symbol::create('a'), null),
-            $symbolAnalyzer->analyze(Symbol::create('a'), $env)
+            $symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -72,7 +72,7 @@ final class GlobalEnvironmentTest extends TestCase
 
         $this->assertEquals(
             new LiteralNode($nodeEnv, __DIR__),
-            $env->resolve($sym, $nodeEnv)
+            $env->resolve($sym, $nodeEnv),
         );
     }
 
@@ -85,7 +85,7 @@ final class GlobalEnvironmentTest extends TestCase
 
         $this->assertEquals(
             new LiteralNode($nodeEnv, __FILE__),
-            $env->resolve($sym, $nodeEnv)
+            $env->resolve($sym, $nodeEnv),
         );
     }
 
@@ -98,9 +98,9 @@ final class GlobalEnvironmentTest extends TestCase
             new PhpClassNameNode(
                 $nodeEnv,
                 Symbol::create('\\Exception'),
-                null
+                null,
             ),
-            $env->resolve(Symbol::create('\\Exception'), $nodeEnv)
+            $env->resolve(Symbol::create('\\Exception'), $nodeEnv),
         );
     }
 
@@ -115,9 +115,9 @@ final class GlobalEnvironmentTest extends TestCase
             new PhpClassNameNode(
                 $nodeEnv,
                 Symbol::create('bar'),
-                null
+                null,
             ),
-            $env->resolve(Symbol::create('b'), $nodeEnv)
+            $env->resolve(Symbol::create('b'), $nodeEnv),
         );
     }
 
@@ -134,9 +134,9 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'foo',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap()
+                TypeFactory::getInstance()->emptyPersistentMap(),
             ),
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -152,9 +152,9 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap()
+                TypeFactory::getInstance()->emptyPersistentMap(),
             ),
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -168,9 +168,9 @@ final class GlobalEnvironmentTest extends TestCase
         $this->assertEquals(
             new PhpClassNameNode(
                 $nodeEnv,
-                Symbol::createForNamespace('bar', 'x')
+                Symbol::createForNamespace('bar', 'x'),
             ),
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -186,9 +186,9 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'phel\\core',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap()
+                TypeFactory::getInstance()->emptyPersistentMap(),
             ),
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -201,7 +201,7 @@ final class GlobalEnvironmentTest extends TestCase
         $nodeEnv = NodeEnvironment::empty();
 
         $this->assertNull(
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -215,9 +215,9 @@ final class GlobalEnvironmentTest extends TestCase
         $this->assertEquals(
             new PhpClassNameNode(
                 $nodeEnv,
-                Symbol::createForNamespace('phel\\core', 'x')
+                Symbol::createForNamespace('phel\\core', 'x'),
             ),
-            $env->resolve(Symbol::create('x'), $nodeEnv)
+            $env->resolve(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -225,7 +225,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $this->assertNull(
-            $env->resolve(Symbol::create('foo'), NodeEnvironment::empty())
+            $env->resolve(Symbol::create('foo'), NodeEnvironment::empty()),
         );
     }
 
@@ -244,9 +244,9 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap()
+                TypeFactory::getInstance()->emptyPersistentMap(),
             ),
-            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
     }
 
@@ -263,9 +263,9 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap()
+                TypeFactory::getInstance()->emptyPersistentMap(),
             ),
-            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv)
+            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
         );
     }
 
@@ -278,7 +278,7 @@ final class GlobalEnvironmentTest extends TestCase
         $nodeEnv = NodeEnvironment::empty();
 
         $this->assertNull(
-            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
     }
 
@@ -292,9 +292,9 @@ final class GlobalEnvironmentTest extends TestCase
         $this->assertEquals(
             new PhpClassNameNode(
                 $nodeEnv,
-                Symbol::createForNamespace('bar', 'x')
+                Symbol::createForNamespace('bar', 'x'),
             ),
-            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv)
+            $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
     }
 
@@ -309,9 +309,9 @@ final class GlobalEnvironmentTest extends TestCase
         $this->assertEquals(
             new PhpClassNameNode(
                 $nodeEnv,
-                Symbol::createForNamespace('bar', 'x')
+                Symbol::createForNamespace('bar', 'x'),
             ),
-            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv)
+            $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
         );
     }
 
@@ -324,7 +324,7 @@ final class GlobalEnvironmentTest extends TestCase
 
         $this->assertEquals(
             Symbol::createForNamespace('bar', 'x'),
-            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv)
+            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv),
         );
     }
 
@@ -335,7 +335,7 @@ final class GlobalEnvironmentTest extends TestCase
         $nodeEnv = NodeEnvironment::empty();
 
         $this->assertNull(
-            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv)
+            $env->resolveAsSymbol(Symbol::create('x'), $nodeEnv),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
@@ -64,10 +64,10 @@ final class ApplySymbolTest extends TestCase
                         new LiteralNode($envLiteral, 1),
                         new LiteralNode($envLiteral, 2),
                         new LiteralNode($envLiteral, 3),
-                    ]
-                )]
+                    ],
+                )],
             ),
-            $applyNode
+            $applyNode,
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -22,8 +22,8 @@ final class MapBindingDeconstructorTest extends TestCase
 
         $this->deconstructor = new MapBindingDeconstructor(
             new Deconstructor(
-                $this->createMock(BindingValidatorInterface::class)
-            )
+                $this->createMock(BindingValidatorInterface::class),
+            ),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
@@ -26,8 +26,8 @@ final class VectorBindingDeconstructorTest extends TestCase
 
         $this->deconstructor = new VectorBindingDeconstructor(
             new Deconstructor(
-                $this->createMock(BindingValidatorInterface::class)
-            )
+                $this->createMock(BindingValidatorInterface::class),
+            ),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -20,14 +20,14 @@ final class DeconstructorTest extends TestCase
         Symbol::resetGen();
 
         $this->deconstructor = new Deconstructor(
-            $this->createStub(BindingValidatorInterface::class)
+            $this->createStub(BindingValidatorInterface::class),
         );
     }
 
     public function test_empty_vector(): void
     {
         $bindings = $this->deconstructor->deconstruct(
-            TypeFactory::getInstance()->persistentVectorFromArray([])
+            TypeFactory::getInstance()->persistentVectorFromArray([]),
         );
 
         self::assertEquals([], $bindings);
@@ -114,7 +114,7 @@ final class DeconstructorTest extends TestCase
             TypeFactory::getInstance()->persistentVectorFromArray([
                 TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
                 Symbol::create('x'),
-            ])
+            ]),
         );
 
         self::assertEquals([

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -103,9 +103,9 @@ final class DefStructSymbolTest extends TestCase
                     Symbol::create('method'),
                     Symbol::create('uri'),
                 ],
-                []
+                [],
             ),
-            $defStructNode
+            $defStructNode,
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -100,7 +100,7 @@ final class DefSymbolTest extends TestCase
                 Symbol::create('name'),
                 new MapNode(
                     $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
-                    []
+                    [],
                 ),
                 new LiteralNode(
                     $env
@@ -108,10 +108,10 @@ final class DefSymbolTest extends TestCase
                         ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
-                    'any value'
-                )
+                    'any value',
+                ),
             ),
-            $defNode
+            $defNode,
         );
     }
 
@@ -136,13 +136,13 @@ final class DefSymbolTest extends TestCase
                     [
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
-                            Keyword::create('doc')
+                            Keyword::create('doc'),
                         ),
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
-                            'my docstring'
+                            'my docstring',
                         ),
-                    ]
+                    ],
                 ),
                 new LiteralNode(
                     $env
@@ -150,10 +150,10 @@ final class DefSymbolTest extends TestCase
                         ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
-                    'any value'
-                )
+                    'any value',
+                ),
             ),
-            $defNode
+            $defNode,
         );
     }
 
@@ -178,13 +178,13 @@ final class DefSymbolTest extends TestCase
                     [
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
-                            Keyword::create('private')
+                            Keyword::create('private'),
                         ),
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
-                            true
+                            true,
                         ),
-                    ]
+                    ],
                 ),
                 new LiteralNode(
                     $env
@@ -192,10 +192,10 @@ final class DefSymbolTest extends TestCase
                         ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
-                    'any value'
-                )
+                    'any value',
+                ),
             ),
-            $defNode
+            $defNode,
         );
     }
 
@@ -221,14 +221,14 @@ final class DefSymbolTest extends TestCase
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
                             Keyword::create('private'),
-                            null
+                            null,
                         ),
                         new LiteralNode(
                             $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION),
                             true,
-                            null
+                            null,
                         ),
-                    ]
+                    ],
                 ),
                 new LiteralNode(
                     $env
@@ -236,10 +236,10 @@ final class DefSymbolTest extends TestCase
                         ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
-                    'any value'
-                )
+                    'any value',
+                ),
             ),
-            $defNode
+            $defNode,
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -45,7 +45,7 @@ final class DoSymbolTest extends TestCase
             $env,
             $stmts = [],
             $this->analyzer->analyze(null, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
 
         $actual = (new DoSymbol($this->analyzer))->analyze($list, $env);
@@ -65,7 +65,7 @@ final class DoSymbolTest extends TestCase
             $env,
             $stmts = [],
             $this->analyzer->analyze(1, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
 
         $actual = (new DoSymbol($this->analyzer))->analyze($list, $env);
@@ -88,7 +88,7 @@ final class DoSymbolTest extends TestCase
                 $this->analyzer->analyze(1, $env->withDisallowRecurFrame()),
             ],
             $this->analyzer->analyze(2, $env),
-            $list->getStartLocation()
+            $list->getStartLocation(),
         );
 
         $actual = (new DoSymbol($this->analyzer))->analyze($list, $env);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -86,12 +86,12 @@ final class ForeachSymbolTest extends TestCase
                 new DoNode(
                     $env->withLocals([Symbol::create('x')]),
                     [],
-                    new LocalVarNode($env->withLocals([Symbol::create('x')]), Symbol::create('x'))
+                    new LocalVarNode($env->withLocals([Symbol::create('x')]), Symbol::create('x')),
                 ),
                 new VectorNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), []),
-                Symbol::create('x')
+                Symbol::create('x'),
             ),
-            $this->analyze($list)
+            $this->analyze($list),
         );
     }
 
@@ -132,13 +132,13 @@ final class ForeachSymbolTest extends TestCase
                 new DoNode(
                     $env->withLocals([Symbol::create('value'), Symbol::create('key')]),
                     [],
-                    new LocalVarNode($env->withLocals([Symbol::create('value'), Symbol::create('key')]), Symbol::create('key'))
+                    new LocalVarNode($env->withLocals([Symbol::create('value'), Symbol::create('key')]), Symbol::create('key')),
                 ),
                 new MapNode($env->withContext(NodeEnvironment::CONTEXT_EXPRESSION), []),
                 Symbol::create('value'),
-                Symbol::create('key')
+                Symbol::create('key'),
             ),
-            $this->analyze($list)
+            $this->analyze($list),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -36,7 +36,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-macro',
             static fn ($a) => $a,
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true)
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-failed-macro'));
@@ -44,7 +44,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-failed-macro',
             static fn ($a) => throw new Exception('my-failed-macro message'),
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true)
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-inline-fn'));
@@ -54,8 +54,8 @@ final class InvokeSymbolTest extends TestCase
             static fn ($a) => 1,
             TypeFactory::getInstance()->persistentMapFromKVs(
                 Keyword::create('inline'),
-                static fn ($a) => 2
-            )
+                static fn ($a) => 2,
+            ),
         );
 
         $env->addDefinition('user', Symbol::create('my-inline-fn-with-arity'));
@@ -67,8 +67,8 @@ final class InvokeSymbolTest extends TestCase
                 Keyword::create('inline'),
                 static fn ($a, $b) => 2,
                 Keyword::create('inline-arity'),
-                static fn ($n) => $n === 2
-            )
+                static fn ($n) => $n === 2,
+            ),
         );
 
         $this->analyzer = new Analyzer($env);
@@ -86,9 +86,9 @@ final class InvokeSymbolTest extends TestCase
             new CallNode(
                 $env,
                 new PhpVarNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(), '+'),
-                []
+                [],
             ),
-            $node
+            $node,
         );
     }
 
@@ -107,9 +107,9 @@ final class InvokeSymbolTest extends TestCase
                 new PhpVarNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(), '+'),
                 [
                     new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(), 1),
-                ]
+                ],
             ),
-            $node
+            $node,
         );
     }
 
@@ -132,12 +132,12 @@ final class InvokeSymbolTest extends TestCase
                         $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(),
                         [
                             new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()->withDisallowRecurFrame(), 1),
-                        ]
+                        ],
                     ),
 
-                ]
+                ],
             ),
-            $node
+            $node,
         );
     }
 
@@ -178,7 +178,7 @@ final class InvokeSymbolTest extends TestCase
 
         $this->assertEquals(
             new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT), 2),
-            $node
+            $node,
         );
     }
 
@@ -193,7 +193,7 @@ final class InvokeSymbolTest extends TestCase
 
         $this->assertEquals(
             new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT), 2),
-            $node
+            $node,
         );
     }
 
@@ -217,14 +217,14 @@ final class InvokeSymbolTest extends TestCase
                         Keyword::create('inline'),
                         static fn ($a, $b) => 2,
                         Keyword::create('inline-arity'),
-                        static fn ($n) => $n === 2
-                    )
+                        static fn ($n) => $n === 2,
+                    ),
                 ),
                 [
                     new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame(), 'foo'),
-                ]
+                ],
             ),
-            $node
+            $node,
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -88,7 +88,7 @@ final class LetSymbolTest extends TestCase
 
         $this->assertEquals(
             new LetNode($env, [], new DoNode($env, [], new LiteralNode($env, null)), false),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 
@@ -113,8 +113,8 @@ final class LetSymbolTest extends TestCase
                         Symbol::create('a_1'),
                         new LiteralNode(
                             $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()->withDisallowRecurFrame()->withBoundTo('.a'),
-                            1
-                        )
+                            1,
+                        ),
                     ),
                 ],
                 new DoNode(
@@ -122,12 +122,12 @@ final class LetSymbolTest extends TestCase
                     [],
                     new LiteralNode(
                         $env->withLocals([Symbol::create('a')])->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
-                        null
-                    )
+                        null,
+                    ),
                 ),
-                false
+                false,
             ),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 
@@ -147,11 +147,11 @@ final class LetSymbolTest extends TestCase
                 new DoNode(
                     $env,
                     [],
-                    new LiteralNode($env, 1)
+                    new LiteralNode($env, 1),
                 ),
-                false
+                false,
             ),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 
@@ -172,11 +172,11 @@ final class LetSymbolTest extends TestCase
                 new DoNode(
                     $env->withContext(NodeEnvironmentInterface::CONTEXT_RETURN),
                     [new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)->withDisallowRecurFrame(), 1)],
-                    new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_RETURN), 2)
+                    new LiteralNode($env->withContext(NodeEnvironmentInterface::CONTEXT_RETURN), 2),
                 ),
-                false
+                false,
             ),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -95,11 +95,11 @@ final class LoopSymbolTest extends TestCase
                 new DoNode(
                     $env->withAddedRecurFrame(new RecurFrame([])),
                     [],
-                    new LiteralNode($env->withAddedRecurFrame(new RecurFrame([])), null)
+                    new LiteralNode($env->withAddedRecurFrame(new RecurFrame([])), null),
                 ),
-                false
+                false,
             ),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 
@@ -125,8 +125,8 @@ final class LoopSymbolTest extends TestCase
                         Symbol::create('a_1'),
                         new LiteralNode(
                             $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()->withDisallowRecurFrame()->withBoundTo('.a'),
-                            1
-                        )
+                            1,
+                        ),
                     ),
                 ],
                 new DoNode(
@@ -138,12 +138,12 @@ final class LoopSymbolTest extends TestCase
                         $env->withAddedRecurFrame(new RecurFrame([Symbol::create('a')]))
                             ->withLocals([Symbol::create('a')])
                             ->withShadowedLocal(Symbol::create('a'), Symbol::create('a_1')),
-                        null
-                    )
+                        null,
+                    ),
                 ),
-                false
+                false,
             ),
-            $this->analyzer->analyze($list, $env)
+            $this->analyzer->analyze($list, $env),
         );
     }
 

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -43,7 +43,7 @@ final class ApplyEmitterTest extends TestCase
         $this->applyEmitter->emit($applyNode);
 
         $this->expectOutputString(
-            'array_reduce([...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });'
+            'array_reduce([...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
         );
     }
 
@@ -71,7 +71,7 @@ final class ApplyEmitterTest extends TestCase
             new PhpVarNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN), 'x'),
             [],
             isVariadic: true,
-            recurs: false
+            recurs: false,
         );
 
         $args = [

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -33,7 +33,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: false,
-            recurs: false
+            recurs: false,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);
@@ -55,7 +55,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: false,
-            recurs: false
+            recurs: false,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);
@@ -77,7 +77,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [Symbol::create('use1'), Symbol::create('use2')],
             isVariadic: false,
-            recurs: false
+            recurs: false,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);
@@ -108,7 +108,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: true,
-            recurs: false
+            recurs: false,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);
@@ -131,7 +131,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: false,
-            recurs: true
+            recurs: true,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);
@@ -155,7 +155,7 @@ final class FnAsClassEmitterTest extends TestCase
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: true,
-            recurs: true
+            recurs: true,
         );
 
         $this->fnAsClassEmitter->emit($fnNode);

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -29,7 +29,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_NEWLINE, "\n", new SourceLocation('string', 2, 2), new SourceLocation('string', 3, 0)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 3, 0), new SourceLocation('string', 3, 0)),
             ],
-            $this->lex(" \t\r\n  \n")
+            $this->lex(" \t\r\n  \n"),
         );
     }
 
@@ -40,7 +40,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_COMMENT, '#', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 1)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 1), new SourceLocation('string', 1, 1)),
             ],
-            $this->lex('#')
+            $this->lex('#'),
         );
     }
 
@@ -51,7 +51,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_COMMENT, '# Mein Kommentar', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 16)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 16), new SourceLocation('string', 1, 16)),
             ],
-            $this->lex('# Mein Kommentar')
+            $this->lex('# Mein Kommentar'),
         );
     }
 
@@ -63,7 +63,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_COMMENT, '# Mein andere Kommentar', new SourceLocation('string', 2, 0), new SourceLocation('string', 2, 23)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 2, 23), new SourceLocation('string', 2, 23)),
             ],
-            $this->lex("# Mein Kommentar\n# Mein andere Kommentar")
+            $this->lex("# Mein Kommentar\n# Mein andere Kommentar"),
         );
     }
 
@@ -74,7 +74,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_OPEN_PARENTHESIS, '(', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 1)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 1), new SourceLocation('string', 1, 1)),
             ],
-            $this->lex('(')
+            $this->lex('('),
         );
     }
 
@@ -86,7 +86,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_CLOSE_PARENTHESIS, ')', new SourceLocation('string', 1, 1), new SourceLocation('string', 1, 2)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 2), new SourceLocation('string', 1, 2)),
             ],
-            $this->lex('()')
+            $this->lex('()'),
         );
     }
 
@@ -97,7 +97,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_ATOM, 'true', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 4)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 4), new SourceLocation('string', 1, 4)),
             ],
-            $this->lex('true')
+            $this->lex('true'),
         );
     }
 
@@ -108,7 +108,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_ATOM, '1', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 1)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 1), new SourceLocation('string', 1, 1)),
             ],
-            $this->lex('1')
+            $this->lex('1'),
         );
     }
 
@@ -119,7 +119,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_STRING, '""', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 2)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 2), new SourceLocation('string', 1, 2)),
             ],
-            $this->lex('""')
+            $this->lex('""'),
         );
     }
 
@@ -130,7 +130,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_STRING, '"test"', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 6)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 6), new SourceLocation('string', 1, 6)),
             ],
-            $this->lex('"test"')
+            $this->lex('"test"'),
         );
     }
 
@@ -141,7 +141,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_STRING, '"te\\"st"', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 8)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 8), new SourceLocation('string', 1, 8)),
             ],
-            $this->lex('"te\\"st"')
+            $this->lex('"te\\"st"'),
         );
     }
 
@@ -156,7 +156,7 @@ final class LexerTest extends TestCase
                 new Token(Token::T_CLOSE_BRACKET, ']', new SourceLocation('string', 1, 11), new SourceLocation('string', 1, 12)),
                 new Token(Token::T_EOF, '', new SourceLocation('string', 1, 12), new SourceLocation('string', 1, 12)),
             ],
-            $this->lex('[true false]')
+            $this->lex('[true false]'),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -30,11 +30,11 @@ final class AtomParserTest extends TestCase
                 'true',
                 $start,
                 $end,
-                true
+                true,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, 'true', $start, $end)
-            )
+                new Token(Token::T_ATOM, 'true', $start, $end),
+            ),
         );
     }
 
@@ -48,11 +48,11 @@ final class AtomParserTest extends TestCase
                 'false',
                 $start,
                 $end,
-                false
+                false,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, 'false', $start, $end)
-            )
+                new Token(Token::T_ATOM, 'false', $start, $end),
+            ),
         );
     }
 
@@ -66,11 +66,11 @@ final class AtomParserTest extends TestCase
                 'nil',
                 $start,
                 $end,
-                null
+                null,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, 'nil', $start, $end)
-            )
+                new Token(Token::T_ATOM, 'nil', $start, $end),
+            ),
         );
     }
 
@@ -84,11 +84,11 @@ final class AtomParserTest extends TestCase
                 ':foo',
                 $start,
                 $end,
-                Keyword::create('foo')
+                Keyword::create('foo'),
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, ':foo', $start, $end)
-            )
+                new Token(Token::T_ATOM, ':foo', $start, $end),
+            ),
         );
     }
 
@@ -105,11 +105,11 @@ final class AtomParserTest extends TestCase
                 '::bar/foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('foobar', 'foo')
+                Keyword::createForNamespace('foobar', 'foo'),
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '::bar/foo', $start, $end)
-            )
+                new Token(Token::T_ATOM, '::bar/foo', $start, $end),
+            ),
         );
     }
 
@@ -126,11 +126,11 @@ final class AtomParserTest extends TestCase
                 '::foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('user', 'foo')
+                Keyword::createForNamespace('user', 'foo'),
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '::foo', $start, $end)
-            )
+                new Token(Token::T_ATOM, '::foo', $start, $end),
+            ),
         );
     }
 
@@ -144,11 +144,11 @@ final class AtomParserTest extends TestCase
                 ':xyz\bar/foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('xyz\bar', 'foo')
+                Keyword::createForNamespace('xyz\bar', 'foo'),
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, ':xyz\bar/foo', $start, $end)
-            )
+                new Token(Token::T_ATOM, ':xyz\bar/foo', $start, $end),
+            ),
         );
     }
 
@@ -160,7 +160,7 @@ final class AtomParserTest extends TestCase
         $start = new SourceLocation('string', 0, 0);
         $end = new SourceLocation('string', 0, 5);
         $parser->parse(
-            new Token(Token::T_ATOM, ':/', $start, $end)
+            new Token(Token::T_ATOM, ':/', $start, $end),
         );
     }
 
@@ -174,11 +174,11 @@ final class AtomParserTest extends TestCase
                 '0b001',
                 $start,
                 $end,
-                1
+                1,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '0b001', $start, $end)
-            )
+                new Token(Token::T_ATOM, '0b001', $start, $end),
+            ),
         );
     }
 
@@ -192,11 +192,11 @@ final class AtomParserTest extends TestCase
                 '0x001',
                 $start,
                 $end,
-                1
+                1,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '0x001', $start, $end)
-            )
+                new Token(Token::T_ATOM, '0x001', $start, $end),
+            ),
         );
     }
 
@@ -210,11 +210,11 @@ final class AtomParserTest extends TestCase
                 '1.2',
                 $start,
                 $end,
-                1.2
+                1.2,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '1.2', $start, $end)
-            )
+                new Token(Token::T_ATOM, '1.2', $start, $end),
+            ),
         );
     }
 
@@ -228,11 +228,11 @@ final class AtomParserTest extends TestCase
                 '01',
                 $start,
                 $end,
-                1
+                1,
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, '01', $start, $end)
-            )
+                new Token(Token::T_ATOM, '01', $start, $end),
+            ),
         );
     }
 
@@ -246,11 +246,11 @@ final class AtomParserTest extends TestCase
                 'x',
                 $start,
                 $end,
-                Symbol::create('x')
+                Symbol::create('x'),
             ),
             $parser->parse(
-                new Token(Token::T_ATOM, 'x', $start, $end)
-            )
+                new Token(Token::T_ATOM, 'x', $start, $end),
+            ),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Parser/ParserNode/BooleanNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/BooleanNodeTest.php
@@ -14,7 +14,7 @@ final class BooleanNodeTest extends TestCase
     {
         self::assertEquals(
             'true',
-            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getCode()
+            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getCode(),
         );
     }
 
@@ -22,7 +22,7 @@ final class BooleanNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 0),
-            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getStartLocation()
+            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getStartLocation(),
         );
     }
 
@@ -30,14 +30,14 @@ final class BooleanNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 4),
-            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getEndLocation()
+            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getEndLocation(),
         );
     }
 
     public function test_value(): void
     {
         self::assertTrue(
-            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getValue()
+            (new BooleanNode('true', $this->loc(1, 0), $this->loc(1, 4), true))->getValue(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/CommentNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/CommentNodeTest.php
@@ -14,7 +14,7 @@ final class CommentNodeTest extends TestCase
     {
         self::assertEquals(
             '# Test',
-            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getCode()
+            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getCode(),
         );
     }
 
@@ -22,7 +22,7 @@ final class CommentNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 0),
-            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getStartLocation()
+            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getStartLocation(),
         );
     }
 
@@ -30,7 +30,7 @@ final class CommentNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 6),
-            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getEndLocation()
+            (new CommentNode('# Test', $this->loc(1, 0), $this->loc(1, 6)))->getEndLocation(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/ListNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/ListNodeTest.php
@@ -19,7 +19,7 @@ final class ListNodeTest extends TestCase
             '(1)',
             (new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getCode()
+            ]))->getCode(),
         );
     }
 
@@ -29,7 +29,7 @@ final class ListNodeTest extends TestCase
             '[1]',
             (new ListNode(Token::T_OPEN_BRACKET, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getCode()
+            ]))->getCode(),
         );
     }
 
@@ -39,7 +39,7 @@ final class ListNodeTest extends TestCase
             '{1}',
             (new ListNode(Token::T_OPEN_BRACE, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getCode()
+            ]))->getCode(),
         );
     }
 
@@ -49,7 +49,7 @@ final class ListNodeTest extends TestCase
             '|(1)',
             (new ListNode(Token::T_FN, $this->loc(1, 0), $this->loc(1, 4), [
                 new NumberNode('1', $this->loc(1, 2), $this->loc(1, 3), 1),
-            ]))->getCode()
+            ]))->getCode(),
         );
     }
 
@@ -67,7 +67,7 @@ final class ListNodeTest extends TestCase
             [new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1)],
             (new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getChildren()
+            ]))->getChildren(),
         );
     }
 
@@ -77,7 +77,7 @@ final class ListNodeTest extends TestCase
             $this->loc(1, 0),
             (new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getStartLocation()
+            ]))->getStartLocation(),
         );
     }
 
@@ -87,7 +87,7 @@ final class ListNodeTest extends TestCase
             $this->loc(1, 3),
             (new ListNode(Token::T_OPEN_PARENTHESIS, $this->loc(1, 0), $this->loc(1, 3), [
                 new NumberNode('1', $this->loc(1, 1), $this->loc(1, 2), 1),
-            ]))->getEndLocation()
+            ]))->getEndLocation(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/MetaNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/MetaNodeTest.php
@@ -26,8 +26,8 @@ final class MetaNodeTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 6), $this->loc(1, 7)),
                     new SymbolNode('test', $this->loc(1, 7), $this->loc(1, 11), Symbol::create('test')),
-                ]
-            ))->getCode()
+                ],
+            ))->getCode(),
         );
     }
 
@@ -42,8 +42,8 @@ final class MetaNodeTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 6), $this->loc(1, 7)),
                     new SymbolNode('test', $this->loc(1, 7), $this->loc(1, 11), Symbol::create('test')),
-                ]
-            ))->getStartLocation()
+                ],
+            ))->getStartLocation(),
         );
     }
 
@@ -58,8 +58,8 @@ final class MetaNodeTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 6), $this->loc(1, 7)),
                     new SymbolNode('test', $this->loc(1, 7), $this->loc(1, 11), Symbol::create('test')),
-                ]
-            ))->getEndLocation()
+                ],
+            ))->getEndLocation(),
         );
     }
 
@@ -78,8 +78,8 @@ final class MetaNodeTest extends TestCase
                 [
                     new WhitespaceNode(' ', $this->loc(1, 6), $this->loc(1, 7)),
                     new SymbolNode('test', $this->loc(1, 7), $this->loc(1, 11), Symbol::create('test')),
-                ]
-            ))->getChildren()
+                ],
+            ))->getChildren(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/NewlineNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/NewlineNodeTest.php
@@ -14,7 +14,7 @@ final class NewlineNodeTest extends TestCase
     {
         self::assertEquals(
             '\n',
-            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getCode()
+            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getCode(),
         );
     }
 
@@ -22,7 +22,7 @@ final class NewlineNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 0),
-            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getStartLocation()
+            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getStartLocation(),
         );
     }
 
@@ -30,7 +30,7 @@ final class NewlineNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(2, 0),
-            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getEndLocation()
+            (new NewlineNode('\n', $this->loc(1, 0), $this->loc(2, 0)))->getEndLocation(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/QuoteNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/QuoteNodeTest.php
@@ -22,8 +22,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_QUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getCode()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getCode(),
         );
     }
 
@@ -35,8 +35,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_UNQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getCode()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getCode(),
         );
     }
 
@@ -48,8 +48,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_UNQUOTE_SPLICING,
                 $this->loc(1, 0),
                 $this->loc(1, 3),
-                new SymbolNode('a', $this->loc(1, 2), $this->loc(1, 3), Symbol::create('a'))
-            ))->getCode()
+                new SymbolNode('a', $this->loc(1, 2), $this->loc(1, 3), Symbol::create('a')),
+            ))->getCode(),
         );
     }
 
@@ -61,8 +61,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getCode()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getCode(),
         );
     }
 
@@ -75,7 +75,7 @@ final class QuoteNodeTest extends TestCase
             3000,
             $this->loc(1, 0),
             $this->loc(1, 2),
-            new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
+            new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
         ))->getCode();
     }
 
@@ -87,8 +87,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getChildren()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getChildren(),
         );
     }
 
@@ -100,8 +100,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getStartLocation()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getStartLocation(),
         );
     }
 
@@ -113,8 +113,8 @@ final class QuoteNodeTest extends TestCase
                 Token::T_QUASIQUOTE,
                 $this->loc(1, 0),
                 $this->loc(1, 2),
-                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a'))
-            ))->getEndLocation()
+                new SymbolNode('a', $this->loc(1, 1), $this->loc(1, 2), Symbol::create('a')),
+            ))->getEndLocation(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ParserNode/WhitespaceNodeTest.php
+++ b/tests/php/Unit/Compiler/Parser/ParserNode/WhitespaceNodeTest.php
@@ -14,7 +14,7 @@ final class WhitespaceNodeTest extends TestCase
     {
         self::assertEquals(
             ' ',
-            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getCode()
+            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getCode(),
         );
     }
 
@@ -22,7 +22,7 @@ final class WhitespaceNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 0),
-            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getStartLocation()
+            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getStartLocation(),
         );
     }
 
@@ -30,7 +30,7 @@ final class WhitespaceNodeTest extends TestCase
     {
         self::assertEquals(
             $this->loc(1, 1),
-            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getEndLocation()
+            (new WhitespaceNode(' ', $this->loc(1, 0), $this->loc(1, 1)))->getEndLocation(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -19,7 +19,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
             1,
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1]))
+            $q->transform(TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
         );
     }
 
@@ -43,7 +43,7 @@ final class QuasiquoteTest extends TestCase
                     TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([1, 2]))
+            $q->transform(TypeFactory::getInstance()->persistentListFromArray([1, 2])),
         );
     }
 
@@ -66,7 +66,7 @@ final class QuasiquoteTest extends TestCase
                     Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                     2,
                 ]),
-            ]))
+            ])),
         );
     }
 
@@ -89,7 +89,7 @@ final class QuasiquoteTest extends TestCase
                     Symbol::create(Symbol::NAME_UNQUOTE),
                     2,
                 ]),
-            ]))
+            ])),
         );
     }
 
@@ -106,7 +106,7 @@ final class QuasiquoteTest extends TestCase
                     TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentVectorFromArray([1, 2]))
+            $q->transform(TypeFactory::getInstance()->persistentVectorFromArray([1, 2])),
         );
     }
 
@@ -125,7 +125,7 @@ final class QuasiquoteTest extends TestCase
                     TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentMapFromKVs('a', 1, 'b', 2))
+            $q->transform(TypeFactory::getInstance()->persistentMapFromKVs('a', 1, 'b', 2)),
         );
     }
 
@@ -134,7 +134,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
             1,
-            $q->transform(1)
+            $q->transform(1),
         );
     }
 
@@ -143,7 +143,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
             'a',
-            $q->transform('a')
+            $q->transform('a'),
         );
     }
 
@@ -152,7 +152,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
             1.1,
-            $q->transform(1.1)
+            $q->transform(1.1),
         );
     }
 
@@ -160,7 +160,7 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertTrue(
-            $q->transform(true)
+            $q->transform(true),
         );
     }
 
@@ -168,7 +168,7 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertNull(
-            $q->transform(null)
+            $q->transform(null),
         );
     }
 
@@ -177,7 +177,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
             Keyword::create('test'),
-            $q->transform(Keyword::create('test'))
+            $q->transform(Keyword::create('test')),
         );
     }
 
@@ -189,7 +189,7 @@ final class QuasiquoteTest extends TestCase
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::create('test'),
             ]),
-            $q->transform(Symbol::create('test'))
+            $q->transform(Symbol::create('test')),
         );
     }
 
@@ -204,7 +204,7 @@ final class QuasiquoteTest extends TestCase
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::createForNamespace('test', 'abc'),
             ]),
-            $q->transform(Symbol::createForNamespace('test', 'abc'))
+            $q->transform(Symbol::createForNamespace('test', 'abc')),
         );
     }
 }

--- a/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
@@ -66,7 +66,7 @@ final class ArrayZipper extends AbstractZipper
         array $leftSiblings,
         array $rightSiblings,
         bool $hasChanged,
-        bool $isEnd
+        bool $isEnd,
     ): self {
         return new self($node, $parent, $leftSiblings, $rightSiblings, $hasChanged, $isEnd);
     }

--- a/tests/php/Unit/Formatter/Domain/Rules/Zipper/ZipperTest.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Zipper/ZipperTest.php
@@ -197,7 +197,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [0, [1, 2], 3, [4, 5]],
-            $zipper->down()->insertLeft(0)->root()
+            $zipper->down()->insertLeft(0)->root(),
         );
     }
 
@@ -217,7 +217,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [[1, 2], 0, 3, [4, 5]],
-            $zipper->down()->insertRight(0)->root()
+            $zipper->down()->insertRight(0)->root(),
         );
     }
 
@@ -237,7 +237,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [0, 3, [4, 5]],
-            $zipper->down()->replace(0)->root()
+            $zipper->down()->replace(0)->root(),
         );
     }
 
@@ -248,7 +248,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [[0, 1, 2], 3, [4, 5]],
-            $zipper->down()->insertChild(0)->root()
+            $zipper->down()->insertChild(0)->root(),
         );
     }
 
@@ -259,7 +259,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [[1, 2, 0], 3, [4, 5]],
-            $zipper->down()->appendChild(0)->root()
+            $zipper->down()->appendChild(0)->root(),
         );
     }
 
@@ -270,7 +270,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [[1, 2], [4, 5]],
-            $zipper->down()->right()->remove()->root()
+            $zipper->down()->right()->remove()->root(),
         );
     }
 
@@ -281,7 +281,7 @@ final class ZipperTest extends TestCase
 
         self::assertEquals(
             [3, [4, 5]],
-            $zipper->down()->remove()->root()
+            $zipper->down()->remove()->root(),
         );
     }
 

--- a/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
+++ b/tests/php/Unit/Interop/Generator/WrapperGeneratorTest.php
@@ -65,9 +65,9 @@ TXT;
         return new WrapperGenerator(
             new CompiledPhpClassBuilder(
                 prefixNamespace: 'PhelGenerated',
-                methodBuilder: new CompiledPhpMethodBuilder()
+                methodBuilder: new CompiledPhpMethodBuilder(),
             ),
-            new WrapperRelativeFilenamePathBuilder()
+            new WrapperRelativeFilenamePathBuilder(),
         );
     }
 }

--- a/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/HashCollisionNodeTest.php
@@ -30,7 +30,7 @@ class HashCollisionNodeTest extends TestCase
             new SimpleEqualizer(),
             $hasher->hash(1),
             2,
-            [1, 'foo', 3, 'bar']
+            [1, 'foo', 3, 'bar'],
         );
 
         $this->assertEquals('foo', $node->find(0, $hasher->hash(1), 1, null));
@@ -116,7 +116,7 @@ class HashCollisionNodeTest extends TestCase
             new SimpleEqualizer(),
             $hasher->hash(1),
             2,
-            [1, 'foo', 3, 'bar']
+            [1, 'foo', 3, 'bar'],
         ))->remove(0, $hasher->hash(3), 3);
 
         $this->assertEquals('foo', $node->find(0, $hasher->hash(1), 1, null));

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -77,7 +77,7 @@ final class StructTest extends TestCase
         $map = PersistentHashMap::fromArray(
             TypeFactory::getInstance()->getHasher(),
             TypeFactory::getInstance()->getEqualizer(),
-            [Keyword::create('a'), 1, Keyword::create('b'), 2]
+            [Keyword::create('a'), 1, Keyword::create('b'), 2],
         );
 
         self::assertFalse($s->equals($map));

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -330,7 +330,7 @@ final class PersistentVectorTest extends TestCase
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $this->assertEquals(
             PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer()),
-            $vector->rest()
+            $vector->rest(),
         );
     }
 
@@ -339,7 +339,7 @@ final class PersistentVectorTest extends TestCase
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
         $this->assertEquals(
             PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer()),
-            $vector->rest()
+            $vector->rest(),
         );
     }
 

--- a/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
@@ -15,7 +15,7 @@ final class RangeIteratorTest extends TestCase
         $it = new RangeIterator(
             TypeFactory::getInstance()->persistentVectorFromArray(range(0, 31)),
             0,
-            32
+            32,
         );
 
         self::assertEquals(range(0, 31), iterator_to_array($it));

--- a/tests/php/Unit/Lang/Collections/Vector/SubVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/SubVectorTest.php
@@ -123,12 +123,12 @@ final class SubVectorTest extends TestCase
             null,
             PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer()),
             0,
-            0
+            0,
         );
 
         $this->assertEquals(
             PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer()),
-            $subVector->pop()
+            $subVector->pop(),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
@@ -16,7 +16,7 @@ final class AnonymousClassPrinterTest extends TestCase
 
         self::assertSame(
             '<PHP-AnonymousClass>',
-            (new AnonymousClassPrinter())->print($class)
+            (new AnonymousClassPrinter())->print($class),
         );
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/BooleanPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/BooleanPrinterTest.php
@@ -17,7 +17,7 @@ final class BooleanPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new BooleanPrinter())->print($boolean)
+            (new BooleanPrinter())->print($boolean),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
@@ -18,7 +18,7 @@ final class KeywordPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new KeywordPrinter())->print($keyword)
+            (new KeywordPrinter())->print($keyword),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
@@ -20,7 +20,7 @@ final class ListPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new PersistentListPrinter(Printer::readable()))->print($list)
+            (new PersistentListPrinter(Printer::readable()))->print($list),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/NumberPrinterTest.php
@@ -17,7 +17,7 @@ final class NumberPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new NumberPrinter())->print($number)
+            (new NumberPrinter())->print($number),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
@@ -18,7 +18,7 @@ final class ObjectPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new ObjectPrinter())->print($object)
+            (new ObjectPrinter())->print($object),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/ResourcePrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ResourcePrinterTest.php
@@ -13,7 +13,7 @@ final class ResourcePrinterTest extends TestCase
     {
         self::assertMatchesRegularExpression(
             '<PHP Resource id #Resource id #\d+>',
-            (new ResourcePrinter())->print($this->getResource())
+            (new ResourcePrinter())->print($this->getResource()),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
@@ -22,7 +22,7 @@ final class StringPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new StringPrinter(true))->print($string)
+            (new StringPrinter(true))->print($string),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/StructPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/StructPrinterTest.php
@@ -20,7 +20,7 @@ final class StructPrinterTest extends TestCase
     {
         self::assertSame(
             $actual,
-            (new StructPrinter(Printer::readable()))->print($struct)
+            (new StructPrinter(Printer::readable()))->print($struct),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
@@ -18,7 +18,7 @@ final class SymbolPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new SymbolPrinter())->print($symbol)
+            (new SymbolPrinter())->print($symbol),
         );
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -20,7 +20,7 @@ final class VectorPrinterTest extends TestCase
     {
         self::assertSame(
             $expected,
-            (new PersistentVectorPrinter(Printer::readable()))->print($vector)
+            (new PersistentVectorPrinter(Printer::readable()))->print($vector),
         );
     }
 

--- a/tests/php/Unit/Run/Domain/Repl/ColorStyleTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ColorStyleTest.php
@@ -18,7 +18,7 @@ final class ColorStyleTest extends TestCase
 
         self::assertEquals(
             sprintf($format, $anyText),
-            $style->color($anyText, $color)
+            $style->color($anyText, $color),
         );
     }
 


### PR DESCRIPTION
## 📚 Description

Since PHP 8.0, it's possible to add `trailing comma` for multiline arrays, arguments, parameters and closures ([RFC¹](https://wiki.php.net/rfc/trailing_comma_in_parameter_list) & [RFC²](https://wiki.php.net/rfc/trailing_comma_in_closure_use_list)).

It's also possible to add the [rule](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.9|fixer:trailing_comma_in_multiline) on `.php-cs-fixer.dist.php`, having this rule, the code will be more standard along the project, also, when we want to add a new parameter to a function/whatever it applies, we will have to update a single line instead of two, eg:
```diff
return new FileCompiler(
    $this->getCompilerFacade(),
-    $this->createNamespaceExtractor()
);

# 👇🏼👇🏼👇🏼

return new FileCompiler(
    $this->getCompilerFacade(),
+    $this->createNamespaceExtractor(),
+    $this->otherDependency()
);

# 💡 will become to

return new FileCompiler(
    $this->getCompilerFacade(),
    $this->createNamespaceExtractor(),
);

# 👇🏼👇🏼👇🏼

return new FileCompiler(
    $this->getCompilerFacade(),
    $this->createNamespaceExtractor(),
+    $this->otherDependency(),
);
```