### PR TITLE
Fix map typo

### DIFF
--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -22,7 +22,7 @@ final class ExportCommand extends Command
     protected function configure(): void
     {
         $this->setName('export')
-            ->setDescription('Export all definitions with the meta data `@{:export true}` as PHP classes.');
+            ->setDescription('Export all definitions with the meta data `{:export true}` as PHP classes.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -164,7 +164,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
-        // (foreach [x y z @{}])
+        // (foreach [x y z {}])
         $list = TypeFactory::getInstance()->persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
             TypeFactory::getInstance()->persistentVectorFromArray([


### PR DESCRIPTION
### 🤔 Background

`@{}` is the deprecated old table data structure, which was removed on `0.6.0` (2022-02-02).

### 🔖 Changes

Use the map syntax `{}` instead of old table syntax `@{}`.
