### PR TITLE
Update gacela 0.25

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "gacela-project/gacela": "^0.24",
+        "gacela-project/gacela": "^0.25",
         "symfony/console": "^5.4",
         "phpunit/php-timer": "^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -2671,16 +2671,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.5",
+            "version": "1.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f6598a5ff12ca4499a836815e08b4d77a2ddeb20"
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f6598a5ff12ca4499a836815e08b4d77a2ddeb20",
-                "reference": "f6598a5ff12ca4499a836815e08b4d77a2ddeb20",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c386ab2741e64cc9e21729f891b28b2b10fe6618",
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618",
                 "shasum": ""
             },
             "require": {
@@ -2710,7 +2710,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.5"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.6"
             },
             "funding": [
                 {
@@ -2726,7 +2726,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-07T16:05:32+00:00"
+            "time": "2022-09-23T09:54:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2989,16 +2989,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.24",
+            "version": "9.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
                 "shasum": ""
             },
             "require": {
@@ -3020,14 +3020,14 @@
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.1",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -3071,7 +3071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
             },
             "funding": [
                 {
@@ -3081,9 +3081,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-30T07:42:16+00:00"
+            "time": "2022-09-25T03:44:45+00:00"
         },
         {
             "name": "psr/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea0bd531b0be60ec360d2d04ae7a4dc1",
+    "content-hash": "046e32e4f71af80f8943d094029493cb",
     "packages": [
         {
             "name": "gacela-project/gacela",
-            "version": "0.24.0",
+            "version": "0.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "e69bbbba62205fd23bb54d543fe0ec721d220408"
+                "reference": "8f94e1345d781cc466d3db5c9f389c7d1a360e62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/e69bbbba62205fd23bb54d543fe0ec721d220408",
-                "reference": "e69bbbba62205fd23bb54d543fe0ec721d220408",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/8f94e1345d781cc466d3db5c9f389c7d1a360e62",
+                "reference": "8f94e1345d781cc466d3db5c9f389c7d1a360e62",
                 "shasum": ""
             },
             "require": {
@@ -72,7 +72,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/0.24.0"
+                "source": "https://github.com/gacela-project/gacela/tree/0.25.0"
             },
             "funding": [
                 {
@@ -80,7 +80,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-23T16:37:11+00:00"
+            "time": "2022-09-18T18:30:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -5195,5 +5195,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### 🔖 Changes

- Update to latest gacela version
  - More details: https://github.com/gacela-project/gacela/releases/tag/0.25.0
- And also some minor versions for dev dependencies

```
phel-lang/ (misc/update-gacela-0.25✗) $ ~/.composer/vendor/bin/composer-lock-diff --from=/tmp/composer-dev.lock --to=composer.lock  
+-----------------------+--------+--------+------------------------------------------------------------------+
| Production Changes    | From   | To     | Compare                                                          |
+-----------------------+--------+--------+------------------------------------------------------------------+
| gacela-project/gacela | 0.24.0 | 0.25.0 | https://github.com/gacela-project/gacela/compare/0.24.0...0.25.0 |
+-----------------------+--------+--------+------------------------------------------------------------------+

+-----------------+--------+--------+----------------------------------------------------------------------+
| Dev Changes     | From   | To     | Compare                                                              |
+-----------------+--------+--------+----------------------------------------------------------------------+
| phpstan/phpstan | 1.8.5  | 1.8.6  | https://github.com/phpstan/phpstan/compare/1.8.5...1.8.6             |
| phpunit/phpunit | 9.5.24 | 9.5.25 | https://github.com/sebastianbergmann/phpunit/compare/9.5.24...9.5.25 |
+-----------------+--------+--------+----------------------------------------------------------------------+
```
