### PR TITLE
Inject FileIoInterface to FileCompiler and NamespaceExtractor

### DIFF
--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -13,6 +13,8 @@ use Phel\Build\Domain\Compile\ProjectCompiler;
 use Phel\Build\Domain\Extractor\NamespaceExtractor;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
+use Phel\Build\Domain\IO\FileIoInterface;
+use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 
@@ -40,6 +42,7 @@ final class BuildFactory extends AbstractFactory
         return new FileCompiler(
             $this->getCompilerFacade(),
             $this->createNamespaceExtractor(),
+            $this->createFileIo(),
         );
     }
 
@@ -56,6 +59,7 @@ final class BuildFactory extends AbstractFactory
         return new NamespaceExtractor(
             $this->getCompilerFacade(),
             $this->createNamespaceSorter(),
+            $this->createFileIo(),
         );
     }
 
@@ -72,5 +76,10 @@ final class BuildFactory extends AbstractFactory
     private function createNamespaceSorter(): NamespaceSorterInterface
     {
         return new TopologicalNamespaceSorter();
+    }
+
+    private function createFileIo(): FileIoInterface
+    {
+        return new SystemFileIo();
     }
 }

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build\Domain\Compile;
 
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
+use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Lang\Registry;
@@ -14,12 +15,13 @@ final class FileCompiler implements FileCompilerInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceExtractorInterface $namespaceExtractor,
+        private FileIoInterface $fileIo,
     ) {
     }
 
     public function compileFile(string $src, string $dest, bool $enableSourceMaps): CompiledFile
     {
-        $phelCode = file_get_contents($src);
+        $phelCode = $this->fileIo->getContents($src);
 
         $options = (new CompileOptions())
             ->setSource($src)

--- a/src/php/Build/Domain/Extractor/NamespaceExtractor.php
+++ b/src/php/Build/Domain/Extractor/NamespaceExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Extractor;
 
+use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -22,6 +23,7 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceSorterInterface $namespaceSorter,
+        private FileIoInterface $fileIo,
     ) {
     }
 
@@ -31,7 +33,7 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
      */
     public function getNamespaceFromFile(string $path): NamespaceInformation
     {
-        $content = file_get_contents($path);
+        $content = $this->fileIo->getContents($path);
 
         try {
             $tokenStream = $this->compilerFacade->lexString($content);

--- a/src/php/Build/Domain/IO/FileIoInterface.php
+++ b/src/php/Build/Domain/IO/FileIoInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\IO;
+
+interface FileIoInterface
+{
+    public function getContents(string $filename): string;
+}

--- a/src/php/Build/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Build/Infrastructure/Command/CompileCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Infrastructure\Command;
 use Gacela\Framework\DocBlockResolverAwareTrait;
 use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\BuildOptions;
+use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,6 +58,9 @@ final class CompileCommand extends Command
         );
     }
 
+    /**
+     * @param list<CompiledFile> $compiledProject
+     */
     private function printOutput(OutputInterface $output, array $compiledProject): void
     {
         foreach ($compiledProject as $i => $compiledFile) {

--- a/src/php/Build/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Build/Infrastructure/IO/SystemFileIo.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\IO;
+
+use Phel\Build\Domain\IO\FileIoInterface;
+
+final class SystemFileIo implements FileIoInterface
+{
+    public function getContents(string $filename): string
+    {
+        return file_get_contents($filename);
+    }
+}

--- a/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Extractor/NamespaceExtractorTest.php
@@ -8,6 +8,7 @@ use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceExtractor;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
+use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Compiler\CompilerFacade;
 use PHPUnit\Framework\TestCase;
 
@@ -60,6 +61,7 @@ final class NamespaceExtractorTest extends TestCase
         $nsExtractor = new NamespaceExtractor(
             new CompilerFacade(),
             new TopologicalNamespaceSorter(),
+            new SystemFileIo(),
         );
 
         return $nsExtractor->getNamespaceFromFile($filePath);


### PR DESCRIPTION
### 🔖 Changes

Instead of using `file_get_contents()` inside the Domain layer, inject `FileIoInterface` to `FileCompiler` and `NamespaceExtractor`.
