### PR TITLE
Add argv argument to Phel::run()

### DIFF
--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -9,6 +9,8 @@ use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phel\Run\RunFacade;
 
+use function in_array;
+
 final class Phel
 {
     public const PHEL_CONFIG_FILE_NAME = 'phel-config.php';
@@ -18,8 +20,10 @@ final class Phel
     /**
      * This function helps to unify the running execution for a custom phel project.
      */
-    public static function run(string $projectRootDir, string $namespace): void
+    public static function run(string $projectRootDir, string $namespace, string $argv = ''): void
     {
+        self::updateGlobalArgv($argv);
+
         Gacela::bootstrap($projectRootDir, self::configFn());
 
         $runFacade = new RunFacade();
@@ -34,5 +38,16 @@ final class Phel
         return static function (GacelaConfig $config): void {
             $config->addAppConfig(self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME);
         };
+    }
+
+    private static function updateGlobalArgv(string $argv): void
+    {
+        if ($argv !== '') {
+            foreach (array_filter(explode(' ', $argv)) as $value) {
+                if (!in_array($value, $GLOBALS['argv'], true)) {
+                    $GLOBALS['argv'][] = $value;
+                }
+            }
+        }
     }
 }

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -10,6 +10,8 @@ use Gacela\Framework\Gacela;
 use Phel\Run\RunFacade;
 
 use function in_array;
+use function is_array;
+use function is_string;
 
 final class Phel
 {
@@ -19,10 +21,14 @@ final class Phel
 
     /**
      * This function helps to unify the running execution for a custom phel project.
+     *
+     * @param list<string>|string|null $argv
      */
-    public static function run(string $projectRootDir, string $namespace, string $argv = ''): void
+    public static function run(string $projectRootDir, string $namespace, array|string $argv = null): void
     {
-        self::updateGlobalArgv($argv);
+        if ($argv !== null) {
+            self::updateGlobalArgv($argv);
+        }
 
         Gacela::bootstrap($projectRootDir, self::configFn());
 
@@ -40,14 +46,23 @@ final class Phel
         };
     }
 
-    private static function updateGlobalArgv(string $argv): void
+    /**
+     * @param list<string>|string $argv
+     */
+    private static function updateGlobalArgv(array|string $argv): void
     {
-        if ($argv !== '') {
-            foreach (array_filter(explode(' ', $argv)) as $value) {
+        $updateGlobals = static function (array $list): void {
+            foreach (array_filter($list) as $value) {
                 if (!in_array($value, $GLOBALS['argv'], true)) {
                     $GLOBALS['argv'][] = $value;
                 }
             }
+        };
+
+        if (is_string($argv) && $argv !== '') {
+            $updateGlobals(explode(' ', $argv));
+        } elseif (is_array($argv) && $argv !== []) {
+            $updateGlobals($argv);
         }
     }
 }

--- a/tests/php/Integration/Phel/PhelTest.php
+++ b/tests/php/Integration/Phel/PhelTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Phel;
+
+use Phel\Phel;
+use PHPUnit\Framework\TestCase;
+
+final class PhelTest extends TestCase
+{
+    private static mixed $originalArgv = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$originalArgv = $GLOBALS['argv'];
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $GLOBALS['argv'] = self::$originalArgv;
+    }
+
+    public function test_globals_argv_via_run(): void
+    {
+        Phel::run(__DIR__ . '/../../../../', 'phel\\testing-argv', 'foo=bar baz');
+
+        self::assertContains('foo=bar', $GLOBALS['argv']);
+        self::assertContains('baz', $GLOBALS['argv']);
+    }
+}

--- a/tests/php/Integration/Phel/PhelTest.php
+++ b/tests/php/Integration/Phel/PhelTest.php
@@ -21,11 +21,19 @@ final class PhelTest extends TestCase
         $GLOBALS['argv'] = self::$originalArgv;
     }
 
-    public function test_globals_argv_via_run(): void
+    public function test_globals_argv_as_string_via_run(): void
     {
-        Phel::run(__DIR__ . '/../../../../', 'phel\\testing-argv', 'foo=bar baz');
+        Phel::run(__DIR__ . '/../../../../', 'phel\\testing-argv', 'k1=v1 additional');
 
-        self::assertContains('foo=bar', $GLOBALS['argv']);
-        self::assertContains('baz', $GLOBALS['argv']);
+        self::assertContains('k1=v1', $GLOBALS['argv']);
+        self::assertContains('additional', $GLOBALS['argv']);
+    }
+
+    public function test_globals_argv_as_array_via_run(): void
+    {
+        Phel::run(__DIR__ . '/../../../../', 'phel\\testing-argv', ['a', 'b']);
+
+        self::assertContains('a', $GLOBALS['argv']);
+        self::assertContains('b', $GLOBALS['argv']);
     }
 }


### PR DESCRIPTION
## 🤔 Background

We have a function `Phel::run()` to run a concrete namespace from phel. However, there might be some need to have some concrete `argv` in that particular namespace. Right now, the only way is to setup manually from the outside like 
```php
$GLOBALS['argv'][] = 'additional arguments';
```

## 💡 Goal

To be able to add your additional phel arguments when running a concrete namespace with `Phel::run()` as an optional argument to that function.

## 🔖 Changes

- Add a new argument to the `Phel::run()` funtion ➡️  `array|string $argv`
