### PR TITLE
Define __MAIN_NS__ in RunCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Allow strings on `empty?` (#492)
 * Improved error message when using strings on `count` (#492)
+* Add __MAIN_NS__ global constant (#524)
 
 ## 0.7.0 (2022-05-05)
 

--- a/src/php/Build/Domain/Compile/BuildOptions.php
+++ b/src/php/Build/Domain/Compile/BuildOptions.php
@@ -9,6 +9,7 @@ class BuildOptions
     public function __construct(
         private bool $enableCache,
         private bool $enableSourceMap,
+        private ?string $mainNamespace,
     ) {
     }
 
@@ -20,5 +21,10 @@ class BuildOptions
     public function isSourceMapEnabled(): bool
     {
         return $this->enableSourceMap;
+    }
+
+    public function getMainNamespace(): ?string
+    {
+        return $this->mainNamespace;
     }
 }

--- a/src/php/Build/Domain/Compile/ProjectCompiler.php
+++ b/src/php/Build/Domain/Compile/ProjectCompiler.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Domain\Compile;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacadeInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use RuntimeException;
 
 use function dirname;
@@ -50,6 +51,8 @@ final class ProjectCompiler
      */
     private function compileFromTo(array $srcDirectories, string $dest, BuildOptions $buildOptions): array
     {
+        GlobalEnvironment::setMainNamespace($buildOptions->getMainNamespace());
+
         $namespaceInformation = $this->namespaceExtractor->getNamespacesFromDirectories($srcDirectories);
         /** @var list<CompiledFile> $result */
         $result = [];

--- a/src/php/Build/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Build/Infrastructure/Command/CompileCommand.php
@@ -24,19 +24,21 @@ final class CompileCommand extends Command
 
     private const OPTION_CACHE = 'cache';
     private const OPTION_SOURCE_MAP = 'source-map';
+    private const OPTION_MAIN_NS = 'main-ns';
 
     protected function configure(): void
     {
         $this->setName('compile')
             ->setDescription('Compile the current project')
             ->addOption(self::OPTION_CACHE, null, InputOption::VALUE_NEGATABLE, 'Enable cache', true)
-            ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true);
+            ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true)
+            ->addOption(self::OPTION_MAIN_NS, null, InputOption::VALUE_OPTIONAL, 'Define the main namespace');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->getFacade()->registerExceptionHandler();
-        $buildOptions = $this->getBuildOptions($input);
+        $buildOptions = $this->createBuildOptions($input);
 
         try {
             $compiledProject = $this->getFacade()->compileProject($buildOptions);
@@ -50,11 +52,12 @@ final class CompileCommand extends Command
         return self::SUCCESS;
     }
 
-    private function getBuildOptions(InputInterface $input): BuildOptions
+    private function createBuildOptions(InputInterface $input): BuildOptions
     {
         return new BuildOptions(
             $input->getOption(self::OPTION_CACHE) === true,
             $input->getOption(self::OPTION_SOURCE_MAP) === true,
+            $input->getOption(self::OPTION_MAIN_NS),
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -49,7 +49,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->addInternalCompileModeDefinition();
     }
 
-    public static function setMainNamespace(string $namespace): void
+    public static function setMainNamespace(?string $namespace): void
     {
         self::$mainNamespace = $namespace;
     }

--- a/src/php/Compiler/Domain/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/Domain/Compiler/EvalCompiler.php
@@ -104,7 +104,9 @@ final class EvalCompiler implements EvalCompilerInterface
      */
     private function evalNode(AbstractNode $node, CompileOptions $compileOptions): mixed
     {
-        $code = $this->emitter->emitNode($node, $compileOptions->isSourceMapsEnabled())->getCodeWithSourceMap();
+        $code = $this->emitter
+            ->emitNode($node, $compileOptions->isSourceMapsEnabled())
+            ->getCodeWithSourceMap();
 
         return $this->evaluator->eval($code);
     }

--- a/src/php/Run/Domain/Runner/NamespaceRunner.php
+++ b/src/php/Run/Domain/Runner/NamespaceRunner.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Domain\Runner;
 
 use Phel\Build\BuildFacadeInterface;
 use Phel\Command\CommandFacadeInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 
 class NamespaceRunner implements NamespaceRunnerInterface
 {
@@ -17,6 +18,8 @@ class NamespaceRunner implements NamespaceRunnerInterface
 
     public function run(string $namespace): void
     {
+        GlobalEnvironment::setMainNamespace($namespace);
+
         $this->commandFacade->registerExceptionHandler();
 
         $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -15,8 +15,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
-use function define;
-
 /**
  * @method RunFacade getFacade()
  */
@@ -55,7 +53,7 @@ final class RunCommand extends Command
             if (file_exists($fileOrPath)) {
                 $namespace = $this->getFacade()->getNamespaceFromFile($fileOrPath)->getNamespace();
             }
-            define('__MAIN_NS__', $namespace);
+
             $this->getFacade()->runNamespace($namespace);
 
             if ($input->getOption('with-time')) {

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function define;
+
 /**
  * @method RunFacade getFacade()
  */
@@ -53,6 +55,7 @@ final class RunCommand extends Command
             if (file_exists($fileOrPath)) {
                 $namespace = $this->getFacade()->getNamespaceFromFile($fileOrPath)->getNamespace();
             }
+            define('__MAIN_NS__', $namespace);
             $this->getFacade()->runNamespace($namespace);
 
             if ($input->getOption('with-time')) {

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -61,8 +61,12 @@
   (is (true? (>= (php/strpos __FILE__ "tests/phel/test/core.phel") 0)) "__FILE__"))
 
 (deftest test-__DIR__
-  (is (true? (and (false? (php/strpos __DIR__ "tests/phel/test/core.phel")) (>= (php/strpos __DIR__ "tests/phel/test") 0))) "__DIR__"))
+  (is (true? (and (false? (php/strpos __DIR__ "tests/phel/test/core.phel"))
+             (>= (php/strpos __DIR__ "tests/phel/test") 0)))
+       "__DIR__"))
 
+(deftest test-__MAIN_NS__
+  (is (nil? __MAIN_NS__)) "__MAIN_NS__")
 
 (deftest test-var
   (is (= :var (type (var 10))) "type of var is :var")


### PR DESCRIPTION
## 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/523

## 💡 Goal

To be able to ignore phel code when running tests or compiling code, especially code that involves I/O operations.

## 🔖 Changes

- Introduce a new global magic constant `__MAIN_NS__` that will return the value of the main namespace that it's being executed

### 🧪 For example

```clojure
(ns phel\game)

(if (= __MAIN_NS__ "phel\\game")
  (loop []
    (play-hand)
    (println)
    (recur)))
```