### PR TITLE
Refactoring FileCompiler and making CompileOptions optional

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1864,4 +1864,4 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [form]
   (let [cf (php/new CompilerFacade)
         opts (php/new CompileOptions)]
-    (php/-> (php/-> cf (compileForm form opts)) (getCode))))
+    (php/-> (php/-> cf (compileForm form opts)) (getPhpCode))))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1855,13 +1855,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 (defn eval
   "Evaluates a form and return the evaluated results."
   [form]
-  (let [cf (php/new CompilerFacade)
-        opts (php/new CompileOptions)]
-    (php/-> cf (evalForm form opts))))
+  (let [cf (php/new CompilerFacade)]
+    (php/-> cf (evalForm form))))
 
 (defn compile
   "Returns the compiled PHP code string for the given form."
   [form]
-  (let [cf (php/new CompilerFacade)
-        opts (php/new CompileOptions)]
-    (php/-> (php/-> cf (compileForm form opts)) (getPhpCode))))
+  (let [cf (php/new CompilerFacade)]
+    (php/-> (php/-> cf (compileForm form)) (getPhpCode))))

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -31,7 +31,7 @@ final class FileCompiler implements FileCompilerInterface
         $result = $this->compilerFacade->compile($phelCode, $options);
         Registry::getInstance()->addDefinition("phel\core", '*compile-mode*', false);
 
-        $this->fileIo->putContents($dest, "<?php\n" . $result->getCode());
+        $this->fileIo->putContents($dest, "<?php\n" . $result->getPhpCode());
         $this->fileIo->putContents(str_replace('.php', '.phel', $dest), $phelCode);
 
         if ($enableSourceMaps) {

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -31,12 +31,13 @@ final class FileCompiler implements FileCompilerInterface
         $result = $this->compilerFacade->compile($phelCode, $options);
         Registry::getInstance()->addDefinition("phel\core", '*compile-mode*', false);
 
-        file_put_contents($dest, "<?php\n" . $result->getCode());
-        file_put_contents(str_replace('.php', '.phel', $dest), $phelCode);
+        $this->fileIo->putContents($dest, "<?php\n" . $result->getCode());
+        $this->fileIo->putContents(str_replace('.php', '.phel', $dest), $phelCode);
+
         if ($enableSourceMaps) {
-            file_put_contents($dest . '.map', $result->getSourceMap());
-        } elseif (file_exists($dest . '.map')) {
-            @unlink($dest . '.map');
+            $this->fileIo->putContents($dest . '.map', $result->getSourceMap());
+        } else {
+            $this->fileIo->removeFile($dest . '.map');
         }
 
         $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);

--- a/src/php/Build/Domain/IO/FileIoInterface.php
+++ b/src/php/Build/Domain/IO/FileIoInterface.php
@@ -7,4 +7,8 @@ namespace Phel\Build\Domain\IO;
 interface FileIoInterface
 {
     public function getContents(string $filename): string;
+
+    public function putContents(string $filename, string $content): void;
+
+    public function removeFile(string $filename): void;
 }

--- a/src/php/Build/Infrastructure/IO/SystemFileIo.php
+++ b/src/php/Build/Infrastructure/IO/SystemFileIo.php
@@ -12,4 +12,16 @@ final class SystemFileIo implements FileIoInterface
     {
         return file_get_contents($filename);
     }
+
+    public function putContents(string $filename, string $content): void
+    {
+        file_put_contents($filename, $content);
+    }
+
+    public function removeFile(string $filename): void
+    {
+        if (file_exists($filename)) {
+            @unlink($filename);
+        }
+    }
 }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -44,15 +44,27 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
      *
      * @return mixed The result of the executed code
      */
-    public function eval(string $phelCode, CompileOptions $compileOptions): mixed
-    {
+    public function eval(
+        string $phelCode,
+        ?CompileOptions $compileOptions = null,
+    ): mixed {
+        if ($compileOptions === null) {
+            $compileOptions = new CompileOptions();
+        }
+
         return $this->getFactory()
             ->createEvalCompiler()
             ->evalString($phelCode, $compileOptions);
     }
 
-    public function evalForm(TypeInterface|string|float|int|bool|null $form, CompileOptions $compileOptions): mixed
-    {
+    public function evalForm(
+        TypeInterface|string|float|int|bool|null $form,
+        ?CompileOptions $compileOptions = null,
+    ): mixed {
+        if ($compileOptions === null) {
+            $compileOptions = new CompileOptions();
+        }
+
         return $this->getFactory()
             ->createEvalCompiler()
             ->evalForm($form, $compileOptions);
@@ -63,8 +75,14 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
      * @throws CompiledCodeIsMalformedException
      * @throws FileException
      */
-    public function compile(string $phelCode, CompileOptions $compileOptions): EmitterResult
-    {
+    public function compile(
+        string $phelCode,
+        ?CompileOptions $compileOptions = null,
+    ): EmitterResult {
+        if ($compileOptions === null) {
+            $compileOptions = new CompileOptions();
+        }
+
         return $this->getFactory()
             ->createCodeCompiler($compileOptions)
             ->compileString($phelCode, $compileOptions);
@@ -75,8 +93,14 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
      * @throws CompiledCodeIsMalformedException
      * @throws FileException
      */
-    public function compileForm(float|bool|int|string|TypeInterface|null $form, CompileOptions $compileOptions): EmitterResult
-    {
+    public function compileForm(
+        float|bool|int|string|TypeInterface|null $form,
+        ?CompileOptions $compileOptions = null,
+    ): EmitterResult {
+        if ($compileOptions === null) {
+            $compileOptions = new CompileOptions();
+        }
+
         return $this->getFactory()
             ->createCodeCompiler($compileOptions)
             ->compileForm($form, $compileOptions);

--- a/src/php/Compiler/Domain/Emitter/EmitterResult.php
+++ b/src/php/Compiler/Domain/Emitter/EmitterResult.php
@@ -8,15 +8,15 @@ final class EmitterResult
 {
     public function __construct(
         private bool $enableSourceMaps,
-        private string $code,
+        private string $phpCode,
         private string $sourceMap,
         private string $source,
     ) {
     }
 
-    public function getCode(): string
+    public function getPhpCode(): string
     {
-        return $this->code;
+        return $this->phpCode;
     }
 
     public function getSourceMap(): string
@@ -35,10 +35,10 @@ final class EmitterResult
             return (
                 '// ' . $this->source . "\n"
                 . '// ;;' . $this->sourceMap . "\n"
-                . $this->code
+                . $this->phpCode
             );
         }
 
-        return $this->code;
+        return $this->phpCode;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/FileEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/FileEmitter.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
 
 final class FileEmitter implements FileEmitterInterface
 {
-    private string $code = '';
+    private string $phpCode = '';
     private string $source = '';
 
     public function __construct(
@@ -23,14 +23,14 @@ final class FileEmitter implements FileEmitterInterface
         $this->outputEmitter->resetIndentLevel();
         $this->outputEmitter->resetSourceMapState();
         $this->source = $source;
-        $this->code = '';
+        $this->phpCode = '';
     }
 
     public function emitNode(AbstractNode $node): void
     {
         ob_start();
         $this->outputEmitter->emitNode($node);
-        $this->code .= ob_get_clean();
+        $this->phpCode .= ob_get_clean();
     }
 
     public function endFile(bool $enableSourceMaps): EmitterResult
@@ -41,7 +41,7 @@ final class FileEmitter implements FileEmitterInterface
 
         return new EmitterResult(
             $enableSourceMaps,
-            $this->code,
+            $this->phpCode,
             $sourceMap,
             $this->source,
         );

--- a/src/php/Compiler/Domain/Emitter/StatementEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/StatementEmitter.php
@@ -26,32 +26,25 @@ final class StatementEmitter implements StatementEmitterInterface
         $this->outputEmitter->resetSourceMapState();
 
         $sourceLocation = $node->getStartSourceLocation();
-        $file = $sourceLocation
-            ? $sourceLocation->getFile()
-            : 'string';
+        $file = $sourceLocation ? $sourceLocation->getFile() : 'string';
 
         ob_start();
         $this->outputEmitter->emitNode($node);
-        $code = ob_get_clean();
-
-        if (!$enableSourceMaps) {
-            return new EmitterResult(
-                $enableSourceMaps,
-                $code,
-                '',
-                $file,
-            );
-        }
-
-        $sourceMap = $this->sourceMapGenerator->encode(
-            $this->outputEmitter->getSourceMapState()->getMappings(),
-        );
+        $phpCode = ob_get_clean();
+        $sourceMap = $enableSourceMaps ? $this->generateSourceMap() : '';
 
         return new EmitterResult(
             $enableSourceMaps,
-            $code,
+            $phpCode,
             $sourceMap,
             $file,
+        );
+    }
+
+    private function generateSourceMap(): string
+    {
+        return $this->sourceMapGenerator->encode(
+            $this->outputEmitter->getSourceMapState()->getMappings(),
         );
     }
 }

--- a/src/php/Compiler/Domain/Emitter/StatementEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/StatementEmitter.php
@@ -25,26 +25,37 @@ final class StatementEmitter implements StatementEmitterInterface
         $this->outputEmitter->resetIndentLevel();
         $this->outputEmitter->resetSourceMapState();
 
-        $sourceLocation = $node->getStartSourceLocation();
-        $file = $sourceLocation ? $sourceLocation->getFile() : 'string';
-
-        ob_start();
-        $this->outputEmitter->emitNode($node);
-        $phpCode = ob_get_clean();
-        $sourceMap = $enableSourceMaps ? $this->generateSourceMap() : '';
-
         return new EmitterResult(
             $enableSourceMaps,
-            $phpCode,
-            $sourceMap,
-            $file,
+            $this->phpCode($node),
+            $this->sourceMap($enableSourceMaps),
+            $this->source($node),
         );
     }
 
-    private function generateSourceMap(): string
+    private function phpCode(AbstractNode $node): string
     {
+        ob_start();
+        $this->outputEmitter->emitNode($node);
+
+        return ob_get_clean();
+    }
+
+    private function sourceMap(bool $enableSourceMaps): string
+    {
+        if (!$enableSourceMaps) {
+            return '';
+        }
+
         return $this->sourceMapGenerator->encode(
             $this->outputEmitter->getSourceMapState()->getMappings(),
         );
+    }
+
+    private function source(AbstractNode $node): string
+    {
+        $sourceLocation = $node->getStartSourceLocation();
+
+        return $sourceLocation ? $sourceLocation->getFile() : 'string';
     }
 }

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -53,7 +53,7 @@ final class IntegrationTest extends TestCase
         $options = (new CompileOptions())
             ->setSource($filename);
 
-        $compiledCode = $this->compilerFacade->compile($phelCode, $options)->getCode();
+        $compiledCode = $this->compilerFacade->compile($phelCode, $options)->getPhpCode();
 
         self::assertSame(
             trim($expectedGeneratedCode),


### PR DESCRIPTION
### 🔖 Changes

- Decouple I/O from `FileCompiler`
- Rename `getCode()` to `getPhpCode()`
- Refactor StatementEmitter
- Make `CompileOptions` argument optional
