### PR TITLE
Fixing broken tests

### DIFF
--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Formatter;
 
+use Gacela\Framework\Gacela;
 use Generator;
 use Phel\Formatter\FormatterFactory;
 use Phel\Lang\Symbol;
@@ -15,6 +16,7 @@ final class FormatterFacadeTest extends TestCase
 
     public function setUp(): void
     {
+        Gacela::bootstrap(__DIR__);
         Symbol::resetGen();
         $this->formatterFactory = new FormatterFactory();
     }

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration;
 
+use Gacela\Framework\Gacela;
 use Generator;
 use Phel\Build\BuildFacade;
 use Phel\Compiler\CompilerFacade;
@@ -24,6 +25,7 @@ final class IntegrationTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        Gacela::bootstrap(__DIR__);
         Symbol::resetGen();
         $globalEnv = GlobalEnvironmentSingleton::initializeNew();
         (new BuildFacade())->compileFile(

--- a/tests/php/Integration/Interop/CallPhelTest.php
+++ b/tests/php/Integration/Interop/CallPhelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Interop;
 
+use Gacela\Framework\Gacela;
 use Phel\Build\BuildFacade;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,8 @@ final class CallPhelTest extends TestCase
 
     public function setUp(): void
     {
+        Gacela::bootstrap(__DIR__);
+
         GlobalEnvironmentSingleton::initializeNew();
 
         (new BuildFacade())->compileFile(


### PR DESCRIPTION
### 🔖 Changes

Since gaclea@0.29 you have to explicitly call `Gacela::bootstrap()` before using Gacela Facade/Factory/Config/DependencyProvider classes.