### PR TITLE
Add psalm/plugin-phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,19 @@
     "require": {
         "php": ">=8.0",
         "gacela-project/gacela": "^0.30",
-        "symfony/console": "^5.4",
-        "phpunit/php-timer": "^5.0"
+        "phpunit/php-timer": "^5.0",
+        "symfony/console": "^5.4"
     },
     "require-dev": {
         "ext-readline": "*",
-        "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^4.30",
-        "symfony/var-dumper": "^5.4",
         "friendsofphp/php-cs-fixer": "^3.13",
-        "phpmetrics/phpmetrics": "^2.8",
         "phpbench/phpbench": "^1.2",
-        "phpstan/phpstan": "^1.9"
+        "phpmetrics/phpmetrics": "^2.8",
+        "phpstan/phpstan": "^1.9",
+        "phpunit/phpunit": "^9.5",
+        "psalm/plugin-phpunit": "^0.17",
+        "symfony/var-dumper": "^5.4",
+        "vimeo/psalm": "^4.30"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98d1dbbfc8148a3b047b09c28d42635f",
+    "content-hash": "27a9936d8b8225a76e2d11d6dfe29909",
     "packages": [
         {
             "name": "gacela-project/gacela",
@@ -3094,6 +3094,66 @@
                 }
             ],
             "time": "2022-10-28T06:00:21+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "45951541beef07e93e3ad197daf01da88e85c31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/45951541beef07e93e3ad197daf01da88e85c31d",
+                "reference": "45951541beef07e93e3ad197daf01da88e85c31d",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.17.0"
+            },
+            "time": "2022-06-14T17:05:57+00:00"
         },
         {
             "name": "psr/cache",

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,10 @@
         </ignoreFiles>
     </projectFiles>
 
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+
     <issueHandlers>
         <DeprecatedClass errorLevel="suppress" />
         <DeprecatedInterface errorLevel="suppress" />


### PR DESCRIPTION
### 🤔 Background

- Sort alphabetically the `composer.json` dependencies, and
- Add `psalm/plugin-phpunit` to composer-dev

This plugin removes the warning in all PHP tests 👇🏼 😄 

<img width="873" alt="Screenshot 2022-11-09 at 20 07 35" src="https://user-images.githubusercontent.com/6381924/200920256-e89cdde4-978d-45c1-9c31-c3d3ee814124.png">

