### PR TITLE
Fix FakeStruct warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.0' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.0', '8.1', '8.2' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.0', '8.1', '8.2' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.0' ]
     steps:
       - uses: actions/checkout@v3
 

--- a/tests/php/Unit/Lang/Collections/Struct/FakeStruct.php
+++ b/tests/php/Unit/Lang/Collections/Struct/FakeStruct.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Collections\Struct;
 
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Struct\AbstractPersistentStruct;
 
 use function count;
@@ -12,20 +13,16 @@ final class FakeStruct extends AbstractPersistentStruct
 {
     protected const ALLOWED_KEYS = ['a', 'b'];
 
-    protected $a;
-    protected $b;
-
-    public function __construct($a, $b, $__meta = null)
-    {
+    public function __construct(
+        protected $a,
+        protected $b,
+    ) {
         parent::__construct();
-        $this->a = $a;
-        $this->b = $b;
-        $this->__meta = $__meta;
     }
 
-    public static function fromKVs(...$kvs): AbstractPersistentStruct
+    public static function fromKVs(mixed ...$kvs): PersistentMapInterface
     {
-        $result = new self(null, null, null);
+        $result = new self(null, null);
         for ($i = 0, $l = count($kvs); $i < $l; $i += 2) {
             $result = $result->put($kvs[$i], $kvs[$i + 1]);
         }


### PR DESCRIPTION
### 🤔 Background

When running PHP 8.2 there are warning messages over the `FakeStruct` class

<img width="1714" alt="Screenshot 2023-01-01 at 13 13 53" src="https://user-images.githubusercontent.com/5256287/210170208-33575672-e303-4cd7-90ff-ad7ea30395b9.png">

### 💡 Goal

Fix the warning messages

### 🔖 Changes

- Remove `__meta` property from `FakeStruct`
- Run CI tests using PHP 8.2 as well
