### PR TITLE
Add phel test-struct-with-types

### DIFF
--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -57,6 +57,10 @@
     (is (true? (my-struct? x)) "struct: correct type")
     (is (false? (my-struct? :a)) "struct: incorrect type")))
 
+(deftest test-struct-with-types
+  (let [x (my-struct true 1 "str" {:a 1} [:b :c])]
+    (is (= x (my-struct true 1 "str" {:a 1} [:b :c])) "structs with same data")))
+
 (deftest test-__FILE__
   (is (true? (>= (php/strpos __FILE__ "tests/phel/test/core.phel") 0)) "__FILE__"))
 


### PR DESCRIPTION
### 🔖 Changes

- Add phel tests to ensure struct with types

While working with structs I thought at the beginning that there might be a bug when comparing structs with different types. Fortunately, I was wrong and the mistake was somewhere else. This test helped me understand that there is no bug on this behaviour, so I think it is useful to keep this test.