### PR TITLE
Create DocCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * New Api module which exposes (via the `ApiFacade`) the functions documentation of Phel (#551)
+* New `phel doc` command (#552)
 
 ## 0.8.0 (2023-01-16)
 

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -33,21 +33,32 @@ final class DocCommand extends Command
             ->addOption(
                 self::OPTION_NAMESPACES,
                 null,
-                InputOption::VALUE_OPTIONAL,
-                'Specify which namespaces to load (comma separated). All by default.',
-                'phel\\core,phel\\http,phel\\html,phel\\test,phel\\json',
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'Specify which namespaces to load.',
+                ['phel\\core', 'phel\\http', 'phel\\html', 'phel\\test', 'phel\\json'],
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $namespaces = $this->normalizeNamespaces(explode(',', $input->getOption(self::OPTION_NAMESPACES)));
+        $namespaces = $this->normalizeNamespaces($input->getOption(self::OPTION_NAMESPACES));
         $groupedFunctions = $this->getFacade()->getGroupedFunctions($namespaces);
 
         $search = $input->getArgument('search');
         $this->printFunctions($output, $groupedFunctions, $search);
 
         return self::SUCCESS;
+    }
+
+    private function normalizeNamespaces(array $namespaces): array
+    {
+        array_walk($namespaces, static function (string &$ns): void {
+            if (in_array($ns, ['core', 'http', 'html', 'test', 'json']) && !str_starts_with($ns, 'phel\\')) {
+                $ns = 'phel\\' . $ns;
+            }
+        });
+
+        return $namespaces;
     }
 
     /**
@@ -109,16 +120,5 @@ final class DocCommand extends Command
         usort($normalized, static fn ($a, $b) => $b['percent'] <=> $a['percent']);
 
         return [$normalized, $longestFuncNameLength];
-    }
-
-    private function normalizeNamespaces(array $namespaces): array
-    {
-        array_walk($namespaces, static function (string &$ns): void {
-            if (in_array($ns, ['core', 'http', 'html', 'test', 'json']) && !str_starts_with($ns, 'phel\\')) {
-                $ns = 'phel\\' . $ns;
-            }
-        });
-
-        return $namespaces;
     }
 }

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -28,13 +28,13 @@ final class DocCommand extends Command
     {
         $this->setName('doc')
             ->setDescription('Display the docs for any/all phel functions.')
-            ->addArgument('search', InputArgument::OPTIONAL, 'Search input', '')
+            ->addArgument('search', InputArgument::OPTIONAL, 'Search input that look for a similar function name', '')
             ->addOption(
                 self::OPTION_NAMESPACES,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Specify which namespaces to load (comma separated)',
-                'phel\\core',
+                'Specify which namespaces to load (comma separated). All by default.',
+                'phel\\core,phel\\http,phel\\html,phel\\test,phel\\json',
             );
     }
 
@@ -42,7 +42,6 @@ final class DocCommand extends Command
     {
         $search = $input->getArgument('search');
         $namespaces = explode(',', $input->getOption(self::OPTION_NAMESPACES));
-
         $groupedFunctions = $this->getFacade()->getGroupedFunctions($namespaces);
         $this->printFunctions($output, $groupedFunctions, $search);
 
@@ -59,8 +58,7 @@ final class DocCommand extends Command
         foreach ($normalized as $func) {
             $output->writeln(
                 sprintf(
-                    '%d || %s: %s - %s',
-                    $func['percent'],
+                    '  %s: %s - %s',
                     str_pad($func['name'], $longestFuncNameLength),
                     $func['signature'],
                     $func['description'],
@@ -106,7 +104,7 @@ final class DocCommand extends Command
                 ];
             }
         }
-        usort($normalized, fn($a, $b) => $b['percent'] <=> $a['percent']);
+        usort($normalized, static fn ($a, $b) => $b['percent'] <=> $a['percent']);
 
         return [$normalized, $longestFuncNameLength];
     }

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Command;
+
+use Gacela\Framework\DocBlockResolverAwareTrait;
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\PhelFunction;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function strlen;
+
+/**
+ * @method ApiFacade getFacade()
+ */
+final class DocCommand extends Command
+{
+    use DocBlockResolverAwareTrait;
+
+    private const OPTION_NAMESPACES = 'ns';
+
+    protected function configure(): void
+    {
+        $this->setName('doc')
+            ->setDescription('Display the docs for any/all phel functions.')
+            ->addOption(
+                self::OPTION_NAMESPACES,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Specify which namespaces to load (comma separated)',
+                'phel\\core',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $namespaces = explode(',', $input->getOption(self::OPTION_NAMESPACES));
+
+        $groupedFunctions = $this->getFacade()->getGroupedFunctions($namespaces);
+        $this->printFunctions($output, $groupedFunctions);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string,list<PhelFunction>> $groupedFunctions
+     */
+    private function printFunctions(OutputInterface $output, array $groupedFunctions): void
+    {
+        [$normalized, $longestFuncNameLength] = $this->normalizeGroupedFunctions($groupedFunctions);
+
+        foreach ($normalized as $func) {
+            $output->writeln(
+                sprintf(
+                    '  %s: %s - %s',
+                    str_pad($func['name'], $longestFuncNameLength),
+                    $func['signature'],
+                    $func['description'],
+                ),
+            );
+        }
+    }
+
+    /**
+     * @return array{
+     *   0: list<array{
+     *     name: string,
+     *     signature: string,
+     *     doc: string,
+     *     description: string,
+     *   }>,
+     *   1: int
+     * }
+     */
+    private function normalizeGroupedFunctions(array $groupedFunctions): array
+    {
+        $longestFuncNameLength = 5;
+        $normalized = [];
+        foreach ($groupedFunctions as $functions) {
+            foreach ($functions as $function) {
+                if (strlen($function->fnName()) > $longestFuncNameLength) {
+                    $longestFuncNameLength = strlen($function->fnName());
+                }
+                $normalized[] = [
+                    'name' => $function->fnName(),
+                    'signature' => $function->fnSignature(),
+                    'doc' => $function->doc(),
+                    'description' => preg_replace('/\r?\n/', '', $function->description()),
+                ];
+            }
+        }
+        return [$normalized, $longestFuncNameLength];
+    }
+}

--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -6,6 +6,7 @@ namespace Phel\Console;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
+use Phel\Api\Infrastructure\Command\DocCommand;
 use Phel\Build\Infrastructure\Command\CompileCommand;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
@@ -26,6 +27,7 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
             new RunCommand(),
             new TestCommand(),
             new CompileCommand(),
+            new DocCommand(),
         ]);
     }
 }


### PR DESCRIPTION
### 🤔 Background

Depends on https://github.com/phel-lang/phel-lang/pull/553

### 🔖 Changes

Create a phel command that list and search phel functions

## 🖼️ Screenshots

#### No extra arguments renders all functions

> php phel doc

<img width="1116" alt="Screenshot 2023-01-27 at 14 28 05" src="https://user-images.githubusercontent.com/5256287/215098155-bb1a4525-a596-4b0d-b965-eae97cd134a5.png">

#### A total of 242 functions

<img width="543" alt="Screenshot 2023-01-27 at 14 30 10" src="https://user-images.githubusercontent.com/5256287/215098536-e598cf01-d382-431b-82c5-6531fe91cbe8.png">

#### Search using a string (over all namespaces)

> php phel doc "encode"

<img width="1154" alt="Screenshot 2023-01-27 at 14 30 44" src="https://user-images.githubusercontent.com/5256287/215098634-ad36b58b-7616-4031-9e81-23e39607b2af.png">

#### Search in a concrete namespace

>  php phel doc "valid" --ns=json 

<img width="1059" alt="Screenshot 2023-01-27 at 14 33 45" src="https://user-images.githubusercontent.com/5256287/215099291-df03c096-af9b-40d9-ae08-bf5681620acc.png">

#### Search in multiple namespaces

> php phel doc --ns=json --ns=test

<img width="1155" alt="Screenshot 2023-01-27 at 14 32 12" src="https://user-images.githubusercontent.com/5256287/215098971-fc440caa-4d6f-409b-b829-41030ae1fef7.png">


