### PR TITLE
Create parse-int function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Added `parse-int` function
 * New Api module which exposes (via the `ApiFacade`) the functions documentation of Phel (#551)
 
 ## 0.8.0 (2023-01-16)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -199,6 +199,11 @@
   []
   (php/:: Symbol (gen)))
 
+(defn parse-int
+  "Coerce to int"
+  [x]
+  (php/intval x))
+
 (defn str
   "Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as an empty

--- a/tests/phel/test/core/cast-operation.phel
+++ b/tests/phel/test/core/cast-operation.phel
@@ -1,0 +1,12 @@
+(ns phel-test\test\core\cast-operation
+  (:require phel\test :refer [deftest is]))
+
+(deftest test-parse-int
+  (is (thrown? \ArgumentCountError (parse-int)) "parse-int with no arg")
+  (is (= 1 (parse-int 1)) "parse-int with one int")
+  (is (= 1 (parse-int 1.23)) "parse-int with one float")
+  (is (= 1 (parse-int true)) "parse-int with true")
+  (is (= 0 (parse-int false)) "parse-int with false")
+  (is (= 1 (parse-int "1")) "parse-int with one numeric string")
+  (is (= 1 (parse-int "1.23")) "parse-int with one float string")
+  (is (= 0 (parse-int "string")) "parse-int with no numeric string"))


### PR DESCRIPTION
## 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/540

## 🔖 Changes

- Added `parse-int` function

## 🖊️ Draft-PR

Although, I am not sure if this function (and similars) make 100% sense in the core, because it's just an alias for the native `intval` function that you can use simply with `(php/intval x)`. I am fixed feelings about this, but anyway, I wanted to do this PR to share the idea with you two @jenshaase & @JesusValera.

>**Note**: The bigger risk that I see is that the more functions we add to the core, the more it might take to run/compile because it needs to process more functions. And it wouldn't be clever to add ALL type of functions, especially if you can already use the native ones from PHP straight forward. 