### PR TITLE
Rename command compile to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * New Api module which exposes (via the `ApiFacade`) the functions documentation of Phel (#551)
+* Rename command `phel compile` to `phel build` (#555)
 
 ## 0.8.0 (2023-01-16)
 

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -19,7 +19,7 @@ use Throwable;
 /**
  * @method BuildFacade getFacade()
  */
-final class CompileCommand extends Command
+final class BuildCommand extends Command
 {
     use DocBlockResolverAwareTrait;
 
@@ -28,8 +28,9 @@ final class CompileCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('compile')
-            ->setDescription('Compile the current project')
+        $this->setName('build')
+            ->setAliases(['compile'])
+            ->setDescription('Build the current project')
             ->addOption(self::OPTION_CACHE, null, InputOption::VALUE_NEGATABLE, 'Enable cache', true)
             ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true);
     }

--- a/src/php/Console/ConsoleDependencyProvider.php
+++ b/src/php/Console/ConsoleDependencyProvider.php
@@ -6,7 +6,7 @@ namespace Phel\Console;
 
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
-use Phel\Build\Infrastructure\Command\CompileCommand;
+use Phel\Build\Infrastructure\Command\BuildCommand;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
 use Phel\Run\Infrastructure\Command\ReplCommand;
@@ -25,7 +25,7 @@ final class ConsoleDependencyProvider extends AbstractDependencyProvider
             new ReplCommand(),
             new RunCommand(),
             new TestCommand(),
-            new CompileCommand(),
+            new BuildCommand(),
         ]);
     }
 }

--- a/tests/php/Integration/Build/Command/BuildCommandTest.php
+++ b/tests/php/Integration/Build/Command/BuildCommandTest.php
@@ -6,14 +6,14 @@ namespace PhelTest\Integration\Build\Command;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
-use Phel\Build\Infrastructure\Command\CompileCommand;
+use Phel\Build\Infrastructure\Command\BuildCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CompileCommandTest extends TestCase
+final class BuildCommandTest extends TestCase
 {
-    private CompileCommand $command;
+    private BuildCommand $command;
 
     public static function setUpBeforeClass(): void
     {
@@ -22,7 +22,7 @@ final class CompileCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->command = new CompileCommand();
+        $this->command = new BuildCommand();
     }
 
     /**
@@ -30,7 +30,7 @@ final class CompileCommandTest extends TestCase
      *
      * @preserveGlobalState disabled
      */
-    public function test_compile_project(): void
+    public function test_build_project(): void
     {
         $this->expectOutputString("This is printed\n");
 
@@ -53,9 +53,9 @@ final class CompileCommandTest extends TestCase
      *
      * @preserveGlobalState disabled
      *
-     * @depends test_compile_project
+     * @depends test_build_project
      */
-    public function test_compile_project_cached(): void
+    public function test_build_project_cached(): void
     {
         // Mark file cache invalid by setting the modification time to 0
         touch(__DIR__ . '/out/hello.php', 1);


### PR DESCRIPTION
### 🤔 Background

The current `phel compile` command is inside the `Build` module:
<img width="1045" alt="Screenshot 2023-01-28 at 11 51 38" src="https://user-images.githubusercontent.com/5256287/215262674-21565ecc-8c2e-42d8-a508-2f2c66a19c5d.png">

 I like that actually, because the `Compiler` module is full of other responsibilities. That's where you find the Analyzer, Compiler, Emitter, Evaluator, Lexer, Parser, and Reader, aka that's where the phel code gets interpreted/transformed to the php code:
<img width="310" alt="Screenshot 2023-01-28 at 11 52 32" src="https://user-images.githubusercontent.com/5256287/215262710-fe90766b-cdc7-47c5-9fb1-6f5e75cf0cae.png">

However, when having a command named `compile` it would make sense to go and look inside the Compiler module (at least for me). 


### 💡 Goal

Instead of moving the command from `Build` inside the `Compiler` (and loosing the Build module separation of concerns), the idea is to rename the command from `phel compile` to `phel build`, and keep the compile as alias for the build command.

### 🔖 Changes

- Rename the class CompileCommand to BuildCommand
- Add `phel compile` as alias for `phel build`
