### PR TITLE
Allow ignore phel files when building the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * New Api module which exposes (via the `ApiFacade`) the functions documentation of Phel (#551)
+* Add new config parameter `ignore-when-compiling`
+  *  Ignore these paths when running `phel build` command
 
 ## 0.8.0 (2023-01-16)
 

--- a/phel-config.php
+++ b/phel-config.php
@@ -12,4 +12,5 @@ return [
         'target-directory' => 'src/PhelGenerated',
     ],
     'out-dir' => 'out',
+    'ignore-when-compiling' => ['src/phel/local.phel'],
 ];

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build;
+
+use Gacela\Framework\AbstractConfig;
+
+/**
+ * @method BuildConfig getConfig()
+ */
+final class BuildConfig extends AbstractConfig
+{
+    public const IGNORE_WHEN_COMPILING = 'ignore-when-compiling';
+
+    /**
+     * @return list<string>
+     */
+    public function getPathsToIgnoreWhenCompiling(): array
+    {
+        return $this->get(self::IGNORE_WHEN_COMPILING, []);
+    }
+}

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Build;
 
-use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFactory;
 use Phel\Build\Domain\Compile\DependenciesForNamespace;
 use Phel\Build\Domain\Compile\FileCompiler;
@@ -31,7 +30,7 @@ final class BuildFactory extends AbstractFactory
             $this->createFileCompiler(),
             $this->getCompilerFacade(),
             $this->getCommandFacade(),
-            $this->getConfig()->getPathsToIgnoreWhenCompiling()
+            $this->getConfig()->getPathsToIgnoreWhenCompiling(),
         );
     }
 

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build;
 
+use Gacela\Framework\AbstractConfig;
 use Gacela\Framework\AbstractFactory;
 use Phel\Build\Domain\Compile\DependenciesForNamespace;
 use Phel\Build\Domain\Compile\FileCompiler;
@@ -18,6 +19,9 @@ use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Command\CommandFacadeInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 
+/**
+ * @method BuildConfig getConfig()
+ */
 final class BuildFactory extends AbstractFactory
 {
     public function createProjectCompiler(): ProjectCompiler
@@ -27,6 +31,7 @@ final class BuildFactory extends AbstractFactory
             $this->createFileCompiler(),
             $this->getCompilerFacade(),
             $this->getCommandFacade(),
+            $this->getConfig()->getPathsToIgnoreWhenCompiling()
         );
     }
 

--- a/src/php/Command/Domain/Shared/Exceptions/Extractor/SourceMapExtractor.php
+++ b/src/php/Command/Domain/Shared/Exceptions/Extractor/SourceMapExtractor.php
@@ -13,7 +13,7 @@ final class SourceMapExtractor implements SourceMapExtractorInterface
         $f = fopen($filename, 'rb');
         $phpPrefix = fgets($f);
         $filenameComment = fgets($f);
-        $sourceMapComment = fgets($f);
+        $sourceMapComment = fgets($f) ?: '';
 
         return new SourceMapInformation($filenameComment, $sourceMapComment);
     }

--- a/tests/php/Integration/Build/Command/config/phel-config.php
+++ b/tests/php/Integration/Build/Command/config/phel-config.php
@@ -9,5 +9,8 @@ return [
     ],
     'out-dir' => 'out',
     'vendor-dir' => '',
-    'ignore-when-compiling' => ['local.phel'],
+    'ignore-when-compiling' => [
+        'local.phel',
+        'failing.phel',
+    ],
 ];

--- a/tests/php/Integration/Build/Command/config/phel-config.php
+++ b/tests/php/Integration/Build/Command/config/phel-config.php
@@ -9,4 +9,5 @@ return [
     ],
     'out-dir' => 'out',
     'vendor-dir' => '',
+    'ignore-when-compiling' => ['local.phel'],
 ];

--- a/tests/php/Integration/Build/Command/src/failing.phel
+++ b/tests/php/Integration/Build/Command/src/failing.phel
@@ -1,0 +1,3 @@
+(ns failing)
+
+(throw (php/new \Exception "This file should be ignore at compile time"))


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/521

Add a new key-value to `phel-config.php` to be able to ignore certain files at compile time (by name or pattern path, for example).

### 🔖 Changes

- Add new config parameter `ignore-when-compiling`
  - Ignore these path(s) when running the `phel compile` command
