### PR TITLE
Allow underscores in decimal numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Rename command `phel compile` to `phel build` (#555)
 * Added config parameter `ignore-when-building` (#557)
 * Added config parameter `keep-generated-temp-files` (#553)
+* Allow underscores in decimal numbers (#564)
 
 ## 0.8.0 (2023-01-16)
 

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -23,7 +23,6 @@ final class AtomParser
     private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX][0-9a-fA-F]+(_[0-9a-fA-F]+)*$/';
     private const REGEX_OCTAL_NUMBER = '/^([+-])?0[0-7]+(_[0-7]+)*$/';
     private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*[\.(_[0-9]+]?|0$/';
-//    private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*|0$/';
 
     public function __construct(private GlobalEnvironmentInterface $globalEnvironment)
     {

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -22,7 +22,8 @@ final class AtomParser
     private const REGEX_BINARY_NUMBER = '/^([+-])?0[bB][01]+(_[01]+)*$/';
     private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX][0-9a-fA-F]+(_[0-9a-fA-F]+)*$/';
     private const REGEX_OCTAL_NUMBER = '/^([+-])?0[0-7]+(_[0-7]+)*$/';
-    private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*$/';
+    private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*[\.(_[0-9]+]?|0$/';
+//    private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*|0$/';
 
     public function __construct(private GlobalEnvironmentInterface $globalEnvironment)
     {
@@ -60,7 +61,11 @@ final class AtomParser
             return $this->parseOctalNumber($matches, $word, $token);
         }
 
-        if (is_numeric($word) || preg_match(self::REGEX_DECIMAL_NUMBER, $word)) {
+        if (is_numeric($word)) {
+            return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $word + 0);
+        }
+
+        if (preg_match(self::REGEX_DECIMAL_NUMBER, $word, $matches)) {
             return $this->parseDecimalNumber($matches, $word, $token);
         }
 

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -60,11 +60,7 @@ final class AtomParser
             return $this->parseOctalNumber($matches, $word, $token);
         }
 
-        if (is_numeric($word)) {
-            return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $word + 0);
-        }
-
-        if (preg_match(self::REGEX_DECIMAL_NUMBER, $word, $matches)) {
+        if (is_numeric($word) || preg_match(self::REGEX_DECIMAL_NUMBER, $word)) {
             return $this->parseDecimalNumber($matches, $word, $token);
         }
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -105,8 +105,8 @@
 (deftest test-numbers-with-underscore
   (is (= 1337 0b10100111001) "binary number")
   (is (= 1337 0b101_0011_1001) "binary number with underscores")
-  (is (= -1337 -0x539) "hexadecimal number")
-  (is (= -1337 -0x5_39) "hexadecimal number with underscores")
+  (is (= 1337 0x539) "hexadecimal number")
+  (is (= 1337 0x5_39) "hexadecimal number with underscores")
   (is (= 1337 02471) "octal number")
   (is (= 1337 024_71) "octal number with underscores")
   (is (= 1337 1_337) "decimal number with underscores"))

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -103,6 +103,10 @@
   (is (= 2 (mean [1 2 3])) "(mean [1 2 3])"))
 
 (deftest test-numbers-with-underscore
+  (is (= 1337 0b10100111001) "binary number")
   (is (= 1337 0b101_0011_1001) "binary number with underscores")
+  (is (= -1337 -0x539) "hexadecimal number")
   (is (= -1337 -0x5_39) "hexadecimal number with underscores")
-  (is (= 1337 024_71) "octal number with underscores"))
+  (is (= 1337 02471) "octal number")
+  (is (= 1337 024_71) "octal number with underscores")
+  (is (= 1337 1_337) "decimal number with underscores"))

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -182,7 +182,7 @@ final class AtomParserTest extends TestCase
         );
     }
 
-    public function test_parse_hexdecimal_number(): void
+    public function test_parse_hexadecimal_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());
         $start = new SourceLocation('string', 0, 0);
@@ -218,7 +218,7 @@ final class AtomParserTest extends TestCase
         );
     }
 
-    public function test_parse_otcal_number(): void
+    public function test_parse_octal_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());
         $start = new SourceLocation('string', 0, 0);


### PR DESCRIPTION
### 🤔 Background

 Idea: https://github.com/phel-lang/phel-lang/discussions/563
We can use underscore for binary, octal and hexa but not decimal.

### 💡 Goal

To be able to use underscore on decimal numbers. Supported from PHP 7.4

### 🔖 Changes

- Changed AtomParser to check for valid decimal numbers with underscores as well
