### PR TITLE
Add testdox option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Added default format paths: 'src', 'tests' (#569)
 * Deprecate `*compile-mode*` in favor of `*build-mode*` (#570)
+* Added `--testdox` argument to `phel test` command (#567)
 
 ## 0.9.0 (2023-02-05)
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -8,17 +8,21 @@
 # Report
 # ------
 
+(def- testdox? (var false))
+
 (def- stats (var {:failed []
                   :counts {:failed 0
                            :error 0
                            :pass 0
                            :total 0}}))
 
+(defn- print-report-testdox-state [data state]
+  (let [s (case state :failed "✘" :pass "✔" :error "E")
+        message (or (:message data) "no test message found")]
+    (println s message)))
+
 (defn- print-report-state [state]
-  (print (case state
-           :failed "F"
-           :pass "."
-           :error "E")))
+  (print (case state :failed "F" :pass "." :error "E")))
 
 (defn- should-report-println? [total-columns]
   (= (% (get-in (deref stats) [:counts :total]) total-columns) 0))
@@ -27,7 +31,9 @@
   (let [{:state state :type type} data
         ok (= state :pass)
         total-columns 80]
-    (print-report-state state)
+    (if (deref testdox?)
+      (print-report-testdox-state data state)
+      (print-report-state state))
     (swap! stats update-in [:counts :total] inc)
     (swap! stats update-in [:counts state] inc)
     (when (should-report-println? total-columns) (println))
@@ -316,6 +322,7 @@
 (defn run-tests
   "Runs all test functions in the given namespaces."
   [options & namespaces]
+  (set! testdox? (:testdox options))
   (dofor [namespace :in namespaces
           :let [ns-name (name namespace)]]
     (run-test options ns-name))

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -10,6 +10,8 @@
 
 (def- testdox? (var false))
 
+(def- *current-test-name* nil)
+
 (def- stats (var {:failed []
                   :counts {:failed 0
                            :error 0
@@ -18,7 +20,7 @@
 
 (defn- print-report-testdox-state [data state]
   (let [s (case state :failed "✘" :pass "✔" :error "E")
-        message (or (:message data) "no test message found")]
+        message (str *current-test-name* ": " (or (:message data) "no test message found"))]
     (println s message)))
 
 (defn- print-report-state [state]
@@ -197,7 +199,8 @@
   "Defines a test function with no arguments."
   [test-name & body]
   `(defn ,test-name {:test true :test-name ,(name test-name)} []
-     ,@body))
+     (binding [*current-test-name* ,(name test-name)]
+       ,@body)))
 
 # ---------------------
 # error/failure printer

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -10,31 +10,36 @@ use Phel\Printer\Printer;
 final class TestCommandOptions
 {
     public const FILTER = 'filter';
+    public const TESTDOX = 'testdox';
 
-    private string $filter = '';
+    private function __construct(
+        private ?string $filter,
+        private bool $testdox,
+    ) {
+    }
 
     public static function empty(): self
     {
-        return new self();
+        return self::fromArray([self::FILTER => null]);
     }
 
     public static function fromArray(array $options): self
     {
-        $self = new self();
-        $self->filter = $options[self::FILTER] ?? '';
-
-        return $self;
+        return new self(
+            $options[self::FILTER] ?? null,
+            !empty($options[self::TESTDOX]),
+        );
     }
 
     public function asPhelHashMap(): string
     {
-        $filter = empty($this->filter) ? null : $this->filter;
-
         $typeFactory = TypeFactory::getInstance();
 
         $optionsMap = $typeFactory->persistentMapFromKVs(
             $typeFactory->keyword(self::FILTER),
-            $filter,
+            $this->filter,
+            $typeFactory->keyword(self::TESTDOX),
+            $this->testdox,
         );
 
         return Printer::readable()->print($optionsMap);

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -13,13 +13,41 @@ final class TestCommandOptionsTest extends TestCase
     {
         $options = TestCommandOptions::empty();
 
-        self::assertSame('{:filter nil}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
     }
 
     public function test_random_filter(): void
     {
         $options = TestCommandOptions::fromArray(['filter' => 'example']);
 
-        self::assertSame('{:filter "example"}', $options->asPhelHashMap());
+        self::assertSame('{:filter "example" :testdox false}', $options->asPhelHashMap());
+    }
+
+    public function test_no_testdox(): void
+    {
+        $options = TestCommandOptions::fromArray([]);
+
+        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+    }
+
+    public function test_false_testdox(): void
+    {
+        $options = TestCommandOptions::fromArray(['testdox' => false]);
+
+        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+    }
+
+    public function test_null_testdox(): void
+    {
+        $options = TestCommandOptions::fromArray(['testdox' => null]);
+
+        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+    }
+
+    public function test_true_testdox(): void
+    {
+        $options = TestCommandOptions::fromArray(['testdox' => 'true']);
+
+        self::assertSame('{:filter nil :testdox true}', $options->asPhelHashMap());
     }
 }


### PR DESCRIPTION
## 🤔 Background

You can use the optional option `--testdox` in PHPUnit, which renders a nicer output. For example:
<img width="787" alt="Screenshot 2023-02-07 at 22 58 58" src="https://user-images.githubusercontent.com/5256287/217376238-c0bad5dc-45f6-4860-952e-ac39e4d46e3f.png">
It would be handy to have such option when running the `phel test` command. 

## 🔖 Changes

I introduced a similar option for our `phel test`. It doesn't render the test-name (I didn't know how to do it), but I could render the test message. 

> **Note**: we can refactor it once we figure out how to use the test-name instead of the test message. At least when there is no test message.

## 🖼️ Screenshots

### Here an example without and with the `--testdox` option
<img width="816" alt="Screenshot 2023-02-13 at 10 24 43" src="https://user-images.githubusercontent.com/5256287/218419962-615198c4-9fb8-4a76-a7cf-8c814ac56372.png">

> It's not as nice as the one from PHPUnit, but step by step 😄 

## 💭 Follow up ideas

IDEA 1: Add the running/execution time for each test next to the text itself (see the PHPUnit screenshot).
IDEA 2: Add color for the **fail** and **pass** checks.
