### PR TITLE
Add default format paths

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -14,4 +14,5 @@ return [
     'out-dir' => 'out',
     'ignore-when-building' => ['src/phel/local.phel'],
     'keep-generated-temp-files' => false,
+    'format-dirs' => ['src', 'tests'],
 ];

--- a/src/php/Formatter/FormatterConfig.php
+++ b/src/php/Formatter/FormatterConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter;
+
+use Gacela\Framework\AbstractConfig;
+
+final class FormatterConfig extends AbstractConfig
+{
+    public const FORMAT_DIRS = 'format-dirs';
+
+    private const DEFAULT_FORMAT_DIRS = ['src', 'tests'];
+
+    public function getFormatDirs(): array
+    {
+        return $this->get(self::FORMAT_DIRS, self::DEFAULT_FORMAT_DIRS);
+    }
+}

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Formatter\Infrastructure\Command;
 
 use Gacela\Framework\DocBlockResolverAwareTrait;
+use Phel\Formatter\FormatterConfig;
 use Phel\Formatter\FormatterFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @method FormatterFacade getFacade()
+ * @method FormatterConfig getConfig()
  */
 final class FormatCommand extends Command
 {
@@ -24,8 +26,9 @@ final class FormatCommand extends Command
             ->setDescription('Formats the given files.')
             ->addArgument(
                 'paths',
-                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'The file paths that you want to format.',
+                InputArgument::IS_ARRAY,
+                'The file paths that you want to format. The default value is ["src", "test"].',
+                $this->getConfig()->getFormatDirs(),
             );
     }
 


### PR DESCRIPTION
### 🤔 Background

This is the implementation for ticket #568

### 💡 Goal

The format command can be run without passing any paths. If no paths are being passed, the default paths "src" and "tests" should be used, as defined in the config.

### 🔖 Changes

In addition to the changes of the command, I updated the test cases to use the CommandTester from Symfony. This allows to run the command without having to mock the input and therefore allows to test the FormatterCommand without passing any paths.
