### PR TITLE
Rename compile-mode to build-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Added default format paths: 'src', 'tests' (#569)
+* Renamed `*compile-mode*` to `*build-mode*` (#570)
 
 ## 0.9.0 (2023-02-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Added default format paths: 'src', 'tests' (#569)
-* Renamed `*compile-mode*` to `*build-mode*` (#570)
+* Deprecate `*compile-mode*` in favor of `*build-mode*` (#570)
 
 ## 0.9.0 (2023-02-05)
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,6 +19,7 @@
     </plugins>
 
     <issueHandlers>
+        <DeprecatedConstant errorLevel="suppress" />
         <DeprecatedClass errorLevel="suppress" />
         <DeprecatedInterface errorLevel="suppress" />
         <DeprecatedMethod errorLevel="suppress" />

--- a/src/php/Build/BuildConstants.php
+++ b/src/php/Build/BuildConstants.php
@@ -6,5 +6,5 @@ namespace Phel\Build;
 
 interface BuildConstants
 {
-    public const BUILD_MODE = '*compile-mode*';
+    public const BUILD_MODE = '*build-mode*';
 }

--- a/src/php/Build/BuildConstants.php
+++ b/src/php/Build/BuildConstants.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build;
+
+interface BuildConstants
+{
+    public const BUILD_MODE = '*compile-mode*';
+}

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Compile;
 
+use Phel\Build\BuildConstants;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Compiler\CompilerFacadeInterface;
@@ -27,9 +28,9 @@ final class FileCompiler implements FileCompilerInterface
             ->setSource($src)
             ->setIsEnabledSourceMaps($enableSourceMaps);
 
-        Registry::getInstance()->addDefinition("phel\core", '*compile-mode*', true);
+        Registry::getInstance()->addDefinition("phel\core", BuildConstants::BUILD_MODE, true);
         $result = $this->compilerFacade->compile($phelCode, $options);
-        Registry::getInstance()->addDefinition("phel\core", '*compile-mode*', false);
+        Registry::getInstance()->addDefinition("phel\core", BuildConstants::BUILD_MODE, false);
 
         $this->fileIo->putContents($dest, "<?php\n" . $result->getPhpCode());
         $this->fileIo->putContents(str_replace('.php', '.phel', $dest), $phelCode);

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -28,8 +28,10 @@ final class FileCompiler implements FileCompilerInterface
             ->setSource($src)
             ->setIsEnabledSourceMaps($enableSourceMaps);
 
+        Registry::getInstance()->addDefinition("phel\core", BuildConstants::COMPILE_MODE, true);
         Registry::getInstance()->addDefinition("phel\core", BuildConstants::BUILD_MODE, true);
         $result = $this->compilerFacade->compile($phelCode, $options);
+        Registry::getInstance()->addDefinition("phel\core", BuildConstants::COMPILE_MODE, false);
         Registry::getInstance()->addDefinition("phel\core", BuildConstants::BUILD_MODE, false);
 
         $this->fileIo->putContents($dest, "<?php\n" . $result->getPhpCode());

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Compile;
 
-use Phel\Build\BuildConstants;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Lang\Registry;
+use Phel\Shared\BuildConstants;
 
 final class FileCompiler implements FileCompilerInterface
 {

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\Environment;
 
+use Phel\Build\BuildConstants;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
@@ -195,7 +196,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     private function addInternalCompileModeDefinition(): void
     {
-        $symbol = Symbol::create('*compile-mode*');
+        $symbol = Symbol::create(BuildConstants::BUILD_MODE);
         $meta = TypeFactory::getInstance()->persistentMapFromKVs(
             Keyword::create('doc'),
             'Set to true when a file is compiled, false otherwise.',

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -44,6 +44,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function __construct()
     {
+        $this->addInternalCompileModeDefinition();
         $this->addInternalBuildModeDefinition();
     }
 
@@ -190,6 +191,20 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         $this->interfaces[$namespace][$name->getName()] = $name;
+    }
+
+    /**
+     * @deprecated remove when `BuildConstants::COMPILE_MODE` is also removed
+     */
+    private function addInternalCompileModeDefinition(): void
+    {
+        $symbol = Symbol::create(BuildConstants::COMPILE_MODE);
+        $meta = TypeFactory::getInstance()->persistentMapFromKVs(
+            Keyword::create('doc'),
+            'Deprecated! Use *build-mode* instead. Set to true when a file is compiled, false otherwise.',
+        );
+        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol->getName(), false, $meta);
+        $this->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol);
     }
 
     private function addInternalBuildModeDefinition(): void

--- a/src/php/Shared/BuildConstants.php
+++ b/src/php/Shared/BuildConstants.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Build;
+namespace Phel\Shared;
 
 interface BuildConstants
 {

--- a/src/php/Shared/BuildConstants.php
+++ b/src/php/Shared/BuildConstants.php
@@ -6,5 +6,8 @@ namespace Phel\Shared;
 
 interface BuildConstants
 {
+    /** @deprecated Use BuildConstants::BUILD_MODE instead */
+    public const COMPILE_MODE = '*compile-mode*';
+
     public const BUILD_MODE = '*build-mode*';
 }

--- a/src/php/Shared/CompilerConstants.php
+++ b/src/php/Shared/CompilerConstants.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+interface CompilerConstants
+{
+    public const PHEL_CORE_NAMESPACE = 'phel\core';
+}

--- a/tests/php/Integration/Build/Command/src/hello.phel
+++ b/tests/php/Integration/Build/Command/src/hello.phel
@@ -6,5 +6,5 @@
 
 (println "This is printed")
 
-(when-not *compile-mode*
+(when-not *build-mode*
   (println "This is not printed"))

--- a/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
+++ b/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
@@ -198,7 +198,7 @@ final class PhelFnNormalizerTest extends TestCase
 
         $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
         $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
-            '*compile-mode*' => $symbol,
+            '*build-mode*' => $symbol,
         ]);
 
         $normalizer = new PhelFnNormalizer($phelFnLoader);
@@ -206,11 +206,11 @@ final class PhelFnNormalizerTest extends TestCase
 
         $expected = [
             PhelFunction::fromArray([
-                'fnName' => '*compile-mode*',
+                'fnName' => '*build-mode*',
                 'doc' => '',
                 'fnSignature' => '',
                 'desc' => '',
-                'groupKey' => 'compile-mode',
+                'groupKey' => 'build-mode',
             ]),
         ];
 


### PR DESCRIPTION
### 🤔 Background

We can use the form `*compile-mode*` to identify if we are during building mode (former "compilation").
We renamed the command from `phel compile` to `phel build`, so it would make sense to use `*build-mode*` 

### 💡 Goal

Deprecate `*compile-mode*` in favor of `*build-mode*`

### 🔖 Changes

- Create a constant for `BuildConstants::BUILD_MODE = '*build-mode*'`
- Moved constant from `GlobalEnvironment::PHEL_CORE_NAMESPACE` to `CompilerConstants::PHEL_CORE_NAMESPACE`
- Create a new dir `Shared` to store these new constants interfaces (`BuildConstants`, `CompilerConstants`)
