### PR TITLE
PhelConfig not accessible as array

### DIFF
--- a/src/php/Command/Domain/Finder/ComposerVendorDirectoriesFinder.php
+++ b/src/php/Command/Domain/Finder/ComposerVendorDirectoriesFinder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Command\Domain\Finder;
 
 use Phel\Command\CommandConfig;
-
 use Phel\Phel;
 
 use function dirname;

--- a/src/php/Config/PhelConfigException.php
+++ b/src/php/Config/PhelConfigException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+use Phel\Phel;
+use RuntimeException;
+
+final class PhelConfigException extends RuntimeException
+{
+    public static function wrongType(): self
+    {
+        return new self(
+            sprintf(
+                'The "%s" must return an array or a PhelConfig object',
+                Phel::PHEL_CONFIG_FILE_NAME,
+            ),
+        );
+    }
+}

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Command\Domain\DirectoryFinder;
 
 use Phel\Command\Domain\Finder\ComposerVendorDirectoriesFinder;
+use Phel\Config\PhelConfigException;
 use PHPUnit\Framework\TestCase;
 
 final class ComposerVendorDirectoriesFinderTest extends TestCase
 {
+    public function test_exception_when_wrong_type(): void
+    {
+        $this->expectExceptionObject(PhelConfigException::wrongType());
+
+        $finder = new ComposerVendorDirectoriesFinder(vendorDirectory: __DIR__ . '/wrong-testing-vendor');
+        $finder->findPhelSourceDirectories();
+    }
+
     public function test_find_phel_source_directories(): void
     {
         $finder = new ComposerVendorDirectoriesFinder(vendorDirectory: __DIR__ . '/testing-vendor');

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
@@ -11,9 +11,11 @@ final class ComposerVendorDirectoriesFinderTest extends TestCase
 {
     public function test_find_phel_source_directories(): void
     {
-        $finder = new ComposerVendorDirectoriesFinder(vendorDirectory: __DIR__.'/testing-vendor');
+        $finder = new ComposerVendorDirectoriesFinder(vendorDirectory: __DIR__ . '/testing-vendor');
         $dirs = $finder->findPhelSourceDirectories();
 
         self::assertCount(2, $dirs);
+        self::assertMatchesRegularExpression('#.*/testing-vendor/root-1/root-2/custom-src-2#', $dirs[0]);
+        self::assertMatchesRegularExpression('#.*/testing-vendor/root-1/root-3/custom-src-3#', $dirs[1]);
     }
 }

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/ComposerVendorDirectoriesFinderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Command\Domain\DirectoryFinder;
+
+use Phel\Command\Domain\Finder\ComposerVendorDirectoriesFinder;
+use PHPUnit\Framework\TestCase;
+
+final class ComposerVendorDirectoriesFinderTest extends TestCase
+{
+    public function test_find_phel_source_directories(): void
+    {
+        $finder = new ComposerVendorDirectoriesFinder(vendorDirectory: __DIR__.'/testing-vendor');
+        $dirs = $finder->findPhelSourceDirectories();
+
+        self::assertCount(2, $dirs);
+    }
+}

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/custom-src-2/hi.phel
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/custom-src-2/hi.phel
@@ -1,0 +1,1 @@
+(ns directory-finder\testing-vendor\root-2\hi)

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/phel-config.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/phel-config.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-use Phel\Config\PhelConfig;
+use Phel\Command\CommandConfig;
 
-return (new PhelConfig())
-    ->setSrcDirs(['custom-src-2']);
+return [
+    CommandConfig::SRC_DIRS => ['custom-src-2'],
+];

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/phel-config.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-2/phel-config.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Phel\Config\PhelConfig;
+
+return (new PhelConfig())
+    ->setSrcDirs(['custom-src-2']);

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/custom-src-3/hi.phel
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/custom-src-3/hi.phel
@@ -1,0 +1,1 @@
+(ns directory-finder\testing-vendor\root-3\hi)

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/phel-config.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/phel-config.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Phel\Config\PhelConfig;
+
+return (new PhelConfig())
+    ->setSrcDirs(['custom-src-3']);

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/wrong-testing-vendor/root-1/root-2/custom-src/hi.phel
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/wrong-testing-vendor/root-1/root-2/custom-src/hi.phel
@@ -1,0 +1,1 @@
+(ns directory-finder\wrong-testing-vendor\root-1\root-2\custom-src\hi)

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/wrong-testing-vendor/root-1/root-2/phel-config.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/wrong-testing-vendor/root-1/root-2/phel-config.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return new stdClass();


### PR DESCRIPTION
### 🤔 Background

After merging https://github.com/phel-lang/phel-lang/pull/572 I wanted to quickly try it with my [phel-snake](https://github.com/Chemaclass/phel-snake) project and I found this error:

<img width="1499" alt="Screenshot 2023-02-16 at 16 18 12" src="https://user-images.githubusercontent.com/5256287/219408913-dc57e292-74a3-450f-9ca9-8c6a858d5bab.png">

>**Note**: My bad, I forgot to add tests for this class, so this was a great opportunity to add some 💡 

### 💡 Goal

Fix the bug 🐛 `Error : Cannot use object of type Phel\Config\PhelConfig as array`

### 🔖 Changes

- When doing the "require file" check if it's an array or a PhelConfig object before trying to access to the `SRC_DIRS `
  - This way we keep total compatibility for both options, you can use the array version or the object version
