### PR TITLE
Enable gacela cache by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea/
 .phpbench/
 .vscode/
-.gacela/
 data/
 out/
 PhelGenerated/
@@ -14,5 +13,5 @@ vendor/
 .phel-repl-history
 local.phel
 phel-config-local.php
-gacela.php
+gacela*.php
 src/php/Api/Infrastructure/phel/doc.phel

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .phpbench/
 .vscode/
+.gacela/
 data/
 out/
 PhelGenerated/
@@ -13,4 +14,5 @@ vendor/
 .phel-repl-history
 local.phel
 phel-config-local.php
+gacela.php
 src/php/Api/Infrastructure/phel/doc.phel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Deprecate `*compile-mode*` in favor of `*build-mode*` (#570)
 * Added `--testdox` argument to `phel test` command (#567)
 * Added support for fluid configuration in `phel-config.php` (#494)
+* Enable gacela cache filesystem by default (#576)
 
 ## 0.9.0 (2023-02-05)
 

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -43,6 +43,7 @@ final class Phel
     {
         return static function (GacelaConfig $config): void {
             $config->addAppConfig(self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME);
+            $config->setFileCacheEnabled(true);
         };
     }
 

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -44,6 +44,7 @@ final class Phel
         return static function (GacelaConfig $config): void {
             $config->addAppConfig(self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME);
             $config->setFileCacheEnabled(true);
+            $config->setFileCacheDirectory('data/.cache');
         };
     }
 


### PR DESCRIPTION
### 🤔 Background

Gacela has a [file cache system](https://gacela-project.com/docs/bootstrap/#gacela-file-cache) with the resolved class names for the internal php modules, and by enabling we can get some performance optimisations. 

The final user wont notice anything, as they should have the `*.cache` pattern in their `.gitignore` file.

This can be easily disabled, anyway, in any project using gacela by defining in their config key values the `'gacela-cache-enabled'` as `false`; you can find it in `Gacela\Framework\ClassResolver\Cache\GacelaFileCache::KEY_ENABLED`.

```php
# whenever you have define your app config files; eg `phel-config.php` or `phel-config-local.php`
return [
    # Using the raw string-key
    'gacela-cache-enabled' => false,

    # Or using the constant
    \Gacela\Framework\ClassResolver\Cache\GacelaFileCache::KEY_ENABLED => false,
];
```

### 🔖 Changes

- Enable gacela cache file system

### 🖼️ Screenshots


This is an example of how the gacela cache files are generated, so it is not necessary to compute this mapping all the time.

<img width="1527" alt="Screenshot 2023-02-19 at 12 55 27" src="https://user-images.githubusercontent.com/5256287/219946310-5cf2a39a-8a35-4c0e-b8fb-c67c44c4da33.png">

We have benchmark tests to verify the performance improvement. 
See the without and with file cache enabled benchmark tests in [gacela's actions](https://github.com/gacela-project/gacela/actions/runs/4217718193/jobs/7321705420):

<img width="825" alt="Screenshot 2023-02-20 at 10 29 30" src="https://user-images.githubusercontent.com/5256287/220066615-044406ac-0ad0-4f33-8dfb-f87b2b3516c2.png">


