### PR TITLE
Fix apush, aset and aunset for global php arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Added `--testdox` argument to `phel test` command (#567)
 * Added support for fluid configuration in `phel-config.php` (#494)
 * Enable gacela cache filesystem by default (#576)
+* Fix `php/apush`, `php/aset` and `php/aunset` for global php arrays (#579)
 
 ## 0.9.0 (2023-02-05)
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/GlobalVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/GlobalVarNode.php
@@ -41,4 +41,9 @@ final class GlobalVarNode extends AbstractNode
     {
         return $this->meta[Keyword::create('macro')] === true;
     }
+
+    public function useReference(): bool
+    {
+        return $this->getEnv()->useGlobalReference();
+    }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -16,6 +16,9 @@ final class NodeEnvironment implements NodeEnvironmentInterface
     /** Def inside of def should not work. This flag help us to keep track of this. */
     private bool $defAllowed = true;
 
+    /** Use Registery::getDefinitionReference() instead of Registry::getDefinition() */
+    private bool $globalReference = false;
+
     /**
      * @param array<int, Symbol> $locals A list of local symbols
      * @param string $context The current context (Expression, Statement or Return)
@@ -126,6 +129,14 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         return $result;
     }
 
+    public function withUseGlobalReference(bool $useGlobalReference): NodeEnvironmentInterface
+    {
+        $result = clone $this;
+        $result->globalReference = $useGlobalReference;
+
+        return $result;
+    }
+
     public function withAddedRecurFrame(RecurFrame $frame): NodeEnvironmentInterface
     {
         $result = clone $this;
@@ -175,5 +186,10 @@ final class NodeEnvironment implements NodeEnvironmentInterface
     public function isDefAllowed(): bool
     {
         return $this->defAllowed;
+    }
+
+    public function useGlobalReference(): bool
+    {
+        return $this->globalReference;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
@@ -50,6 +50,8 @@ interface NodeEnvironmentInterface
 
     public function withContext(string $context): self;
 
+    public function withUseGlobalReference(bool $useGlobalReference): self;
+
     public function withAddedRecurFrame(RecurFrame $frame): self;
 
     public function withDisallowRecurFrame(): self;
@@ -63,4 +65,6 @@ interface NodeEnvironmentInterface
     public function getBoundTo(): string;
 
     public function isDefAllowed(): bool;
+
+    public function useGlobalReference(): bool;
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAPushSymbol.php
@@ -17,7 +17,7 @@ final class PhpAPushSymbol implements SpecialFormAnalyzerInterface
     {
         return new PhpArrayPushNode(
             $env,
-            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withUseGlobalReference(true)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $list->getStartLocation(),
         );

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpASetSymbol.php
@@ -17,7 +17,7 @@ final class PhpASetSymbol implements SpecialFormAnalyzerInterface
     {
         return new PhpArraySetNode(
             $env,
-            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withUseGlobalReference(true)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $this->analyzer->analyze($list->get(3), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $list->getStartLocation(),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpAUnsetSymbol.php
@@ -22,7 +22,7 @@ final class PhpAUnsetSymbol implements SpecialFormAnalyzerInterface
 
         return new PhpArrayUnsetNode(
             $env,
-            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($list->get(1), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withUseGlobalReference(true)),
             $this->analyzer->analyze($list->get(2), $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $list->getStartLocation(),
         );

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/GlobalVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/GlobalVarEmitter.php
@@ -19,7 +19,11 @@ final class GlobalVarEmitter implements NodeEmitterInterface
         assert($node instanceof GlobalVarNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\\Phel\\Lang\\Registry::getInstance()->getDefinition("');
+        if ($node->useReference()) {
+            $this->outputEmitter->emitStr('\\Phel\\Lang\\Registry::getInstance()->getDefinitionReference("');
+        } else {
+            $this->outputEmitter->emitStr('\\Phel\\Lang\\Registry::getInstance()->getDefinition("');
+        }
         $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeNs($node->getNamespace())));
         $this->outputEmitter->emitStr('", "');
         $this->outputEmitter->emitStr(addslashes($node->getName()->getName()));

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpArrayPushEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpArrayPushEmitter.php
@@ -19,10 +19,11 @@ final class PhpArrayPushEmitter implements NodeEmitterInterface
         assert($node instanceof PhpArrayPushNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('array_push(', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getArrayExpr());
-        $this->outputEmitter->emitStr(')[] = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getValueExpr());
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpArrayPushEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpArrayPushEmitter.php
@@ -19,11 +19,10 @@ final class PhpArrayPushEmitter implements NodeEmitterInterface
         assert($node instanceof PhpArrayPushNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('array_push(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getArrayExpr());
-        $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(')[] = ', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getValueExpr());
-        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -6,6 +6,8 @@ namespace Phel\Lang;
 
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 
+use RuntimeException;
+
 use function array_key_exists;
 
 final class Registry
@@ -61,7 +63,7 @@ final class Registry
             return $value;
         }
 
-        return null;
+        throw new RuntimeException('Only variables can be returned by reference');
     }
 
     public function getDefinitionMetaData(string $ns, string $name): ?PersistentMapInterface

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -54,6 +54,16 @@ final class Registry
         return $this->definitions[$ns][$name] ?? null;
     }
 
+    public function &getDefinitionReference(string $ns, string $name): mixed
+    {
+        if (isset($this->definitions[$ns][$name])) {
+            $value = &$this->definitions[$ns][$name];
+            return $value;
+        }
+
+        return null;
+    }
+
     public function getDefinitionMetaData(string $ns, string $name): ?PersistentMapInterface
     {
         if (array_key_exists($ns, $this->definitions) && array_key_exists($name, $this->definitions[$ns])) {

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -158,6 +158,7 @@ final class ReplCommand extends Command
 
         ++$this->lineNumber;
 
+        /** @psalm-suppress RedundantCondition */
         if ($input === null && $isInitialInput) {
             // Ctrl+D will exit the repl
             $this->inputBuffer[] = self::EXIT_REPL;

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -7,11 +7,23 @@
   (is (= 3 (peek (php/array 1 2 3))) "peek on php array")
   (is (nil? (peek (php/array))) "peek on empty php array"))
 
-(def- test-global-array (php/array 1 2 3))
+(def- test-set-global-array (php/array 1 2 3))
+
+(deftest test-native-global-array-set
+  (php/aset test-set-global-array 0 4)
+  (is (= (php/array 4 2 3) test-set-global-array) "native global set on PHP array"))
+
+(def- test-unset-global-array (php/array 1 2 3))
+
+(deftest test-native-global-array-unset
+  (php/aunset test-unset-global-array 2)
+  (is (= (php/array 1 2) test-unset-global-array) "native global unset on PHP array"))
+
+(def- test-push-global-array (php/array 1 2 3))
 
 (deftest test-native-global-array-push
-  (php/apush test-global-array 4)
-  (is (= (php/array 1 2 3 4) test-global-array) "native global push on PHP array"))
+  (php/apush test-push-global-array 4)
+  (is (= (php/array 1 2 3 4) test-push-global-array) "native global push on PHP array"))
 
 (deftest test-push
   (let [x (php/array)]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -7,6 +7,12 @@
   (is (= 3 (peek (php/array 1 2 3))) "peek on php array")
   (is (nil? (peek (php/array))) "peek on empty php array"))
 
+(def- test-global-array (php/array 1 2 3))
+
+(deftest test-native-global-array-push
+  (php/apush test-global-array 4)
+  (is (= (php/array 1 2 3 4) test-global-array) "native global push on PHP array"))
+
 (deftest test-push
   (let [x (php/array)]
     (php/apush x 1)

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -7,23 +7,23 @@
   (is (= 3 (peek (php/array 1 2 3))) "peek on php array")
   (is (nil? (peek (php/array))) "peek on empty php array"))
 
-(def- test-set-global-array (php/array 1 2 3))
+(def- testing-set-global-array (php/array 1 2 3))
 
 (deftest test-native-global-array-set
-  (php/aset test-set-global-array 0 4)
-  (is (= (php/array 4 2 3) test-set-global-array) "native global set on PHP array"))
+  (php/aset testing-set-global-array 0 4)
+  (is (= (php/array 4 2 3) testing-set-global-array) "native global set on PHP array"))
 
-(def- test-unset-global-array (php/array 1 2 3))
+(def- testing-unset-global-array (php/array 1 2 3))
 
 (deftest test-native-global-array-unset
-  (php/aunset test-unset-global-array 2)
-  (is (= (php/array 1 2) test-unset-global-array) "native global unset on PHP array"))
+  (php/aunset testing-unset-global-array 2)
+  (is (= (php/array 1 2) testing-unset-global-array) "native global unset on PHP array"))
 
-(def- test-push-global-array (php/array 1 2 3))
+(def- testing-push-global-array (php/array 1 2 3))
 
 (deftest test-native-global-array-push
-  (php/apush test-push-global-array 4)
-  (is (= (php/array 1 2 3 4) test-push-global-array) "native global push on PHP array"))
+  (php/apush testing-push-global-array 4)
+  (is (= (php/array 1 2 3 4) testing-push-global-array) "native global push on PHP array"))
 
 (deftest test-push
   (let [x (php/array)]

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -1,0 +1,22 @@
+--PHEL--
+(def arr (php/array 1 2 3))
+(php/apush arr 4)
+--PHP--
+\Phel\Lang\Registry::getInstance()->addDefinition(
+  "user",
+  "arr",
+  array(1, 2, 3),
+  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
+      \Phel\Lang\Keyword::create("line"), 1,
+      \Phel\Lang\Keyword::create("column"), 0
+    ),
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
+      \Phel\Lang\Keyword::create("line"), 1,
+      \Phel\Lang\Keyword::create("column"), 27
+    )
+  )
+);
+array_push(\Phel\Lang\Registry::getInstance()->getDefinitionReference("user", "arr"), 4);

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -19,4 +19,4 @@
     )
   )
 );
-array_push(\Phel\Lang\Registry::getInstance()->getDefinitionReference("user", "arr"), 4);
+(\Phel\Lang\Registry::getInstance()->getDefinitionReference("user", "arr"))[] = 4;

--- a/tests/php/Integration/Fixtures/Call/php-push.test
+++ b/tests/php/Integration/Fixtures/Call/php-push.test
@@ -3,4 +3,4 @@
   (php/apush arr 4))
 --PHP--
 $arr_1 = array(1, 2, 3);
-array_push($arr_1, 4);
+($arr_1)[] = 4;

--- a/tests/php/Integration/Fixtures/Call/php-push.test
+++ b/tests/php/Integration/Fixtures/Call/php-push.test
@@ -3,4 +3,4 @@
   (php/apush arr 4))
 --PHP--
 $arr_1 = array(1, 2, 3);
-($arr_1)[] = 4;
+array_push($arr_1, 4);

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Phel\Lang\Registry;
+use PHPUnit\Framework\TestCase;
+
+final class RegistryTest extends TestCase
+{
+    private Registry $registry;
+
+    public static function tearDownAfterClass(): void
+    {
+        Registry::getInstance()->clear();
+    }
+
+    protected function setUp(): void
+    {
+        $this->registry = Registry::getInstance();
+        $this->registry->clear();
+    }
+
+    public function test_null_when_non_existing_definition_by_value(): void
+    {
+        $actual = $this->registry->getDefinition('ns', 'non-existing');
+
+        self::assertNull($actual);
+    }
+
+    public function test_value_definition(): void
+    {
+        $this->registry->addDefinition('ns', 'array', [1, 2, 3]);
+        $this->registry->getDefinition('ns', 'array')[] = 4;
+        $a = $this->registry->getDefinition('ns', 'array');
+
+        self::assertSame([1, 2, 3], $a);
+    }
+
+    public function test_error_when_non_existing_definition_by_reference(): void
+    {
+        $this->expectExceptionMessage('Only variables can be returned by reference');
+
+        $this->registry->getDefinitionReference('ns', 'non-existing');
+    }
+
+    public function test_reference_definition(): void
+    {
+        $this->registry->addDefinition('ns', 'array', [1, 2, 3]);
+        $this->registry->getDefinitionReference('ns', 'array')[] = 4;
+        $b = $this->registry->getDefinition('ns', 'array');
+
+        self::assertSame([1, 2, 3, 4], $b);
+    }
+}

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -33,9 +33,9 @@ final class RegistryTest extends TestCase
     {
         $this->registry->addDefinition('ns', 'array', [1, 2, 3]);
         $this->registry->getDefinition('ns', 'array')[] = 4;
-        $a = $this->registry->getDefinition('ns', 'array');
+        $actual = $this->registry->getDefinition('ns', 'array');
 
-        self::assertSame([1, 2, 3], $a);
+        self::assertSame([1, 2, 3], $actual);
     }
 
     public function test_error_when_non_existing_definition_by_reference(): void
@@ -49,8 +49,8 @@ final class RegistryTest extends TestCase
     {
         $this->registry->addDefinition('ns', 'array', [1, 2, 3]);
         $this->registry->getDefinitionReference('ns', 'array')[] = 4;
-        $b = $this->registry->getDefinition('ns', 'array');
+        $actual = $this->registry->getDefinition('ns', 'array');
 
-        self::assertSame([1, 2, 3, 4], $b);
+        self::assertSame([1, 2, 3, 4], $actual);
     }
 }


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/578

### 💡 Goal

Fix `php/push`, `php/aset` and `php/aunset` on native php arrays when using global definitions.

### 🔖 Changes

- Allowing using `getDefinitionReference()` that will be used when dealing with native php arrays