### PR TITLE
Use all ns by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "gacela-project/gacela": "^1.1",
+        "gacela-project/gacela": "^1.3",
         "phpunit/php-timer": "^5.0",
         "symfony/console": "^6.0"
     },

--- a/src/php/Api/ApiConfig.php
+++ b/src/php/Api/ApiConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ApiConfig extends AbstractConfig
+{
+    /**
+     * @return list<string>
+     */
+    public function allNamespaces(): array
+    {
+        return [
+            'phel\\core',
+            'phel\\repl',
+            'phel\\http',
+            'phel\\html',
+            'phel\\test',
+            'phel\\json',
+        ];
+    }
+}

--- a/src/php/Api/ApiFacadeInterface.php
+++ b/src/php/Api/ApiFacadeInterface.php
@@ -11,7 +11,7 @@ interface ApiFacadeInterface
     /**
      * Get all public phel functions in the namespaces.
      *
-     * @param list<string> $namespaces
+     * @param list<string> $namespaces If empty then it will get all
      *
      * @return list<PhelFunction>
      */

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -10,12 +10,16 @@ use Phel\Api\Domain\PhelFnNormalizerInterface;
 use Phel\Api\Infrastructure\PhelFnLoader;
 use Phel\Api\Infrastructure\PhelFnLoaderInterface;
 
+/**
+ * @method ApiConfig getConfig()
+ */
 final class ApiFactory extends AbstractFactory
 {
     public function createPhelFnNormalizer(): PhelFnNormalizerInterface
     {
         return new PhelFnNormalizer(
             $this->createPhelFnLoader(),
+            $this->getConfig()->allNamespaces(),
         );
     }
 

--- a/src/php/Api/Domain/PhelFnNormalizer.php
+++ b/src/php/Api/Domain/PhelFnNormalizer.php
@@ -12,6 +12,7 @@ final class PhelFnNormalizer implements PhelFnNormalizerInterface
 {
     public function __construct(
         private PhelFnLoaderInterface $phelFnLoader,
+        private array $allNamespaces = [],
     ) {
     }
 
@@ -22,6 +23,10 @@ final class PhelFnNormalizer implements PhelFnNormalizerInterface
      */
     public function getPhelFunctions(array $namespaces = []): array
     {
+        if ($namespaces === []) {
+            $namespaces = $this->allNamespaces;
+        }
+
         $normalizedData = $this->phelFnLoader->getNormalizedPhelFunctions($namespaces);
 
         $result = [];

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -43,8 +43,7 @@ final class Phel
     {
         return static function (GacelaConfig $config): void {
             $config->addAppConfig(self::PHEL_CONFIG_FILE_NAME, self::PHEL_CONFIG_LOCAL_FILE_NAME);
-            $config->setFileCacheEnabled(true);
-            $config->setFileCacheDirectory('data/.cache');
+            $config->setFileCache(true, 'data/.cache');
         };
     }
 

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -21,7 +21,7 @@ final class ApiFacadeTest extends TestCase
         // it crashes when it tries to load all phel funcs again. See: `PhelFnLoader::loadAllPhelFunctions()`
         $this->markTestSkipped('Useful to debug the facade, but useless to keep it in the CI');
 
-        Gacela::bootstrap(__DIR__, GacelaConfig::withPhpConfigDefault());
+        Gacela::bootstrap(__DIR__, GacelaConfig::defaultPhpConfig());
 
         Registry::getInstance()->clear();
         Symbol::resetGen();


### PR DESCRIPTION
### 🤔 Background

Currently, you have to pass a list with all namespaces which you are interested on knowing the functions via the Api.

### 🔖 Changes

Move the responsibility to the Api itself to retrieve all namespaces in case you don't specify anyone.
