### PR TITLE
Minor clean up for DocCommand

### DIFF
--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -35,7 +35,7 @@ final class DocCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Specify which namespaces to load.',
-                ['phel\\core', 'phel\\http', 'phel\\html', 'phel\\test', 'phel\\json'],
+                [],
             );
     }
 


### PR DESCRIPTION
### 🔖 Changes

Remove unnecessary array from `DocCommand`, because if `getPhelFunctions()` receive an empty list of ns then it will search for all of them. 

<img width="1074" alt="Screenshot 2023-05-27 at 15 52 44" src="https://github.com/phel-lang/phel-lang/assets/5256287/91a69cf9-7694-40ef-b8db-e23a017b24d6">
