### PR TITLE
Move githooks to /.github/git-hooks + run when composer install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 /adrs                   export-ignore
 /docker                 export-ignore
 /tests                  export-ignore
-/tools                  export-ignore
 /.editorconfig          export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,4 +126,4 @@ composer test-all      # csrun, psalm, compiler & core tests after each other
 
 ### Git Hooks
 
-Enable the git hooks with `./tools/git-hooks/init.sh`
+Enable the git hooks with `./.github/git-hooks/init.sh`

--- a/.github/git-hooks/init.sh
+++ b/.github/git-hooks/init.sh
@@ -5,7 +5,7 @@ set -e
 function setup_git_hooks()
 {
   echo "Initialising git hooks..."
-  ln -sf "$PWD/tools/git-hooks/pre-commit.sh" "$PWD/.git/hooks/pre-commit"
+  ln -sf "$PWD/.github/git-hooks/pre-commit.sh" "$PWD/.git/hooks/pre-commit"
   chmod +x "$PWD/.git/hooks/pre-commit"
   echo "Done"
 }

--- a/.github/git-hooks/pre-commit.sh
+++ b/.github/git-hooks/pre-commit.sh
@@ -3,4 +3,3 @@
 set -e
 
 composer test-all
-

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         }
     },
     "scripts": {
+        "post-install-cmd": ".github/git-hooks/init.sh",
         "test-all": [
             "@static-clear-cache",
             "@test-quality",


### PR DESCRIPTION
## 📚 Description
- Move the `tools` dir to `.github`
- Delete `tools` folder
- Add `post-install-cmd` script to install git hooks when updating dependencies