### PR TITLE
Do not create the entrypoint when namespace isn't set

### DIFF
--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -35,6 +35,7 @@ final class BuildFactory extends AbstractFactory
             $this->getCommandFacade(),
             $this->createMainPhpEntryPointFile(),
             $this->getConfig()->getPathsToIgnore(),
+            $this->getConfig()->getPhelOutConfig()->shouldCreateEntryPointPhpFile(),
         );
     }
 

--- a/src/php/Build/Domain/Compile/ProjectCompiler.php
+++ b/src/php/Build/Domain/Compile/ProjectCompiler.php
@@ -27,6 +27,7 @@ final class ProjectCompiler
         private CommandFacadeInterface $commandFacade,
         private EntryPointPhpFileInterface $entryPointPhpFile,
         private array $pathsToIgnore,
+        private bool $shouldCreateEntryPointPhpFile,
     ) {
     }
 
@@ -81,7 +82,9 @@ final class ProjectCompiler
             touch($targetFile, filemtime($info->getFile()));
         }
 
-        $this->entryPointPhpFile->createFile();
+        if ($this->shouldCreateEntryPointPhpFile) {
+            $this->entryPointPhpFile->createFile();
+        }
 
         return $result;
     }

--- a/src/php/Config/PhelOutConfig.php
+++ b/src/php/Config/PhelOutConfig.php
@@ -66,6 +66,11 @@ final class PhelOutConfig implements JsonSerializable
         return $this;
     }
 
+    public function shouldCreateEntryPointPhpFile(): bool
+    {
+        return (bool) $this->getMainPhelNamespace();
+    }
+
     public function jsonSerialize(): array
     {
         return [

--- a/tests/php/Integration/Build/Command/config/phel-config-no-namespace.php
+++ b/tests/php/Integration/Build/Command/config/phel-config-no-namespace.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Phel\Config\PhelOutConfig;
+
+return (new \Phel\Config\PhelConfig())
+    ->setSrcDirs(['../../../../../src/phel/', 'src'])
+    ->setVendorDir('')
+    ->setOut((new PhelOutConfig())
+        ->setDestDir('out'))
+    ->setIgnoreWhenBuilding(['local.phel', 'failing.phel'])
+;


### PR DESCRIPTION
### 🤔 Background

Fixes #613.

### 💡 Goal

Skip the PHP entrypoint creation when the Phel namespace isn't configured.

### 🔖 Changes

- Add a boolean attribute to `ProjectCompiler` that controls if the entrypoint will be created.
- Add a method in `PhelOutConfig` to determine whether the entrypoint should be created or not.
- Add the corresponding integration test
