### PR TITLE
Fix AtomParser decimal regex

### DIFF
--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -22,7 +22,7 @@ final class AtomParser
     private const REGEX_BINARY_NUMBER = '/^([+-])?0[bB][01]+(_[01]+)*$/';
     private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX][0-9a-fA-F]+(_[0-9a-fA-F]+)*$/';
     private const REGEX_OCTAL_NUMBER = '/^([+-])?0[0-7]+(_[0-7]+)*$/';
-    private const REGEX_DECIMAL_NUMBER = '/^([+-])?[0-9]+(_[0-9]+)*[\.(_[0-9]+]?|0$/';
+    private const REGEX_DECIMAL_NUMBER = '/^(?:([+-])?[0-9]+(_[0-9]+)*[\.(_[0-9]+]?|0)$/';
 
     public function __construct(private GlobalEnvironmentInterface $globalEnvironment)
     {

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -253,4 +253,25 @@ final class AtomParserTest extends TestCase
             ),
         );
     }
+
+    /**
+     * Regression test for https://github.com/phel-lang/phel-lang/issues/616
+     */
+    public function test_parse_symbol_ending_in_zero(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 2);
+        $this->assertEquals(
+            new SymbolNode(
+                'x0',
+                $start,
+                $end,
+                Symbol::create('x0'),
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, 'x0', $start, $end),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Previously, symbols ending in zero were being parsed as numbers.

### 🤔 Background

Fixes: #616

### 💡 Goal

Fix a bug in the AtomParser were symbols ending in zero would be parsed as a decimal number.

It was happening because the decimal regex was structured as `^A|B$`, and that reads as:  
"(The beginning of a line followed by A) OR (B followed by a line end)"

Looks like the original intent was `^(A|B)$`, as in:
"The beginning of a line followed by (A OR B) followed by a line end"


### 🔖 Changes

- Fix decimal regex in AtomParser by wrapping the `OR` condition in a non-capturing group `(?: )`
- Add a regression test
