### PR TITLE
Copy config after install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,9 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "tools/git-hooks/init.sh",
+            "tools/git-hooks/init.sh"
+        ],
+        "post-package-install": [
             "tools/cp-phel-config.sh"
         ],
         "test-all": [

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
         }
     },
     "scripts": {
-        "post-install-cmd": "tools/git-hooks/init.sh",
+        "post-install-cmd": [
+            "tools/git-hooks/init.sh",
+            "tools/cp-phel-config.sh"
+        ],
         "test-all": [
             "@static-clear-cache",
             "@test-quality",

--- a/tools/cp-phel-config.sh
+++ b/tools/cp-phel-config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+current_dir="$(cd "$(dirname "$0")" && pwd)"
+vendor_dir="$current_dir/../vendor"
+phel_vendor_dir="$vendor_dir/phel-lang/phel-lang"
+
+cp "$phel_vendor_dir/phel-config.php" $current_dir

--- a/tools/cp-phel-config.sh
+++ b/tools/cp-phel-config.sh
@@ -3,5 +3,8 @@
 current_dir="$(cd "$(dirname "$0")" && pwd)"
 vendor_dir="$current_dir/../vendor"
 phel_vendor_dir="$vendor_dir/phel-lang/phel-lang"
+phel_config_path="$phel_vendor_dir/phel-config.php"
 
-cp "$phel_vendor_dir/phel-config.php" $current_dir
+if [[ -e "$phel_config_path" ]]; then
+    cp "$phel_config_path" "$current_dir"
+fi

--- a/tools/cp-phel-config.sh
+++ b/tools/cp-phel-config.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+echo "Copying phel-config..."
+
 current_dir="$(cd "$(dirname "$0")" && pwd)"
-vendor_dir="$current_dir/../vendor"
-phel_vendor_dir="$vendor_dir/phel-lang/phel-lang"
-phel_config_path="$phel_vendor_dir/phel-config.php"
+phel_config_path="$current_dir/../phel-config.php"
 
 if [[ -e "$phel_config_path" ]]; then
-    cp "$phel_config_path" "$current_dir"
+    cp "$phel_config_path" .
 fi
+
+echo "Done"


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/593

### 💡 Goal

The goal is to copy automatically the phel-config.php from phel-lang to the project where it's been required.
However, I am not sure if this is possible like this, because I think the `post-package-install` (as well as other [composer events](https://getcomposer.org/doc/articles/scripts.md#event-names)) are linked to the project itself, and not projects requiring other projects.

