### PR TITLE
Define a custom registerDeprecatedHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Fix do not create the entrypoint when namespace isn't set
 * Fix AtomParser decimal regex
+* Improve deprecated notes output
 
 ## 0.11.0 (2023-08-26)
 


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/614

### 💡 Goal

Improve the dev experience when seen deprecated notes.

### 🔖 Changes

Define a custom register handler for deprecated notes. This will render a similar output as the current "notices" in the terminal + add a new entry to the `error.log`.

### 🖼️  Screenshots

#### BEFORE

![Screenshot 2023-10-21 at 18 49 47](https://github.com/phel-lang/phel-lang/assets/5256287/da379837-cd23-43ee-9cd4-4b3a92a426a4)


#### AFTER

![Screenshot 2023-10-21 at 18 48 54](https://github.com/phel-lang/phel-lang/assets/5256287/97bdc07a-1576-400c-8954-529ba41c0f1f)

