### PR TITLE
Fix `phel repl` when not in the phel directory

### DIFF
--- a/src/php/Build/Domain/Compile/DependenciesForNamespace.php
+++ b/src/php/Build/Domain/Compile/DependenciesForNamespace.php
@@ -7,7 +7,7 @@ namespace Phel\Build\Domain\Compile;
 use Phel\Build\Domain\Extractor\NamespaceExtractor;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 
-use function count;
+use function array_key_exists;
 use function in_array;
 
 final class DependenciesForNamespace
@@ -33,13 +33,17 @@ final class DependenciesForNamespace
         }
 
         $requiredNamespaces = [];
-        while (count($queue) > 0) {
+        while ($queue !== []) {
             $currentNs = array_shift($queue);
-            if (!isset($requiredNamespaces[$currentNs])) {
-                foreach ($index[$currentNs]->getDependencies() as $depNs) {
-                    $queue[] = $depNs;
+
+            if (array_key_exists($currentNs, $requiredNamespaces) === false) {
+                if (array_key_exists($currentNs, $index)) {
+                    foreach ($index[$currentNs]->getDependencies() as $depNs) {
+                        $queue[] = $depNs;
+                    }
                 }
             }
+
             $requiredNamespaces[$currentNs] = true;
         }
 

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -27,7 +27,7 @@ final class CommandConfig extends AbstractConfig
         $out = $this->get(self::OUTPUT, []);
 
         return new CodeDirectories(
-            (array)$this->get(self::SRC_DIRS, self::DEFAULT_SRC_DIRS),
+            array_merge([__DIR__ . '/../../'], (array)$this->get(self::SRC_DIRS, self::DEFAULT_SRC_DIRS)),
             (array)$this->get(self::TEST_DIRS, self::DEFAULT_TEST_DIRS),
             (string)($out[PhelOutConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
         );

--- a/src/php/Command/Domain/Finder/DirectoryFinder.php
+++ b/src/php/Command/Domain/Finder/DirectoryFinder.php
@@ -50,7 +50,11 @@ final class DirectoryFinder implements DirectoryFinderInterface
     private function toAbsoluteDirectories(array $relativeDirectories): array
     {
         return array_map(
-            fn (string $dir): string => $this->applicationRootDir . '/' . $dir,
+            function (string $dir): string {
+                return realpath($dir) !== false
+                    ? $dir
+                    : $this->applicationRootDir . '/' . $dir;
+            },
             $relativeDirectories,
         );
     }

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -23,7 +23,7 @@ final class NamespaceCollector
     public function getDependenciesFromPaths(array $paths): array
     {
         $namespaces = $this->getNamespacesFromPaths($paths);
-        if (empty($namespaces)) {
+        if ($namespaces === []) {
             throw CannotFindAnyTestsException::inPaths($paths);
         }
         $namespaces[] = 'phel\\test';

--- a/tests/php/Integration/Build/Command/config/phel-config-no-namespace.php
+++ b/tests/php/Integration/Build/Command/config/phel-config-no-namespace.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Phel\Config\PhelOutConfig;
 
 return (new \Phel\Config\PhelConfig())
-    ->setSrcDirs(['../../../../../src/phel/', 'src'])
+    ->setSrcDirs([__DIR__ . '/../'])
     ->setVendorDir('')
     ->setOut((new PhelOutConfig())
         ->setDestDir('out'))

--- a/tests/php/Integration/Build/Command/config/phel-config.php
+++ b/tests/php/Integration/Build/Command/config/phel-config.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Phel\Config\PhelOutConfig;
 
 return (new \Phel\Config\PhelConfig())
-    ->setSrcDirs(['../../../../../src/phel/', 'src'])
+    ->setSrcDirs([__DIR__ . '/../'])
     ->setVendorDir('')
     ->setOut((new PhelOutConfig())
         ->setDestDir('out')

--- a/tests/php/Integration/Interop/Command/Export/config/phel-config.php
+++ b/tests/php/Integration/Interop/Command/Export/config/phel-config.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 return [
     'src-dirs' => [
-        '../../../../../../src/phel/',
-        'src',
+        __DIR__ . '/../',
     ],
     'test-dirs' => [],
     'vendor-dir' => '',


### PR DESCRIPTION
How to reproduce the issue:

1. `mkdir -p ~/Code/phel-lang`
2. `cd ~/Code/phel-lang`
3. `git clone https://github.com/phel-lang/phel-lang`
4. `cd phel-lang`
5. `composer install`
6. `cd ..`
7. `./phel-lang/bin/phel`

I believe that the REPL should work from any directory, not only from the source directory.

This PR is a WIP since I've been trying to find for a solution... but couldn't find anything working yet. 

### 🤔 Background

<!-- Provide some context to the reviewer before going to any code. -->

### 💡 Goal

<!-- The goal of this PR. -->

### 🔖 Changes

<!-- List individual changes in more detail as you might consider them important. -->
