### PR TITLE
Increase Psalm level 1

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="2"
+    errorLevel="1"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -28,6 +28,19 @@
         <ArgumentTypeCoercion errorLevel="suppress" />
         <LessSpecificReturnStatement errorLevel="suppress" />
         <NamedArgumentNotAllowed errorLevel="suppress" />
+        <MixedArgument errorLevel="suppress" />
+        <MixedArgumentTypeCoercion errorLevel="suppress" />
+        <MixedArrayAccess errorLevel="suppress" />
+        <MixedArrayAssignment errorLevel="suppress" />
+        <MixedArrayOffset errorLevel="suppress" />
+        <MixedAssignment errorLevel="suppress" />
+        <MixedFunctionCall errorLevel="suppress" />
+        <MixedInferredReturnType errorLevel="suppress" />
+        <MixedMethodCall errorLevel="suppress" />
+        <MixedOperand errorLevel="suppress" />
+        <MixedPropertyTypeCoercion errorLevel="suppress" />
+        <MixedReturnStatement errorLevel="suppress" />
+        <MixedReturnTypeCoercion errorLevel="suppress" />
         <MoreSpecificReturnType errorLevel="suppress" />
         <InvalidArrayOffset errorLevel="suppress" />
         <RiskyTruthyFalsyComparison errorLevel="suppress" />

--- a/src/php/Compiler/Domain/Parser/ParserNode/ListNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/ListNode.php
@@ -46,7 +46,7 @@ final class ListNode implements InnerNodeInterface
             $code .= $child->getCode();
         }
 
-        return $this->getCodePrefix() . $code . $this->getCodePostfix();
+        return $this->getCodePrefix() . $code . ($this->getCodePostfix() ?? '');
     }
 
     public function getCodePrefix(): string

--- a/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
+++ b/src/php/Formatter/Domain/Rules/Indenter/InnerIndenter.php
@@ -30,7 +30,7 @@ final readonly class InnerIndenter implements IndenterInterface
             || $this->indentMatches($this->symbol, $this->formSymbol($top))) {
             $up = $loc->upSkipWhitespace();
 
-            return $this->lineIndenter->getMargin($up, $indentWidth) + $indentWidth;
+            return (int) $this->lineIndenter->getMargin($up, $indentWidth) + $indentWidth;
         }
 
         return null;


### PR DESCRIPTION
### 📚 Description

Closes https://github.com/phel-lang/phel-lang/issues/464

Increase Psalm level 1 by adding to ignore some checkers.
All of them are `Mixed...`, that is, we depend on third-party tools like `Symfony` or `Gacela`, as a result, we need to deal with the type of var that was defined originally as `mixed`.

I suggest ignoring all of them as they only will make the code polluter with more lines and unnecessary information most of them.