### PR TITLE
Use ArrayPrinter when printerName == array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
   * in favor of `->setMainPhpFilename()`
 * Add `phel fmt` alias for format
 * Add support for numeric on `empty?`
+* Fix `Printer` for arrays
 
 ## [0.12.0](https://github.com/phel-lang/phel-lang/compare/v0.11.0...v0.12.0) - 2023-11-01
 

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -145,7 +145,7 @@ final readonly class Printer implements PrinterInterface
             return new NullPrinter($this->withColor);
         }
 
-        if ($printerName === 'array' && !$this->readable) {
+        if ($printerName === 'array') {
             return new ArrayPrinter($this, $this->withColor);
         }
 


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/670

### 💡 Goal

Avoid crash when running `phel build` with cache

### 🖼️ Screenshots

Example https://github.com/phel-lang/web-skeleton using latest phel:0.12 running `phel build` twice

![Screenshot 2024-03-16 at 15 38 36](https://github.com/phel-lang/phel-lang/assets/5256287/33836430-c8c4-4256-8a18-e41b35781e08)

I am still not able to avoid/hide the message `cannot determine HTTP Method` from the output console. 
Any ideas, @jenshaase ?