### PR TITLE
Add fmt as alias for format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Require PHP>=8.2
 * Add `PhelOutConfig->setMainPhpPath()`
   * in favor of `->setMainPhpFilename()`
+* Add `phel fmt` alias for format
 
 ## [0.12.0](https://github.com/phel-lang/phel-lang/compare/v0.11.0...v0.12.0) - 2023-11-01
 

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -24,6 +24,7 @@ final class FormatCommand extends Command
     {
         $this->setName('format')
             ->setDescription('Formats the given files')
+            ->setAliases(['fmt'])
             ->addArgument(
                 'paths',
                 InputArgument::IS_ARRAY,


### PR DESCRIPTION
### 💡 Goal

Allow using `fmt` to format the phel code

You can now use both:
- `bin/phel format`
- `bin/phel fmt`

> Inspired by `cargo fmt` command - for rust