### PR TITLE
Fix interleave with nil values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to this project will be documented in this file.
 * Require PHP>=8.2
 * Add `PhelOutConfig->setMainPhpPath()`
   * in favor of `->setMainPhpFilename()`
-* Add `phel fmt` alias for format
-* Add support for numeric on `empty?`
+* Add `phel fmt` alias for format (#673)
+* Add support for numeric on `empty?` (#683)
+* Fix `interleave` allowing nil keys and values (#682)
 
 ## [0.12.0](https://github.com/phel-lang/phel-lang/compare/v0.11.0...v0.12.0) - 2023-11-01
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1123,12 +1123,13 @@ arrays. Use (php/aunset ds key)"))
 (defn interleave
   "Returns a vector with the first items of each col, then the second items, etc."
   [& xs]
-  (loop [i 0
-         res []]
-    (let [nths (map |(get $ i) xs)]
-      (if (some? nil? nths)
-        res
-        (recur (php/+ i 1) (concat res nths))))))
+  (let [size (count (first xs))]
+    (loop [i 0
+           res []]
+      (let [nths (map |(get $ i) xs)]
+        (if (<= size i)
+          res
+          (recur (php/+ i 1) (concat res nths)))))))
 
 (defn interpose
   "Returns a vector of elements separated by `sep`."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -123,7 +123,8 @@
 
 (deftest test-interleave
   (is (= [:a 1 :b 2 :c 3] (interleave [:a :b :c] [1 2 3])) "interleave equal size")
-  (is (= [:a 1 :b 2] (interleave [:a :b :c] [1 2])) "interleave different size"))
+  (is (= [:a 1 :b 2] (interleave [:a :b :c] [1 2])) "interleave different size")
+  (is (= [:a 1 :b nil] (interleave [:a :b] [1 nil])) "interleave include nil values"))
 
 (deftest test-interpose
   (is (= ["a" "," "b" "," "c"] (interpose "," ["a" "b" "c"])) "interpose"))

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -123,8 +123,10 @@
 
 (deftest test-interleave
   (is (= [:a 1 :b 2 :c 3] (interleave [:a :b :c] [1 2 3])) "interleave equal size")
-  (is (= [:a 1 :b 2] (interleave [:a :b :c] [1 2])) "interleave different size")
-  (is (= [:a 1 :b nil] (interleave [:a :b] [1 nil])) "interleave include nil values"))
+  (is (= [:a 1 :b 2 :c nil] (interleave [:a :b :c] [1 2])) "interleave different size; more keys")
+  (is (= [:a 1 :b 2] (interleave [:a :b] [1 2 3])) "interleave different size; more values")
+  (is (= [:a 1 nil 2 :c 3] (interleave [:a nil :c] [1 2 3])) "interleave include nil keys")
+  (is (= [:a 1 :b nil :c 3] (interleave [:a :b :c] [1 nil 3])) "interleave include nil values"))
 
 (deftest test-interpose
   (is (= ["a" "," "b" "," "c"] (interpose "," ["a" "b" "c"])) "interpose"))


### PR DESCRIPTION
### 🤔 Background

In Phel-lang, when using the interleave function with two collections where one contains nil values, the nil values are ignored in the resulting sequence. This differs from Clojure, where nil values are included in the resulting sequence.

### 💡 Goal

Fixes: https://github.com/phel-lang/phel-lang/issues/681

### 🔖 Changes

Store in a var the size of the first collection and iterate until the first collection is completely looped through.

Inspired by the current Clojure behaviour:
<img width="556" alt="Screenshot 2024-04-16 at 17 49 23" src="https://github.com/phel-lang/phel-lang/assets/5256287/57413e08-6269-4ec6-aad4-5818458228f4">


> Kudos to @smeghead - https://github.com/phel-lang/phel-lang/issues/681#issuecomment-2059230380 
