### PR TITLE
fix: BuildMode when transpiling the code

### DIFF
--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -9,6 +9,9 @@ use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Lang\Registry;
+use Phel\Shared\BuildConstants;
+use Phel\Shared\CompilerConstants;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -17,6 +20,18 @@ use Throwable;
  */
 final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
 {
+    public static function enableBuildMode(): void
+    {
+        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, true);
+        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, true);
+    }
+
+    public static function disableBuildMode(): void
+    {
+        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, false);
+        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, false);
+    }
+
     /**
      * Extracts the namespace from a given file. It expects that the
      * first statement in the file is the 'ns statement.

--- a/src/php/Build/Domain/Compile/FileCompiler.php
+++ b/src/php/Build/Domain/Compile/FileCompiler.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Compile;
 
+use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
-use Phel\Lang\Registry;
-use Phel\Shared\BuildConstants;
-use Phel\Shared\CompilerConstants;
 
 final readonly class FileCompiler implements FileCompilerInterface
 {
@@ -29,13 +27,9 @@ final readonly class FileCompiler implements FileCompilerInterface
             ->setSource($src)
             ->setIsEnabledSourceMaps($enableSourceMaps);
 
-        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, true);
-        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, true);
-
+        BuildFacade::enableBuildMode();
         $result = $this->compilerFacade->compile($phelCode, $options);
-
-        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, false);
-        Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, false);
+        BuildFacade::disableBuildMode();
 
         $this->fileIo->putContents($dest, "<?php\n" . $result->getPhpCode());
         $this->fileIo->putContents(str_replace('.php', '.phel', $dest), $phelCode);

--- a/src/php/Build/Domain/Compile/ProjectCompiler.php
+++ b/src/php/Build/Domain/Compile/ProjectCompiler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build\Domain\Compile;
 
 use Phel\Build\BuildConfigInterface;
+use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\Output\EntryPointPhpFileInterface;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
@@ -33,6 +34,7 @@ final readonly class ProjectCompiler
      */
     public function compileProject(BuildOptions $buildOptions): array
     {
+
         $srcDirectories = [
             ...$this->commandFacade->getSourceDirectories(),
             ...$this->commandFacade->getVendorSourceDirectories(),
@@ -63,8 +65,10 @@ final readonly class ProjectCompiler
             }
 
             if ($this->canUseCache($buildOptions, $targetFile, $info)) {
+                BuildFacade::enableBuildMode();
                 /** @psalm-suppress UnresolvableInclude */
                 require_once $targetFile;
+                BuildFacade::disableBuildMode();
                 continue;
             }
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -212,7 +212,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $symbol = Symbol::create(BuildConstants::BUILD_MODE);
         $meta = TypeFactory::getInstance()->persistentMapFromKVs(
             Keyword::create('doc'),
-            'Set to true when a file is compiled, false otherwise.',
+            'Set to true when a file is being built/transpiled, false otherwise.',
         );
         Registry::getInstance()->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol->getName(), false, $meta);
         $this->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol);


### PR DESCRIPTION
### 🤔 Background

The `**build-mode**` is ignore when `require_once $targetFile;` in the `FileCompiler`.

### 🔖 Changes

We need to enable/disable the build mode on `ProjectCompiler` and also on the `FileCompiler`; before it was only at `ProjectCompiler`, and this resulted in bugs when loading a cached filed from the `FileCompiler`. 
