### PR TITLE
feat: add string functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Add `phel/str` functions
+  * `split`: Splits string on a regular expression
+  * `join`: Returns a string of all elements in coll
+  * `reverse`: Returns s with its characters reversed
+  * `upper-case`: Converts string to all upper-case
+  * `replace`: Replaces all instance of match with replacement in string
+  * `replace-first`: Replaces the first instance of match with replacement in string
+  * `trim-newline`: Removes all trailing newline \n or return \r characters from string
+  * `capitalize`: Converts first character of the string to upper-case, all other characters to lower-case
+  * `lower-case`: Converts string to all lower-case
+  * `upper-case`: Converts string to all upper-case
+  * `trim`: Removes whitespace from both ends of string
+  * `triml`: Removes whitespace from the left side of string
+  * `trimr`: Removes whitespace from the right side of string
+  * `blank?`: True if s is nil, empty, or contains only whitespace
+  * `starts-with?`: True if string starts with substr
+  * `ends-with?`: True if string ends with substr
+  * `includes?`: True if string includes substr
+  * `re-quote-replacement`: Escaping of special characters
+  * `escape`: Return a new string, using cmap to escape each character from string
+  * `index-of`: Return index of value in string, optionally searching forward
+  * `last-index-of`: Return last index of value in string, optionally searching backward
+  * `split-lines`: Splits string with on \n or \r\n
+
 ## [0.13.0](https://github.com/phel-lang/phel-lang/compare/v0.12.0...v0.13.0) - 2024-04-17
 
 * Require PHP>=8.2

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -1,0 +1,230 @@
+(ns phel\str
+  (:require phel\core))
+
+(defn split
+  "Splits string on a regular expression.  Optional argument limit is
+  the maximum number of parts. Not lazy. Returns vector of the parts.
+  Trailing empty strings are not returned - pass limit of -1 to return all."
+  [s re & [limit]]
+  (values (php-array-to-map (php/preg_split re s (or limit -1)))))
+
+(defn join
+  "Returns a string of all elements in coll, as returned by (seq coll),
+   separated by an optional separator."
+  [separator & [coll]]
+  (let [[coll separator] (if (nil? coll) [separator ""] [coll separator])]
+    (php/implode separator (to-php-array coll))))
+
+(defn reverse
+  "Returns s with its characters reversed."
+  [s]
+  (let [chars (php/mb_str_split s)]
+    (join (core/reverse chars))))
+
+(defn upper-case
+  "Converts string to all upper-case."
+  [s]
+  (php/strtoupper s))
+
+(defn replace
+  "Replaces all instance of match with replacement in s.
+
+   match/replacement can be:
+
+   string / string
+   pattern / (string or function of match).
+
+   See also replace-first.
+
+   The replacement is literal (i.e. none of its characters are treated
+   specially) for all cases above except pattern / string.
+
+   For pattern / string, $1, $2, etc. in the replacement string are
+   substituted with the string that matched the corresponding
+   parenthesized group in the pattern.  If you wish your replacement
+   string r to be used literally, use (re-quote-replacement r) as the
+   replacement argument."
+  [s match replacement]
+  (let [match (if (and
+                    (> (php/mb_strlen match) 1)
+                    (=
+                      (php/substr match 0 1)
+                      (php/substr match -1 1)))
+                match
+                (format "/%s/" (php/preg_quote match "/")))]
+    (if (function? replacement)
+      (php/preg_replace_callback match (fn [x]
+                                         (let [x (values (php-array-to-map x))]
+                                           (apply replacement x))) s)
+      (php/preg_replace match replacement s))))
+
+(defn replace-first
+  "Replaces the first instance of match with replacement in s.
+
+   match/replacement can be:
+
+   char / char
+   string / string
+   pattern / (string or function of match).
+
+   See also replace.
+
+   The replacement is literal (i.e. none of its characters are treated
+   specially) for all cases above except pattern / string.
+
+   For pattern / string, $1, $2, etc. in the replacement string are
+   substituted with the string that matched the corresponding
+   parenthesized group in the pattern.  If you wish your replacement
+   string r to be used literally, use (re-quote-replacement r) as the
+   replacement argument.
+
+   Example:
+   (str/replace-first \"swap first two words\"
+                                 #\"(\\w+)(\\s+)(\\w+)\" \"$3$2$1\")
+   -> \"first swap two words\""
+  [s match replacement]
+  (let [match (if (and
+                    (> (php/mb_strlen match) 1)
+                    (=
+                      (php/substr match 0 1)
+                      (php/substr match -1 1)))
+                match
+                (format "/%s/" (php/preg_quote match "/")))]
+    (if (function? replacement)
+      (php/preg_replace_callback match (fn [x]
+                                         (let [x (values (php-array-to-map x))]
+                                           (apply replacement x))) s 1)
+      (php/preg_replace match replacement s 1))))
+
+(defn trim-newline
+  "Removes all trailing newline \\n or return \\r characters from
+  string.  Similar to Perl's chomp."
+  [s]
+  (loop [index (php/mb_strlen s)]
+    (if (zero? index)
+      ""
+      (let [ch (php/mb_substr s (dec index) 1)]
+        (if (or (= ch "\n") (= ch "\r"))
+          (recur (dec index))
+          (php/mb_substr s 0 index))))))
+
+(defn capitalize
+  "Converts first character of the string to upper-case, all other
+  characters to lower-case."
+  [s]
+  (php/ucfirst (php/strtolower s)))
+
+(defn lower-case
+  "Converts string to all lower-case."
+  [s]
+  (php/strtolower s))
+
+(defn upper-case
+  "Converts string to all upper-case."
+  [s]
+  (php/strtoupper s))
+
+(defn trim
+  "Removes whitespace from both ends of string."
+  [s]
+  (php/preg_replace "/^[\s]+|[\s]+$/u" "" s))
+
+(defn triml
+  "Removes whitespace from the left side of string."
+  [s]
+  (php/preg_replace "/^[\s]+/u" "" s))
+
+(defn trimr
+  "Removes whitespace from the right side of string."
+  [s]
+  (php/preg_replace "/[\s]+$/u" "" s))
+
+(defn blank?
+  "True if s is nil, empty, or contains only whitespace."
+  [s]
+  (if s
+    (loop [index 0]
+      (if (= (php/mb_strlen s) index)
+        true
+        (if (php/preg_match "/^\s$/u" (php/mb_substr s index 1))
+          (recur (inc index))
+          false)))
+    true))
+
+(defn starts-with?
+  "True if s starts with substr."
+  [s substr]
+  (php/str_starts_with s substr))
+
+(defn ends-with?
+  "True if s ends with substr."
+  [s substr]
+  (php/str_ends_with s substr))
+
+(defn includes?
+  "True if s includes substr."
+  [s substr]
+  (php/str_contains s substr))
+
+(defn re-quote-replacement
+  "Given a replacement string that you wish to be a literal
+   replacement for a pattern match in replace or replace-first, do the
+   necessary escaping of special characters in the replacement."
+  [replacement]
+  (php/preg_replace "/([\\\$])/" "\$1" replacement))
+
+(defn escape
+  "Return a new string, using cmap to escape each character ch
+   from s as follows:
+
+   If (cmap ch) is nil, append ch to the new string.
+   If (cmap ch) is non-nil, append (str (cmap ch)) instead."
+  [s cmap]
+  (loop [index 0
+         buffer ""]
+    (if (= (php/mb_strlen s) index)
+      buffer
+      (let [ch (php/mb_substr s index 1)]
+        (let [ch (or (cmap ch) ch)]
+          (recur (inc index) (format "%s%s" buffer ch)))))))
+
+(defn index-of
+  "Return index of value (string or char) in s, optionally searching
+  forward from from-index. Return nil if value not found."
+  [s value & [from-index]]
+  (let [from-index (or from-index 0)
+        from-index (let [abs (php/abs from-index)
+                         v (min abs (dec (php/mb_strlen s)))]
+                     (if (< from-index 0)
+                       (* v -1)
+                       v))
+        result (php/mb_strpos s value from-index)]
+    (if (= result false)
+      nil
+      result)))
+
+(defn last-index-of
+  "Return last index of value (string or char) in s, optionally
+  searching backward from from-index. Return nil if value not found."
+  [s value & [from-index]]
+  (let [max-index (dec (php/mb_strlen s))
+        from-index (or from-index max-index)
+        from-index (let [abs (php/abs from-index)
+                         v (min abs max-index)]
+                     (if (< from-index 0)
+                       (- max-index v)
+                       v))]
+    (loop [s s
+           value value
+           from-index from-index]
+      (if (< from-index 0)
+        nil
+        (let [target (php/mb_substr s from-index)]
+          (if (includes? target value)
+            from-index
+            (recur s value (dec from-index))))))))
+
+(defn split-lines
+  "Splits s on \\n or \\r\\n. Trailing empty lines are not returned."
+  [s]
+  (split s "/\r?\n/"))

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -1,0 +1,165 @@
+(ns phel-test\test\str
+  (:require phel\test :refer [deftest is])
+  (:require phel\str :as s))
+
+(deftest test-split
+  (is (= ["a" "b"] (s/split "a-b" "/-/")))
+  (is (= ["a" "b-c"] (s/split "a-b-c" "/-/" 2)))
+  (is (= ["ａ" "ｂ-ｃ"] (s/split "ａ-ｂ-ｃ" "/-/" 2)))
+  (is (vector? (s/split "abc" "/-/"))))
+
+(deftest test-reverse
+  (is (= "tab" (s/reverse "bat")))
+  (is (= "ｔａｂ" (s/reverse "ｂａｔ"))))
+
+(deftest test-replace
+  (is (= "barbarbar" (s/replace "foobarfoo" "foo" "bar")))
+  (is (= "foobarfoo" (s/replace "foobarfoo" "baz" "bar")))
+  (is (= "f$$d" (s/replace "food" "o" "$")))
+  (is (= "f\\\\d" (s/replace "food" "o" "\\")))
+  (is (= "barbarbar" (s/replace "foobarfoo" "/foo/" "bar")))
+  (is (= "foobarfoo" (s/replace "foobarfoo" "/baz/" "bar")))
+  (is (= "f$$d" (s/replace "food" "/o/" "$")))
+  (is (= "f\\\\d" (s/replace "food" "/o/" "\\")))
+  (is (= "FOObarFOO" (s/replace "foobarfoo" "/foo/" s/upper-case)))
+  (is (= "foobarfoo" (s/replace "foobarfoo" "/baz/" s/upper-case)))
+  (is (= "OObarOO" (s/replace "foobarfoo" "/f(o+)/" (fn [m g1] (s/upper-case g1)))))
+  (is (= "baz\\bang\\" (s/replace "bazslashbangslash" "/slash/" (fn [m] "\\")))))
+
+(deftest test-replace-first
+  (is (= "faobar" (s/replace-first "foobar" "o" "a")))
+  (is (= "foobar" (s/replace-first "foobar" "z" "a")))
+  (is (= "z.ology" (s/replace-first "zoology" "o" ".")))
+  (is (= "barbarfoo" (s/replace-first "foobarfoo" "foo" "bar")))
+  (is (= "foobarfoo" (s/replace-first "foobarfoo" "baz" "bar")))
+  (is (= "f$od" (s/replace-first "food" "o" "$")))
+  (is (= "f\\od" (s/replace-first "food" "o" "\\")))
+  (is (= "barbarfoo" (s/replace-first "foobarfoo" "/foo/" "bar")))
+  (is (= "foobarfoo" (s/replace-first "foobarfoo" "/baz/" "bar")))
+  (is (= "f$od" (s/replace-first "food" "/o/" (s/re-quote-replacement "$"))))
+  (is (= "f\\od" (s/replace-first "food" "/o/" (s/re-quote-replacement "\\"))))
+  (is (= "FOObarfoo" (s/replace-first "foobarfoo" "/foo/" s/upper-case)))
+  (is (= "foobarfoo" (s/replace-first "foobarfoo" "/baz/" s/upper-case)))
+  (is (= "OObarfoo" (s/replace-first "foobarfoo" "/f(o+)/" (fn [m g1] (s/upper-case g1)))))
+  (is (= "baz\\bangslash" (s/replace-first "bazslashbangslash" "/slash/" (fn [m] "\\")))))
+
+
+(deftest test-join
+  (is (= "" (s/join nil)))
+  (is (= "" (s/join [])))
+  (is (= "1" (s/join [1])))
+  (is (= "12" (s/join [1 2]))))
+
+(deftest test-trim-newline
+  (is (= "foo" (s/trim-newline "foo\n")))
+  (is (= "foo" (s/trim-newline "foo\r\n")))
+  (is (= "foo" (s/trim-newline "foo")))
+  (is (= "ｆｏｏ" (s/trim-newline "ｆｏｏ\r\n")))
+  (is (= "" (s/trim-newline ""))))
+
+(deftest test-capitalize
+  (is (= "Foobar" (s/capitalize "foobar")))
+  (is (= "Foobar" (s/capitalize "FOOBAR"))))
+
+(deftest test-triml
+  (is (= "foo " (s/triml " foo ")))
+  (is (= "" (s/triml "   ")))
+  (is (= "bar" (s/triml "\u{2002} \tbar"))))
+
+(deftest test-trimr
+  (is (= " foo" (s/trimr " foo ")))
+  (is (= "" (s/trimr "   ")))
+  (is (= "bar" (s/trimr "bar\t \u{2002}"))))
+
+(deftest test-trim
+  (is (= "foo" (s/trim "  foo  \r\n")))
+  (is (= "bar" (s/trim "\u{2000}bar\t \u{2002}"))))
+
+(deftest test-upper-case
+  (is (= "FOOBAR" (s/upper-case "Foobar"))))
+
+(deftest test-lower-case
+  (is (= "foobar" (s/lower-case "FooBar"))))
+
+(deftest test-escape
+  (is (= "&lt;foo&amp;bar&gt;"
+         (s/escape "<foo&bar>" {"&" "&amp;" "<" "&lt;" ">" "&gt;"})))
+  (is (= " \\\"foo\\\" "
+         (s/escape " \"foo\" " {"\"" "\\\""})))
+  (is (= "faabor"
+         (s/escape "foobar" {"a" "o" "o" "a"}))))
+
+(deftest test-blank
+  (is (s/blank? nil))
+  (is (s/blank? ""))
+  (is (s/blank? " "))
+  (is (s/blank? " \t \n  \r "))
+  (is (not (s/blank? "  foo  "))))
+
+(deftest test-split-lines
+  (let [result (s/split-lines "one\ntwo\r\nthree")]
+    (is (= ["one" "two" "three"] result))
+    (is (vector? result)))
+  (is (= ["foo"] (s/split-lines "foo"))))
+
+(deftest test-index-of
+  (let [sb "tacos"]
+    (is (= 2  (s/index-of sb "c")))
+    (is (= 1  (s/index-of sb "ac")))
+    (is (= 3  (s/index-of sb "o" 2)))
+    (is (= 3  (s/index-of sb "o" -100)))
+    (is (= nil (s/index-of sb "z")))
+    (is (= nil (s/index-of sb "z" 2)))
+    (is (= nil (s/index-of sb "z" 100))
+    (is (= nil (s/index-of sb "z" -10)))))
+  (let [sb "ｔａｃｏｓ"]
+    (is (= 2  (s/index-of sb "ｃ")))
+    (is (= 1  (s/index-of sb "ａｃ")))
+    (is (= 3  (s/index-of sb "ｏ" 2)))
+    (is (= 3  (s/index-of sb "ｏ" -100)))
+    (is (= nil (s/index-of sb "ｚ")))
+    (is (= nil (s/index-of sb "ｚ" 2)))
+    (is (= nil (s/index-of sb "ｚ" 100))
+    (is (= nil (s/index-of sb "ｚ" -10))))))
+
+(deftest test-last-index-of
+  (let [sb "banana"]
+    (is (= 4 (s/last-index-of sb "n")))
+    (is (= 3 (s/last-index-of sb "an")))
+    (is (= 4 (s/last-index-of sb "n" )))
+    (is (= 4 (s/last-index-of sb "n" 5)))
+    (is (= 4 (s/last-index-of sb "n" 500)))
+    (is (= nil (s/last-index-of sb "z")))
+    (is (= nil (s/last-index-of sb "z" 1)))
+    (is (= nil (s/last-index-of sb "z" 100))
+    (is (= nil (s/last-index-of sb "z" -10)))))
+  (let [sb "ｂａｎａｎａ"]
+    (is (= 4 (s/last-index-of sb "ｎ")))
+    (is (= 3 (s/last-index-of sb "ａｎ")))
+    (is (= 4 (s/last-index-of sb "ｎ" )))
+    (is (= 4 (s/last-index-of sb "ｎ" 5)))
+    (is (= 4 (s/last-index-of sb "ｎ" 500)))
+    (is (= nil (s/last-index-of sb "ｚ")))
+    (is (= nil (s/last-index-of sb "ｚ" 1)))
+    (is (= nil (s/last-index-of sb "ｚ" 100))
+    (is (= nil (s/last-index-of sb "ｚ" -10))))))
+
+(deftest test-starts-with?
+  (is (= true (s/starts-with? "clojure west" "clojure")))
+  (is (= false (s/starts-with? "conj" "clojure")))
+  (is (= true (s/starts-with? "ｃｌｏｊｕｒｅ　ｗｅｓｔ" "ｃｌｏｊｕｒｅ")))
+  (is (= false (s/starts-with? "ｃｏｎｊ" "ｃｌｏｊｕｒｅ"))))
+
+(deftest test-ends-with?
+  (is (= true (s/ends-with? "Clojure West" "West")))
+  (is (= false (s/ends-with? "Conj" "West")))
+  (is (= true (s/ends-with? "Ｃｌｏｊｕｒｅ　Ｗｅｓｔ" "Ｗｅｓｔ")))
+  (is (= false (s/ends-with? "Ｃｏｎｊ" "Ｗｅｓｔ"))))
+
+(deftest test-includes?
+  (let [sb "Clojure Applied Book"]
+    (is (= true (s/includes? sb "Applied")))
+    (is (= false (s/includes? sb "Living"))))
+  (let [sb "Ｃｌｏｊｕｒｅ　Ａｐｐｌｉｅｄ　Ｂｏｏｋ"]
+    (is (= true (s/includes? sb "Ａｐｐｌｉｅｄ")))
+    (is (= false (s/includes? sb "Ｌｉｖｉｎｇ")))))


### PR DESCRIPTION
Add the namespace phel\str and add the string function below.

split join reverse upper-case replace replace-first trim-newline capitalize lower-case upper-case trim triml trimr blank? starts-with?  ends-with?  includes?  re-quote-replacement escape index-of last-index-of split-lines

### 🤔 Background

I created a string manipulation function library that is not available in phel, using clojure as a reference.
https://github.com/smeghead/phel-str
This is a pull request to introduce the functions of this library to phel.

### 💡 Goal

You can now use the added functions.

```
phel:1> (require phel\str)
phel\str
phel:2> (str/join ["a" "b" "c"])
abc
phel:3> (str/upper-case "hello!")
HELLO!
```

### 🔖 Changes

added `src/phel/str.phel` file includes functions. and added namespace `phel\str`.