### PR TITLE
Remove output from tests

### DIFF
--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -34,8 +34,9 @@ final class ApiFacadeTest extends TestCase
             'phel\\html',
             'phel\\test',
             'phel\\json',
+            'phel\\str',
         ]);
 
-        self::assertCount(243, $groupedFns);
+        self::assertCount(264, $groupedFns);
     }
 }


### PR DESCRIPTION

### 💡 Goal

Remove the output text while running the PHP tests

### 🔖 Changes

BEFORE
<img width="727" alt="Screenshot 2024-05-01 at 10 41 19" src="https://github.com/phel-lang/phel-lang/assets/5256287/b78409bb-c962-4bb2-aa11-57c0cce5ada5">

AFTER
<img width="898" alt="Screenshot 2024-05-01 at 10 42 22" src="https://github.com/phel-lang/phel-lang/assets/5256287/0a391481-7875-40cf-b9ed-da53de2e5fba">


