### PR TITLE
Fix $ as named parameter in macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Fix $ as named parameter in macros
 * Add `phel/str` functions (#688)
   * `split`: Splits string on a regular expression
   * `join`: Returns a string of all elements in coll

--- a/src/php/Compiler/Infrastructure/Munge.php
+++ b/src/php/Compiler/Infrastructure/Munge.php
@@ -38,6 +38,7 @@ final readonly class Munge implements MungeInterface
         '/' => '_SLASH_',
         '\\' => '_BSLASH_',
         '?' => '_QMARK_',
+        '$' => '_DOLLAR_',
     ];
 
     public function __construct(

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -15,3 +15,7 @@
   (is (= 1 (as-> 1 v)))
   (is (= -3 (as-> 5 v (+ 3 v) (/ v 2) (- 1 v))))
   (is (= "oo" (as-> [:foo :bar] v (map |(php/-> $ (getName)) v) (first v) (php/substr v 1)))))
+
+(deftest test-as->$
+  (let [animals [{:name "Rex" :type :dog} {:name "Kitty" :type :cat}]]
+    (is (= :cat (as-> animals o (o 1) (o :type))))))

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -18,4 +18,5 @@
 
 (deftest test-as->$
   (let [animals [{:name "Rex" :type :dog} {:name "Kitty" :type :cat}]]
-    (is (= :cat (as-> animals o (o 1) (o :type))))))
+    (is (= :cat (as-> animals o (o 1) (o :type))))
+    (is (= :cat (as-> animals $ ($ 1) ($ :type))))))

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -14,9 +14,8 @@
 (deftest test-as->
   (is (= 1 (as-> 1 v)))
   (is (= -3 (as-> 5 v (+ 3 v) (/ v 2) (- 1 v))))
-  (is (= "oo" (as-> [:foo :bar] v (map |(php/-> $ (getName)) v) (first v) (php/substr v 1)))))
-
-(deftest test-as->$
+  (is (= "oo" (as-> [:foo :bar] v (map |(php/-> $ (getName)) v) (first v) (php/substr v 1))))
   (let [animals [{:name "Rex" :type :dog} {:name "Kitty" :type :cat}]]
     (is (= :cat (as-> animals o (o 1) (o :type))))
     (is (= :cat (as-> animals $ ($ 1) ($ :type))))))
+


### PR DESCRIPTION
### 🤔 Background

Closes: https://github.com/phel-lang/phel-lang/issues/694

### 💡 Goal

Allow using $ as named param to for any macro

### 🔖 Changes

Add `$` => `__DOLLAR__` to the `Munge::DEFAULT_MAPPING`