### PR TITLE
Fix setMainPhpPath() when not dir is not defined

### DIFF
--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -6,6 +6,8 @@ namespace Phel\Config;
 
 use JsonSerializable;
 
+use function count;
+
 /**
  * @psalm-suppress DeprecatedProperty
  */
@@ -84,7 +86,12 @@ final class PhelBuildConfig implements JsonSerializable
     public function getMainPhpPath(): string
     {
         if ($this->mainPhpPath !== '') {
-            return $this->mainPhpPath;
+            $explode = explode('/', $this->mainPhpPath);
+            if (count($explode) === 2) {
+                return $this->mainPhpPath;
+            }
+
+            return sprintf('out/%s', $this->getPhpFilename());
         }
 
         return sprintf(
@@ -121,7 +128,12 @@ final class PhelBuildConfig implements JsonSerializable
         }
 
         if ($this->mainPhpPath !== '') {
-            return explode('/', $this->mainPhpPath)[0];
+            $explode = explode('/', $this->mainPhpPath);
+            if (count($explode) === 1) {
+                return self::DEFAULT_DEST_DIR;
+            }
+
+            return $explode[0];
         }
 
         return self::DEFAULT_DEST_DIR;
@@ -130,7 +142,12 @@ final class PhelBuildConfig implements JsonSerializable
     private function getPhpFilename(): string
     {
         if ($this->mainPhpPath !== '') {
-            return explode('/', $this->mainPhpPath)[1];
+            $explode = explode('/', $this->mainPhpPath);
+            if (count($explode) === 1) {
+                return $explode[0];
+            }
+
+            return $explode[1];
         }
 
         if ($this->mainPhpFilename !== '') {

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -114,7 +114,7 @@ final class PhelBuildConfigTest extends TestCase
 
         self::assertSame($expected, $config->jsonSerialize());
     }
-    
+
     public function test_main_php_path_bug_when_not_dir_defined(): void
     {
         $config = (new PhelBuildConfig())

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -114,4 +114,19 @@ final class PhelBuildConfigTest extends TestCase
 
         self::assertSame($expected, $config->jsonSerialize());
     }
+    
+    public function test_main_php_path_bug_when_not_dir_defined(): void
+    {
+        $config = (new PhelBuildConfig())
+            ->setMainPhpPath('custom-index');
+
+        $expected = [
+            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
+            PhelBuildConfig::DEST_DIR => 'out',
+            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-index.php',
+            PhelBuildConfig::MAIN_PHP_PATH => 'out/custom-index.php',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
 }


### PR DESCRIPTION
### 🤔 Background

When using `setMainPhpPath()` if there is no directory defined, there is an internal error: `Undefined array key 1`

<img width="979" alt="Screenshot 2024-05-16 at 17 00 17" src="https://github.com/phel-lang/phel-lang/assets/5256287/56a71a43-b26d-454f-af55-07d217abc048">


### 🔖 Changes

Use `out` as default directory in case it's not defined in `PhelBuildConfig->setMainPhpPath()`
