### PR TITLE
Fix avoid using trim on PhelBuildConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Fix `PhelBuildConfig` when using `trim` (#698)
 * Fix `setMainPhpPath()` without directory or more than one (#697)
 * Rename `PhelOutConfig` to `PhelBuildConfig` (#687)
 * Fix `$` as named parameter in macros (#695)

--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -7,7 +7,6 @@ namespace Phel\Config;
 use JsonSerializable;
 
 use function count;
-use function strlen;
 
 /**
  * @psalm-suppress DeprecatedProperty
@@ -80,7 +79,7 @@ final class PhelBuildConfig implements JsonSerializable
 
     public function setMainPhpPath(string $path): self
     {
-        $this->mainPhpPath = $this->stripSuffix($path, '.php') . '.php';
+        $this->mainPhpPath = $this->normalizePhpExtension($path);
         return $this;
     }
 
@@ -146,18 +145,19 @@ final class PhelBuildConfig implements JsonSerializable
         }
 
         if ($this->mainPhpFilename !== '') {
-            return $this->stripSuffix($this->mainPhpFilename, '.php') . '.php';
+            return $this->normalizePhpExtension($this->mainPhpFilename);
         }
 
         return self::DEFAULT_PHP_FILENAME;
     }
 
-    private function stripSuffix(string $string, string $suffix): string
+    private function normalizePhpExtension(string $string): string
     {
-        if (!str_ends_with($string, $suffix)) {
+        $suffix = '.php';
+        if (str_ends_with($string, $suffix)) {
             return $string;
         }
 
-        return substr($string, 0, -strlen($suffix));
+        return $string . $suffix;
     }
 }

--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -7,6 +7,7 @@ namespace Phel\Config;
 use JsonSerializable;
 
 use function count;
+use function strlen;
 
 /**
  * @psalm-suppress DeprecatedProperty
@@ -79,7 +80,7 @@ final class PhelBuildConfig implements JsonSerializable
 
     public function setMainPhpPath(string $path): self
     {
-        $this->mainPhpPath = rtrim($path, '.php') . '.php';
+        $this->mainPhpPath = $this->stripSuffix($path, '.php') . '.php';
         return $this;
     }
 
@@ -145,9 +146,18 @@ final class PhelBuildConfig implements JsonSerializable
         }
 
         if ($this->mainPhpFilename !== '') {
-            return rtrim($this->mainPhpFilename, '.php') . '.php';
+            return $this->stripSuffix($this->mainPhpFilename, '.php') . '.php';
         }
 
         return self::DEFAULT_PHP_FILENAME;
+    }
+
+    private function stripSuffix(string $string, string $suffix): string
+    {
+        if (!str_ends_with($string, $suffix)) {
+            return $string;
+        }
+
+        return substr($string, 0, -strlen($suffix));
     }
 }

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -100,21 +100,6 @@ final class PhelBuildConfigTest extends TestCase
         self::assertSame($expected, $config->jsonSerialize());
     }
 
-    public function test_main_php_path_without_ext(): void
-    {
-        $config = (new PhelBuildConfig())
-            ->setMainPhpPath('custom-out/custom-index');
-
-        $expected = [
-            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
-            PhelBuildConfig::DEST_DIR => 'custom-out',
-            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-index.php',
-            PhelBuildConfig::MAIN_PHP_PATH => 'custom-out/custom-index.php',
-        ];
-
-        self::assertSame($expected, $config->jsonSerialize());
-    }
-
     public function test_main_php_path_bug_when_not_dir_defined(): void
     {
         $config = (new PhelBuildConfig())
@@ -140,6 +125,21 @@ final class PhelBuildConfigTest extends TestCase
             PhelBuildConfig::DEST_DIR => 'custom-dir1/dir2',
             PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-index.php',
             PhelBuildConfig::MAIN_PHP_PATH => 'custom-dir1/dir2/custom-index.php',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_main_php_path_without_ext(): void
+    {
+        $config = (new PhelBuildConfig())
+            ->setMainPhpPath('custom-flip');
+
+        $expected = [
+            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
+            PhelBuildConfig::DEST_DIR => 'out',
+            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-flip.php',
+            PhelBuildConfig::MAIN_PHP_PATH => 'out/custom-flip.php',
         ];
 
         self::assertSame($expected, $config->jsonSerialize());

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -100,6 +100,21 @@ final class PhelBuildConfigTest extends TestCase
         self::assertSame($expected, $config->jsonSerialize());
     }
 
+    public function test_main_php_path_without_ext(): void
+    {
+        $config = (new PhelBuildConfig())
+            ->setMainPhpPath('custom-flip');
+
+        $expected = [
+            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
+            PhelBuildConfig::DEST_DIR => 'out',
+            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-flip.php',
+            PhelBuildConfig::MAIN_PHP_PATH => 'out/custom-flip.php',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
     public function test_main_php_path_bug_when_not_dir_defined(): void
     {
         $config = (new PhelBuildConfig())
@@ -125,21 +140,6 @@ final class PhelBuildConfigTest extends TestCase
             PhelBuildConfig::DEST_DIR => 'custom-dir1/dir2',
             PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-index.php',
             PhelBuildConfig::MAIN_PHP_PATH => 'custom-dir1/dir2/custom-index.php',
-        ];
-
-        self::assertSame($expected, $config->jsonSerialize());
-    }
-
-    public function test_main_php_path_without_ext(): void
-    {
-        $config = (new PhelBuildConfig())
-            ->setMainPhpPath('custom-flip');
-
-        $expected = [
-            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
-            PhelBuildConfig::DEST_DIR => 'out',
-            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-flip.php',
-            PhelBuildConfig::MAIN_PHP_PATH => 'out/custom-flip.php',
         ];
 
         self::assertSame($expected, $config->jsonSerialize());


### PR DESCRIPTION
### 🤔 Background

Bug found: https://x.com/azjezz/status/1791104988904673706 by @azjezz


### 🔖 Changes

Use a custom `normalizePhpExtension()` instead of `rtrim()` on `PhelBuildConfig`
