### PR TITLE
Change default config dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Change `PhelConfig` default src and tests directories (#699)
 * Fix `PhelBuildConfig` when using `trim` (#698)
 * Fix `setMainPhpPath()` without directory or more than one (#697)
 * Rename `PhelOutConfig` to `PhelBuildConfig` (#687)

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -43,7 +43,7 @@ final class PhelConfig implements JsonSerializable
     private PhelBuildConfig $buildConfig;
 
     /** @var list<string> */
-    private array $ignoreWhenBuilding = ['src/phel/local.phel'];
+    private array $ignoreWhenBuilding = ['local.phel'];
 
     /** @var list<string> */
     private array $noCacheWhenBuilding = [];

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -43,7 +43,7 @@ final class PhelConfig implements JsonSerializable
     private PhelBuildConfig $buildConfig;
 
     /** @var list<string> */
-    private array $ignoreWhenBuilding = ['local.phel'];
+    private array $ignoreWhenBuilding = ['ignore-when-building.phel'];
 
     /** @var list<string> */
     private array $noCacheWhenBuilding = [];

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -29,10 +29,10 @@ final class PhelConfig implements JsonSerializable
     public const FORMAT_DIRS = 'format-dirs';
 
     /** @var list<string> */
-    private array $srcDirs = ['src/phel'];
+    private array $srcDirs = ['src'];
 
     /** @var list<string> */
-    private array $testDirs = ['tests/phel'];
+    private array $testDirs = ['tests'];
 
     private string $vendorDir = 'vendor';
 

--- a/src/php/Config/PhelExportConfig.php
+++ b/src/php/Config/PhelExportConfig.php
@@ -15,7 +15,7 @@ final class PhelExportConfig implements JsonSerializable
     public const TARGET_DIRECTORY = 'target-directory';
 
     /** @var list<string> */
-    private array $fromDirectories = ['src/phel'];
+    private array $fromDirectories = ['src'];
 
     private string $namespacePrefix = 'PhelGenerated';
 

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -11,20 +11,53 @@ use PHPUnit\Framework\TestCase;
 
 final class PhelConfigTest extends TestCase
 {
-    public function test_json_serialize(): void
+    public function test_default_json_serialize(): void
+    {
+        $config = new PhelConfig();
+
+        $expected = [
+            PhelConfig::SRC_DIRS => ['src'],
+            PhelConfig::TEST_DIRS => ['tests'],
+            PhelConfig::VENDOR_DIR => 'vendor',
+            PhelConfig::ERROR_LOG_FILE => 'data/error.log',
+            PhelConfig::BUILD_CONFIG => [
+                PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
+                PhelBuildConfig::DEST_DIR => 'out',
+                PhelBuildConfig::MAIN_PHP_FILENAME => 'index.php',
+                PhelBuildConfig::MAIN_PHP_PATH => 'out/index.php',
+            ],
+            PhelConfig::EXPORT_CONFIG => [
+                PhelExportConfig::TARGET_DIRECTORY => 'src/PhelGenerated',
+                PhelExportConfig::FROM_DIRECTORIES => ['src/phel'],
+                PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
+            ],
+            PhelConfig::IGNORE_WHEN_BUILDING => ['src/phel/local.phel'],
+            PhelConfig::NO_CACHE_WHEN_BUILDING => [],
+            PhelConfig::KEEP_GENERATED_TEMP_FILES => false,
+            PhelConfig::FORMAT_DIRS => ['src', 'tests'],
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_custom_json_serialize(): void
     {
         $config = (new PhelConfig())
             ->setSrcDirs(['some/directory'])
             ->setTestDirs(['another/directory'])
             ->setVendorDir('vendor')
             ->setErrorLogFile('error-log.file')
-            ->setBuildConfig((new PhelBuildConfig())
-                ->setMainPhpPath('out/custom-index.php')
-                ->setMainPhelNamespace('test-ns/boot'), )
-            ->setExportConfig((new PhelExportConfig())
-                ->setFromDirectories(['some/other/dir'])
-                ->setNamespacePrefix('Generated')
-                ->setTargetDirectory('src/Generated'))
+            ->setBuildConfig(
+                (new PhelBuildConfig())
+                    ->setMainPhpPath('out/custom-index.php')
+                    ->setMainPhelNamespace('test-ns/boot'),
+            )
+            ->setExportConfig(
+                (new PhelExportConfig())
+                    ->setFromDirectories(['some/other/dir'])
+                    ->setNamespacePrefix('Generated')
+                    ->setTargetDirectory('src/Generated'),
+            )
             ->setIgnoreWhenBuilding(['src/ignore.me'])
             ->setNoCacheWhenBuilding(['should-not-be-cached'])
             ->setKeepGeneratedTempFiles(true)

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -31,7 +31,7 @@ final class PhelConfigTest extends TestCase
                 PhelExportConfig::FROM_DIRECTORIES => ['src'],
                 PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
             ],
-            PhelConfig::IGNORE_WHEN_BUILDING => ['src/phel/local.phel'],
+            PhelConfig::IGNORE_WHEN_BUILDING => ['local.phel'],
             PhelConfig::NO_CACHE_WHEN_BUILDING => [],
             PhelConfig::KEEP_GENERATED_TEMP_FILES => false,
             PhelConfig::FORMAT_DIRS => ['src', 'tests'],

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -31,7 +31,7 @@ final class PhelConfigTest extends TestCase
                 PhelExportConfig::FROM_DIRECTORIES => ['src'],
                 PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
             ],
-            PhelConfig::IGNORE_WHEN_BUILDING => ['local.phel'],
+            PhelConfig::IGNORE_WHEN_BUILDING => ['ignore-when-building.phel'],
             PhelConfig::NO_CACHE_WHEN_BUILDING => [],
             PhelConfig::KEEP_GENERATED_TEMP_FILES => false,
             PhelConfig::FORMAT_DIRS => ['src', 'tests'],

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -47,17 +47,13 @@ final class PhelConfigTest extends TestCase
             ->setTestDirs(['another/directory'])
             ->setVendorDir('vendor')
             ->setErrorLogFile('error-log.file')
-            ->setBuildConfig(
-                (new PhelBuildConfig())
-                    ->setMainPhpPath('out/custom-index.php')
-                    ->setMainPhelNamespace('test-ns/boot'),
-            )
-            ->setExportConfig(
-                (new PhelExportConfig())
-                    ->setFromDirectories(['some/other/dir'])
-                    ->setNamespacePrefix('Generated')
-                    ->setTargetDirectory('src/Generated'),
-            )
+            ->setBuildConfig((new PhelBuildConfig())
+                ->setMainPhpPath('out/custom-index.php')
+                ->setMainPhelNamespace('test-ns/boot'))
+            ->setExportConfig((new PhelExportConfig())
+                ->setFromDirectories(['some/other/dir'])
+                ->setNamespacePrefix('Generated')
+                ->setTargetDirectory('src/Generated'))
             ->setIgnoreWhenBuilding(['src/ignore.me'])
             ->setNoCacheWhenBuilding(['should-not-be-cached'])
             ->setKeepGeneratedTempFiles(true)

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -28,7 +28,7 @@ final class PhelConfigTest extends TestCase
             ],
             PhelConfig::EXPORT_CONFIG => [
                 PhelExportConfig::TARGET_DIRECTORY => 'src/PhelGenerated',
-                PhelExportConfig::FROM_DIRECTORIES => ['src/phel'],
+                PhelExportConfig::FROM_DIRECTORIES => ['src'],
                 PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
             ],
             PhelConfig::IGNORE_WHEN_BUILDING => ['src/phel/local.phel'],


### PR DESCRIPTION
### 🤔 Background

RIght now, it's almost mandatory to create your own phel-config.php file, because the default values are 
Using `src/phel` for the default src directory. Using `test/phel` for the default test directory.
But for a phel project, the phel code will live most luckely under src directly.

### 💡 Goal

Smooth the starting DX when using phel with the min setup as possible.

### 🔖 Changes

- Using `src` for the default src directory
- Using `test` for the default test directory

### 🏗️ TODO

Update docs: https://phel-lang.org/documentation/getting-started/#manually-initialize-a-new-project-using-composer  
> https://github.com/phel-lang/phel-lang.org/blob/master/content/documentation/getting-started.md 
![Screenshot 2024-05-23 at 16 31 27](https://github.com/phel-lang/phel-lang/assets/5256287/6f89a9f3-d1db-4add-be69-ab0b71a51f86)
There is no need to create `phel-config.php`, only if you would like to customize the default behaviour. 
