### PR TITLE
Move str-contains? to str/contains?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.14.0](https://github.com/phel-lang/phel-lang/compare/v0.13.0...v0.14.0) - 2024-05-24
 
-* Remove `str-contains?` in favor of `contains?` (#700)
+* Move `str-contains?` to `str/contains?` (#700)
 * Change `PhelConfig` default src and tests directories (#699)
 * Fix `PhelBuildConfig` when using `trim` (#698)
 * Fix `setMainPhpPath()` without directory or more than one (#697)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.14.0](https://github.com/phel-lang/phel-lang/compare/v0.13.0...v0.14.0) - 2024-05-24
 
+* Remove `str-contains?` in favor of `contains?` (#700)
 * Change `PhelConfig` default src and tests directories (#699)
 * Fix `PhelBuildConfig` when using `trim` (#698)
 * Fix `setMainPhpPath()` without directory or more than one (#697)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -533,12 +533,11 @@ Calling the `and` function without arguments returns true."
   (id x nil))
 
 (defn contains?
-  "Returns true if key is present in the given collection or string, otherwise returns false."
+  "Returns true if key is present in the given collection, otherwise returns false."
   [coll key]
   (cond
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
     (php/is_array coll) (php/array_key_exists key coll)
-    (php/is_string coll) (php/str_contains coll key)
     (throw (php/new InvalidArgumentException (php/. "cannot call 'contains?' on " (php/get_class coll))))))
 
 (defn compare

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -543,6 +543,7 @@ Calling the `and` function without arguments returns true."
   (cond
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
     (php/is_array coll) (php/array_key_exists key coll)
+    (php/is_string coll) (php/str_contains coll key)
     (throw (php/new InvalidArgumentException (php/. "cannot call 'contains?' on " (php/get_class coll))))))
 
 (defn compare

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -533,7 +533,7 @@ Calling the `and` function without arguments returns true."
   (id x nil))
 
 (defn contains?
-  "Returns true if key is present in the given collection, otherwise returns false."
+  "Returns true if key is present in the given collection or string, otherwise returns false."
   [coll key]
   (cond
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -533,7 +533,7 @@ Calling the `and` function without arguments returns true."
   (id x nil))
 
 (defn str-contains?
-  "Returns true if str contains s."
+  "Returns true if str contains s. **Deprecated** in favor of `str/contains?`"
   [str s]
   (php/str_contains str s))
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -532,11 +532,6 @@ Calling the `and` function without arguments returns true."
   [x]
   (id x nil))
 
-(defn str-contains?
-  "Returns true if str contains s. **Deprecated** in favor of `str/contains?`"
-  [str s]
-  (php/str_contains str s))
-
 (defn contains?
   "Returns true if key is present in the given collection, otherwise returns false."
   [coll key]

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -1,11 +1,6 @@
 (ns phel\str
   (:require phel\core))
 
-(defn contains?
-  "Returns true if str contains s."
-  [str s]
-  (php/str_contains str s))
-
 (defn split
   "Splits string on a regular expression.  Optional argument limit is
   the maximum number of parts. Not lazy. Returns vector of the parts.

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -1,6 +1,11 @@
 (ns phel\str
   (:require phel\core))
 
+(defn contains?
+  "Returns true if str contains s."
+  [str s]
+  (php/str_contains str s))
+
 (defn split
   "Splits string on a regular expression.  Optional argument limit is
   the maximum number of parts. Not lazy. Returns vector of the parts.

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -314,7 +314,7 @@
         registry (php/:: Registry (getInstance))]
     (for [fn-name :keys (php/-> registry (getDefinitionInNamespace munge-ns))
           :let [meta (php/-> registry (getDefinitionMetaData munge-ns fn-name))]
-          :when (and (:test meta) (or (nil? filter) (str-contains? (:test-name meta) filter)))]
+          :when (and (:test meta) (or (nil? filter) (contains? (:test-name meta) filter)))]
       (php/-> registry (getDefinition munge-ns fn-name)))))
 
 (defn- run-test [options ns]

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -2,7 +2,8 @@
   (:use Phel\Lang\Symbol)
   (:use Phel\Lang\Registry)
   (:use Phel\Compiler\Infrastructure\Munge)
-  (:use Phel\Command\CommandFacade))
+  (:use Phel\Command\CommandFacade)
+  (:require phel\str :as s))
 
 # ------
 # Report
@@ -314,7 +315,7 @@
         registry (php/:: Registry (getInstance))]
     (for [fn-name :keys (php/-> registry (getDefinitionInNamespace munge-ns))
           :let [meta (php/-> registry (getDefinitionMetaData munge-ns fn-name))]
-          :when (and (:test meta) (or (nil? filter) (contains? (:test-name meta) filter)))]
+          :when (and (:test meta) (or (nil? filter) (s/contains? (:test-name meta) filter)))]
       (php/-> registry (getDefinition munge-ns fn-name)))))
 
 (defn- run-test [options ns]

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -156,10 +156,6 @@
   (is (false? (false? nil)) "(false? nil)")
   (is (false? (false? true)) "(false? true)"))
 
-(deftest test-contains?-str
-  (is (true? (contains? "abc" "a")))
-  (is (false? (contains? "abc" "d"))))
-
 (deftest test-contains?-map
   (let [full-name {:first-name "Marco" :last-name "Polo" :street nil}]
     (is (true? (contains? full-name :first-name)))

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -156,10 +156,6 @@
   (is (false? (false? nil)) "(false? nil)")
   (is (false? (false? true)) "(false? true)"))
 
-(deftest test-str-contains?
-  (is (true? (str-contains? "abc" "a")))
-  (is (false? (str-contains? "abc" "d"))))
-
 (deftest test-contains?-str
   (is (true? (contains? "abc" "a")))
   (is (false? (contains? "abc" "d"))))

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -160,6 +160,10 @@
   (is (true? (str-contains? "abc" "a")))
   (is (false? (str-contains? "abc" "d"))))
 
+(deftest test-contains?-str
+  (is (true? (contains? "abc" "a")))
+  (is (false? (contains? "abc" "d"))))
+
 (deftest test-contains?-map
   (let [full-name {:first-name "Marco" :last-name "Polo" :street nil}]
     (is (true? (contains? full-name :first-name)))

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -2,6 +2,10 @@
   (:require phel\test :refer [deftest is])
   (:require phel\str :as s))
 
+(deftest test-contains?
+  (is (true? (s/contains? "abc" "a")))
+  (is (false? (s/contains? "abc" "d"))))
+
 (deftest test-split
   (is (= ["a" "b"] (s/split "a-b" "/-/")))
   (is (= ["a" "b-c"] (s/split "a-b-c" "/-/" 2)))

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -2,10 +2,6 @@
   (:require phel\test :refer [deftest is])
   (:require phel\str :as s))
 
-(deftest test-contains?
-  (is (true? (s/contains? "abc" "a")))
-  (is (false? (s/contains? "abc" "d"))))
-
 (deftest test-split
   (is (= ["a" "b"] (s/split "a-b" "/-/")))
   (is (= ["a" "b-c"] (s/split "a-b-c" "/-/" 2)))

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -2,6 +2,10 @@
   (:require phel\test :refer [deftest is])
   (:require phel\str :as s))
 
+(deftest test-str-contains?
+  (is (true? (s/contains? "abc" "a")))
+  (is (false? (s/contains? "abc" "d"))))
+
 (deftest test-split
   (is (= ["a" "b"] (s/split "a-b" "/-/")))
   (is (= ["a" "b-c"] (s/split "a-b-c" "/-/" 2)))


### PR DESCRIPTION
### 🔖 Changes

Remove `str-contains?` in favor of `contains?` from the `phel/str` namespace
