### PR TITLE
Remove unnecessary condition in ReplCommandTest

### DIFF
--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
@@ -104,10 +104,6 @@ final class ReplCommandTest extends AbstractCommandTest
                 continue;
             }
 
-            if (preg_match('/\.test$/', $file->getRealPath()) === 0) {
-                continue;
-            }
-
             if (preg_match('/\.test$/', $file->getRealPath()) === false) {
                 continue;
             }


### PR DESCRIPTION
### 🔖 Changes

Remove unnecessary condition inside `ReplCommandTest::buildDataProviderFromDirectory()`. 
That same condition is duplicated right above.
