### PR TITLE
fix: check for readline extension in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Fix add check for readline extension in REPL to handle missing dependencies (#712)
+
 ## [0.14.1](https://github.com/phel-lang/phel-lang/compare/v0.14.0...v0.14.1) - 2024-05-24
 
 * Fix `bin/phel` after refactor

--- a/src/php/Run/Domain/Repl/MissingDependencyException.php
+++ b/src/php/Run/Domain/Repl/MissingDependencyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl;
+
+use RuntimeException;
+
+final class MissingDependencyException extends RuntimeException
+{
+    public static function missingExtension(string $extensionName): self
+    {
+        return new self(sprintf('Missing PHP extension: %s', $extensionName));
+    }
+}

--- a/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
@@ -9,12 +9,17 @@ use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Throwable;
 
+use function extension_loaded;
+
 final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
 {
     public function __construct(
         private string $historyFile,
         private CommandFacadeInterface $commandFacade,
     ) {
+        if (!extension_loaded('readline')) {
+            throw MissingDependencyException::missingExtension('readline');
+        }
     }
 
     public function readHistory(): void


### PR DESCRIPTION
### 🤔 Background

The current codebase for the REPL (Read-Eval-Print Loop) system lacks proper handling of missing PHP extensions, which can lead to runtime errors and poor user experience. The goal of this pull request is to add a mechanism to check for required PHP extensions and handle cases where they are missing.

### 💡 Goal

The goal of this PR is to improve the robustness and user-friendliness of the REPL system by adding a check for the required readline PHP extension. If the extension is not loaded, a custom exception will be thrown to inform the user about the missing dependency.

### 🔖 Changes

#### 1. Addition of MissingDependencyException class:

- Created a new class MissingDependencyException in the src/php/Run/Domain/Repl namespace.
- This class extends RuntimeException and provides a static method missingExtension for creating exceptions with a message about the missing PHP extension.

#### 2.Modification of ReplCommandSystemIo class:

- Added a check in the constructor to verify if the readline extension is loaded.
- If the readline extension is not loaded, the MissingDependencyException is thrown with an appropriate message.

Reasons why the check is directly inside ReplCommandSystemIo :

- By placing the extension check in ReplCommandSystemIo, the dependency management is centralized, ensuring all commands relying on it have necessary dependencies verified at instantiation, avoiding possible repetitive checks across commands.
- The ReplCommandSystemIo constructor acts as a guard, ensuring the object is created only when all necessary dependencies are available, aligning with the fail-fast principle to detect issues early.

**Note: Tests are missing, as I was not able to find out how to test the absence of the readline extension without disabling it during the PHP build.**