### PR TITLE
Compatibility of lists and vectors in the cons function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Compatibility of lists and vectors in the cons function (#714)
+
 ## [0.14.1](https://github.com/phel-lang/phel-lang/compare/v0.14.0...v0.14.1) - 2024-05-24
 
 * Fix `bin/phel` after refactor

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -307,6 +307,11 @@ final class PersistentVector extends AbstractPersistentVector
         );
     }
 
+    public function cons(mixed $x): PersistentVectorInterface
+    {
+        return self::fromArray($this->hasher, $this->equalizer, [$x, ...$this->root, ...$this->tail]);
+    }
+
     protected function sliceNormalized(int $start, int $end): PersistentVectorInterface
     {
         return new SubVector($this->hasher, $this->equalizer, $this->meta, $this, $start, $end);

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -309,7 +309,7 @@ final class PersistentVector extends AbstractPersistentVector
 
     public function cons(mixed $x): PersistentVectorInterface
     {
-        return self::fromArray($this->hasher, $this->equalizer, [$x, ...$this->root, ...$this->tail]);
+        return self::fromArray($this->hasher, $this->equalizer, [$x, ...$this->toArray()]);
     }
 
     protected function sliceNormalized(int $start, int $end): PersistentVectorInterface

--- a/src/php/Lang/Collections/Vector/PersistentVectorInterface.php
+++ b/src/php/Lang/Collections/Vector/PersistentVectorInterface.php
@@ -9,6 +9,7 @@ use Countable;
 use IteratorAggregate;
 use Phel\Lang\Collections\AsTransientInterface;
 use Phel\Lang\ConcatInterface;
+use Phel\Lang\ConsInterface;
 use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\PushInterface;
@@ -28,7 +29,7 @@ use Phel\Lang\TypeInterface;
  * @extends AsTransientInterface<TransientVectorInterface>
  * @extends ContainsInterface<int>
  */
-interface PersistentVectorInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ArrayAccess, ConcatInterface, PushInterface, SliceInterface, AsTransientInterface, FnInterface, ContainsInterface
+interface PersistentVectorInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ConsInterface, ArrayAccess, ConcatInterface, PushInterface, SliceInterface, AsTransientInterface, FnInterface, ContainsInterface
 {
     public const BRANCH_FACTOR = 32;
 

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -122,6 +122,11 @@ final class SubVector extends AbstractPersistentVector
         throw new MethodNotSupportedException('asTransient is not supported on SubVector');
     }
 
+    public function cons(mixed $x): PersistentVectorInterface
+    {
+        return PersistentVector::fromArray($this->hasher, $this->equalizer, [$x, ...$this->toArray()]);
+    }
+
     protected function sliceNormalized(int $start, int $end): PersistentVectorInterface
     {
         return new self($this->hasher, $this->equalizer, $this->meta, $this->vector, $this->start + $start, $this->start + $end);

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -11,6 +11,20 @@
   (is (= [1 2 3] (cons 1 (rest [1 2 3]))) "cons sub vector multiple elements")
   (is (= [1] (cons 1 nil)) "cons nil"))
 
+(deftest test-cons-32-more-elements
+  (is (= (php/array 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39)
+         (cons 0 (php/range 1 39)))
+      "cons php array with 32 or more elements")
+  (is (= '(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39)
+         (cons 0 (apply list (range 1 40))))
+      "cons list with 32 or more elements")
+  (is (= [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39]
+         (cons 0 (range 1 40)))
+      "cons vector with 32 or more elements")
+  (is (= [0 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39]
+         (cons 0 (rest (range 1 40))))
+      "cons sub vector with 32 or more elements"))
+
 (deftest test-first
   (is (= 1 (first [1])) "first of vector")
   (is (nil? (first [])) "frist of empty vector")

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -4,6 +4,11 @@
 (deftest test-cons
   (is (= (php/array 1 2) (cons 1 (php/array 2))) "cons php array")
   (is (= '(1 2) (cons 1 '(2))) "cons list")
+  (is (= '(1 2 3) (cons 1 '(2 3))) "cons list multiple elements")
+  (is (= [1 2] (cons 1 [2])) "cons vector")
+  (is (= [1 2 3] (cons 1 [2 3])) "cons vector multiple elements")
+  (is (= [1 2] (cons 1 (rest [1 2]))) "cons sub vector")
+  (is (= [1 2 3] (cons 1 (rest [1 2 3]))) "cons sub vector multiple elements")
   (is (= [1] (cons 1 nil)) "cons nil"))
 
 (deftest test-first


### PR DESCRIPTION
### 🤔 Background

closes: #709 

Fixed an issue where an error would occur when passing a Vector as the second argument to the `cons` function.

### 💡 Goal

Making List and Vector compatible in the `cons` function

### 🔖 Changes

`ConsInterface` has been added to `PersistentVectorInterface`.

With my current knowledge of the `phel-lang` source code, I was not able to implement it with performance in mind. Therefore, it is in a state where it just works for the time being. Could you please review and fix it?
