### PR TITLE
fix: deprecation notice about signed binary number in REPL

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
          defaultTestSuite="unit"
          executionOrder="random"
          processIsolation="false"

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -20,7 +20,7 @@ final readonly class AtomParser
 {
     private const REGEX_KEYWORD = '/:(?<second_colon>:?)((?<namespace>[^\/]+)\/)?(?<keyword>[^\/]+)/';
 
-    private const REGEX_BINARY_NUMBER = '/^([+-])?0[bB][01]+(_[01]+)*$/';
+    private const REGEX_BINARY_NUMBER = '/^([+-])?0[bB]([01]+(?:_[01]+)*)$/';
 
     private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX][0-9a-fA-F]+(_[0-9a-fA-F]+)*$/';
 
@@ -121,12 +121,13 @@ final readonly class AtomParser
     private function parseBinaryNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
+        $unsignedInteger = $matches[2] ?? $word;
 
         return new NumberNode(
             $word,
             $token->getStartLocation(),
             $token->getEndLocation(),
-            $sign * bindec(str_replace('_', '', $word)),
+            $sign * bindec(str_replace('_', '', $unsignedInteger)),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -180,6 +180,28 @@ final class AtomParserTest extends TestCase
                 new Token(Token::T_ATOM, '0b001', $start, $end),
             ),
         );
+        $this->assertEquals(
+            new NumberNode(
+                '+0b001',
+                $start,
+                $end,
+                1,
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, '+0b001', $start, $end),
+            ),
+        );
+        $this->assertEquals(
+            new NumberNode(
+                '-0b001',
+                $start,
+                $end,
+                -1,
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, '-0b001', $start, $end),
+            ),
+        );
     }
 
     public function test_parse_hexadecimal_number(): void


### PR DESCRIPTION
### 🤔 Background

When evaluating a negative binary number in the REPL:

> phel:1> -0b1

The following deprecation notice is raised:

> [2024-06-07T10:58:02+00:00] Error Unknown(22527) found!
message: "Invalid characters passed for attempted conversion, these have been ignored"
file: phel-lang/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php:129
context: {"errno":8192}

It is also raised for a positively-signed binary number.

Phel evaluates binary numbers using the [bindec()](https://php.net/bindec) function, which only accepts unsigned values; therefore, `bindec()` raises a deprecation notice in the REPL.

### 💡 Goal

The goal of this P.R. is to solve the cause of the deprecation notice.

### 🔖 Changes

- `bindec()` also does not accept the underscores in numbers. For this reason, Phel removes them before passing the binary number to `bindec()` in the `AtomParser` class. This commit modifies the regular expression for binary numbers to capture the unsigned value of the number, then passes that to `bindec()`.
- It includes in `AtomParserTest::test_parse_binary_number()` assertions for signed binary numbers.
- It configures PHPUnit to convert deprecation notices into exceptions so that the new assertions can be useful.
