### PR TITLE
feat: Check mandatory function parameters during compile time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Fix add check for readline extension in REPL to handle missing dependencies (#712)
+* Check mandatory function parameters during compile time (#717)
 
 ## [0.14.1](https://github.com/phel-lang/phel-lang/compare/v0.14.0...v0.14.1) - 2024-05-24
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
@@ -8,6 +8,8 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
+use function count;
+
 final class FnNode extends AbstractNode
 {
     /**
@@ -50,6 +52,16 @@ final class FnNode extends AbstractNode
     public function isVariadic(): bool
     {
         return $this->isVariadic;
+    }
+
+    public function getMinArity(): int
+    {
+        $arity = count($this->params);
+        if ($this->isVariadic) {
+            --$arity;
+        }
+
+        return $arity;
     }
 
     public function getRecurs(): bool

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -54,4 +54,21 @@ final class AnalyzerException extends AbstractLocatedException
             $exception,
         );
     }
+
+    public static function whenExpandingMacro(
+        PersistentListInterface $list,
+        GlobalVarNode $node,
+        Exception $exception,
+    ): self {
+        throw self::withLocation(
+            sprintf(
+                'Error in expanding macro "%s\\%s": %s',
+                $node->getNamespace(),
+                $node->getName()->getName(),
+                $exception->getMessage(),
+            ),
+            $list,
+            $exception,
+        );
+    }
 }

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\Exceptions;
 
 use Exception;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\TypeInterface;
+
+use function count;
 
 final class AnalyzerException extends AbstractLocatedException
 {
@@ -17,6 +21,20 @@ final class AnalyzerException extends AbstractLocatedException
             $type->getStartLocation(),
             $type->getEndLocation(),
             $nested,
+        );
+    }
+
+    public static function notEnoughArgsProvided(GlobalVarNode $f, PersistentListInterface $list, int $minArity): self
+    {
+        return self::withLocation(
+            sprintf(
+                'Not enough arguments provided to function "%s\\%s". Got: %d Expected: %d',
+                $f->getNamespace(),
+                $f->getName()->getName(),
+                count($list->rest()),
+                $minArity,
+            ),
+            $list,
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -37,4 +37,21 @@ final class AnalyzerException extends AbstractLocatedException
             $list,
         );
     }
+
+    public static function whenExpandingInlineFn(
+        PersistentListInterface $list,
+        GlobalVarNode $node,
+        Exception $exception,
+    ): self {
+        throw self::withLocation(
+            sprintf(
+                'Error in expanding inline function of "%s\\%s": %s',
+                $node->getNamespace(),
+                $node->getName()->getName(),
+                $exception->getMessage(),
+            ),
+            $list,
+            $exception,
+        );
+    }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -49,6 +50,12 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         $this->analyzer->addDefinition($namespace, $nameSymbol);
 
         [$metaMap, $init] = $this->createMetaMapAndInit($list);
+
+        $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol);
+        if ($initNode instanceof FnNode) {
+            $metaMap = $metaMap->put('min-arity', $initNode->getMinArity());
+        }
+
         $meta = $this->analyzer->analyze($metaMap, $env->withExpressionContext());
         assert($meta instanceof MapNode);
 
@@ -57,7 +64,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $namespace,
             $nameSymbol,
             $meta,
-            $this->analyzeInit($init, $env, $namespace, $nameSymbol),
+            $initNode,
             $list->getStartLocation(),
         );
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -41,14 +41,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         }
 
         if ($f instanceof GlobalVarNode) {
-            $nodeName = $f->getName()->getName();
-            $data = Registry::getInstance()->getDefinitionMetaData($f->getNamespace(), $nodeName);
-            if ($data instanceof PersistentMapInterface) {
-                $minArity = $data->find('min-arity');
-                if ($minArity && count($list->rest()) < $minArity) {
-                    throw AnalyzerException::notEnoughArgsProvided($f, $list, $minArity);
-                }
-            }
+            $this->validateEnoughArgsProvided($f, $list);
         }
 
         return new CallNode(
@@ -59,8 +52,11 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         );
     }
 
-    private function inlineMacro(PersistentListInterface $list, GlobalVarNode $f, NodeEnvironmentInterface $env): AbstractNode
-    {
+    private function inlineMacro(
+        PersistentListInterface $list,
+        GlobalVarNode $f,
+        NodeEnvironmentInterface $env,
+    ): AbstractNode {
         return $this->analyzer->analyzeMacro($this->inlineExpand($list, $f), $env);
     }
 
@@ -81,13 +77,18 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         return $arityFn($arity);
     }
 
-    private function globalMacro(PersistentListInterface $list, GlobalVarNode $f, NodeEnvironmentInterface $env): AbstractNode
-    {
+    private function globalMacro(
+        PersistentListInterface $list,
+        GlobalVarNode $f,
+        NodeEnvironmentInterface $env,
+    ): AbstractNode {
         return $this->analyzer->analyzeMacro($this->macroExpand($list, $f), $env);
     }
 
-    private function inlineExpand(PersistentListInterface $list, GlobalVarNode $node): float|bool|int|string|TypeInterface|array|null
-    {
+    private function inlineExpand(
+        PersistentListInterface $list,
+        GlobalVarNode $node,
+    ): float|bool|int|string|TypeInterface|array|null {
         $meta = $node->getMeta();
         $fn = $meta[Keyword::create('inline')];
 
@@ -95,15 +96,18 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
             throw AnalyzerException::withLocation(
-                'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName() . '": ' . $exception->getMessage(),
+                'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName(
+                ) . '": ' . $exception->getMessage(),
                 $list,
                 $exception,
             );
         }
     }
 
-    private function macroExpand(PersistentListInterface $list, GlobalVarNode $macroNode): float|bool|int|string|TypeInterface|array|null
-    {
+    private function macroExpand(
+        PersistentListInterface $list,
+        GlobalVarNode $macroNode,
+    ): float|bool|int|string|TypeInterface|array|null {
         /** @psalm-suppress PossiblyNullArgument */
         $nodeName = $macroNode->getName()->getName();
         $fn = Registry::getInstance()->getDefinition($macroNode->getNamespace(), $nodeName);
@@ -112,15 +116,18 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
             throw AnalyzerException::withLocation(
-                'Error in expanding macro "' . $macroNode->getNamespace() . '\\' . $nodeName . '": ' . $exception->getMessage(),
+                'Error in expanding macro "' . $macroNode->getNamespace(
+                ) . '\\' . $nodeName . '": ' . $exception->getMessage(),
                 $list,
                 $exception,
             );
         }
     }
 
-    private function callMacroFn(callable $fn, PersistentListInterface $list): float|bool|int|string|TypeInterface|array|null
-    {
+    private function callMacroFn(
+        callable $fn,
+        PersistentListInterface $list,
+    ): float|bool|int|string|TypeInterface|array|null {
         $arguments = $list->rest()->toArray();
 
         $result = $fn(...$arguments);
@@ -179,5 +186,17 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $arguments;
+    }
+
+    private function validateEnoughArgsProvided(GlobalVarNode $f, PersistentListInterface $list): void
+    {
+        $nodeName = $f->getName()->getName();
+        $data = Registry::getInstance()->getDefinitionMetaData($f->getNamespace(), $nodeName);
+        if ($data instanceof PersistentMapInterface) {
+            $minArity = $data->find('min-arity');
+            if ($minArity && count($list->rest()) < $minArity) {
+                throw AnalyzerException::notEnoughArgsProvided($f, $list, $minArity);
+            }
+        }
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -110,11 +110,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         try {
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
-            throw AnalyzerException::withLocation(
-                'Error in expanding macro "' . $macroNode->getNamespace() . '\\' . $nodeName . '": ' . $exception->getMessage(),
-                $list,
-                $exception,
-            );
+            throw AnalyzerException::whenExpandingMacro($list, $macroNode, $exception);
         }
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -46,10 +46,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             if ($data instanceof PersistentMapInterface) {
                 $minArity = $data->find('min-arity');
                 if ($minArity && count($list->rest()) < $minArity) {
-                    throw AnalyzerException::withLocation(
-                        'Not enough arguments provided to function "' . $f->getNamespace() . '\\' . $f->getName()->getName() . '". Got: ' . count($list->rest()) . ' Expected: ' . $minArity,
-                        $list,
-                    );
+                    throw AnalyzerException::notEnoughArgsProvided($f, $list, $minArity);
                 }
             }
         }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -95,11 +95,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         try {
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
-            throw AnalyzerException::withLocation(
-                'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName() . '": ' . $exception->getMessage(),
-                $list,
-                $exception,
-            );
+            throw AnalyzerException::whenExpandingInlineFn($list, $node, $exception);
         }
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -96,8 +96,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
             throw AnalyzerException::withLocation(
-                'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName(
-                ) . '": ' . $exception->getMessage(),
+                'Error in expanding inline function of "' . $node->getNamespace() . '\\' . $node->getName()->getName() . '": ' . $exception->getMessage(),
                 $list,
                 $exception,
             );
@@ -116,8 +115,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             return $this->callMacroFn($fn, $list);
         } catch (Exception $exception) {
             throw AnalyzerException::withLocation(
-                'Error in expanding macro "' . $macroNode->getNamespace(
-                ) . '\\' . $nodeName . '": ' . $exception->getMessage(),
+                'Error in expanding macro "' . $macroNode->getNamespace() . '\\' . $nodeName . '": ' . $exception->getMessage(),
                 $list,
                 $exception,
             );

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -23,7 +23,8 @@
       \Phel\Lang\Keyword::create("file"), "Call/global-call.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 18
-    )
+    ),
+    "min-arity", 1
   )
 );
 (\Phel\Lang\Registry::getInstance()->getDefinition("user", "x"))(1);

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -23,7 +23,8 @@
       \Phel\Lang\Keyword::create("file"), "Call/php-fn-reference.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 37
-    )
+    ),
+    "min-arity", 2
   )
 );
 (\Phel\Lang\Registry::getInstance()->getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -48,7 +48,8 @@ interface IPlayer {
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
-    )
+    ),
+    "min-arity", 1
   )
 );
 
@@ -81,7 +82,8 @@ interface IPlayer {
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
-    )
+    ),
+    "min-arity", 3
   )
 );
 ("foo" instanceof \interface_instance\IPlayer);

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -46,7 +46,8 @@ interface IPlayer {
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
-    )
+    ),
+    "min-arity", 1
   )
 );
 
@@ -79,6 +80,7 @@ interface IPlayer {
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
-    )
+    ),
+    "min-arity", 3
   )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -23,6 +23,7 @@
       \Phel\Lang\Keyword::create("file"), "Def/defn-meta.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 36
-    )
+    ),
+    "min-arity", 1
   )
 );

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -28,6 +28,7 @@
       \Phel\Lang\Keyword::create("file"), "Foreach/foreach-expr.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 18
-    )
+    ),
+    "min-arity", 0
   )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -28,7 +28,8 @@
       \Phel\Lang\Keyword::create("file"), "MacroExpand/macro-expand.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 36
-    )
+    ),
+    "min-arity", 1
   )
 );
 (1 + 1);

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -24,7 +24,8 @@
       \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 55
-    )
+    ),
+    "min-arity", 1
   )
 );
 \Phel\Lang\Registry::getInstance()->addDefinition(

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -70,7 +70,8 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 19
-    )
+    ),
+    "min-arity", 1
   )
 );
 
@@ -95,6 +96,7 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 19
-    )
+    ),
+    "min-arity", 1
   )
 );

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -24,6 +24,7 @@
       \Phel\Lang\Keyword::create("file"), "Try/throw-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 56
-    )
+    ),
+    "min-arity", 0
   )
 );

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -30,10 +30,10 @@ final class InvokeSymbolTest extends TestCase
     {
         Registry::getInstance()->clear();
         $env = new GlobalEnvironment();
-        $env->addDefinition('user', Symbol::create('my-global-var'));
+        $env->addDefinition('user', Symbol::create('my-global-fn'));
         Registry::getInstance()->addDefinition(
             'user',
-            'my-global-var',
+            'my-global-fn',
             static fn ($a, $b): int => $a + $b,
             TypeFactory::getInstance()->persistentMapFromKVs('min-arity', 2),
         );
@@ -87,12 +87,12 @@ final class InvokeSymbolTest extends TestCase
         $f = new GlobalVarNode(
             $env->withExpressionContext()->withDisallowRecurFrame(),
             'user',
-            Symbol::create('my-global-var'),
+            Symbol::create('my-global-fn'),
             TypeFactory::getInstance()->emptyPersistentMap(),
         );
 
         $list = TypeFactory::getInstance()->persistentListFromArray([
-            Symbol::createForNamespace('user', 'my-global-var'),
+            Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
         ]);
 


### PR DESCRIPTION
### 🤔 Background

Issue: https://github.com/phel-lang/phel-lang/issues/704

### 💡 Goal

Fail on compilation time when passing wrong number of args to a function.

### 🔖 Changes

Added a `'min-arity'` meta data to the `FnNode` and check that when analyzing the `InvokeSymbol`


### 🖼️ Screenshots

![Screenshot 2024-06-08 at 17 36 19](https://github.com/phel-lang/phel-lang/assets/5256287/04ac8240-68ff-4199-b9cb-9037adcc3b7c)
