### PR TITLE
fix: deprecation notice for signed hexadecimals

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
          defaultTestSuite="unit"
          executionOrder="random"
          processIsolation="false"

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -22,7 +22,7 @@ final readonly class AtomParser
 
     private const REGEX_BINARY_NUMBER = '/^([+-])?0[bB][01]+(_[01]+)*$/';
 
-    private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX][0-9a-fA-F]+(_[0-9a-fA-F]+)*$/';
+    private const REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX]([0-9a-fA-F]+(?:_[0-9a-fA-F]+)*)$/';
 
     private const REGEX_OCTAL_NUMBER = '/^([+-])?0[0-7]+(_[0-7]+)*$/';
 
@@ -133,12 +133,13 @@ final readonly class AtomParser
     private function parseHexadecimalNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
+        $unsignedInteger = $matches[2] ?? $word;
 
         return new NumberNode(
             $word,
             $token->getStartLocation(),
             $token->getEndLocation(),
-            $sign * hexdec(str_replace('_', '', $word)),
+            $sign * hexdec(str_replace('_', '', $unsignedInteger)),
         );
     }
 

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -200,6 +200,42 @@ final class AtomParserTest extends TestCase
         );
     }
 
+    public function test_parse_positively_signed_hexadecimal_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+        $this->assertEquals(
+            new NumberNode(
+                '+0x001',
+                $start,
+                $end,
+                1,
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, '+0x001', $start, $end),
+            ),
+        );
+    }
+
+    public function test_parse_negative_hexadecimal_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+        $this->assertEquals(
+            new NumberNode(
+                '-0x001',
+                $start,
+                $end,
+                -1,
+            ),
+            $parser->parse(
+                new Token(Token::T_ATOM, '-0x001', $start, $end),
+            ),
+        );
+    }
+
     public function test_parse_numeric_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -200,7 +200,7 @@ final class AtomParserTest extends TestCase
         );
     }
 
-    public function test_parse_positively_signed_hexadecimal_number(): void
+    public function test_parse_positive_signed_hexadecimal_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());
         $start = new SourceLocation('string', 0, 0);


### PR DESCRIPTION
### 🤔 Background

When evaluating a negative hexadecimal number in the REPL:

> phel:1> -0x1

The following deprecation notice is raised:

> [2024-06-08T13:22:33+00:00] Error Unknown(22527) found!
message: "Invalid characters passed for attempted conversion, these have been ignored"
file: phel-lang/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php:141 
context: {"errno":8192}

It is also raised for positively-signed hexadecimal numbers.

Phel evaluates hexadecimal numbers using the
[hexdec()](https://php.net/hexdec) function, which only accepts unsigned values; therefore, `hexdec()` raises a deprecation notice in the REPL.

### 💡 Goal

The goal of this P.R. is to solve the cause of the deprecation notice.

### 🔖 Changes

- `hexdec()` also does not accept the underscores in numbers. For this reason, Phel removes them before passing the hexadecimal number to `hexdec()`. This commit modifies the regular expression for hexadecimal numbers to capture the unsigned value of the number, then passes that to `hexdec()`.
- It adds two new tests to `AtomParserTest::class` for parsing positively-signed and negative hexadecimal numbers.
- It configures PHPUnit to convert deprecation notices into exceptions so that the new tests can be useful.
