### PR TITLE
Fix doc command

### DIFF
--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -94,8 +94,7 @@ final class DocCommand extends Command
      */
     private function calculateWithProportionalToCurrentScreen(): array
     {
-        /** @psalm-suppress ForbiddenCode */
-        $colCount = (int)shell_exec('tput cols');
+        $colCount = (int)getenv('COLUMNS');
         $proportion1 = 25;
         $proportion2 = 40;
         $proportion3 = 50;

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 
 use function in_array;
 
@@ -94,7 +95,7 @@ final class DocCommand extends Command
      */
     private function calculateWithProportionalToCurrentScreen(): array
     {
-        $colCount = (int)getenv('COLUMNS');
+        $colCount = (new Terminal())->getWidth();
         $proportion1 = 25;
         $proportion2 = 40;
         $proportion3 = 50;


### PR DESCRIPTION
### 🤔 Background

https://github.com/phel-lang/phel-lang/pull/720#issuecomment-2156510943 

The display process of the table format depends on the `tput` command.
So, if you dont have `tput` the `doc` command wont cause an error.

### 🔖 Changes

- Use env `$COLUMNS` instead of `tput`
