### PR TITLE
feat: add `macroexpand` special form. wip

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+
+final class MacroExpandNode extends AbstractNode
+{
+    public function __construct(
+        private NodeEnvironmentInterface $env,
+        private readonly AbstractNode $value,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getValue(): AbstractNode
+    {
+        return $this->value; // as dummy.
+
+        // Note:
+        // `$this->value` is expanded Node.
+        // If returned as is, the Node is passed to Emitter and evaluated when PHP is executed.
+        // I thought that if we could convert the Node to a `quote`ed Node that is not evaluated in this method, we could reproduce the state in which the macro is expanded.
+
+        // return $this->quoteNode($this->value);
+    }
+
+    /** Implementation is not complete. */
+    private function quoteNode(AbstractNode $node): AbstractNode
+    {
+        switch (true) {
+            case $node instanceof DoNode:
+                return array_map(fn($x) => $this->quoteNode($x), $node->getStmts());
+            case $node instanceof BindingNode:
+                return new VectorNode($this->env, [
+                    Symbol::create($node->getSymbol()->getName()),
+                    $this->quoteNode($node->getInitExpr()),
+                ]);
+            case $node instanceof LetNode:
+                return TypeFactory::getInstance()->persistentListFromArray([
+                    Symbol::create(Symbol::NAME_LET),
+                    ...array_map(fn($x) => $this->quoteNode($x), $node->getBindings()),
+                    $this->quoteNode($node->getBodyExpr()),                    
+                ]);
+            default:
+                return $node;
+        }
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
@@ -17,7 +17,7 @@ final class MacroExpandNode extends AbstractNode
         parent::__construct($env, $sourceLocation);
     }
 
-    public function getValue(): AbstractNode|LiteralNode
+    public function getValue(): AbstractNode
     {
         return $this->value;
     }

--- a/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MacroExpandNode.php
@@ -6,50 +6,19 @@ namespace Phel\Compiler\Domain\Analyzer\Ast;
 
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
 
 final class MacroExpandNode extends AbstractNode
 {
     public function __construct(
-        private NodeEnvironmentInterface $env,
+        NodeEnvironmentInterface $env,
         private readonly AbstractNode $value,
         ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
 
-    public function getValue(): AbstractNode
+    public function getValue(): AbstractNode|LiteralNode
     {
-        return $this->value; // as dummy.
-
-        // Note:
-        // `$this->value` is expanded Node.
-        // If returned as is, the Node is passed to Emitter and evaluated when PHP is executed.
-        // I thought that if we could convert the Node to a `quote`ed Node that is not evaluated in this method, we could reproduce the state in which the macro is expanded.
-
-        // return $this->quoteNode($this->value);
-    }
-
-    /** Implementation is not complete. */
-    private function quoteNode(AbstractNode $node): AbstractNode
-    {
-        switch (true) {
-            case $node instanceof DoNode:
-                return array_map(fn($x) => $this->quoteNode($x), $node->getStmts());
-            case $node instanceof BindingNode:
-                return new VectorNode($this->env, [
-                    Symbol::create($node->getSymbol()->getName()),
-                    $this->quoteNode($node->getInitExpr()),
-                ]);
-            case $node instanceof LetNode:
-                return TypeFactory::getInstance()->persistentListFromArray([
-                    Symbol::create(Symbol::NAME_LET),
-                    ...array_map(fn($x) => $this->quoteNode($x), $node->getBindings()),
-                    $this->quoteNode($node->getBodyExpr()),                    
-                ]);
-            default:
-                return $node;
-        }
+        return $this->value;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -21,6 +21,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\IfSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\InvokeSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LoopSymbol;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MacroExpandSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\NsSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAGetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAPushSymbol;
@@ -91,6 +92,7 @@ final class AnalyzePersistentList
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),
             Symbol::NAME_DEF_INTERFACE => new DefInterfaceSymbol($this->analyzer),
+            Symbol::NAME_MACRO_EXPAND => new MacroExpandSymbol($this->analyzer),
             default => new InvokeSymbol($this->analyzer),
         };
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroExpandSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroExpandSymbol.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
-use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
@@ -20,7 +19,9 @@ final class MacroExpandSymbol implements SpecialFormAnalyzerInterface
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): MacroExpandNode
     {
-        if (!($list->get(0) instanceof Symbol && $list->get(0)->getName() === Symbol::NAME_MACRO_EXPAND)) {
+        if (!($list->get(0) instanceof Symbol
+            && $list->get(0)->getName() === Symbol::NAME_MACRO_EXPAND)
+        ) {
             throw AnalyzerException::withLocation("This is not a 'macroexpand.", $list);
         }
 
@@ -29,12 +30,11 @@ final class MacroExpandSymbol implements SpecialFormAnalyzerInterface
         }
 
         $form = $list->get(1);
-        if ($form instanceof PersistentListInterface) {
-            if ($form->get(0) instanceof Symbol) {
-                if ($form->get(0)->getName() === Symbol::NAME_QUOTE) {
-                    $form = $form->rest()->first();
-                }
-            }
+        if ($form instanceof PersistentListInterface
+            && $form->get(0) instanceof Symbol
+            && $form->get(0)->getName() === Symbol::NAME_QUOTE
+        ) {
+            $form = $form->rest()->first();
         }
 
         return new MacroExpandNode(

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroExpandSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MacroExpandSymbol.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+final class MacroExpandSymbol implements SpecialFormAnalyzerInterface
+{
+    use WithAnalyzerTrait;
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): MacroExpandNode
+    {
+        if (!($list->get(0) instanceof Symbol && $list->get(0)->getName() === Symbol::NAME_MACRO_EXPAND)) {
+            throw AnalyzerException::withLocation("This is not a 'macroexpand.", $list);
+        }
+
+        if (count($list) !== 2) {
+            throw AnalyzerException::withLocation("Exactly one argument is required for 'macroexpand", $list);
+        }
+
+        $form = $list->get(1);
+        if ($form instanceof PersistentListInterface) {
+            if ($form->get(0) instanceof Symbol) {
+                if ($form->get(0)->getName() === Symbol::NAME_QUOTE) {
+                    $form = $form->rest()->first();
+                }
+            }
+        }
+
+        return new MacroExpandNode(
+            $env,
+            $this->analyzer->analyze($form, $env),
+            $list->getStartLocation(),
+        );
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
@@ -6,7 +6,6 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
-use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
@@ -18,9 +18,7 @@ final class MacroExpandEmitter implements NodeEmitterInterface
     {
         assert($node instanceof MacroExpandNode);
 
-        // $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $form = $node->getValue();
         $this->outputEmitter->emitNode($form);
-        // $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MacroExpandEmitter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+
+use function assert;
+
+final class MacroExpandEmitter implements NodeEmitterInterface
+{
+    use WithOutputEmitterTrait;
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof MacroExpandNode);
+
+        // $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $form = $node->getValue();
+        $this->outputEmitter->emitNode($form);
+        // $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -18,6 +18,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
@@ -50,6 +51,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\IfEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LiteralEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LocalVarEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MacroExpandEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MethodEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\NsEmitter;
@@ -108,6 +110,7 @@ final class NodeEmitterFactory
             MapNode::class => new MapEmitter($outputEmitter),
             SetVarNode::class => new SetVarEmitter($outputEmitter),
             DefInterfaceNode::class => new DefInterfaceEmitter($outputEmitter),
+            MacroExpandNode::class => new MacroExpandEmitter($outputEmitter),
             default => throw NotSupportedAstException::withClassName($astNodeClassName),
         };
     }

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -29,7 +29,7 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
     public const NAME_LOOP = 'loop';
 
     public const NAME_MACRO_EXPAND = 'macroexpand';
-    
+
     public const NAME_NS = 'ns';
 
     public const NAME_PHP_ARRAY_GET = 'php/aget';

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -28,6 +28,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
 
     public const NAME_LOOP = 'loop';
 
+    public const NAME_MACRO_EXPAND = 'macroexpand';
+    
     public const NAME_NS = 'ns';
 
     public const NAME_PHP_ARRAY_GET = 'php/aget';

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
@@ -4,38 +4,70 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MacroExpandSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
 use PHPUnit\Framework\TestCase;
 
 final class MacroExpandSymbolTest extends TestCase
 {
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(
+            new GlobalEnvironment()
+        );
+    }
+
     public function test_list_with_wrong_symbol(): void
     {
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'macroexpand.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray(['any symbol', 'any text']);
-        (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+        $list = TypeFactory::getInstance()
+            ->persistentListFromArray(['any symbol', 'any text']);
+
+        $this->analyze($list);
     }
 
     public function test_list_without_argument(): void
     {
         $this->expectException(AbstractLocatedException::class);
-        $this->expectExceptionMessage("Exactly one argument is required for 'quote");
+        $this->expectExceptionMessage("Exactly one argument is required for 'macroexpand");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_MACRO_EXPAND)]);
-        (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+        $list = TypeFactory::getInstance()
+            ->persistentListFromArray([
+                Symbol::create(Symbol::NAME_MACRO_EXPAND)
+            ]);
+
+        $this->analyze($list);
     }
 
     public function test_macro_expand_list_with_any_text(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_MACRO_EXPAND), 'any text']);
-        $symbol = (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+        $list = TypeFactory::getInstance()
+            ->persistentListFromArray([
+                Symbol::create(Symbol::NAME_MACRO_EXPAND),
+                'any text'
+            ]);
 
-        self::assertSame('any text', $symbol->getValue());
+        $symbol = $this->analyze($list);
+        $value = $symbol->getValue();
+        self::assertSame('any text', $value->getValue());
+    }
+
+    private function analyze(PersistentListInterface $list): MacroExpandNode
+    {
+        return (new MacroExpandSymbol($this->analyzer))
+            ->analyze($list, NodeEnvironment::empty());
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
@@ -6,7 +6,6 @@ namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
-use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -24,7 +23,7 @@ final class MacroExpandSymbolTest extends TestCase
     protected function setUp(): void
     {
         $this->analyzer = new Analyzer(
-            new GlobalEnvironment()
+            new GlobalEnvironment(),
         );
     }
 
@@ -46,7 +45,7 @@ final class MacroExpandSymbolTest extends TestCase
 
         $list = TypeFactory::getInstance()
             ->persistentListFromArray([
-                Symbol::create(Symbol::NAME_MACRO_EXPAND)
+                Symbol::create(Symbol::NAME_MACRO_EXPAND),
             ]);
 
         $this->analyze($list);
@@ -57,7 +56,7 @@ final class MacroExpandSymbolTest extends TestCase
         $list = TypeFactory::getInstance()
             ->persistentListFromArray([
                 Symbol::create(Symbol::NAME_MACRO_EXPAND),
-                'any text'
+                'any text',
             ]);
 
         $symbol = $this->analyze($list);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MacroExpandSymbol;
+use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class MacroExpandSymbolTest extends TestCase
+{
+    public function test_list_with_wrong_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("This is not a 'macroexpand.");
+
+        $list = TypeFactory::getInstance()->persistentListFromArray(['any symbol', 'any text']);
+        (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_list_without_argument(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("Exactly one argument is required for 'quote");
+
+        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_MACRO_EXPAND)]);
+        (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_macro_expand_list_with_any_text(): void
+    {
+        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_MACRO_EXPAND), 'any text']);
+        $symbol = (new MacroExpandSymbol())->analyze($list, NodeEnvironment::empty());
+
+        self::assertSame('any text', $symbol->getValue());
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/MacroExpandSymbolTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MacroExpandNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -60,7 +61,9 @@ final class MacroExpandSymbolTest extends TestCase
             ]);
 
         $symbol = $this->analyze($list);
+        /** @var LiteralNode $value */
         $value = $symbol->getValue();
+
         self::assertSame('any text', $value->getValue());
     }
 


### PR DESCRIPTION
### 🤔 Background

Investigate the form after the macro has been expanded (like macroexpand in clojure) #728

I want to add `macroexpand`.

### 💡 Goal

The goal is to be able to use `macroexpand` to examine the form after the macro has been expanded.

### 🔖 Changes

Added `macroexpand` as a special form.
However, I have not been able to implement the part where the macro expands the form and displays it as is, because of the complexity of how to implement it.

Is there a better way to achieve this than the current method?