### PR TITLE
Fix result elements order of split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Fix a result of str/split-lines is in the wrong order (#735)
+
 ## [0.15.0](https://github.com/phel-lang/phel-lang/compare/v0.14.1...v0.15.0) - 2024-06-22
 
 * Fix add check for readline extension in REPL to handle missing dependencies (#712)

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -6,7 +6,7 @@
   the maximum number of parts. Not lazy. Returns vector of the parts.
   Trailing empty strings are not returned - pass limit of -1 to return all."
   [s re & [limit]]
-  (values (php-array-to-map (php/preg_split re s (or limit -1)))))
+  (values (php/preg_split re s (or limit -1))))
 
 (defn join
   "Returns a string of all elements in coll, as returned by (seq coll),
@@ -227,4 +227,4 @@
 (defn split-lines
   "Splits s on \\n or \\r\\n. Trailing empty lines are not returned."
   [s]
-  (split s "/\r?\n/"))
+  (split s "/\\r?\\n/"))

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -8,6 +8,11 @@
   (is (= ["ａ" "ｂ-ｃ"] (s/split "ａ-ｂ-ｃ" "/-/" 2)))
   (is (vector? (s/split "abc" "/-/"))))
 
+(deftest test-split-with-more-than-16-elements
+  (let [result (s/split "str-1\nstr-2\nstr-3\nstr-4\nstr-5\nstr-6\nstr-7\nstr-8\nstr-9\nstr-10\nstr-11\nstr-12\nstr-13\nstr-14\nstr-15\nstr-16\nstr-17" "/\\n/")]
+    (is (= ["str-1" "str-2" "str-3" "str-4" "str-5" "str-6" "str-7" "str-8" "str-9" "str-10" "str-11" "str-12" "str-13" "str-14" "str-15" "str-16" "str-17"] result))
+    (is (vector? result))))
+
 (deftest test-reverse
   (is (= "tab" (s/reverse "bat")))
   (is (= "ｔａｂ" (s/reverse "ｂａｔ"))))
@@ -101,6 +106,11 @@
     (is (= ["one" "two" "three"] result))
     (is (vector? result)))
   (is (= ["foo"] (s/split-lines "foo"))))
+
+(deftest test-split-lines-with-more-than-16-elements
+  (let [result (s/split-lines "str-1\nstr-2\nstr-3\nstr-4\nstr-5\nstr-6\nstr-7\nstr-8\nstr-9\nstr-10\nstr-11\nstr-12\nstr-13\nstr-14\nstr-15\nstr-16\nstr-17")]
+    (is (= ["str-1" "str-2" "str-3" "str-4" "str-5" "str-6" "str-7" "str-8" "str-9" "str-10" "str-11" "str-12" "str-13" "str-14" "str-15" "str-16" "str-17"] result))
+    (is (vector? result))))
 
 (deftest test-index-of
   (let [sb "tacos"]


### PR DESCRIPTION
### 🤔 Background

Closes: #735

### 💡 Goal

 Results of `str/split` are returned in the correct order even when the number of elements is greater than 16.

### 🔖 Changes

Removed unnecessary `php-array-to-map` calls.

```clojure
phel:1> (require phel\str)
phel\str
phel:2> (str/split-lines "str-1\nstr-2\nstr-3\nstr-4\nstr-5\nstr-6\nstr-7\nstr-8\nstr-9\nstr-10\nstr-11\nstr-12\nstr-13\nstr-14\nstr-15\nstr-16\nstr-17\n")
[str-1 str-2 str-3 str-4 str-5 str-6 str-7 str-8 str-9 str-10 str-11 str-12 str-13 str-14 str-15 str-16 str-17 ]
```

