### PR TITLE
Fix `find` function for an empty vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Fix a result of str/split-lines is in the wrong order (#735)
+* Fix `find` function for an empty vector (#737)
 
 ## [0.15.0](https://github.com/phel-lang/phel-lang/compare/v0.14.1...v0.15.0) - 2024-06-22
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1032,9 +1032,11 @@ arrays. Use (php/aunset ds key)"))
   "Drops all elements at the front `xs` where `(pred x)` is true."
   [pred xs]
   (loop [s xs]
-    (if (and s (pred (first s)))
-      (recur (next s))
-      (if s s []))))
+    (if (empty? s)
+      (or s [])
+      (if (pred (first s))
+        (recur (next s))
+        s))))
 
 (defn take
   "Takes the first `n` elements of `xs`."
@@ -1085,22 +1087,22 @@ arrays. Use (php/aunset ds key)"))
   "Returns the first item in `xs` where `(pred item)` evaluates to true."
   [pred xs]
   (loop [s xs]
-    (if s
+    (if (empty? s)
+      nil
       (if (pred (first s))
         (first s)
-        (recur (next s)))
-      nil)))
+        (recur (next s))))))
 
 (defn find-index
   "Returns the first item in `xs` where `(pred index item)` evaluates to true."
   [pred xs]
   (loop [s xs
          i 0]
-    (if s
+    (if (empty? s)
+      nil
       (if (pred (first s))
         i
-        (recur (next s) (php/+ i 1)))
-      nil)))
+        (recur (next s) (php/+ i 1))))))
 
 (defn distinct
   "Returns a vector with duplicated values removed in `xs`."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -58,6 +58,9 @@
   (is (= [1 2 3 4 -1 -2 -3] (drop-while neg? [-1 -2 -3 1 2 3 4 -1 -2 -3])) "drop-while: vector")
   (is (= (php/array 1 2 3 4 -1 -2 -3) (drop-while neg? (php/array -1 -2 -3 1 2 3 4 -1 -2 -3))) "drop-while: php array"))
 
+(deftest test-drop-while-empty-element
+  (is (= [] (drop-while |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+
 (deftest test-take
   (is (= ["a" "b"] (take 2 ["a" "b" "c"])) "take two elements")
   (is (= ["a" "b" "c"] (take 3 ["a" "b" "c"])) "take three elements")
@@ -108,10 +111,16 @@
   (is (nil? (find neg? [1 2 3 2 3])) "find: nothing to find")
   (is (nil? (find neg? [])) "find on empty array"))
 
+(deftest test-find-empty-element
+  (is (nil? (find |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+
 (deftest test-find-index?
   (is (= 3 (find-index neg? [1 2 3 -1 2 3])) "find-index first neg number")
   (is (nil? (find-index neg? [1 2 3 2 3])) "find-index: nothing to find")
   (is (nil? (find-index neg? [])) "find-index on empty array"))
+
+(deftest test-find-index-empty-element
+  (is (nil? (find-index |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-distinct
   (is (= [1 2 3] (distinct [1 1 2 3 2 2 3 1])) "distinct: array")


### PR DESCRIPTION
### 🤔 Background

Closes: #737 

### 💡 Goal

The `pred` function is not executed when an empty vector is searched for by the `find` function, etc.

### 🔖 Changes

Fix `loop` recursion termination conditions to evaluate using `empty?`.
