### PR TITLE
Fix `some?` function for an empty vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Fix a result of str/split-lines is in the wrong order (#735)
 * Fix `find` function for an empty vector (#737)
+* Fix `some?` function for an empty vector (#741)
 
 ## [0.15.0](https://github.com/phel-lang/phel-lang/compare/v0.14.1...v0.15.0) - 2024-06-22
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -505,12 +505,17 @@ Calling the `and` function without arguments returns true."
     (pred (first xs))     (recur pred (next xs))
     false))
 
+(declare empty?)
+(declare truthy?)
+
 (defn some?
   "Returns true if `(pred x)` is logical true for at least one `x` in `xs`, else false."
   [pred xs]
-  (if xs
-    (or (pred (first xs)) (recur pred (next xs)))
-    false))
+  (if (empty? xs)
+    false
+    (if (truthy? (pred (first xs)))
+      true
+      (recur pred (next xs)))))
 
 (defn true?
   "Checks if `x` is true. Same as `x === true` in PHP."

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -131,11 +131,17 @@
   (is (true? (all? pos? [])) "all pos? in empty list")
   (is (false? (all? pos? [1 -1 3])) "all pos? in list"))
 
+(deftest test-all?-empty-element
+  (is (true? (all? |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+
 (deftest test-some?
   (is (true? (some? pos? [1 2 3])) "some pos? in list")
   (is (false? (some? pos? [])) "some pos? in empty list")
   (is (true? (some? pos? [1 -1 3])) "some pos? in list")
   (is (false? (some? pos? [-1 -1 -3])) "some pos? in list"))
+
+(deftest test-some?-empty-element
+  (is (false? (some? |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-true?
   (is (true? (true? true)) "(true? true)")

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -9,6 +9,9 @@
 (deftest test-map-indexed
   (is (= [[0 "a"] [1 "b"] [2 "c"]] (map-indexed vector ["a" "b" "c"])) "map-indexed"))
 
+(deftest test-map-empty-element
+  (is (= [] (map |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
+
 (deftest test-mapcat
   (is (= [1 2 3 4 5 6] (mapcat reverse [[3 2 1] [6 5 4]])) "mapcat")
   (is (= [] (mapcat identity [])) "mapcat on empty vector"))
@@ -98,6 +101,9 @@
   (is (= [-1 -2 -3] (filter neg? [-1 2 3 -2 -3 4 5])) "filter: neg?")
   (is (= [-1 -2 -3] (filter neg? [-1 2 3 -2 -3 4 5])) "filter on vector")
   (is (= [-1 -2 -3] (filter neg? (php/array -1 2 3 -2 -3 4 5))) "filter on php array"))
+
+(deftest test-filter-empty-element
+  (is (= [] (filter |(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
 (deftest test-keep
   (is (= [true false false true true false false] (keep neg? [-1 2 3 -2 -3 4 5])) "keep: neg?")


### PR DESCRIPTION
### 🤔 Background

Closes: #741

### 💡 Goal

The pred function is not executed when an empty vector is searched for by the `some?` function.

### 🔖 Changes

Fix loop recursion termination conditions to evaluate using `empty?`.
