### PR TITLE
Fix `binding` function for atom body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Fix a result of str/split-lines is in the wrong order (#735)
 * Fix `find` function for an empty vector (#737)
 * Fix `some?` function for an empty vector (#741)
+* Fix `binding` function for atom body (#748)
 
 ## [0.15.0](https://github.com/phel-lang/phel-lang/compare/v0.14.1...v0.15.0) - 2024-06-22
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1802,7 +1802,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
            ,@(interleave temp-val-syms vals)]
        ,@(map bind-value binds)
        (try
-         ,@body
+         (do ,@body)
          (finally
            ,@(map bind-value resets))))))
 

--- a/tests/phel/test/core/binding.phel
+++ b/tests/phel/test/core/binding.phel
@@ -6,3 +6,7 @@
 (deftest test-binding
   (is (= 3 (binding [*my-binding-var* 2] (inc *my-binding-var*))) "binding inc")
   (is (= 1 *my-binding-var*) "binding is not changing the value"))
+
+(deftest test-binding-atom-body
+  (let [form (read-string "(do (def *my-binding-var* 1) (binding [*my-binding-var* 2] *my-binding-var*))")]
+    (is (= 2 (eval form)) "binding atom")))


### PR DESCRIPTION
### 🤔 Background

Closes: #748

### 💡 Goal

No error occurs when an atom value is specified in the `body` of the `binding` function.

### 🔖 Changes

In `binding` macro expansion, the way `body` is expanded has been corrected.
