### PR TITLE
Upgrade gacela 1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "gacela-project/gacela": "^1.7",
+        "gacela-project/gacela": "^1.8",
         "phpunit/php-timer": "^5.0",
         "symfony/console": "^7.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5b59c1ce3df1d01dd7d3588c0b537e4",
+    "content-hash": "10047e16d26f86cd16e81ce4f8dd5ad8",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -80,12 +80,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "ae23f24517d4853a11968dce3c3a0851d60790de"
+                "reference": "1a17f86353d67e890de312aafbe0a1aa6c732db6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/ae23f24517d4853a11968dce3c3a0851d60790de",
-                "reference": "ae23f24517d4853a11968dce3c3a0851d60790de",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/1a17f86353d67e890de312aafbe0a1aa6c732db6",
+                "reference": "1a17f86353d67e890de312aafbe0a1aa6c732db6",
                 "shasum": ""
             },
             "require": {
@@ -156,7 +156,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-08-17T20:20:53+00:00"
+            "time": "2024-08-17T20:50:15+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5988011510cfbe16a9cd6238e46035cf",
+    "content-hash": "a5b59c1ce3df1d01dd7d3588c0b537e4",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -76,16 +76,16 @@
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.7.1",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "b5b93f364c8fc4621b77eb0253f75a0d48fa2bd1"
+                "reference": "ae23f24517d4853a11968dce3c3a0851d60790de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/b5b93f364c8fc4621b77eb0253f75a0d48fa2bd1",
-                "reference": "b5b93f364c8fc4621b77eb0253f75a0d48fa2bd1",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/ae23f24517d4853a11968dce3c3a0851d60790de",
+                "reference": "ae23f24517d4853a11968dce3c3a0851d60790de",
                 "shasum": ""
             },
             "require": {
@@ -93,18 +93,19 @@
                 "php": ">=8.1"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.42",
-                "friendsofphp/php-cs-fixer": "^3.53",
+                "ergebnis/composer-normalize": "^2.43",
+                "friendsofphp/php-cs-fixer": "^3.56",
                 "infection/infection": "^0.26",
-                "phpbench/phpbench": "^1.2",
+                "phpbench/phpbench": "^1.3",
                 "phpmetrics/phpmetrics": "^2.8",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.6",
-                "psalm/plugin-phpunit": "^0.18",
-                "rector/rector": "^0.18",
-                "symfony/console": "^5.4",
-                "symfony/var-dumper": "^5.4",
-                "vimeo/psalm": "^5.22"
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.19",
+                "rector/rector": "^1.2",
+                "symfony/console": "^6.4",
+                "symfony/var-dumper": "^6.4",
+                "vimeo/psalm": "^5.25"
             },
             "suggest": {
                 "gacela-project/gacela-env-config-reader": "Allows to read .env config files",
@@ -113,7 +114,7 @@
                 "symfony/console": "Allows to use vendor/bin/gacela script"
             },
             "bin": [
-                "gacela"
+                "bin/gacela"
             ],
             "type": "library",
             "autoload": {
@@ -147,7 +148,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.7.1"
+                "source": "https://github.com/gacela-project/gacela/tree/1.8.0"
             },
             "funding": [
                 {
@@ -155,7 +156,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-04-16T20:26:38+00:00"
+            "time": "2024-08-17T20:20:53+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -26,7 +26,7 @@ final class ApiFactory extends AbstractFactory
     private function createPhelFnLoader(): PhelFnLoaderInterface
     {
         return new PhelFnLoader(
-            $this->getProvidedDependency(ApiDependencyProvider::FACADE_RUN),
+            $this->getProvidedDependency(ApiProvider::FACADE_RUN),
         );
     }
 }

--- a/src/php/Api/ApiProvider.php
+++ b/src/php/Api/ApiProvider.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Api;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Run\RunFacade;
 
-final class ApiDependencyProvider extends AbstractDependencyProvider
+final class ApiProvider extends AbstractProvider
 {
     public const FACADE_RUN = 'FACADE_RUN';
 

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -73,12 +73,12 @@ final class BuildFactory extends AbstractFactory
 
     public function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMPILER);
+        return $this->getProvidedDependency(BuildProvider::FACADE_COMPILER);
     }
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(BuildDependencyProvider::FACADE_COMMAND);
+        return $this->getProvidedDependency(BuildProvider::FACADE_COMMAND);
     }
 
     private function createMainPhpEntryPointFile(): EntryPointPhpFileInterface

--- a/src/php/Build/BuildProvider.php
+++ b/src/php/Build/BuildProvider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Build;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
 
-final class BuildDependencyProvider extends AbstractDependencyProvider
+final class BuildProvider extends AbstractProvider
 {
     public const FACADE_COMPILER = 'FACADE_COMPILER';
 

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -65,7 +65,7 @@ final class CommandFactory extends AbstractFactory
 
     public function getPhpConfigReader(): PhpConfigReader
     {
-        return $this->getProvidedDependency(CommandDependencyProvider::PHP_CONFIG_READER);
+        return $this->getProvidedDependency(CommandProvider::PHP_CONFIG_READER);
     }
 
     private function createComposerVendorDirectoriesFinder(): VendorDirectoriesFinderInterface

--- a/src/php/Command/CommandProvider.php
+++ b/src/php/Command/CommandProvider.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Command;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Container\Container;
 
-final class CommandDependencyProvider extends AbstractDependencyProvider
+final class CommandProvider extends AbstractProvider
 {
     public const PHP_CONFIG_READER = 'PHP_CONFIG_READER';
 

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -142,7 +142,7 @@ final class CompilerFactory extends AbstractFactory
 
     private function getFilesystemFacade(): FilesystemFacadeInterface
     {
-        return $this->getProvidedDependency(CompilerDependencyProvider::FACADE_FILESYSTEM);
+        return $this->getProvidedDependency(CompilerProvider::FACADE_FILESYSTEM);
     }
 
     private function getGlobalEnvironment(): GlobalEnvironmentInterface

--- a/src/php/Compiler/CompilerProvider.php
+++ b/src/php/Compiler/CompilerProvider.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Compiler;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Filesystem\FilesystemFacade;
 
-final class CompilerDependencyProvider extends AbstractDependencyProvider
+final class CompilerProvider extends AbstractProvider
 {
     public const FACADE_FILESYSTEM = 'FACADE_FILESYSTEM';
 

--- a/src/php/Console/ConsoleFactory.php
+++ b/src/php/Console/ConsoleFactory.php
@@ -11,11 +11,11 @@ final class ConsoleFactory extends AbstractFactory
 {
     public function getConsoleCommands(): array
     {
-        return $this->getProvidedDependency(ConsoleDependencyProvider::COMMANDS);
+        return $this->getProvidedDependency(ConsoleProvider::COMMANDS);
     }
 
     public function getFilesystemFacade(): FilesystemFacadeInterface
     {
-        return $this->getProvidedDependency(ConsoleDependencyProvider::FACADE_FILESYSTEM);
+        return $this->getProvidedDependency(ConsoleProvider::FACADE_FILESYSTEM);
     }
 }

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Console;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Api\Infrastructure\Command\DocCommand;
 use Phel\Build\Infrastructure\Command\BuildCommand;
@@ -15,7 +15,7 @@ use Phel\Run\Infrastructure\Command\ReplCommand;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
 
-final class ConsoleDependencyProvider extends AbstractDependencyProvider
+final class ConsoleProvider extends AbstractProvider
 {
     public const COMMANDS = 'COMMANDS';
 

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -99,12 +99,12 @@ final class FormatterFactory extends AbstractFactory
 
     private function getFacadeCompiler(): CompilerFacade
     {
-        return $this->getProvidedDependency(FormatterDependencyProvider::FACADE_COMPILER);
+        return $this->getProvidedDependency(FormatterProvider::FACADE_COMPILER);
     }
 
     private function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(FormatterDependencyProvider::FACADE_COMMAND);
+        return $this->getProvidedDependency(FormatterProvider::FACADE_COMMAND);
     }
 
     private function createFileIo(): FileIoInterface

--- a/src/php/Formatter/FormatterProvider.php
+++ b/src/php/Formatter/FormatterProvider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Formatter;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
 
-final class FormatterDependencyProvider extends AbstractDependencyProvider
+final class FormatterProvider extends AbstractProvider
 {
     public const FACADE_COMPILER = 'FACADE_COMPILER';
 

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -38,7 +38,7 @@ final class InteropFactory extends AbstractFactory
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_COMMAND);
+        return $this->getProvidedDependency(InteropProvider::FACADE_COMMAND);
     }
 
     private function createDirectoryRemover(): DirectoryRemoverInterface
@@ -93,7 +93,7 @@ final class InteropFactory extends AbstractFactory
 
     private function getBuildFacade(): BuildFacadeInterface
     {
-        return $this->getProvidedDependency(InteropDependencyProvider::FACADE_BUILD);
+        return $this->getProvidedDependency(InteropProvider::FACADE_BUILD);
     }
 
     private function createFileSystemIo(): FileIoInterface

--- a/src/php/Interop/InteropProvider.php
+++ b/src/php/Interop/InteropProvider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Interop;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
 
-final class InteropDependencyProvider extends AbstractDependencyProvider
+final class InteropProvider extends AbstractProvider
 {
     public const FACADE_COMMAND = 'FACADE_COMMAND';
 

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -33,17 +33,17 @@ class RunFactory extends AbstractFactory
 
     public function getCommandFacade(): CommandFacadeInterface
     {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMMAND);
+        return $this->getProvidedDependency(RunProvider::FACADE_COMMAND);
     }
 
     public function getBuildFacade(): BuildFacadeInterface
     {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_BUILD);
+        return $this->getProvidedDependency(RunProvider::FACADE_BUILD);
     }
 
     public function getCompilerFacade(): CompilerFacadeInterface
     {
-        return $this->getProvidedDependency(RunDependencyProvider::FACADE_COMPILER);
+        return $this->getProvidedDependency(RunProvider::FACADE_COMPILER);
     }
 
     public function createNamespaceCollector(): NamespaceCollector

--- a/src/php/Run/RunProvider.php
+++ b/src/php/Run/RunProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Run;
 
-use Gacela\Framework\AbstractDependencyProvider;
+use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
@@ -12,7 +12,7 @@ use Phel\Compiler\CompilerFacade;
 use Phel\Formatter\FormatterFacade;
 use Phel\Interop\InteropFacade;
 
-final class RunDependencyProvider extends AbstractDependencyProvider
+final class RunProvider extends AbstractProvider
 {
     public const FACADE_COMMAND = 'FACADE_COMMAND';
 

--- a/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCommandTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Run\Command\Repl;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
-use Gacela\Framework\ClassResolver\GlobalInstance\AnonymousGlobal;
 use Gacela\Framework\Gacela;
 use Generator;
 use Phel\Command\Application\TextExceptionPrinter;
@@ -45,7 +44,7 @@ final class ReplCommandTest extends AbstractCommandTest
     {
         $io = $this->createReplTestIo();
         $io->setInputs(...$inputs);
-        $this->prepareRunDependencyProvider($io);
+        $this->prepareRunFactory($io);
 
         $repl = $this->createReplCommand();
         $repl->run(
@@ -68,7 +67,7 @@ final class ReplCommandTest extends AbstractCommandTest
     {
         $io = $this->createReplTestIo();
         $io->setInputs(...$inputs);
-        $this->prepareRunDependencyProvider($io);
+        $this->prepareRunFactory($io);
 
         $repl = $this->createReplCommandWithCoreLib();
         $repl->run(
@@ -162,9 +161,9 @@ final class ReplCommandTest extends AbstractCommandTest
         return new ReplTestIo($exceptionPrinter);
     }
 
-    private function prepareRunDependencyProvider(ReplCommandIoInterface $io): void
+    private function prepareRunFactory(ReplCommandIoInterface $io): void
     {
-        AnonymousGlobal::overrideExistingResolvedClass(
+        Gacela::overrideExistingResolvedClass(
             RunFactory::class,
             new class($io) extends RunFactory {
                 public function __construct(private readonly ReplCommandIoInterface $io)


### PR DESCRIPTION
### 🤔 Background

In Gacela 1.8 the `DependencyProvider` is deprecated in favor of `Provider`

### 🔖 Changes

- Upgrade Gacela to `^1.8`
- Use the `AbstractProvider` instead of `DependencyProvider`
