### PR TITLE
Run in separate process the ApiFacadeTest

### DIFF
--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -15,13 +15,13 @@ use PHPUnit\Framework\TestCase;
 
 final class ApiFacadeTest extends TestCase
 {
-    public function test_number_of_grouped_functions(): never
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function test_number_of_grouped_functions(): void
     {
-        // This test in isolation works, but when running with all other integration tests fails,
-        // because the IntegrationTest loads already the core and all internal code, which
-        // it crashes when it tries to load all phel funcs again. See: `PhelFnLoader::loadAllPhelFunctions()`
-        $this->markTestSkipped('Useful to debug the facade, but useless to keep it in the CI');
-
         Gacela::bootstrap(__DIR__, GacelaConfig::defaultPhpConfig());
 
         Registry::getInstance()->clear();
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(264, $groupedFns);
+        self::assertCount(272, $groupedFns);
     }
 }


### PR DESCRIPTION
## 📚 Description

Remove the `skipped` statement from `ApiFacadeTest`.

Using the combination of `@runInSeparateProcess` and `@preserveGlobalState disabled` the test works.

src: https://docs.phpunit.de/en/9.6/annotations.html?highlight=preserveGlobalState#preserveglobalstate