### PR TITLE
Display the root source file on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Improve exception messages on REPL
+* Display the root source file on errors
 * Remove unused `ExceptionHandler`
 
 ## [0.15.3](https://github.com/phel-lang/phel-lang/compare/v0.15.2...v0.15.3) - 2024-11-02

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -28,7 +28,7 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     ): void {
         $output->writeln(sprintf(
             '%s // file: %s',
-            $e->getMessage(),
+            $e->getPrevious()?->getMessage() ?? $e->getMessage(),
             $e->getPrevious()?->getFile() ?? $e->getFile(),
         ));
         $output->writeln('> Dont you see the file? Check your phel config got `KeepGeneratedTempFiles=true`');

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -12,6 +12,8 @@ use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function sprintf;
+
 final readonly class CommandExceptionWriter implements CommandExceptionWriterInterface
 {
     public function __construct(
@@ -24,7 +26,12 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         OutputInterface $output,
         Throwable $e,
     ): void {
-        $output->writeln($e->getMessage());
+        $output->writeln(sprintf(
+            '%s // file: %s',
+            $e->getMessage(),
+            $e->getPrevious()?->getFile() ?? $e->getFile(),
+        ));
+        $output->writeln('> Dont you see the file? Check your phel config got `KeepGeneratedTempFiles=true`');
 
         $this->errorLog->writeln($this->getStackTraceString($e));
     }

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -93,9 +93,9 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
     {
         $str = '';
         $type = $e::class;
-        $msg = $e->getMessage();
-        $errorFile = $e->getFile();
-        $errorLine = $e->getLine();
+        $msg = $e->getPrevious()?->getMessage() ?? $e->getMessage();
+        $errorFile = $e->getPrevious()?->getFile() ?? $e->getFile();
+        $errorLine = $e->getPrevious()?->getLine() ?? $e->getLine();
         $pos = $this->filePositionExtractor->getOriginal($errorFile, $errorLine);
 
         $str .= $this->style->blue(sprintf('%s: %s', $type, $msg) . PHP_EOL);

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -41,7 +41,9 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 
     public function printException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void
     {
-        echo sprintf('%s: %s', $e::class, $e->getMessage()) . PHP_EOL;
+        $msg = $e->getPrevious()?->getMessage() ?? $e->getMessage();
+        echo sprintf('%s: %s', $e::class, $msg) . PHP_EOL;
+
         $this->errorLog->writeln($this->getExceptionString($e, $codeSnippet));
     }
 
@@ -85,7 +87,9 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 
     public function printStackTrace(Throwable $e): void
     {
-        echo sprintf('%s: %s', $e::class, $e->getMessage()) . PHP_EOL;
+        $msg = $e->getPrevious()?->getMessage() ?? $e->getMessage();
+        echo sprintf('%s: %s', $e::class, $msg) . PHP_EOL;
+
         $this->errorLog->writeln($this->getStackTraceString($e));
     }
 


### PR DESCRIPTION
### 🤔 Background


Right now, I dont know the root of the error when I try to build a project but there is an error somewhere hidden. 

Related: https://github.com/jasalt/phel-wp-plugin/issues/4

### 💡 Goal

Improve DX for errors.

### 🔖 Changes

- use the parent error, which contains the information of the actual error.
- this will show the actual error origin coming from PHP transpiled code

## 🖼️ Screenshots

### BEFORE

Terminal:
![Screenshot 2024-11-17 at 19 35 30](https://github.com/user-attachments/assets/bfcef1c1-cf15-4c6a-9955-c7836f1bf55a)
And on the `data/error.log`:
<img width="1505" alt="Screenshot 2024-11-17 at 19 35 47" src="https://github.com/user-attachments/assets/7c1e5a0c-1373-4692-9b08-baa8141624f7">


### AFTER

Terminal:
![Screenshot 2024-11-17 at 19 35 09](https://github.com/user-attachments/assets/679735db-fc32-41b1-934c-2ea38af6b097)

And on the `data/error.log`:
<img width="1498" alt="Screenshot 2024-11-17 at 19 37 58" src="https://github.com/user-attachments/assets/9da58af8-5c98-4a66-a74b-bee18dd8fb09">


