### PR TITLE
Document `all?` returns true for empty collection

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -498,7 +498,8 @@ Calling the `and` function without arguments returns true."
   (php/<=> b a))
 
 (defn all?
-  "Returns true if `(pred x)` is logical true for every `x` in `xs`, else false."
+  "Returns true if `(pred x)` is logical true for every `x` in collection `xs` 
+   or if `xs` is empty. Otherwise returns false."
   [pred xs]
   (cond
     (php/=== (count xs) 0) true


### PR DESCRIPTION
### 🤔 Background

This behavior was easy to miss without reading sources or [test code](https://github.com/phel-lang/phel-lang/blob/f89f425685ba79f4ad5a2fc10190417f6da0d0a7/tests/phel/test/core/boolean-operation.phel#L131).

### 💡 Goal

Improve function documentation visible also at https://phel-lang.org/documentation/api/#all

### 🔖 Changes

Suggestion for the wording:
```
"Returns true if `(pred x)` is logical true for every `x` in collection `xs` 
   or if `xs` is empty. Otherwise returns false."
```
Had hard time fitting all into one sentence..