### PR TITLE
Add doto macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Use PHPStan level 2
+- Add `doto` macro (#791)
 
 ## [0.16.1](https://github.com/phel-lang/phel-lang/compare/v0.16.0...v0.16.1) - 2024-12-13
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1772,6 +1772,21 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
            ,@(interleave (repeat (count forms) name) forms)]
        ,name)))
 
+(defmacro doto
+  "Evaluates x then calls all of the methods and functions with the
+  value of x supplied at the front of the given arguments. The forms
+  are evaluated in order. Returns x."
+  [x & forms]
+  (let [gx (gensym)]
+    `(let [,gx ,x]
+       ,@(map (fn [f]
+                (if (list? f)
+                  `(,(first f) ,gx ,@(next f))
+                  `(,f ,gx))
+                )
+              forms)
+          ,gx)))
+
 # ---------------
 # Regex functions
 # ---------------

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -1,4 +1,5 @@
 (ns phel-test\test\core\threading-macros
+  (:use DateTime)
   (:require phel\test :refer [deftest is]))
 
 (deftest test->
@@ -19,3 +20,11 @@
     (is (= :cat (as-> animals o (o 1) (o :type))))
     (is (= :cat (as-> animals $ ($ 1) ($ :type))))))
 
+(deftest test-doto
+  (let [dt (doto (php/new DateTime "2025-02-02 12:00:00")
+             (php/-> (modify "+1 hour"))
+             (php/-> (modify "+1 week"))
+             (php/-> (modify "+1 year")))]
+    (is (= :php/object (type dt)))
+    (is (= "DateTime" (php/get_class dt)))
+    (is (= "2026-02-09 13:00:00" (php/-> dt (format "Y-m-d H:i:s"))))))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(298, $groupedFns);
+        self::assertCount(299, $groupedFns);
     }
 }


### PR DESCRIPTION
Add Clojure influenced macro saving some typing while mutating objects. Sending PR to core as I had trouble using it from a utility library (https://github.com/phel-lang/phel-lang/issues/784) but nevertheless this could be useful to include in `core.phel`. Similar macro has been in Clojure core library since 1.0 ([clojuredocs.org](https://clojuredocs.org/clojure.core/doto)).

I followed example of existing threading macros in `core.phel` which seem to originate from Clojure core also and added this near those as it seemed fitting.

One note is that I was left wondering why `core.phel` threading macros don't preserve the metadata as Clojure does, is it not possible in Phel or could it be that it just has been left unimplemented while the equivalent functions for reading/writing metadata seemingly exist (`set-meta!` and `meta`)? Following the example of existing macros, I left out preserving the metadata with the `doto` included in PR. The original version preserving metadata was following (didn't test metadata part though):

```clojure

(defmacro doto
  "Evaluates x then calls all of the methods and functions with the
  value of x supplied at the front of the given arguments.  The forms
  are evaluated in order.  Returns x."
  [x & forms]
  (let [gx (gensym)]
    `(let [,gx ,x]
       ,@(map (fn [f]
                (set-meta!
                 (if (list? f)
                   `(,(first f) ,gx ,@(next f))
                   `(,f ,gx))
                 (meta f))
                )
              forms)
          ,gx)))
;;## Example code (not in PR)
```

While preparing commit I noted a pre-commit hook test failing while I had added test to the macro, I incremented the hardcoded number in `ApiFacadeTest.php` expecting that it's supposed to be incremented by hand like that as I didn't notice info on it in contributor docs.