### PR TITLE
Add `time` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Use PHPStan level 2
+- Add `time` macro
 - Add `doto` macro (#791)
+- Use PHPStan level 2
 
 ## [0.16.1](https://github.com/phel-lang/phel-lang/compare/v0.16.0...v0.16.1) - 2024-12-13
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1844,6 +1844,15 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        (definterface* ,name ,@fns)
        ,@defs)))
 
+(defmacro time
+  "Evaluates expr and prints the time it took. Returns the value of expr."
+  [expr]
+  (let [start (gensym)
+        ret (gensym)]
+    `(let [,start (php/microtime true)
+           ,ret ,expr]
+       (println "Elapsed time:" (* 1000 (- (php/microtime true) ,start)) "msecs")
+       ,ret)))
 
 (defn name
   "Returns the name string of a string, keyword or symbol."

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -76,6 +76,12 @@
   (is (= 20 (let [x (var 10)] (set! x 20) (deref x))) "set new value to variable")
   (is (= 11 (let [x (var 10)] (swap! x + 1) (deref x))) "swap a value by incrementing the number"))
 
+(deftest test-time
+  (is (= 2 (+ 1 1)) "time returns expr value")
+  (let [output-print (with-output-buffer (time (+ 1 1)))]
+    (is (string? output-print) "time prints to output")
+    (is (str-contains? output-print "Elapsed time:"))
+    (is (str-contains? output-print "msecs"))))
 
 (deftest test-name
   (is (= "string" (name "string")) "name on string")

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(299, $groupedFns);
+        self::assertCount(300, $groupedFns);
     }
 }


### PR DESCRIPTION
Add another macro from Clojure (since 1.0). Allows rough timing of executed code with execution time printed in stdout and execution result being returned to caller.

Test only checks that printing happens and expression value is returned as expected. Testing that measurement is actually effective might be useful but it gets bit tricky. I didn't notice any tests for the macro in Clojure core either so it's probably not that important. Macro is generally used ad-hoc during development and not as something a running system would rely on to produce correct results.