### PR TITLE
Add if-let and when-let macros

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1844,6 +1844,46 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        (definterface* ,name ,@fns)
        ,@defs)))
 
+(defmacro if-let
+  "If test is true, evaluates then with binding-form bound to the value of test,
+  if not, yields else"
+  [bindings then & [else]]
+  (let [err |(throw (php/new \InvalidArgumentException $))]
+    (when-not
+        (vector? bindings)
+      (err (str "if-let requires a vector for it's bindings, "
+                (type bindings) " given")))
+    (when-not
+        (= 2 (count bindings))
+      (err (str "if-let requires bindings to have 2 elements, "
+                (count bindings) " given"))))
+
+  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
+    `(let [temp-sym ,tst]
+       (if temp-sym
+         (let [,form temp-sym]
+           ,then)
+         ,else))))
+
+(defmacro when-let
+  "When test is true, evaluates body with binding-form bound to the value of test"
+  [bindings & body]
+  (let [err |(throw (php/new \InvalidArgumentException $))]
+    (when-not
+        (vector? bindings)
+      (err (str "when-let requires a vector for it's bindings, "
+                (type bindings) " given")))
+    (when-not
+        (= 2 (count bindings))
+      (err (str "when-let requires bindings to have 2 elements, "
+                (count bindings) " given"))))
+
+  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
+    `(let [temp-sym ,tst]
+       (when temp-sym
+         (let [,form temp-sym]
+           ,@body)))))
+
 (defmacro time
   "Evaluates expr and prints the time it took. Returns the value of expr."
   [expr]

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -76,6 +76,19 @@
   (is (= 20 (let [x (var 10)] (set! x 20) (deref x))) "set new value to variable")
   (is (= 11 (let [x (var 10)] (swap! x + 1) (deref x))) "swap a value by incrementing the number"))
 
+(deftest test-if-let
+  (is (= 1 (if-let [a 1] a)))
+  (is (= 2 (if-let [[a b] '(1 2)] b)))
+  (is (= nil (if-let [a false] (throw (php/new \Exception)))))
+  (is (= 1 (if-let [a false] a 1)))
+  (is (= 1 (if-let [[a b] nil] b 1)))
+  (is (= 1 (if-let [a false] (throw (php/new \Exception)) 1))))
+
+(deftest test-when-let
+  (is (= 1 (when-let [a 1] a)))
+  (is (= 2 (when-let [[a b] '(1 2)] b)))
+  (is (= nil (when-let [a false] (throw (php/new \Exception))))))
+
 (deftest test-time
   (is (= 2 (+ 1 1)) "time returns expr value")
   (let [output-print (with-output-buffer (time (+ 1 1)))]

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(300, $groupedFns);
+        self::assertCount(302, $groupedFns);
     }
 }


### PR DESCRIPTION
It does similar validation to Clojure in somewhat verbose way as private assert-args macro was left out:
https://github.com/clojure/clojure/blob/ce55092f2b2f5481d25cff6205470c1335760ef6/src/clj/clojure/core.clj#L1849

Opinions / improvement ideas welcome.

### 🤔 Background

Noting these are quite popular in general and I have been missing them quite often..