### PR TITLE
fix: Fix `php/echo` does not work #729

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add `doto` macro (#791)
 - Use PHPStan level 2
 - Add `if-let` and `when-let` macros (#795)
+- Fix `php/echo` does not work (#729)
 
 ## [0.16.1](https://github.com/phel-lang/phel-lang/compare/v0.16.0...v0.16.1) - 2024-12-13
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -45,7 +45,15 @@ final class CallEmitter implements NodeEmitterInterface
     private function emitPhpVarNode(CallNode $node, AbstractNode $fnNode): void
     {
         if ($fnNode instanceof PhpVarNode) {
-            $this->outputEmitter->emitStr($fnNode->getName(), $fnNode->getStartSourceLocation());
+            $name = $fnNode->getName();
+            // The only language structure that can be called like a function
+            // and cannot be called using parentheses is `echo`.
+            // For this reason, only for `echo` use `print` instead. #729
+            if ($name === 'echo') {
+                $name = 'print';
+            }
+
+            $this->outputEmitter->emitStr($name, $fnNode->getStartSourceLocation());
         } else {
             $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($node->getFn());

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CallEmitter;
+use PHPUnit\Framework\TestCase;
+
+final class CallEmitterTest extends TestCase
+{
+    private CallEmitter $callEmitter;
+
+    protected function setUp(): void
+    {
+        $outputEmitter = (new CompilerFactory())
+            ->createOutputEmitter();
+
+        $this->callEmitter = new CallEmitter($outputEmitter);
+    }
+
+    public function test_php_var_node_print_language_constructs(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'print');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('print("abc");');
+    }
+
+    public function test_php_var_node_print_language_constructs_multi_auguments(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'print');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'def'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('print("abc", "def");');
+    }
+
+    public function test_php_var_node_echo_language_constructs(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'echo');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('print("abc");');
+    }
+
+}


### PR DESCRIPTION
## 🤔 Background

fix #729 

``` 
(ns test)

(php/echo "Hi!") 
```

The above Phel code will compile to the following PHP code.

``` 
<?php 
// /usr/src/src/example.phel 
// ;;AAEA,OAAC,KAAD,MAAA,CAAA 
return echo("Hi!"); 
```

``echo`` is a language construct that does not return a value. It appears that a syntax error occurs when a language construct that does not return a value is placed after ``return`.

## 💡 Goal

`php/echo` should work as well as `php/print`.

## 🔖 Changes

Replace `php/echo` with `print` when outputting to PHP so that it is not affected by `echo`, a language construct that does not return a value.

The concern is that the PHP `echo` is not executed even though it is listed as `php/echo`.
If it should be important to run PHP `echo`, there is a way to create a wrapper function and call the wrapper function instead of `echo`.