### PR TITLE
fix: Fix Hash-map malfunction notice #786

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Use PHPStan level 2
 - Add `if-let` and `when-let` macros (#795)
 - Fix `php/echo` does not work (#729)
+- Fix Hash-map malfunction notice (#786)
 
 ## [0.16.1](https://github.com/phel-lang/phel-lang/compare/v0.16.0...v0.16.1) - 2024-12-13
 

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -50,7 +50,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
             /** @var HashMapNodeInterface $node */
             $node = $this->childNodes[$index];
             $n = $node->put($shift + 5, $hash, $key, $value, $addedLeaf);
-            if ($n == $node) {
+            if ($n === $node) {
                 return $this;
             }
 

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -123,3 +123,25 @@
 
 (deftest test-compile-form
   (is (= "(1 + 1);" (compile '(+ 1 1))) "compile simple expression"))
+
+(deftest test-hash-map-put-17th-notice-issue-786
+  (let [m {""              1
+           "0Mlq3z"        1
+           "bTOQLr"        1
+           "P0dH3t"        1
+           "1238924228357" 1
+           "AB18924230123" 1
+           "BC1892423005"  1
+           "A7I8924230I8"  1
+           "987182423015"  1
+           "9871892423017" 1
+           "JF0010"        1
+           "JF1102"        1
+           "JF1017"        1
+           "JF1015"        1
+           "JF1260"        1
+           "JF1261"        1
+           "jiKUic"        1}
+        result (put m "PU4NVO" 1)]
+   (is (= 18 (count result)))
+   (is (= 1 (result "PU4NVO")))))


### PR DESCRIPTION
## 🤔 Background

close #786 

When adding elements to a HashMap with more than 16 elements, a Notice message may appear.

## 💡 Goal

When adding an element to a HashMap with more than 16 elements, a Notice message may not be displayed.

## 🔖 Changes

In ArrayNode.php, line 53, you used `==` to compare objects. In ambiguous comparisons, a cast to int was sometimes performed and a Notice message was displayed, so I changed it to `===`.