### PR TITLE
Add native yield support

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/PhpKeywords.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/PhpKeywords.php
@@ -75,5 +75,6 @@ final class PhpKeywords
         'var',
         'while',
         'xor',
+        'yield',
     ];
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
+use function count;
 
 final class CallEmitter implements NodeEmitterInterface
 {
@@ -51,6 +52,25 @@ final class CallEmitter implements NodeEmitterInterface
             // For this reason, only for `echo` use `print` instead. #729
             if ($name === 'echo') {
                 $name = 'print';
+            }
+
+            if ($name === 'yield') {
+                $this->outputEmitter->emitStr('yield', $fnNode->getStartSourceLocation());
+
+                $args = $node->getArguments();
+                $argsCount = count($args);
+                if ($argsCount > 0) {
+                    $this->outputEmitter->emitStr(' ', $fnNode->getStartSourceLocation());
+                    if ($argsCount === 1) {
+                        $this->outputEmitter->emitNode($args[0]);
+                    } else {
+                        $this->outputEmitter->emitNode($args[0]);
+                        $this->outputEmitter->emitStr(' => ', $fnNode->getStartSourceLocation());
+                        $this->outputEmitter->emitNode($args[1]);
+                    }
+                }
+
+                return;
             }
 
             $this->outputEmitter->emitStr($name, $fnNode->getStartSourceLocation());

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -64,4 +64,31 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('print("abc");');
     }
 
+    public function test_php_var_node_yield_language_construct(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'yield');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('yield "abc";');
+    }
+
+    public function test_php_var_node_yield_key_value(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'yield');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 1),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 2),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('yield 1 => 2;');
+    }
+
 }


### PR DESCRIPTION
## Summary
- support the PHP `yield` keyword without parentheses in the call emitter
- register `yield` as a PHP keyword
- test new behaviour for single and key/value `yield`

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*