### PR TITLE
Fix header injection vulnerability

### DIFF
--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -361,10 +361,17 @@
        true
        status))))
 
+
+(defn- assert-no-crlf [value]
+  (when (and (string? value)
+             (or (php/str_contains value "\r") (php/str_contains value "\n")))
+    (throw (php/new InvalidArgumentException "Header must not contain CR or LF characters")))
+  value)
+
 (defn- normalize-header-name [header-name]
   (when-not (or (keyword? header-name) (string? header-name))
     (throw (php/new InvalidArgumentException (str "Header must be a keyword or string. Given: " header-name))))
-  (php/ucwords (name header-name) "-"))
+  (assert-no-crlf (php/ucwords (name header-name) "-")))
 
 (defn- emit-headers [{:status status :headers headers}]
   (when-not (php/headers_sent)
@@ -374,10 +381,10 @@
                                (not (id 0 (php/strcasecmp normalized-name "Set-Cookie"))))]]
       (cond
         (string? values)
-        (php/header (php/sprintf "%s: %s" normalized-name values) replace status)
+        (php/header (php/sprintf "%s: %s" normalized-name (assert-no-crlf values)) replace status)
         (indexed? values)
         (dofor [value :in values]
-          (php/header (php/sprintf "%s: %s" normalized-name value) replace status))))))
+          (php/header (php/sprintf "%s: %s" normalized-name (assert-no-crlf value)) replace status))))))
 
 (defn emit-response
   "Emits the response."


### PR DESCRIPTION
## Summary
- validate HTTP headers to block CRLF injection

## Testing
- `php` *(fails: command not found)*