### PR TITLE
Improve string case functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix `php/echo` does not work (#729)
 - Fix Hash-map malfunction notice (#786)
 - Fix header injection vulnerability (#803)
+- Fix multibyte functions in capitalize, lower-case, and upper-case (#805)
 - Add `time` macro
 - Add `doto` macro (#791)
 - Add `if-let` and `when-let` macros (#795)

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -110,19 +110,22 @@
 
 (defn capitalize
   "Converts first character of the string to upper-case, all other
-  characters to lower-case."
+  characters to lower-case. Handles multibyte characters."
   [s]
-  (php/ucfirst (php/strtolower s)))
+  (let [first-char (php/mb_substr s 0 1)
+        rest (php/mb_substr s 1)]
+    (str (php/mb_strtoupper first-char)
+         (php/mb_strtolower rest))))
 
 (defn lower-case
-  "Converts string to all lower-case."
+  "Converts string to all lower-case. Handles multibyte characters."
   [s]
-  (php/strtolower s))
+  (php/mb_strtolower s))
 
 (defn upper-case
-  "Converts string to all upper-case."
+  "Converts string to all upper-case. Handles multibyte characters."
   [s]
-  (php/strtoupper s))
+  (php/mb_strtoupper s))
 
 (defn trim
   "Removes whitespace from both ends of string."

--- a/tests/phel/test/str.phel
+++ b/tests/phel/test/str.phel
@@ -64,7 +64,8 @@
 
 (deftest test-capitalize
   (is (= "Foobar" (s/capitalize "foobar")))
-  (is (= "Foobar" (s/capitalize "FOOBAR"))))
+  (is (= "Foobar" (s/capitalize "FOOBAR")))
+  (is (= "Öbar" (s/capitalize "öbar"))))
 
 (deftest test-triml
   (is (= "foo " (s/triml " foo ")))
@@ -81,10 +82,12 @@
   (is (= "bar" (s/trim "\u{2000}bar\t \u{2002}"))))
 
 (deftest test-upper-case
-  (is (= "FOOBAR" (s/upper-case "Foobar"))))
+  (is (= "FOOBAR" (s/upper-case "Foobar")))
+  (is (= "ÖBAR" (s/upper-case "Öbar"))))
 
 (deftest test-lower-case
-  (is (= "foobar" (s/lower-case "FooBar"))))
+  (is (= "foobar" (s/lower-case "FooBar")))
+  (is (= "öbar" (s/lower-case "ÖBAR"))))
 
 (deftest test-escape
   (is (= "&lt;foo&amp;bar&gt;"


### PR DESCRIPTION
## Summary
- use multibyte functions in `capitalize`, `lower-case`, and `upper-case`
- test these functions with multibyte text
