### PR TITLE
Fix null checks on Analyzer forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix Hash-map malfunction notice (#786)
 - Fix header injection vulnerability (#803)
 - Fix multibyte functions in capitalize, lower-case, and upper-case (#805)
+- Fix null checks on Analyzer forms (#807)
 - Add `time` macro
 - Add `doto` macro (#791)
 - Add `if-let` and `when-let` macros (#795)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -92,7 +92,7 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
         }
 
         $interfaces = [];
-        for ($forms = $list; $forms != null; $forms = $forms->cdr()) {
+        for ($forms = $list; $forms !== null; $forms = $forms->cdr()) {
             $first = $forms->first();
 
             if (!$first instanceof Symbol) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
@@ -28,11 +28,11 @@ final class DoSymbol implements SpecialFormAnalyzerInterface
 
         $forms = $list->cdr();
         $stmts = [];
-        for (; $forms != null; $forms = $forms->cdr()) {
-            if ($forms->cdr() == null && $stmts === []) {
+        for (; $forms !== null; $forms = $forms->cdr()) {
+            if ($forms->cdr() === null && $stmts === []) {
                 // Only one statement?
                 $envStmt = $env;
-            } elseif ($forms->cdr() == null && $stmts !== []) {
+            } elseif ($forms->cdr() === null && $stmts !== []) {
                 // Return statement
                 $envStmt = $env->isContext(NodeEnvironment::CONTEXT_STATEMENT)
                     ? $env->withStatementContext()

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -55,7 +55,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
 
         $requireNs = [];
         $requireFiles = [];
-        for ($forms = $list->rest()->cdr(); $forms != null; $forms = $forms->cdr()) {
+        for ($forms = $list->rest()->cdr(); $forms !== null; $forms = $forms->cdr()) {
             $import = $forms->first();
 
             if (!($import instanceof PersistentListInterface)) {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
@@ -28,7 +28,7 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
             $env->withExpressionContext()->withDisallowRecurFrame(),
         );
         $args = [];
-        for ($forms = $list->rest()->cdr(); $forms != null; $forms = $forms->cdr()) {
+        for ($forms = $list->rest()->cdr(); $forms !== null; $forms = $forms->cdr()) {
             $args[] = $this->analyzer->analyze(
                 $forms->first(),
                 $env->withExpressionContext()->withDisallowRecurFrame(),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -66,7 +66,7 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
         /** @var PersistentListInterface $list2 */
         $list2 = $list->get(2);
         $args = [];
-        for ($forms = $list2->cdr(); $forms != null; $forms = $forms->cdr()) {
+        for ($forms = $list2->cdr(); $forms !== null; $forms = $forms->cdr()) {
             $args[] = $this->analyzer->analyze(
                 $forms->first(),
                 $env->withExpressionContext()->withDisallowRecurFrame(),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
@@ -53,7 +53,7 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
     public function expressions(PersistentListInterface $list, NodeEnvironmentInterface $env): array
     {
         $expressions = [];
-        for ($forms = $list->cdr(); $forms != null; $forms = $forms->cdr()) {
+        for ($forms = $list->cdr(); $forms !== null; $forms = $forms->cdr()) {
             $expressions[] = $this->analyzer->analyze(
                 $forms->first(),
                 $env->withExpressionContext()->withDisallowRecurFrame(),

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -123,7 +123,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
         $s = $this;
         $ms = $other;
-        for ($s = $this; $s != null; $s = $s->cdr(), $ms = $ms->cdr()) {
+        for ($s = $this; $s !== null; $s = $s->cdr(), $ms = $ms->cdr()) {
             /** @var PersistentList $s */
             /** @var ?PersistentList $ms */
             if (!$ms instanceof self || !$this->equalizer->equals($s->first(), $ms->first())) {
@@ -151,7 +151,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
      */
     public function getIterator(): Traversable
     {
-        for ($s = $this; $s != null; $s = $s->cdr()) {
+        for ($s = $this; $s !== null; $s = $s->cdr()) {
             /** @var PersistentList<T> $s */
             /** @var T $first  */
             $first = $s->first();

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -83,7 +83,7 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
         }
 
         $ms = $other;
-        for ($s = $this; $s != null; $s = $s->cdr(), $ms = $ms->cdr()) {
+        for ($s = $this; $s !== null; $s = $s->cdr(), $ms = $ms->cdr()) {
             /** @var PersistentVectorInterface $s */
             /** @var ?PersistentVectorInterface $ms */
             if (!$ms instanceof PersistentVectorInterface || !$this->equalizer->equals($s->first(), $ms->first())) {

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -64,7 +64,7 @@ final class SubVector extends AbstractPersistentVector
      */
     public function getIterator(): Traversable
     {
-        for ($s = $this; $s != null; $s = $s->cdr()) {
+        for ($s = $this; $s !== null; $s = $s->cdr()) {
             /** @var \Phel\Lang\Collections\LinkedList\PersistentList<T> $s */
             /** @var T $first  */
             $first = $s->first();

--- a/src/php/Lang/Collections/Vector/SubVector.php
+++ b/src/php/Lang/Collections/Vector/SubVector.php
@@ -64,7 +64,7 @@ final class SubVector extends AbstractPersistentVector
      */
     public function getIterator(): Traversable
     {
-        for ($s = $this; $s !== null; $s = $s->cdr()) {
+        for ($s = $this; $s instanceof self; $s = $s->cdr()) {
             /** @var \Phel\Lang\Collections\LinkedList\PersistentList<T> $s */
             /** @var T $first  */
             $first = $s->first();


### PR DESCRIPTION


## Summary

- Replaced loose comparisons with strict null checks in the “do” special form handler to avoid type juggling
- Updated interface iteration in DefStructSymbol to use strict null comparison for safer loops
- Ensured namespace imports iterate with strict null checks in NsSymbol
- Applied the same strict null comparison updates in object creation and method call analyzers
- Revised collection iterators to check for null strictly, preventing unintended truthiness
