### PR TITLE
Fix RangeIterator rewind state reset

### DIFF
--- a/src/php/Lang/Collections/Vector/RangeIterator.php
+++ b/src/php/Lang/Collections/Vector/RangeIterator.php
@@ -53,6 +53,12 @@ final class RangeIterator implements Iterator
     public function rewind(): void
     {
         $this->currentIndex = $this->start;
+        $this->base = $this->currentIndex - ($this->currentIndex % 32);
+
+        $this->currentArray = null;
+        if ($this->start < count($this->vector)) {
+            $this->currentArray = $this->vector->getArrayForIndex($this->currentIndex);
+        }
     }
 
     public function key(): mixed

--- a/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
@@ -20,4 +20,21 @@ final class RangeIteratorTest extends TestCase
 
         self::assertSame(range(0, 31), iterator_to_array($it));
     }
+
+    public function test_iterator_can_be_reused_after_rewind(): void
+    {
+        $start = 60;
+        $end = 90;
+
+        $it = new RangeIterator(
+            TypeFactory::getInstance()->persistentVectorFromArray(range(0, 100)),
+            $start,
+            $end,
+        );
+
+        $expected = iterator_to_array($it);
+
+        // Reusing the iterator should yield the same result
+        self::assertSame($expected, iterator_to_array($it));
+    }
 }


### PR DESCRIPTION
## Summary
- fix RangeIterator `rewind()` to reset base and current array
- add regression test for reusing RangeIterator after rewind

## Testing
- `./vendor/bin/phpunit --filter RangeIteratorTest`
- `./vendor/bin/phpunit`
- `./vendor/bin/phpstan --no-progress --error-format=raw`
- `./vendor/bin/psalm --no-progress --show-info=true`
