### PR TITLE
Fix private symbol refer resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Fix null checks on Analyzer forms (#807)
 - Fix calling php/$_SERVER more than once errors on repl (#789)
 - Fix inmutable global binding (#811)
+- Fix private symbol refer resolution (#813)
 - Add `time` macro
 - Add `doto` macro (#791)
 - Add `if-let` and `when-let` macros (#795)

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -308,6 +308,9 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $currentNs = $this->ns;
         if (isset($this->refers[$this->ns][$name->getName()])) {
             $currentNs = $this->refers[$this->ns][$name->getName()]->getName();
+
+            return $this->resolveInterfaceOrDefinition($name, $env, $currentNs)
+                ?? $this->resolveInterfaceOrDefinition($name, $env, CompilerConstants::PHEL_CORE_NAMESPACE);
         }
 
         return $this->resolveInterfaceOrDefinitionForCurrentNs($name, $env, $currentNs)

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -143,6 +143,26 @@ final class GlobalEnvironmentTest extends TestCase
         );
     }
 
+    public function test_resolve_private_definition_from_refer(): void
+    {
+        $env = new GlobalEnvironment();
+        $env->addDefinition('foo', Symbol::create('x'));
+        Registry::getInstance()->addDefinition(
+            'foo',
+            'x',
+            null,
+            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true),
+        );
+        $env->setNs('bar');
+        $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        $this->assertNull(
+            $env->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
     public function test_resolve_definition_in_same_ns(): void
     {
         $env = new GlobalEnvironment();


### PR DESCRIPTION
Fixes:  https://github.com/phel-lang/phel-lang/issues/750

## Summary
- prevent accessing private symbols via `:refer`
- add regression test for resolving private definitions through refer
