### PR TITLE
Fix html macro when using `when` forms

### DIFF
--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -128,10 +128,14 @@
   (let [form-name (if (and (list? form) (symbol? (first form)))
                     (name (first form)))]
     (case form-name
-      "for" (let [[_ bindings body] form]
-              `(apply str (for ,bindings ,(compile-html body))))
-      "if"  (let [[_ condition & body] form]
-              `(if ,condition ,@(for [x :in body] (compile-html x))))
+      "for"       (let [[_ bindings body] form]
+                    `(apply str (for ,bindings ,(compile-html body))))
+      "if"        (let [[_ condition & body] form]
+                    `(if ,condition ,@(for [x :in body] (compile-html x))))
+      "when"      (let [[_ condition & body] form]
+                    `(if ,condition ,@(for [x :in body] (compile-html x))))
+      "when-not"  (let [[_ condition & body] form]
+                    `(if (not ,condition) ,@(for [x :in body] (compile-html x))))
       `(render-html ,form))))
 
 (defn- compile-seq [content]

--- a/tests/phel/test/html.phel
+++ b/tests/phel/test/html.phel
@@ -82,3 +82,9 @@
 
 (deftest doctypes
   (is (= "<!DOCTYPE html>\n<div></div>" (html (doctype :html5) [:div]))))
+
+(deftest when-forms
+  (is (= "<div>xxxxxx</div>"
+         (html (when true [:div (for [i :range [0 6]] "x")]))))
+  (is (= "<div>xxxxxx</div>"
+         (html (when-not false [:div (for [i :range [0 6]] "x")])))))


### PR DESCRIPTION
## Summary
- handle `when` and `when-not` in html compiler
- test html macro with `when` forms

## Testing
- `./bin/phel test tests/phel/test/html.phel`
- `./vendor/bin/phpunit --testsuite=unit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_683a19510008832382f5f292b29dc353