### PR TITLE
Implement defexception special form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Add strings wrapped with quotes on REPL (#806)
 - Add `macroexpand` function (#810)
 - Add source filename:line on repl exceptions (#812)
+- Add `defexception` special form (#819)
 - Use PHPStan level 2
 
 ## [0.16.1](https://github.com/phel-lang/phel-lang/compare/v0.16.0...v0.16.1) - 2024-12-13

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -194,6 +194,18 @@
        (defn ,name ,(php/. "Creates a new " name " struct.") ,keys (php/new ,class-name-str ,@keys))
        (defn ,is-name ,(php/. "Checks if `x` is an instance of the " name " struct.") [x] (php/is_a x ,class-name-str)))))
 
+(defmacro defexception
+  "Define a new exception."
+  [name]
+  (let [name-str (php/-> name (getName))
+        munge (php/new Munge)
+        class-name-str (php/. *ns* "\\" (php/-> munge (encode name-str)))
+        is-name (php/:: Symbol (create (php/. name-str "?")))]
+    `(do
+       (defexception* ,name)
+       (defn ,name ,(php/. "Creates a new " name " exception.") [& args] (apply php/new ,class-name-str args))
+       (defn ,is-name ,(php/. "Checks if `x` is an instance of the " name " exception.") [x] (php/is_a x ,class-name-str)))))
+
 (defmacro comment
   "Ignores the body of the comment."
   [&])

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -47,6 +47,14 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
             'fnSignature' => '(defstruct my-struct [a b c])',
             'desc' => 'A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function.',
         ],
+        Symbol::NAME_DEF_EXCEPTION => [
+            'doc' => '```phel
+(defexception my-ex)
+```',
+            'url' => '/documentation/exceptions',
+            'fnSignature' => '(defexception name)',
+            'desc' => 'Defines a new exception.',
+        ],
         Symbol::NAME_DO => [
             'doc' => '```phel
 (do expr*)

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefExceptionNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefExceptionNode.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+final class DefExceptionNode extends AbstractNode
+{
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly string $namespace,
+        private readonly Symbol $name,
+        private readonly PhpClassNameNode $parent,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getName(): Symbol
+    {
+        return $this->name;
+    }
+
+    public function getParent(): PhpClassNameNode
+    {
+        return $this->parent;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefExceptionSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefInterfaceSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefSymbol;
@@ -88,6 +89,7 @@ final class AnalyzePersistentList
             Symbol::NAME_LOOP => new LoopSymbol($this->analyzer, new BindingValidator()),
             Symbol::NAME_FOREACH => new ForeachSymbol($this->analyzer),
             Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, new Munge()),
+            Symbol::NAME_DEF_EXCEPTION => new DefExceptionSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),
             Symbol::NAME_DEF_INTERFACE => new DefInterfaceSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefExceptionSymbol.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+final class DefExceptionSymbol implements SpecialFormAnalyzerInterface
+{
+    use WithAnalyzerTrait;
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefExceptionNode
+    {
+        if (count($list) !== 2) {
+            throw AnalyzerException::withLocation("Exact one argument is required for 'defexception", $list);
+        }
+
+        $name = $list->get(1);
+        if (!$name instanceof Symbol) {
+            throw AnalyzerException::withLocation("First argument of 'defexception must be a Symbol.", $list);
+        }
+
+        $parent = new PhpClassNameNode(
+            $env,
+            Symbol::create('\\Exception'),
+            $list->getStartLocation(),
+        );
+
+        return new DefExceptionNode(
+            $env,
+            $this->analyzer->getNamespace(),
+            $name,
+            $parent,
+            $list->getStartLocation(),
+        );
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+
+use function assert;
+
+final readonly class DefExceptionEmitter implements NodeEmitterInterface
+{
+    public function __construct(private OutputEmitterInterface $outputEmitter)
+    {
+    }
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof DefExceptionNode);
+
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            $this->outputEmitter->emitLine(
+                'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        $this->outputEmitter->emitStr(
+            'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends ',
+            $node->getStartSourceLocation(),
+        );
+        $this->outputEmitter->emitNode($node->getParent());
+        $this->outputEmitter->emitLine(' {');
+        $this->outputEmitter->increaseIndentLevel();
+
+        $this->outputEmitter->emitLine('public function __construct($message = "", $code = 0, \Throwable $previous = null) {');
+        $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->emitLine('parent::__construct($message, $code, $previous);');
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}');
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefInterfaceNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
@@ -40,6 +41,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ApplyEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CallEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CatchEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefExceptionEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefInterfaceEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefStructEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DoEmitter;
@@ -104,6 +106,7 @@ final class NodeEmitterFactory
             PhpArrayPushNode::class => new PhpArrayPushEmitter($outputEmitter),
             ForeachNode::class => new ForeachEmitter($outputEmitter),
             DefStructNode::class => new DefStructEmitter($outputEmitter, new MethodEmitter($outputEmitter)),
+            DefExceptionNode::class => new DefExceptionEmitter($outputEmitter),
             PhpObjectSetNode::class => new PhpObjectSetEmitter($outputEmitter),
             MapNode::class => new MapEmitter($outputEmitter),
             SetVarNode::class => new SetVarEmitter($outputEmitter),

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -68,6 +68,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
 
     public const NAME_DEF_INTERFACE = 'definterface*';
 
+    public const NAME_DEF_EXCEPTION = 'defexception*';
+
     private static int $symGenCounter = 1;
 
     public function __construct(

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(305, $groupedFns);
+        self::assertCount(307, $groupedFns);
     }
 }

--- a/tests/php/Integration/Fixtures/Def/defexception.test
+++ b/tests/php/Integration/Fixtures/Def/defexception.test
@@ -1,0 +1,8 @@
+--PHEL--
+(defexception* MyException)
+--PHP--
+class MyException extends \Exception {
+  public function __construct($message = "", $code = 0, \Throwable $previous = null) {
+    parent::__construct($message, $code, $previous);
+  }
+}

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Compiler\Analyzer;
 
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
@@ -253,5 +254,14 @@ final class AnalyzePersistentListTest extends TestCase
             TypeFactory::getInstance()->persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(DefStructNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
+    }
+
+    public function test_symbol_with_name_def_exception(): void
+    {
+        $list = TypeFactory::getInstance()->persistentListFromArray([
+            Symbol::create(Symbol::NAME_DEF_EXCEPTION),
+            Symbol::create('MyExc'),
+        ]);
+        self::assertInstanceOf(DefExceptionNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\DefExceptionNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefExceptionSymbol;
+use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DefExceptionSymbolTest extends TestCase
+{
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_with_wrong_number_of_arguments(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("Exact one argument is required for 'defexception");
+
+        $list = TypeFactory::getInstance()->persistentListFromArray([
+            Symbol::create(Symbol::NAME_DEF_EXCEPTION),
+            Symbol::create('A'),
+            Symbol::create('B'),
+        ]);
+
+        (new DefExceptionSymbol($this->analyzer))
+            ->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_first_arg_is_not_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("First argument of 'defexception must be a Symbol.");
+
+        $list = TypeFactory::getInstance()->persistentListFromArray([
+            Symbol::create(Symbol::NAME_DEF_EXCEPTION),
+            'no-symbol',
+        ]);
+
+        (new DefExceptionSymbol($this->analyzer))
+            ->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_def_exception_symbol(): void
+    {
+        $list = TypeFactory::getInstance()->persistentListFromArray([
+            Symbol::create(Symbol::NAME_DEF_EXCEPTION),
+            Symbol::create('MyExc'),
+        ]);
+
+        $defExceptionNode = (new DefExceptionSymbol($this->analyzer))
+            ->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals(
+            new DefExceptionNode(
+                NodeEnvironment::empty(),
+                'user',
+                Symbol::create('MyExc'),
+                new PhpClassNameNode(NodeEnvironment::empty(), Symbol::create('\\Exception')),
+            ),
+            $defExceptionNode,
+        );
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/phel-lang/phel-lang/issues/194

## Summary
- introduce `defexception` macro & special form to declare new exception types
- add `DefExceptionNode` and emitter to generate PHP classes
- support resolving `defexception*` in analyzer and output emitter
- document the macro in `PhelFnLoader`
- add unit and integration tests for exception definitions
