### PR TITLE
Fix REPL ns evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fix calling php/$_SERVER more than once errors on repl (#789)
 - Fix inmutable global binding (#811)
 - Fix private symbol refer resolution (#813)
+- Fix REPL ns evaluation (#820)
 - Add `time` macro
 - Add `doto` macro (#791)
 - Add `if-let` and `when-let` macros (#795)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -13,8 +13,11 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
+use Phel\Shared\CompilerConstants;
+use Phel\Shared\ReplConstants;
 
 use function count;
 use function in_array;
@@ -77,6 +80,22 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
                     $value,
                 );
             }
+        }
+
+        if (Registry::getInstance()->getDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, ReplConstants::REPL_MODE)) {
+            $replSymbol = Symbol::create('phel\\repl');
+            $this->analyzer->addRequireAlias($ns, Symbol::create('repl'), $replSymbol);
+            $this->analyzer->addRefers(
+                $ns,
+                [
+                    Symbol::create('doc'),
+                    Symbol::create('require'),
+                    Symbol::create('use'),
+                    Symbol::create('print-colorful'),
+                    Symbol::create('println-colorful'),
+                ],
+                $replSymbol,
+            );
         }
 
         return new NsNode($ns, $requireNs, $requireFiles, $list->getStartLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -60,6 +60,34 @@ final class NsEmitter implements NodeEmitterInterface
                     $ns->getStartLocation(),
                 );
             }
+        } else {
+            $this->outputEmitter->emitLine('$__phelBuildFacade = new \\Phel\\Build\\BuildFacade();');
+            $this->outputEmitter->emitLine('$__phelSrcDirs = \\Phel\\Lang\\Registry::getInstance()->getDefinition(');
+            $this->outputEmitter->increaseIndentLevel();
+            $this->outputEmitter->emitStr('"');
+            $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeNs('phel\\repl')));
+            $this->outputEmitter->emitLine('",');
+            $this->outputEmitter->emitStr('"src-dirs"');
+            $this->outputEmitter->emitLine(') ?? [];');
+            $this->outputEmitter->decreaseIndentLevel();
+
+            foreach ($node->getRequireNs() as $ns) {
+                $this->outputEmitter->emitLine(
+                    '$__phelNsInfos = $__phelBuildFacade->getDependenciesForNamespace($__phelSrcDirs, ['
+                    . "'" . addslashes($ns->getName()) . "'"
+                    . ']);',
+                );
+                $this->outputEmitter->emitLine('foreach ($__phelNsInfos as $__phelNsInfo) {');
+                $this->outputEmitter->increaseIndentLevel();
+                $this->outputEmitter->emitLine('if (!in_array($__phelNsInfo->getNamespace(), \\Phel\\Lang\\Registry::getInstance()->getNamespaces(), true)) {');
+                $this->outputEmitter->increaseIndentLevel();
+                $this->outputEmitter->emitLine('$__phelBuildFacade->evalFile($__phelNsInfo->getFile());');
+                $this->outputEmitter->emitLine('\\Phel\\Compiler\\Infrastructure\\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");');
+                $this->outputEmitter->decreaseIndentLevel();
+                $this->outputEmitter->emitLine('}');
+                $this->outputEmitter->decreaseIndentLevel();
+                $this->outputEmitter->emitLine('}');
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/phel-lang/phel-lang/issues/766

## Summary
- keep REPL helper macros after evaluating an ns form
- load required namespaces when ns forms are evaluated in the REPL

## 🖼️  Demo

### BEFORE

![Screenshot 2025-05-30 at 23 43 01](https://github.com/user-attachments/assets/bdfac431-60cf-4de2-a00a-d21bfb6d15d4)


### AFTER
![Screenshot 2025-05-30 at 23 40 38](https://github.com/user-attachments/assets/c16a050c-248f-4292-b1b9-b83bc40f172e)

