### PR TITLE
Resolve macros in ns that contain hyphens

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -75,7 +75,10 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     {
         return (
             isset($this->definitions[$namespace][$name->getName()])
-            || Registry::getInstance()->hasDefinition($namespace, $name->getName())
+            || Registry::getInstance()->hasDefinition(
+                $this->mungeEncodeNs($namespace),
+                $name->getName(),
+            )
         );
     }
 
@@ -83,7 +86,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     {
         if ($this->hasDefinition($namespace, $name)) {
             return Registry::getInstance()->getDefinitionMetaData(
-                $namespace,
+                $this->mungeEncodeNs($namespace),
                 $name->getName(),
             ) ?? TypeFactory::getInstance()->emptyPersistentMap();
         }
@@ -375,5 +378,10 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     {
         return $this->allowPrivateAccessCounter > 0
             || !$meta[Keyword::create('private')];
+    }
+
+    private function mungeEncodeNs(string $ns): string
+    {
+        return str_replace('-', '_', $ns);
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -371,6 +371,17 @@ final class GlobalEnvironmentTest extends TestCase
         );
     }
 
+    public function test_has_definition_with_hyphenated_namespace(): void
+    {
+        $env = new GlobalEnvironment();
+        $sym = Symbol::create('m');
+        $env->addDefinition('foo-bar', $sym);
+        Registry::getInstance()->addDefinition('foo_bar', 'm', null);
+
+        self::assertTrue($env->hasDefinition('foo-bar', $sym));
+        self::assertNull($env->getDefinition('foo-bar', Symbol::create('other')));
+    }
+
     public function test_add_duplicate_definition_throws_exception(): void
     {
         $env = new GlobalEnvironment();


### PR DESCRIPTION
Relates: https://github.com/phel-lang/phel-lang/issues/784

## Summary

- GlobalEnvironment resolves macros defined in namespaces that contain hyphens
