### PR TITLE
Fix macroExpand to encode ns by replacing hyphens with underscores

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -105,7 +105,9 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
     ): float|bool|int|string|TypeInterface|array|null {
         /** @psalm-suppress PossiblyNullArgument */
         $nodeName = $macroNode->getName()->getName();
-        $fn = Registry::getInstance()->getDefinition($macroNode->getNamespace(), $nodeName);
+
+        $ns = str_replace('-', '_', $macroNode->getNamespace());
+        $fn = Registry::getInstance()->getDefinition($ns, $nodeName);
 
         try {
             return $this->callMacroFn($fn, $list);


### PR DESCRIPTION


## 🤔 Background

Relates: https://github.com/phel-lang/phel-lang/issues/784

## 🔖 Changes

- Fixed macro macroExpand to encode namespaces by replacing hyphens with underscores before fetching definitions, preventing null callable errors

- Introduced a unit test verifying macro calls in a hyphenated namespace function correctly, including necessary imports for Munge encoding
