### PR TITLE
Add recursive PHP-Phel conversion functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Add source filename:line on repl exceptions (#812)
 - Add `defexception` special form (#819)
 - Add completion to REPL (#821)
+- Add `phel->php` and `php->phel` functions (#829)
 - Improve vector performance (#823)
 - Use PHPStan level 2
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -524,6 +524,7 @@ Calling the `and` function without arguments returns true."
 
 (declare empty?)
 (declare truthy?)
+(declare name)
 
 (defn some?
   "Returns true if `(pred x)` is logical true for at least one `x` in `xs`, else false."
@@ -1209,6 +1210,55 @@ arrays. Use (php/aunset ds key)"))
     (foreach [k v arr]
       (put res k v))
     (persistent res)))
+
+
+(defn phel->php
+  "Recursively converts a Phel data structure to a PHP array."
+  [x]
+  (cond
+    (php-array? x)
+    (let [arr (php/array)]
+      (foreach [k v x]
+        (php/aset arr k (phel->php v)))
+      arr)
+
+    (indexed? x)
+    (let [arr (php/array)]
+      (foreach [v x]
+        (php/apush arr (phel->php v)))
+      arr)
+
+    (associative? x)
+    (let [arr (php/array)]
+      (foreach [k v x]
+        (php/aset arr (name k) (phel->php v)))
+      arr)
+
+    (set? x)
+    (let [arr (php/array)]
+      (foreach [v x]
+        (php/apush arr (phel->php v)))
+      arr)
+
+    true x))
+
+(defn php->phel
+  "Recursively converts a PHP array to Phel data structures."
+  [x]
+  (cond
+    (indexed-php-array? x)
+    (let [res (transient [])]
+      (foreach [v x]
+        (push res (php->phel v)))
+      (persistent res))
+
+    (php-array? x)
+    (let [res (transient {})]
+      (foreach [k v x]
+        (put res k (php->phel v)))
+      (persistent res))
+
+    true x))
 
 (defn contains-value?
   "Returns true if the value is present in the given collection, otherwise returns false."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -242,3 +242,16 @@
   (is (= [[1 2] [3]] (partition 2 [1 2 3])) "partition-2 three elements")
   (is (= [[1 2] [3 4]] (partition 2 [1 2 3 4])) "partition-2 four elements")
   (is (= [[1 2] [3 4] [5]] (partition 2 [1 2 3 4 5])) "partition-2 five elements"))
+
+(deftest test-phel-php-roundtrip
+  (let [data {:a [1 {:b 2}]}]
+    (let [arr (phel->php data)]
+      (is (php-array? arr) "phel->php returns php array")
+      (is (= {"a" [1 {"b" 2}]} (php->phel arr)) "phel->php -> php->phel roundtrip"))))
+
+(deftest test-php-phel-roundtrip
+  (let [m (php/array)
+        inner (php/array)]
+    (php/aset inner "b" 2)
+    (php/aset m "a" (php/array 1 inner))
+    (is (= m (phel->php (php->phel m))) "php->phel -> phel->php roundtrip")))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(307, $groupedFns);
+        self::assertCount(309, $groupedFns);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/phel-lang/phel-lang/issues/826

## Summary
- implement `phel->php` and `php->phel` for recursive conversion
- test roundtrip conversions
- update expected API function count
