### PR TITLE
Display deprecated metadata on doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Add `phel->php` and `php->phel` functions (#829)
 - Add `ApiFacade::replComplete` service (#830)
 - Add `str\contains?` function (#833)
+- Add display deprecated metadata on doc (#834)
 - Improve vector performance (#823)
 - Improve `DependenciesForNamespace` performance
 - Use PHPStan level 2

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -41,7 +41,12 @@
   (let [registry (php/:: Registry (getInstance))
         meta (php/-> registry (getDefinitionMetaData namespace name))]
     (when meta
-      (clean-doc (get meta :doc)))))
+      (let [doc (or (get meta :doc) "")
+            deprecated (get meta :deprecated)
+            message (if deprecated
+                      (str doc (if (= doc "") "" "\n") "DEPRECATED: " deprecated)
+                      doc)]
+        (clean-doc message)))))
 
 (defmacro doc
   "Prints the documentation for the given symbol."

--- a/tests/php/Integration/Run/Command/Repl/Fixtures/doc-deprecated.test
+++ b/tests/php/Integration/Run/Command/Repl/Fixtures/doc-deprecated.test
@@ -1,0 +1,12 @@
+phel:1> (defn str-contains?
+....:2>   "Returns true if str contains s."
+....:3>   {:deprecated "Use phel\\str\\contains?"}
+....:4>   [str s]
+....:5>   (php/str_contains str s))
+1
+phel:6> (doc str-contains?)
+(str-contains? str s)
+
+Returns true if str contains s.
+DEPRECATED: Use phel\str\contains?
+nil


### PR DESCRIPTION
## 🔖 Changes

Display deprecated metadata on doc

## 🖼️  Demo

![Screenshot 2025-06-01 at 02 49 37](https://github.com/user-attachments/assets/88241e49-5a9c-4cc9-8d2d-7d824b0524c9)
