### PR TITLE
Allow recur in anonymous functions within def

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -181,7 +181,6 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         $initEnv = $env
             ->withBoundTo($namespace . '\\' . $nameSymbol)
             ->withExpressionContext()
-            ->withDisallowRecurFrame()
             ->withDefAllowed(false);
 
         return $this->analyzer->analyze($init, $initEnv);

--- a/tests/php/Integration/Fixtures/Recur/recur-def-fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-def-fn-one-arg.test
@@ -1,0 +1,40 @@
+--PHEL--
+(def fact (fn [x]
+  (if (php/== x 0)
+    x
+    (recur (php/- x 1)))))
+--PHP--
+\Phel\Lang\Registry::getInstance()->addDefinition(
+  "user",
+  "fact",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\fact";
+
+    public function __invoke($x) {
+      while (true) {
+        if (\Phel\Lang\Truthy::isTruthy(($x == 0))) {
+          return $x;
+        } else {
+          $__phel_1 = ($x - 1);
+          $x = $__phel_1;
+          continue;
+
+        }
+        break;
+      }
+    }
+  },
+  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "Recur/recur-def-fn-one-arg.test",
+      \Phel\Lang\Keyword::create("line"), 1,
+      \Phel\Lang\Keyword::create("column"), 0
+    ),
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+      \Phel\Lang\Keyword::create("file"), "Recur/recur-def-fn-one-arg.test",
+      \Phel\Lang\Keyword::create("line"), 4,
+      \Phel\Lang\Keyword::create("column"), 26
+    ),
+    "min-arity", 1
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -105,7 +105,6 @@ final class DefSymbolTest extends TestCase
                 new LiteralNode(
                     $env
                         ->withExpressionContext()
-                        ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
                     'any value',
@@ -147,7 +146,6 @@ final class DefSymbolTest extends TestCase
                 new LiteralNode(
                     $env
                         ->withExpressionContext()
-                        ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
                     'any value',
@@ -189,7 +187,6 @@ final class DefSymbolTest extends TestCase
                 new LiteralNode(
                     $env
                         ->withExpressionContext()
-                        ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
                     'any value',
@@ -233,7 +230,6 @@ final class DefSymbolTest extends TestCase
                 new LiteralNode(
                     $env
                         ->withExpressionContext()
-                        ->withDisallowRecurFrame()
                         ->withBoundTo('user\name')
                         ->withDefAllowed(false),
                     'any value',


### PR DESCRIPTION
## Summary
- permit recursion inside anonymous functions assigned with `def`
- adjust DefSymbol analyzer to keep recur frame
- update unit tests
- add integration fixture for recur in anon-def
