### PR TITLE
Fix build-phar.php

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -26,7 +26,7 @@ $iterator = new RecursiveIteratorIterator(
         new RecursiveDirectoryIterator($root, FilesystemIterator::FOLLOW_SYMLINKS),
         function ($current, $key, $iterator) {
             $basename = $current->getBasename();
-            $exclude = ['.', '..', '.git', 'docs', 'tests', 'docker', 'data', 'tools'];
+            $exclude = ['.', '..', '.git', 'docs', 'tests', 'docker', 'tools'];
             if ($current->isDir() && in_array($basename, $exclude, true)) {
                 return false;
             }


### PR DESCRIPTION
## 🤔 Background

Data directories are required by some vendor packages (e.g. symfony/string) so only exclude project specific folders.

![Screenshot 2025-06-09 at 19 57 19](https://github.com/user-attachments/assets/b8ae1c70-dd9f-498c-9b67-5b7b51e934a9)

