### PR TITLE
Add memoize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
   - `TopologicalNamespaceSorter`
   - `DependenciesForNamespace`
   - `NamespaceExtractor`
-- Add function `unset-in` 
+- Add core functions
+  - `unset-in`
+  - `memoize`
 - Add base64 functions
   - `base64/encode`
   - `base64/decode`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1459,6 +1459,19 @@ arrays. Use (php/aunset ds key)"))
   [f & args]
   |(apply f (concat [] args $&)))
 
+(defn memoize
+  "Returns a memoized version of the function `f`. The memoized function
+  caches the return value for each set of arguments."
+  [f]
+  (let [memoize-cache (var {})]
+    (fn [& args]
+      (let [c (deref memoize-cache)]
+        (if (contains? c args)
+          (get c args)
+          (let [res (apply f args)]
+            (set! memoize-cache (put c args res))
+            res))))) )
+
 # -----------------------
 # More sequence operation
 # -----------------------

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -17,3 +17,11 @@
 
 (deftest test-partial
   (is (= 3 ((partial + 2) 1)) "partial of add"))
+
+(deftest test-memoize
+  (let [counter (var 0)
+        f (memoize (fn [x] (swap! counter inc) (+ x 1)))]
+    (is (= 2 (f 1)) "first call")
+    (is (= 2 (f 1)) "cached call")
+    (is (= 3 (f 2)) "different arg")
+    (is (= 2 (deref counter)) "function executed twice")))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -33,6 +33,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(318, $groupedFns);
+        self::assertCount(319, $groupedFns);
     }
 }


### PR DESCRIPTION

## 🔖 Changes

- Introduced a new memoize function that caches a function’s return value for each argument set, improving performance on repeated calls
- Added corresponding tests ensuring the memoized function only executes the underlying function when necessary
