### PR TITLE
Fix repl prints unicode chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Replaced array-based queue handling with a more efficient `SplQueue` in the dependency traversal logic
 - Fix DefException Emitter compatible with PHP 8.4
 - Optimize test command - disabling the sourcemap
+- Fix repl prints unicode chars
 
 ## [0.18.1](https://github.com/phel-lang/phel-lang/compare/v0.18.0...v0.18.1) - 2025-06-18
 

--- a/src/php/Printer/TypePrinter/StringPrinter.php
+++ b/src/php/Printer/TypePrinter/StringPrinter.php
@@ -74,22 +74,19 @@ final readonly class StringPrinter implements TypePrinterInterface
             }
 
             if ($this->isMask110XXXXX($asciiChar)) {
-                $hex = $this->utf8ToUnicodePoint(substr($str, $index, 2));
-                $return .= sprintf('\u{%04s}', $hex);
+                $return .= substr($str, $index, 2);
                 ++$index;
                 continue;
             }
 
             if ($this->isMask1110XXXX($asciiChar)) {
-                $hex = $this->utf8ToUnicodePoint(substr($str, $index, 3));
-                $return .= sprintf('\u{%04s}', $hex);
+                $return .= substr($str, $index, 3);
                 $index += 2;
                 continue;
             }
 
             if ($this->isMask11110XXX($asciiChar)) {
-                $hex = $this->utf8ToUnicodePoint(substr($str, $index, 4));
-                $return .= sprintf('\u{%04s}', $hex);
+                $return .= substr($str, $index, 4);
                 $index += 3;
                 continue;
             }
@@ -135,24 +132,6 @@ final readonly class StringPrinter implements TypePrinterInterface
     private function isMask11110XXX(int $asciiChar): bool
     {
         return ($asciiChar & 0xF8) === 0xF0;
-    }
-
-    private function utf8ToUnicodePoint(string $str): string
-    {
-        $a = ($str = unpack('C*', $str)) ? ((int) $str[1]) : 0;
-        if (0xF0 <= $a) {
-            return dechex((($a - 0xF0) << 18) + ((((int) $str[2]) - 0x80) << 12) + ((((int) $str[3]) - 0x80) << 6) + ((int) $str[4]) - 0x80);
-        }
-
-        if (0xE0 <= $a) {
-            return dechex((($a - 0xE0) << 12) + ((((int) $str[2]) - 0x80) << 6) + ((int) $str[3]) - 0x80);
-        }
-
-        if (0xC0 <= $a) {
-            return dechex((($a - 0xC0) << 6) + ((int) $str[2]) - 0x80);
-        }
-
-        return (string) $a;
     }
 
     private function color(string $str): string

--- a/tests/php/Integration/Printer/PrinterTest.php
+++ b/tests/php/Integration/Printer/PrinterTest.php
@@ -61,7 +61,7 @@ final class PrinterTest extends TestCase
     public function test_print_escaped_unicode_chars(): void
     {
         self::assertSame(
-            '"\u{1000}"',
+            '"က"',
             $this->print("\u{1000}"),
         );
     }

--- a/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/StringPrinterTest.php
@@ -26,16 +26,31 @@ final class StringPrinterTest extends TestCase
 
     public function test_mark_110(): void
     {
-        self::assertSame('"\u{0100}"', StringPrinter::readable()->print("\u{100}"));
+        self::assertSame('"Ā"', StringPrinter::readable()->print("\u{100}"));
     }
 
     public function test_mark_1110(): void
     {
-        self::assertSame('"\u{1100}"', StringPrinter::readable()->print("\u{1100}"));
+        self::assertSame('"ᄀ"', StringPrinter::readable()->print("\u{1100}"));
     }
 
     public function test_mark_11110(): void
     {
-        self::assertSame('"\u{11110}"', StringPrinter::readable()->print("\u{11110}"));
+        self::assertSame('"𑄐"', StringPrinter::readable()->print("\u{11110}"));
+    }
+
+    public function test_non_readable_mark_110(): void
+    {
+        self::assertSame('"\u{0100}"', StringPrinter::nonReadable()->print('"\u{0100}"'));
+    }
+
+    public function test_non_readable_mark_1110(): void
+    {
+        self::assertSame('"\u{1100}"', StringPrinter::nonReadable()->print('"\u{1100}"'));
+    }
+
+    public function test_non_readable_mark_11110(): void
+    {
+        self::assertSame('"\u{11110}"', StringPrinter::nonReadable()->print('"\u{11110}"'));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Fixes: https://github.com/phel-lang/phel-lang/issues/856 by @jasalt 

## 🔖 Changes

- Update StringPrinter to support unicode chars

<img width="574" height="157" alt="Screenshot 2025-08-01 at 22 07 40" src="https://github.com/user-attachments/assets/0cfce77e-30a9-49b9-889d-33307cb91e72" />


