### PR TITLE
Add `symbol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Add `symbol` function
+
 ## [0.19.0](https://github.com/phel-lang/phel-lang/compare/v0.18.1...v0.19.0) - 2025-08-02
 
 - Fix `DefException` Emitter compatible with PHP 8.4

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -210,11 +210,6 @@
   "Ignores the body of the comment."
   [&])
 
-(defn gensym
-  "Generates a new unique symbol."
-  []
-  (php/:: Symbol (gen)))
-
 (defn str
   "Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as an empty
@@ -226,6 +221,17 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   (if (php/== (php/count args) 0)
     ""
     (apply php/. "" args)))
+
+(defn symbol
+  "Creates a symbol by concatenating the elements of `xs` together.
+   Returns the new symbol."
+  [& xs]
+  (php/:: Symbol (create (apply str xs))))
+
+(defn gensym
+  "Generates a new unique symbol."
+  []
+  (php/:: Symbol (gen)))
 
 (defn transient
   "Converts a persistent collection to a transient collection."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -210,6 +210,19 @@
   "Ignores the body of the comment."
   [&])
 
+(defn symbol
+  "Returns a new symbol for given string with optional namespace.
+   Arity-1 returns a symbol without namespace. Arity-2 returns a symbol in given namespace."
+  [name-or-ns & [name]]
+  (if name
+    (php/:: Symbol (createForNamespace name-or-ns name))
+    (php/:: Symbol (create name-or-ns))))
+
+(defn gensym
+  "Generates a new unique symbol."
+  []
+  (php/:: Symbol (gen)))
+
 (defn str
   "Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as an empty
@@ -221,17 +234,6 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   (if (php/== (php/count args) 0)
     ""
     (apply php/. "" args)))
-
-(defn symbol
-  "Creates a symbol by concatenating the elements of `xs` together.
-   Returns the new symbol."
-  [& xs]
-  (php/:: Symbol (create (apply str xs))))
-
-(defn gensym
-  "Generates a new unique symbol."
-  []
-  (php/:: Symbol (gen)))
 
 (defn transient
   "Converts a persistent collection to a transient collection."

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -103,8 +103,13 @@
   (is (= "keyword" (name :keyword)) "name of keyword"))
 
 (deftest test-symbol
-  (is (= (symbol "abc") 'abc) "symbol on string")
-  (is (= (symbol "abc" 123) 'abc123) "symbol on string and integer"))
+  (is (= "Phel\\Lang\\Symbol" (php/get_class (symbol "abc"))) "symbol returns Symbol class instance")
+  (is (= 'abc (symbol "abc")) "symbol on simple string")
+  (is (= '*_.%;!:+-? (symbol "*_.%;!:+-?")) "symbol on complex string")
+  (is (= 'foo/bar (symbol "foo" "bar")) "symbol on string with namespace")
+  (is (= "foo" (php/-> (symbol "foo" "bar") (getNamespace))) "symbol on string with namespace using getNamespace")
+  (is (= nil (php/-> (symbol "bar") (getNamespace))) "symbol on string without namespace using getNamespace")
+  (is (= 'foo (php/:: (symbol (str "\Phel" "\Lang" "\Symbol")) (create "foo"))) "symbol on PHP class identifier string"))
 
 (deftest test-namespace
   (is (= nil (namespace 'symbol)) "namespace on symbol without ns")

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -102,6 +102,10 @@
   (is (= "symbol" (name 'symbol)) "name on symbol")
   (is (= "keyword" (name :keyword)) "name of keyword"))
 
+(deftest test-symbol
+  (is (= (symbol "abc") 'abc) "symbol on string")
+  (is (= (symbol "abc" 123) 'abc123) "symbol on string and integer"))
+
 (deftest test-namespace
   (is (= nil (namespace 'symbol)) "namespace on symbol without ns")
   (is (= nil (namespace :keyword)) "namespace of keyword without ns")

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -32,6 +32,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(319, $groupedFns);
+        self::assertCount(320, $groupedFns);
     }
 }


### PR DESCRIPTION
Needed way to define `php/CONSTANT`'s dynamically in macro. With this it's possible e.g. `(symbol (str "php/" "MY-CONSTANT"))`.

Looked at [Janet](https://github.com/janet-lang/janet/blob/ddc122958be34a18edd754743851536b5a16a3cc/src/core/corelib.c#L337) and [Clojure](https://github.com/clojure/clojure/blob/da1c748123c80fa3e82e24fc8e24a950a3ebccd9/src/clj/clojure/core.clj#L591) implementations, Clojure having explicit namespace support seemed more robust so took more influence from it as it seems to match `\Phel\Lang\Symbol` class static methods also nicely. 

Not sure of best way to define two different arities and couldn't grasp the usage of `{:inline-arity ...}` in some core library functions but better ideas are welcome.

Noted one warning in test suite but it's not related to this change, adding issue about it..