### PR TITLE
Fix trigger warning in RequireEvaluatorTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Fix `require` broke in repl (#861)
+- Fix trigger warning in tests (#864)
 
 ## [0.19.0](https://github.com/phel-lang/phel-lang/compare/v0.18.1...v0.19.0) - 2025-08-02
 

--- a/tests/php/Integration/Compiler/Evaluator/RequireEvaluatorTest.php
+++ b/tests/php/Integration/Compiler/Evaluator/RequireEvaluatorTest.php
@@ -32,7 +32,7 @@ final class RequireEvaluatorTest extends TestCase
         $this->filesystem->clearAll();
 
         if ($this->tempDir !== '' && is_dir($this->tempDir)) {
-            rmdir($this->tempDir);
+            $this->deleteDirRecursive($this->tempDir);
         }
     }
 
@@ -54,5 +54,32 @@ final class RequireEvaluatorTest extends TestCase
 
         self::assertSame(42, $result);
         self::assertDirectoryExists($this->tempDir);
+    }
+
+    private function deleteDirRecursive(string $dir): void
+    {
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path)) {
+                $this->deleteDirRecursive($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Fix https://github.com/phel-lang/phel-lang/issues/860 by @jasalt

## 🔖 Changes

- Prevented `"Directory not empty"` warnings by adding a class-level temp directory property and cleaning it in tearDown after the generated files are cleared

- Updated the test to assign the temporary directory to the new property and removed the final rmdir call from the test
