### PR TITLE
Ensured temporary directories are created without restrictive umask

### DIFF
--- a/tests/php/Unit/Filesystem/Application/TempDirFinderTest.php
+++ b/tests/php/Unit/Filesystem/Application/TempDirFinderTest.php
@@ -32,4 +32,25 @@ final class TempDirFinderTest extends TestCase
             rmdir($dir);
         }
     }
+
+    #[RunInSeparateProcess]
+    public function test_makes_dir_writable_when_possible(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-unwritable-' . uniqid('', true);
+        mkdir($dir);
+        chmod($dir, 0555);
+
+        $fileIo = $this->createMock(FileIoInterface::class);
+        $fileIo->expects(self::exactly(2))
+            ->method('isWritable')
+            ->with($dir)
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $finder = new TempDirFinder($fileIo, $dir);
+
+        self::assertSame($dir, $finder->getOrCreateTempDir());
+
+        chmod($dir, 0755);
+        rmdir($dir);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Fixes: https://github.com/phel-lang/phel-lang/issues/871 by @jasalt

## 🔖 Changes

- Ensured temporary directories are created without restrictive umask and automatically corrected with chmod if initially unwritable, preventing fatal errors when the default temp directory lacks the right permissions

- Added a unit test verifying that TempDirFinder can adjust permissions on an unwritable directory, allowing subsequent operations to proceed successfully
