### PR TITLE
Fix `map` function exhaustion with empty collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Fix `map` function exhaustion with empty collections (#874)
+
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03
 
 - Fix `require` broke in repl

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -989,7 +989,7 @@ arrays. Use (php/aunset ds key)"))
     1 (for [x :in (first xs)] (f x))
     (loop [res (transient [])
            seq xs]
-      (if (some? nil? seq)
+      (if (some? empty? seq)
         (persistent res)
         (do
           (push res (apply f (map first seq)))

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -2,9 +2,11 @@
   (:require phel\test :refer [deftest is]))
 
 (deftest test-map
+  (is (= [] (map str [])) "map1 with empty collection")
   (is (= ["1" "2"] (map str [1 2])) "map1")
   (is (= ["13" "24"] (map str [1 2] [3 4])) "map2")
   (is (= ["13" "24"] (map str [1 2 10] [3 4])) "map2 unequal size")
+  (is (= [] (map str [] [])) "map2 with empty collections")
   (is (= [] (map str [1 2 3] [])) "map2 with empty and non-empty collection"))
 
 (deftest test-map-indexed

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -4,7 +4,8 @@
 (deftest test-map
   (is (= ["1" "2"] (map str [1 2])) "map1")
   (is (= ["13" "24"] (map str [1 2] [3 4])) "map2")
-  (is (= ["13" "24"] (map str [1 2 10] [3 4])) "map2 unequal size"))
+  (is (= ["13" "24"] (map str [1 2 10] [3 4])) "map2 unequal size")
+  (is (= [] (map str [1 2 3] [])) "map2 with empty and non-empty collection"))
 
 (deftest test-map-indexed
   (is (= [[0 "a"] [1 "b"] [2 "c"]] (map-indexed vector ["a" "b" "c"])) "map-indexed"))


### PR DESCRIPTION
Fixing https://github.com/phel-lang/phel-lang/issues/874
