### PR TITLE
feat: add `select-keys` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Add `select-keys`
+
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03
 
 - Fix `require` broke in repl

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1341,11 +1341,12 @@ arrays. Use (php/aunset ds key)"))
     (put res k v)))
 
 (defn select-keys
-  "Returns a new map including key value pairs from `m` selected with vector of keys `ks`."
+  "Returns a new map including key value pairs from `m` selected with of keys `ks`."
   [m ks]
-  (for [[k v] :pairs m :reduce [acc {}]]
-    (if (contains-value? ks k)
-      (put acc k v) acc)))
+  (for [[k v] :pairs m
+        :when (contains-value? ks k)
+        :reduce [acc {}]]
+    (put acc k v)))
 
 (defn invert
   "Returns a new map where the keys and values are swapped. If map has

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1340,6 +1340,13 @@ arrays. Use (php/aunset ds key)"))
         :reduce [res {}]]
     (put res k v)))
 
+(defn select-keys
+  "Returns a new map including key value pairs from `m` selected with vector of keys `ks`."
+  [m ks]
+  (for [[k v] :pairs m :reduce [acc {}]]
+    (if (contains-value? ks k)
+      (put acc k v) acc)))
+
 (defn invert
   "Returns a new map where the keys and values are swapped. If map has
   duplicated values, some keys will be ignored."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1342,7 +1342,7 @@ arrays. Use (php/aunset ds key)"))
   "Returns a new map including key value pairs from `m` selected with of keys `ks`."
   [m ks]
   (for [[k v] :pairs m
-        :when (some? |(= $ k) ks)
+        :when (contains-value? ks k)
         :reduce [acc {}]]
     (put acc k v)))
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1344,7 +1344,7 @@ arrays. Use (php/aunset ds key)"))
   "Returns a new map including key value pairs from `m` selected with of keys `ks`."
   [m ks]
   (for [[k v] :pairs m
-        :when (contains-value? ks k)
+        :when (some? |(= $ k) ks)
         :reduce [acc {}]]
     (put acc k v)))
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -201,6 +201,19 @@
 (deftest test-merge-with-mulitple-maps
   (is (= {:a 3 :b 2 :c 3} (merge-with + {:a 1} {:a 1 :b 2} {:a 1 :c 3}))))
 
+(deftest test-select-keys
+  (is (= {:a 1 :b 2} (select-keys {:a 1 :b 2 :c 3} [:a :b])) "select-keys for map with matching ks keys")
+  (is (= {} (select-keys {:a 1 :b 2 :c 3} [])) "select-keys for map without ks keys")
+  (is (= {:a 1} (select-keys {:a 1 :b 2 :c 3} [:a :d])) "select-keys for map with one ks key not found")
+  (is (= {} (select-keys {:a 1 :b 2 :c 3} [:d])) "select-keys for map with ks key not found")
+  (is (= {:a 1 :b 2 :c 3} (select-keys {:a 1 :b 2 :c 3} [:a :b :c])) "select-keys for map with all keys present")
+  (is (= {} (select-keys {} [:a :b])) "select-keys for empty map")
+  (is (= {1 10 2 20} (select-keys {1 10 2 20 3 30} [1 2])) "select-keys with numeric keys")
+  (is (= {:a 1} (select-keys {:a 1 :b 2 :c 3} [:a nil])) "select-keys with nil key in ks")
+  ## TODO next fails because contains-value? does not support nil values
+  (is (= {:a 1 nil 4} (select-keys {:a 1 :b 2 :c 3 nil 4} [:a nil])) "select-keys with nil key in m")
+  )
+
 (deftest test-simple-deep-merge
   (is (= {:a 1 :b 3 :c 4} (deep-merge {:a 1 :b 2} {:b 3 :c 4}))))
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -210,9 +210,7 @@
   (is (= {} (select-keys {} [:a :b])) "select-keys for empty map")
   (is (= {1 10 2 20} (select-keys {1 10 2 20 3 30} [1 2])) "select-keys with numeric keys")
   (is (= {:a 1} (select-keys {:a 1 :b 2 :c 3} [:a nil])) "select-keys with nil key in ks")
-  ## TODO next fails because contains-value? does not support nil values
-  (is (= {:a 1 nil 4} (select-keys {:a 1 :b 2 :c 3 nil 4} [:a nil])) "select-keys with nil key in m")
-  )
+  (is (= {:a 1 nil 4} (select-keys {:a 1 :b 2 :c 3 nil 4} [:a nil])) "select-keys with nil key in m"))
 
 (deftest test-simple-deep-merge
   (is (= {:a 1 :b 3 :c 4} (deep-merge {:a 1 :b 2} {:b 3 :c 4}))))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -32,6 +32,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(320, $groupedFns);
+        self::assertCount(321, $groupedFns);
     }
 }


### PR DESCRIPTION
Add convenience function familiar from Clojure for working with maps.

Draft as diagnosing why `contains-value?` is not behaving correctly with `nil` value..