### PR TITLE
Mention `CHANGELOG.md` in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@
 
 <!-- List individual changes in more detail as you might consider them important. -->
 
-<!-- Remember to also update the CHANGELOG.md for changes that are worthwhile to mention in release notes. -->
+<!-- Remember to add a mention about the fix/feature to the 'unreleased' section at the beginning of CHANGELOG.md for changes that are worth including in release notes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,5 @@
 ## 🔖 Changes
 
 <!-- List individual changes in more detail as you might consider them important. -->
+
+<!-- Remember to also update the CHANGELOG.md for changes that are worthwhile to mention in release notes. -->


### PR DESCRIPTION
It seems easy to forget updating `CHANGELOG.md` with pull requests.

This adds a mention about it in the end of the pull request template.

For this PR I don't add a mention to it as it seems too meta.