### PR TITLE
Fix set difference errors with certain input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix `map` function exhaustion with empty collections (#874)
 - Fix `contains-value?` with `nil` value (#880)
 - Add `select-keys` (#878)
+- Fix set `difference` errors with certain input
 
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03
 

--- a/src/php/Lang/Collections/Map/ArrayNodeIterator.php
+++ b/src/php/Lang/Collections/Map/ArrayNodeIterator.php
@@ -7,6 +7,8 @@ namespace Phel\Lang\Collections\Map;
 use Iterator;
 use RuntimeException;
 
+use function array_filter;
+use function array_values;
 use function count;
 
 /**
@@ -17,7 +19,7 @@ use function count;
  */
 final class ArrayNodeIterator implements Iterator
 {
-    /** @var array<int, HashMapNodeInterface<K, V>> A fixed size array of nodes */
+    /** @var list<HashMapNodeInterface<K, V>> A list of nodes */
     private readonly array $childNodes;
 
     private readonly int $count;
@@ -28,7 +30,7 @@ final class ArrayNodeIterator implements Iterator
 
     public function __construct(array $childNodes)
     {
-        $this->childNodes = array_values($childNodes);
+        $this->childNodes = array_values(array_filter($childNodes));
         $this->count = count($this->childNodes);
     }
 

--- a/tests/php/Unit/Lang/Collections/Map/ArrayNodeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Map/ArrayNodeIteratorTest.php
@@ -50,4 +50,30 @@ final class ArrayNodeIteratorTest extends TestCase
 
         $this->assertSame([1 => 'foo', 2 => 'bar'], $result);
     }
+
+    public function test_iterate_on_node_with_removed_entry(): void
+    {
+        $node = ArrayNode::empty(new ModuloHasher(), new SimpleEqualizer());
+        for ($i = 1; $i <= 9; ++$i) {
+            $node = $node->put(0, $i, $i, 'value' . $i, new Box(false));
+        }
+
+        $node = $node->remove(0, 5, 5);
+
+        $result = [];
+        foreach ($node as $k => $v) {
+            $result[$k] = $v;
+        }
+
+        $this->assertSame([
+            1 => 'value1',
+            2 => 'value2',
+            3 => 'value3',
+            4 => 'value4',
+            6 => 'value6',
+            7 => 'value7',
+            8 => 'value8',
+            9 => 'value9',
+        ], $result);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Fixes https://github.com/phel-lang/phel-lang/issues/882

## 🔖 Changes

- Update `ArrayNodeIterator` with `array_filter` to remove null values

## 🧪 QA

### BEFORE
<img width="1335" height="694" alt="Screenshot 2025-08-22 at 19 39 13" src="https://github.com/user-attachments/assets/fdabcbab-3833-49cd-9d24-fdd21a8dbb40" />

### AFTER
<img width="1038" height="546" alt="Screenshot 2025-08-22 at 19 39 50" src="https://github.com/user-attachments/assets/3a7a90f4-045d-4d42-81b3-e0f5b93af00c" />

> The behavior is correct. The difference removed "/y/" from the first set. The seemingly “random” order is just because sets in Phel are unordered.