### PR TITLE
Refactor TypeFactory to PhelType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Avoid coercing `nil` to 0 in math operations
 - Add `\Phel` as public entry class instead of `\Phel\Phel` 
 - Use `Phel` as proxy for singleton `Registry` methods
+- Use `PhelType` as proxy for singleton `TypeFactory` methods
 
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
             "Phel\\": "src/php/"
         },
         "classmap": [
-            "src/Phel.php"
+            "src/Phel.php",
+            "src/PhelType.php"
         ]
     },
     "autoload-dev": {

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -4,25 +4,28 @@ declare(strict_types=1);
 
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Registry;
-use Phel\Phel as OriginalPhel;
+use Phel\Phel as InternalPhel;
 
 /**
  * Public API for Phel.
  *
- * @method static void clear()
  * @method static void addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null)
+ * @method static void clear()
  * @method static bool hasDefinition(string $ns, string $name)
  * @method static mixed getDefinition(string $ns, string $name)
- * @method static null|PersistentMapInterface getDefinitionMetaData(string $ns, string $name)
- * @method static array<string, mixed> getDefinitionInNamespace(string $ns)
+ * @method static PersistentMapInterface|null getDefinitionMetaData(string $ns, string $name)
+ * @method static array<string,mixed> getDefinitionInNamespace(string $ns)
  * @method static list<string> getNamespaces()
  */
-final class Phel extends OriginalPhel
+final class Phel extends InternalPhel
 {
     /**
-     * Proxy undefined static method calls the registry instance.
+     * Proxy undefined static method calls to the {@see Registry} singleton.
      *
-     * @param  list<mixed>  $arguments
+     * @param string      $name
+     * @param list<mixed> $arguments
+     *
+     * @return mixed
      */
     public static function __callStatic(string $name, array $arguments): mixed
     {
@@ -35,9 +38,12 @@ final class Phel extends OriginalPhel
     }
 
     /**
-     * @see          GlobalVarEmitter
+     * Get a reference to a stored definition.
      *
+     * @see GlobalVarEmitter
      * @noinspection PhpUnused
+     *
+     * @return mixed Reference to the stored definition.
      */
     public static function &getDefinitionReference(string $ns, string $name): mixed
     {

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -2,28 +2,21 @@
 
 declare(strict_types=1);
 
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Registry;
 use Phel\Phel as InternalPhel;
 
 /**
  * Public API for Phel.
  *
- * @method static void addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null)
- * @method static void clear()
- * @method static bool hasDefinition(string $ns, string $name)
- * @method static mixed getDefinition(string $ns, string $name)
- * @method static PersistentMapInterface|null getDefinitionMetaData(string $ns, string $name)
- * @method static array<string,mixed> getDefinitionInNamespace(string $ns)
- * @method static list<string> getNamespaces()
+ * @mixin Registry
  */
 final class Phel extends InternalPhel
 {
     /**
      * Proxy undefined static method calls to the {@see Registry} singleton.
      *
-     * @param string      $name
-     * @param list<mixed> $arguments
+     * @param  string  $name
+     * @param  list<mixed>  $arguments
      *
      * @return mixed
      */
@@ -40,8 +33,8 @@ final class Phel extends InternalPhel
     /**
      * Get a reference to a stored definition.
      *
-     * @see GlobalVarEmitter
      * @noinspection PhpUnused
+     * @see GlobalVarEmitter
      *
      * @return mixed Reference to the stored definition.
      */

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -2,11 +2,45 @@
 
 declare(strict_types=1);
 
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Registry;
 use Phel\Phel as OriginalPhel;
 
 /**
  * Public API for Phel.
+ *
+ * @method static void clear()
+ * @method static void addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null)
+ * @method static bool hasDefinition(string $ns, string $name)
+ * @method static mixed getDefinition(string $ns, string $name)
+ * @method static null|PersistentMapInterface getDefinitionMetaData(string $ns, string $name)
+ * @method static array<string, mixed> getDefinitionInNamespace(string $ns)
+ * @method static list<string> getNamespaces()
  */
 final class Phel extends OriginalPhel
 {
+    /**
+     * Proxy undefined static method calls the registry instance.
+     *
+     * @param  list<mixed>  $arguments
+     */
+    public static function __callStatic(string $name, array $arguments): mixed
+    {
+        $registry = Registry::getInstance();
+        if (is_callable([$registry, $name])) {
+            return $registry->$name(...$arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Method "%s" does not exist', $name));
+    }
+
+    /**
+     * @see          GlobalVarEmitter
+     *
+     * @noinspection PhpUnused
+     */
+    public static function &getDefinitionReference(string $ns, string $name): mixed
+    {
+        return Registry::getInstance()->getDefinitionReference($ns, $name);
+    }
 }

--- a/src/PhelType.php
+++ b/src/PhelType.php
@@ -15,26 +15,36 @@ use Phel\Lang\TypeFactory;
 use Phel\Lang\Variable;
 
 /**
- * @method static PersistentMapInterface emptyPersistentMap()
- * @method static PersistentMapInterface persistentMapFromKVs(...$kvs)
- * @method static PersistentMapInterface persistentMapFromArray(array $kvs)
- * @method static PersistentHashSetInterface persistentHashSetFromArray(array $values)
- * @method static EmptyList emptyPersistentList()
- * @method static PersistentListInterface persistentListFromArray(array $values)
- * @method static PersistentVectorInterface emptyPersistentVector()
- * @method static PersistentVectorInterface persistentVectorFromArray(array $values)
- * @method static Variable variable(mixed $value)
- * @method static Symbol symbol(string $name)
- * @method static Keyword keyword(string $name, string $namespace = null)
- * @method static EqualizerInterface getEqualizer()
- * @method static HasherInterface getHasher()
+ * Static proxy to TypeFactory.
+ *
+ * @mixin TypeFactory
+ *
+ * Factory helpers:
+ * @method static PersistentMapInterface     emptyPersistentMap()
+ * @method static PersistentMapInterface     persistentMapFromKVs(mixed ...$kvs)
+ * @method static PersistentMapInterface     persistentMapFromArray(array<string|int, mixed> $kvs)
+ * @method static PersistentHashSetInterface persistentHashSetFromArray(list<mixed> $values)
+ * @method static EmptyList                  emptyPersistentList()
+ * @method static PersistentListInterface    persistentListFromArray(list<mixed> $values)
+ * @method static PersistentVectorInterface  emptyPersistentVector()
+ * @method static PersistentVectorInterface  persistentVectorFromArray(list<mixed> $values)
+ *
+ * Language values:
+ * @method static Variable                   variable(mixed $value)
+ * @method static Symbol                     symbol(string $name)
+ * @method static Keyword                    keyword(string $name, ?string $namespace = null)
+ *
+ * Utilities:
+ * @method static EqualizerInterface         getEqualizer()
+ * @method static HasherInterface            getHasher()
  */
 final class PhelType
 {
     /**
-     * Proxy static method calls the TypeFactory instance.
+     * Proxy undefined static method calls to the {@see TypeFactory} singleton.
      *
-     * @param list<mixed> $arguments
+     * @param  list<mixed>  $arguments
+     * @return mixed
      */
     public static function __callStatic(string $name, array $arguments): mixed
     {

--- a/src/PhelType.php
+++ b/src/PhelType.php
@@ -2,41 +2,12 @@
 
 declare(strict_types=1);
 
-use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
-use Phel\Lang\Collections\LinkedList\EmptyList;
-use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\EqualizerInterface;
-use Phel\Lang\HasherInterface;
-use Phel\Lang\Keyword;
-use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
-use Phel\Lang\Variable;
 
 /**
  * Static proxy to TypeFactory.
  *
  * @mixin TypeFactory
- *
- * Factory helpers:
- * @method static PersistentMapInterface     emptyPersistentMap()
- * @method static PersistentMapInterface     persistentMapFromKVs(mixed ...$kvs)
- * @method static PersistentMapInterface     persistentMapFromArray(array<string|int, mixed> $kvs)
- * @method static PersistentHashSetInterface persistentHashSetFromArray(list<mixed> $values)
- * @method static EmptyList                  emptyPersistentList()
- * @method static PersistentListInterface    persistentListFromArray(list<mixed> $values)
- * @method static PersistentVectorInterface  emptyPersistentVector()
- * @method static PersistentVectorInterface  persistentVectorFromArray(list<mixed> $values)
- *
- * Language values:
- * @method static Variable                   variable(mixed $value)
- * @method static Symbol                     symbol(string $name)
- * @method static Keyword                    keyword(string $name, ?string $namespace = null)
- *
- * Utilities:
- * @method static EqualizerInterface         getEqualizer()
- * @method static HasherInterface            getHasher()
  */
 final class PhelType
 {

--- a/src/PhelType.php
+++ b/src/PhelType.php
@@ -2,22 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Phel\Lang;
-
-use BadMethodCallException;
-
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-
-use function is_callable;
-use function sprintf;
+use Phel\Lang\EqualizerInterface;
+use Phel\Lang\HasherInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeFactory;
+use Phel\Lang\Variable;
 
 /**
  * @method static PersistentMapInterface emptyPersistentMap()
- * @method static PersistentMapInterface persistentMapFromKVs(mixed ...$kvs)
+ * @method static PersistentMapInterface persistentMapFromKVs(...$kvs)
  * @method static PersistentMapInterface persistentMapFromArray(array $kvs)
  * @method static PersistentHashSetInterface persistentHashSetFromArray(array $values)
  * @method static EmptyList emptyPersistentList()
@@ -26,11 +25,11 @@ use function sprintf;
  * @method static PersistentVectorInterface persistentVectorFromArray(array $values)
  * @method static Variable variable(mixed $value)
  * @method static Symbol symbol(string $name)
- * @method static Keyword keyword(string $name)
+ * @method static Keyword keyword(string $name, string $namespace = null)
  * @method static EqualizerInterface getEqualizer()
  * @method static HasherInterface getHasher()
  */
-final class Type
+final class PhelType
 {
     /**
      * Proxy static method calls the TypeFactory instance.

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -31,7 +31,7 @@
   (:use Phel\Lang\SliceInterface)
   (:use Phel\Lang\Symbol)
   (:use Phel\Lang\Truthy)
-  (:use Phel\Lang\TypeFactory)
+  (:use Phel\Lang\Type)
   (:use Phel\Lang\Variable)
   (:use Phel\Printer\Printer))
 
@@ -49,15 +49,15 @@
 
 (def list
   "```phel\n(list & xs)\n```\nCreates a new list. If no argument is provided, an empty list is created."
-  (fn [& xs] (php/-> (php/:: TypeFactory (getInstance)) (persistentListFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Type (persistentListFromArray (apply php/array xs)))))
 
 (def vector
   "```phel\n(vector & xs)\n```\nCreates a new vector. If no argument is provided, an empty vector is created."
-  (fn [& xs] (php/-> (php/:: TypeFactory (getInstance)) (persistentVectorFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Type (persistentVectorFromArray (apply php/array xs)))))
 
 (def hash-map
   "```phel\n(hash-map & xs)\n```\nCreates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even."
-  (fn [& xs] (php/-> (php/:: TypeFactory (getInstance)) (persistentMapFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Type (persistentMapFromArray (apply php/array xs)))))
 
 (def next
   "```phel\n(next xs)\n```\nReturns the sequence of elements after the first element. If there are no elements, returns nil."
@@ -248,7 +248,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 (defn set
   "Creates a new Set. If no argument is provided, an empty Set is created."
   [& xs]
-  (php/-> (php/:: TypeFactory (getInstance)) (persistentHashSetFromArray (apply php/array xs))))
+  (php/:: Type (persistentHashSetFromArray (apply php/array xs))))
 
 (defn keyword
   "Creates a new Keyword from a given string."
@@ -828,7 +828,7 @@ arrays. Use (php/aunset ds key)"))
 (defn var
   "Creates a new variable with the given value."
   [value]
-  (php/-> (php/:: TypeFactory (getInstance)) (variable value)))
+  (php/:: Type (variable value)))
 
 (defn var?
   "Checks if the given value is a variable."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2,6 +2,7 @@
   (:use Countable)
   (:use InvalidArgumentException)
   (:use Phel)
+  (:use PhelType)
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Compiler\CompilerFacade)
   (:use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode)
@@ -31,7 +32,6 @@
   (:use Phel\Lang\SliceInterface)
   (:use Phel\Lang\Symbol)
   (:use Phel\Lang\Truthy)
-  (:use Phel\Lang\Type)
   (:use Phel\Lang\Variable)
   (:use Phel\Printer\Printer))
 
@@ -49,15 +49,15 @@
 
 (def list
   "```phel\n(list & xs)\n```\nCreates a new list. If no argument is provided, an empty list is created."
-  (fn [& xs] (php/:: Type (persistentListFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: PhelType (persistentListFromArray (apply php/array xs)))))
 
 (def vector
   "```phel\n(vector & xs)\n```\nCreates a new vector. If no argument is provided, an empty vector is created."
-  (fn [& xs] (php/:: Type (persistentVectorFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: PhelType (persistentVectorFromArray (apply php/array xs)))))
 
 (def hash-map
   "```phel\n(hash-map & xs)\n```\nCreates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even."
-  (fn [& xs] (php/:: Type (persistentMapFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: PhelType (persistentMapFromArray (apply php/array xs)))))
 
 (def next
   "```phel\n(next xs)\n```\nReturns the sequence of elements after the first element. If there are no elements, returns nil."
@@ -248,7 +248,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 (defn set
   "Creates a new Set. If no argument is provided, an empty Set is created."
   [& xs]
-  (php/:: Type (persistentHashSetFromArray (apply php/array xs))))
+  (php/:: PhelType (persistentHashSetFromArray (apply php/array xs))))
 
 (defn keyword
   "Creates a new Keyword from a given string."
@@ -828,7 +828,7 @@ arrays. Use (php/aunset ds key)"))
 (defn var
   "Creates a new variable with the given value."
   [value]
-  (php/:: Type (variable value)))
+  (php/:: PhelType (variable value)))
 
 (defn var?
   "Checks if the given value is a variable."

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -9,7 +9,7 @@ use Phel\Api\Domain\PhelFnLoaderInterface;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Run\RunFacadeInterface;
 
 use function dirname;
@@ -404,6 +404,6 @@ EOF;
     private function getPhelMeta(string $ns, string $fnName): PersistentMapInterface
     {
         return Phel::getDefinitionMetaData($ns, $fnName)
-            ?? TypeFactory::getInstance()->emptyPersistentMap();
+            ?? Type::emptyPersistentMap();
     }
 }

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -9,8 +9,8 @@ use Phel\Api\Domain\PhelFnLoaderInterface;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Run\RunFacadeInterface;
+use PhelType;
 
 use function dirname;
 use function in_array;
@@ -404,6 +404,6 @@ EOF;
     private function getPhelMeta(string $ns, string $fnName): PersistentMapInterface
     {
         return Phel::getDefinitionMetaData($ns, $fnName)
-            ?? Type::emptyPersistentMap();
+            ?? PhelType::emptyPersistentMap();
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -14,11 +14,10 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Shared\BuildConstants;
 use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
-
+use PhelType;
 use RuntimeException;
 
 use function array_key_exists;
@@ -89,7 +88,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             return Phel::getDefinitionMetaData(
                 $this->mungeEncodeNs($namespace),
                 $name->getName(),
-            ) ?? Type::emptyPersistentMap();
+            ) ?? PhelType::emptyPersistentMap();
         }
 
         return null;
@@ -240,7 +239,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalCompileModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::COMPILE_MODE);
-        $meta = Type::persistentMapFromKVs(
+        $meta = PhelType::persistentMapFromKVs(
             Keyword::create('doc'),
             'Deprecated! Use *build-mode* instead. Set to true when a file is compiled, false otherwise.',
         );
@@ -256,7 +255,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalBuildModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::BUILD_MODE);
-        $meta = Type::persistentMapFromKVs(
+        $meta = PhelType::persistentMapFromKVs(
             Keyword::create('doc'),
             'Set to true when a file is being built/transpiled, false otherwise.',
         );

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -14,7 +14,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Shared\BuildConstants;
 use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
@@ -89,7 +89,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             return Phel::getDefinitionMetaData(
                 $this->mungeEncodeNs($namespace),
                 $name->getName(),
-            ) ?? TypeFactory::getInstance()->emptyPersistentMap();
+            ) ?? Type::emptyPersistentMap();
         }
 
         return null;
@@ -240,7 +240,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalCompileModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::COMPILE_MODE);
-        $meta = TypeFactory::getInstance()->persistentMapFromKVs(
+        $meta = Type::persistentMapFromKVs(
             Keyword::create('doc'),
             'Deprecated! Use *build-mode* instead. Set to true when a file is compiled, false otherwise.',
         );
@@ -256,7 +256,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalBuildModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::BUILD_MODE);
-        $meta = TypeFactory::getInstance()->persistentMapFromKVs(
+        $meta = Type::persistentMapFromKVs(
             Keyword::create('doc'),
             'Set to true when a file is being built/transpiled, false otherwise.',
         );

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -8,8 +8,8 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 
 /**
  * @implements BindingDeconstructorInterface<PersistentMapInterface>
@@ -55,7 +55,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         PersistentMapInterface $binding,
         float|bool|int|string|TypeInterface|null $key,
     ): PersistentListInterface {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_PHP_ARRAY_GET))->copyLocationFrom($binding),
             $this->mapSymbol,
             $key,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 
 /**
@@ -55,7 +55,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         PersistentMapInterface $binding,
         float|bool|int|string|TypeInterface|null $key,
     ): PersistentListInterface {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_PHP_ARRAY_GET))->copyLocationFrom($binding),
             $this->mapSymbol,
             $key,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -10,8 +10,7 @@ use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-
-use Phel\Lang\Type;
+use PhelType;
 
 use function sprintf;
 
@@ -104,7 +103,7 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
 
     private function createBindingValue(string $symbolName, mixed $current): PersistentListInterface
     {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create($symbolName))->copyLocationFrom($current),
             $this->currentListSymbol,
         ])->copyLocationFrom($current);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -10,7 +10,8 @@ use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+
+use Phel\Lang\Type;
 
 use function sprintf;
 
@@ -103,7 +104,7 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
 
     private function createBindingValue(string $symbolName, mixed $current): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create($symbolName))->copyLocationFrom($current),
             $this->currentListSymbol,
         ])->copyLocationFrom($current);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use ReflectionMethod;
 
 use function count;
@@ -170,12 +170,12 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
 
         // Analyze arguments and body as (fn arguments (do body))
         $fnNode = $this->analyzer->analyze(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create('fn'),
                 $arguments->rest(), // remove the first argument. The first argument is bound to $this
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('let'),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         $arguments->first(),
                         Symbol::createForNamespace('php', '$this'),
                     ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use ReflectionMethod;
 
 use function count;
@@ -170,12 +170,12 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
 
         // Analyze arguments and body as (fn arguments (do body))
         $fnNode = $this->analyzer->analyze(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create('fn'),
                 $arguments->rest(), // remove the first argument. The first argument is bound to $this
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('let'),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         $arguments->first(),
                         Symbol::createForNamespace('php', '$this'),
                     ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -17,8 +17,8 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 
 use function assert;
 use function count;
@@ -115,7 +115,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $startLocation = $list->getStartLocation();
         if ($startLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('start-location'), Type::persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('start-location'), PhelType::persistentMapFromKVs(
                 Keyword::create('file'),
                 $startLocation->getFile(),
                 Keyword::create('line'),
@@ -127,7 +127,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $endLocation = $list->getEndLocation();
         if ($endLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('end-location'), Type::persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('end-location'), PhelType::persistentMapFromKVs(
                 Keyword::create('file'),
                 $endLocation->getFile(),
                 Keyword::create('line'),
@@ -145,12 +145,12 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         if (is_string($meta)) {
             $key = (Keyword::create('doc'))->copyLocationFrom($list);
 
-            return Type::persistentMapFromKVs($key, $meta)
+            return PhelType::persistentMapFromKVs($key, $meta)
                 ->copyLocationFrom($list);
         }
 
         if ($meta instanceof Keyword) {
-            return Type::persistentMapFromKVs($meta, true)
+            return PhelType::persistentMapFromKVs($meta, true)
                 ->copyLocationFrom($meta);
         }
 
@@ -164,7 +164,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     private function getInitialMetaAndInit(PersistentListInterface $list): array
     {
         if (count($list) === 3) {
-            return [Type::emptyPersistentMap(), $list->get(2)];
+            return [PhelType::emptyPersistentMap(), $list->get(2)];
         }
 
         return [$list->get(2), $list->get(3)];

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -17,7 +17,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 
 use function assert;
@@ -115,7 +115,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $startLocation = $list->getStartLocation();
         if ($startLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('start-location'), TypeFactory::getInstance()->persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('start-location'), Type::persistentMapFromKVs(
                 Keyword::create('file'),
                 $startLocation->getFile(),
                 Keyword::create('line'),
@@ -127,7 +127,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $endLocation = $list->getEndLocation();
         if ($endLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('end-location'), TypeFactory::getInstance()->persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('end-location'), Type::persistentMapFromKVs(
                 Keyword::create('file'),
                 $endLocation->getFile(),
                 Keyword::create('line'),
@@ -145,14 +145,12 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         if (is_string($meta)) {
             $key = (Keyword::create('doc'))->copyLocationFrom($list);
 
-            return TypeFactory::getInstance()
-                ->persistentMapFromKVs($key, $meta)
+            return Type::persistentMapFromKVs($key, $meta)
                 ->copyLocationFrom($list);
         }
 
         if ($meta instanceof Keyword) {
-            return TypeFactory::getInstance()
-                ->persistentMapFromKVs($meta, true)
+            return Type::persistentMapFromKVs($meta, true)
                 ->copyLocationFrom($meta);
         }
 
@@ -166,7 +164,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     private function getInitialMetaAndInit(PersistentListInterface $list): array
     {
         if (count($list) === 3) {
-            return [TypeFactory::getInstance()->emptyPersistentMap(), $list->get(2)];
+            return [Type::emptyPersistentMap(), $list->get(2)];
         }
 
         return [$list->get(2), $list->get(3)];

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -14,8 +14,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-
-use Phel\Lang\Type;
+use PhelType;
 
 use function count;
 
@@ -73,7 +72,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createDoTupleWithBody(array $body): PersistentListInterface
     {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_DO))->copyLocationFrom($body),
             ...$body,
         ])->copyLocationFrom($body);
@@ -84,9 +83,9 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createLetTupleWithBody(FnSymbolTuple $fnSymbolTuple, array $listBody): PersistentListInterface
     {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_LET))->copyLocationFrom($listBody),
-            Type::persistentVectorFromArray($fnSymbolTuple->lets())->copyLocationFrom($listBody),
+            PhelType::persistentVectorFromArray($fnSymbolTuple->lets())->copyLocationFrom($listBody),
             ...$listBody,
         ])->copyLocationFrom($listBody);
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -14,7 +14,8 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+
+use Phel\Lang\Type;
 
 use function count;
 
@@ -72,7 +73,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createDoTupleWithBody(array $body): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_DO))->copyLocationFrom($body),
             ...$body,
         ])->copyLocationFrom($body);
@@ -83,9 +84,9 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createLetTupleWithBody(FnSymbolTuple $fnSymbolTuple, array $listBody): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_LET))->copyLocationFrom($listBody),
-            TypeFactory::getInstance()->persistentVectorFromArray($fnSymbolTuple->lets())->copyLocationFrom($listBody),
+            Type::persistentVectorFromArray($fnSymbolTuple->lets())->copyLocationFrom($listBody),
             ...$listBody,
         ])->copyLocationFrom($listBody);
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
@@ -12,7 +12,8 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+
+use Phel\Lang\Type;
 
 use function count;
 
@@ -130,14 +131,14 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
         $bodys = $list->rest()->rest()->toArray();
 
         if ($lets !== []) {
-            return TypeFactory::getInstance()->persistentListFromArray([
+            return Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_LET),
-                TypeFactory::getInstance()->persistentVectorFromArray($lets),
+                Type::persistentVectorFromArray($lets),
                 ...$bodys,
             ]);
         }
 
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             ...$bodys,
         ]);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
@@ -12,8 +12,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-
-use Phel\Lang\Type;
+use PhelType;
 
 use function count;
 
@@ -131,14 +130,14 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
         $bodys = $list->rest()->rest()->toArray();
 
         if ($lets !== []) {
-            return Type::persistentListFromArray([
+            return PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_LET),
-                Type::persistentVectorFromArray($lets),
+                PhelType::persistentVectorFromArray($lets),
                 ...$bodys,
             ]);
         }
 
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             ...$bodys,
         ]);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -16,9 +16,8 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
-
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 
 use function count;
 
@@ -150,7 +149,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $this->enrichLocationForAbstractType(
-            Type::persistentListFromArray($result)->withMeta($list->getMeta()),
+            PhelType::persistentListFromArray($result)->withMeta($list->getMeta()),
             $parent,
         );
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -16,8 +16,8 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\TypeFactory;
 
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 
 use function count;
@@ -150,7 +150,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $this->enrichLocationForAbstractType(
-            TypeFactory::getInstance()->persistentListFromArray($result)->withMeta($list->getMeta()),
+            Type::persistentListFromArray($result)->withMeta($list->getMeta()),
             $parent,
         );
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -14,7 +14,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 
 use function count;
 use function gettype;
@@ -53,8 +53,8 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
         }
 
         $newListData = $list->toArray();
-        $newListData[1] = Type::persistentVectorFromArray($bindingData);
-        $newList = Type::persistentListFromArray($newListData)
+        $newListData[1] = PhelType::persistentVectorFromArray($bindingData);
+        $newList = PhelType::persistentListFromArray($newListData)
             ->copyLocationFrom($list)
             ->withMeta($list->getMeta());
 
@@ -84,7 +84,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
 
         $exprs = $list->rest()->rest()->toArray();
         $bodyExpr = $this->analyzer->analyze(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -14,7 +14,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 use function count;
 use function gettype;
@@ -53,9 +53,8 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
         }
 
         $newListData = $list->toArray();
-        $newListData[1] = TypeFactory::getInstance()->persistentVectorFromArray($bindingData);
-        $newList = TypeFactory::getInstance()
-            ->persistentListFromArray($newListData)
+        $newListData[1] = Type::persistentVectorFromArray($bindingData);
+        $newList = Type::persistentListFromArray($newListData)
             ->copyLocationFrom($list)
             ->withMeta($list->getMeta());
 
@@ -85,7 +84,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
 
         $exprs = $list->rest()->rest()->toArray();
         $bodyExpr = $this->analyzer->analyze(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -15,8 +15,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-
-use Phel\Lang\Type;
+use PhelType;
 
 use function count;
 use function gettype;
@@ -75,14 +74,14 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         if ($lets !== []) {
             $bodyExpr = $list->rest()->rest()->toArray();
             $letSym = Symbol::create(Symbol::NAME_LET)->copyLocationFrom($list->get(0));
-            $letExpr = Type::persistentListFromArray([
+            $letExpr = PhelType::persistentListFromArray([
                 $letSym,
-                Type::persistentVectorFromArray($lets),
+                PhelType::persistentVectorFromArray($lets),
                 ...$bodyExpr,
             ])->copyLocationFrom($list);
-            $newExpr = Type::persistentListFromArray([
+            $newExpr = PhelType::persistentListFromArray([
                 $list->get(0),
-                Type::persistentVectorFromArray($preInits),
+                PhelType::persistentVectorFromArray($preInits),
                 $letExpr,
             ])->copyLocationFrom($list);
 
@@ -120,7 +119,7 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         }
 
         $bodyExpr = $this->analyzer->analyze(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -15,7 +15,8 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+
+use Phel\Lang\Type;
 
 use function count;
 use function gettype;
@@ -74,14 +75,14 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         if ($lets !== []) {
             $bodyExpr = $list->rest()->rest()->toArray();
             $letSym = Symbol::create(Symbol::NAME_LET)->copyLocationFrom($list->get(0));
-            $letExpr = TypeFactory::getInstance()->persistentListFromArray([
+            $letExpr = Type::persistentListFromArray([
                 $letSym,
-                TypeFactory::getInstance()->persistentVectorFromArray($lets),
+                Type::persistentVectorFromArray($lets),
                 ...$bodyExpr,
             ])->copyLocationFrom($list);
-            $newExpr = TypeFactory::getInstance()->persistentListFromArray([
+            $newExpr = Type::persistentListFromArray([
                 $list->get(0),
-                TypeFactory::getInstance()->persistentVectorFromArray($preInits),
+                Type::persistentVectorFromArray($preInits),
                 $letExpr,
             ])->copyLocationFrom($list);
 
@@ -119,7 +120,7 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         }
 
         $bodyExpr = $this->analyzer->analyze(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -15,10 +15,9 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Shared\CompilerConstants;
-
 use Phel\Shared\ReplConstants;
+use PhelType;
 
 use function count;
 use function in_array;
@@ -123,7 +122,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             $useSymbol = Symbol::createForNamespace($useSymbol->getNamespace(), '\\' . $useSymbol->getName());
         }
 
-        $useData = Type::persistentMapFromKVs(...$import->toArray());
+        $useData = PhelType::persistentMapFromKVs(...$import->toArray());
         $alias = $this->extractAlias($useData, $import, 'use');
         $this->analyzer->addUseAlias($ns, $alias, $useSymbol);
     }
@@ -189,7 +188,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation('First argument in :require must be a symbol.', $import);
         }
 
-        $requireData = Type::persistentMapFromKVs(...$import->toArray());
+        $requireData = PhelType::persistentMapFromKVs(...$import->toArray());
         $alias = $this->extractAlias($requireData, $import, 'require');
         $referSymbols = $this->extractRefer($requireData, $import);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -15,7 +15,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Shared\CompilerConstants;
 
 use Phel\Shared\ReplConstants;
@@ -123,7 +123,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             $useSymbol = Symbol::createForNamespace($useSymbol->getNamespace(), '\\' . $useSymbol->getName());
         }
 
-        $useData = TypeFactory::getInstance()->persistentMapFromKVs(...$import->toArray());
+        $useData = Type::persistentMapFromKVs(...$import->toArray());
         $alias = $this->extractAlias($useData, $import, 'use');
         $this->analyzer->addUseAlias($ns, $alias, $useSymbol);
     }
@@ -189,7 +189,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation('First argument in :require must be a symbol.', $import);
         }
 
-        $requireData = TypeFactory::getInstance()->persistentMapFromKVs(...$import->toArray());
+        $requireData = Type::persistentMapFromKVs(...$import->toArray());
         $alias = $this->extractAlias($requireData, $import, 'require');
         $referSymbols = $this->extractRefer($requireData, $import);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 
 final class TrySymbol implements SpecialFormAnalyzerInterface
 {
@@ -66,7 +66,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
 
         if ($finally instanceof PersistentListInterface) {
             /** @psalm-suppress InvalidOperand */
-            $finally = Type::persistentListFromArray([
+            $finally = PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$finally->rest(),
             ])->copyLocationFrom($finally);
@@ -104,7 +104,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             $exprs = [Symbol::create(Symbol::NAME_DO), ...$catch->rest()->rest()->rest()->toArray()];
 
             $catchBody = $this->analyzer->analyze(
-                Type::persistentListFromArray($exprs),
+                PhelType::persistentListFromArray($exprs),
                 $env->withContext($catchCtx)
                     ->withMergedLocals([$name])
                     ->withDisallowRecurFrame(),
@@ -120,7 +120,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
         }
 
         $body = $this->analyzer->analyze(
-            Type::persistentListFromArray([Symbol::create(Symbol::NAME_DO), ...$body]),
+            PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_DO), ...$body]),
             $env->withContext($catchNodes !== [] || $finally ? $catchCtx : $env->getContext())
                 ->withDisallowRecurFrame(),
         );

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final class TrySymbol implements SpecialFormAnalyzerInterface
 {
@@ -66,7 +66,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
 
         if ($finally instanceof PersistentListInterface) {
             /** @psalm-suppress InvalidOperand */
-            $finally = TypeFactory::getInstance()->persistentListFromArray([
+            $finally = Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DO),
                 ...$finally->rest(),
             ])->copyLocationFrom($finally);
@@ -104,7 +104,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             $exprs = [Symbol::create(Symbol::NAME_DO), ...$catch->rest()->rest()->rest()->toArray()];
 
             $catchBody = $this->analyzer->analyze(
-                TypeFactory::getInstance()->persistentListFromArray($exprs),
+                Type::persistentListFromArray($exprs),
                 $env->withContext($catchCtx)
                     ->withMergedLocals([$name])
                     ->withDisallowRecurFrame(),
@@ -120,7 +120,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
         }
 
         $body = $this->analyzer->analyze(
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_DO), ...$body]),
+            Type::persistentListFromArray([Symbol::create(Symbol::NAME_DO), ...$body]),
             $env->withContext($catchNodes !== [] || $finally ? $catchCtx : $env->getContext())
                 ->withDisallowRecurFrame(),
         );

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -96,12 +96,12 @@ final readonly class LiteralEmitter
     {
         if ($x->getNamespace() !== null && $x->getNamespace() !== '') {
             $this->outputEmitter->emitStr(
-                '\Phel\Lang\Keyword::createForNamespace("' . addslashes($x->getNamespace()) . '", "' . addslashes($x->getName()) . '")',
+                '\PhelType::keyword("' . addslashes($x->getName()) . '", "' . addslashes($x->getNamespace()) . '")',
                 $x->getStartLocation(),
             );
         } else {
             $this->outputEmitter->emitStr(
-                '\Phel\Lang\Keyword::create("' . addslashes($x->getName()) . '")',
+                '\PhelType::keyword("' . addslashes($x->getName()) . '")',
                 $x->getStartLocation(),
             );
         }
@@ -118,7 +118,7 @@ final readonly class LiteralEmitter
     private function emitMap(PersistentMapInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentMapFromKVs(', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\PhelType::persistentMapFromKVs(', $x->getStartLocation());
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();
@@ -147,7 +147,7 @@ final readonly class LiteralEmitter
     private function emitList(PersistentListInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentListFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\PhelType::persistentListFromArray([', $x->getStartLocation());
 
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
@@ -173,7 +173,7 @@ final readonly class LiteralEmitter
     private function emitVector(PersistentVector $x): void
     {
         $countVector = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentVectorFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\PhelType::persistentVectorFromArray([', $x->getStartLocation());
 
         if ($countVector > 0) {
             $this->outputEmitter->increaseIndentLevel();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -118,7 +118,7 @@ final readonly class LiteralEmitter
     private function emitMap(PersistentMapInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentMapFromKVs(', $x->getStartLocation());
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();
@@ -147,7 +147,7 @@ final readonly class LiteralEmitter
     private function emitList(PersistentListInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentListFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentListFromArray([', $x->getStartLocation());
 
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
@@ -173,7 +173,7 @@ final readonly class LiteralEmitter
     private function emitVector(PersistentVector $x): void
     {
         $countVector = count($x);
-        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentVectorFromArray([', $x->getStartLocation());
 
         if ($countVector > 0) {
             $this->outputEmitter->increaseIndentLevel();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -23,7 +23,7 @@ final class MapEmitter implements NodeEmitterInterface
         $countKeyValues = count($keyValues);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentMapFromKVs(', $node->getStartSourceLocation());
         if ($countKeyValues > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -23,7 +23,7 @@ final class MapEmitter implements NodeEmitterInterface
         $countKeyValues = count($keyValues);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentMapFromKVs(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\PhelType::persistentMapFromKVs(', $node->getStartSourceLocation());
         if ($countKeyValues > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -76,7 +76,7 @@ final class MethodEmitter
             $varName = $this->munge($p);
 
             $this->outputEmitter->emitLine(
-                '$' . $varName . ' = \Phel\Lang\Type::persistentVectorFromArray($' . $varName . ');',
+                '$' . $varName . ' = \PhelType::persistentVectorFromArray($' . $varName . ');',
                 $node->getStartSourceLocation(),
             );
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -76,7 +76,7 @@ final class MethodEmitter
             $varName = $this->munge($p);
 
             $this->outputEmitter->emitLine(
-                '$' . $varName . ' = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($' . $varName . ');',
+                '$' . $varName . ' = \Phel\Lang\Type::persistentVectorFromArray($' . $varName . ');',
                 $node->getStartSourceLocation(),
             );
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -19,7 +19,7 @@ final class VectorEmitter implements NodeEmitterInterface
         assert($node instanceof VectorNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentVectorFromArray([', $node->getStartSourceLocation());
         $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -19,7 +19,7 @@ final class VectorEmitter implements NodeEmitterInterface
         assert($node instanceof VectorNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel\Lang\Type::persistentVectorFromArray([', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\PhelType::persistentVectorFromArray([', $node->getStartSourceLocation());
         $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -108,15 +108,11 @@ final readonly class AtomParser
             $namespace = $matches['namespace'];
         }
 
-        $keyword = ($namespace !== null && $namespace !== '')
-            ? Keyword::createForNamespace($namespace, $matches['keyword'])
-            : Keyword::create($matches['keyword']);
-
         return new KeywordNode(
             $word,
             $token->getStartLocation(),
             $token->getEndLocation(),
-            $keyword,
+            Keyword::create($matches['keyword'], $namespace),
         );
     }
 

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class ListFnReader
 {
@@ -23,9 +23,9 @@ final readonly class ListFnReader
         $params = $this->extractParams($fnArgs);
         $fnArgs = null;
 
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray($params),
+            PhelType::persistentVectorFromArray($params),
             $body,
         ])->setStartLocation($node->getStartLocation())->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class ListFnReader
 {
@@ -23,9 +23,9 @@ final readonly class ListFnReader
         $params = $this->extractParams($fnArgs);
         $fnArgs = null;
 
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray($params),
+            Type::persistentVectorFromArray($params),
             $body,
         ])->setStartLocation($node->getStartLocation())->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class ListReader
 {
@@ -28,7 +28,7 @@ final readonly class ListReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return Type::persistentListFromArray($acc)
+        return PhelType::persistentListFromArray($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class ListReader
 {
@@ -28,8 +28,7 @@ final readonly class ListReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return TypeFactory::getInstance()
-            ->persistentListFromArray($acc)
+        return Type::persistentListFromArray($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class MapReader
 {
@@ -25,8 +25,7 @@ final readonly class MapReader
             throw ReaderException::forNode($node, $root, 'Maps must have an even number of parameters');
         }
 
-        return TypeFactory::getInstance()
-            ->persistentMapFromKVs(...$list->toArray())
+        return Type::persistentMapFromKVs(...$list->toArray())
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class MapReader
 {
@@ -25,7 +25,7 @@ final readonly class MapReader
             throw ReaderException::forNode($node, $root, 'Maps must have an even number of parameters');
         }
 
-        return Type::persistentMapFromKVs(...$list->toArray())
+        return PhelType::persistentMapFromKVs(...$list->toArray())
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
@@ -12,8 +12,8 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\MetaInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 
 use function count;
 use function is_string;
@@ -34,9 +34,9 @@ final readonly class MetaReader
 
         $meta = $this->reader->readExpression($metaExpression, $root);
         if (is_string($meta) || $meta instanceof Symbol) {
-            $meta = Type::persistentMapFromKVs(Keyword::create('tag'), $meta);
+            $meta = PhelType::persistentMapFromKVs(Keyword::create('tag'), $meta);
         } elseif ($meta instanceof Keyword) {
-            $meta = Type::persistentMapFromKVs($meta, true);
+            $meta = PhelType::persistentMapFromKVs($meta, true);
         } elseif (!$meta instanceof PersistentMapInterface) {
             throw ReaderException::forNode($node, $root, 'Metadata must be a Symbol, String, Keyword or Map');
         }
@@ -47,7 +47,7 @@ final readonly class MetaReader
             throw ReaderException::forNode($node, $root, 'Metadata can only applied to classes that implement MetaInterface');
         }
 
-        $objMeta = $object->getMeta() ?? Type::emptyPersistentMap();
+        $objMeta = $object->getMeta() ?? PhelType::emptyPersistentMap();
         foreach ($meta as $k => $v) {
             if ($k) {
                 $objMeta = $objMeta->put($k, $v);

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
@@ -12,7 +12,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\MetaInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 
 use function count;
@@ -34,9 +34,9 @@ final readonly class MetaReader
 
         $meta = $this->reader->readExpression($metaExpression, $root);
         if (is_string($meta) || $meta instanceof Symbol) {
-            $meta = TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('tag'), $meta);
+            $meta = Type::persistentMapFromKVs(Keyword::create('tag'), $meta);
         } elseif ($meta instanceof Keyword) {
-            $meta = TypeFactory::getInstance()->persistentMapFromKVs($meta, true);
+            $meta = Type::persistentMapFromKVs($meta, true);
         } elseif (!$meta instanceof PersistentMapInterface) {
             throw ReaderException::forNode($node, $root, 'Metadata must be a Symbol, String, Keyword or Map');
         }
@@ -47,7 +47,7 @@ final readonly class MetaReader
             throw ReaderException::forNode($node, $root, 'Metadata can only applied to classes that implement MetaInterface');
         }
 
-        $objMeta = $object->getMeta() ?? TypeFactory::getInstance()->emptyPersistentMap();
+        $objMeta = $object->getMeta() ?? Type::emptyPersistentMap();
         foreach ($meta as $k => $v) {
             if ($k) {
                 $objMeta = $objMeta->put($k, $v);

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class VectorReader
 {
@@ -28,7 +28,7 @@ final readonly class VectorReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return Type::persistentVectorFromArray($acc)
+        return PhelType::persistentVectorFromArray($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class VectorReader
 {
@@ -28,8 +28,7 @@ final readonly class VectorReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return TypeFactory::getInstance()
-            ->persistentVectorFromArray($acc)
+        return Type::persistentVectorFromArray($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class WrapReader
 {
@@ -21,8 +21,7 @@ final readonly class WrapReader
     {
         $expression = $this->reader->readExpression($node->getExpression(), $root);
 
-        return TypeFactory::getInstance()
-            ->persistentListFromArray([Symbol::create($wrapFn), $expression])
+        return Type::persistentListFromArray([Symbol::create($wrapFn), $expression])
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class WrapReader
 {
@@ -21,7 +21,7 @@ final readonly class WrapReader
     {
         $expression = $this->reader->readExpression($node->getExpression(), $root);
 
-        return Type::persistentListFromArray([Symbol::create($wrapFn), $expression])
+        return PhelType::persistentListFromArray([Symbol::create($wrapFn), $expression])
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -14,7 +14,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 
 use function count;
@@ -85,10 +85,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentList(PersistentList $form): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($form),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -97,10 +97,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentVector(PersistentVector $form): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_VECTOR))->copyLocationFrom($form),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -115,10 +115,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             $kvs[] = $v;
         }
 
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_MAP))->copyLocationFrom($form),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($kvs),
             ])->copyLocationFrom($form),
@@ -133,14 +133,14 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
         $xs = [];
         foreach ($seq as $item) {
             if ($this->isUnquote($item)) {
-                $xs[] = TypeFactory::getInstance()->persistentListFromArray([
+                $xs[] = Type::persistentListFromArray([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $item->get(1),
                 ])->copyLocationFrom($item);
             } elseif ($this->isUnquoteSplicing($item)) {
                 $xs[] = $item->get(1);
             } else {
-                $xs[] = TypeFactory::getInstance()->persistentListFromArray([
+                $xs[] = Type::persistentListFromArray([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $this->transform($item),
                 ])->copyLocationFrom($item);
@@ -177,7 +177,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             }
         }
 
-        return TypeFactory::getInstance()->persistentListFromArray([
+        return Type::persistentListFromArray([
             (Symbol::create(Symbol::NAME_QUOTE))->copyLocationFrom($form),
             $form,
         ])->copyLocationFrom($form);

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -14,8 +14,8 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 
 use function count;
 use function is_bool;
@@ -85,10 +85,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentList(PersistentList $form): PersistentListInterface
     {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($form),
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -97,10 +97,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentVector(PersistentVector $form): PersistentListInterface
     {
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_VECTOR))->copyLocationFrom($form),
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -115,10 +115,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             $kvs[] = $v;
         }
 
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_MAP))->copyLocationFrom($form),
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($kvs),
             ])->copyLocationFrom($form),
@@ -133,14 +133,14 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
         $xs = [];
         foreach ($seq as $item) {
             if ($this->isUnquote($item)) {
-                $xs[] = Type::persistentListFromArray([
+                $xs[] = PhelType::persistentListFromArray([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $item->get(1),
                 ])->copyLocationFrom($item);
             } elseif ($this->isUnquoteSplicing($item)) {
                 $xs[] = $item->get(1);
             } else {
-                $xs[] = Type::persistentListFromArray([
+                $xs[] = PhelType::persistentListFromArray([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $this->transform($item),
                 ])->copyLocationFrom($item);
@@ -177,7 +177,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             }
         }
 
-        return Type::persistentListFromArray([
+        return PhelType::persistentListFromArray([
             (Symbol::create(Symbol::NAME_QUOTE))->copyLocationFrom($form),
             $form,
         ])->copyLocationFrom($form);

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Interop\Domain\ReadModel\FunctionToExport;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 
 final readonly class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 {
@@ -93,7 +93,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
     {
         /** @var PersistentMapInterface $meta */
         $meta = Phel::getDefinitionMetaData($ns, $fnName)
-            ?? TypeFactory::getInstance()->emptyPersistentList();
+            ?? Type::emptyPersistentList();
 
         return (bool)($meta[Keyword::create('export')] ?? false);
     }

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Interop\Domain\ReadModel\FunctionToExport;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\Type;
+use PhelType;
 
 final readonly class FunctionsToExportFinder implements FunctionsToExportFinderInterface
 {
@@ -93,7 +93,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
     {
         /** @var PersistentMapInterface $meta */
         $meta = Phel::getDefinitionMetaData($ns, $fnName)
-            ?? Type::emptyPersistentList();
+            ?? PhelType::emptyPersistentList();
 
         return (bool)($meta[Keyword::create('export')] ?? false);
     }

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -12,7 +12,7 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Printer\Printer;
 use Traversable;
 
@@ -34,8 +34,8 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function __construct()
     {
         parent::__construct(
-            TypeFactory::getInstance()->getHasher(),
-            TypeFactory::getInstance()->getEqualizer(),
+            Type::getHasher(),
+            Type::getEqualizer(),
             null,
         );
         $this->munge = new Munge();
@@ -85,7 +85,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getIterator(): Traversable
     {
         foreach (static::ALLOWED_KEYS as $key) {
-            yield TypeFactory::getInstance()->keyword($key) => $this->{$this->munge->encode($key)};
+            yield Type::keyword($key) => $this->{$this->munge->encode($key)};
         }
     }
 
@@ -107,7 +107,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getAllowedKeys(): array
     {
         return array_map(
-            static fn (string $k): Keyword => TypeFactory::getInstance()->keyword($k),
+            static fn (string $k): Keyword => Type::keyword($k),
             static::ALLOWED_KEYS,
         );
     }

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -12,8 +12,8 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\Type;
 use Phel\Printer\Printer;
+use PhelType;
 use Traversable;
 
 use function count;
@@ -34,8 +34,8 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function __construct()
     {
         parent::__construct(
-            Type::getHasher(),
-            Type::getEqualizer(),
+            PhelType::getHasher(),
+            PhelType::getEqualizer(),
             null,
         );
         $this->munge = new Munge();
@@ -85,7 +85,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getIterator(): Traversable
     {
         foreach (static::ALLOWED_KEYS as $key) {
-            yield Type::keyword($key) => $this->{$this->munge->encode($key)};
+            yield PhelType::keyword($key) => $this->{$this->munge->encode($key)};
         }
     }
 
@@ -107,7 +107,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getAllowedKeys(): array
     {
         return array_map(
-            static fn (string $k): Keyword => Type::keyword($k),
+            static fn (string $k): Keyword => PhelType::keyword($k),
             static::ALLOWED_KEYS,
         );
     }

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -31,11 +31,14 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
         return $obj[$this] ?? $default;
     }
 
-    public static function create(string $name): self
+    public static function create(string $name, ?string $namespace = null): self
     {
-        return new self(null, $name);
+        return new self($namespace, $name);
     }
 
+    /**
+     * @deprecated in favor of create()
+     */
     public static function createForNamespace(string $namespace, string $name): self
     {
         return new self($namespace, $name);

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Lang;
 
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-
+use PhelType;
 use RuntimeException;
 
 use function array_key_exists;
@@ -76,7 +76,7 @@ final class Registry
             return null;
         }
 
-        return $this->definitionsMetaData[$ns][$name] ?? Type::emptyPersistentMap();
+        return $this->definitionsMetaData[$ns][$name] ?? PhelType::emptyPersistentMap();
     }
 
     /**

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -79,7 +79,7 @@ final class Registry
             return null;
         }
 
-        return $this->definitionsMetaData[$ns][$name] ?? TypeFactory::getInstance()->emptyPersistentMap();
+        return $this->definitionsMetaData[$ns][$name] ?? Type::emptyPersistentMap();
     }
 
     /**

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -11,9 +11,6 @@ use RuntimeException;
 use function array_key_exists;
 use function sprintf;
 
-/**
- * @internal
- */
 final class Registry
 {
     /** @var array<string, array<string, mixed>> */

--- a/src/php/Lang/Type.php
+++ b/src/php/Lang/Type.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use BadMethodCallException;
+
+use function is_callable;
+use function sprintf;
+
+final class Type
+{
+    /**
+     * Proxy static method calls to the TypeFactory instance.
+     *
+     * @param list<mixed> $arguments
+     */
+    public static function __callStatic(string $name, array $arguments): mixed
+    {
+        $factory = TypeFactory::getInstance();
+        if (is_callable([$factory, $name])) {
+            return $factory->$name(...$arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Method "%s" does not exist', $name));
+    }
+}

--- a/src/php/Lang/Type.php
+++ b/src/php/Lang/Type.php
@@ -6,13 +6,34 @@ namespace Phel\Lang;
 
 use BadMethodCallException;
 
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\LinkedList\EmptyList;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
 use function is_callable;
 use function sprintf;
 
+/**
+ * @method static PersistentMapInterface emptyPersistentMap()
+ * @method static PersistentMapInterface persistentMapFromKVs(mixed ...$kvs)
+ * @method static PersistentMapInterface persistentMapFromArray(array $kvs)
+ * @method static PersistentHashSetInterface persistentHashSetFromArray(array $values)
+ * @method static EmptyList emptyPersistentList()
+ * @method static PersistentListInterface persistentListFromArray(array $values)
+ * @method static PersistentVectorInterface emptyPersistentVector()
+ * @method static PersistentVectorInterface persistentVectorFromArray(array $values)
+ * @method static Variable variable(mixed $value)
+ * @method static Symbol symbol(string $name)
+ * @method static Keyword keyword(string $name)
+ * @method static EqualizerInterface getEqualizer()
+ * @method static HasherInterface getHasher()
+ */
 final class Type
 {
     /**
-     * Proxy static method calls to the TypeFactory instance.
+     * Proxy static method calls the TypeFactory instance.
      *
      * @param list<mixed> $arguments
      */

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -109,9 +109,9 @@ final class TypeFactory
         return Symbol::create($name);
     }
 
-    public function keyword(string $name): Keyword
+    public function keyword(string $name, ?string $namespace = null): Keyword
     {
-        return Keyword::create($name);
+        return Keyword::create($name, $namespace);
     }
 
     public function getEqualizer(): EqualizerInterface

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -4,34 +4,20 @@ declare(strict_types=1);
 
 namespace Phel;
 
-use BadMethodCallException;
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Phar;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\GlobalVarEmitter;
 use Phel\Filesystem\FilesystemFacade;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Registry;
 use Phel\Run\RunFacade;
 
 use function dirname;
 use function in_array;
 use function is_array;
-use function is_callable;
 use function is_string;
-use function sprintf;
 
 /**
  * @internal use \Phel instead
- *
- * @method static void clear()
- * @method static void addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null)
- * @method static bool hasDefinition(string $ns, string $name)
- * @method static mixed getDefinition(string $ns, string $name)
- * @method static null|PersistentMapInterface getDefinitionMetaData(string $ns, string $name)
- * @method static array<string, mixed> getDefinitionInNamespace(string $ns)
- * @method static list<string> getNamespaces()
  */
 class Phel
 {
@@ -46,31 +32,6 @@ class Phel
      * @see https://github.com/gacela-project/gacela/pull/322
      */
     private const string FILE_CACHE_DIR = '';
-
-    /**
-     * Proxy undefined static method calls the registry instance.
-     *
-     * @param  list<mixed>  $arguments
-     */
-    public static function __callStatic(string $name, array $arguments): mixed
-    {
-        $registry = Registry::getInstance();
-        if (is_callable([$registry, $name])) {
-            return $registry->$name(...$arguments);
-        }
-
-        throw new BadMethodCallException(sprintf('Method "%s" does not exist', $name));
-    }
-
-    /**
-     * @see GlobalVarEmitter
-     *
-     * @noinspection PhpUnused
-     */
-    public static function &getDefinitionReference(string $ns, string $name): mixed
-    {
-        return Registry::getInstance()->getDefinitionReference($ns, $name);
-    }
 
     public static function bootstrap(string $projectRootDir, array|string|null $argv = null): void
     {

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Test;
 
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Printer\Printer;
 
 final readonly class TestCommandOptions
@@ -34,12 +34,10 @@ final readonly class TestCommandOptions
 
     public function asPhelHashMap(): string
     {
-        $typeFactory = TypeFactory::getInstance();
-
-        $optionsMap = $typeFactory->persistentMapFromKVs(
-            $typeFactory->keyword(self::FILTER),
+        $optionsMap = Type::persistentMapFromKVs(
+            Type::keyword(self::FILTER),
             $this->filter,
-            $typeFactory->keyword(self::TESTDOX),
+            Type::keyword(self::TESTDOX),
             $this->testdox,
         );
 

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Test;
 
-use Phel\Lang\Type;
 use Phel\Printer\Printer;
+use PhelType;
 
 final readonly class TestCommandOptions
 {
@@ -34,10 +34,10 @@ final readonly class TestCommandOptions
 
     public function asPhelHashMap(): string
     {
-        $optionsMap = Type::persistentMapFromKVs(
-            Type::keyword(self::FILTER),
+        $optionsMap = PhelType::persistentMapFromKVs(
+            PhelType::keyword(self::FILTER),
             $this->filter,
-            Type::keyword(self::TESTDOX),
+            PhelType::keyword(self::TESTDOX),
             $this->testdox,
         );
 

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -15,8 +15,8 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 use function sprintf;
@@ -97,25 +97,25 @@ final class ReaderTest extends TestCase
     public function test_read_list(): void
     {
         self::assertEquals(
-            $this->loc(Type::emptyPersistentList(), 1, 0, 1, 2),
+            $this->loc(PhelType::emptyPersistentList(), 1, 0, 1, 2),
             $this->read('()'),
         );
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
-                $this->loc(Type::emptyPersistentList(), 1, 1, 1, 3),
+            $this->loc(PhelType::persistentListFromArray([
+                $this->loc(PhelType::emptyPersistentList(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('(())'),
         );
 
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('(a)'),
         );
 
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -126,25 +126,25 @@ final class ReaderTest extends TestCase
     public function test_read_vector(): void
     {
         self::assertEquals(
-            $this->loc(Type::emptyPersistentVector(), 1, 0, 1, 2),
+            $this->loc(PhelType::emptyPersistentVector(), 1, 0, 1, 2),
             $this->read('[]'),
         );
         self::assertEquals(
-            $this->loc(Type::persistentVectorFromArray([
-                $this->loc(Type::emptyPersistentVector(), 1, 1, 1, 3),
+            $this->loc(PhelType::persistentVectorFromArray([
+                $this->loc(PhelType::emptyPersistentVector(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('[[]]'),
         );
 
         self::assertEquals(
-            $this->loc(Type::persistentVectorFromArray([
+            $this->loc(PhelType::persistentVectorFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('[a]'),
         );
 
         self::assertEquals(
-            $this->loc(Type::persistentVectorFromArray([
+            $this->loc(PhelType::persistentVectorFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -155,7 +155,7 @@ final class ReaderTest extends TestCase
     public function test_quote(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -166,7 +166,7 @@ final class ReaderTest extends TestCase
     public function test_unquote(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_UNQUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -177,7 +177,7 @@ final class ReaderTest extends TestCase
     public function test_unquote_splice(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                 $this->loc(Symbol::create('a'), 1, 2, 1, 3),
             ]), 1, 0, 1, 3),
@@ -188,7 +188,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote1(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 8),
                 $this->loc(Symbol::create(Symbol::NAME_UNQUOTE), 1, 1, 1, 8),
             ]), 1, 0, 1, 8),
@@ -199,7 +199,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote2(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentListFromArray([
+            $this->loc(PhelType::persistentListFromArray([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 2),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -305,7 +305,7 @@ final class ReaderTest extends TestCase
     public function test_read_empty_map(): void
     {
         self::assertEquals(
-            $this->loc(Type::emptyPersistentMap(), 1, 0, 1, 2),
+            $this->loc(PhelType::emptyPersistentMap(), 1, 0, 1, 2),
             $this->read('{}'),
         );
     }
@@ -314,7 +314,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentMapFromKVs(
+                PhelType::persistentMapFromKVs(
                     $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                     1,
                 ),
@@ -330,7 +330,7 @@ final class ReaderTest extends TestCase
     public function test_map_table2(): void
     {
         self::assertEquals(
-            $this->loc(Type::persistentMapFromKVs(
+            $this->loc(PhelType::persistentMapFromKVs(
                 $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                 1,
                 $this->loc(Keyword::create('b'), 1, 6, 1, 8),
@@ -352,7 +352,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         $this->loc(Keyword::create('test'), 1, 1, 1, 6),
                         true,
                     ),
@@ -372,7 +372,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         Keyword::create('tag'),
                         'test',
                     ),
@@ -392,7 +392,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         Keyword::create('tag'),
                         $this->loc(Symbol::create('String'), 1, 1, 1, 7),
                     ),
@@ -412,7 +412,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         $this->loc(Keyword::create('a'), 1, 2, 1, 4),
                         1,
                         $this->loc(Keyword::create('b'), 1, 7, 1, 9),
@@ -434,7 +434,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         $this->loc(Keyword::create('b'), 1, 5, 1, 7),
                         true,
                         $this->loc(Keyword::create('a'), 1, 1, 1, 3),
@@ -468,11 +468,11 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::emptyPersistentVector(),
+                    PhelType::emptyPersistentVector(),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                         ]),
                         1,
@@ -494,13 +494,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                         ]),
@@ -523,13 +523,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 8, 1, 9),
@@ -553,14 +553,14 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_2_2'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_2_2'), 1, 9, 1, 11),
@@ -584,13 +584,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 9, 1, 11),
@@ -614,15 +614,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_undefined_3'),
                         Symbol::create('__short_fn_3_2'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_3_2'), 1, 9, 1, 11),
@@ -646,15 +646,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_2'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_2'), 1, 9, 1, 11),
@@ -678,14 +678,14 @@ final class ReaderTest extends TestCase
     {
         $this->assertEquals(
             $this->loc(
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    Type::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_1'),
                     ]),
                     $this->loc(
-                        Type::persistentListFromArray([
+                        PhelType::persistentListFromArray([
                             $this->loc(Symbol::create('concat'), 1, 2, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 9, 1, 11),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 12, 1, 14),

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -15,7 +15,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Lang\TypeInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -97,25 +97,25 @@ final class ReaderTest extends TestCase
     public function test_read_list(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->emptyPersistentList(), 1, 0, 1, 2),
+            $this->loc(Type::emptyPersistentList(), 1, 0, 1, 2),
             $this->read('()'),
         );
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
-                $this->loc(TypeFactory::getInstance()->emptyPersistentList(), 1, 1, 1, 3),
+            $this->loc(Type::persistentListFromArray([
+                $this->loc(Type::emptyPersistentList(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('(())'),
         );
 
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('(a)'),
         );
 
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -126,25 +126,25 @@ final class ReaderTest extends TestCase
     public function test_read_vector(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->emptyPersistentVector(), 1, 0, 1, 2),
+            $this->loc(Type::emptyPersistentVector(), 1, 0, 1, 2),
             $this->read('[]'),
         );
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentVectorFromArray([
-                $this->loc(TypeFactory::getInstance()->emptyPersistentVector(), 1, 1, 1, 3),
+            $this->loc(Type::persistentVectorFromArray([
+                $this->loc(Type::emptyPersistentVector(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('[[]]'),
         );
 
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentVectorFromArray([
+            $this->loc(Type::persistentVectorFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('[a]'),
         );
 
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentVectorFromArray([
+            $this->loc(Type::persistentVectorFromArray([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -155,7 +155,7 @@ final class ReaderTest extends TestCase
     public function test_quote(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -166,7 +166,7 @@ final class ReaderTest extends TestCase
     public function test_unquote(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_UNQUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -177,7 +177,7 @@ final class ReaderTest extends TestCase
     public function test_unquote_splice(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                 $this->loc(Symbol::create('a'), 1, 2, 1, 3),
             ]), 1, 0, 1, 3),
@@ -188,7 +188,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote1(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 8),
                 $this->loc(Symbol::create(Symbol::NAME_UNQUOTE), 1, 1, 1, 8),
             ]), 1, 0, 1, 8),
@@ -199,7 +199,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote2(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentListFromArray([
+            $this->loc(Type::persistentListFromArray([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 2),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -305,7 +305,7 @@ final class ReaderTest extends TestCase
     public function test_read_empty_map(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->emptyPersistentMap(), 1, 0, 1, 2),
+            $this->loc(Type::emptyPersistentMap(), 1, 0, 1, 2),
             $this->read('{}'),
         );
     }
@@ -314,7 +314,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentMapFromKVs(
+                Type::persistentMapFromKVs(
                     $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                     1,
                 ),
@@ -330,7 +330,7 @@ final class ReaderTest extends TestCase
     public function test_map_table2(): void
     {
         self::assertEquals(
-            $this->loc(TypeFactory::getInstance()->persistentMapFromKVs(
+            $this->loc(Type::persistentMapFromKVs(
                 $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                 1,
                 $this->loc(Keyword::create('b'), 1, 6, 1, 8),
@@ -352,7 +352,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         $this->loc(Keyword::create('test'), 1, 1, 1, 6),
                         true,
                     ),
@@ -372,7 +372,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         Keyword::create('tag'),
                         'test',
                     ),
@@ -392,7 +392,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         Keyword::create('tag'),
                         $this->loc(Symbol::create('String'), 1, 1, 1, 7),
                     ),
@@ -412,7 +412,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         $this->loc(Keyword::create('a'), 1, 2, 1, 4),
                         1,
                         $this->loc(Keyword::create('b'), 1, 7, 1, 9),
@@ -434,7 +434,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         $this->loc(Keyword::create('b'), 1, 5, 1, 7),
                         true,
                         $this->loc(Keyword::create('a'), 1, 1, 1, 3),
@@ -468,11 +468,11 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->emptyPersistentVector(),
+                    Type::emptyPersistentVector(),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                         ]),
                         1,
@@ -494,13 +494,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                         ]),
@@ -523,13 +523,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 8, 1, 9),
@@ -553,14 +553,14 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_2_2'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_2_2'), 1, 9, 1, 11),
@@ -584,13 +584,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 9, 1, 11),
@@ -614,15 +614,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_undefined_3'),
                         Symbol::create('__short_fn_3_2'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_3_2'), 1, 9, 1, 11),
@@ -646,15 +646,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_2'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_2'), 1, 9, 1, 11),
@@ -678,14 +678,14 @@ final class ReaderTest extends TestCase
     {
         $this->assertEquals(
             $this->loc(
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_FN),
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_1'),
                     ]),
                     $this->loc(
-                        TypeFactory::getInstance()->persistentListFromArray([
+                        Type::persistentListFromArray([
                             $this->loc(Symbol::create('concat'), 1, 2, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 9, 1, 11),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 12, 1, 14),

--- a/tests/php/Integration/Fixtures/Apply/apply-infix.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-infix.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/+ 1 2 [3])
 --PHP--
-array_reduce([1, 2, ...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? [])], function($a, $b) { return ($a + $b); });
+array_reduce([1, 2, ...((\PhelType::persistentVectorFromArray([3])) ?? [])], function($a, $b) { return ($a + $b); });

--- a/tests/php/Integration/Fixtures/Apply/apply-infix.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-infix.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/+ 1 2 [3])
 --PHP--
-array_reduce([1, 2, ...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([3])) ?? [])], function($a, $b) { return ($a + $b); });
+array_reduce([1, 2, ...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? [])], function($a, $b) { return ($a + $b); });

--- a/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array [3])
 --PHP--
-array(...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? []));
+array(...((\PhelType::persistentVectorFromArray([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array [3])
 --PHP--
-array(...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([3])) ?? []));
+array(...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Apply/apply-php.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-php.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array 1 2 [3])
 --PHP--
-array(1, 2, ...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? []));
+array(1, 2, ...((\PhelType::persistentVectorFromArray([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Apply/apply-php.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-php.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array 1 2 [3])
 --PHP--
-array(1, 2, ...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([3])) ?? []));
+array(1, 2, ...((\Phel\Lang\Type::persistentVectorFromArray([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,16 +13,16 @@
       return 1;
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/global-call.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/global-call.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/global-call.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 18
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/global-call.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 18
     ),
     "min-arity", 1
   )

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,13 +13,13 @@
       return 1;
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/global-call.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/global-call.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 18

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,18 +13,18 @@
       return ($f)(...(($xs) ?? []));
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/php-fn-reference.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/php-fn-reference.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/php-fn-reference.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 37
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/php-fn-reference.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 37
     ),
     "min-arity", 2
   )
 );
-(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]));
+(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \PhelType::persistentVectorFromArray([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,13 +13,13 @@
       return ($f)(...(($xs) ?? []));
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/php-fn-reference.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/php-fn-reference.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 37
@@ -27,4 +27,4 @@
     "min-arity", 2
   )
 );
-(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]));
+(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -6,16 +6,16 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/php-push-global-reference.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 27
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Call/php-push-global-reference.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 27
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -6,13 +6,13 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Call/php-push-global-reference.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 27

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -5,16 +5,16 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/basic-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/basic-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/basic-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 9
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/basic-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 9
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -5,13 +5,13 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/basic-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/basic-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 9

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -37,14 +37,14 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
@@ -71,14 +71,14 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -37,17 +37,17 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface-instance-of.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 31
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface-instance-of.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 31
     ),
     "min-arity", 1
   )
@@ -71,17 +71,17 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface-instance-of.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface-instance-of.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 31
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface-instance-of.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 31
     ),
     "min-arity", 3
   )

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -35,14 +35,14 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31
@@ -69,14 +69,14 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 31

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -35,17 +35,17 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 31
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 31
     ),
     "min-arity", 1
   )
@@ -69,17 +69,17 @@ interface IPlayer {
 
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/definterface.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 31
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/definterface.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 31
     ),
     "min-arity", 3
   )

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,15 +11,15 @@
       return $x;
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("export"), true,
     \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/defn-meta.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/defn-meta.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 36

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,18 +11,18 @@
       return $x;
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("export"), true,
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/defn-meta.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("export"), true,
+    \PhelType::keyword("doc"), "```phel\n(identity x)\n```\n",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/defn-meta.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/defn-meta.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 36
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/defn-meta.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 36
     ),
     "min-arity", 1
   )

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,17 +5,17 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/doc-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "my number",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/doc-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/doc-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 21
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/doc-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 21
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,14 +5,14 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/doc-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/doc-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 21

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -14,13 +14,13 @@ require_once __DIR__ . '/../phel/core.php';
   "my\\ns",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/namespace-def.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/namespace-def.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 9

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -14,16 +14,16 @@ require_once __DIR__ . '/../phel/core.php';
   "my\\ns",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/namespace-def.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/namespace-def.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/namespace-def.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 9
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/namespace-def.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 9
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,15 +5,15 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("private"), true,
     \Phel\Lang\Keyword::create("export"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-def-meta.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-def-meta.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 38

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,18 +5,18 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("export"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-def-meta.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("private"), true,
+    \PhelType::keyword("export"), true,
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-def-meta.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-def-meta.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 38
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-def-meta.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 38
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,14 +5,14 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 18

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,17 +5,17 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("private"), true,
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 18
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 18
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,18 +5,18 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-doc-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("private"), true,
+    \PhelType::keyword("doc"), "my number",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-doc-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Def/private-doc-def.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 42
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Def/private-doc-def.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 42
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,15 +5,15 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("private"), true,
     \Phel\Lang\Keyword::create("doc"), "my number",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-doc-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Def/private-doc-def.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 42

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -8,16 +8,16 @@
     (1 + 2);
     return (3 + 4);
   })(),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Do/do-in-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Do/do-in-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Do/do-in-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 36
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Do/do-in-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 36
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -8,13 +8,13 @@
     (1 + 2);
     return (3 + 4);
   })(),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Do/do-in-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Do/do-in-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 36

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
     $__phel_2_7 = $__phel_1;
     $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
     $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \PhelType::persistentVectorFromArray($__phel_1);
     $__phel_2_7 = $__phel_1;
     $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
     $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \PhelType::persistentVectorFromArray($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel\Lang\Type::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \PhelType::persistentVectorFromArray($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$xs) {
-    $xs = \Phel\Lang\Type::persistentVectorFromArray($xs);
+    $xs = \PhelType::persistentVectorFromArray($xs);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$xs) {
-    $xs = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($xs);
+    $xs = \Phel\Lang\Type::persistentVectorFromArray($xs);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/issue-443.test
+++ b/tests/php/Integration/Fixtures/Fn/issue-443.test
@@ -4,7 +4,7 @@
       f (fn [matches] matches)])
 --PHP--
 $matches_6 = array();
-$__phel_1_7 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2]);
+$__phel_1_7 = \Phel\Lang\Type::persistentVectorFromArray([1, 2]);
 $__phel_2_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_7);
 $__phel_3_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_7);
 $a_10 = $__phel_2_8;

--- a/tests/php/Integration/Fixtures/Fn/issue-443.test
+++ b/tests/php/Integration/Fixtures/Fn/issue-443.test
@@ -4,7 +4,7 @@
       f (fn [matches] matches)])
 --PHP--
 $matches_6 = array();
-$__phel_1_7 = \Phel\Lang\Type::persistentVectorFromArray([1, 2]);
+$__phel_1_7 = \PhelType::persistentVectorFromArray([1, 2]);
 $__phel_2_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_7);
 $__phel_3_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_7);
 $a_10 = $__phel_2_8;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -11,20 +11,20 @@
 
     public function __invoke() {
       return (function() {
-        foreach ((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+        foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
           ($v + $v);
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Foreach/foreach-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Foreach/foreach-expr.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 18

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -11,23 +11,23 @@
 
     public function __invoke() {
       return (function() {
-        foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+        foreach ((\PhelType::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
           ($v + $v);
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Foreach/foreach-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Foreach/foreach-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Foreach/foreach-expr.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 18
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Foreach/foreach-expr.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 18
     ),
     "min-arity", 0
   )

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -10,7 +10,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public function __invoke() {
     $b_1 = 10;
     return (function() use($b_1) {
-      foreach ((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]) ?? []) as $b) {
+      foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $b) {
         (\Phel::getDefinition("phel\\core", "println"))($b);
       }
       return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -10,7 +10,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public function __invoke() {
     $b_1 = 10;
     return (function() use($b_1) {
-      foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $b) {
+      foreach ((\PhelType::persistentVectorFromArray([1, 2, 3]) ?? []) as $b) {
         (\Phel::getDefinition("phel\\core", "println"))($b);
       }
       return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
@@ -2,6 +2,6 @@
 (foreach [k v [1 2 3]]
   (php/+ k v))
 --PHP--
-foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $k => $v) {
+foreach ((\PhelType::persistentVectorFromArray([1, 2, 3]) ?? []) as $k => $v) {
   ($k + $v);
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
@@ -2,6 +2,6 @@
 (foreach [k v [1 2 3]]
   (php/+ k v))
 --PHP--
-foreach ((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]) ?? []) as $k => $v) {
+foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $k => $v) {
   ($k + $v);
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-value.test
@@ -2,6 +2,6 @@
 (foreach [v [1 2 3]]
   (php/+ v v))
 --PHP--
-foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+foreach ((\PhelType::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
   ($v + $v);
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-value.test
@@ -2,6 +2,6 @@
 (foreach [v [1 2 3]]
   (php/+ v v))
 --PHP--
-foreach ((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+foreach ((\Phel\Lang\Type::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
   ($v + $v);
 }

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -17,68 +17,68 @@ require_once __DIR__ . '/xyz/foo.php';
 \Phel::addDefinition(
   "test",
   "a",
-  \Phel\Lang\Keyword::create("bar"),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::keyword("bar"),
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 12
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 12
     )
   )
 );
 \Phel::addDefinition(
   "test",
   "b",
-  \Phel\Lang\Keyword::createForNamespace("test", "bar"),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 4,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::keyword("bar", "test"),
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 4,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 4,
-      \Phel\Lang\Keyword::create("column"), 13
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 4,
+      \PhelType::keyword("column"), 13
     )
   )
 );
 \Phel::addDefinition(
   "test",
   "c",
-  \Phel\Lang\Keyword::createForNamespace("xyz\\foo", "bar"),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::keyword("bar", "xyz\\foo"),
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 17
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 17
     )
   )
 );
 \Phel::addDefinition(
   "test",
   "d",
-  \Phel\Lang\Keyword::createForNamespace("xyz\\foo", "bar"),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 6,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::keyword("bar", "xyz\\foo"),
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 6,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
-      \Phel\Lang\Keyword::create("line"), 6,
-      \Phel\Lang\Keyword::create("column"), 20
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Keyword/keywords.test",
+      \PhelType::keyword("line"), 6,
+      \PhelType::keyword("column"), 20
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -18,13 +18,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "a",
   \Phel\Lang\Keyword::create("bar"),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 12
@@ -35,13 +35,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "b",
   \Phel\Lang\Keyword::createForNamespace("test", "bar"),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 4,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 4,
       \Phel\Lang\Keyword::create("column"), 13
@@ -52,13 +52,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "c",
   \Phel\Lang\Keyword::createForNamespace("xyz\\foo", "bar"),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 17
@@ -69,13 +69,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "d",
   \Phel\Lang\Keyword::createForNamespace("xyz\\foo", "bar"),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 6,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Keyword/keywords.test",
       \Phel\Lang\Keyword::create("line"), 6,
       \Phel\Lang\Keyword::create("column"), 20

--- a/tests/php/Integration/Fixtures/Let/let-binding.test
+++ b/tests/php/Integration/Fixtures/Let/let-binding.test
@@ -7,35 +7,35 @@
       [h & [i]] [1 2 3 4]]
   (php/+ b c d e f))
 --PHP--
-$a_27 = \Phel\Lang\Type::persistentVectorFromArray([1, 2]);
-$__phel_1_28 = \Phel\Lang\Type::persistentVectorFromArray([3, 4]);
+$a_27 = \PhelType::persistentVectorFromArray([1, 2]);
+$__phel_1_28 = \PhelType::persistentVectorFromArray([3, 4]);
 $__phel_2_29 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_28);
 $__phel_3_30 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_28);
 $b_31 = $__phel_2_29;
 $__phel_4_32 = (\Phel::getDefinition("phel\\core", "first"))($__phel_3_30);
 $__phel_5_33 = (\Phel::getDefinition("phel\\core", "next"))($__phel_3_30);
 $c_34 = $__phel_4_32;
-$__phel_6_35 = \Phel\Lang\Type::persistentVectorFromArray([5, 6, 7]);
+$__phel_6_35 = \PhelType::persistentVectorFromArray([5, 6, 7]);
 $__phel_7_36 = (\Phel::getDefinition("phel\\core", "first"))($__phel_6_35);
 $__phel_8_37 = (\Phel::getDefinition("phel\\core", "next"))($__phel_6_35);
 $d_38 = $__phel_7_36;
 $__phel_9_39 = (\Phel::getDefinition("phel\\core", "first"))($__phel_8_37);
 $__phel_10_40 = (\Phel::getDefinition("phel\\core", "next"))($__phel_8_37);
 $e_41 = $__phel_9_39;
-$__phel_11_42 = \Phel\Lang\Type::persistentVectorFromArray([8]);
+$__phel_11_42 = \PhelType::persistentVectorFromArray([8]);
 $__phel_12_43 = (\Phel::getDefinition("phel\\core", "first"))($__phel_11_42);
 $__phel_13_44 = (\Phel::getDefinition("phel\\core", "next"))($__phel_11_42);
 $f_45 = $__phel_12_43;
 $__phel_14_46 = (\Phel::getDefinition("phel\\core", "first"))($__phel_13_44);
 $__phel_15_47 = (\Phel::getDefinition("phel\\core", "next"))($__phel_13_44);
 $g_48 = $__phel_14_46;
-$__phel_16_49 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_16_49 = \PhelType::persistentVectorFromArray([1, 2, 3, 4]);
 $__phel_17_50 = (\Phel::getDefinition("phel\\core", "first"))($__phel_16_49);
 $__phel_18_51 = (\Phel::getDefinition("phel\\core", "next"))($__phel_16_49);
 $h_52 = $__phel_17_50;
 $__phel_19_53 = $__phel_18_51;
 $xs_54 = $__phel_19_53;
-$__phel_20_55 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_20_55 = \PhelType::persistentVectorFromArray([1, 2, 3, 4]);
 $__phel_21_56 = (\Phel::getDefinition("phel\\core", "first"))($__phel_20_55);
 $__phel_22_57 = (\Phel::getDefinition("phel\\core", "next"))($__phel_20_55);
 $h_58 = $__phel_21_56;

--- a/tests/php/Integration/Fixtures/Let/let-binding.test
+++ b/tests/php/Integration/Fixtures/Let/let-binding.test
@@ -7,35 +7,35 @@
       [h & [i]] [1 2 3 4]]
   (php/+ b c d e f))
 --PHP--
-$a_27 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2]);
-$__phel_1_28 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([3, 4]);
+$a_27 = \Phel\Lang\Type::persistentVectorFromArray([1, 2]);
+$__phel_1_28 = \Phel\Lang\Type::persistentVectorFromArray([3, 4]);
 $__phel_2_29 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_28);
 $__phel_3_30 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_28);
 $b_31 = $__phel_2_29;
 $__phel_4_32 = (\Phel::getDefinition("phel\\core", "first"))($__phel_3_30);
 $__phel_5_33 = (\Phel::getDefinition("phel\\core", "next"))($__phel_3_30);
 $c_34 = $__phel_4_32;
-$__phel_6_35 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([5, 6, 7]);
+$__phel_6_35 = \Phel\Lang\Type::persistentVectorFromArray([5, 6, 7]);
 $__phel_7_36 = (\Phel::getDefinition("phel\\core", "first"))($__phel_6_35);
 $__phel_8_37 = (\Phel::getDefinition("phel\\core", "next"))($__phel_6_35);
 $d_38 = $__phel_7_36;
 $__phel_9_39 = (\Phel::getDefinition("phel\\core", "first"))($__phel_8_37);
 $__phel_10_40 = (\Phel::getDefinition("phel\\core", "next"))($__phel_8_37);
 $e_41 = $__phel_9_39;
-$__phel_11_42 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([8]);
+$__phel_11_42 = \Phel\Lang\Type::persistentVectorFromArray([8]);
 $__phel_12_43 = (\Phel::getDefinition("phel\\core", "first"))($__phel_11_42);
 $__phel_13_44 = (\Phel::getDefinition("phel\\core", "next"))($__phel_11_42);
 $f_45 = $__phel_12_43;
 $__phel_14_46 = (\Phel::getDefinition("phel\\core", "first"))($__phel_13_44);
 $__phel_15_47 = (\Phel::getDefinition("phel\\core", "next"))($__phel_13_44);
 $g_48 = $__phel_14_46;
-$__phel_16_49 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_16_49 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
 $__phel_17_50 = (\Phel::getDefinition("phel\\core", "first"))($__phel_16_49);
 $__phel_18_51 = (\Phel::getDefinition("phel\\core", "next"))($__phel_16_49);
 $h_52 = $__phel_17_50;
 $__phel_19_53 = $__phel_18_51;
 $xs_54 = $__phel_19_53;
-$__phel_20_55 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_20_55 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
 $__phel_21_56 = (\Phel::getDefinition("phel\\core", "first"))($__phel_20_55);
 $__phel_22_57 = (\Phel::getDefinition("phel\\core", "next"))($__phel_20_55);
 $h_58 = $__phel_21_56;

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -9,16 +9,16 @@
     $y_2 = 2;
     return ($x_1 + $y_2);
   })(),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Let/let-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Let/let-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Let/let-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 35
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Let/let-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 35
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -9,13 +9,13 @@
     $y_2 = 2;
     return ($x_1 + $y_2);
   })(),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Let/let-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Let/let-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 35

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -14,7 +14,7 @@ require_once __DIR__ . '/phel/core.php';
   "*ns*",
   "test"
 );
-$__phel_1_2 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_1_2 = \PhelType::persistentVectorFromArray([1, 2, 3, 4]);
 $sum_3 = 0;
 while (true) {
   $__phel_4_8 = $__phel_1_2;

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -14,7 +14,7 @@ require_once __DIR__ . '/phel/core.php';
   "*ns*",
   "test"
 );
-$__phel_1_2 = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_1_2 = \Phel\Lang\Type::persistentVectorFromArray([1, 2, 3, 4]);
 $sum_3 = 0;
 while (true) {
   $__phel_4_8 = $__phel_1_2;

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -10,24 +10,24 @@
     public const BOUND_TO = "user\\foo";
 
     public function __invoke($n) {
-      return \Phel\Lang\Type::persistentListFromArray([
+      return \PhelType::persistentListFromArray([
         (\Phel\Lang\Symbol::create("php/+")),
         1,
         1
       ]);
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/macro-expand.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("macro"), true,
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/macro-expand.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/macro-expand.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 38
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/macro-expand.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 38
     ),
     "min-arity", 1
   )

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -10,21 +10,21 @@
     public const BOUND_TO = "user\\foo";
 
     public function __invoke($n) {
-      return \Phel\Lang\TypeFactory::getInstance()->persistentListFromArray([
+      return \Phel\Lang\Type::persistentListFromArray([
         (\Phel\Lang\Symbol::create("php/+")),
         1,
         1
       ]);
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/macro-expand.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/macro-expand.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 38

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,17 +13,17 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("macro"), true,
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/return-array.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 55
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/return-array.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 55
     ),
     "min-arity", 1
   )
@@ -32,16 +32,16 @@
   "user",
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/return-array.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 13
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "MacroExpand/return-array.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 13
     )
   )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,14 +13,14 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("macro"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 55
@@ -32,13 +32,13 @@
   "user",
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "MacroExpand/return-array.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 13

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -19,14 +19,14 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 5,
       \Phel\Lang\Keyword::create("column"), 19
@@ -61,14 +61,14 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       })();
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 19
@@ -87,14 +87,14 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
       \Phel\Lang\Keyword::create("line"), 7,
       \Phel\Lang\Keyword::create("column"), 19

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -19,17 +19,17 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("private"), true,
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("private"), true,
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 5,
-      \Phel\Lang\Keyword::create("column"), 19
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 5,
+      \PhelType::keyword("column"), 19
     )
   )
 );
@@ -61,17 +61,17 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       })();
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 7,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 7,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 7,
-      \Phel\Lang\Keyword::create("column"), 19
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 7,
+      \PhelType::keyword("column"), 19
     ),
     "min-arity", 1
   )
@@ -87,17 +87,17 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 7,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 7,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Ns/munge-ns.test",
-      \Phel\Lang\Keyword::create("line"), 7,
-      \Phel\Lang\Keyword::create("column"), 19
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Ns/munge-ns.test",
+      \PhelType::keyword("line"), 7,
+      \PhelType::keyword("column"), 19
     ),
     "min-arity", 1
   )

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -6,13 +6,13 @@
   "user",
   "a",
   (new \stdClass()),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "PhpObjectSet/set-class-property.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "PhpObjectSet/set-class-property.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 27

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -6,16 +6,16 @@
   "user",
   "a",
   (new \stdClass()),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "PhpObjectSet/set-class-property.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "PhpObjectSet/set-class-property.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "PhpObjectSet/set-class-property.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 27
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "PhpObjectSet/set-class-property.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 27
     )
   )
 );

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -6,13 +6,13 @@
   "user",
   "x",
   1,
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "SetVar/set-var.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "SetVar/set-var.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 9

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -6,16 +6,16 @@
   "user",
   "x",
   1,
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "SetVar/set-var.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "SetVar/set-var.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "SetVar/set-var.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 9
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "SetVar/set-var.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 9
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,16 +14,16 @@
       return $e_1;
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/throw-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/throw-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/throw-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 56
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/throw-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 56
     ),
     "min-arity", 0
   )

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,13 +14,13 @@
       return $e_1;
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/throw-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/throw-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 56

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -16,13 +16,13 @@
       (3 + 3);
     }
   })(),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr-throw.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr-throw.test",
       \Phel\Lang\Keyword::create("line"), 4,
       \Phel\Lang\Keyword::create("column"), 27

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -16,16 +16,16 @@
       (3 + 3);
     }
   })(),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr-throw.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/try-catch-finally-expr-throw.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr-throw.test",
-      \Phel\Lang\Keyword::create("line"), 4,
-      \Phel\Lang\Keyword::create("column"), 27
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/try-catch-finally-expr-throw.test",
+      \PhelType::keyword("line"), 4,
+      \PhelType::keyword("column"), 27
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -16,13 +16,13 @@
       (3 + 3);
     }
   })(),
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr.test",
       \Phel\Lang\Keyword::create("line"), 4,
       \Phel\Lang\Keyword::create("column"), 27

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -16,16 +16,16 @@
       (3 + 3);
     }
   })(),
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/try-catch-finally-expr.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Try/try-catch-finally-expr.test",
-      \Phel\Lang\Keyword::create("line"), 4,
-      \Phel\Lang\Keyword::create("column"), 27
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Try/try-catch-finally-expr.test",
+      \PhelType::keyword("line"), 4,
+      \PhelType::keyword("column"), 27
     )
   )
 );

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -11,24 +11,24 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\Type::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\PhelType::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
           yield $i => 21;
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array )\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Yield/yield-array.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(yield_generator_array )\n```\n",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Yield/yield-array.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Yield/yield-array.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 26
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Yield/yield-array.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 26
     ),
     "min-arity", 0
   )

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -11,21 +11,21 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\Type::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
           yield $i => 21;
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array )\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Yield/yield-array.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Yield/yield-array.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 26

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -11,21 +11,21 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\Type::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
           yield $i;
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+  \Phel\Lang\Type::persistentMapFromKVs(
     \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str )\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Yield/yield-str.test",
       \Phel\Lang\Keyword::create("line"), 1,
       \Phel\Lang\Keyword::create("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\TypeFactory::getInstance()->persistentMapFromKVs(
+    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
       \Phel\Lang\Keyword::create("file"), "Yield/yield-str.test",
       \Phel\Lang\Keyword::create("line"), 3,
       \Phel\Lang\Keyword::create("column"), 23

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -11,24 +11,24 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel\Lang\Type::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\PhelType::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
           yield $i;
         }
         return null;
       })();
     }
   },
-  \Phel\Lang\Type::persistentMapFromKVs(
-    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str )\n```\n",
-    \Phel\Lang\Keyword::create("start-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Yield/yield-str.test",
-      \Phel\Lang\Keyword::create("line"), 1,
-      \Phel\Lang\Keyword::create("column"), 0
+  \PhelType::persistentMapFromKVs(
+    \PhelType::keyword("doc"), "```phel\n(yield_generator_str )\n```\n",
+    \PhelType::keyword("start-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Yield/yield-str.test",
+      \PhelType::keyword("line"), 1,
+      \PhelType::keyword("column"), 0
     ),
-    \Phel\Lang\Keyword::create("end-location"), \Phel\Lang\Type::persistentMapFromKVs(
-      \Phel\Lang\Keyword::create("file"), "Yield/yield-str.test",
-      \Phel\Lang\Keyword::create("line"), 3,
-      \Phel\Lang\Keyword::create("column"), 23
+    \PhelType::keyword("end-location"), \PhelType::persistentMapFromKVs(
+      \PhelType::keyword("file"), "Yield/yield-str.test",
+      \PhelType::keyword("line"), 3,
+      \PhelType::keyword("column"), 23
     ),
     "min-arity", 0
   )

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -30,7 +30,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentList;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentListTest extends TestCase
@@ -44,7 +44,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_def(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('increment'),
             'inc',
@@ -54,7 +54,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_ns(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('def-ns'),
         ]);
@@ -63,16 +63,16 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_fn(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(FnNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_quote(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_QUOTE),
              'any text',
         ]);
@@ -81,7 +81,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_do(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO), 1,
         ]);
         self::assertInstanceOf(DoNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -89,7 +89,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_if(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),
             true,
             true,
@@ -99,25 +99,25 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_apply(): void
     {
-        $list = Type::persistentListFromArray([
-            Symbol::create(Symbol::NAME_APPLY), '+', Type::persistentVectorFromArray(['']),
+        $list = PhelType::persistentListFromArray([
+            Symbol::create(Symbol::NAME_APPLY), '+', PhelType::persistentVectorFromArray(['']),
         ]);
         self::assertInstanceOf(ApplyNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_let(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_LET),
-            Type::persistentVectorFromArray([]),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_php_new(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_NEW), '',
         ]);
         self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -125,7 +125,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_call(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -136,7 +136,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_static_call(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -147,9 +147,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_get(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
-            Type::persistentListFromArray([Symbol::create('php/array')]),
+            PhelType::persistentListFromArray([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -160,9 +160,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_set(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_SET),
-            Type::persistentListFromArray([Symbol::create('php/array')]),
+            PhelType::persistentListFromArray([Symbol::create('php/array')]),
             0,
             1,
         ]);
@@ -174,9 +174,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_push(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH),
-            Type::persistentListFromArray([Symbol::create('php/array')]),
+            PhelType::persistentListFromArray([Symbol::create('php/array')]),
             1,
         ]);
         self::assertInstanceOf(
@@ -187,9 +187,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_unset(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET),
-            Type::persistentListFromArray([Symbol::create('php/array')]),
+            PhelType::persistentListFromArray([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -200,7 +200,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_recur(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_RECUR), 1,
         ]);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
@@ -210,7 +210,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_try(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_TRY),
         ]);
         self::assertInstanceOf(TryNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -218,7 +218,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_throw(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_THROW), '',
         ]);
         self::assertInstanceOf(ThrowNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -226,39 +226,39 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_loop(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_LOOP),
-            Type::persistentVectorFromArray([]),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_foreach(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
-                Symbol::create(''), Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([
+                Symbol::create(''), PhelType::persistentVectorFromArray([]),
             ]),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(ForeachNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_struct(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create(''),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(DefStructNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_exception(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -30,7 +30,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentList;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentListTest extends TestCase
@@ -44,7 +44,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_def(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('increment'),
             'inc',
@@ -54,7 +54,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_ns(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('def-ns'),
         ]);
@@ -63,16 +63,16 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_fn(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(FnNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_quote(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_QUOTE),
              'any text',
         ]);
@@ -81,7 +81,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_do(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO), 1,
         ]);
         self::assertInstanceOf(DoNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -89,7 +89,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_if(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),
             true,
             true,
@@ -99,25 +99,25 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_apply(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
-            Symbol::create(Symbol::NAME_APPLY), '+', TypeFactory::getInstance()->persistentVectorFromArray(['']),
+        $list = Type::persistentListFromArray([
+            Symbol::create(Symbol::NAME_APPLY), '+', Type::persistentVectorFromArray(['']),
         ]);
         self::assertInstanceOf(ApplyNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_let(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_LET),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_php_new(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_NEW), '',
         ]);
         self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -125,7 +125,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_call(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -136,7 +136,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_static_call(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -147,9 +147,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_get(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create('php/array')]),
+            Type::persistentListFromArray([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -160,9 +160,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_set(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_SET),
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create('php/array')]),
+            Type::persistentListFromArray([Symbol::create('php/array')]),
             0,
             1,
         ]);
@@ -174,9 +174,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_push(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH),
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create('php/array')]),
+            Type::persistentListFromArray([Symbol::create('php/array')]),
             1,
         ]);
         self::assertInstanceOf(
@@ -187,9 +187,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_unset(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET),
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create('php/array')]),
+            Type::persistentListFromArray([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -200,7 +200,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_recur(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_RECUR), 1,
         ]);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
@@ -210,7 +210,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_try(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_TRY),
         ]);
         self::assertInstanceOf(TryNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -218,7 +218,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_throw(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_THROW), '',
         ]);
         self::assertInstanceOf(ThrowNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -226,39 +226,39 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_loop(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_LOOP),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_foreach(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                Symbol::create(''), TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([
+                Symbol::create(''), Type::persistentVectorFromArray([]),
             ]),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(ForeachNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_struct(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create(''),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         self::assertInstanceOf(DefStructNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_exception(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -10,7 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentMap;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentMapTest extends TestCase
@@ -27,7 +27,7 @@ final class AnalyzePersistentMapTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new MapNode($env, [], null),
-            $this->mapAnalyzer->analyze(Type::emptyPersistentMap(), $env),
+            $this->mapAnalyzer->analyze(PhelType::emptyPersistentMap(), $env),
         );
     }
 
@@ -39,7 +39,7 @@ final class AnalyzePersistentMapTest extends TestCase
                 new LiteralNode($env->withExpressionContext(), 'a', null),
                 new LiteralNode($env->withExpressionContext(), 1, null),
             ], null),
-            $this->mapAnalyzer->analyze(Type::persistentMapFromKVs('a', 1), $env),
+            $this->mapAnalyzer->analyze(PhelType::persistentMapFromKVs('a', 1), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -10,7 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentMap;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentMapTest extends TestCase
@@ -27,7 +27,7 @@ final class AnalyzePersistentMapTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new MapNode($env, [], null),
-            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->emptyPersistentMap(), $env),
+            $this->mapAnalyzer->analyze(Type::emptyPersistentMap(), $env),
         );
     }
 
@@ -39,7 +39,7 @@ final class AnalyzePersistentMapTest extends TestCase
                 new LiteralNode($env->withExpressionContext(), 'a', null),
                 new LiteralNode($env->withExpressionContext(), 1, null),
             ], null),
-            $this->mapAnalyzer->analyze(TypeFactory::getInstance()->persistentMapFromKVs('a', 1), $env),
+            $this->mapAnalyzer->analyze(Type::persistentMapFromKVs('a', 1), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
@@ -10,7 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentVector;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentVectorTest extends TestCase
@@ -27,7 +27,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new VectorNode($env, [], null),
-            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->emptyPersistentVector(), $env),
+            $this->vectorAnalzyer->analyze(Type::emptyPersistentVector(), $env),
         );
     }
 
@@ -38,7 +38,7 @@ final class AnalyzePersistentVectorTest extends TestCase
             new VectorNode($env, [
                 new LiteralNode($env->withDisallowRecurFrame()->withExpressionContext(), 1, null),
             ], null),
-            $this->vectorAnalzyer->analyze(TypeFactory::getInstance()->persistentVectorFromArray([1]), $env),
+            $this->vectorAnalzyer->analyze(Type::persistentVectorFromArray([1]), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
@@ -10,7 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzePersistentVector;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzePersistentVectorTest extends TestCase
@@ -27,7 +27,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new VectorNode($env, [], null),
-            $this->vectorAnalzyer->analyze(Type::emptyPersistentVector(), $env),
+            $this->vectorAnalzyer->analyze(PhelType::emptyPersistentVector(), $env),
         );
     }
 
@@ -38,7 +38,7 @@ final class AnalyzePersistentVectorTest extends TestCase
             new VectorNode($env, [
                 new LiteralNode($env->withDisallowRecurFrame()->withExpressionContext(), 1, null),
             ], null),
-            $this->vectorAnalzyer->analyze(Type::persistentVectorFromArray([1]), $env),
+            $this->vectorAnalzyer->analyze(PhelType::persistentVectorFromArray([1]), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -14,7 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzeSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzeSymbolTest extends TestCase
@@ -67,7 +67,7 @@ final class AnalyzeSymbolTest extends TestCase
 
         $env = NodeEnvironment::empty();
         self::assertEquals(
-            new GlobalVarNode($env, 'test', Symbol::create('a'), TypeFactory::getInstance()->emptyPersistentMap(), null),
+            new GlobalVarNode($env, 'test', Symbol::create('a'), Type::emptyPersistentMap(), null),
             $symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -14,7 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzeSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class AnalyzeSymbolTest extends TestCase
@@ -67,7 +67,7 @@ final class AnalyzeSymbolTest extends TestCase
 
         $env = NodeEnvironment::empty();
         self::assertEquals(
-            new GlobalVarNode($env, 'test', Symbol::create('a'), Type::emptyPersistentMap(), null),
+            new GlobalVarNode($env, 'test', Symbol::create('a'), PhelType::emptyPersistentMap(), null),
             $symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -15,7 +15,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -37,7 +37,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_add_definition(): void
     {
         $env = new GlobalEnvironment();
-        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $meta = Type::emptyPersistentMap();
         $env->addDefinition('foo', Symbol::create('bar'));
 
         $this->assertTrue($env->hasDefinition('foo', Symbol::create('bar')));
@@ -139,7 +139,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'foo',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -153,7 +153,7 @@ final class GlobalEnvironmentTest extends TestCase
             'foo',
             'x',
             null,
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true),
+            Type::persistentMapFromKVs(Keyword::create('private'), true),
         );
         $env->setNs('bar');
         $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
@@ -179,7 +179,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -215,7 +215,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'phel\\core',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -225,7 +225,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('phel\\core', Symbol::create('x'));
-        Phel::addDefinition('phel\\core', 'x', null, TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('phel\\core', 'x', null, Type::persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('bar');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -276,7 +276,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
@@ -296,7 +296,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
         );
@@ -306,7 +306,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('bar', Symbol::create('x'));
-        Phel::addDefinition('bar', 'x', null, TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('bar', 'x', null, Type::persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('foo');
         $nodeEnv = NodeEnvironment::empty();
 

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -15,7 +15,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -37,7 +37,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_add_definition(): void
     {
         $env = new GlobalEnvironment();
-        $meta = Type::emptyPersistentMap();
+        $meta = PhelType::emptyPersistentMap();
         $env->addDefinition('foo', Symbol::create('bar'));
 
         $this->assertTrue($env->hasDefinition('foo', Symbol::create('bar')));
@@ -139,7 +139,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'foo',
                 Symbol::create('x'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -153,7 +153,7 @@ final class GlobalEnvironmentTest extends TestCase
             'foo',
             'x',
             null,
-            Type::persistentMapFromKVs(Keyword::create('private'), true),
+            PhelType::persistentMapFromKVs(Keyword::create('private'), true),
         );
         $env->setNs('bar');
         $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
@@ -179,7 +179,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -215,7 +215,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'phel\\core',
                 Symbol::create('x'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -225,7 +225,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('phel\\core', Symbol::create('x'));
-        Phel::addDefinition('phel\\core', 'x', null, Type::persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('phel\\core', 'x', null, PhelType::persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('bar');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -276,7 +276,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
@@ -296,7 +296,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ),
             $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
         );
@@ -306,7 +306,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('bar', Symbol::create('x'));
-        Phel::addDefinition('bar', 'x', null, Type::persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('bar', 'x', null, PhelType::persistentMapFromKVs(Keyword::create('private'), true));
         $env->setNs('foo');
         $nodeEnv = NodeEnvironment::empty();
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class ApplySymbolTest extends TestCase
@@ -32,7 +32,7 @@ final class ApplySymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least three arguments are required for 'apply");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::create('\\'),
         ]);
@@ -41,10 +41,10 @@ final class ApplySymbolTest extends TestCase
 
     public function test_apply_node(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::createForNamespace('php', '+'),
-            Type::persistentVectorFromArray([1, 2, 3]),
+            PhelType::persistentVectorFromArray([1, 2, 3]),
         ]);
         $applyNode = (new ApplySymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class ApplySymbolTest extends TestCase
@@ -32,7 +32,7 @@ final class ApplySymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least three arguments are required for 'apply");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::create('\\'),
         ]);
@@ -41,10 +41,10 @@ final class ApplySymbolTest extends TestCase
 
     public function test_apply_node(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::createForNamespace('php', '+'),
-            TypeFactory::getInstance()->persistentVectorFromArray([1, 2, 3]),
+            Type::persistentVectorFromArray([1, 2, 3]),
         ]);
         $applyNode = (new ApplySymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Lang\AbstractType;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -67,11 +67,11 @@ final class BindingValidatorTest extends TestCase
         ];
 
         yield 'Vector type' => [
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ];
 
         yield 'Map type' => [
-            TypeFactory::getInstance()->emptyPersistentMap(),
+            Type::emptyPersistentMap(),
         ];
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Lang\AbstractType;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -67,11 +67,11 @@ final class BindingValidatorTest extends TestCase
         ];
 
         yield 'Vector type' => [
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ];
 
         yield 'Map type' => [
-            Type::emptyPersistentMap(),
+            PhelType::emptyPersistentMap(),
         ];
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\MapBindingDeconstructor;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class MapBindingDeconstructorTest extends TestCase
@@ -38,7 +38,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Type::persistentMapFromKVs($key, $bindTo);
+        $binding = PhelType::persistentMapFromKVs($key, $bindTo);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -52,7 +52,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -81,7 +81,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Type::persistentMapFromKVs($key, Type::persistentVectorFromArray([$bindTo]));
+        $binding = PhelType::persistentMapFromKVs($key, PhelType::persistentVectorFromArray([$bindTo]));
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -95,7 +95,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -109,7 +109,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_4 (first __phel_3)
             [
                 Symbol::create('__phel_4'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_3'),
                 ]),
@@ -117,7 +117,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_5 (next __phel_3)
             [
                 Symbol::create('__phel_5'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_3'),
                 ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\MapBindingDeconstructor;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class MapBindingDeconstructorTest extends TestCase
@@ -38,7 +38,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentMapFromKVs($key, $bindTo);
+        $binding = Type::persistentMapFromKVs($key, $bindTo);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -52,7 +52,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -81,7 +81,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentMapFromKVs($key, TypeFactory::getInstance()->persistentVectorFromArray([$bindTo]));
+        $binding = Type::persistentMapFromKVs($key, Type::persistentVectorFromArray([$bindTo]));
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -95,7 +95,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -109,7 +109,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_4 (first __phel_3)
             [
                 Symbol::create('__phel_4'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_3'),
                 ]),
@@ -117,7 +117,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_5 (next __phel_3)
             [
                 Symbol::create('__phel_5'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_3'),
                 ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\VectorBindingDeconstructor;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class VectorBindingDeconstructorTest extends TestCase
@@ -39,7 +39,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         // This will be destructured to this:
         // (let [__phel_1 x])
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentListFromArray([]);
+        $binding = Type::persistentListFromArray([]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -63,7 +63,7 @@ final class VectorBindingDeconstructorTest extends TestCase
 
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentListFromArray([$bindTo]);
+        $binding = Type::persistentListFromArray([$bindTo]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -75,14 +75,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -110,7 +110,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentVectorFromArray([$bindToA, $bindToB]);
+        $binding = Type::persistentVectorFromArray([$bindToA, $bindToB]);
 
         $this->deconstructor->deconstruct($bindings, $binding, $value);
 
@@ -121,14 +121,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -139,14 +139,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
             ],
             [
                 Symbol::create('__phel_5'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
@@ -172,7 +172,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentVectorFromArray([
+        $binding = Type::persistentVectorFromArray([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             $bindToB,
@@ -188,14 +188,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -220,7 +220,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = TypeFactory::getInstance()->persistentVectorFromArray([
+        $binding = Type::persistentVectorFromArray([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             Symbol::create(self::REST_SYMBOL),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\VectorBindingDeconstructor;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class VectorBindingDeconstructorTest extends TestCase
@@ -39,7 +39,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         // This will be destructured to this:
         // (let [__phel_1 x])
         $value = Symbol::create('x');
-        $binding = Type::persistentListFromArray([]);
+        $binding = PhelType::persistentListFromArray([]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -63,7 +63,7 @@ final class VectorBindingDeconstructorTest extends TestCase
 
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Type::persistentListFromArray([$bindTo]);
+        $binding = PhelType::persistentListFromArray([$bindTo]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -75,14 +75,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -110,7 +110,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Type::persistentVectorFromArray([$bindToA, $bindToB]);
+        $binding = PhelType::persistentVectorFromArray([$bindToA, $bindToB]);
 
         $this->deconstructor->deconstruct($bindings, $binding, $value);
 
@@ -121,14 +121,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -139,14 +139,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
             ],
             [
                 Symbol::create('__phel_5'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
@@ -172,7 +172,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Type::persistentVectorFromArray([
+        $binding = PhelType::persistentVectorFromArray([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             $bindToB,
@@ -188,14 +188,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -220,7 +220,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Type::persistentVectorFromArray([
+        $binding = PhelType::persistentVectorFromArray([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             Symbol::create(self::REST_SYMBOL),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class DeconstructorTest extends TestCase
@@ -27,7 +27,7 @@ final class DeconstructorTest extends TestCase
     public function test_empty_vector(): void
     {
         $bindings = $this->deconstructor->deconstruct(
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         );
 
         self::assertSame([], $bindings);
@@ -46,11 +46,11 @@ final class DeconstructorTest extends TestCase
         //       __phel_5 (first __phel_4)
         //       __phel_6 (next __phel_4)
         //       b __phel_5])
-        $list = TypeFactory::getInstance()->persistentVectorFromArray([
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('a')]),
-            TypeFactory::getInstance()->persistentVectorFromArray([10]),
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('b')]),
-            TypeFactory::getInstance()->persistentVectorFromArray([20]),
+        $list = Type::persistentVectorFromArray([
+            Type::persistentVectorFromArray([Symbol::create('a')]),
+            Type::persistentVectorFromArray([10]),
+            Type::persistentVectorFromArray([Symbol::create('b')]),
+            Type::persistentVectorFromArray([20]),
         ]);
 
         $bindings = $this->deconstructor->deconstruct($list);
@@ -58,18 +58,18 @@ final class DeconstructorTest extends TestCase
         self::assertEquals([
             [
                 Symbol::create('__phel_1'),
-                TypeFactory::getInstance()->persistentVectorFromArray([10]),
+                Type::persistentVectorFromArray([10]),
             ],
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_1'),
                 ]),
@@ -80,18 +80,18 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                TypeFactory::getInstance()->persistentVectorFromArray([20]),
+                Type::persistentVectorFromArray([20]),
             ],
             [
                 Symbol::create('__phel_5'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_4'),
                 ]),
             ],
             [
                 Symbol::create('__phel_6'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_4'),
                 ]),
@@ -111,8 +111,8 @@ final class DeconstructorTest extends TestCase
         //       __phel 2 (get __phel_1 :key)
         //       a __phel_2])
         $bindings = $this->deconstructor->deconstruct(
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
+            Type::persistentVectorFromArray([
+                Type::persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
                 Symbol::create('x'),
             ]),
         );
@@ -124,7 +124,7 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     Keyword::create('key'),
@@ -142,7 +142,7 @@ final class DeconstructorTest extends TestCase
         // Test for binding like this (let [nil x])
         // This will be destructured to this:
         // (let [])
-        $bindings = $this->deconstructor->deconstruct(TypeFactory::getInstance()->persistentVectorFromArray([null, Symbol::create('x')]));
+        $bindings = $this->deconstructor->deconstruct(Type::persistentVectorFromArray([null, Symbol::create('x')]));
 
         self::assertSame([], $bindings);
     }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValida
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class DeconstructorTest extends TestCase
@@ -27,7 +27,7 @@ final class DeconstructorTest extends TestCase
     public function test_empty_vector(): void
     {
         $bindings = $this->deconstructor->deconstruct(
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         );
 
         self::assertSame([], $bindings);
@@ -46,11 +46,11 @@ final class DeconstructorTest extends TestCase
         //       __phel_5 (first __phel_4)
         //       __phel_6 (next __phel_4)
         //       b __phel_5])
-        $list = Type::persistentVectorFromArray([
-            Type::persistentVectorFromArray([Symbol::create('a')]),
-            Type::persistentVectorFromArray([10]),
-            Type::persistentVectorFromArray([Symbol::create('b')]),
-            Type::persistentVectorFromArray([20]),
+        $list = PhelType::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([Symbol::create('a')]),
+            PhelType::persistentVectorFromArray([10]),
+            PhelType::persistentVectorFromArray([Symbol::create('b')]),
+            PhelType::persistentVectorFromArray([20]),
         ]);
 
         $bindings = $this->deconstructor->deconstruct($list);
@@ -58,18 +58,18 @@ final class DeconstructorTest extends TestCase
         self::assertEquals([
             [
                 Symbol::create('__phel_1'),
-                Type::persistentVectorFromArray([10]),
+                PhelType::persistentVectorFromArray([10]),
             ],
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_1'),
                 ]),
@@ -80,18 +80,18 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                Type::persistentVectorFromArray([20]),
+                PhelType::persistentVectorFromArray([20]),
             ],
             [
                 Symbol::create('__phel_5'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('first'),
                     Symbol::create('__phel_4'),
                 ]),
             ],
             [
                 Symbol::create('__phel_6'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('next'),
                     Symbol::create('__phel_4'),
                 ]),
@@ -111,8 +111,8 @@ final class DeconstructorTest extends TestCase
         //       __phel 2 (get __phel_1 :key)
         //       a __phel_2])
         $bindings = $this->deconstructor->deconstruct(
-            Type::persistentVectorFromArray([
-                Type::persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
+            PhelType::persistentVectorFromArray([
+                PhelType::persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
                 Symbol::create('x'),
             ]),
         );
@@ -124,7 +124,7 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     Keyword::create('key'),
@@ -142,7 +142,7 @@ final class DeconstructorTest extends TestCase
         // Test for binding like this (let [nil x])
         // This will be destructured to this:
         // (let [])
-        $bindings = $this->deconstructor->deconstruct(Type::persistentVectorFromArray([null, Symbol::create('x')]));
+        $bindings = $this->deconstructor->deconstruct(PhelType::persistentVectorFromArray([null, Symbol::create('x')]));
 
         self::assertSame([], $bindings);
     }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefExceptionSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class DefExceptionSymbolTest extends TestCase
@@ -30,7 +30,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exact one argument is required for 'defexception");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('A'),
             Symbol::create('B'),
@@ -45,7 +45,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defexception must be a Symbol.");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             'no-symbol',
         ]);
@@ -56,7 +56,7 @@ final class DefExceptionSymbolTest extends TestCase
 
     public function test_def_exception_symbol(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefExceptionSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class DefExceptionSymbolTest extends TestCase
@@ -30,7 +30,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exact one argument is required for 'defexception");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('A'),
             Symbol::create('B'),
@@ -45,7 +45,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defexception must be a Symbol.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             'no-symbol',
         ]);
@@ -56,7 +56,7 @@ final class DefExceptionSymbolTest extends TestCase
 
     public function test_def_exception_symbol(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class DefStructSymbolTest extends TestCase
@@ -30,7 +30,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'defstruct. Got 1");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
         ]);
 
@@ -43,10 +43,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defstruct must be a Symbol.");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             '',
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -58,7 +58,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'defstruct must be a vector.");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
             '',
@@ -73,10 +73,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage('Defstruct field elements must be Symbols.');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            Type::persistentVectorFromArray(['method']),
+            PhelType::persistentVectorFromArray(['method']),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -85,10 +85,10 @@ final class DefStructSymbolTest extends TestCase
 
     public function test_def_struct_symbol(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            Type::persistentVectorFromArray([Symbol::create('method'), Symbol::create('uri')]),
+            PhelType::persistentVectorFromArray([Symbol::create('method'), Symbol::create('uri')]),
         ]);
 
         $defStructNode = (new DefStructSymbol($this->analyzer, new Munge()))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class DefStructSymbolTest extends TestCase
@@ -30,7 +30,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'defstruct. Got 1");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
         ]);
 
@@ -43,10 +43,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defstruct must be a Symbol.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             '',
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -58,7 +58,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'defstruct must be a vector.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
             '',
@@ -73,10 +73,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage('Defstruct field elements must be Symbols.');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            TypeFactory::getInstance()->persistentVectorFromArray(['method']),
+            Type::persistentVectorFromArray(['method']),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -85,10 +85,10 @@ final class DefStructSymbolTest extends TestCase
 
     public function test_def_struct_symbol(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('method'), Symbol::create('uri')]),
+            Type::persistentVectorFromArray([Symbol::create('method'), Symbol::create('uri')]),
         ]);
 
         $defStructNode = (new DefStructSymbol($this->analyzer, new Munge()))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefSymbol;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -33,10 +33,10 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("'def inside of a 'def is forbidden");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DEF),
                 Symbol::create('name2'),
                 1,
@@ -50,7 +50,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('1'),
         ]);
@@ -62,7 +62,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             'not a symbol',
             '2',
@@ -75,7 +75,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('$init must be TypeInterface|string|float|int|bool|null');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             new stdClass(),
@@ -85,7 +85,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_init_values(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'any value',
@@ -117,7 +117,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_docstring(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'my docstring',
@@ -159,7 +159,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_keyword(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             Keyword::create('private'),
@@ -201,10 +201,10 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_table_keyword(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            Type::persistentMapFromKVs(Keyword::create('private'), true),
+            PhelType::persistentMapFromKVs(Keyword::create('private'), true),
             'any value',
         ]);
         $env = NodeEnvironment::empty();
@@ -248,7 +248,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Metadata must be a String, Keyword or Map');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefSymbol;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -33,10 +33,10 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("'def inside of a 'def is forbidden");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_DEF),
                 Symbol::create('name2'),
                 1,
@@ -50,7 +50,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('1'),
         ]);
@@ -62,7 +62,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             'not a symbol',
             '2',
@@ -75,7 +75,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('$init must be TypeInterface|string|float|int|bool|null');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             new stdClass(),
@@ -85,7 +85,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_init_values(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'any value',
@@ -117,7 +117,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_docstring(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'my docstring',
@@ -159,7 +159,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_keyword(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             Keyword::create('private'),
@@ -201,10 +201,10 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_table_keyword(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('private'), true),
+            Type::persistentMapFromKVs(Keyword::create('private'), true),
             'any value',
         ]);
         $env = NodeEnvironment::empty();
@@ -248,7 +248,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Metadata must be a String, Keyword or Map');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -12,7 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DoSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class DoSymbolTest extends TestCase
@@ -29,7 +29,7 @@ final class DoSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'do.");
 
-        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
         (new DoSymbol($this->analyzer))->analyze($list, $env);
     }
@@ -37,7 +37,7 @@ final class DoSymbolTest extends TestCase
     public function test_empty_list(): void
     {
         $env = NodeEnvironment::empty();
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
         ]);
 
@@ -56,7 +56,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             1,
         ]);
@@ -76,7 +76,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             1,
             2,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -12,7 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DoSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class DoSymbolTest extends TestCase
@@ -29,7 +29,7 @@ final class DoSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'do.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('unknown')]);
+        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
         (new DoSymbol($this->analyzer))->analyze($list, $env);
     }
@@ -37,7 +37,7 @@ final class DoSymbolTest extends TestCase
     public function test_empty_list(): void
     {
         $env = NodeEnvironment::empty();
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
         ]);
 
@@ -56,7 +56,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             1,
         ]);
@@ -76,7 +76,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_DO),
             1,
             2,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\FnSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +38,7 @@ final class FnSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("'fn requires at least one argument");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
         ]);
 
@@ -51,7 +51,7 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage("Second argument of 'fn must be a vector");
 
         // This is the same as: (fn anything)
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
             Symbol::create('anything'),
         ]);
@@ -62,9 +62,9 @@ final class FnSymbolTest extends TestCase
     public function test_is_not_variadic(): void
     {
         // This is the same as: (fn [anything])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('anything'),
             ]),
         ]);
@@ -85,9 +85,9 @@ final class FnSymbolTest extends TestCase
         }
 
         // This is the same as: (fn [paramName])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create($paramName),
             ]),
         ]);
@@ -129,9 +129,9 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage('Unsupported parameter form, only one symbol can follow the & parameter');
 
         // This is the same as: (fn [& param-1 param-2])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('&'),
                 Symbol::create('param-1'),
                 Symbol::create('param-2'),
@@ -152,9 +152,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetParams(): Generator
     {
         yield '(fn [& param-1])' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                Type::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([
                     Symbol::create('&'),
                     Symbol::create('param-1'),
                 ]),
@@ -165,9 +165,9 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield '(fn [param-1 param-2 param-3])' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                Type::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([
                     Symbol::create('param-1'),
                     Symbol::create('param-2'),
                     Symbol::create('param-3'),
@@ -192,9 +192,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetBody(): Generator
     {
         yield 'DoNode body => (fn [x] x)' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                Type::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([
                     Symbol::create('x'),
                 ]),
                 Symbol::create('x'),
@@ -203,10 +203,10 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield 'LetNode body => (fn [[x y]] x)' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                Type::persistentVectorFromArray([
-                    Type::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([
+                    PhelType::persistentVectorFromArray([
                         Symbol::create('x'),
                         Symbol::create('y'),
                     ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\FnSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +38,7 @@ final class FnSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("'fn requires at least one argument");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
         ]);
 
@@ -51,7 +51,7 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage("Second argument of 'fn must be a vector");
 
         // This is the same as: (fn anything)
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
             Symbol::create('anything'),
         ]);
@@ -62,9 +62,9 @@ final class FnSymbolTest extends TestCase
     public function test_is_not_variadic(): void
     {
         // This is the same as: (fn [anything])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('anything'),
             ]),
         ]);
@@ -85,9 +85,9 @@ final class FnSymbolTest extends TestCase
         }
 
         // This is the same as: (fn [paramName])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create($paramName),
             ]),
         ]);
@@ -129,9 +129,9 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage('Unsupported parameter form, only one symbol can follow the & parameter');
 
         // This is the same as: (fn [& param-1 param-2])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('&'),
                 Symbol::create('param-1'),
                 Symbol::create('param-2'),
@@ -152,9 +152,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetParams(): Generator
     {
         yield '(fn [& param-1])' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                TypeFactory::getInstance()->persistentVectorFromArray([
+                Type::persistentVectorFromArray([
                     Symbol::create('&'),
                     Symbol::create('param-1'),
                 ]),
@@ -165,9 +165,9 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield '(fn [param-1 param-2 param-3])' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                TypeFactory::getInstance()->persistentVectorFromArray([
+                Type::persistentVectorFromArray([
                     Symbol::create('param-1'),
                     Symbol::create('param-2'),
                     Symbol::create('param-3'),
@@ -192,9 +192,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetBody(): Generator
     {
         yield 'DoNode body => (fn [x] x)' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                TypeFactory::getInstance()->persistentVectorFromArray([
+                Type::persistentVectorFromArray([
                     Symbol::create('x'),
                 ]),
                 Symbol::create('x'),
@@ -203,10 +203,10 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield 'LetNode body => (fn [[x y]] x)' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_FN),
-                TypeFactory::getInstance()->persistentVectorFromArray([
-                    TypeFactory::getInstance()->persistentVectorFromArray([
+                Type::persistentVectorFromArray([
+                    Type::persistentVectorFromArray([
                         Symbol::create('x'),
                         Symbol::create('y'),
                     ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -17,7 +17,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ForeachSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class ForeachSymbolTest extends TestCase
@@ -28,7 +28,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("At least two arguments are required for 'foreach");
 
         // (foreach)
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
         ]);
 
@@ -41,7 +41,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("First argument of 'foreach must be a vector.");
 
         // (foreach x)
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
             Symbol::create('x'),
         ]);
@@ -55,9 +55,9 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('x'),
             ]),
         ]);
@@ -68,11 +68,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_from_vector_with2_args(): void
     {
         // (foreach [x []])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('x'),
-                Type::persistentVectorFromArray([]),
+                PhelType::persistentVectorFromArray([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -97,11 +97,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_two_args(): void
     {
         // (foreach [[x] []])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
-                Type::persistentVectorFromArray([Symbol::create('x')]),
-                Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([Symbol::create('x')]),
+                PhelType::persistentVectorFromArray([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -113,12 +113,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_vector_with3_args(): void
     {
         // (foreach [key value {}])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('key'),
                 Symbol::create('value'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ]),
             Symbol::create('key'),
         ]);
@@ -144,12 +144,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_three_args(): void
     {
         // (foreach [[key] [value] []])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
-                Type::persistentVectorFromArray([Symbol::create('key')]),
-                Type::persistentVectorFromArray([Symbol::create('value')]),
-                Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([Symbol::create('key')]),
+                PhelType::persistentVectorFromArray([Symbol::create('value')]),
+                PhelType::persistentVectorFromArray([]),
             ]),
             Symbol::create('key'),
         ]);
@@ -164,13 +164,13 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x y z {}])
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('x'),
                 Symbol::create('y'),
                 Symbol::create('z'),
-                Type::emptyPersistentMap(),
+                PhelType::emptyPersistentMap(),
             ]),
         ]);
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -17,7 +17,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ForeachSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class ForeachSymbolTest extends TestCase
@@ -28,7 +28,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("At least two arguments are required for 'foreach");
 
         // (foreach)
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
         ]);
 
@@ -41,7 +41,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("First argument of 'foreach must be a vector.");
 
         // (foreach x)
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
             Symbol::create('x'),
         ]);
@@ -55,9 +55,9 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('x'),
             ]),
         ]);
@@ -68,11 +68,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_from_vector_with2_args(): void
     {
         // (foreach [x []])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('x'),
-                TypeFactory::getInstance()->persistentVectorFromArray([]),
+                Type::persistentVectorFromArray([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -97,11 +97,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_two_args(): void
     {
         // (foreach [[x] []])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('x')]),
-                TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([
+                Type::persistentVectorFromArray([Symbol::create('x')]),
+                Type::persistentVectorFromArray([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -113,12 +113,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_vector_with3_args(): void
     {
         // (foreach [key value {}])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('key'),
                 Symbol::create('value'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ]),
             Symbol::create('key'),
         ]);
@@ -144,12 +144,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_three_args(): void
     {
         // (foreach [[key] [value] []])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('key')]),
-                TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('value')]),
-                TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([
+                Type::persistentVectorFromArray([Symbol::create('key')]),
+                Type::persistentVectorFromArray([Symbol::create('value')]),
+                Type::persistentVectorFromArray([]),
             ]),
             Symbol::create('key'),
         ]);
@@ -164,13 +164,13 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x y z {}])
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FOREACH),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('x'),
                 Symbol::create('y'),
                 Symbol::create('z'),
-                TypeFactory::getInstance()->emptyPersistentMap(),
+                Type::emptyPersistentMap(),
             ]),
         ]);
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\IfSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -31,20 +31,20 @@ final class IfSymbolTest extends TestCase
     public static function providerRequiresAtLeastTwoOrThreeArgs(): Generator
     {
         yield 'No arguments provided: (if)' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
             ]),
         ];
 
         yield 'Only one argument provided: (if "one")' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
             ]),
         ];
 
         yield 'Only one argument provided: (if "one" "two" "three" "four")' => [
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
                 'two',
@@ -56,7 +56,7 @@ final class IfSymbolTest extends TestCase
 
     public function test_analyze(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),
             true,
             'then-expression',

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
@@ -13,7 +13,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\IfSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -31,20 +31,20 @@ final class IfSymbolTest extends TestCase
     public static function providerRequiresAtLeastTwoOrThreeArgs(): Generator
     {
         yield 'No arguments provided: (if)' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
             ]),
         ];
 
         yield 'Only one argument provided: (if "one")' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
             ]),
         ];
 
         yield 'Only one argument provided: (if "one" "two" "three" "four")' => [
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
                 'two',
@@ -56,7 +56,7 @@ final class IfSymbolTest extends TestCase
 
     public function test_analyze(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_IF),
             true,
             'then-expression',

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -21,7 +21,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\InvokeSymbol;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class InvokeSymbolTest extends TestCase
@@ -37,7 +37,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-global-fn',
             static fn ($a, $b): int => $a + $b,
-            TypeFactory::getInstance()->persistentMapFromKVs('min-arity', 2),
+            Type::persistentMapFromKVs('min-arity', 2),
         );
 
         $env->addDefinition('user', Symbol::create('my-macro'));
@@ -45,7 +45,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-macro',
             static fn ($a) => $a,
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true),
+            Type::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-failed-macro'));
@@ -53,7 +53,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-failed-macro',
             static fn ($a) => throw new Exception('my-failed-macro message'),
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true),
+            Type::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-inline-fn'));
@@ -61,7 +61,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn',
             static fn ($a): int => 1,
-            TypeFactory::getInstance()->persistentMapFromKVs(
+            Type::persistentMapFromKVs(
                 Keyword::create('inline'),
                 static fn ($a): int => 2,
             ),
@@ -72,7 +72,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn-with-arity',
             static fn ($a, $b): int => 1,
-            TypeFactory::getInstance()->persistentMapFromKVs(
+            Type::persistentMapFromKVs(
                 Keyword::create('inline'),
                 static fn ($a, $b): int => 2,
                 Keyword::create('inline-arity'),
@@ -87,7 +87,7 @@ final class InvokeSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
         ]);
@@ -110,7 +110,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_valid_enough_args_provided(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
             '2arg',
@@ -123,7 +123,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_without_arguments(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
         ]);
         $env = NodeEnvironment::empty();
@@ -141,7 +141,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_with_one_arguments(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
             1,
         ]);
@@ -162,10 +162,10 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_macro_expand(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-macro'),
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                TypeFactory::getInstance()->persistentVectorFromArray([1]),
+            Type::persistentVectorFromArray([
+                Type::persistentVectorFromArray([1]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -193,9 +193,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Error in expanding macro "user\\my-failed-macro": my-failed-macro message');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-failed-macro'),
-            TypeFactory::getInstance()->persistentVectorFromArray([1]),
+            Type::persistentVectorFromArray([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -206,9 +206,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Cannot resolve symbol 'user/my-undefined-macro'");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-undefined-macro'),
-            TypeFactory::getInstance()->persistentVectorFromArray([1]),
+            Type::persistentVectorFromArray([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -216,7 +216,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn'),
             'foo',
         ]);
@@ -231,7 +231,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo', 'bar',
         ]);
@@ -246,7 +246,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check_failed(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo',
         ]);
@@ -260,7 +260,7 @@ final class InvokeSymbolTest extends TestCase
                     $env->withExpressionContext()->withDisallowRecurFrame(),
                     'user',
                     Symbol::create('my-inline-fn-with-arity'),
-                    TypeFactory::getInstance()->persistentMapFromKVs(
+                    Type::persistentMapFromKVs(
                         Keyword::create('inline'),
                         static fn ($a, $b): int => 2,
                         Keyword::create('inline-arity'),
@@ -287,10 +287,10 @@ final class InvokeSymbolTest extends TestCase
             $mungedNs,
             $macroName,
             static fn ($x) => $x,
-            TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('macro'), true),
+            Type::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::createForNamespace($ns, $macroName),
             'foo',
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -21,7 +21,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\InvokeSymbol;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class InvokeSymbolTest extends TestCase
@@ -37,7 +37,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-global-fn',
             static fn ($a, $b): int => $a + $b,
-            Type::persistentMapFromKVs('min-arity', 2),
+            PhelType::persistentMapFromKVs('min-arity', 2),
         );
 
         $env->addDefinition('user', Symbol::create('my-macro'));
@@ -45,7 +45,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-macro',
             static fn ($a) => $a,
-            Type::persistentMapFromKVs(Keyword::create('macro'), true),
+            PhelType::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-failed-macro'));
@@ -53,7 +53,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-failed-macro',
             static fn ($a) => throw new Exception('my-failed-macro message'),
-            Type::persistentMapFromKVs(Keyword::create('macro'), true),
+            PhelType::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-inline-fn'));
@@ -61,7 +61,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn',
             static fn ($a): int => 1,
-            Type::persistentMapFromKVs(
+            PhelType::persistentMapFromKVs(
                 Keyword::create('inline'),
                 static fn ($a): int => 2,
             ),
@@ -72,7 +72,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn-with-arity',
             static fn ($a, $b): int => 1,
-            Type::persistentMapFromKVs(
+            PhelType::persistentMapFromKVs(
                 Keyword::create('inline'),
                 static fn ($a, $b): int => 2,
                 Keyword::create('inline-arity'),
@@ -87,7 +87,7 @@ final class InvokeSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
         ]);
@@ -110,7 +110,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_valid_enough_args_provided(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
             '2arg',
@@ -123,7 +123,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_without_arguments(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
         ]);
         $env = NodeEnvironment::empty();
@@ -141,7 +141,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_with_one_arguments(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('php', '+'),
             1,
         ]);
@@ -162,10 +162,10 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_macro_expand(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-macro'),
-            Type::persistentVectorFromArray([
-                Type::persistentVectorFromArray([1]),
+            PhelType::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([1]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -193,9 +193,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Error in expanding macro "user\\my-failed-macro": my-failed-macro message');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-failed-macro'),
-            Type::persistentVectorFromArray([1]),
+            PhelType::persistentVectorFromArray([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -206,9 +206,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Cannot resolve symbol 'user/my-undefined-macro'");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-undefined-macro'),
-            Type::persistentVectorFromArray([1]),
+            PhelType::persistentVectorFromArray([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -216,7 +216,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn'),
             'foo',
         ]);
@@ -231,7 +231,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo', 'bar',
         ]);
@@ -246,7 +246,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check_failed(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo',
         ]);
@@ -260,7 +260,7 @@ final class InvokeSymbolTest extends TestCase
                     $env->withExpressionContext()->withDisallowRecurFrame(),
                     'user',
                     Symbol::create('my-inline-fn-with-arity'),
-                    Type::persistentMapFromKVs(
+                    PhelType::persistentMapFromKVs(
                         Keyword::create('inline'),
                         static fn ($a, $b): int => 2,
                         Keyword::create('inline-arity'),
@@ -287,10 +287,10 @@ final class InvokeSymbolTest extends TestCase
             $mungedNs,
             $macroName,
             static fn ($x) => $x,
-            Type::persistentMapFromKVs(Keyword::create('macro'), true),
+            PhelType::persistentMapFromKVs(Keyword::create('macro'), true),
         );
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::createForNamespace($ns, $macroName),
             'foo',
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\DeconstructorInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class LetSymbolTest extends TestCase
@@ -33,7 +33,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'let.");
 
-        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         $analyzer = new LetSymbol($this->analyzer, $this->createMock(DeconstructorInterface::class));
@@ -46,7 +46,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'let");
 
-        $list = Type::persistentListFromArray([Symbol::create('let')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('let')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -57,7 +57,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = Type::persistentListFromArray([Symbol::create('let'), 12]);
+        $list = PhelType::persistentListFromArray([Symbol::create('let'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -68,9 +68,9 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('let'),
-            Type::persistentVectorFromArray([12]),
+            PhelType::persistentVectorFromArray([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -79,9 +79,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_no_bindings(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('let'),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -94,9 +94,9 @@ final class LetSymbolTest extends TestCase
     public function test_with_one_binding(): void
     {
         Symbol::resetGen();
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('let'),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('a'), 1,
             ]),
         ]);
@@ -132,9 +132,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_one_body_expression(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('let'),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
             1,
         ]);
         $env = NodeEnvironment::empty();
@@ -156,9 +156,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_two_body_expression(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('let'),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
             1,
             2,
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -16,7 +16,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\DeconstructorInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class LetSymbolTest extends TestCase
@@ -33,7 +33,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'let.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('unknown')]);
+        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         $analyzer = new LetSymbol($this->analyzer, $this->createMock(DeconstructorInterface::class));
@@ -46,7 +46,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'let");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('let')]);
+        $list = Type::persistentListFromArray([Symbol::create('let')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -57,7 +57,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('let'), 12]);
+        $list = Type::persistentListFromArray([Symbol::create('let'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -68,9 +68,9 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('let'),
-            TypeFactory::getInstance()->persistentVectorFromArray([12]),
+            Type::persistentVectorFromArray([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -79,9 +79,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_no_bindings(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('let'),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -94,9 +94,9 @@ final class LetSymbolTest extends TestCase
     public function test_with_one_binding(): void
     {
         Symbol::resetGen();
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('let'),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('a'), 1,
             ]),
         ]);
@@ -132,9 +132,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_one_body_expression(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('let'),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
             1,
         ]);
         $env = NodeEnvironment::empty();
@@ -156,9 +156,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_two_body_expression(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('let'),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
             1,
             2,
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -17,7 +17,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LoopSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class LoopSymbolTest extends TestCase
@@ -38,7 +38,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'loop.");
 
-        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new LoopSymbol($this->analyzer, new BindingValidator()))->analyze($list, $env);
@@ -49,7 +49,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'loop.");
 
-        $list = Type::persistentListFromArray([Symbol::create('loop')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('loop')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -60,7 +60,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = Type::persistentListFromArray([Symbol::create('loop'), 12]);
+        $list = PhelType::persistentListFromArray([Symbol::create('loop'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -71,9 +71,9 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('loop'),
-            Type::persistentVectorFromArray([12]),
+            PhelType::persistentVectorFromArray([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -82,9 +82,9 @@ final class LoopSymbolTest extends TestCase
 
     public function test_basic_loop(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('loop'),
-            Type::persistentVectorFromArray([]),
+            PhelType::persistentVectorFromArray([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -106,9 +106,9 @@ final class LoopSymbolTest extends TestCase
     public function test_loop_with_binding(): void
     {
         Symbol::resetGen();
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('loop'),
-            Type::persistentVectorFromArray([
+            PhelType::persistentVectorFromArray([
                 Symbol::create('a'),
                 1,
             ]),
@@ -150,10 +150,10 @@ final class LoopSymbolTest extends TestCase
     public function test_with_destruction(): void
     {
         Symbol::resetGen();
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create('loop'),
-            Type::persistentVectorFromArray([
-                Type::persistentVectorFromArray([Symbol::create('a')]),
+            PhelType::persistentVectorFromArray([
+                PhelType::persistentVectorFromArray([Symbol::create('a')]),
                 1,
             ]),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -17,7 +17,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidator;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LoopSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class LoopSymbolTest extends TestCase
@@ -38,7 +38,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'loop.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('unknown')]);
+        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new LoopSymbol($this->analyzer, new BindingValidator()))->analyze($list, $env);
@@ -49,7 +49,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'loop.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('loop')]);
+        $list = Type::persistentListFromArray([Symbol::create('loop')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -60,7 +60,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('loop'), 12]);
+        $list = Type::persistentListFromArray([Symbol::create('loop'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -71,9 +71,9 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('loop'),
-            TypeFactory::getInstance()->persistentVectorFromArray([12]),
+            Type::persistentVectorFromArray([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -82,9 +82,9 @@ final class LoopSymbolTest extends TestCase
 
     public function test_basic_loop(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('loop'),
-            TypeFactory::getInstance()->persistentVectorFromArray([]),
+            Type::persistentVectorFromArray([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -106,9 +106,9 @@ final class LoopSymbolTest extends TestCase
     public function test_loop_with_binding(): void
     {
         Symbol::resetGen();
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('loop'),
-            TypeFactory::getInstance()->persistentVectorFromArray([
+            Type::persistentVectorFromArray([
                 Symbol::create('a'),
                 1,
             ]),
@@ -150,10 +150,10 @@ final class LoopSymbolTest extends TestCase
     public function test_with_destruction(): void
     {
         Symbol::resetGen();
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create('loop'),
-            TypeFactory::getInstance()->persistentVectorFromArray([
-                TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('a')]),
+            Type::persistentVectorFromArray([
+                Type::persistentVectorFromArray([Symbol::create('a')]),
                 1,
             ]),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpObjectCallSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class PhpObjectCallSymbolTest extends TestCase
@@ -32,7 +32,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are expected for 'php/::");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
         ]);
@@ -46,7 +46,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Argument 2 of 'php/->' must be a List or a Symbol");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             '',
@@ -57,7 +57,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_static(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -71,7 +71,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_not_static(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -87,10 +87,10 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_list(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
-            TypeFactory::getInstance()->persistentListFromArray([Symbol::create(''), '', '']),
+            Type::persistentListFromArray([Symbol::create(''), '', '']),
         ]);
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, isStatic: true))
@@ -103,7 +103,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_symbol(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -119,7 +119,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_nested_calls(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create('foo'),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
@@ -15,7 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpObjectCallSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class PhpObjectCallSymbolTest extends TestCase
@@ -32,7 +32,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are expected for 'php/::");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
         ]);
@@ -46,7 +46,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Argument 2 of 'php/->' must be a List or a Symbol");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             '',
@@ -57,7 +57,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_static(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -71,7 +71,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_not_static(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -87,10 +87,10 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_list(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
-            Type::persistentListFromArray([Symbol::create(''), '', '']),
+            PhelType::persistentListFromArray([Symbol::create(''), '', '']),
         ]);
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, isStatic: true))
@@ -103,7 +103,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_symbol(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -119,7 +119,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_nested_calls(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create('foo'),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\QuoteSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class QuoteSymbolTest extends TestCase
@@ -18,7 +18,7 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'quote.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray(['any symbol', 'any text']);
+        $list = Type::persistentListFromArray(['any symbol', 'any text']);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
@@ -27,13 +27,13 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE)]);
+        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE)]);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_quote_list_with_any_text(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
+        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
         $symbol = (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
 
         self::assertSame('any text', $symbol->getValue());

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\QuoteSymbol;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class QuoteSymbolTest extends TestCase
@@ -18,7 +18,7 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'quote.");
 
-        $list = Type::persistentListFromArray(['any symbol', 'any text']);
+        $list = PhelType::persistentListFromArray(['any symbol', 'any text']);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
@@ -27,13 +27,13 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
 
-        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE)]);
+        $list = PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE)]);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_quote_list_with_any_text(): void
     {
-        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
+        $list = PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
         $symbol = (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
 
         self::assertSame('any text', $symbol->getValue());

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
@@ -20,7 +20,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\RecurSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class RecurSymbolTest extends TestCase
@@ -37,7 +37,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'recur.");
 
-        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
+        $list = PhelType::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new RecurSymbol($this->analyzer))->analyze($list, $env);
@@ -48,7 +48,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Can't call 'recur here");
 
-        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_RECUR)]);
+        $list = PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_RECUR)]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -59,10 +59,10 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 1 args, got: 0");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([Symbol::create('x')]),
-            Type::persistentListFromArray([
+            PhelType::persistentVectorFromArray([Symbol::create('x')]),
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_RECUR),
             ]),
         ]);
@@ -76,12 +76,12 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 2 args, got: 1");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([Symbol::create('x'), Symbol::create('y')]),
-            Type::persistentListFromArray([
+            PhelType::persistentVectorFromArray([Symbol::create('x'), Symbol::create('y')]),
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_RECUR),
-                Type::persistentVectorFromArray([Symbol::create('x')]),
+                PhelType::persistentVectorFromArray([Symbol::create('x')]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -91,20 +91,20 @@ final class RecurSymbolTest extends TestCase
 
     public function test_fn_recursion_point(): void
     {
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            Type::persistentVectorFromArray([Symbol::create('x')]),
-            Type::persistentListFromArray([
+            PhelType::persistentVectorFromArray([Symbol::create('x')]),
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create('php/=='),
                     Symbol::create('x'),
                     0,
                 ]),
                 Symbol::create('x'),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_RECUR),
-                    Type::persistentListFromArray([
+                    PhelType::persistentListFromArray([
                         Symbol::create('php/-'),
                         Symbol::create('x'),
                         1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
@@ -20,7 +20,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\RecurSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class RecurSymbolTest extends TestCase
@@ -37,7 +37,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'recur.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create('unknown')]);
+        $list = Type::persistentListFromArray([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new RecurSymbol($this->analyzer))->analyze($list, $env);
@@ -48,7 +48,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Can't call 'recur here");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_RECUR)]);
+        $list = Type::persistentListFromArray([Symbol::create(Symbol::NAME_RECUR)]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -59,10 +59,10 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 1 args, got: 0");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('x')]),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentVectorFromArray([Symbol::create('x')]),
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_RECUR),
             ]),
         ]);
@@ -76,12 +76,12 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 2 args, got: 1");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('x'), Symbol::create('y')]),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentVectorFromArray([Symbol::create('x'), Symbol::create('y')]),
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_RECUR),
-                TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('x')]),
+                Type::persistentVectorFromArray([Symbol::create('x')]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -91,20 +91,20 @@ final class RecurSymbolTest extends TestCase
 
     public function test_fn_recursion_point(): void
     {
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_FN),
-            TypeFactory::getInstance()->persistentVectorFromArray([Symbol::create('x')]),
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentVectorFromArray([Symbol::create('x')]),
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_IF),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create('php/=='),
                     Symbol::create('x'),
                     0,
                 ]),
                 Symbol::create('x'),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_RECUR),
-                    TypeFactory::getInstance()->persistentListFromArray([
+                    Type::persistentListFromArray([
                         Symbol::create('php/-'),
                         Symbol::create('x'),
                         1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
@@ -12,7 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\SetVarSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class SetVarSymbolTest extends TestCase
@@ -29,7 +29,7 @@ final class SetVarSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_SET_VAR),
             'not-a-symbol',
             1,
@@ -45,7 +45,7 @@ final class SetVarSymbolTest extends TestCase
 
         $analyzer = new Analyzer($globalEnv);
 
-        $list = Type::persistentListFromArray([
+        $list = PhelType::persistentListFromArray([
             Symbol::create(Symbol::NAME_SET_VAR),
             Symbol::create('x'),
             2,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
@@ -12,7 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\SetVarSymbol;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class SetVarSymbolTest extends TestCase
@@ -29,7 +29,7 @@ final class SetVarSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_SET_VAR),
             'not-a-symbol',
             1,
@@ -45,7 +45,7 @@ final class SetVarSymbolTest extends TestCase
 
         $analyzer = new Analyzer($globalEnv);
 
-        $list = TypeFactory::getInstance()->persistentListFromArray([
+        $list = Type::persistentListFromArray([
             Symbol::create(Symbol::NAME_SET_VAR),
             Symbol::create('x'),
             2,

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -42,7 +42,7 @@ final class ApplyEmitterTest extends TestCase
         $this->applyEmitter->emit($applyNode);
 
         $this->expectOutputString(
-            'array_reduce([...((\Phel\Lang\Type::persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
+            'array_reduce([...((\PhelType::persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
         );
     }
 
@@ -59,7 +59,7 @@ final class ApplyEmitterTest extends TestCase
         $applyNode = new ApplyNode(NodeEnvironment::empty(), $node, $args);
         $this->applyEmitter->emit($applyNode);
 
-        $this->expectOutputString('str("abc", ...((\Phel\Lang\Type::persistentVectorFromArray(["def"])) ?? []));');
+        $this->expectOutputString('str("abc", ...((\PhelType::persistentVectorFromArray(["def"])) ?? []));');
     }
 
     public function test_no_php_var_node(): void
@@ -86,9 +86,9 @@ final class ApplyEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
+    $x = \PhelType::persistentVectorFromArray($x);
     return x;
   }
-};)(...((\Phel\Lang\Type::persistentVectorFromArray([1])) ?? []));');
+};)(...((\PhelType::persistentVectorFromArray([1])) ?? []));');
     }
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -42,7 +42,7 @@ final class ApplyEmitterTest extends TestCase
         $this->applyEmitter->emit($applyNode);
 
         $this->expectOutputString(
-            'array_reduce([...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
+            'array_reduce([...((\Phel\Lang\Type::persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
         );
     }
 
@@ -59,7 +59,7 @@ final class ApplyEmitterTest extends TestCase
         $applyNode = new ApplyNode(NodeEnvironment::empty(), $node, $args);
         $this->applyEmitter->emit($applyNode);
 
-        $this->expectOutputString('str("abc", ...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray(["def"])) ?? []));');
+        $this->expectOutputString('str("abc", ...((\Phel\Lang\Type::persistentVectorFromArray(["def"])) ?? []));');
     }
 
     public function test_no_php_var_node(): void
@@ -86,9 +86,9 @@ final class ApplyEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($x);
+    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
     return x;
   }
-};)(...((\Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray([1])) ?? []));');
+};)(...((\Phel\Lang\Type::persistentVectorFromArray([1])) ?? []));');
     }
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -117,7 +117,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($x);
+    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
     return $x;
   }
 };');
@@ -164,7 +164,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\TypeFactory::getInstance()->persistentVectorFromArray($x);
+    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
     while (true) {
       return $x;break;
     }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -117,7 +117,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
+    $x = \PhelType::persistentVectorFromArray($x);
     return $x;
   }
 };');
@@ -164,7 +164,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel\Lang\Type::persistentVectorFromArray($x);
+    $x = \PhelType::persistentVectorFromArray($x);
     while (true) {
       return $x;break;
     }

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -105,7 +105,7 @@ final class AtomParserTest extends TestCase
                 '::bar/foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('foobar', 'foo'),
+                Keyword::create('foo', 'foobar'),
             ),
             $parser->parse(
                 new Token(Token::T_ATOM, '::bar/foo', $start, $end),
@@ -126,7 +126,7 @@ final class AtomParserTest extends TestCase
                 '::foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('user', 'foo'),
+                Keyword::create('foo', 'user'),
             ),
             $parser->parse(
                 new Token(Token::T_ATOM, '::foo', $start, $end),
@@ -144,7 +144,7 @@ final class AtomParserTest extends TestCase
                 ':xyz\bar/foo',
                 $start,
                 $end,
-                Keyword::createForNamespace('xyz\bar', 'foo'),
+                Keyword::create('foo', 'xyz\bar'),
             ),
             $parser->parse(
                 new Token(Token::T_ATOM, ':xyz\bar/foo', $start, $end),

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Reader\QuasiquoteTransformer;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -19,7 +19,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertSame(
             1,
-            $q->transform(Type::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
+            $q->transform(PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
         );
     }
 
@@ -27,23 +27,23 @@ final class QuasiquoteTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
-        $q->transform(Type::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
+        $q->transform(PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
     }
 
     public function test_transform_create_list(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Type::persistentListFromArray([1, 2])),
+            $q->transform(PhelType::persistentListFromArray([1, 2])),
         );
     }
 
@@ -51,18 +51,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
                     2,
                 ]),
             ]),
-            $q->transform(Type::persistentListFromArray([
+            $q->transform(PhelType::persistentListFromArray([
                 1,
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                     2,
                 ]),
@@ -74,18 +74,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Type::persistentListFromArray([
+            $q->transform(PhelType::persistentListFromArray([
                 1,
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_UNQUOTE),
                     2,
                 ]),
@@ -97,16 +97,16 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_VECTOR),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Type::persistentVectorFromArray([1, 2])),
+            $q->transform(PhelType::persistentVectorFromArray([1, 2])),
         );
     }
 
@@ -114,18 +114,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_MAP),
-                Type::persistentListFromArray([
+                PhelType::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'a']),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'b']),
-                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'a']),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'b']),
+                    PhelType::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Type::persistentMapFromKVs('a', 1, 'b', 2)),
+            $q->transform(PhelType::persistentMapFromKVs('a', 1, 'b', 2)),
         );
     }
 
@@ -185,7 +185,7 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::create('test'),
             ]),
@@ -200,7 +200,7 @@ final class QuasiquoteTest extends TestCase
 
         $q = new QuasiquoteTransformer($env);
         self::assertEquals(
-            Type::persistentListFromArray([
+            PhelType::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::createForNamespace('test', 'abc'),
             ]),

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Reader\QuasiquoteTransformer;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -19,7 +19,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertSame(
             1,
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
+            $q->transform(Type::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
         );
     }
 
@@ -27,23 +27,23 @@ final class QuasiquoteTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
-        $q->transform(TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
+        $q->transform(Type::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
     }
 
     public function test_transform_create_list(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([1, 2])),
+            $q->transform(Type::persistentListFromArray([1, 2])),
         );
     }
 
@@ -51,18 +51,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
                     2,
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([
+            $q->transform(Type::persistentListFromArray([
                 1,
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                     2,
                 ]),
@@ -74,18 +74,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentListFromArray([
+            $q->transform(Type::persistentListFromArray([
                 1,
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_UNQUOTE),
                     2,
                 ]),
@@ -97,16 +97,16 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_VECTOR),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentVectorFromArray([1, 2])),
+            $q->transform(Type::persistentVectorFromArray([1, 2])),
         );
     }
 
@@ -114,18 +114,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_MAP),
-                TypeFactory::getInstance()->persistentListFromArray([
+                Type::persistentListFromArray([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'a']),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'b']),
-                    TypeFactory::getInstance()->persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'a']),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'b']),
+                    Type::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(TypeFactory::getInstance()->persistentMapFromKVs('a', 1, 'b', 2)),
+            $q->transform(Type::persistentMapFromKVs('a', 1, 'b', 2)),
         );
     }
 
@@ -185,7 +185,7 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::create('test'),
             ]),
@@ -200,7 +200,7 @@ final class QuasiquoteTest extends TestCase
 
         $q = new QuasiquoteTransformer($env);
         self::assertEquals(
-            TypeFactory::getInstance()->persistentListFromArray([
+            Type::persistentListFromArray([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::createForNamespace('test', 'abc'),
             ]),

--- a/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
@@ -8,7 +8,7 @@ use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -144,7 +144,7 @@ final class EmptyListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $meta = Type::emptyPersistentMap();
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
@@ -8,9 +8,9 @@ use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -144,7 +144,7 @@ final class EmptyListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Type::emptyPersistentMap();
+        $meta = PhelType::emptyPersistentMap();
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -9,9 +9,9 @@ use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class PersistentListTest extends TestCase
@@ -179,7 +179,7 @@ final class PersistentListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Type::emptyPersistentMap();
+        $meta = PhelType::emptyPersistentMap();
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -9,7 +9,7 @@ use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -179,7 +179,7 @@ final class PersistentListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $meta = Type::emptyPersistentMap();
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class StructTest extends TestCase
@@ -78,8 +78,8 @@ final class StructTest extends TestCase
     {
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $map = PersistentHashMap::fromArray(
-            TypeFactory::getInstance()->getHasher(),
-            TypeFactory::getInstance()->getEqualizer(),
+            Type::getHasher(),
+            Type::getEqualizer(),
             [Keyword::create('a'), 1, Keyword::create('b'), 2],
         );
 
@@ -113,7 +113,7 @@ final class StructTest extends TestCase
 
     public function test_with_meta(): void
     {
-        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $meta = Type::emptyPersistentMap();
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $sWithMeta = $s->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class StructTest extends TestCase
@@ -78,8 +78,8 @@ final class StructTest extends TestCase
     {
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $map = PersistentHashMap::fromArray(
-            Type::getHasher(),
-            Type::getEqualizer(),
+            PhelType::getHasher(),
+            PhelType::getEqualizer(),
             [Keyword::create('a'), 1, Keyword::create('b'), 2],
         );
 
@@ -113,7 +113,7 @@ final class StructTest extends TestCase
 
     public function test_with_meta(): void
     {
-        $meta = Type::emptyPersistentMap();
+        $meta = PhelType::emptyPersistentMap();
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $sWithMeta = $s->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -11,9 +11,9 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Collections\Vector\RangeIterator;
 use Phel\Lang\Collections\Vector\SubVector;
 use Phel\Lang\Collections\Vector\TransientVector;
-use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -241,7 +241,7 @@ final class PersistentVectorTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Type::emptyPersistentMap();
+        $meta = PhelType::emptyPersistentMap();
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $vectorWithMeta = $vector->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -11,7 +11,7 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Collections\Vector\RangeIterator;
 use Phel\Lang\Collections\Vector\SubVector;
 use Phel\Lang\Collections\Vector\TransientVector;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -241,7 +241,7 @@ final class PersistentVectorTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = TypeFactory::getInstance()->emptyPersistentMap();
+        $meta = Type::emptyPersistentMap();
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $vectorWithMeta = $vector->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Vector;
 
 use Phel\Lang\Collections\Vector\RangeIterator;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class RangeIteratorTest extends TestCase
@@ -13,7 +13,7 @@ final class RangeIteratorTest extends TestCase
     public function test_range_iterator_with32_elements(): void
     {
         $it = new RangeIterator(
-            Type::persistentVectorFromArray(range(0, 31)),
+            PhelType::persistentVectorFromArray(range(0, 31)),
             0,
             32,
         );
@@ -27,7 +27,7 @@ final class RangeIteratorTest extends TestCase
         $end = 90;
 
         $it = new RangeIterator(
-            Type::persistentVectorFromArray(range(0, 100)),
+            PhelType::persistentVectorFromArray(range(0, 100)),
             $start,
             $end,
         );

--- a/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Vector;
 
 use Phel\Lang\Collections\Vector\RangeIterator;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class RangeIteratorTest extends TestCase
@@ -13,7 +13,7 @@ final class RangeIteratorTest extends TestCase
     public function test_range_iterator_with32_elements(): void
     {
         $it = new RangeIterator(
-            TypeFactory::getInstance()->persistentVectorFromArray(range(0, 31)),
+            Type::persistentVectorFromArray(range(0, 31)),
             0,
             32,
         );
@@ -27,7 +27,7 @@ final class RangeIteratorTest extends TestCase
         $end = 90;
 
         $it = new RangeIterator(
-            TypeFactory::getInstance()->persistentVectorFromArray(range(0, 100)),
+            Type::persistentVectorFromArray(range(0, 100)),
             $start,
             $end,
         );

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang;
 
 use Phel\Lang\Keyword;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use PHPUnit\Framework\TestCase;
 
 final class KeywordTest extends TestCase
@@ -103,7 +103,7 @@ final class KeywordTest extends TestCase
     {
         $keyword1 = Keyword::create('test1');
         $keyword2 = Keyword::create('test2');
-        $table = TypeFactory::getInstance()->persistentMapFromKVs(Keyword::create('test1'), 'abc');
+        $table = Type::persistentMapFromKVs(Keyword::create('test1'), 'abc');
         $this->assertSame('abc', $keyword1($table));
         $this->assertNull($keyword2($table));
         $this->assertSame('xyz', $keyword2($table, 'xyz'));

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang;
 
 use Phel\Lang\Keyword;
-use Phel\Lang\Type;
+use PhelType;
 use PHPUnit\Framework\TestCase;
 
 final class KeywordTest extends TestCase
@@ -103,7 +103,7 @@ final class KeywordTest extends TestCase
     {
         $keyword1 = Keyword::create('test1');
         $keyword2 = Keyword::create('test2');
-        $table = Type::persistentMapFromKVs(Keyword::create('test1'), 'abc');
+        $table = PhelType::persistentMapFromKVs(Keyword::create('test1'), 'abc');
         $this->assertSame('abc', $keyword1($table));
         $this->assertNull($keyword2($table));
         $this->assertSame('xyz', $keyword2($table, 'xyz'));

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -21,13 +21,13 @@ final class KeywordTest extends TestCase
         $keyword = Keyword::create('test');
         $this->assertSame(crc32(':test'), $keyword->hash());
 
-        $keyword = Keyword::createForNamespace('foo', 'test');
+        $keyword = Keyword::create('test', 'foo');
         $this->assertSame(crc32(':foo/test'), $keyword->hash());
     }
 
     public function test_get_namespace(): void
     {
-        $keyword = Keyword::createForNamespace('foo', 'bar');
+        $keyword = Keyword::create('bar', 'foo');
         $this->assertSame('foo', $keyword->getNamespace());
 
         $keyword = Keyword::create('bar');
@@ -45,8 +45,8 @@ final class KeywordTest extends TestCase
 
     public function test_equals_with_namespace(): void
     {
-        $keyword1 = Keyword::createForNamespace('foo', 'test');
-        $keyword2 = Keyword::createForNamespace('foo', 'test');
+        $keyword1 = Keyword::create('test', 'foo');
+        $keyword2 = Keyword::create('test', 'foo');
         $this->assertTrue($keyword1->equals($keyword1));
         $this->assertTrue($keyword1->equals($keyword2));
         $this->assertTrue($keyword2->equals($keyword1));
@@ -64,9 +64,9 @@ final class KeywordTest extends TestCase
 
     public function test_not_equals_with_namespace(): void
     {
-        $keyword1 = Keyword::createForNamespace('foo', 'test');
-        $keyword2 = Keyword::createForNamespace('foo', 'test1');
-        $keyword3 = Keyword::createForNamespace('bar', 'test');
+        $keyword1 = Keyword::create('test', 'foo');
+        $keyword2 = Keyword::create('test1', 'foo');
+        $keyword3 = Keyword::create('test', 'bar');
         $this->assertFalse($keyword1->equals($keyword2));
         $this->assertFalse($keyword2->equals($keyword1));
         $this->assertFalse($keyword1->equals('test'));
@@ -86,8 +86,8 @@ final class KeywordTest extends TestCase
 
     public function test_identical_with_namespace(): void
     {
-        $keyword1 = Keyword::createForNamespace('foo', 'test');
-        $keyword2 = Keyword::createForNamespace('foo', 'test');
+        $keyword1 = Keyword::create('test', 'foo');
+        $keyword2 = Keyword::create('test', 'foo');
         $this->assertTrue($keyword1->identical($keyword1));
         $this->assertTrue($keyword1->identical($keyword2));
         $this->assertTrue($keyword2->identical($keyword1));

--- a/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
@@ -6,9 +6,9 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Type;
 use Phel\Printer\Printer;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
+use PhelType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -27,12 +27,12 @@ final class ListPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '()',
-            Type::emptyPersistentList(),
+            PhelType::emptyPersistentList(),
         ];
 
         yield 'vector with values' => [
             '("a" 1)',
-            Type::persistentListFromArray(['a', 1]),
+            PhelType::persistentListFromArray(['a', 1]),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
@@ -6,7 +6,7 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Printer\Printer;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -27,12 +27,12 @@ final class ListPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '()',
-            TypeFactory::getInstance()->emptyPersistentList(),
+            Type::emptyPersistentList(),
         ];
 
         yield 'vector with values' => [
             '("a" 1)',
-            TypeFactory::getInstance()->persistentListFromArray(['a', 1]),
+            Type::persistentListFromArray(['a', 1]),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -6,7 +6,7 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\TypeFactory;
+use Phel\Lang\Type;
 use Phel\Printer\Printer;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -27,12 +27,12 @@ final class VectorPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '[]',
-            TypeFactory::getInstance()->emptyPersistentVector(),
+            Type::emptyPersistentVector(),
         ];
 
         yield 'vector with values' => [
             '["a" 1]',
-            TypeFactory::getInstance()->persistentVectorFromArray(['a', 1]),
+            Type::persistentVectorFromArray(['a', 1]),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -6,9 +6,9 @@ namespace PhelTest\Unit\Printer\TypePrinter;
 
 use Generator;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\Type;
 use Phel\Printer\Printer;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
+use PhelType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -27,12 +27,12 @@ final class VectorPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '[]',
-            Type::emptyPersistentVector(),
+            PhelType::emptyPersistentVector(),
         ];
 
         yield 'vector with values' => [
             '["a" 1]',
-            Type::persistentVectorFromArray(['a', 1]),
+            PhelType::persistentVectorFromArray(['a', 1]),
         ];
     }
 }


### PR DESCRIPTION
## 🤔 Background

Apply similar logic that we did https://github.com/phel-lang/phel-lang/pull/889 for `\Phel` to the `TypeFactory` singleton 

## 💡 Goal

Extract `TypeFactory` singleton to its own proxy `PhelType`

## 🔖 Changes

- Use `PhelType` instead of `TypeFactory::getInstance()`
- Move proxy logic from `\Phel\Phel` to `\Phel`