### PR TITLE
Refactor phpcs with more rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,8 +8,8 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = Finder::create()
     ->files()
-    ->in(__DIR__ . '/src/php')
-    ->in(__DIR__ . '/tests/php')
+    ->in(__DIR__.'/src/php')
+    ->in(__DIR__.'/tests/php')
     ->exclude(['out', 'PhelGenerated']);
 
 return (new Config())

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -49,7 +49,6 @@ return (new Config())
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'braces_position' => true,
 
         // ------------------------------------------------------------------
         // Classes, methods & visibility
@@ -103,7 +102,6 @@ return (new Config())
         'no_mixed_echo_print' => ['use' => 'echo'],
         'short_scalar_cast' => true,
         'single_quote' => true,
-        'standardize_increment' => true,
 
         // ------------------------------------------------------------------
         // Whitespace, spacing & formatting
@@ -132,7 +130,7 @@ return (new Config())
         ],
         // Canonical tag order and casing
         'phpdoc_order' => true,
-        'phpdoc_tag_casing' => ['tags' => ['inheritDoc' => 'inheritDoc']],
+        'phpdoc_tag_casing' => true,
         // Normalize type lists and always put null last (e.g., int|string|null)
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_last',
@@ -159,15 +157,12 @@ return (new Config())
         'phpdoc_var_without_name' => true,
         'no_empty_phpdoc' => true,
         'no_empty_comment' => true,
-        // Prefer comments (/** → /*) when it’s not real PHPDoc
-        'phpdoc_to_comment' => false,
 
         // ------------------------------------------------------------------
         // PHPUnit rules
         // ------------------------------------------------------------------
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_method_casing' => ['case' => 'snake_case'],
 
         // ------------------------------------------------------------------

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,121 +18,164 @@ return (new Config())
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules([
+        // ------------------------------------------------------------------
+        // Base preset
+        // ------------------------------------------------------------------
         '@PSR12' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'backtick_to_shell_exec' => true,
-        'single_space_around_construct' => true,
+
+        // ------------------------------------------------------------------
+        // Language level & typing
+        // ------------------------------------------------------------------
+        'declare_strict_types' => true,
+        'encoding' => true,
+        'fully_qualified_strict_types' => true,
+        'native_type_declaration_casing' => true,
+        'type_declaration_spaces' => true,
+        'void_return' => true,
+
+        // ------------------------------------------------------------------
+        // Control structures & flow
+        // ------------------------------------------------------------------
         'control_structure_braces' => true,
         'control_structure_continuation_position' => true,
         'declare_parentheses' => true,
-        'no_multiple_statements_per_line' => true,
-        'braces_position' => true,
-        'statement_indentation' => true,
-        'no_extra_blank_lines' => true,
-        'class_definition' => ['single_line' => true],
-        'concat_space' => ['spacing' => 'one'],
-        'declare_strict_types' => true,
         'elseif' => true,
-        'encoding' => true,
-        'ereg_to_preg' => true,
-        'explicit_string_variable' => true,
-        'fully_qualified_strict_types' => true,
-        'type_declaration_spaces' => true,
-        'general_phpdoc_annotation_remove' => [
-            'annotations' => [
-                'author',
-                'package',
-                'subpackage',
-                'version',
-            ],
-        ],
-        'global_namespace_import' => [
-            'import_functions' => true,
-        ],
-        'include' => true,
-        'increment_style' => ['style' => 'pre'],
-        'list_syntax' => ['syntax' => 'short'],
-        'native_function_invocation' => [
-            'include' => ['@compiler_optimized'],
-        ],
-        'native_type_declaration_casing' => true,
-        'new_with_parentheses' => true,
-        'no_blank_lines_after_class_opening' => true,
-        'no_empty_comment' => true,
-        'no_empty_phpdoc' => true,
-        'no_empty_statement' => true,
-        'no_homoglyph_names' => true,
-        'no_leading_import_slash' => true,
-        'no_leading_namespace_whitespace' => true,
-        'no_mixed_echo_print' => ['use' => 'echo'],
-        'no_multiline_whitespace_around_double_arrow' => true,
-        'no_singleline_whitespace_before_semicolons' => true,
-        'no_short_bool_cast' => true,
-        'no_trailing_comma_in_singleline' => true,
-        'no_trailing_whitespace' => true,
-        'no_trailing_whitespace_in_comment' => true,
+        'no_multiple_statements_per_line' => true,
         'no_useless_else' => true,
-        'no_useless_return' => true,
-        'no_whitespace_before_comma_in_array' => true,
-        'no_whitespace_in_blank_line' => true,
-        'no_unused_imports' => true,
-        'non_printable_character' => [
-            'use_escape_sequences_in_strings' => true,
-        ],
-        'normalize_index_brace' => true,
-        'object_operator_without_whitespace' => true,
-        'ordered_class_elements' => true,
-        'ordered_imports' => [
-            'imports_order' => [
-                'class',
-                'function',
-                'const',
-            ],
-            'sort_algorithm' => 'alpha',
-        ],
-        'php_unit_construct' => true,
-        'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => true,
-        'php_unit_method_casing' => ['case' => 'snake_case'],
-        'phpdoc_add_missing_param_annotation' => true,
-        'phpdoc_annotation_without_dot' => true,
-        'phpdoc_indent' => true,
-        'phpdoc_line_span' => ['const' => 'single', 'property' => 'single', 'method' => 'multi'],
-        'phpdoc_order' => true,
-        'phpdoc_scalar' => true,
-        'phpdoc_separation' => true,
-        'phpdoc_summary' => false,
-        'phpdoc_trim' => true,
-        'phpdoc_types' => true,
-        'phpdoc_var_annotation_correct_order' => true,
-        'phpdoc_var_without_name' => true,
-        'self_accessor' => true,
-        'single_quote' => true,
-        'short_scalar_cast' => true,
-        'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline' => [
-            'elements' => [
-                'arrays',
-                'arguments',
-                'parameters',
-            ],
-        ],
-        'trim_array_spaces' => true,
-        'unary_operator_spaces' => true,
-        'types_spaces' => true,
+        'braces_position' => true,
+
+        // ------------------------------------------------------------------
+        // Classes, methods & visibility
+        // ------------------------------------------------------------------
+        'class_definition' => ['single_line' => true],
+        'no_blank_lines_after_class_opening' => true,
+        'ordered_class_elements' => true,
+        'self_accessor' => true,
         'visibility_required' => true,
-        'void_return' => true,
-        'yoda_style' => [
-            'equal' => false,
-            'identical' => false,
-            'less_and_greater' => null,
+
+        // ------------------------------------------------------------------
+        // Functions & invocations
+        // ------------------------------------------------------------------
+        'global_namespace_import' => ['import_functions' => true],
+        'include' => true,
+        'increment_style' => ['style' => 'pre'],
+        'native_function_invocation' => ['include' => ['@compiler_optimized']],
+        'new_with_parentheses' => true,
+        'static_lambda' => true,
+
+        // ------------------------------------------------------------------
+        // Namespaces & imports ordering
+        // ------------------------------------------------------------------
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => ['class', 'function', 'const'],
+            'sort_algorithm' => 'alpha',
         ],
+
+        // ------------------------------------------------------------------
+        // Arrays & list syntax
+        // ------------------------------------------------------------------
+        'array_syntax' => ['syntax' => 'short'],
+        'list_syntax' => ['syntax' => 'short'],
+        'normalize_index_brace' => true,
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'trim_array_spaces' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+
+        // ------------------------------------------------------------------
+        // Strings, echoes & operators
+        // ------------------------------------------------------------------
+        'backtick_to_shell_exec' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'explicit_string_variable' => true,
+        'non_printable_character' => ['use_escape_sequences_in_strings' => true],
+        'no_mixed_echo_print' => ['use' => 'echo'],
+        'short_scalar_cast' => true,
+        'single_quote' => true,
+        'standardize_increment' => true,
+
+        // ------------------------------------------------------------------
+        // Whitespace, spacing & formatting
+        // ------------------------------------------------------------------
+        'no_extra_blank_lines' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'no_whitespace_in_blank_line' => true,
+        'object_operator_without_whitespace' => true,
+        'single_space_around_construct' => true,
+        'statement_indentation' => true,
+        'unary_operator_spaces' => true,
+
+        // ------------------------------------------------------------------
+        // PHPDoc consistency
+        // ------------------------------------------------------------------
+        // Remove noisy author/package/version tags across the codebase
+        'general_phpdoc_annotation_remove' => [
+            'annotations' => ['author', 'package', 'subpackage', 'version'],
+        ],
+        // Align @param/@return/@throws neatly
+        'phpdoc_align' => [
+            'align' => 'vertical',
+            'tags' => ['param', 'return', 'throws', 'var'],
+        ],
+        // Canonical tag order and casing
+        'phpdoc_order' => true,
+        'phpdoc_tag_casing' => ['tags' => ['inheritDoc' => 'inheritDoc']],
+        // Normalize type lists and always put null last (e.g., int|string|null)
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'alpha',
+        ],
+        'phpdoc_types' => true,
+        'phpdoc_scalar' => true,
+        // Tighten spacing/blank lines inside blocks
+        'phpdoc_indent' => true,
+        'phpdoc_line_span' => ['const' => 'single', 'property' => 'single', 'method' => 'multi'],
+        'phpdoc_separation' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_annotation_without_dot' => true,
+        // Add missing @param when it’s absent (for non-typed params)
+        'phpdoc_add_missing_param_annotation' => true,
+        // Keep only meaningful @param/@return/@var; avoids duplicates with native types
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'allow_hidden_params' => false,
+        ],
+        'phpdoc_var_annotation_correct_order' => true,
+        'phpdoc_var_without_name' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_comment' => true,
+        // Prefer comments (/** → /*) when it’s not real PHPDoc
+        'phpdoc_to_comment' => false,
+
+        // ------------------------------------------------------------------
+        // PHPUnit rules
+        // ------------------------------------------------------------------
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => true,
+        'php_unit_dedicate_assert_internal_type' => true,
+        'php_unit_method_casing' => ['case' => 'snake_case'],
+
+        // ------------------------------------------------------------------
+        // Miscellaneous
+        // ------------------------------------------------------------------
+        'ereg_to_preg' => true,
+        'no_empty_statement' => true,
+        'no_homoglyph_names' => true,
+        'no_useless_return' => true,
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => null],
     ]);

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -12,7 +12,7 @@ use Phel\Lang\Keyword;
 final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
 {
     /**
-     * @param  list<string>  $allNamespaces
+     * @param list<string> $allNamespaces
      */
     public function __construct(
         private PhelFnLoaderInterface $phelFnLoader,
@@ -21,7 +21,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     }
 
     /**
-     * @param  list<string>  $namespaces
+     * @param list<string> $namespaces
      *
      * @return list<PhelFunction>
      */
@@ -89,7 +89,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     /**
      * @param array<string, PhelFunction> $originalNormalizedFns
      *
-     * @return  list<PhelFunction>
+     * @return list<PhelFunction>
      */
     private function normalizeNativeSymbols(array $originalNormalizedFns): array
     {
@@ -109,7 +109,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
     }
 
     /**
-     * @param  list<PhelFunction>  $fns
+     * @param list<PhelFunction> $fns
      *
      * @return list<PhelFunction>
      */

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -29,7 +29,7 @@ final class ReplCompleter implements ReplCompleterInterface
     private static array $phpClasses = [];
 
     /**
-     * @param  list<string>  $allNamespaces
+     * @param list<string> $allNamespaces
      */
     public function __construct(
         private readonly PhelFnLoaderInterface $phelFnLoader,
@@ -40,7 +40,7 @@ final class ReplCompleter implements ReplCompleterInterface
     /**
      * Complete input from either PHP or Phel context.
      *
-     * @param  string  $input  the input string for which to find completions
+     * @param string $input the input string for which to find completions
      *
      * @return list<string> a list of autocompletion suggestions
      */
@@ -64,7 +64,7 @@ final class ReplCompleter implements ReplCompleterInterface
     /**
      * Complete native PHP functions and classes.
      *
-     * @param  string  $prefix  the input string without the `php/` prefix
+     * @param string $prefix the input string without the `php/` prefix
      *
      * @return list<string>
      */
@@ -100,7 +100,7 @@ final class ReplCompleter implements ReplCompleterInterface
     /**
      * Complete available Phel functions.
      *
-     * @param  string  $input  the input string to match
+     * @param string $input the input string to match
      *
      * @return list<string>
      */

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -312,7 +312,7 @@ An interface in Phel defines an abstract set of functions. It is directly mapped
     }
 
     /**
-     * @param  list<string>  $namespaces
+     * @param list<string> $namespaces
      *
      * @return array<string,PersistentMapInterface>
      */

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -73,7 +73,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     }
 
     /**
-     * @param  list<string>  $directories
+     * @param list<string> $directories
      *
      * @throws ExtractorException
      *
@@ -98,7 +98,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     }
 
     /**
-     * @param  list<NamespaceInformation>  $namespaceInformationList
+     * @param list<NamespaceInformation> $namespaceInformationList
      *
      * @return list<NamespaceInformation>
      */

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -66,7 +66,7 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
      * topological sorted subset of this namespace information.
      *
      * @param string[] $directories The list of the directories
-     * @param string[] $ns A list of namespace for which we should find the subset
+     * @param string[] $ns          A list of namespace for which we should find the subset
      *
      * @return list<NamespaceInformation>
      */
@@ -80,7 +80,7 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
     /**
      * Compiles a phel file and saves it to the give destination.
      *
-     * @param string $src The source file
+     * @param string $src  The source file
      * @param string $dest The destination
      */
     public function compileFile(string $src, string $dest): CompiledFile

--- a/src/php/Build/BuildFacadeInterface.php
+++ b/src/php/Build/BuildFacadeInterface.php
@@ -36,7 +36,7 @@ interface BuildFacadeInterface
      * topological sorted subset of these namespaces' information.
      *
      * @param string[] $directories The list of the directories
-     * @param string[] $ns A list of namespace for which we should find the subset
+     * @param string[] $ns          A list of namespace for which we should find the subset
      *
      * @return list<NamespaceInformation>
      */
@@ -45,7 +45,7 @@ interface BuildFacadeInterface
     /**
      * Compiles a phel file and saves it to the give destination.
      *
-     * @param string $src The source file
+     * @param string $src  The source file
      * @param string $dest The destination
      */
     public function compileFile(string $src, string $dest): CompiledFile;

--- a/src/php/Build/Domain/Extractor/NamespaceSorterInterface.php
+++ b/src/php/Build/Domain/Extractor/NamespaceSorterInterface.php
@@ -7,7 +7,7 @@ namespace Phel\Build\Domain\Extractor;
 interface NamespaceSorterInterface
 {
     /**
-     * @param list<string> $data the data array that should be sorted
+     * @param list<string>                $data         the data array that should be sorted
      * @param array<string, list<string>> $dependencies a map of dependencies for each data node
      *
      * @return list<string> The sorted array

--- a/src/php/Build/Domain/Extractor/TopologicalNamespaceSorter.php
+++ b/src/php/Build/Domain/Extractor/TopologicalNamespaceSorter.php
@@ -9,7 +9,7 @@ use RuntimeException;
 final class TopologicalNamespaceSorter implements NamespaceSorterInterface
 {
     /**
-     * @param list<string> $data
+     * @param list<string>                $data
      * @param array<string, list<string>> $dependencies
      *
      * @return list<string>
@@ -29,8 +29,8 @@ final class TopologicalNamespaceSorter implements NamespaceSorterInterface
 
     /**
      * @param array<string, list<string>> $dependencies
-     * @param array<string, bool> $visited
-     * @param array<string, bool> $visiting
+     * @param array<string, bool>         $visited
+     * @param array<string, bool>         $visiting
      */
     private function visit(
         string $item,

--- a/src/php/Compiler/CompilerFacadeInterface.php
+++ b/src/php/Compiler/CompilerFacadeInterface.php
@@ -34,7 +34,7 @@ interface CompilerFacadeInterface
      * Evaluates all expression in the given phel code. Returns the result
      * of the last expression.
      *
-     * @param string $phelCode The phel code that should be evaluated
+     * @param string         $phelCode       The phel code that should be evaluated
      * @param CompileOptions $compileOptions The compile options
      *
      * @throws CompilerException|UnfinishedParserException
@@ -44,8 +44,8 @@ interface CompilerFacadeInterface
     public function eval(string $phelCode, CompileOptions $compileOptions): mixed;
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
-     * @param CompileOptions $compileOptions The compile options
+     * @param bool|float|int|string|TypeInterface|null $form           The phel form to evaluate
+     * @param CompileOptions                           $compileOptions The compile options
      *
      * @throws CompilerException
      *
@@ -56,7 +56,7 @@ interface CompilerFacadeInterface
     /**
      * Compiles the given phel code to PHP code.
      *
-     * @param string $phelCode The phel code that should be compiled
+     * @param string         $phelCode       The phel code that should be compiled
      * @param CompileOptions $compileOptions The compilation options
      *
      * @throws CompilerException

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefStructNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefStructNode.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 final class DefStructNode extends AbstractNode
 {
     /**
-     * @param list<Symbol> $params
+     * @param list<Symbol>             $params
      * @param list<DefStructInterface> $interfaces
      */
     public function __construct(

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -95,9 +95,9 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     }
 
     /**
-     * @param  string  $inNamespace  The namespace in which the alias exist
-     * @param  Symbol  $name  The alias name
-     * @param  Symbol  $fullName  The namespace that will be resolved
+     * @param string $inNamespace The namespace in which the alias exist
+     * @param Symbol $name        The alias name
+     * @param Symbol $fullName    The namespace that will be resolved
      */
     public function addRequireAlias(string $inNamespace, Symbol $name, Symbol $fullName): void
     {
@@ -105,8 +105,8 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     }
 
     /**
-     * @param  string  $inNamespace  The namespace in which the alias should exist
-     * @param  Symbol  $name  The alias name
+     * @param string $inNamespace The namespace in which the alias should exist
+     * @param Symbol $name        The alias name
      */
     public function hasRequireAlias(string $inNamespace, Symbol $name): bool
     {
@@ -114,9 +114,9 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     }
 
     /**
-     * @param  string  $inNamespace  The namespace in which the alias exist
-     * @param  Symbol  $alias  The alias name
-     * @param  Symbol  $fullName  The namespace that will be resolved
+     * @param string $inNamespace The namespace in which the alias exist
+     * @param Symbol $alias       The alias name
+     * @param Symbol $fullName    The namespace that will be resolved
      */
     public function addUseAlias(string $inNamespace, Symbol $alias, Symbol $fullName): void
     {
@@ -124,8 +124,8 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     }
 
     /**
-     * @param  string  $inNamespace  The namespace in which the alias should exist
-     * @param  Symbol  $alias  The alias name
+     * @param string $inNamespace The namespace in which the alias should exist
+     * @param Symbol $alias       The alias name
      */
     public function hasUseAlias(string $inNamespace, Symbol $alias): bool
     {

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -26,11 +26,11 @@ final class NodeEnvironment implements NodeEnvironmentInterface
     private bool $globalReference = false;
 
     /**
-     * @param array<int, Symbol> $locals A list of local symbols
-     * @param string $context The current context (Expression, Statement or Return)
-     * @param array<string, Symbol> $shadowed A mapping list of local variables to shadowed names
+     * @param array<int, Symbol>     $locals      A list of local symbols
+     * @param string                 $context     The current context (Expression, Statement or Return)
+     * @param array<string, Symbol>  $shadowed    A mapping list of local variables to shadowed names
      * @param array<RecurFrame|null> $recurFrames A list of RecurFrame
-     * @param string $boundTo A variable this is bound to
+     * @param string                 $boundTo     A variable this is bound to
      */
     public function __construct(
         private array $locals,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -47,7 +47,7 @@ final class AnalyzePersistentList
     private const string EMPTY_SYMBOL_NAME = '';
 
     /**
-     * @throws AnalyzerException|AbstractLocatedException
+     * @throws AbstractLocatedException|AnalyzerException
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentMap.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentMap.php
@@ -18,9 +18,9 @@ final class AnalyzePersistentMap
         $keyValues = [];
         $kvEnv = $env->withExpressionContext();
 
-        /** @var TypeInterface|string|float|int|bool|null $value */
+        /** @var bool|float|int|string|TypeInterface|null $value */
         foreach ($map as $key => $value) {
-            /** @var TypeInterface|string|float|int|bool|null $key */
+            /** @var bool|float|int|string|TypeInterface|null $key */
             $keyValues[] = $this->analyzer->analyze($key, $kvEnv);
             $keyValues[] = $this->analyzer->analyze($value, $kvEnv);
         }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentVector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentVector.php
@@ -17,7 +17,7 @@ final class AnalyzePersistentVector
     {
         $args = [];
 
-        /** @var TypeInterface|string|float|int|bool|null $arg */
+        /** @var bool|float|int|string|TypeInterface|null $arg */
         foreach ($vector->getIterator() as $arg) {
             $envDisallowRecur = $env->withExpressionContext()->withDisallowRecurFrame();
             $args[] = $this->analyzer->analyze($arg, $envDisallowRecur);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
@@ -38,9 +38,9 @@ final readonly class Deconstructor implements DeconstructorInterface
     /**
      * Destructure a $binding $value pair and add the result to $bindings.
      *
-     * @param array $bindings A reference to already defined bindings
-     * @param float|bool|int|string|TypeInterface|null $binding The binding form
-     * @param float|bool|int|string|TypeInterface|null $value The value form
+     * @param array                                    $bindings A reference to already defined bindings
+     * @param bool|float|int|string|TypeInterface|null $binding  The binding form
+     * @param bool|float|int|string|TypeInterface|null $value    The value form
      *
      * @throws AnalyzerException
      */
@@ -56,7 +56,7 @@ final readonly class Deconstructor implements DeconstructorInterface
     }
 
     /**
-     * @param float|bool|int|string|TypeInterface|null $binding The binding form
+     * @param bool|float|int|string|TypeInterface|null $binding The binding form
      */
     private function createDeconstructorForBinding(float|bool|int|string|TypeInterface|null $binding): BindingDeconstructorInterface
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/BindingDeconstructorInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/BindingDeconstructorInterface.php
@@ -14,9 +14,9 @@ interface BindingDeconstructorInterface
     /**
      * Destructure a symbol $binding and add the result to $bindings.
      *
-     * @param array $bindings A reference to already defined bindings
-     * @param T $binding The binding form
-     * @param TypeInterface|string|float|int|bool|null $value The value form
+     * @param array                                    $bindings A reference to already defined bindings
+     * @param T                                        $binding  The binding form
+     * @param bool|float|int|string|TypeInterface|null $value    The value form
      */
     public function deconstruct(array &$bindings, mixed $binding, $value): void;
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -25,8 +25,8 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
     }
 
     /**
-     * @param PersistentMapInterface $binding The binding form
-     * @param TypeInterface|string|float|int|bool|null $value The value form
+     * @param PersistentMapInterface                   $binding The binding form
+     * @param bool|float|int|string|TypeInterface|null $value   The value form
      */
     public function deconstruct(array &$bindings, $binding, $value): void
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/SymbolBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/SymbolBindingDeconstructor.php
@@ -13,8 +13,8 @@ use Phel\Lang\TypeInterface;
 final class SymbolBindingDeconstructor implements BindingDeconstructorInterface
 {
     /**
-     * @param Symbol $binding The binding form
-     * @param TypeInterface|string|float|int|bool|null $value The value form
+     * @param Symbol                                   $binding The binding form
+     * @param bool|float|int|string|TypeInterface|null $value   The value form
      */
     public function deconstruct(array &$bindings, $binding, $value): void
     {

--- a/src/php/Compiler/Domain/Compiler/CodeCompilerInterface.php
+++ b/src/php/Compiler/Domain/Compiler/CodeCompilerInterface.php
@@ -21,7 +21,7 @@ interface CodeCompilerInterface
     public function compileString(string $phelCode, CompileOptions $compileOptions): EmitterResult;
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
+     * @param bool|float|int|string|TypeInterface|null $form The phel form to evaluate
      *
      * @throws CompilerException
      * @throws CompiledCodeIsMalformedException

--- a/src/php/Compiler/Domain/Compiler/EvalCompilerInterface.php
+++ b/src/php/Compiler/Domain/Compiler/EvalCompilerInterface.php
@@ -23,7 +23,7 @@ interface EvalCompilerInterface
     /**
      * Evaluates a provided Phel form.
      *
-     * @param TypeInterface|string|float|int|bool|null $form The phel form to evaluate
+     * @param bool|float|int|string|TypeInterface|null $form The phel form to evaluate
      *
      * @throws CompilerException|UnfinishedParserException
      *

--- a/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
@@ -12,10 +12,10 @@ use Phel\Lang\SourceLocation;
 abstract class AbstractAtomNode implements NodeInterface
 {
     /**
-     * @param string $code The code of the node
+     * @param string         $code          The code of the node
      * @param SourceLocation $startLocation The start location of the atom
-     * @param SourceLocation $endLocation The end location of the atom
-     * @param T $value The value of the atom
+     * @param SourceLocation $endLocation   The end location of the atom
+     * @param T              $value         The value of the atom
      */
     public function __construct(
         private readonly string $code,

--- a/src/php/Compiler/Domain/Parser/ParserNode/NumberNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/NumberNode.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Parser\ParserNode;
 
 /**
- * @extends AbstractAtomNode<int|float>
+ * @extends AbstractAtomNode<float|int>
  */
 final class NumberNode extends AbstractAtomNode
 {

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -31,11 +31,11 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form The form to quasiqoute
+     * @param bool|float|int|string|TypeInterface|null $form The form to quasiqoute
      *
      * @throws SpliceNotInListException
      *
-     * @return TypeInterface|string|float|int|bool|null
+     * @return bool|float|int|string|TypeInterface|null
      */
     public function transform($form)
     {
@@ -68,7 +68,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form
+     * @param bool|float|int|string|TypeInterface|null $form
      */
     private function isUnquote($form): bool
     {
@@ -76,7 +76,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form
+     * @param bool|float|int|string|TypeInterface|null $form
      */
     private function isUnquoteSplicing($form): bool
     {
@@ -151,7 +151,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $x The form to check
+     * @param bool|float|int|string|TypeInterface|null $x The form to check
      */
     private function isLiteral($x): bool
     {
@@ -164,7 +164,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
     }
 
     /**
-     * @param TypeInterface|string|float|int|bool|null $form
+     * @param bool|float|int|string|TypeInterface|null $form
      */
     private function createOtherwise($form): PersistentListInterface
     {

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformerInterface.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformerInterface.php
@@ -9,9 +9,9 @@ use Phel\Lang\TypeInterface;
 interface QuasiquoteTransformerInterface
 {
     /**
-     * @param TypeInterface|string|float|int|bool|null $form The form to quasiqoute
+     * @param bool|float|int|string|TypeInterface|null $form The form to quasiqoute
      *
-     * @return TypeInterface|string|float|int|bool|null
+     * @return bool|float|int|string|TypeInterface|null
      */
     public function transform($form);
 }

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -65,7 +65,7 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * @param  list<string>  $list
+     * @param list<string> $list
      */
     public function setSrcDirs(array $list): self
     {
@@ -75,7 +75,7 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * @param  list<string>  $list
+     * @param list<string> $list
      */
     public function setTestDirs(array $list): self
     {
@@ -121,7 +121,7 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * @param  list<string>  $list
+     * @param list<string> $list
      */
     public function setIgnoreWhenBuilding(array $list): self
     {
@@ -145,7 +145,7 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * @param  list<string>  $list
+     * @param list<string> $list
      */
     public function setFormatDirs(array $list): self
     {
@@ -155,7 +155,7 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * @param  list<string>  $list
+     * @param list<string> $list
      */
     public function setNoCacheWhenBuilding(array $list): self
     {

--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -12,10 +12,10 @@ namespace Phel\Formatter\Domain\Rules\Zipper;
 abstract class AbstractZipper
 {
     /**
-     * @param T $node
+     * @param T                  $node
      * @param ?AbstractZipper<T> $parent
-     * @param list<T> $leftSiblings
-     * @param list<T> $rightSiblings
+     * @param list<T>            $leftSiblings
+     * @param list<T>            $rightSiblings
      */
     final public function __construct(
         protected mixed $node,
@@ -35,7 +35,7 @@ abstract class AbstractZipper
     abstract public function isBranch(): bool;
 
     /**
-     * @param T $node
+     * @param T       $node
      * @param list<T> $children
      *
      * @return T
@@ -405,10 +405,10 @@ abstract class AbstractZipper
     }
 
     /**
-     * @param T $node
+     * @param T                  $node
      * @param ?AbstractZipper<T> $parent
-     * @param list<T> $leftSiblings
-     * @param list<T> $rightSiblings
+     * @param list<T>            $leftSiblings
+     * @param list<T>            $rightSiblings
      */
     abstract protected function createNewInstance(
         mixed $node,

--- a/src/php/Formatter/Domain/Rules/Zipper/ParseTreeZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/ParseTreeZipper.php
@@ -146,10 +146,10 @@ final class ParseTreeZipper extends AbstractZipper
     }
 
     /**
-     * @param NodeInterface $node
+     * @param NodeInterface                  $node
      * @param ?AbstractZipper<NodeInterface> $parent
-     * @param list<NodeInterface> $leftSiblings
-     * @param list<NodeInterface> $rightSiblings
+     * @param list<NodeInterface>            $leftSiblings
+     * @param list<NodeInterface>            $rightSiblings
      */
     protected function createNewInstance(
         $node,

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -26,7 +26,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
     private int $hashCache = 0;
 
     /**
-     * @param T $first
+     * @param T                          $first
      * @param PersistentListInterface<T> $rest
      */
     public function __construct(

--- a/src/php/Lang/Collections/Map/HashMapNodeInterface.php
+++ b/src/php/Lang/Collections/Map/HashMapNodeInterface.php
@@ -15,7 +15,7 @@ use IteratorAggregate;
 interface HashMapNodeInterface extends IteratorAggregate
 {
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      */
     public function put(int $shift, int $hash, mixed $key, mixed $value, Box $addedLeaf): self;
@@ -28,10 +28,10 @@ interface HashMapNodeInterface extends IteratorAggregate
     /**
      * @template TDefault
      *
-     * @param TKey $key
+     * @param TKey      $key
      * @param ?TDefault $notFound
      *
-     * @return TValue|TDefault
+     * @return TDefault|TValue
      */
     public function find(int $shift, int $hash, mixed $key, $notFound);
 }

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -22,7 +22,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     /**
      * @param list<array{
      *     0: TKey|null,
-     *     1: TValue|HashMapNodeInterface<TKey, TValue>,
+     *     1: HashMapNodeInterface<TKey, TValue>|TValue,
      * }> $objects
      */
     public function __construct(
@@ -38,7 +38,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      *
      * @return HashMapNodeInterface<TKey, TValue>
@@ -157,9 +157,9 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key1
+     * @param TKey   $key1
      * @param TValue $value1
-     * @param TKey $key2
+     * @param TKey   $key2
      * @param TValue $value2
      *
      * @return HashMapNodeInterface<TKey, TValue>
@@ -195,7 +195,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      *
      * @return HashMapNodeInterface<TKey, TValue>
@@ -216,7 +216,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      *
      * @return HashMapNodeInterface<TKey, TValue>
@@ -231,7 +231,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      *
      * @return HashMapNodeInterface<TKey, TValue>
@@ -253,7 +253,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
     }
 
     /**
-     * @param TKey $key
+     * @param TKey   $key
      * @param TValue $value
      *
      * @return IndexedNode<TKey, TValue>

--- a/src/php/Lang/Collections/Map/IndexedNodeIterator.php
+++ b/src/php/Lang/Collections/Map/IndexedNodeIterator.php
@@ -16,7 +16,7 @@ use function count;
  */
 final class IndexedNodeIterator implements Iterator
 {
-    /** @var array<int, array{0: K|null, 1: V|HashMapNodeInterface<K, V>}> */
+    /** @var array<int, array{0: K|null, 1: HashMapNodeInterface<K, V>|V}> */
     private readonly array $entries;
 
     private readonly int $count;

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -25,7 +25,7 @@ final class PersistentHashMap extends AbstractPersistentMap
 
     /**
      * @param ?HashMapNodeInterface<K, V> $root
-     * @param V $nullValue
+     * @param V                           $nullValue
      */
     public function __construct(
         HasherInterface $hasher,

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -21,7 +21,7 @@ final class TransientHashMap implements TransientMapInterface
 
     /**
      * @param ?HashMapNodeInterface<K, V> $root
-     * @param ?V $nullValue
+     * @param ?V                          $nullValue
      */
     public function __construct(
         private readonly HasherInterface $hasher,

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -147,7 +147,7 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
     /**
      * Remove values on a indexed data structures.
      *
-     * @param int $offset The offset where to start to remove values
+     * @param int  $offset The offset where to start to remove values
      * @param ?int $length The number of how many elements should be removed
      */
     public function slice(int $offset = 0, ?int $length = null): PersistentVectorInterface

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -38,9 +38,9 @@ final class PersistentVector extends AbstractPersistentVector
     private readonly int $tailSize;
 
     /**
-     * @param  int  $count  The number of elements stored in this vector
-     * @param  array<array>  $root  The root node of this vector
-     * @param  array<int, T>  $tail  The tail of the vector. This is an optimization
+     * @param int           $count The number of elements stored in this vector
+     * @param array<array>  $root  The root node of this vector
+     * @param array<int, T> $tail  The tail of the vector. This is an optimization
      */
     public function __construct(
         HasherInterface $hasher,
@@ -97,7 +97,7 @@ final class PersistentVector extends AbstractPersistentVector
      * 3. There is not enough space in the current root.
      * (Source: https://hypirion.com/musings/understanding-persistent-vector-pt-1)
      *
-     * @param  T  $value
+     * @param T $value
      */
     public function append($value): self
     {
@@ -146,8 +146,8 @@ final class PersistentVector extends AbstractPersistentVector
      * replace with the new value. We then return the new vector with the modified path.
      * (Source: https://hypirion.com/musings/understanding-persistent-vector-pt-1)
      *
-     * @param  int  $i  the index in the vector
-     * @param  T  $value  The new value
+     * @param int $i     the index in the vector
+     * @param T   $value The new value
      */
     public function update(int $i, $value): self
     {
@@ -188,7 +188,7 @@ final class PersistentVector extends AbstractPersistentVector
     /**
      * Gets the value at index $i.
      *
-     * @param  int  $i  The index
+     * @param int $i The index
      *
      * @return T
      */
@@ -355,7 +355,7 @@ final class PersistentVector extends AbstractPersistentVector
     }
 
     /**
-     * @param  T  $value
+     * @param T $value
      */
     private function doUpdate(int $level, array $node, int $i, mixed $value): array
     {

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -22,10 +22,10 @@ final class TransientVector implements TransientVectorInterface
     private int $tailSize;
 
     /**
-     * @param int $count The number of elements inside this vector
-     * @param int $shift The shift value
-     * @param array<array> $root The root node of this vector
-     * @param T[] $tail The tail of the vector. This is an optimization
+     * @param int          $count The number of elements inside this vector
+     * @param int          $shift The shift value
+     * @param array<array> $root  The root node of this vector
+     * @param T[]          $tail  The tail of the vector. This is an optimization
      */
     public function __construct(
         private readonly HasherInterface $hasher,

--- a/src/php/Lang/ConsInterface.php
+++ b/src/php/Lang/ConsInterface.php
@@ -12,7 +12,6 @@ interface ConsInterface
     /**
      * Appends a value to the front of a data structure.
      *
-     *
      * @return T
      */
     public function cons(mixed $x);

--- a/src/php/Lang/PushInterface.php
+++ b/src/php/Lang/PushInterface.php
@@ -12,7 +12,6 @@ interface PushInterface
     /**
      * Pushes a new value of the data structure.
      *
-     *
      * @return TSelf
      */
     public function push(mixed $x);

--- a/src/php/Lang/RemoveInterface.php
+++ b/src/php/Lang/RemoveInterface.php
@@ -9,7 +9,7 @@ interface RemoveInterface
     /**
      * Remove values on a indexed data structures.
      *
-     * @param int $offset The offset where to start to remove values
+     * @param int  $offset The offset where to start to remove values
      * @param ?int $length The number of how many elements should be removed
      */
     public function remove(int $offset, ?int $length = null): self;

--- a/src/php/Lang/SliceInterface.php
+++ b/src/php/Lang/SliceInterface.php
@@ -12,7 +12,7 @@ interface SliceInterface
     /**
      * Remove values on a indexed data structures.
      *
-     * @param int $offset The offset where to start to remove values
+     * @param int  $offset The offset where to start to remove values
      * @param ?int $length The number of how many elements should be removed
      *
      * @return T

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -56,7 +56,7 @@ class Phel
     /**
      * This function helps to unify the running execution for a custom phel project.
      *
-     * @param  list<string>|string|null  $argv
+     * @param list<string>|string|null $argv
      */
     public static function run(string $projectRootDir, string $namespace, array|string|null $argv = null): void
     {
@@ -80,7 +80,7 @@ class Phel
     }
 
     /**
-     * @param  list<string>|string  $argv
+     * @param list<string>|string $argv
      */
     private static function updateGlobalArgv(array|string $argv): void
     {

--- a/src/php/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Printer/TypePrinter/NumberPrinter.php
@@ -7,14 +7,14 @@ namespace Phel\Printer\TypePrinter;
 use function sprintf;
 
 /**
- * @implements TypePrinterInterface<int|float>
+ * @implements TypePrinterInterface<float|int>
  */
 final class NumberPrinter implements TypePrinterInterface
 {
     use WithColorTrait;
 
     /**
-     * @param int|float $form
+     * @param float|int $form
      */
     public function print(mixed $form): string
     {

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -102,7 +102,7 @@ final class TestCommand extends Command
     }
 
     /**
-     * @param  list<NamespaceInformation>  $namespacesInfo
+     * @param list<NamespaceInformation> $namespacesInfo
      */
     private function namespacesAsString(array $namespacesInfo): string
     {

--- a/src/php/Run/RunFacadeInterface.php
+++ b/src/php/Run/RunFacadeInterface.php
@@ -27,8 +27,8 @@ interface RunFacadeInterface
     public function getAllPhelDirectories(): array;
 
     /**
-     * @param  list<string>  $directories
-     * @param  list<string>  $ns
+     * @param list<string> $directories
+     * @param list<string> $ns
      *
      * @return list<NamespaceInformation>
      */
@@ -37,7 +37,7 @@ interface RunFacadeInterface
     public function evalFile(NamespaceInformation $info): void;
 
     /**
-     * @param  list<string>  $paths
+     * @param list<string> $paths
      *
      * @return list<NamespaceInformation>
      */

--- a/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
+++ b/tests/php/Unit/Formatter/Domain/Rules/Zipper/ArrayZipper.php
@@ -42,7 +42,7 @@ final class ArrayZipper extends AbstractZipper
     }
 
     /**
-     * @param list<int> $node
+     * @param list<int>       $node
      * @param list<list<int>> $children
      *
      * @return list<int>
@@ -53,10 +53,10 @@ final class ArrayZipper extends AbstractZipper
     }
 
     /**
-     * @param list<int|list<int>> $node
+     * @param list<int|list<int>>        $node
      * @param ?AbstractZipper<list<int>> $parent
-     * @param list<int|list<int>> $leftSiblings
-     * @param list<int|list<int>> $rightSiblings
+     * @param list<int|list<int>>        $leftSiblings
+     * @param list<int|list<int>>        $rightSiblings
      */
     protected function createNewInstance(
         $node,


### PR DESCRIPTION
## 🤔 Background

Sometimes the PHPDoc have different code styles, which is odd. 
I want to unify and standarise all possible areas of the code style to avoid unnecessary diff changes due to code style.

## 🔖 Changes

- Group php-cs-fixer rules – and add more for better code consistancy
- Apply the `composer fix` rules