### PR TITLE
fix: Ensured intermediate segments of php/-> are analyzed

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -58,8 +58,11 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
                 $callExpr = $this->callExprForPropertyCall($env, $current);
             }
 
+            $isLast = $i === $counter - 1;
+            $nodeEnv = $isLast ? $env : $env->withExpressionContext();
+
             $targetExpr = new PhpObjectCallNode(
-                $env,
+                $nodeEnv,
                 $targetExpr,
                 $callExpr,
                 $this->isStatic && $i === 2,

--- a/tests/php/Integration/Fixtures/Call/php-method-chain.test
+++ b/tests/php/Integration/Fixtures/Call/php-method-chain.test
@@ -5,6 +5,6 @@
   $target_1 = (function() {
     $target_2 = (new \DateTimeImmutable());
     return $target_2->modify("+1 day");
-  })();;
+  })();
   return $target_1->format("Y-m-d");
 })();

--- a/tests/php/Integration/Fixtures/Call/php-nested-property-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-nested-property-call.test
@@ -6,8 +6,8 @@
     $target_2 = (function() {
       $target_3 = (new \SimpleXMLElement("<root><user id='1'><data><name>John</name></data></user></root>"));
       return $target_3->user;
-    })();;
+    })();
     return $target_2->data;
-  })();;
+  })();
   return $target_1->name;
 })();

--- a/tests/php/Integration/Fixtures/Call/php-property-method-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-property-method-call.test
@@ -1,0 +1,10 @@
+--PHEL--
+(php/-> (php/new \SimpleXMLElement "<root><user id='1'/></root>") user (count))
+--PHP--
+(function() {
+  $target_1 = (function() {
+    $target_2 = (new \SimpleXMLElement("<root><user id='1'/></root>"));
+    return $target_2->user;
+  })();
+  return $target_1->count();
+})();


### PR DESCRIPTION
## 🤔 Background

Fixed: https://github.com/phel-lang/phel-lang/issues/891#issuecomment-3217817196

## 💡 Goal

Noticing some weird double semicolon syntax `;;` generated least here.

## 🔖 Changes

- Ensured intermediate segments of php/-> are analyzed in expression context so property-to-method chains emit valid code without stray semicolons
- Added an integration test covering a property followed by a method call to guard against regressions