### PR TITLE
Fix require ns loading code without build-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to this project will be documented in this file.
 - Fix `map` function exhaustion with empty collections
 - Fix `contains-value?` with `nil` value
 - Fix set `difference` errors with certain input
+- Fix `require` loading code without `*build-mode*`
 - Add `slurp` and `spit` file reading and writing functions
 - Add `select-keys`
 - Enhance `php/->` for nested calls
 - Auto-assign-author GH workflow
 - Avoid coercing `nil` to 0 in math operations
-- Add `\Phel` as public entry class instead of `\Phel\Phel` 
+- Add `Phel` as public entry class instead of `\Phel\Phel` 
 - Use `Phel` as proxy for singleton `Registry` and `TypeFactory` methods
 
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -81,7 +81,9 @@ final class NsEmitter implements NodeEmitterInterface
                 $this->outputEmitter->increaseIndentLevel();
                 $this->outputEmitter->emitLine('if (!in_array($__phelNsInfo->getNamespace(), \\Phel::getNamespaces(), true)) {');
                 $this->outputEmitter->increaseIndentLevel();
+                $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::enableBuildMode();');
                 $this->outputEmitter->emitLine('$__phelBuildFacade->evalFile($__phelNsInfo->getFile());');
+                $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::disableBuildMode();');
                 $this->outputEmitter->emitLine('\\Phel\\Compiler\\Infrastructure\\GlobalEnvironmentSingleton::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");');
                 $this->outputEmitter->decreaseIndentLevel();
                 $this->outputEmitter->emitLine('}');

--- a/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
+++ b/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/game.phel
@@ -1,0 +1,6 @@
+(ns example\game)
+
+(def executed-file (str (php/constant "__DIR__") "/executed.txt"))
+
+(when-not *build-mode*
+  (php/file_put_contents executed-file "executed"))

--- a/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/main.phel
+++ b/tests/php/Integration/Run/RequireBuildMode/Fixtures/example/main.phel
@@ -1,0 +1,2 @@
+(ns example\main
+  (:require example\game))

--- a/tests/php/Integration/Run/RequireBuildMode/RequireBuildModeTest.php
+++ b/tests/php/Integration/Run/RequireBuildMode/RequireBuildModeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\RequireBuildMode;
+
+use Gacela\Framework\Gacela;
+use Phel;
+use Phel\Build\BuildFacade;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class RequireBuildModeTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_require_loads_in_build_mode(): void
+    {
+        $fixtures = __DIR__ . '/Fixtures';
+        Gacela::bootstrap(__DIR__);
+
+        Phel::addDefinition('phel\\repl', 'src-dirs', [$fixtures]);
+
+        $executedFile = $fixtures . '/example/executed.txt';
+        if (file_exists($executedFile)) {
+            unlink($executedFile);
+        }
+
+        (new BuildFacade())->evalFile($fixtures . '/example/main.phel');
+
+        self::assertFileDoesNotExist($executedFile);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Fixes: https://github.com/phel-lang/phel-lang/issues/571

When doing a :require the file is loaded without the *build-mode* (formerly known as *compile-mode*), and if that phel file is running any I/O, then that file gets loading first, blocking the execution of the program.

## 💡 Goal

The `(:require namespace)` shouldn't load the code on build-mode on that scope, so we can avoid executing code that shouldn't be execute on the ns scope.

## 🔖 Changes

- Ensures `:require` imports don't run top-level code by setting `*build-mode*` to true while loading the namespace.
- Adds a test confirming that required modules no longer create files or trigger other side effects.