### PR TITLE
Use new list, vector, set and map constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Avoid coercing `nil` to 0 in math operations
 - Add `Phel` as public entry class instead of `\Phel\Phel` 
 - Use `Phel` as proxy for singleton `Registry` and `TypeFactory` methods
+- Use new `list`, `vector`, `set` and `map` constructors from `Phel`
 
 ## [0.19.1](https://github.com/phel-lang/phel-lang/compare/v0.19.0...v0.19.1) - 2025-08-03
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Registry;
 use Phel\Lang\TypeFactory;
 use Phel\Phel as InternalPhel;
@@ -37,6 +41,51 @@ final class Phel extends InternalPhel
         }
 
         throw new BadMethodCallException(sprintf('Method "%s" does not exist', $name));
+    }
+
+    /**
+     * Create a persistent vector from an array of values.
+     *
+     * @param list<mixed> $values
+     */
+    public static function vector(array $values = []): PersistentVectorInterface
+    {
+        return TypeFactory::getInstance()->persistentVectorFromArray($values);
+    }
+
+    /**
+     * Create a persistent list from an array of values.
+     *
+     * @param list<mixed> $values
+     */
+    public static function list(array $values = []): PersistentListInterface
+    {
+        return TypeFactory::getInstance()->persistentListFromArray($values);
+    }
+
+    /**
+     * Create a persistent map from key-value pairs.
+     *
+     * @param list<mixed> $kvs
+     */
+    public static function map(...$kvs): PersistentMapInterface
+    {
+        $typeFactory = TypeFactory::getInstance();
+        if (count($kvs) === 1 && is_array($kvs[0])) {
+            return $typeFactory->persistentMapFromArray($kvs[0]);
+        }
+
+        return $typeFactory->persistentMapFromKVs(...$kvs);
+    }
+
+    /**
+     * Create a persistent hash set from an array of values.
+     *
+     * @param list<mixed> $values
+     */
+    public static function set(array $values = []): PersistentHashSetInterface
+    {
+        return TypeFactory::getInstance()->persistentHashSetFromArray($values);
     }
 
     /**

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -46,17 +46,18 @@
 # Basic methods for quasiquote and destructure
 # --------------------------------------------
 
+
 (def list
   "```phel\n(list & xs)\n```\nCreates a new list. If no argument is provided, an empty list is created."
-  (fn [& xs] (php/:: Phel (persistentListFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Phel (list (apply php/array xs)))))
 
 (def vector
   "```phel\n(vector & xs)\n```\nCreates a new vector. If no argument is provided, an empty vector is created."
-  (fn [& xs] (php/:: Phel (persistentVectorFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Phel (vector (apply php/array xs)))))
 
 (def hash-map
   "```phel\n(hash-map & xs)\n```\nCreates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even."
-  (fn [& xs] (php/:: Phel (persistentMapFromArray (apply php/array xs)))))
+  (fn [& xs] (php/:: Phel (map (apply php/array xs)))))
 
 (def next
   "```phel\n(next xs)\n```\nReturns the sequence of elements after the first element. If there are no elements, returns nil."
@@ -247,7 +248,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 (defn set
   "Creates a new Set. If no argument is provided, an empty Set is created."
   [& xs]
-  (php/:: Phel (persistentHashSetFromArray (apply php/array xs))))
+  (php/:: Phel (set (apply php/array xs))))
 
 (defn keyword
   "Creates a new Keyword from a given string."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -46,7 +46,6 @@
 # Basic methods for quasiquote and destructure
 # --------------------------------------------
 
-
 (def list
   "```phel\n(list & xs)\n```\nCreates a new list. If no argument is provided, an empty list is created."
   (fn [& xs] (php/:: Phel (list (apply php/array xs)))))

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -403,6 +403,6 @@ EOF;
     private function getPhelMeta(string $ns, string $fnName): PersistentMapInterface
     {
         return Phel::getDefinitionMetaData($ns, $fnName)
-            ?? Phel::emptyPersistentMap();
+            ?? Phel::map();
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -87,7 +87,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             return Phel::getDefinitionMetaData(
                 $this->mungeEncodeNs($namespace),
                 $name->getName(),
-            ) ?? Phel::emptyPersistentMap();
+            ) ?? Phel::map();
         }
 
         return null;

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -238,7 +238,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalCompileModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::COMPILE_MODE);
-        $meta = Phel::persistentMapFromKVs(
+        $meta = Phel::map(
             Keyword::create('doc'),
             'Deprecated! Use *build-mode* instead. Set to true when a file is compiled, false otherwise.',
         );
@@ -254,7 +254,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     private function addInternalBuildModeDefinition(): void
     {
         $symbol = Symbol::create(BuildConstants::BUILD_MODE);
-        $meta = Phel::persistentMapFromKVs(
+        $meta = Phel::map(
             Keyword::create('doc'),
             'Set to true when a file is being built/transpiled, false otherwise.',
         );

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -55,7 +55,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         PersistentMapInterface $binding,
         float|bool|int|string|TypeInterface|null $key,
     ): PersistentListInterface {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_PHP_ARRAY_GET))->copyLocationFrom($binding),
             $this->mapSymbol,
             $key,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -103,7 +103,7 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
 
     private function createBindingValue(string $symbolName, mixed $current): PersistentListInterface
     {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create($symbolName))->copyLocationFrom($current),
             $this->currentListSymbol,
         ])->copyLocationFrom($current);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -170,12 +170,12 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
 
         // Analyze arguments and body as (fn arguments (do body))
         $fnNode = $this->analyzer->analyze(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create('fn'),
                 $arguments->rest(), // remove the first argument. The first argument is bound to $this
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('let'),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         $arguments->first(),
                         Symbol::createForNamespace('php', '$this'),
                     ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -164,7 +164,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     private function getInitialMetaAndInit(PersistentListInterface $list): array
     {
         if (count($list) === 3) {
-            return [Phel::emptyPersistentMap(), $list->get(2)];
+            return [Phel::map(), $list->get(2)];
         }
 
         return [$list->get(2), $list->get(3)];

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -115,7 +115,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $startLocation = $list->getStartLocation();
         if ($startLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('start-location'), Phel::persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('start-location'), Phel::map(
                 Keyword::create('file'),
                 $startLocation->getFile(),
                 Keyword::create('line'),
@@ -127,7 +127,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $endLocation = $list->getEndLocation();
         if ($endLocation instanceof SourceLocation) {
-            $meta = $meta->put(Keyword::create('end-location'), Phel::persistentMapFromKVs(
+            $meta = $meta->put(Keyword::create('end-location'), Phel::map(
                 Keyword::create('file'),
                 $endLocation->getFile(),
                 Keyword::create('line'),
@@ -145,12 +145,12 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         if (is_string($meta)) {
             $key = (Keyword::create('doc'))->copyLocationFrom($list);
 
-            return Phel::persistentMapFromKVs($key, $meta)
+            return Phel::map($key, $meta)
                 ->copyLocationFrom($list);
         }
 
         if ($meta instanceof Keyword) {
-            return Phel::persistentMapFromKVs($meta, true)
+            return Phel::map($meta, true)
                 ->copyLocationFrom($meta);
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -72,7 +72,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createDoTupleWithBody(array $body): PersistentListInterface
     {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_DO))->copyLocationFrom($body),
             ...$body,
         ])->copyLocationFrom($body);
@@ -83,9 +83,9 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
      */
     private function createLetTupleWithBody(FnSymbolTuple $fnSymbolTuple, array $listBody): PersistentListInterface
     {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_LET))->copyLocationFrom($listBody),
-            Phel::persistentVectorFromArray($fnSymbolTuple->lets())->copyLocationFrom($listBody),
+            Phel::vector($fnSymbolTuple->lets())->copyLocationFrom($listBody),
             ...$listBody,
         ])->copyLocationFrom($listBody);
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ForeachSymbol.php
@@ -130,14 +130,14 @@ final class ForeachSymbol implements SpecialFormAnalyzerInterface
         $bodys = $list->rest()->rest()->toArray();
 
         if ($lets !== []) {
-            return Phel::persistentListFromArray([
+            return Phel::list([
                 Symbol::create(Symbol::NAME_LET),
-                Phel::persistentVectorFromArray($lets),
+                Phel::vector($lets),
                 ...$bodys,
             ]);
         }
 
-        return Phel::persistentListFromArray([
+        return Phel::list([
             Symbol::create(Symbol::NAME_DO),
             ...$bodys,
         ]);

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -148,7 +148,7 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $this->enrichLocationForAbstractType(
-            Phel::persistentListFromArray($result)->withMeta($list->getMeta()),
+            Phel::list($result)->withMeta($list->getMeta()),
             $parent,
         );
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -53,8 +53,8 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
         }
 
         $newListData = $list->toArray();
-        $newListData[1] = Phel::persistentVectorFromArray($bindingData);
-        $newList = Phel::persistentListFromArray($newListData)
+        $newListData[1] = Phel::vector($bindingData);
+        $newList = Phel::list($newListData)
             ->copyLocationFrom($list)
             ->withMeta($list->getMeta());
 
@@ -84,7 +84,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
 
         $exprs = $list->rest()->rest()->toArray();
         $bodyExpr = $this->analyzer->analyze(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -74,14 +74,14 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         if ($lets !== []) {
             $bodyExpr = $list->rest()->rest()->toArray();
             $letSym = Symbol::create(Symbol::NAME_LET)->copyLocationFrom($list->get(0));
-            $letExpr = Phel::persistentListFromArray([
+            $letExpr = Phel::list([
                 $letSym,
-                Phel::persistentVectorFromArray($lets),
+                Phel::vector($lets),
                 ...$bodyExpr,
             ])->copyLocationFrom($list);
-            $newExpr = Phel::persistentListFromArray([
+            $newExpr = Phel::list([
                 $list->get(0),
-                Phel::persistentVectorFromArray($preInits),
+                Phel::vector($preInits),
                 $letExpr,
             ])->copyLocationFrom($list);
 
@@ -119,7 +119,7 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
         }
 
         $bodyExpr = $this->analyzer->analyze(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_DO),
                 ...$exprs,
             ]),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -121,7 +121,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             $useSymbol = Symbol::createForNamespace($useSymbol->getNamespace(), '\\' . $useSymbol->getName());
         }
 
-        $useData = Phel::persistentMapFromKVs(...$import->toArray());
+        $useData = Phel::map(...$import->toArray());
         $alias = $this->extractAlias($useData, $import, 'use');
         $this->analyzer->addUseAlias($ns, $alias, $useSymbol);
     }
@@ -187,7 +187,7 @@ final class NsSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation('First argument in :require must be a symbol.', $import);
         }
 
-        $requireData = Phel::persistentMapFromKVs(...$import->toArray());
+        $requireData = Phel::map(...$import->toArray());
         $alias = $this->extractAlias($requireData, $import, 'require');
         $referSymbols = $this->extractRefer($requireData, $import);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -66,7 +66,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
 
         if ($finally instanceof PersistentListInterface) {
             /** @psalm-suppress InvalidOperand */
-            $finally = Phel::persistentListFromArray([
+            $finally = Phel::list([
                 Symbol::create(Symbol::NAME_DO),
                 ...$finally->rest(),
             ])->copyLocationFrom($finally);
@@ -104,7 +104,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
             $exprs = [Symbol::create(Symbol::NAME_DO), ...$catch->rest()->rest()->rest()->toArray()];
 
             $catchBody = $this->analyzer->analyze(
-                Phel::persistentListFromArray($exprs),
+                Phel::list($exprs),
                 $env->withContext($catchCtx)
                     ->withMergedLocals([$name])
                     ->withDisallowRecurFrame(),
@@ -120,7 +120,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
         }
 
         $body = $this->analyzer->analyze(
-            Phel::persistentListFromArray([Symbol::create(Symbol::NAME_DO), ...$body]),
+            Phel::list([Symbol::create(Symbol::NAME_DO), ...$body]),
             $env->withContext($catchNodes !== [] || $finally ? $catchCtx : $env->getContext())
                 ->withDisallowRecurFrame(),
         );

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -147,7 +147,7 @@ final readonly class LiteralEmitter
     private function emitList(PersistentListInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel::persistentListFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel::list([', $x->getStartLocation());
 
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
@@ -173,7 +173,7 @@ final readonly class LiteralEmitter
     private function emitVector(PersistentVector $x): void
     {
         $countVector = count($x);
-        $this->outputEmitter->emitStr('\Phel::persistentVectorFromArray([', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel::vector([', $x->getStartLocation());
 
         if ($countVector > 0) {
             $this->outputEmitter->increaseIndentLevel();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -118,7 +118,7 @@ final readonly class LiteralEmitter
     private function emitMap(PersistentMapInterface $x): void
     {
         $count = count($x);
-        $this->outputEmitter->emitStr('\Phel::persistentMapFromKVs(', $x->getStartLocation());
+        $this->outputEmitter->emitStr('\Phel::map(', $x->getStartLocation());
         if ($count > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -23,7 +23,7 @@ final class MapEmitter implements NodeEmitterInterface
         $countKeyValues = count($keyValues);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel::persistentMapFromKVs(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\Phel::map(', $node->getStartSourceLocation());
         if ($countKeyValues > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -76,7 +76,7 @@ final class MethodEmitter
             $varName = $this->munge($p);
 
             $this->outputEmitter->emitLine(
-                '$' . $varName . ' = \Phel::persistentVectorFromArray($' . $varName . ');',
+                '$' . $varName . ' = \Phel::vector($' . $varName . ');',
                 $node->getStartSourceLocation(),
             );
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -19,7 +19,7 @@ final class VectorEmitter implements NodeEmitterInterface
         assert($node instanceof VectorNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel::persistentVectorFromArray([', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('\Phel::vector([', $node->getStartSourceLocation());
         $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
@@ -23,9 +23,9 @@ final readonly class ListFnReader
         $params = $this->extractParams($fnArgs);
         $fnArgs = null;
 
-        return Phel::persistentListFromArray([
+        return Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray($params),
+            Phel::vector($params),
             $body,
         ])->setStartLocation($node->getStartLocation())->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
@@ -28,7 +28,7 @@ final readonly class ListReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return Phel::persistentListFromArray($acc)
+        return Phel::list($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
@@ -25,7 +25,7 @@ final readonly class MapReader
             throw ReaderException::forNode($node, $root, 'Maps must have an even number of parameters');
         }
 
-        return Phel::persistentMapFromKVs(...$list->toArray())
+        return Phel::map(...$list->toArray())
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
@@ -47,7 +47,7 @@ final readonly class MetaReader
             throw ReaderException::forNode($node, $root, 'Metadata can only applied to classes that implement MetaInterface');
         }
 
-        $objMeta = $object->getMeta() ?? Phel::emptyPersistentMap();
+        $objMeta = $object->getMeta() ?? Phel::map();
         foreach ($meta as $k => $v) {
             if ($k) {
                 $objMeta = $objMeta->put($k, $v);

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
@@ -34,9 +34,9 @@ final readonly class MetaReader
 
         $meta = $this->reader->readExpression($metaExpression, $root);
         if (is_string($meta) || $meta instanceof Symbol) {
-            $meta = Phel::persistentMapFromKVs(Keyword::create('tag'), $meta);
+            $meta = Phel::map(Keyword::create('tag'), $meta);
         } elseif ($meta instanceof Keyword) {
-            $meta = Phel::persistentMapFromKVs($meta, true);
+            $meta = Phel::map($meta, true);
         } elseif (!$meta instanceof PersistentMapInterface) {
             throw ReaderException::forNode($node, $root, 'Metadata must be a Symbol, String, Keyword or Map');
         }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
@@ -28,7 +28,7 @@ final readonly class VectorReader
             $acc[] = $this->reader->readExpression($child, $root);
         }
 
-        return Phel::persistentVectorFromArray($acc)
+        return Phel::vector($acc)
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
@@ -21,7 +21,7 @@ final readonly class WrapReader
     {
         $expression = $this->reader->readExpression($node->getExpression(), $root);
 
-        return Phel::persistentListFromArray([Symbol::create($wrapFn), $expression])
+        return Phel::list([Symbol::create($wrapFn), $expression])
             ->setStartLocation($node->getStartLocation())
             ->setEndLocation($node->getEndLocation());
     }

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -85,10 +85,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentList(PersistentList $form): PersistentListInterface
     {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($form),
-            Phel::persistentListFromArray([
+            Phel::list([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -97,10 +97,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 
     private function createFromPersistentVector(PersistentVector $form): PersistentListInterface
     {
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_VECTOR))->copyLocationFrom($form),
-            Phel::persistentListFromArray([
+            Phel::list([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($form),
             ])->copyLocationFrom($form),
@@ -115,10 +115,10 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             $kvs[] = $v;
         }
 
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_APPLY))->copyLocationFrom($form),
             (Symbol::create(Symbol::NAME_MAP))->copyLocationFrom($form),
-            Phel::persistentListFromArray([
+            Phel::list([
                 (Symbol::create(Symbol::NAME_CONCAT))->copyLocationFrom($form),
                 ...$this->expandList($kvs),
             ])->copyLocationFrom($form),
@@ -133,14 +133,14 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
         $xs = [];
         foreach ($seq as $item) {
             if ($this->isUnquote($item)) {
-                $xs[] = Phel::persistentListFromArray([
+                $xs[] = Phel::list([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $item->get(1),
                 ])->copyLocationFrom($item);
             } elseif ($this->isUnquoteSplicing($item)) {
                 $xs[] = $item->get(1);
             } else {
-                $xs[] = Phel::persistentListFromArray([
+                $xs[] = Phel::list([
                     (Symbol::create(Symbol::NAME_LIST))->copyLocationFrom($item),
                     $this->transform($item),
                 ])->copyLocationFrom($item);
@@ -177,7 +177,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             }
         }
 
-        return Phel::persistentListFromArray([
+        return Phel::list([
             (Symbol::create(Symbol::NAME_QUOTE))->copyLocationFrom($form),
             $form,
         ])->copyLocationFrom($form);

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -92,7 +92,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
     {
         /** @var PersistentMapInterface $meta */
         $meta = Phel::getDefinitionMetaData($ns, $fnName)
-            ?? Phel::emptyPersistentList();
+            ?? Phel::list();
 
         return (bool)($meta[Keyword::create('export')] ?? false);
     }

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -49,6 +49,10 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
     public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $values): PersistentListInterface
     {
+        if ($values === []) {
+            return self::empty($hasher, $equalizer);
+        }
+
         $result = self::empty($hasher, $equalizer);
         for ($i = count($values) - 1; $i >= 0; --$i) {
             $result = $result->prepend($values[$i]);

--- a/src/php/Lang/Collections/Map/PersistentHashMap.php
+++ b/src/php/Lang/Collections/Map/PersistentHashMap.php
@@ -46,6 +46,10 @@ final class PersistentHashMap extends AbstractPersistentMap
 
     public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $kvs): PersistentMapInterface
     {
+        if ($kvs === []) {
+            return self::empty($hasher, $equalizer);
+        }
+
         if (count($kvs) % 2 !== 0) {
             throw new RuntimeException('A even number of elements must be provided');
         }

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -13,6 +13,7 @@ use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\TypeFactory;
 use Phel\Printer\Printer;
 use Traversable;
 
@@ -34,8 +35,8 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function __construct()
     {
         parent::__construct(
-            Phel::getHasher(),
-            Phel::getEqualizer(),
+            TypeFactory::getInstance()->getHasher(),
+            TypeFactory::getInstance()->getEqualizer(),
             null,
         );
         $this->munge = new Munge();

--- a/src/php/Lang/Collections/Vector/PersistentVector.php
+++ b/src/php/Lang/Collections/Vector/PersistentVector.php
@@ -65,6 +65,10 @@ final class PersistentVector extends AbstractPersistentVector
         EqualizerInterface $equalizer,
         array $values,
     ): PersistentVectorInterface {
+        if ($values === []) {
+            return self::empty($hasher, $equalizer);
+        }
+
         $tv = TransientVector::empty($hasher, $equalizer);
         foreach ($values as $value) {
             $tv->append($value);

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -76,7 +76,7 @@ final class Registry
             return null;
         }
 
-        return $this->definitionsMetaData[$ns][$name] ?? Phel::emptyPersistentMap();
+        return $this->definitionsMetaData[$ns][$name] ?? Phel::map();
     }
 
     /**

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -34,7 +34,7 @@ final readonly class TestCommandOptions
 
     public function asPhelHashMap(): string
     {
-        $optionsMap = Phel::persistentMapFromKVs(
+        $optionsMap = Phel::map(
             Phel::keyword(self::FILTER),
             $this->filter,
             Phel::keyword(self::TESTDOX),

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -96,25 +96,25 @@ final class ReaderTest extends TestCase
     public function test_read_list(): void
     {
         self::assertEquals(
-            $this->loc(Phel::emptyPersistentList(), 1, 0, 1, 2),
+            $this->loc(Phel::list(), 1, 0, 1, 2),
             $this->read('()'),
         );
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
-                $this->loc(Phel::emptyPersistentList(), 1, 1, 1, 3),
+            $this->loc(Phel::list([
+                $this->loc(Phel::list(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('(())'),
         );
 
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('(a)'),
         );
 
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -125,25 +125,25 @@ final class ReaderTest extends TestCase
     public function test_read_vector(): void
     {
         self::assertEquals(
-            $this->loc(Phel::emptyPersistentVector(), 1, 0, 1, 2),
+            $this->loc(Phel::vector(), 1, 0, 1, 2),
             $this->read('[]'),
         );
         self::assertEquals(
-            $this->loc(Phel::persistentVectorFromArray([
-                $this->loc(Phel::emptyPersistentVector(), 1, 1, 1, 3),
+            $this->loc(Phel::vector([
+                $this->loc(Phel::vector(), 1, 1, 1, 3),
             ]), 1, 0, 1, 4),
             $this->read('[[]]'),
         );
 
         self::assertEquals(
-            $this->loc(Phel::persistentVectorFromArray([
+            $this->loc(Phel::vector([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 3),
             $this->read('[a]'),
         );
 
         self::assertEquals(
-            $this->loc(Phel::persistentVectorFromArray([
+            $this->loc(Phel::vector([
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
                 $this->loc(Symbol::create('b'), 1, 3, 1, 4),
             ]), 1, 0, 1, 5),
@@ -154,7 +154,7 @@ final class ReaderTest extends TestCase
     public function test_quote(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 Symbol::create(Symbol::NAME_QUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -165,7 +165,7 @@ final class ReaderTest extends TestCase
     public function test_unquote(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 Symbol::create(Symbol::NAME_UNQUOTE),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -176,7 +176,7 @@ final class ReaderTest extends TestCase
     public function test_unquote_splice(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                 $this->loc(Symbol::create('a'), 1, 2, 1, 3),
             ]), 1, 0, 1, 3),
@@ -187,7 +187,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote1(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 8),
                 $this->loc(Symbol::create(Symbol::NAME_UNQUOTE), 1, 1, 1, 8),
             ]), 1, 0, 1, 8),
@@ -198,7 +198,7 @@ final class ReaderTest extends TestCase
     public function test_quasiquote2(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentListFromArray([
+            $this->loc(Phel::list([
                 $this->loc(Symbol::create(Symbol::NAME_QUOTE), 1, 1, 1, 2),
                 $this->loc(Symbol::create('a'), 1, 1, 1, 2),
             ]), 1, 0, 1, 2),
@@ -304,7 +304,7 @@ final class ReaderTest extends TestCase
     public function test_read_empty_map(): void
     {
         self::assertEquals(
-            $this->loc(Phel::emptyPersistentMap(), 1, 0, 1, 2),
+            $this->loc(Phel::map(), 1, 0, 1, 2),
             $this->read('{}'),
         );
     }
@@ -467,11 +467,11 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::emptyPersistentVector(),
+                    Phel::vector(),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                         ]),
                         1,
@@ -493,13 +493,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                         ]),
@@ -522,13 +522,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 7),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 8, 1, 9),
@@ -552,14 +552,14 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_2_2'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_2_2'), 1, 9, 1, 11),
@@ -583,13 +583,13 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 9, 1, 11),
@@ -613,15 +613,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('__short_fn_undefined_3'),
                         Symbol::create('__short_fn_3_2'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_3_2'), 1, 9, 1, 11),
@@ -645,15 +645,15 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('__short_fn_1_1'),
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_2'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('add'), 1, 2, 1, 5),
                             $this->loc(Symbol::create('__short_fn_1_1'), 1, 6, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_2'), 1, 9, 1, 11),
@@ -677,14 +677,14 @@ final class ReaderTest extends TestCase
     {
         $this->assertEquals(
             $this->loc(
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_FN),
-                    Phel::persistentVectorFromArray([
+                    Phel::vector([
                         Symbol::create('&'),
                         Symbol::create('__short_fn_rest_1'),
                     ]),
                     $this->loc(
-                        Phel::persistentListFromArray([
+                        Phel::list([
                             $this->loc(Symbol::create('concat'), 1, 2, 1, 8),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 9, 1, 11),
                             $this->loc(Symbol::create('__short_fn_rest_1'), 1, 12, 1, 14),

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -313,7 +313,7 @@ final class ReaderTest extends TestCase
     {
         self::assertEquals(
             $this->loc(
-                Phel::persistentMapFromKVs(
+                Phel::map(
                     $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                     1,
                 ),
@@ -329,7 +329,7 @@ final class ReaderTest extends TestCase
     public function test_map_table2(): void
     {
         self::assertEquals(
-            $this->loc(Phel::persistentMapFromKVs(
+            $this->loc(Phel::map(
                 $this->loc(Keyword::create('a'), 1, 1, 1, 3),
                 1,
                 $this->loc(Keyword::create('b'), 1, 6, 1, 8),
@@ -351,7 +351,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         $this->loc(Keyword::create('test'), 1, 1, 1, 6),
                         true,
                     ),
@@ -371,7 +371,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         Keyword::create('tag'),
                         'test',
                     ),
@@ -391,7 +391,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         Keyword::create('tag'),
                         $this->loc(Symbol::create('String'), 1, 1, 1, 7),
                     ),
@@ -411,7 +411,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         $this->loc(Keyword::create('a'), 1, 2, 1, 4),
                         1,
                         $this->loc(Keyword::create('b'), 1, 7, 1, 9),
@@ -433,7 +433,7 @@ final class ReaderTest extends TestCase
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         $this->loc(Keyword::create('b'), 1, 5, 1, 7),
                         true,
                         $this->loc(Keyword::create('a'), 1, 1, 1, 3),

--- a/tests/php/Integration/Fixtures/Apply/apply-infix.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-infix.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/+ 1 2 [3])
 --PHP--
-array_reduce([1, 2, ...((\Phel::persistentVectorFromArray([3])) ?? [])], function($a, $b) { return ($a + $b); });
+array_reduce([1, 2, ...((\Phel::vector([3])) ?? [])], function($a, $b) { return ($a + $b); });

--- a/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-one-arg.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array [3])
 --PHP--
-array(...((\Phel::persistentVectorFromArray([3])) ?? []));
+array(...((\Phel::vector([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Apply/apply-php.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-php.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/array 1 2 [3])
 --PHP--
-array(1, 2, ...((\Phel::persistentVectorFromArray([3])) ?? []));
+array(1, 2, ...((\Phel::vector([3])) ?? []));

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -13,13 +13,13 @@
       return 1;
     }
   },
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Call/global-call.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Call/global-call.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 18

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -27,4 +27,4 @@
     "min-arity", 2
   )
 );
-(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel::persistentVectorFromArray([1, 2, 3]));
+(\Phel::getDefinition("user", "reduce"))((function(...$args) { return array(...$args);}), \Phel::vector([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -13,13 +13,13 @@
       return ($f)(...(($xs) ?? []));
     }
   },
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Call/php-fn-reference.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Call/php-fn-reference.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 37

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -6,13 +6,13 @@
   "user",
   "arr",
   array(1, 2, 3),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Call/php-push-global-reference.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Call/php-push-global-reference.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 27

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -5,13 +5,13 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/basic-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/basic-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 9

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -37,14 +37,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface-instance-of.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface-instance-of.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 31
@@ -71,14 +71,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface-instance-of.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface-instance-of.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 31

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -35,14 +35,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 31
@@ -69,14 +69,14 @@ interface IPlayer {
 
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/definterface.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 31

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -11,15 +11,15 @@
       return $x;
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("export"), true,
     \Phel::keyword("doc"), "```phel\n(identity x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/defn-meta.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/defn-meta.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 36

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -5,14 +5,14 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/doc-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/doc-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 21

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -14,13 +14,13 @@ require_once __DIR__ . '/../phel/core.php';
   "my\\ns",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/namespace-def.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/namespace-def.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 9

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -5,15 +5,15 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("private"), true,
     \Phel::keyword("export"), true,
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-def-meta.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-def-meta.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 38

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -5,14 +5,14 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 18

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -5,15 +5,15 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("private"), true,
     \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-doc-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Def/private-doc-def.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 42

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -8,13 +8,13 @@
     (1 + 2);
     return (3 + 4);
   })(),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Do/do-in-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Do/do-in-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 36

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel::vector($__phel_1);
     $__phel_2_7 = $__phel_1;
     $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
     $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel::vector($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::persistentVectorFromArray($__phel_1);
+    $__phel_1 = \Phel::vector($__phel_1);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic.test
@@ -5,7 +5,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public const BOUND_TO = "";
 
   public function __invoke(...$xs) {
-    $xs = \Phel::persistentVectorFromArray($xs);
+    $xs = \Phel::vector($xs);
     return 1;
   }
 };

--- a/tests/php/Integration/Fixtures/Fn/issue-443.test
+++ b/tests/php/Integration/Fixtures/Fn/issue-443.test
@@ -4,7 +4,7 @@
       f (fn [matches] matches)])
 --PHP--
 $matches_6 = array();
-$__phel_1_7 = \Phel::persistentVectorFromArray([1, 2]);
+$__phel_1_7 = \Phel::vector([1, 2]);
 $__phel_2_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_7);
 $__phel_3_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_7);
 $a_10 = $__phel_2_8;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -11,7 +11,7 @@
 
     public function __invoke() {
       return (function() {
-        foreach ((\Phel::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+        foreach ((\Phel::vector([1, 2, 3]) ?? []) as $v) {
           ($v + $v);
         }
         return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -18,13 +18,13 @@
       })();
     }
   },
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Foreach/foreach-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Foreach/foreach-expr.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 18

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -10,7 +10,7 @@ new class() extends \Phel\Lang\AbstractFn {
   public function __invoke() {
     $b_1 = 10;
     return (function() use($b_1) {
-      foreach ((\Phel::persistentVectorFromArray([1, 2, 3]) ?? []) as $b) {
+      foreach ((\Phel::vector([1, 2, 3]) ?? []) as $b) {
         (\Phel::getDefinition("phel\\core", "println"))($b);
       }
       return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
@@ -2,6 +2,6 @@
 (foreach [k v [1 2 3]]
   (php/+ k v))
 --PHP--
-foreach ((\Phel::persistentVectorFromArray([1, 2, 3]) ?? []) as $k => $v) {
+foreach ((\Phel::vector([1, 2, 3]) ?? []) as $k => $v) {
   ($k + $v);
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-value.test
@@ -2,6 +2,6 @@
 (foreach [v [1 2 3]]
   (php/+ v v))
 --PHP--
-foreach ((\Phel::persistentVectorFromArray([1, 2, 3]) ?? []) as $v) {
+foreach ((\Phel::vector([1, 2, 3]) ?? []) as $v) {
   ($v + $v);
 }

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -18,13 +18,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "a",
   \Phel::keyword("bar"),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 12
@@ -35,13 +35,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "b",
   \Phel::keyword("bar", "test"),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 4,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 4,
       \Phel::keyword("column"), 13
@@ -52,13 +52,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "c",
   \Phel::keyword("bar", "xyz\\foo"),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 17
@@ -69,13 +69,13 @@ require_once __DIR__ . '/xyz/foo.php';
   "test",
   "d",
   \Phel::keyword("bar", "xyz\\foo"),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 6,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Keyword/keywords.test",
       \Phel::keyword("line"), 6,
       \Phel::keyword("column"), 20

--- a/tests/php/Integration/Fixtures/Let/let-binding.test
+++ b/tests/php/Integration/Fixtures/Let/let-binding.test
@@ -7,35 +7,35 @@
       [h & [i]] [1 2 3 4]]
   (php/+ b c d e f))
 --PHP--
-$a_27 = \Phel::persistentVectorFromArray([1, 2]);
-$__phel_1_28 = \Phel::persistentVectorFromArray([3, 4]);
+$a_27 = \Phel::vector([1, 2]);
+$__phel_1_28 = \Phel::vector([3, 4]);
 $__phel_2_29 = (\Phel::getDefinition("phel\\core", "first"))($__phel_1_28);
 $__phel_3_30 = (\Phel::getDefinition("phel\\core", "next"))($__phel_1_28);
 $b_31 = $__phel_2_29;
 $__phel_4_32 = (\Phel::getDefinition("phel\\core", "first"))($__phel_3_30);
 $__phel_5_33 = (\Phel::getDefinition("phel\\core", "next"))($__phel_3_30);
 $c_34 = $__phel_4_32;
-$__phel_6_35 = \Phel::persistentVectorFromArray([5, 6, 7]);
+$__phel_6_35 = \Phel::vector([5, 6, 7]);
 $__phel_7_36 = (\Phel::getDefinition("phel\\core", "first"))($__phel_6_35);
 $__phel_8_37 = (\Phel::getDefinition("phel\\core", "next"))($__phel_6_35);
 $d_38 = $__phel_7_36;
 $__phel_9_39 = (\Phel::getDefinition("phel\\core", "first"))($__phel_8_37);
 $__phel_10_40 = (\Phel::getDefinition("phel\\core", "next"))($__phel_8_37);
 $e_41 = $__phel_9_39;
-$__phel_11_42 = \Phel::persistentVectorFromArray([8]);
+$__phel_11_42 = \Phel::vector([8]);
 $__phel_12_43 = (\Phel::getDefinition("phel\\core", "first"))($__phel_11_42);
 $__phel_13_44 = (\Phel::getDefinition("phel\\core", "next"))($__phel_11_42);
 $f_45 = $__phel_12_43;
 $__phel_14_46 = (\Phel::getDefinition("phel\\core", "first"))($__phel_13_44);
 $__phel_15_47 = (\Phel::getDefinition("phel\\core", "next"))($__phel_13_44);
 $g_48 = $__phel_14_46;
-$__phel_16_49 = \Phel::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_16_49 = \Phel::vector([1, 2, 3, 4]);
 $__phel_17_50 = (\Phel::getDefinition("phel\\core", "first"))($__phel_16_49);
 $__phel_18_51 = (\Phel::getDefinition("phel\\core", "next"))($__phel_16_49);
 $h_52 = $__phel_17_50;
 $__phel_19_53 = $__phel_18_51;
 $xs_54 = $__phel_19_53;
-$__phel_20_55 = \Phel::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_20_55 = \Phel::vector([1, 2, 3, 4]);
 $__phel_21_56 = (\Phel::getDefinition("phel\\core", "first"))($__phel_20_55);
 $__phel_22_57 = (\Phel::getDefinition("phel\\core", "next"))($__phel_20_55);
 $h_58 = $__phel_21_56;

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -9,13 +9,13 @@
     $y_2 = 2;
     return ($x_1 + $y_2);
   })(),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Let/let-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Let/let-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 35

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -14,7 +14,7 @@ require_once __DIR__ . '/phel/core.php';
   "*ns*",
   "test"
 );
-$__phel_1_2 = \Phel::persistentVectorFromArray([1, 2, 3, 4]);
+$__phel_1_2 = \Phel::vector([1, 2, 3, 4]);
 $sum_3 = 0;
 while (true) {
   $__phel_4_8 = $__phel_1_2;

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -17,14 +17,14 @@
       ]);
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/macro-expand.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/macro-expand.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 38

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -10,7 +10,7 @@
     public const BOUND_TO = "user\\foo";
 
     public function __invoke($n) {
-      return \Phel::persistentListFromArray([
+      return \Phel::list([
         (\Phel\Lang\Symbol::create("php/+")),
         1,
         1

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -13,14 +13,14 @@
       return array(1, 2, array(3, 4));
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/return-array.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/return-array.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 55
@@ -32,13 +32,13 @@
   "user",
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/return-array.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "MacroExpand/return-array.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 13

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -19,14 +19,14 @@ require_once __DIR__ . '/my_namespace/core.php';
   "hello_world",
   "x",
   10,
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 5,
       \Phel::keyword("column"), 19
@@ -61,14 +61,14 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       })();
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 7,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 7,
       \Phel::keyword("column"), 19
@@ -87,14 +87,14 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
       return is_a($x, "hello_world\\abc");
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 7,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Ns/munge-ns.test",
       \Phel::keyword("line"), 7,
       \Phel::keyword("column"), 19

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -6,13 +6,13 @@
   "user",
   "a",
   (new \stdClass()),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "PhpObjectSet/set-class-property.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "PhpObjectSet/set-class-property.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 27

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -6,13 +6,13 @@
   "user",
   "x",
   1,
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "SetVar/set-var.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "SetVar/set-var.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 9

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -14,13 +14,13 @@
       return $e_1;
     }
   },
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Try/throw-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Try/throw-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 56

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -16,13 +16,13 @@
       (3 + 3);
     }
   })(),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Try/try-catch-finally-expr-throw.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Try/try-catch-finally-expr-throw.test",
       \Phel::keyword("line"), 4,
       \Phel::keyword("column"), 27

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -16,13 +16,13 @@
       (3 + 3);
     }
   })(),
-  \Phel::persistentMapFromKVs(
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Try/try-catch-finally-expr.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Try/try-catch-finally-expr.test",
       \Phel::keyword("line"), 4,
       \Phel::keyword("column"), 27

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -18,14 +18,14 @@
       })();
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_generator_array )\n```\n",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Yield/yield-array.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Yield/yield-array.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 26

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -11,7 +11,7 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel::vector([0, 3])) ?? [])) ?? []) as $i) {
           yield $i => 21;
         }
         return null;

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -18,14 +18,14 @@
       })();
     }
   },
-  \Phel::persistentMapFromKVs(
+  \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_generator_str )\n```\n",
-    \Phel::keyword("start-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("start-location"), \Phel::map(
       \Phel::keyword("file"), "Yield/yield-str.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
-    \Phel::keyword("end-location"), \Phel::persistentMapFromKVs(
+    \Phel::keyword("end-location"), \Phel::map(
       \Phel::keyword("file"), "Yield/yield-str.test",
       \Phel::keyword("line"), 3,
       \Phel::keyword("column"), 23

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -11,7 +11,7 @@
 
     public function __invoke() {
       return (function() {
-        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel::persistentVectorFromArray([0, 3])) ?? [])) ?? []) as $i) {
+        foreach (((\Phel::getDefinition("phel\\core", "range"))(...((\Phel::vector([0, 3])) ?? [])) ?? []) as $i) {
           yield $i;
         }
         return null;

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -44,7 +44,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_def(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('increment'),
             'inc',
@@ -54,7 +54,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_ns(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('def-ns'),
         ]);
@@ -63,16 +63,16 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_fn(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
         self::assertInstanceOf(FnNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_quote(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_QUOTE),
              'any text',
         ]);
@@ -81,7 +81,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_do(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DO), 1,
         ]);
         self::assertInstanceOf(DoNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -89,7 +89,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_if(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_IF),
             true,
             true,
@@ -99,25 +99,25 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_apply(): void
     {
-        $list = Phel::persistentListFromArray([
-            Symbol::create(Symbol::NAME_APPLY), '+', Phel::persistentVectorFromArray(['']),
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_APPLY), '+', Phel::vector(['']),
         ]);
         self::assertInstanceOf(ApplyNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_let(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_LET),
-            Phel::persistentVectorFromArray([]),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
+            Phel::vector([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_php_new(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_NEW), '',
         ]);
         self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -125,7 +125,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_call(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -136,7 +136,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_object_static_call(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''),
         ]);
         self::assertInstanceOf(
@@ -147,9 +147,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_get(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
-            Phel::persistentListFromArray([Symbol::create('php/array')]),
+            Phel::list([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -160,9 +160,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_set(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_ARRAY_SET),
-            Phel::persistentListFromArray([Symbol::create('php/array')]),
+            Phel::list([Symbol::create('php/array')]),
             0,
             1,
         ]);
@@ -174,9 +174,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_push(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH),
-            Phel::persistentListFromArray([Symbol::create('php/array')]),
+            Phel::list([Symbol::create('php/array')]),
             1,
         ]);
         self::assertInstanceOf(
@@ -187,9 +187,9 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_php_array_unset(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET),
-            Phel::persistentListFromArray([Symbol::create('php/array')]),
+            Phel::list([Symbol::create('php/array')]),
             0,
         ]);
         self::assertInstanceOf(
@@ -200,7 +200,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_recur(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_RECUR), 1,
         ]);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
@@ -210,7 +210,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_try(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_TRY),
         ]);
         self::assertInstanceOf(TryNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -218,7 +218,7 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_throw(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_THROW), '',
         ]);
         self::assertInstanceOf(ThrowNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
@@ -226,39 +226,39 @@ final class AnalyzePersistentListTest extends TestCase
 
     public function test_symbol_with_name_loop(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_LOOP),
-            Phel::persistentVectorFromArray([]),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
+            Phel::vector([]),
         ]);
         self::assertInstanceOf(LetNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_foreach(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
-                Symbol::create(''), Phel::persistentVectorFromArray([]),
+            Phel::vector([
+                Symbol::create(''), Phel::vector([]),
             ]),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
         self::assertInstanceOf(ForeachNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_struct(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create(''),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
         self::assertInstanceOf(DefStructNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
     public function test_symbol_with_name_def_exception(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -27,7 +27,7 @@ final class AnalyzePersistentMapTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new MapNode($env, [], null),
-            $this->mapAnalyzer->analyze(Phel::emptyPersistentMap(), $env),
+            $this->mapAnalyzer->analyze(Phel::map(), $env),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentMapTest.php
@@ -39,7 +39,7 @@ final class AnalyzePersistentMapTest extends TestCase
                 new LiteralNode($env->withExpressionContext(), 'a', null),
                 new LiteralNode($env->withExpressionContext(), 1, null),
             ], null),
-            $this->mapAnalyzer->analyze(Phel::persistentMapFromKVs('a', 1), $env),
+            $this->mapAnalyzer->analyze(Phel::map('a', 1), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentVectorTest.php
@@ -27,7 +27,7 @@ final class AnalyzePersistentVectorTest extends TestCase
         $env = NodeEnvironment::empty();
         self::assertEquals(
             new VectorNode($env, [], null),
-            $this->vectorAnalzyer->analyze(Phel::emptyPersistentVector(), $env),
+            $this->vectorAnalzyer->analyze(Phel::vector(), $env),
         );
     }
 
@@ -38,7 +38,7 @@ final class AnalyzePersistentVectorTest extends TestCase
             new VectorNode($env, [
                 new LiteralNode($env->withDisallowRecurFrame()->withExpressionContext(), 1, null),
             ], null),
-            $this->vectorAnalzyer->analyze(Phel::persistentVectorFromArray([1]), $env),
+            $this->vectorAnalzyer->analyze(Phel::vector([1]), $env),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -66,7 +66,7 @@ final class AnalyzeSymbolTest extends TestCase
 
         $env = NodeEnvironment::empty();
         self::assertEquals(
-            new GlobalVarNode($env, 'test', Symbol::create('a'), Phel::emptyPersistentMap(), null),
+            new GlobalVarNode($env, 'test', Symbol::create('a'), Phel::map(), null),
             $symbolAnalyzer->analyze(Symbol::create('a'), $env),
         );
     }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -152,7 +152,7 @@ final class GlobalEnvironmentTest extends TestCase
             'foo',
             'x',
             null,
-            Phel::persistentMapFromKVs(Keyword::create('private'), true),
+            Phel::map(Keyword::create('private'), true),
         );
         $env->setNs('bar');
         $env->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
@@ -224,7 +224,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('phel\\core', Symbol::create('x'));
-        Phel::addDefinition('phel\\core', 'x', null, Phel::persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('phel\\core', 'x', null, Phel::map(Keyword::create('private'), true));
         $env->setNs('bar');
         $nodeEnv = NodeEnvironment::empty();
 
@@ -305,7 +305,7 @@ final class GlobalEnvironmentTest extends TestCase
     {
         $env = new GlobalEnvironment();
         $env->addDefinition('bar', Symbol::create('x'));
-        Phel::addDefinition('bar', 'x', null, Phel::persistentMapFromKVs(Keyword::create('private'), true));
+        Phel::addDefinition('bar', 'x', null, Phel::map(Keyword::create('private'), true));
         $env->setNs('foo');
         $nodeEnv = NodeEnvironment::empty();
 

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -36,7 +36,7 @@ final class GlobalEnvironmentTest extends TestCase
     public function test_add_definition(): void
     {
         $env = new GlobalEnvironment();
-        $meta = Phel::emptyPersistentMap();
+        $meta = Phel::map();
         $env->addDefinition('foo', Symbol::create('bar'));
 
         $this->assertTrue($env->hasDefinition('foo', Symbol::create('bar')));
@@ -138,7 +138,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'foo',
                 Symbol::create('x'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -178,7 +178,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -214,7 +214,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'phel\\core',
                 Symbol::create('x'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ),
             $env->resolve(Symbol::create('x'), $nodeEnv),
         );
@@ -275,7 +275,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ),
             $env->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
         );
@@ -295,7 +295,7 @@ final class GlobalEnvironmentTest extends TestCase
                 $nodeEnv,
                 'bar',
                 Symbol::create('x'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ),
             $env->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
         );

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ApplySymbolTest.php
@@ -32,7 +32,7 @@ final class ApplySymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least three arguments are required for 'apply");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::create('\\'),
         ]);
@@ -41,10 +41,10 @@ final class ApplySymbolTest extends TestCase
 
     public function test_apply_node(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::createForNamespace('php', '+'),
-            Phel::persistentVectorFromArray([1, 2, 3]),
+            Phel::vector([1, 2, 3]),
         ]);
         $applyNode = (new ApplySymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/BindingValidatorTest.php
@@ -67,11 +67,11 @@ final class BindingValidatorTest extends TestCase
         ];
 
         yield 'Vector type' => [
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ];
 
         yield 'Map type' => [
-            Phel::emptyPersistentMap(),
+            Phel::map(),
         ];
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -38,7 +38,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Phel::persistentMapFromKVs($key, $bindTo);
+        $binding = Phel::map($key, $bindTo);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -81,7 +81,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Phel::persistentMapFromKVs($key, Phel::persistentVectorFromArray([$bindTo]));
+        $binding = Phel::map($key, Phel::persistentVectorFromArray([$bindTo]));
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -52,7 +52,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -81,7 +81,7 @@ final class MapBindingDeconstructorTest extends TestCase
         $key = Keyword::create('key');
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Phel::map($key, Phel::persistentVectorFromArray([$bindTo]));
+        $binding = Phel::map($key, Phel::vector([$bindTo]));
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -95,7 +95,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel 2 (get __phel_1 :key)
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     $key,
@@ -109,7 +109,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_4 (first __phel_3)
             [
                 Symbol::create('__phel_4'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('first'),
                     Symbol::create('__phel_3'),
                 ]),
@@ -117,7 +117,7 @@ final class MapBindingDeconstructorTest extends TestCase
             // __phel_5 (next __phel_3)
             [
                 Symbol::create('__phel_5'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('next'),
                     Symbol::create('__phel_3'),
                 ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructorTest.php
@@ -39,7 +39,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         // This will be destructured to this:
         // (let [__phel_1 x])
         $value = Symbol::create('x');
-        $binding = Phel::persistentListFromArray([]);
+        $binding = Phel::list([]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -63,7 +63,7 @@ final class VectorBindingDeconstructorTest extends TestCase
 
         $bindTo = Symbol::create('a');
         $value = Symbol::create('x');
-        $binding = Phel::persistentListFromArray([$bindTo]);
+        $binding = Phel::list([$bindTo]);
 
         $bindings = [];
         $this->deconstructor->deconstruct($bindings, $binding, $value);
@@ -75,14 +75,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -110,7 +110,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Phel::persistentVectorFromArray([$bindToA, $bindToB]);
+        $binding = Phel::vector([$bindToA, $bindToB]);
 
         $this->deconstructor->deconstruct($bindings, $binding, $value);
 
@@ -121,14 +121,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -139,14 +139,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
             ],
             [
                 Symbol::create('__phel_5'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_3'),
                 ]),
@@ -172,7 +172,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Phel::persistentVectorFromArray([
+        $binding = Phel::vector([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             $bindToB,
@@ -188,14 +188,14 @@ final class VectorBindingDeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::FIRST_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(self::NEXT_SYMBOL),
                     Symbol::create('__phel_1'),
                 ]),
@@ -220,7 +220,7 @@ final class VectorBindingDeconstructorTest extends TestCase
         $bindToA = Symbol::create('a');
         $bindToB = Symbol::create('b');
         $value = Symbol::create('x');
-        $binding = Phel::persistentVectorFromArray([
+        $binding = Phel::vector([
             $bindToA,
             Symbol::create(self::REST_SYMBOL),
             Symbol::create(self::REST_SYMBOL),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -27,7 +27,7 @@ final class DeconstructorTest extends TestCase
     public function test_empty_vector(): void
     {
         $bindings = $this->deconstructor->deconstruct(
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         );
 
         self::assertSame([], $bindings);
@@ -46,11 +46,11 @@ final class DeconstructorTest extends TestCase
         //       __phel_5 (first __phel_4)
         //       __phel_6 (next __phel_4)
         //       b __phel_5])
-        $list = Phel::persistentVectorFromArray([
-            Phel::persistentVectorFromArray([Symbol::create('a')]),
-            Phel::persistentVectorFromArray([10]),
-            Phel::persistentVectorFromArray([Symbol::create('b')]),
-            Phel::persistentVectorFromArray([20]),
+        $list = Phel::vector([
+            Phel::vector([Symbol::create('a')]),
+            Phel::vector([10]),
+            Phel::vector([Symbol::create('b')]),
+            Phel::vector([20]),
         ]);
 
         $bindings = $this->deconstructor->deconstruct($list);
@@ -58,18 +58,18 @@ final class DeconstructorTest extends TestCase
         self::assertEquals([
             [
                 Symbol::create('__phel_1'),
-                Phel::persistentVectorFromArray([10]),
+                Phel::vector([10]),
             ],
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('first'),
                     Symbol::create('__phel_1'),
                 ]),
             ],
             [
                 Symbol::create('__phel_3'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('next'),
                     Symbol::create('__phel_1'),
                 ]),
@@ -80,18 +80,18 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_4'),
-                Phel::persistentVectorFromArray([20]),
+                Phel::vector([20]),
             ],
             [
                 Symbol::create('__phel_5'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('first'),
                     Symbol::create('__phel_4'),
                 ]),
             ],
             [
                 Symbol::create('__phel_6'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('next'),
                     Symbol::create('__phel_4'),
                 ]),
@@ -111,7 +111,7 @@ final class DeconstructorTest extends TestCase
         //       __phel 2 (get __phel_1 :key)
         //       a __phel_2])
         $bindings = $this->deconstructor->deconstruct(
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Phel::map(Keyword::create('key'), Symbol::create('a')),
                 Symbol::create('x'),
             ]),
@@ -124,7 +124,7 @@ final class DeconstructorTest extends TestCase
             ],
             [
                 Symbol::create('__phel_2'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
                     Symbol::create('__phel_1'),
                     Keyword::create('key'),
@@ -142,7 +142,7 @@ final class DeconstructorTest extends TestCase
         // Test for binding like this (let [nil x])
         // This will be destructured to this:
         // (let [])
-        $bindings = $this->deconstructor->deconstruct(Phel::persistentVectorFromArray([null, Symbol::create('x')]));
+        $bindings = $this->deconstructor->deconstruct(Phel::vector([null, Symbol::create('x')]));
 
         self::assertSame([], $bindings);
     }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/DeconstructorTest.php
@@ -112,7 +112,7 @@ final class DeconstructorTest extends TestCase
         //       a __phel_2])
         $bindings = $this->deconstructor->deconstruct(
             Phel::persistentVectorFromArray([
-                Phel::persistentMapFromKVs(Keyword::create('key'), Symbol::create('a')),
+                Phel::map(Keyword::create('key'), Symbol::create('a')),
                 Symbol::create('x'),
             ]),
         );

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefExceptionSymbolTest.php
@@ -30,7 +30,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exact one argument is required for 'defexception");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('A'),
             Symbol::create('B'),
@@ -45,7 +45,7 @@ final class DefExceptionSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defexception must be a Symbol.");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             'no-symbol',
         ]);
@@ -56,7 +56,7 @@ final class DefExceptionSymbolTest extends TestCase
 
     public function test_def_exception_symbol(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_EXCEPTION),
             Symbol::create('MyExc'),
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -30,7 +30,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'defstruct. Got 1");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
         ]);
 
@@ -43,10 +43,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("First argument of 'defstruct must be a Symbol.");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             '',
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -58,7 +58,7 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'defstruct must be a vector.");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
             '',
@@ -73,10 +73,10 @@ final class DefStructSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage('Defstruct field elements must be Symbols.');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            Phel::persistentVectorFromArray(['method']),
+            Phel::vector(['method']),
         ]);
 
         (new DefStructSymbol($this->analyzer, new Munge()))
@@ -85,10 +85,10 @@ final class DefStructSymbolTest extends TestCase
 
     public function test_def_struct_symbol(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF_STRUCT),
             Symbol::create('request'),
-            Phel::persistentVectorFromArray([Symbol::create('method'), Symbol::create('uri')]),
+            Phel::vector([Symbol::create('method'), Symbol::create('uri')]),
         ]);
 
         $defStructNode = (new DefStructSymbol($this->analyzer, new Munge()))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -204,7 +204,7 @@ final class DefSymbolTest extends TestCase
         $list = Phel::persistentListFromArray([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            Phel::persistentMapFromKVs(Keyword::create('private'), true),
+            Phel::map(Keyword::create('private'), true),
             'any value',
         ]);
         $env = NodeEnvironment::empty();

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -33,10 +33,10 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("'def inside of a 'def is forbidden");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_DEF),
                 Symbol::create('name2'),
                 1,
@@ -50,7 +50,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('1'),
         ]);
@@ -62,7 +62,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             'not a symbol',
             '2',
@@ -75,7 +75,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('$init must be TypeInterface|string|float|int|bool|null');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             new stdClass(),
@@ -85,7 +85,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_init_values(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'any value',
@@ -117,7 +117,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_docstring(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             'my docstring',
@@ -159,7 +159,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_keyword(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             Keyword::create('private'),
@@ -201,7 +201,7 @@ final class DefSymbolTest extends TestCase
 
     public function test_meta_table_keyword(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             Phel::map(Keyword::create('private'), true),
@@ -248,7 +248,7 @@ final class DefSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Metadata must be a String, Keyword or Map');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
             Symbol::create('name'),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -29,7 +29,7 @@ final class DoSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'do.");
 
-        $list = Phel::persistentListFromArray([Symbol::create('unknown')]);
+        $list = Phel::list([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
         (new DoSymbol($this->analyzer))->analyze($list, $env);
     }
@@ -37,7 +37,7 @@ final class DoSymbolTest extends TestCase
     public function test_empty_list(): void
     {
         $env = NodeEnvironment::empty();
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DO),
         ]);
 
@@ -56,7 +56,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DO),
             1,
         ]);
@@ -76,7 +76,7 @@ final class DoSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_DO),
             1,
             2,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -38,7 +38,7 @@ final class FnSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("'fn requires at least one argument");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
         ]);
 
@@ -51,7 +51,7 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage("Second argument of 'fn must be a vector");
 
         // This is the same as: (fn anything)
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
             Symbol::create('anything'),
         ]);
@@ -62,9 +62,9 @@ final class FnSymbolTest extends TestCase
     public function test_is_not_variadic(): void
     {
         // This is the same as: (fn [anything])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('anything'),
             ]),
         ]);
@@ -85,9 +85,9 @@ final class FnSymbolTest extends TestCase
         }
 
         // This is the same as: (fn [paramName])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create($paramName),
             ]),
         ]);
@@ -129,9 +129,9 @@ final class FnSymbolTest extends TestCase
         $this->expectExceptionMessage('Unsupported parameter form, only one symbol can follow the & parameter');
 
         // This is the same as: (fn [& param-1 param-2])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('&'),
                 Symbol::create('param-1'),
                 Symbol::create('param-2'),
@@ -152,9 +152,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetParams(): Generator
     {
         yield '(fn [& param-1])' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_FN),
-                Phel::persistentVectorFromArray([
+                Phel::vector([
                     Symbol::create('&'),
                     Symbol::create('param-1'),
                 ]),
@@ -165,9 +165,9 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield '(fn [param-1 param-2 param-3])' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_FN),
-                Phel::persistentVectorFromArray([
+                Phel::vector([
                     Symbol::create('param-1'),
                     Symbol::create('param-2'),
                     Symbol::create('param-3'),
@@ -192,9 +192,9 @@ final class FnSymbolTest extends TestCase
     public static function providerGetBody(): Generator
     {
         yield 'DoNode body => (fn [x] x)' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_FN),
-                Phel::persistentVectorFromArray([
+                Phel::vector([
                     Symbol::create('x'),
                 ]),
                 Symbol::create('x'),
@@ -203,10 +203,10 @@ final class FnSymbolTest extends TestCase
         ];
 
         yield 'LetNode body => (fn [[x y]] x)' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_FN),
-                Phel::persistentVectorFromArray([
-                    Phel::persistentVectorFromArray([
+                Phel::vector([
+                    Phel::vector([
                         Symbol::create('x'),
                         Symbol::create('y'),
                     ]),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ForeachSymbolTest.php
@@ -28,7 +28,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("At least two arguments are required for 'foreach");
 
         // (foreach)
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
         ]);
 
@@ -41,7 +41,7 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("First argument of 'foreach must be a vector.");
 
         // (foreach x)
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
             Symbol::create('x'),
         ]);
@@ -55,9 +55,9 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('x'),
             ]),
         ]);
@@ -68,11 +68,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_from_vector_with2_args(): void
     {
         // (foreach [x []])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('x'),
-                Phel::persistentVectorFromArray([]),
+                Phel::vector([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -97,11 +97,11 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_two_args(): void
     {
         // (foreach [[x] []])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
-                Phel::persistentVectorFromArray([Symbol::create('x')]),
-                Phel::persistentVectorFromArray([]),
+            Phel::vector([
+                Phel::vector([Symbol::create('x')]),
+                Phel::vector([]),
             ]),
             Symbol::create('x'),
         ]);
@@ -113,12 +113,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_value_symbol_vector_with3_args(): void
     {
         // (foreach [key value {}])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('key'),
                 Symbol::create('value'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ]),
             Symbol::create('key'),
         ]);
@@ -144,12 +144,12 @@ final class ForeachSymbolTest extends TestCase
     public function test_deconstrution_with_three_args(): void
     {
         // (foreach [[key] [value] []])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
-                Phel::persistentVectorFromArray([Symbol::create('key')]),
-                Phel::persistentVectorFromArray([Symbol::create('value')]),
-                Phel::persistentVectorFromArray([]),
+            Phel::vector([
+                Phel::vector([Symbol::create('key')]),
+                Phel::vector([Symbol::create('value')]),
+                Phel::vector([]),
             ]),
             Symbol::create('key'),
         ]);
@@ -164,13 +164,13 @@ final class ForeachSymbolTest extends TestCase
         $this->expectExceptionMessage("Vector of 'foreach must have exactly two or three elements.");
 
         // (foreach [x y z {}])
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FOREACH),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('x'),
                 Symbol::create('y'),
                 Symbol::create('z'),
-                Phel::emptyPersistentMap(),
+                Phel::map(),
             ]),
         ]);
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/IfSymbolTest.php
@@ -31,20 +31,20 @@ final class IfSymbolTest extends TestCase
     public static function providerRequiresAtLeastTwoOrThreeArgs(): Generator
     {
         yield 'No arguments provided: (if)' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_IF),
             ]),
         ];
 
         yield 'Only one argument provided: (if "one")' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
             ]),
         ];
 
         yield 'Only one argument provided: (if "one" "two" "three" "four")' => [
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_IF),
                 'one',
                 'two',
@@ -56,7 +56,7 @@ final class IfSymbolTest extends TestCase
 
     public function test_analyze(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_IF),
             true,
             'then-expression',

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -36,7 +36,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-global-fn',
             static fn ($a, $b): int => $a + $b,
-            Phel::persistentMapFromKVs('min-arity', 2),
+            Phel::map('min-arity', 2),
         );
 
         $env->addDefinition('user', Symbol::create('my-macro'));
@@ -44,7 +44,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-macro',
             static fn ($a) => $a,
-            Phel::persistentMapFromKVs(Keyword::create('macro'), true),
+            Phel::map(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-failed-macro'));
@@ -52,7 +52,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-failed-macro',
             static fn ($a) => throw new Exception('my-failed-macro message'),
-            Phel::persistentMapFromKVs(Keyword::create('macro'), true),
+            Phel::map(Keyword::create('macro'), true),
         );
 
         $env->addDefinition('user', Symbol::create('my-inline-fn'));
@@ -60,7 +60,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn',
             static fn ($a): int => 1,
-            Phel::persistentMapFromKVs(
+            Phel::map(
                 Keyword::create('inline'),
                 static fn ($a): int => 2,
             ),
@@ -71,7 +71,7 @@ final class InvokeSymbolTest extends TestCase
             'user',
             'my-inline-fn-with-arity',
             static fn ($a, $b): int => 1,
-            Phel::persistentMapFromKVs(
+            Phel::map(
                 Keyword::create('inline'),
                 static fn ($a, $b): int => 2,
                 Keyword::create('inline-arity'),
@@ -259,7 +259,7 @@ final class InvokeSymbolTest extends TestCase
                     $env->withExpressionContext()->withDisallowRecurFrame(),
                     'user',
                     Symbol::create('my-inline-fn-with-arity'),
-                    Phel::persistentMapFromKVs(
+                    Phel::map(
                         Keyword::create('inline'),
                         static fn ($a, $b): int => 2,
                         Keyword::create('inline-arity'),
@@ -286,7 +286,7 @@ final class InvokeSymbolTest extends TestCase
             $mungedNs,
             $macroName,
             static fn ($x) => $x,
-            Phel::persistentMapFromKVs(Keyword::create('macro'), true),
+            Phel::map(Keyword::create('macro'), true),
         );
 
         $list = Phel::persistentListFromArray([

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -86,7 +86,7 @@ final class InvokeSymbolTest extends TestCase
     {
         $env = NodeEnvironment::empty();
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
         ]);
@@ -109,7 +109,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_valid_enough_args_provided(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-global-fn'),
             '1arg',
             '2arg',
@@ -122,7 +122,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_without_arguments(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('php', '+'),
         ]);
         $env = NodeEnvironment::empty();
@@ -140,7 +140,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_invoke_with_one_arguments(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('php', '+'),
             1,
         ]);
@@ -161,10 +161,10 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_macro_expand(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-macro'),
-            Phel::persistentVectorFromArray([
-                Phel::persistentVectorFromArray([1]),
+            Phel::vector([
+                Phel::vector([1]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -192,9 +192,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Error in expanding macro "user\\my-failed-macro": my-failed-macro message');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-failed-macro'),
-            Phel::persistentVectorFromArray([1]),
+            Phel::vector([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -205,9 +205,9 @@ final class InvokeSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Cannot resolve symbol 'user/my-undefined-macro'");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-undefined-macro'),
-            Phel::persistentVectorFromArray([1]),
+            Phel::vector([1]),
         ]);
         $env = NodeEnvironment::empty();
         (new InvokeSymbol($this->analyzer))->analyze($list, $env);
@@ -215,7 +215,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-inline-fn'),
             'foo',
         ]);
@@ -230,7 +230,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo', 'bar',
         ]);
@@ -245,7 +245,7 @@ final class InvokeSymbolTest extends TestCase
 
     public function test_inline_expand_with_arity_check_failed(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace('user', 'my-inline-fn-with-arity'),
             'foo',
         ]);
@@ -289,7 +289,7 @@ final class InvokeSymbolTest extends TestCase
             Phel::map(Keyword::create('macro'), true),
         );
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::createForNamespace($ns, $macroName),
             'foo',
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -33,7 +33,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'let.");
 
-        $list = Phel::persistentListFromArray([Symbol::create('unknown')]);
+        $list = Phel::list([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         $analyzer = new LetSymbol($this->analyzer, $this->createMock(DeconstructorInterface::class));
@@ -46,7 +46,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'let");
 
-        $list = Phel::persistentListFromArray([Symbol::create('let')]);
+        $list = Phel::list([Symbol::create('let')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -57,7 +57,7 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = Phel::persistentListFromArray([Symbol::create('let'), 12]);
+        $list = Phel::list([Symbol::create('let'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -68,9 +68,9 @@ final class LetSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('let'),
-            Phel::persistentVectorFromArray([12]),
+            Phel::vector([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -79,9 +79,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_no_bindings(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('let'),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -94,9 +94,9 @@ final class LetSymbolTest extends TestCase
     public function test_with_one_binding(): void
     {
         Symbol::resetGen();
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('let'),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('a'), 1,
             ]),
         ]);
@@ -132,9 +132,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_one_body_expression(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('let'),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
             1,
         ]);
         $env = NodeEnvironment::empty();
@@ -156,9 +156,9 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_two_body_expression(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('let'),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
             1,
             2,
         ]);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LoopSymbolTest.php
@@ -38,7 +38,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'loop.");
 
-        $list = Phel::persistentListFromArray([Symbol::create('unknown')]);
+        $list = Phel::list([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new LoopSymbol($this->analyzer, new BindingValidator()))->analyze($list, $env);
@@ -49,7 +49,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("At least two arguments are required for 'loop.");
 
-        $list = Phel::persistentListFromArray([Symbol::create('loop')]);
+        $list = Phel::list([Symbol::create('loop')]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -60,7 +60,7 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Binding parameter must be a vector');
 
-        $list = Phel::persistentListFromArray([Symbol::create('loop'), 12]);
+        $list = Phel::list([Symbol::create('loop'), 12]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -71,9 +71,9 @@ final class LoopSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage('Bindings must be a even number of parameters');
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('loop'),
-            Phel::persistentVectorFromArray([12]),
+            Phel::vector([12]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -82,9 +82,9 @@ final class LoopSymbolTest extends TestCase
 
     public function test_basic_loop(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('loop'),
-            Phel::persistentVectorFromArray([]),
+            Phel::vector([]),
         ]);
         $env = NodeEnvironment::empty();
 
@@ -106,9 +106,9 @@ final class LoopSymbolTest extends TestCase
     public function test_loop_with_binding(): void
     {
         Symbol::resetGen();
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('loop'),
-            Phel::persistentVectorFromArray([
+            Phel::vector([
                 Symbol::create('a'),
                 1,
             ]),
@@ -150,10 +150,10 @@ final class LoopSymbolTest extends TestCase
     public function test_with_destruction(): void
     {
         Symbol::resetGen();
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create('loop'),
-            Phel::persistentVectorFromArray([
-                Phel::persistentVectorFromArray([Symbol::create('a')]),
+            Phel::vector([
+                Phel::vector([Symbol::create('a')]),
                 1,
             ]),
             1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/PhpObjectCallSymbolTest.php
@@ -32,7 +32,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("At least two arguments are expected for 'php/::");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
         ]);
@@ -46,7 +46,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Argument 2 of 'php/->' must be a List or a Symbol");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             '',
@@ -57,7 +57,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_static(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -71,7 +71,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_is_not_static(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -87,10 +87,10 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_list(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\'),
-            Phel::persistentListFromArray([Symbol::create(''), '', '']),
+            Phel::list([Symbol::create(''), '', '']),
         ]);
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, isStatic: true))
@@ -103,7 +103,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_list2nd_elem_is_symbol(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create(''),
@@ -119,7 +119,7 @@ final class PhpObjectCallSymbolTest extends TestCase
 
     public function test_nested_calls(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
             Symbol::create('\\'),
             Symbol::create('foo'),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/QuoteSymbolTest.php
@@ -18,7 +18,7 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("This is not a 'quote.");
 
-        $list = Phel::persistentListFromArray(['any symbol', 'any text']);
+        $list = Phel::list(['any symbol', 'any text']);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
@@ -27,13 +27,13 @@ final class QuoteSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
 
-        $list = Phel::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE)]);
+        $list = Phel::list([Symbol::create(Symbol::NAME_QUOTE)]);
         (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_quote_list_with_any_text(): void
     {
-        $list = Phel::persistentListFromArray([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
+        $list = Phel::list([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
         $symbol = (new QuoteSymbol())->analyze($list, NodeEnvironment::empty());
 
         self::assertSame('any text', $symbol->getValue());

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/RecurSymbolTest.php
@@ -37,7 +37,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("This is not a 'recur.");
 
-        $list = Phel::persistentListFromArray([Symbol::create('unknown')]);
+        $list = Phel::list([Symbol::create('unknown')]);
         $env = NodeEnvironment::empty();
 
         (new RecurSymbol($this->analyzer))->analyze($list, $env);
@@ -48,7 +48,7 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Can't call 'recur here");
 
-        $list = Phel::persistentListFromArray([Symbol::create(Symbol::NAME_RECUR)]);
+        $list = Phel::list([Symbol::create(Symbol::NAME_RECUR)]);
         $env = NodeEnvironment::empty();
 
         $this->analyzer->analyze($list, $env);
@@ -59,10 +59,10 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 1 args, got: 0");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([Symbol::create('x')]),
-            Phel::persistentListFromArray([
+            Phel::vector([Symbol::create('x')]),
+            Phel::list([
                 Symbol::create(Symbol::NAME_RECUR),
             ]),
         ]);
@@ -76,12 +76,12 @@ final class RecurSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("Wrong number of arguments for 'recur. Expected: 2 args, got: 1");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([Symbol::create('x'), Symbol::create('y')]),
-            Phel::persistentListFromArray([
+            Phel::vector([Symbol::create('x'), Symbol::create('y')]),
+            Phel::list([
                 Symbol::create(Symbol::NAME_RECUR),
-                Phel::persistentVectorFromArray([Symbol::create('x')]),
+                Phel::vector([Symbol::create('x')]),
             ]),
         ]);
         $env = NodeEnvironment::empty();
@@ -91,20 +91,20 @@ final class RecurSymbolTest extends TestCase
 
     public function test_fn_recursion_point(): void
     {
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Phel::persistentVectorFromArray([Symbol::create('x')]),
-            Phel::persistentListFromArray([
+            Phel::vector([Symbol::create('x')]),
+            Phel::list([
                 Symbol::create(Symbol::NAME_IF),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create('php/=='),
                     Symbol::create('x'),
                     0,
                 ]),
                 Symbol::create('x'),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_RECUR),
-                    Phel::persistentListFromArray([
+                    Phel::list([
                         Symbol::create('php/-'),
                         Symbol::create('x'),
                         1,

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/SetVarSymbolTest.php
@@ -29,7 +29,7 @@ final class SetVarSymbolTest extends TestCase
         $this->expectException(AnalyzerException::class);
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_SET_VAR),
             'not-a-symbol',
             1,
@@ -45,7 +45,7 @@ final class SetVarSymbolTest extends TestCase
 
         $analyzer = new Analyzer($globalEnv);
 
-        $list = Phel::persistentListFromArray([
+        $list = Phel::list([
             Symbol::create(Symbol::NAME_SET_VAR),
             Symbol::create('x'),
             2,

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -42,7 +42,7 @@ final class ApplyEmitterTest extends TestCase
         $this->applyEmitter->emit($applyNode);
 
         $this->expectOutputString(
-            'array_reduce([...((\Phel::persistentVectorFromArray([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
+            'array_reduce([...((\Phel::vector([2, 3, 4])) ?? [])], function($a, $b) { return ($a + $b); });',
         );
     }
 
@@ -59,7 +59,7 @@ final class ApplyEmitterTest extends TestCase
         $applyNode = new ApplyNode(NodeEnvironment::empty(), $node, $args);
         $this->applyEmitter->emit($applyNode);
 
-        $this->expectOutputString('str("abc", ...((\Phel::persistentVectorFromArray(["def"])) ?? []));');
+        $this->expectOutputString('str("abc", ...((\Phel::vector(["def"])) ?? []));');
     }
 
     public function test_no_php_var_node(): void
@@ -86,9 +86,9 @@ final class ApplyEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel::persistentVectorFromArray($x);
+    $x = \Phel::vector($x);
     return x;
   }
-};)(...((\Phel::persistentVectorFromArray([1])) ?? []));');
+};)(...((\Phel::vector([1])) ?? []));');
     }
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -117,7 +117,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel::persistentVectorFromArray($x);
+    $x = \Phel::vector($x);
     return $x;
   }
 };');
@@ -164,7 +164,7 @@ final class FnAsClassEmitterTest extends TestCase
   public const BOUND_TO = "";
 
   public function __invoke(...$x) {
-    $x = \Phel::persistentVectorFromArray($x);
+    $x = \Phel::vector($x);
     while (true) {
       return $x;break;
     }

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -125,7 +125,7 @@ final class QuasiquoteTest extends TestCase
                     Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Phel::persistentMapFromKVs('a', 1, 'b', 2)),
+            $q->transform(Phel::map('a', 1, 'b', 2)),
         );
     }
 

--- a/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
+++ b/tests/php/Unit/Compiler/Reader/QuasiquoteTest.php
@@ -19,7 +19,7 @@ final class QuasiquoteTest extends TestCase
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertSame(
             1,
-            $q->transform(Phel::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
+            $q->transform(Phel::list([Symbol::create(Symbol::NAME_UNQUOTE), 1])),
         );
     }
 
@@ -27,23 +27,23 @@ final class QuasiquoteTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
-        $q->transform(Phel::persistentListFromArray([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
+        $q->transform(Phel::list([Symbol::create(Symbol::NAME_UNQUOTE_SPLICING), 1]));
     }
 
     public function test_transform_create_list(): void
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Phel::persistentListFromArray([1, 2])),
+            $q->transform(Phel::list([1, 2])),
         );
     }
 
@@ -51,18 +51,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 1]),
                     2,
                 ]),
             ]),
-            $q->transform(Phel::persistentListFromArray([
+            $q->transform(Phel::list([
                 1,
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_UNQUOTE_SPLICING),
                     2,
                 ]),
@@ -74,18 +74,18 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_LIST),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Phel::persistentListFromArray([
+            $q->transform(Phel::list([
                 1,
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_UNQUOTE),
                     2,
                 ]),
@@ -97,16 +97,16 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_VECTOR),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
-            $q->transform(Phel::persistentVectorFromArray([1, 2])),
+            $q->transform(Phel::vector([1, 2])),
         );
     }
 
@@ -114,15 +114,15 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_APPLY),
                 Symbol::create(Symbol::NAME_MAP),
-                Phel::persistentListFromArray([
+                Phel::list([
                     Symbol::create(Symbol::NAME_CONCAT),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'a']),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 1]),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 'b']),
-                    Phel::persistentListFromArray([Symbol::create(Symbol::NAME_LIST), 2]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 'a']),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 1]),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 'b']),
+                    Phel::list([Symbol::create(Symbol::NAME_LIST), 2]),
                 ]),
             ]),
             $q->transform(Phel::map('a', 1, 'b', 2)),
@@ -185,7 +185,7 @@ final class QuasiquoteTest extends TestCase
     {
         $q = new QuasiquoteTransformer(new GlobalEnvironment());
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::create('test'),
             ]),
@@ -200,7 +200,7 @@ final class QuasiquoteTest extends TestCase
 
         $q = new QuasiquoteTransformer($env);
         self::assertEquals(
-            Phel::persistentListFromArray([
+            Phel::list([
                 Symbol::create(Symbol::NAME_QUOTE),
                 Symbol::createForNamespace('test', 'abc'),
             ]),

--- a/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
@@ -144,7 +144,7 @@ final class EmptyListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Phel::emptyPersistentMap();
+        $meta = Phel::map();
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -179,7 +179,7 @@ final class PersistentListTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Phel::emptyPersistentMap();
+        $meta = Phel::map();
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
         $listWithMeta = $list->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -113,7 +113,7 @@ final class StructTest extends TestCase
 
     public function test_with_meta(): void
     {
-        $meta = Phel::emptyPersistentMap();
+        $meta = Phel::map();
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $sWithMeta = $s->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -241,7 +241,7 @@ final class PersistentVectorTest extends TestCase
 
     public function test_add_meta_data(): void
     {
-        $meta = Phel::emptyPersistentMap();
+        $meta = Phel::map();
         $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
         $vectorWithMeta = $vector->withMeta($meta);
 

--- a/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/RangeIteratorTest.php
@@ -13,7 +13,7 @@ final class RangeIteratorTest extends TestCase
     public function test_range_iterator_with32_elements(): void
     {
         $it = new RangeIterator(
-            Phel::persistentVectorFromArray(range(0, 31)),
+            Phel::vector(range(0, 31)),
             0,
             32,
         );
@@ -27,7 +27,7 @@ final class RangeIteratorTest extends TestCase
         $end = 90;
 
         $it = new RangeIterator(
-            Phel::persistentVectorFromArray(range(0, 100)),
+            Phel::vector(range(0, 100)),
             $start,
             $end,
         );

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -103,7 +103,7 @@ final class KeywordTest extends TestCase
     {
         $keyword1 = Keyword::create('test1');
         $keyword2 = Keyword::create('test2');
-        $table = Phel::persistentMapFromKVs(Keyword::create('test1'), 'abc');
+        $table = Phel::map(Keyword::create('test1'), 'abc');
         $this->assertSame('abc', $keyword1($table));
         $this->assertNull($keyword2($table));
         $this->assertSame('xyz', $keyword2($table, 'xyz'));

--- a/tests/php/Unit/Phel/PhelConstructorsTest.php
+++ b/tests/php/Unit/Phel/PhelConstructorsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Phel;
+
+use Phel;
+use PHPUnit\Framework\TestCase;
+
+final class PhelConstructorsTest extends TestCase
+{
+    public function test_vector(): void
+    {
+        $vector = Phel::vector([1, 2]);
+        self::assertSame([1, 2], $vector->toArray());
+    }
+
+    public function test_list(): void
+    {
+        $list = Phel::list([1, 2]);
+        self::assertSame([1, 2], $list->toArray());
+    }
+
+    public function test_map(): void
+    {
+        $map = Phel::map('a', 1, 'b', 2);
+        self::assertSame(['a' => 1, 'b' => 2], iterator_to_array($map));
+    }
+
+    public function test_map_from_array(): void
+    {
+        $map = Phel::map(['a', 1, 'b', 2]);
+        self::assertSame(['a' => 1, 'b' => 2], iterator_to_array($map));
+    }
+
+    public function test_set(): void
+    {
+        $set = Phel::set([1, 2]);
+        self::assertSame([1, 2], $set->toPhpArray());
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ListPrinterTest.php
@@ -27,12 +27,12 @@ final class ListPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '()',
-            Phel::emptyPersistentList(),
+            Phel::list(),
         ];
 
         yield 'vector with values' => [
             '("a" 1)',
-            Phel::persistentListFromArray(['a', 1]),
+            Phel::list(['a', 1]),
         ];
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VectorPrinterTest.php
@@ -27,12 +27,12 @@ final class VectorPrinterTest extends TestCase
     {
         yield 'empty vector' => [
             '[]',
-            Phel::emptyPersistentVector(),
+            Phel::vector(),
         ];
 
         yield 'vector with values' => [
             '["a" 1]',
-            Phel::persistentVectorFromArray(['a', 1]),
+            Phel::vector(['a', 1]),
         ];
     }
 }


### PR DESCRIPTION
## 🔖 Changes

- Exposed vector, list, map, and set constructors via the `\Phel` facade, replacing direct `TypeFactory` usage for clearer compiled code and a tighter public API

- Updated core library and compiler components to leverage `\Phel::map` and other new helpers for consistent collection creation

- Added unit and integration tests to verify the behavior of the new constructors and adapted fixtures accordingly 