### PR TITLE
Add Clojure-style aliases for assoc and dissoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fix `require` loading code without `*build-mode*`
 - Add `slurp` and `spit` file reading and writing functions
 - Add `select-keys`
+- Add aliases `assoc`, `assoc-in`, `dissoc`, and `dissoc-in`
 - Enhance `php/->` for nested calls
 - Auto-assign-author GH workflow
 - Avoid coercing `nil` to 0 in math operations

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -802,6 +802,11 @@ arrays. Use (php/aset ds key value)"))
       (php/aset ds key value)
       ds)))
 
+(defn assoc
+  "Alias for `put`."
+  [ds key value]
+  (put ds key value))
+
 (defn unset
   "Returns `ds` without `key`."
   [ds key]
@@ -819,6 +824,11 @@ arrays. Use (php/aunset ds key)"))
     (let [x ds]
       (php/aunset x key)
       x)))
+
+(defn dissoc
+  "Alias for `unset`."
+  [ds key]
+  (unset ds key))
 
 # --------
 # Variable
@@ -1037,6 +1047,11 @@ arrays. Use (php/aunset ds key)"))
     (put ds k (put-in (get ds k {}) ks v))
     (put ds k v)))
 
+(defn assoc-in
+  "Alias for `put-in`."
+  [ds ks v]
+  (put-in ds ks v))
+
 (defn update
   "Updates a value in a datastructure by applying `f` to the current element and replacing it with the result of `f`."
   [ds k f & args]
@@ -1059,6 +1074,11 @@ arrays. Use (php/aunset ds key)"))
         ds
         (put ds k (unset-in sub ks))))
     (unset ds k)))
+
+(defn dissoc-in
+  "Alias for `unset-in`."
+  [ds ks]
+  (unset-in ds ks))
 
 (defn drop
   "Drops the first `n` elements of `xs`."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -42,6 +42,11 @@
   (is (= {:a {:b {:c 2}}} (put-in {:a {:b {:c 1}}} [:a :b :c] 2)) "put-in (map): update value of table")
   (is (= {:a {:b [2]}} (put-in {:a {:b [1]}} [:a :b 0] 2)) "put-in (map): update value of array"))
 
+(deftest test-assoc-in
+  (is (= {:a {:b {:c 1}}} (assoc-in {:a {}} [:a :b :c] 1)) "assoc-in: autocreate tables")
+  (is (= {:a {:b {:c 2}}} (assoc-in {:a {:b {:c 1}}} [:a :b :c] 2)) "assoc-in: update value of table")
+  (is (= {:a {:b [2]}} (assoc-in {:a {:b [1]}} [:a :b 0] 2)) "assoc-in: update value of array"))
+
 (deftest test-update-in
   (is (= {:a 2} (update-in {:a 1} [:a] inc)) "update-in: update value of table")
   (is (= {:a {:b {:c 1}}}
@@ -52,6 +57,10 @@
 (deftest test-unset-in
   (is (= {:a {:b {}}} (unset-in {:a {:b {:c 1}}} [:a :b :c])) "unset-in: nested map")
   (is (= {:a {:b {:c 1}}} (unset-in {:a {:b {:c 1}}} [:a :x])) "unset-in: missing key"))
+
+(deftest test-dissoc-in
+  (is (= {:a {:b {}}} (dissoc-in {:a {:b {:c 1}}} [:a :b :c])) "dissoc-in: nested map")
+  (is (= {:a {:b {:c 1}}} (dissoc-in {:a {:b {:c 1}}} [:a :x])) "dissoc-in: missing key"))
 
 (deftest test-drop
   (is (= ["a" "b" "c"] (drop 0 ["a" "b" "c"])) "drop zero elements")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -96,5 +96,12 @@
   (is (= {:a 3 :b 2} (put {:a 1 :b 2} :a 3)) "put: replace entry on map")
   (is (= {:a 1 :b 2 :c 3} (put {:a 1 :b 2} :c 3)) "put: append entry on map"))
 
+(deftest test-assoc
+  (is (= {:a 3 :b 2} (assoc {:a 1 :b 2} :a 3)) "assoc: replace entry on map")
+  (is (= {:a 1 :b 2 :c 3} (assoc {:a 1 :b 2} :c 3)) "assoc: append entry on map"))
+
 (deftest test-unset
   (is (= {:b 2} (unset {:a 1 :b 2} :a)) "unset: remove key from map"))
+
+(deftest test-dissoc
+  (is (= {:b 2} (dissoc {:a 1 :b 2} :a)) "dissoc: remove key from map"))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -32,6 +32,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(324, $groupedFns);
+        self::assertCount(328, $groupedFns);
     }
 }


### PR DESCRIPTION
## 🔖 Changes

- Introduced Clojure-style aliases `assoc`, `assoc-in` for adding entries and `dissoc`, `dissoc-in` for removing entries, enhancing map manipulation ergonomics
- Added tests validating the new aliases and updated integration coverage to reflect the additional core functions