### PR TITLE
Add iterate to core and extend take to handle generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,12 @@ All notable changes to this project will be documented in this file.
     - `butlast`
     - `partition-by`
     - `dedupe`
+    - `iterate`
 - Add new macros:
     - `some->`
     - `some->>`
+- Extend `take` to handle PHP Traversable inputs
+    - enabling safe slicing of generators and other iterables for infinite list scenarios
 - Enhance `php/->` for nested calls
 - Auto-assign-author GH workflow
 - Avoid coercing `nil` to 0 in math operations

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1,5 +1,6 @@
 (ns phel\core
   (:use Countable)
+  (:use Traversable)
   (:use InvalidArgumentException)
   (:use Phel)
   (:use Phel\Compiler\Application\Munge)
@@ -1152,7 +1153,17 @@ arrays. Use (php/aunset ds key)"))
 (defn take
   "Takes the first `n` elements of `xs`."
   [n xs]
-  (slice xs 0 (if (php/< n 0) 0 n)))
+  (let [n (if (php/< n 0) 0 n)]
+    (cond
+      (php-array? xs) (php/array_slice xs 0 n)
+      (php/instanceof xs SliceInterface) (php/-> xs (slice 0 n))
+      (php/instanceof xs Traversable)
+        (let [i (var 0)]
+          (for [x :in xs
+                :while (php/< (deref i) n)
+                :let [_ (swap! i |(php/+ $ 1))]]
+            x))
+      (throw (php/new InvalidArgumentException "Cannot take")))))
 
 (defn take-last
   "Takes the last `n` elements of `xs`."
@@ -1386,6 +1397,13 @@ arrays. Use (php/aunset ds key)"))
   "Returns a vector of length n with values produced by repeatedly calling f."
   [n f]
   (for [i :range [n]] (f)))
+
+(defn iterate
+  "Returns an infinite sequence of `x`, `(f x)`, `(f (f x))`, ..."
+  [f x]
+  (loop [v x]
+    (php/yield v)
+    (recur (f v))))
 
 (defn group-by
   "Returns a map of the elements of xs keyed by the result of

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -1,6 +1,11 @@
 (ns phel-test\test\core\sequence-functions
   (:require phel\test :refer [deftest is]))
 
+(defn naturals []
+  (loop [i 0]
+    (php/yield i)
+    (recur (inc i))))
+
 (deftest test-map
   (is (= [] (map str [])) "map1 with empty collection")
   (is (= ["1" "2"] (map str [1 2])) "map1")
@@ -115,6 +120,12 @@
   (is (= [] (take -1 ["a" "b" "c"])) "take on vector")
   (is (= (php/array "a" "b") (take 2 (php/array "a" "b" "c"))) "take on php array")
   (is (= (php/array) (take -1 (php/array "a" "b" "c"))) "take on php array"))
+
+(deftest test-take-generator
+  (is (= [0 1 2] (take 3 (naturals))) "take on generator"))
+
+(deftest test-iterate
+  (is (= [0 1 2] (take 3 (iterate inc 0))) "iterate infinite sequence"))
 
 (deftest test-take-last
   (is (= ["c"] (take-last 1 ["a" "b" "c"])) "take-last element")

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -32,6 +32,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(346, $groupedFns);
+        self::assertCount(347, $groupedFns);
     }
 }


### PR DESCRIPTION
## 💡 Goal

We want to enable infinite lists generated on run time.

## 🔖 Changes

- Extended `take` to handle PHP Traversable inputs, enabling safe slicing of generators and other iterables for infinite list scenarios
- Introduced an `iterate` function that yields an unbounded sequence by repeatedly applying a function to its previous result
- Added generator-based tests, including a naturals helper, to verify take and iterate with endless streams

## 🧪  Demo

<img width="766" height="291" alt="Screenshot 2025-08-24 at 22 47 13" src="https://github.com/user-attachments/assets/4f9e3bae-6538-422b-a85c-5e00a828b812" />
