### PR TITLE
feat: add Clojure-like `last` alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Add alias `last`
+
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 
 - Fix `map` function exhaustion with empty collections

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -784,6 +784,10 @@ Calling the `and` function without arguments returns true."
   [xs]
   (php/aget xs (php/- (count xs) 1)))
 
+(defn last
+  "Alias for `peek`."
+  [xs]
+  (peek xs))
 
 (defn push
   "Inserts `x` at the end of the sequence `xs`."

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -7,6 +7,12 @@
   (is (= 3 (peek (php/array 1 2 3))) "peek on php array")
   (is (nil? (peek (php/array))) "peek on empty php array"))
 
+(deftest test-last
+  (is (= 3 (last [1 2 3])) "last on vector")
+  (is (nil? (last [])) "last on empty vector")
+  (is (= 3 (last (php/array 1 2 3))) "last on php array")
+  (is (nil? (last (php/array))) "last on empty php array"))
+
 (def- testing-set-global-array (php/array 1 2 3))
 
 (deftest test-native-global-array-set


### PR DESCRIPTION
Inspired by recent Clojure-like aliases added in https://github.com/phel-lang/phel-lang/pull/899.

For some reason, when I incremented the `ApiFacadeTest.php` `self::assertCount(346, $groupedFns);` for this added function, the test failed. So I kept the number as it was.
