### PR TITLE
Fix autoload phel classes from phar

### DIFF
--- a/bin/phel
+++ b/bin/phel
@@ -5,37 +5,49 @@ declare(strict_types=1);
 
 use Phel\Console\Infrastructure\ConsoleBootstrap;
 
+// NOTE: When packaged as a PHAR, the stub requires the PHAR's vendor/autoload.php.
+// Avoid loading any *host* Composer autoloader to prevent conflicts.
 (static function (): void {
-    $appRootDir = (static function (): ?string {
-        $dir = getcwd();
-        while (is_dir($dir)) {
-            $autoload = $dir . '/vendor/autoload.php';
-            if (is_file($autoload)) {
-                require_once $autoload;
-                return $dir;
+    $runningInPhar = \Phar::running() !== '';
+
+    $appRootDir = null;
+
+    if ($runningInPhar) {
+        // We're inside phel.phar. Autoload is already in place (from the stub).
+        // For app root, prefer the current working directory (the user's project).
+        $appRootDir = getcwd() ?: __DIR__;
+    } else {
+        // Source checkout: find and load the host Composer autoloader.
+        $appRootDir = (static function (): ?string {
+            $dir = getcwd();
+            while (is_dir($dir)) {
+                $autoload = $dir . '/vendor/autoload.php';
+                if (is_file($autoload)) {
+                    require_once $autoload;
+                    return $dir;
+                }
+                $parent = dirname($dir);
+                if ($parent === $dir) {
+                    break;
+                }
+                $dir = $parent;
             }
 
-            $parent = dirname($dir);
-            if ($parent === $dir) {
-                break;
+            foreach ([
+                         [__DIR__, '/../vendor/autoload.php'],
+                         [__DIR__, '/../../vendor/autoload.php'],
+                         [__DIR__, '/../../../autoload.php'],
+                     ] as $files) {
+                $file = sprintf('%s%s', ...$files);
+                if (is_file($file)) {
+                    require_once $file;
+                    return $files[0];
+                }
             }
-            $dir = $parent;
-        }
 
-        foreach ([
-            [__DIR__, '/../vendor/autoload.php'],
-            [__DIR__, '/../../vendor/autoload.php'],
-            [__DIR__, '/../../../autoload.php'],
-        ] as $files) {
-            $file = sprintf('%s%s', ...$files);
-            if (is_file($file)) {
-                require_once $file;
-                return $files[0];
-            }
-        }
-
-        return null;
-    })();
+            return null;
+        })();
+    }
 
     if ($appRootDir === null) {
         fwrite(
@@ -44,10 +56,11 @@ use Phel\Console\Infrastructure\ConsoleBootstrap;
             'curl -s https://getcomposer.org/installer | php' . PHP_EOL .
             'php composer.phar install' . PHP_EOL,
         );
-
         exit(1);
     }
 
+    // Phel classes are available either via the PHAR autoloader (in PHAR mode)
+    // or the host Composer autoloader (source mode).
     Phel::bootstrap($appRootDir);
 
     $bootstrap = new ConsoleBootstrap(name: 'Phel', version: 'v0.20.0');

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -46,6 +46,7 @@ $stub = <<<'EOF'
 #!/usr/bin/env php
 <?php
 Phar::mapPhar('phel.phar');
+require_once 'phar://phel.phar/vendor/autoload.php';
 require 'phar://phel.phar/bin/phel';
 __HALT_COMPILER();
 EOF;


### PR DESCRIPTION
## 🤔 Background

Related to https://github.com/phel-lang/phel-lang/issues/902#issuecomment-3221024608 by @jasalt 

When using PHAR with composer, the autoloader is not working properly

```bash
PHP Fatal error:  Uncaught Error: Class "Phel" not found in phar:///Users/chema/Code/Chemaclass/temporal/bin/phel-0200.phar/bin/phel:51
Stack trace:
#0 phar:///Users/chema/Code/Chemaclass/temporal/bin/phel-0200.phar/bin/phel(55): {closure}()
#1 /Users/chema/Code/Chemaclass/temporal/bin/phel-0200.phar(4): require('phar:///Users/c...')
#2 {main}
  thrown in phar:///Users/chema/Code/Chemaclass/temporal/bin/phel-0200.phar/bin/phel on line 51
```

## 💡 Goal

Enable running PHAR with composer in place.

## 🔖 Changes

- Require the `vendor/autoload.php` from the PHAR stub when building the phar

## 🖼️  Demo

### BEFORE

<img width="1239" height="298" alt="Screenshot 2025-08-25 at 20 52 41" src="https://github.com/user-attachments/assets/c2285e95-6b63-4def-8d3d-4e647e868716" />


### AFTER

<img width="574" height="78" alt="Screenshot 2025-08-25 at 20 53 15" src="https://github.com/user-attachments/assets/fdb49d3c-9bf1-4d1b-b8aa-0a75dfb7d045" />
