### PR TITLE
Fix REPL symbol resolution issue loading current dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix autoload phel classes from phar
 - Fix vector and hash map literals in try
+- Fix REPL symbol resolution issue loading current dir
 
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -29,6 +29,7 @@ use Throwable;
 
 use function count;
 use function dirname;
+use function getcwd;
 use function is_string;
 use function sprintf;
 
@@ -139,7 +140,9 @@ final class ReplCommand extends Command
             ->getNamespaceFromFile($this->replStartupFile)
             ->getNamespace();
 
+        $cwd = getcwd();
         $srcDirectories = [
+            ...($cwd !== false ? [$cwd] : []),
             dirname($this->replStartupFile),
             ...$this->getFacade()->getAllPhelDirectories(),
         ];

--- a/tests/php/Integration/Run/Command/Repl/Fixtures/require-current-dir.test
+++ b/tests/php/Integration/Run/Command/Repl/Fixtures/require-current-dir.test
@@ -1,0 +1,5 @@
+phel:1> (ns main (:require util :refer [greeter]))
+1
+phel:2> (println (greeter "Johny"))
+hi, Johny
+nil

--- a/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
@@ -14,6 +14,7 @@ use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
 use Phel\Command\Infrastructure\SourceMapExtractor;
 use Phel\Compiler\Application\Munge;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
 use Phel\Run\Domain\Repl\ColorStyle;
@@ -31,6 +32,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class ReplTestCommand extends AbstractTestCommand
 {
+    private string $previousCwd = '';
+
     public function __construct()
     {
         parent::__construct(self::class);
@@ -39,10 +42,21 @@ final class ReplTestCommand extends AbstractTestCommand
     #[Override]
     protected function setUp(): void
     {
+        $this->previousCwd = getcwd() ?: '';
+        chdir(__DIR__);
+
+        GlobalEnvironmentSingleton::reset();
+
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
             $config->resetInMemoryCache();
             $config->addAppConfig('config/*.php', 'config/local.php');
         });
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        chdir($this->previousCwd);
     }
 
     #[DataProvider('providerIntegration')]

--- a/tests/php/Integration/Run/Command/Repl/util.phel
+++ b/tests/php/Integration/Run/Command/Repl/util.phel
@@ -1,0 +1,4 @@
+(ns util)
+
+(defn greeter [x]
+  (str "hi, " x))


### PR DESCRIPTION
## 🤔 Background

Related https://github.com/phel-lang/phel-lang/issues/902#issuecomment-3221169009 by @jasalt 

## 🔖 Changes

- Updated the REPL to include the current working directory in its search paths so functions defined alongside the REPL session can be resolved correctly

- Added a dedicated test module and fixture verifying that functions in the working directory are found and executed by the REPL