### PR TITLE
Add ; as alternative comment symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix vector and hash map literals in try
 - Fix REPL symbol resolution issue loading current dir
 - Add `#_` macro for inline comments
+- Allow `;` as alternative comment character
 
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -20,7 +20,7 @@ final class Lexer implements LexerInterface
         "([ \t]+)", // Whitespace (index: 2)
         "(\r?\n)", // Newline (index: 3)
         '(#_)', // Inline comment (index: 4)
-        "([#;][^\n]*\n?)", // Comment (index: 5)
+        "([#;][^\n]*\n?)", // Comment (# or ;) (index: 5)
         '(,@)', // unquote-splicing (index: 6)
         "(\()", // open parenthesis (index: 7)
         "(\))", // close parenthesis (index: 8)

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -20,7 +20,7 @@ final class Lexer implements LexerInterface
         "([ \t]+)", // Whitespace (index: 2)
         "(\r?\n)", // Newline (index: 3)
         '(#_)', // Inline comment (index: 4)
-        "(\#[^\n]*\n?)", // Comment (index: 5)
+        "([#;][^\n]*\n?)", // Comment (index: 5)
         '(,@)', // unquote-splicing (index: 6)
         "(\()", // open parenthesis (index: 7)
         "(\))", // close parenthesis (index: 8)

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -483,6 +483,14 @@ final class ParserTest extends TestCase
         );
     }
 
+    public function test_read_semicolon_comment(): void
+    {
+        self::assertEquals(
+            new CommentNode('; Test', $this->loc(1, 0), $this->loc(1, 6)),
+            $this->parse('; Test'),
+        );
+    }
+
     public function test_read_comment_macro(): void
     {
         self::assertEquals(

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -67,6 +67,40 @@ final class LexerTest extends TestCase
         );
     }
 
+    public function test_read_semicolon_comment_without_text(): void
+    {
+        self::assertEquals(
+            [
+                new Token(Token::T_COMMENT, ';', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 1)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 1, 1), new SourceLocation('string', 1, 1)),
+            ],
+            $this->lex(';'),
+        );
+    }
+
+    public function test_read_semicolon_comment_without_new_line(): void
+    {
+        self::assertEquals(
+            [
+                new Token(Token::T_COMMENT, '; Mein Kommentar', new SourceLocation('string', 1, 0), new SourceLocation('string', 1, 16)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 1, 16), new SourceLocation('string', 1, 16)),
+            ],
+            $this->lex('; Mein Kommentar'),
+        );
+    }
+
+    public function test_read_semicolon_comment_with_new_line(): void
+    {
+        self::assertEquals(
+            [
+                new Token(Token::T_COMMENT, "; Mein Kommentar\n", new SourceLocation('string', 1, 0), new SourceLocation('string', 2, 0)),
+                new Token(Token::T_COMMENT, '; Mein andere Kommentar', new SourceLocation('string', 2, 0), new SourceLocation('string', 2, 23)),
+                new Token(Token::T_EOF, '', new SourceLocation('string', 2, 23), new SourceLocation('string', 2, 23)),
+            ],
+            $this->lex("; Mein Kommentar\n; Mein andere Kommentar"),
+        );
+    }
+
     public function test_read_comment_macro(): void
     {
         self::assertEquals(


### PR DESCRIPTION
## 🤔 Background

Most lisps as far as I know use `;` as comment character and Phel using `#` is a slight inconvenience when switching between languages. I thought initially that maybe `;` is avoided cause of it's strong meaning in PHP, but then I'm interested to know what practical implications it would have if it was allowed as a alternative comment character in Phel. 

This PR experiments with adding that as alternative to the current `#` comment character in lexer.
Tests show green which is a good sign.

Thoughts?

With this, following syntax is valid:

```clojure
(ns testing-semicolon)

;; Demo comment
## Alternative to #
(defn hello []
  (print "hello world"))

(hello)  ; Nice
```
Added benefit is also that it works better with Clojure syntax highlighting rules.