### PR TITLE
Add metadata pre/post conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix vector and hash map literals in try
 - Fix REPL symbol resolution issue loading current dir
 - Add `#_` macro for inline comments
+- Add `:pre/:post` function metadata conditions
 
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -208,7 +208,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
     private function replacePercent(mixed $form, Symbol $sym): mixed
     {
         if ($form instanceof Symbol) {
-            if ($form->getName() === '$') {
+            if ($form->getName() === Symbol::NAME_DOLLAR) {
                 return $sym;
             }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -208,7 +208,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
     private function replacePercent(mixed $form, Symbol $sym): mixed
     {
         if ($form instanceof Symbol) {
-            if ($form->getName() === '%') {
+            if ($form->getName() === '$') {
                 return $sym;
             }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -13,9 +13,11 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReadModel\FnSymbolTuple;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
 
+use function array_slice;
 use function count;
 
 final class FnSymbol implements SpecialFormAnalyzerInterface
@@ -55,9 +57,13 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
     {
         $listBody = $fnSymbolTuple->parentListBody();
 
+        [$preConditions, $postConditions, $listBody] = $this->extractPrePostConditions($listBody);
+
         $body = $fnSymbolTuple->lets() === []
             ? $this->createDoTupleWithBody($listBody)
             : $this->createLetTupleWithBody($fnSymbolTuple, $listBody);
+
+        $body = $this->wrapWithPreAndPostConditions($body, $preConditions, $postConditions);
 
         $bodyEnv = $env
             ->withMergedLocals($fnSymbolTuple->params())
@@ -93,5 +99,150 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
     private function buildUsesFromEnv(NodeEnvironmentInterface $env, FnSymbolTuple $fnSymbolTuple): array
     {
         return array_values(array_diff($env->getLocals(), $fnSymbolTuple->params()));
+    }
+
+    /**
+     * @param array<int, mixed> $listBody
+     *
+     * @return array{0: list<mixed>, 1: list<mixed>, 2: array<int, mixed>}
+     */
+    private function extractPrePostConditions(array $listBody): array
+    {
+        $pre = [];
+        $post = [];
+
+        if ($listBody !== [] && $listBody[0] instanceof PersistentMapInterface) {
+            $map = $listBody[0];
+
+            $preVec = $map->find(Phel::keyword('pre'));
+            if ($preVec instanceof PersistentVectorInterface) {
+                foreach ($preVec->getIterator() as $p) {
+                    $pre[] = $p;
+                }
+            }
+
+            $postVec = $map->find(Phel::keyword('post'));
+            if ($postVec instanceof PersistentVectorInterface) {
+                foreach ($postVec->getIterator() as $p) {
+                    $post[] = $p;
+                }
+            }
+
+            $listBody = array_slice($listBody, 1);
+        }
+
+        return [$pre, $post, $listBody];
+    }
+
+    /**
+     * @param list<mixed> $pre
+     * @param list<mixed> $post
+     */
+    private function wrapWithPreAndPostConditions(
+        PersistentListInterface $body,
+        array $pre,
+        array $post,
+    ): PersistentListInterface {
+        if ($pre === [] && $post === []) {
+            return $body;
+        }
+
+        $preForms = [];
+        foreach ($pre as $p) {
+            $preForms[] = $this->createAssertForm($p, $p);
+        }
+
+        if ($post === []) {
+            return Phel::list([
+                Symbol::create(Symbol::NAME_DO)->copyLocationFrom($body),
+                ...$preForms,
+                $body,
+            ])->copyLocationFrom($body);
+        }
+
+        $resultSym = Symbol::gen()->copyLocationFrom($body);
+
+        $postForms = [];
+        foreach ($post as $p) {
+            $postForms[] = $this->createAssertForm(
+                $this->replacePercent($p, $resultSym),
+                $p,
+            );
+        }
+
+        $let = Phel::list([
+            Symbol::create(Symbol::NAME_LET)->copyLocationFrom($body),
+            Phel::vector([$resultSym, $body])->copyLocationFrom($body),
+            ...$postForms,
+            $resultSym,
+        ])->copyLocationFrom($body);
+
+        return Phel::list([
+            Symbol::create(Symbol::NAME_DO)->copyLocationFrom($body),
+            ...$preForms,
+            $let,
+        ])->copyLocationFrom($body);
+    }
+
+    private function createAssertForm(mixed $form, mixed $formForMessage): PersistentListInterface
+    {
+        $message = Phel::list([
+            Symbol::create('php/.'),
+            'Assert failed: ',
+            Phel::list([
+                Symbol::create('print-str'),
+                Phel::list([
+                    Symbol::create('quote'),
+                    $formForMessage,
+                ])->copyLocationFrom($formForMessage),
+            ])->copyLocationFrom($formForMessage),
+        ])->copyLocationFrom($formForMessage);
+
+        return Phel::list([
+            Symbol::create('php/assert')->copyLocationFrom($form),
+            $form,
+            $message,
+        ])->copyLocationFrom($form);
+    }
+
+    private function replacePercent(mixed $form, Symbol $sym): mixed
+    {
+        if ($form instanceof Symbol) {
+            if ($form->getName() === '%') {
+                return $sym;
+            }
+
+            return $form;
+        }
+
+        if ($form instanceof PersistentListInterface) {
+            $items = [];
+            foreach ($form->getIterator() as $item) {
+                $items[] = $this->replacePercent($item, $sym);
+            }
+
+            return Phel::list($items)->copyLocationFrom($form);
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            $items = [];
+            foreach ($form->getIterator() as $item) {
+                $items[] = $this->replacePercent($item, $sym);
+            }
+
+            return Phel::vector($items)->copyLocationFrom($form);
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            $kvs = [];
+            foreach ($form->getIterator() as $k => $v) {
+                $kvs[] = $this->replacePercent($k, $sym);
+                $kvs[] = $this->replacePercent($v, $sym);
+            }
+
+            return Phel::map(...$kvs)->copyLocationFrom($form);
+        }
+
+        return $form;
     }
 }

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -70,6 +70,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
 
     public const string NAME_DEF_EXCEPTION = 'defexception*';
 
+    public const string NAME_DOLLAR = '$';
+
     private static int $symGenCounter = 1;
 
     public function __construct(

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -24,17 +24,17 @@
         "pre condition failure: y is zero")))
 
 (deftest test-post-condition
-  (let [get-username (fn [user] {:post [(not (nil? %))]} (get user :name))]
+  (let [get-username (fn [user] {:post [(not (nil? $))]} (get user :name))]
     (is (= "test" (get-username {:id 1 :name "test"})) "post condition success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (not (nil? %))"
+         \AssertionError "Assert failed: (not (nil? $))"
          (get-username {:id 4 :joined 2000}))
         "post condition failure")))
 
 (deftest test-pre-and-post
   (let [divide (fn [x y]
                  {:pre [(not= y 0)]
-                  :post [(pos? %)]}
+                  :post [(pos? $)]}
                  (/ x y))]
     (is (= 3 (divide 6 2)) "pre and post success")
     (is (thrown-with-msg?
@@ -42,6 +42,6 @@
          (divide 6 0))
         "pre failure in pre and post")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (pos? %)"
+         \AssertionError "Assert failed: (pos? $)"
          (divide 6 -2))
         "post failure in pre and post")))

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -1,0 +1,47 @@
+(ns phel-test\test\core\pre-post-conditions
+  (:require phel\test :refer [deftest is thrown? thrown-with-msg?]))
+
+(deftest test-pre-condition
+  (let [divide (fn [x y] {:pre [(not= y 0)]} (/ x y))]
+    (is (= 3 (divide 6 2)) "pre condition success")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (not= y 0)"
+         (divide 6 0))
+        "pre condition failure")))
+
+(deftest test-pre-condition-multiple
+  (let [divide (fn [x y]
+                 {:pre [(number? x) (number? y) (not= y 0)]}
+                 (/ x y))]
+    (is (= 3 (divide 6 2)) "multiple pre conditions success")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (number? x)"
+         (divide "foo" 2))
+        "pre condition failure: x not number")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (not= y 0)"
+         (divide 6 0))
+        "pre condition failure: y is zero")))
+
+(deftest test-post-condition
+  (let [get-username (fn [user] {:post [(not (nil? %))]} (get user :name))]
+    (is (= "test" (get-username {:id 1 :name "test"})) "post condition success")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (not (nil? %))"
+         (get-username {:id 4 :joined 2000}))
+        "post condition failure")))
+
+(deftest test-pre-and-post
+  (let [divide (fn [x y]
+                 {:pre [(not= y 0)]
+                  :post [(pos? %)]}
+                 (/ x y))]
+    (is (= 3 (divide 6 2)) "pre and post success")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (not= y 0)"
+         (divide 6 0))
+        "pre failure in pre and post")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (pos? %)"
+         (divide 6 -2))
+        "post failure in pre and post")))


### PR DESCRIPTION
## 🤔 Background

Resolves https://github.com/phel-lang/phel-lang/issues/904 

Pre and post conditions are a handy Clojure feature where predicate functions can be set in function metadata which are run before and after function invocations with access to the incoming arguments (in both `:pre` and `:post`) and the outgoing return value (only in `:post`).

## 💡 Goal

If `:pre` or `:post` returns non true, a `\AssertionError` will inform about the failing assert.

## 🔖 Changes

- Add `:pre/:post` function metadata conditions