### PR TITLE
Add map destructuring with keys and as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix REPL symbol resolution issue loading current dir
 - Add `#_` macro for inline comments
 - Add `:pre/:post` function metadata conditions
+- Add map destructuring with `:keys` and `:as`
 
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -15,7 +15,9 @@
 
 (deftest destructure-hash-map
   (is (= 3 (let [{:a a :b b} {:a 1 :b 2}] (+ a b))) "destructure hash map")
-  (is (= 6 (let [{:a [a1 a2] :b b} {:a [1 3] :b 2}] (+ a1 a2 b))) "nested destructure hash map"))
+  (is (= 6 (let [{:a [a1 a2] :b b} {:a [1 3] :b 2}] (+ a1 a2 b))) "nested destructure hash map")
+  (is (= 3 (let [{:keys [a b]} {:a 1 :b 2}] (+ a b))) "destructure hash map with :keys")
+  (is (= {:a 1 :b 2} (let [{:keys [a b] :as user} {:a 1 :b 2}] user)) "destructure hash map with :keys and :as"))
 
 # ----------------------------
 # Basic methods for quasiquote


### PR DESCRIPTION
## 🤔 Background

Resolves https://github.com/phel-lang/phel-lang/issues/905 by @jasalt 

I miss Clojure map destructuring semantics when writing Phel. It allows destructuring map keys with :keys and a vector of names with less repetition, and the reference to original can be kept with :as and a name.

## 🔖 Changes

- Add map destructuring with `:keys` and `:as`

## 🖼️  Demo

#### BEFORE

<img width="615" height="362" alt="Screenshot 2025-08-26 at 22 06 03" src="https://github.com/user-attachments/assets/a75f31cb-8705-48f3-afb0-b02101c6de99" />

### AFTER

<img width="734" height="362" alt="Screenshot 2025-08-26 at 22 03 27" src="https://github.com/user-attachments/assets/ffbcd8ea-2be2-4902-8cd4-2fa4f170ced0" />

