### PR TITLE
Fix destructured names not available in :pre assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix autoload phel classes from phar
 - Fix vector and hash map literals in try
 - Fix REPL symbol resolution issue loading current dir
+- Fix destructured names not available in :pre assert
 - Add `#_` macro for inline comments
 - Allow `;` as alternative comment character
 - Add `:pre/:post` function metadata conditions

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -45,3 +45,13 @@
          \AssertionError "Assert failed: (pos? $)"
          (divide 6 -2))
         "post failure in pre and post")))
+
+(deftest test-pre-condition-with-destructuring
+  (let [request (fn [{:keys [method]}]
+                  {:pre [(= method "GET")]}
+                  method)]
+    (is (= "GET" (request {:method "GET"})) "pre condition with destructuring success")
+    (is (thrown-with-msg?
+         \AssertionError "Assert failed: (= method GET)"
+         (request {:method "POST"}))
+        "pre condition with destructuring failure")))


### PR DESCRIPTION
## 🤔 Background

Fix https://github.com/phel-lang/phel-lang/issues/921

<img width="832" height="375" alt="Screenshot 2025-08-29 at 18 53 10" src="https://github.com/user-attachments/assets/dcd49ecd-9b24-403e-aedb-d7b940b787f3" />


## 🔖 Changes

When the body starts with a `let` form (e.g. due to parameter destructuring) the pre/post conditions must be evaluated inside the `let` body so that destructured names are available in the conditions. Therefore, unwrap the `let`, apply the conditions to the inner body and wrap it again.


## 🖼️  Demo

<img width="829" height="335" alt="Screenshot 2025-08-29 at 18 52 31" src="https://github.com/user-attachments/assets/2e97d13c-c38f-4599-84af-8e1a6575a3db" />

