### PR TITLE
Fix func metadata parsing conflict with literal hashmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix vector and hash map literals in try
 - Fix REPL symbol resolution issue loading current dir
 - Fix destructured names not available in :pre assert
+- Fix func metadata parsing conflict with literal hashmap
 - Add `#_` macro for inline comments
 - Allow `;` as alternative comment character
 - Add `:pre/:post` function metadata conditions

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -111,7 +111,14 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
         $pre = [];
         $post = [];
 
-        if ($listBody !== [] && $listBody[0] instanceof PersistentMapInterface) {
+        if (
+            $listBody !== []
+            && $listBody[0] instanceof PersistentMapInterface
+            && (
+                $listBody[0]->find(Phel::keyword('pre')) instanceof PersistentVectorInterface
+                || $listBody[0]->find(Phel::keyword('post')) instanceof PersistentVectorInterface
+            )
+        ) {
             $map = $listBody[0];
 
             $preVec = $map->find(Phel::keyword('pre'));

--- a/tests/phel/test/core/fn-map-body.phel
+++ b/tests/phel/test/core/fn-map-body.phel
@@ -1,0 +1,6 @@
+(ns phel-test\test\core\fn-map-body
+  (:require phel\test :refer [deftest is]))
+
+(deftest test-fn-map-body
+  (let [xfun (fn [x] {:value x})]
+    (is (= {:value 1} (xfun 1)) "map literal as fn body")))


### PR DESCRIPTION
## 🤔 Background

Fix https://github.com/phel-lang/phel-lang/issues/922

The hashmap literal {:value x} being the function body seems to not get parsed as the function correctly with latest changes incorrectly resulting to nil.

## 💡 Goal

Correct hash-map metadata parsing

## 🖼️  Demo


### BEFORE

<img width="467" height="226" alt="Screenshot 2025-08-29 at 19 06 47" src="https://github.com/user-attachments/assets/3efac54e-d99b-48ce-91e3-5e10d40894a1" />

### AFTER

<img width="524" height="227" alt="Screenshot 2025-08-29 at 19 07 26" src="https://github.com/user-attachments/assets/ed8c8eea-4f54-4a62-ae54-9c6682a3ef11" />
