### PR TITLE
Update default error log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add map destructuring with `:keys` and `:as`
 - Show the current Phel version in the REPL welcome message
 - Append commit hash to the version string when not on a tagged release
+- Update default error log file
 
 ## [0.20.0](https://github.com/phel-lang/phel-lang/compare/v0.19.1...v0.20.0) - 2025-08-25
 

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -19,7 +19,7 @@ final class CommandConfig extends AbstractConfig
 
     private const string DEFAULT_OUTPUT_DIR = 'out';
 
-    private const string DEFAULT_ERROR_LOG_FILE = 'data/error.log';
+    private const string DEFAULT_ERROR_LOG_FILE = 'phel-error.log';
 
     public function getCodeDirs(): CodeDirectories
     {


### PR DESCRIPTION
## 🤔 Background

The deafult error log file was pointing to the data folder, which might end up into an error itself if the execution does not have permissions to create such folder in case it does not exist. Therefore, as default path for the error_log file, it will be in the same place of the execution of phel itself.

## 💡 Goal

Make sure there is no need to create a new folder for the default error_log file for phel.

## 🔖 Changes

- Change the 'data/error.log' to  'phel-error.log' for the `DEFAULT_ERROR_LOG_FILE`