### PR TITLE
Add macro auto-gensym syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Allow `;` as alternative comment character
 - Add `:pre/:post` function metadata conditions
 - Add map destructuring with `:keys` and `:as`
+- Add macro auto-gensym syntax
 - Show the current Phel version in the REPL welcome message
 - Append commit hash to the version string when not on a tagged release
 - Update default error log file

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2233,12 +2233,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 (defmacro time
   "Evaluates expr and prints the time it took. Returns the value of expr."
   [expr]
-  (let [start (gensym)
-        ret (gensym)]
-    `(let [,start (php/microtime true)
-           ,ret ,expr]
-       (println "Elapsed time:" (* 1000 (- (php/microtime true) ,start)) "msecs")
-       ,ret)))
+  `(let [start$ (php/microtime true)
+         ret$ ,expr]
+     (println "Elapsed time:" (* 1000 (- (php/microtime true) start$)) "msecs")
+     ret$))
 
 (defn name
   "Returns the name string of a string, keyword or symbol."

--- a/src/php/Compiler/Domain/Reader/GensymContext.php
+++ b/src/php/Compiler/Domain/Reader/GensymContext.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Reader;
+
+use Phel\Lang\Symbol;
+
+final class GensymContext
+{
+    /** @var array<string, Symbol> */
+    public array $symbols = [];
+}

--- a/src/php/Compiler/Domain/Reader/GensymContext.php
+++ b/src/php/Compiler/Domain/Reader/GensymContext.php
@@ -9,5 +9,10 @@ use Phel\Lang\Symbol;
 final class GensymContext
 {
     /** @var array<string, Symbol> */
-    public array $symbols = [];
+    private array $symbols = [];
+
+    public function getSymbolOrCreate(string $base): Symbol
+    {
+        return $this->symbols[$base] ??= Symbol::gen($base);
+    }
 }

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -188,7 +188,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
             $name = $form->getFullName();
             if (str_ends_with($name, Symbol::NAME_DOLLAR)) {
                 $base = substr($name, 0, -1) . '__';
-                $sym = $context->symbols[$base] ??= Symbol::gen($base);
+                $sym = $context->getSymbolOrCreate($base);
 
                 return Phel::list([
                     (Symbol::create(Symbol::NAME_QUOTE))->copyLocationFrom($form),

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -261,8 +261,22 @@ final class ReaderTest extends TestCase
 
     public function test_quasiquote_auto_gensym(): void
     {
+        $l1 = $this->read('(apply list (concat (list (quote foo__1)) (list (quote bar__2))))', true);
+        $l2 = $this->read('`(foo$ bar$)', true);
+        self::assertTrue($l1->equals($l2));
+    }
+
+    public function test_quasiquote_auto_gensym_cached_value(): void
+    {
         $l1 = $this->read('(apply list (concat (list (quote foo__1)) (list (quote foo__1))))', true);
         $l2 = $this->read('`(foo$ foo$)', true);
+        self::assertTrue($l1->equals($l2));
+    }
+
+    public function test_quasiquote_auto_gensym_mixed_values(): void
+    {
+        $l1 = $this->read('(apply list (concat (list (quote foo__1)) (list (quote bar__2)) (list (quote foo__1))))', true);
+        $l2 = $this->read('`(foo$ bar$ foo$)', true);
         self::assertTrue($l1->equals($l2));
     }
 

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -259,6 +259,13 @@ final class ReaderTest extends TestCase
         self::assertTrue($l1->equals($l2));
     }
 
+    public function test_quasiquote_auto_gensym(): void
+    {
+        $l1 = $this->read('(apply list (concat (list (quote foo__1)) (list (quote foo__1))))', true);
+        $l2 = $this->read('`(foo$ foo$)', true);
+        self::assertTrue($l1->equals($l2));
+    }
+
     public function test_read_string(): void
     {
         self::assertSame(


### PR DESCRIPTION
## 🤔 Background

Resolves https://github.com/phel-lang/phel-lang/issues/919 

In macros, symbols generated with (gensym) often require an extra let form around the quoted forms for binding them to names. 

## 💡 Goal

While either could improve working with generated symbols in macros, to me Clojure's behavior seems slightly more advanced and there would be potentially more code that would be easier to port to Phel with less structural changes. Hash character however might not be applicable as it's used for comments, maybe `$` could do.

#### Clojure example ([source](https://github.com/clojure/clojure/blob/ce55092f2b2f5481d25cff6205470c1335760ef6/src/clj/clojure/core.clj#L3885C1-L3893C12))

```clojure
(defmacro time
  "Evaluates expr and prints the time it took.  Returns the value of
 expr."
  {:added "1.0"}
  [expr]
  `(let [start# (. System (nanoTime))
         ret# ~expr]
     (prn (str "Elapsed time: " (/ (double (- (. System (nanoTime)) start#)) 1000000.0) " msecs"))
     ret#))
```

## 🔖 Changes

- Add auto-gensym support in quasiquoted forms by recognizing symbols with a trailing `$`, ensuring repeated occurrences map to a single generated symbol

- Simplified the time macro by leveraging the new auto-gensym syntax


## 🖼️  Demo

```phel
(defmacro time
  "Evaluates expr and prints the time it took. Returns the value of expr."
  [expr]
  `(let [start$ (php/microtime true)
         ret$ ,expr]
     (println "Elapsed time:" (* 1000 (- (php/microtime true) start$)) "msecs")
     ret$))
```

<img width="616" height="167" alt="Screenshot 2025-08-31 at 17 37 43" src="https://github.com/user-attachments/assets/fdd96021-d684-4616-b0c7-7b4eb5cfe1ea" />
