### PR TITLE
Add multi-arity function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add `:pre/:post` function metadata conditions
 - Add map destructuring with `:keys` and `:as`
 - Add macro auto-gensym syntax
+- Add multi-arity function support
 - Show the current Phel version in the REPL welcome message
 - Append commit hash to the version string when not on a tagged release
 - Update default error log file

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -143,7 +143,9 @@
           fdecl (if (php/instanceof (php/aget fdecl 0) PersistentMapInterface)
                   (next fdecl)
                   fdecl)
-          args (php/aget fdecl 0)
+          args (if (php/instanceof (php/aget fdecl 0) PersistentVectorInterface)
+                   (php/aget fdecl 0)
+                   (php/aget (php/aget fdecl 0) 0))
           docstring (php/aget meta :doc)
           docstring (php/. "```phel\n(" name " " (php/implode " " (apply php/array args)) ")\n```\n" docstring)
           meta (php/-> meta (put :doc docstring))]

--- a/src/php/Compiler/Domain/Analyzer/Ast/MultiFnNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MultiFnNode.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+
+use function array_map;
+use function min;
+
+final class MultiFnNode extends AbstractNode
+{
+    /**
+     * @param list<FnNode> $fnNodes
+     */
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly array $fnNodes,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    /**
+     * @return list<FnNode>
+     */
+    public function getFnNodes(): array
+    {
+        return $this->fnNodes;
+    }
+
+    public function getMinArity(): int
+    {
+        return min(array_map(static fn (FnNode $n): int => $n->getMinArity(), $this->fnNodes));
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -53,9 +53,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         [$metaMap, $init] = $this->createMetaMapAndInit($list);
 
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol);
-        if ($initNode instanceof FnNode) {
-            $metaMap = $metaMap->put('min-arity', $initNode->getMinArity());
-        } elseif ($initNode instanceof MultiFnNode) {
+        if ($initNode instanceof FnNode || $initNode instanceof MultiFnNode) {
             $metaMap = $metaMap->put('min-arity', $initNode->getMinArity());
         }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
@@ -53,6 +54,8 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol);
         if ($initNode instanceof FnNode) {
+            $metaMap = $metaMap->put('min-arity', $initNode->getMinArity());
+        } elseif ($initNode instanceof MultiFnNode) {
             $metaMap = $metaMap->put('min-arity', $initNode->getMinArity());
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -11,7 +11,6 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Symbol;
 
-use function array_merge;
 use function assert;
 use function count;
 
@@ -43,22 +42,18 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
      */
     private function collectUses(array $fnNodes): array
     {
-        $allUses = [];
-        foreach ($fnNodes as $fnNode) {
-            $allUses = array_merge($allUses, $fnNode->getUses());
-        }
+        $byName = [];   // name => first Use instance seen
 
-        $result = [];
-        $names = [];
-        foreach ($allUses as $use) {
-            $name = $use->getName();
-            if (!isset($names[$name])) {
-                $names[$name] = true;
-                $result[] = $use;
+        foreach ($fnNodes as $fnNode) {
+            foreach ($fnNode->getUses() as $use) {
+                $name = $use->getName();
+                if (!isset($byName[$name])) {
+                    $byName[$name] = $use;
+                }
             }
         }
 
-        return $result;
+        return array_values($byName);
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Symbol;
+
+use function array_merge;
+use function assert;
+use function count;
+
+final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
+{
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+    ) {
+    }
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof MultiFnNode);
+
+        $fnNodes = $node->getFnNodes();
+        $uses = $this->collectUses($fnNodes);
+
+        $this->emitClassBegin($node, $uses);
+        $this->emitProperties($node, $uses, count($fnNodes));
+        $this->emitConstructor($node, $uses, $fnNodes);
+        $this->emitInvoke($node, $fnNodes);
+        $this->emitClassEnd($node);
+    }
+
+    /**
+     * @param list<FnNode> $fnNodes
+     *
+     * @return list<Symbol>
+     */
+    private function collectUses(array $fnNodes): array
+    {
+        $allUses = [];
+        foreach ($fnNodes as $fnNode) {
+            $allUses = array_merge($allUses, $fnNode->getUses());
+        }
+
+        $result = [];
+        $names = [];
+        foreach ($allUses as $use) {
+            $name = $use->getName();
+            if (!isset($names[$name])) {
+                $names[$name] = true;
+                $result[] = $use;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<Symbol> $uses
+     */
+    private function emitClassBegin(MultiFnNode $node, array $uses): void
+    {
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('new class(', $node->getStartSourceLocation());
+
+        $usesCount = count($uses);
+        foreach ($uses as $i => $use) {
+            $loc = $use->getStartLocation();
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $this->outputEmitter->emitPhpVariable($normalizedUse, $loc);
+            if ($i < $usesCount - 1) {
+                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            }
+        }
+
+        $this->outputEmitter->emitLine(') extends \\Phel\\Lang\\AbstractFn {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+    }
+
+    /**
+     * @param list<Symbol> $uses
+     */
+    private function emitProperties(MultiFnNode $node, array $uses, int $fnCount): void
+    {
+        $ns = addslashes($this->outputEmitter->mungeEncodeNs($node->getEnv()->getBoundTo()));
+        $this->outputEmitter->emitLine('public const BOUND_TO = "' . $ns . '";', $node->getStartSourceLocation());
+
+        foreach ($uses as $use) {
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $this->outputEmitter->emitLine(
+                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        for ($i = 0; $i < $fnCount; ++$i) {
+            $this->outputEmitter->emitLine('private $fn' . $i . ';', $node->getStartSourceLocation());
+        }
+    }
+
+    /**
+     * @param list<Symbol> $uses
+     * @param list<FnNode> $fnNodes
+     */
+    private function emitConstructor(MultiFnNode $node, array $uses, array $fnNodes): void
+    {
+        $usesCount = count($uses);
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitStr('public function __construct(', $node->getStartSourceLocation());
+        foreach ($uses as $i => $use) {
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $this->outputEmitter->emitPhpVariable($normalizedUse, $node->getStartSourceLocation());
+            if ($i < $usesCount - 1) {
+                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            }
+        }
+
+        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        foreach ($uses as $use) {
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
+            $this->outputEmitter->emitLine(
+                '$this->' . $varName . ' = $' . $varName . ';',
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        foreach ($fnNodes as $i => $fnNode) {
+            $this->outputEmitter->emitStr('$this->fn' . $i . ' = ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($fnNode);
+            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine();
+    }
+
+    /**
+     * @param list<FnNode> $fnNodes
+     */
+    private function emitInvoke(MultiFnNode $node, array $fnNodes): void
+    {
+        $this->outputEmitter->emitLine('public function __invoke(...$args) {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->emitLine('$argc = \count($args);', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('switch ($argc) {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $variadicIndex = null;
+        foreach ($fnNodes as $i => $fnNode) {
+            if ($fnNode->isVariadic()) {
+                $variadicIndex = $i;
+                continue;
+            }
+
+            $arity = count($fnNode->getParams());
+            $this->outputEmitter->emitLine('case ' . $arity . ':', $node->getStartSourceLocation());
+            $this->outputEmitter->increaseIndentLevel();
+            $params = [];
+            for ($p = 0; $p < $arity; ++$p) {
+                $params[] = '$args[' . $p . ']';
+            }
+
+            $this->outputEmitter->emitLine('return ($this->fn' . $i . ')(' . implode(', ', $params) . ');', $node->getStartSourceLocation());
+            $this->outputEmitter->decreaseIndentLevel();
+        }
+
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+
+        if ($variadicIndex !== null) {
+            $min = $fnNodes[$variadicIndex]->getMinArity();
+            $this->outputEmitter->emitLine('if ($argc >= ' . $min . ') {', $node->getStartSourceLocation());
+            $this->outputEmitter->increaseIndentLevel();
+            $this->outputEmitter->emitLine('return ($this->fn' . $variadicIndex . ')(...$args);', $node->getStartSourceLocation());
+            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->emitLine('throw new \\InvalidArgumentException("No matching function arity");', $node->getStartSourceLocation());
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitClassEnd(MultiFnNode $node): void
+    {
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -20,6 +20,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
@@ -54,6 +55,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LiteralEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\LocalVarEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MapEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MethodEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MultiFnAsClassEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\NsEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayGetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpArrayPushEmitter;
@@ -111,6 +113,7 @@ final class NodeEmitterFactory
             MapNode::class => new MapEmitter($outputEmitter),
             SetVarNode::class => new SetVarEmitter($outputEmitter),
             DefInterfaceNode::class => new DefInterfaceEmitter($outputEmitter),
+            MultiFnNode::class => new MultiFnAsClassEmitter($outputEmitter),
             default => throw NotSupportedAstException::withClassName($astNodeClassName),
         };
     }

--- a/tests/phel/test/multi-arity-fn.phel
+++ b/tests/phel/test/multi-arity-fn.phel
@@ -1,0 +1,23 @@
+(ns phel-test\test\multi-arity-fn
+  (:require phel\test :refer [deftest is thrown?]))
+
+(defn- greet
+  ([] "hi")
+  ([name] (str "hi " name))
+  ([greeting name] (str greeting " " name)))
+
+(deftest greet-dispatch
+  (is (= "hi" (greet)) "zero arity")
+  (is (= "hi Ada" (greet "Ada")) "one arity")
+  (is (= "hello Ada" (greet "hello" "Ada")) "two arity")
+  (is (thrown? \InvalidArgumentException (greet "hey" "Ada" "extra")) "invalid arity"))
+
+(defn- f-var-dis
+  ([x] x)
+  ([x y & rest] [x y rest]))
+
+(deftest variadic-dispatch
+  (is (= 1 (f-var-dis 1)) "single arity")
+  (is (= [1 2 []] (f-var-dis 1 2)) "two args no rest")
+  (is (= [1 2 [3 4]] (f-var-dis 1 2 3 4)) "variadic with rest")
+  (is (thrown? \InvalidArgumentException (f-var-dis)) "no matching arity"))


### PR DESCRIPTION
## 🤔 Background

Resolves https://github.com/phel-lang/phel-lang/issues/903

## 💡 Goal

Allow:

```phel
(defn f 
  ([] …) 
  ([x] …) 
  ([x y] …) 
  ([x y & rest] …))
```

with dispatch by **argument count** (and variadic where declared). The most specific matching arity must be chosen; if none matches, throw a readable compile-time or runtime error as appropriate.


## 🔖 Changes

- Adapt `defn-builder`  to support multi-arity arguments
- Adapt `FnSymbol` to support/return `MultiFnNode`
- Create `MultiFnAsClassEmitter`