### PR TITLE
Allow passing cli flags args to phel run scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Add map destructuring with `:keys` and `:as`
 - Add macro auto-gensym syntax
 - Add multi-arity function support
+- Allow passing CLI flag arguments to `phel run` scripts
 - Show the current Phel version in the REPL welcome message
 - Append commit hash to the version string when not on a tagged release
 - Update default error log file

--- a/src/php/Console/Application/ArgvInputSanitizer.php
+++ b/src/php/Console/Application/ArgvInputSanitizer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Application;
+
+use function array_slice;
+use function count;
+use function in_array;
+
+final class ArgvInputSanitizer
+{
+    /** @var list<string> */
+    private const array RUN_OPTIONS = ['-t', '--with-time', '--clear-opcache'];
+
+    /**
+     * Normalizes `phel run` invocations so options/command/args are well-structured.
+     *
+     * Examples:
+     *   phel run -t cmd arg1 arg2 => [script, run, -t, cmd, --, arg1, arg2]
+     *   phel run --with-time      => [script, run, --with-time]
+     *
+     * @param list<string> $argv
+     *
+     * @return list<string>
+     */
+    public function sanitize(array $argv): array
+    {
+        // Nothing to do if this isn't a `run` invocation (or argv too short).
+        if (($argv[1] ?? null) !== 'run') {
+            return $argv;
+        }
+
+        $argc = count($argv);
+        $result = [$argv[0], 'run'];
+
+        // Cursor starts after "run"
+        $i = 2;
+
+        // Collect known run-options
+        while ($i < $argc && in_array($argv[$i], self::RUN_OPTIONS, true)) {
+            $result[] = $argv[$i];
+            ++$i;
+        }
+
+        // The next token (if any) is the command to run
+        if ($i < $argc) {
+            $result[] = $argv[$i];
+            ++$i;
+        }
+
+        // Any remaining tokens are passed through after a "--" separator
+        if ($i < $argc) {
+            $result[] = '--';
+            /** @var list<string> $rest */
+            $rest = array_slice($argv, $i);
+            array_push($result, ...$rest);
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Console/ConsoleFactory.php
+++ b/src/php/Console/ConsoleFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Console;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Console\Application\ArgvInputSanitizer;
 use Phel\Console\Application\VersionFinder;
 use Phel\Console\Infrastructure\ConsoleBootstrap;
 use Phel\Filesystem\FilesystemFacadeInterface;
@@ -37,5 +38,10 @@ final class ConsoleFactory extends AbstractFactory
             $this->getProvidedDependency(ConsoleProvider::TAG_COMMIT_HASH),
             $this->getProvidedDependency(ConsoleProvider::CURRENT_COMMIT),
         );
+    }
+
+    public function createArgvInputSanitizer(): ArgvInputSanitizer
+    {
+        return new ArgvInputSanitizer();
     }
 }

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -9,6 +9,7 @@ use Override;
 use Phel\Console\ConsoleFactory;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -23,6 +24,13 @@ final class ConsoleBootstrap extends Application
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         $this->setAutoExit(false);
+
+        if (!$input instanceof InputInterface) {
+            $input = new ArgvInput($this->getFactory()
+                ->createArgvInputSanitizer()
+                ->sanitize($_SERVER['argv'] ?? []));
+        }
+
         $exitCode = parent::run($input, $output);
         $this->getFactory()->getFilesystemFacade()->clearAll();
 

--- a/tests/php/Integration/Run/Command/Run/Fixtures/argv-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/argv-script.phel
@@ -1,0 +1,3 @@
+(ns test\argv-script)
+
+(php/print (last (php->phel argv)))

--- a/tests/php/Integration/Run/Command/Run/RunTestCommand.php
+++ b/tests/php/Integration/Run/Command/Run/RunTestCommand.php
@@ -74,19 +74,16 @@ final class RunTestCommand extends AbstractTestCommand
 
     public function test_pass_flag_arguments_to_script(): void
     {
-        $tmpFile = __DIR__ . '/Fixtures/argv-script.phel';
-        file_put_contents($tmpFile, '(ns test\\argv-script)\\n(php/print (last (php->phel argv)))');
-
         $this->expectOutputRegex('~--myarg~');
 
-        $sanitized = (new ArgvInputSanitizer())->sanitize(['bin/phel', 'run', $tmpFile, '--myarg']);
+        $sanitized = (new ArgvInputSanitizer())->sanitize([
+            'bin/phel', 'run', __DIR__ . '/Fixtures/argv-script.phel', '--myarg',
+        ]);
 
         (new RunCommand())->run(
             new ArgvInput($sanitized),
             $this->stubOutput(),
         );
-
-        unlink($tmpFile);
     }
 
     private function createRunCommand(): RunCommand

--- a/tests/php/Integration/Run/Command/Run/RunTestCommand.php
+++ b/tests/php/Integration/Run/Command/Run/RunTestCommand.php
@@ -6,8 +6,10 @@ namespace PhelTest\Integration\Run\Command\Run;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use Phel\Console\Application\ArgvInputSanitizer;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 
 final class RunTestCommand extends AbstractTestCommand
@@ -64,6 +66,23 @@ final class RunTestCommand extends AbstractTestCommand
 
         $this->createRunCommand()->run(
             $this->stubInput($tmpFile),
+            $this->stubOutput(),
+        );
+
+        unlink($tmpFile);
+    }
+
+    public function test_pass_flag_arguments_to_script(): void
+    {
+        $tmpFile = __DIR__ . '/Fixtures/argv-script.phel';
+        file_put_contents($tmpFile, '(ns test\\argv-script)\\n(php/print (last (php->phel argv)))');
+
+        $this->expectOutputRegex('~--myarg~');
+
+        $sanitized = (new ArgvInputSanitizer())->sanitize(['bin/phel', 'run', $tmpFile, '--myarg']);
+
+        (new RunCommand())->run(
+            new ArgvInput($sanitized),
             $this->stubOutput(),
         );
 


### PR DESCRIPTION
## 🤔 Background

Fixes https://github.com/phel-lang/phel-lang/issues/933

The PHP side argument parsing for phel command seems to grab all flag arguments like `--example` or `-h` that come after `phel run <script-name>`, this makes it impossible to use them as part of with Phel script command line interface.

<img width="1044" height="214" alt="Screenshot 2025-08-31 at 23 04 51" src="https://github.com/user-attachments/assets/930f979b-e928-46f5-ac0f-cc756689700d" />

## 🔖 Changes

- Enhanced the console bootstrap to sanitize argv, ensuring that when running Phel scripts via phel run, flag-style arguments after the script path are preserved instead of being consumed by the CLI

## 🖼️  Demo

<img width="1049" height="680" alt="Screenshot 2025-08-31 at 23 02 21" src="https://github.com/user-attachments/assets/e78995c5-d762-424b-ba60-c8cd5298f918" />

