### PR TITLE
fix: `find-index` docstring correction

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1221,7 +1221,7 @@ arrays. Use (php/aunset ds key)"))
         (recur (next s))))))
 
 (defn find-index
-  "Returns the first item in `xs` where `(pred index item)` evaluates to true."
+  "Returns the index of the first item in `xs` where `(pred index item)` evaluates to true."
   [pred xs]
   (loop [s xs
          i 0]


### PR DESCRIPTION
It had the same docstring as `find` which was incorrect, not mentioning it returns the index.