### PR TITLE
Add rawDoc to PhelFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Generate relative file paths and GitHub URLs for Phel functions
+- Improve public Api module
 
 ## [0.21.0](https://github.com/phel-lang/phel-lang/compare/v0.20.0...v0.21.0) - 2025-09-01
 

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -46,7 +46,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
             }
 
             $doc = $meta[Keyword::create('doc')] ?? '';
-            preg_match('#(```phel\n(?<fnSignature>.*)\n```\n)?(?<desc>.*)#s', (string) $doc, $matches);
+            preg_match('#(```phel\n(?<signature>.*)\n```\n)?(?<desc>.*)#s', $doc, $matches);
             $groupKey = $this->groupKey($fnName);
 
             $file = '';
@@ -64,7 +64,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
                 $this->extractNamespace($fnName),
                 $this->extractNameWithoutNamespace($fnName),
                 $doc,
-                $matches['fnSignature'] ?? '',
+                $matches['signature'] ?? '',
                 $matches['desc'] ?? '',
                 $groupKey,
                 $githubUrl,
@@ -141,23 +141,21 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
         foreach ($this->phelFnLoader->getNormalizedNativeSymbols() as $name => $meta) {
             $file = $this->toRelativeFile($meta['file'] ?? '');
             $line = $meta['line'] ?? 0;
-            $docUrl = $meta['docUrl'] ?? '';
-            $githubUrl = $this->toGithubUrl($file, $line);
-            $namespace = $this->extractNamespace($name);
-            $shortName = $this->extractNameWithoutNamespace($name);
 
-            $result[] = new PhelFunction(
-                $namespace,
-                $shortName,
+            $phelFunction = new PhelFunction(
+                $this->extractNamespace($name),
+                $this->extractNameWithoutNamespace($name),
                 $meta['doc'] ?? $originalNormalizedFns[$name]->doc(),
-                $meta['fnSignature'] ?? $originalNormalizedFns[$name]->fnSignature(),
+                $meta['signature'] ?? $originalNormalizedFns[$name]->signature(),
                 $meta['desc'] ?? $originalNormalizedFns[$name]->description(),
                 $this->groupKey($name),
-                $githubUrl,
-                $docUrl,
+                $this->toGithubUrl($file, $line),
+                $meta['docUrl'] ?? '',
                 $file,
                 $line,
             );
+
+            $result[] = $phelFunction;
         }
 
         return $result;

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -11,7 +11,6 @@ use Phel\Lang\FnInterface;
 
 use function get_declared_classes;
 use function get_defined_functions;
-use function sprintf;
 use function str_starts_with;
 use function trim;
 
@@ -114,7 +113,9 @@ final class ReplCompleter implements ReplCompleterInterface
                     continue;
                 }
 
-                $qualifiedName = ($namespace === 'phel\\core') ? $name : sprintf('%s\\%s', $namespace, $name);
+                $qualifiedName = $namespace === 'phel\\core'
+                    ? $name
+                    : $namespace . '\\' . $name;
                 if (str_starts_with($qualifiedName, $input)) {
                     $matches[] = $qualifiedName;
                 }

--- a/src/php/Api/Domain/PhelFnLoaderInterface.php
+++ b/src/php/Api/Domain/PhelFnLoaderInterface.php
@@ -18,7 +18,7 @@ interface PhelFnLoaderInterface
     /**
      * @return array<string,array{
      *     doc?: string,
-     *     fnSignature?: string,
+     *     signature?: string,
      *     desc?: string,
      *     docUrl?: string,
      * }>

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -23,7 +23,7 @@ final readonly class PhelFnLoader implements PhelFnLoaderInterface
 *ns*
 ```
 Returns the namespace in the current scope.',
-            'fnSignature' => '*ns*',
+            'signature' => '*ns*',
             'desc' => 'Returns the namespace in the current scope.',
         ],
         Symbol::NAME_APPLY => [
@@ -32,7 +32,7 @@ Returns the namespace in the current scope.',
 ```
 Calls the function with the given arguments. The last argument must be a list of values, which are passed as separate arguments, rather than a single list. Apply returns the result of the calling function.',
             'docUrl' => '/documentation/functions-and-recursion/#apply-functions',
-            'fnSignature' => '(apply f expr*)',
+            'signature' => '(apply f expr*)',
             'desc' => 'Calls the function with the given arguments. The last argument must be a list of values, which are passed as separate arguments, rather than a single list. Apply returns the result of the calling function.',
         ],
 //      Symbol::NAME_CONCAT => [ # this is already in core.phel:97
@@ -42,7 +42,7 @@ Calls the function with the given arguments. The last argument must be a list of
 ```
 This special form binds a value to a global symbol.',
             'docUrl' => '/documentation/global-and-local-bindings/#definition-def',
-            'fnSignature' => '(def name meta? value)',
+            'signature' => '(def name meta? value)',
             'desc' => 'This special form binds a value to a global symbol.',
         ],
         Symbol::NAME_DEF_STRUCT => [
@@ -51,7 +51,7 @@ This special form binds a value to a global symbol.',
 ```
 A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function.',
             'docUrl' => '/documentation/data-structures/#structs',
-            'fnSignature' => '(defstruct my-struct [a b c])',
+            'signature' => '(defstruct my-struct [a b c])',
             'desc' => 'A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function.',
         ],
         Symbol::NAME_DEF_EXCEPTION => [
@@ -59,7 +59,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
 (defexception my-ex)
 ```',
             'docUrl' => '/documentation/exceptions',
-            'fnSignature' => '(defexception name)',
+            'signature' => '(defexception name)',
             'desc' => 'Defines a new exception.',
         ],
         Symbol::NAME_DO => [
@@ -68,7 +68,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
 ```
 Evaluates the expressions in order and returns the value of the last expression. If no expression is given, nil is returned.',
             'docUrl' => '/documentation/control-flow/#statements-do',
-            'fnSignature' => '(do expr*)',
+            'signature' => '(do expr*)',
             'desc' => 'Evaluates the expressions in order and returns the value of the last expression. If no expression is given, nil is returned.',
         ],
         Symbol::NAME_FN => [
@@ -77,7 +77,7 @@ Evaluates the expressions in order and returns the value of the last expression.
 ```
 Defines a function. A function consists of a list of parameters and a list of expression. The value of the last expression is returned as the result of the function. All other expression are only evaluated for side effects. If no expression is given, the function returns nil.',
             'docUrl' => '/documentation/functions-and-recursion/#anonymous-function-fn',
-            'fnSignature' => '(fn [params*] expr*)',
+            'signature' => '(fn [params*] expr*)',
             'desc' => 'Defines a function. A function consists of a list of parameters and a list of expression. The value of the last expression is returned as the result of the function. All other expression are only evaluated for side effects. If no expression is given, the function returns nil.',
         ],
         'for' => [
@@ -89,7 +89,7 @@ Defines a function. A function consists of a list of parameters and a list of ex
 (foreach [key value valueExpr] expr*)
 ```
 The foreach special form can be used to iterate over all kind of PHP datastructures. The return value of foreach is always nil. The loop special form should be preferred of the foreach special form whenever possible.',
-            'fnSignature' => '(foreach [key value valueExpr] expr*)',
+            'signature' => '(foreach [key value valueExpr] expr*)',
             'desc' => 'The foreach special form can be used to iterate over all kind of PHP datastructures. The return value of foreach is always nil. The loop special form should be preferred of the foreach special form whenever possible.',
             'docUrl' => '/documentation/control-flow/#foreach',
         ],
@@ -101,7 +101,7 @@ A control flow structure. First evaluates test. If test evaluates to true, only 
 
 The test evaluates to false if its value is false or equal to nil. Every other value evaluates to true. In sense of PHP this means (test != null && test !== false).',
             'docUrl' => '/documentation/control-flow/#if',
-            'fnSignature' => '(if test then else?)',
+            'signature' => '(if test then else?)',
             'desc' => 'A control flow structure. First evaluates test. If test evaluates to true, only the then form is evaluated and the result is returned. If test evaluates to false only the else form is evaluated and the result is returned. If no else form is given, nil will be returned.',
         ],
         Symbol::NAME_LET => [
@@ -110,7 +110,7 @@ The test evaluates to false if its value is false or equal to nil. Every other v
 ```
 Creates a new lexical context with assignments defined in bindings. Afterwards the list of expressions is evaluated and the value of the last expression is returned. If no expression is given nil is returned.',
             'docUrl' => '/documentation/global-and-local-bindings/#local-bindings-let',
-            'fnSignature' => '(let [bindings*] expr*)',
+            'signature' => '(let [bindings*] expr*)',
             'desc' => 'Creates a new lexical context with assignments defined in bindings. Afterwards the list of expressions is evaluated and the value of the last expression is returned. If no expression is given nil is returned.',
         ],
         Symbol::NAME_LOOP => [
@@ -118,7 +118,7 @@ Creates a new lexical context with assignments defined in bindings. Afterwards t
 (loop [bindings*] expr*)
 ```
 Creates a new lexical context with variables defined in bindings and defines a recursion point at the top of the loop.',
-            'fnSignature' => '(loop [bindings*] expr*)',
+            'signature' => '(loop [bindings*] expr*)',
             'desc' => 'Creates a new lexical context with variables defined in bindings and defines a recursion point at the top of the loop.',
         ],
         Symbol::NAME_NS => [
@@ -127,7 +127,7 @@ Creates a new lexical context with variables defined in bindings and defines a r
 ```
 Defines the namespace for the current file and adds imports to the environment. Imports can either be uses or requires. The keyword `:use` is used to import PHP classes, the keyword `:require` is used to import Phel modules and the keyword `:require-file` is used to load php files.',
             'docUrl' => '/documentation/namespaces/#namespace-ns',
-            'fnSignature' => '(ns name imports*)',
+            'signature' => '(ns name imports*)',
             'desc' => 'Defines the namespace for the current file and adds imports to the environment. Imports can either be uses or requires. The keyword :use is used to import PHP classes, the keyword :require is used to import Phel modules and the keyword :require-file is used to load php files.',
         ],
         Symbol::NAME_PHP_ARRAY_GET => [
@@ -136,7 +136,7 @@ Defines the namespace for the current file and adds imports to the environment. 
 ```
 Equivalent to PHP\'s `arr[index] ?? null`.',
             'docUrl' => '/documentation/php-interop/#get-php-array-value',
-            'fnSignature' => '(php/aget arr index)',
+            'signature' => '(php/aget arr index)',
             'desc' => "Equivalent to PHP's `arr[index] ?? null`.",
         ],
         Symbol::NAME_PHP_ARRAY_SET => [
@@ -145,7 +145,7 @@ Equivalent to PHP\'s `arr[index] ?? null`.',
 ```
 Equivalent to PHP\'s `arr[index] = value`.',
             'docUrl' => '/documentation/php-interop/#set-php-array-value',
-            'fnSignature' => '(php/aset arr index value)',
+            'signature' => '(php/aset arr index value)',
             'desc' => "Equivalent to PHP's `arr[index] = value`.",
         ],
         Symbol::NAME_PHP_ARRAY_PUSH => [
@@ -154,7 +154,7 @@ Equivalent to PHP\'s `arr[index] = value`.',
 ```
 Equivalent to PHP\'s `arr[] = value`.',
             'docUrl' => '/documentation/php-interop/#append-php-array-value',
-            'fnSignature' => '(php/apush arr value)',
+            'signature' => '(php/apush arr value)',
             'desc' => "Equivalent to PHP's arr[] = value.",
         ],
         Symbol::NAME_PHP_ARRAY_UNSET => [
@@ -163,7 +163,7 @@ Equivalent to PHP\'s `arr[] = value`.',
 ```
 Equivalent to PHP\'s `unset(arr[index])`.',
             'docUrl' => '/documentation/php-interop/#unset-php-array-value',
-            'fnSignature' => '(php/aunset arr index)',
+            'signature' => '(php/aunset arr index)',
             'desc' => "Equivalent to PHP's `unset(arr[index])`.",
         ],
         Symbol::NAME_PHP_NEW => [
@@ -172,7 +172,7 @@ Equivalent to PHP\'s `unset(arr[index])`.',
 ```
 Evaluates expr and creates a new PHP class using the arguments. The instance of the class is returned.',
             'docUrl' => '/documentation/php-interop/#php-class-instantiation',
-            'fnSignature' => '(php/new expr args*)',
+            'signature' => '(php/new expr args*)',
             'desc' => 'Evaluates expr and creates a new PHP class using the arguments. The instance of the class is returned.',
         ],
         Symbol::NAME_PHP_OBJECT_CALL => [
@@ -182,7 +182,7 @@ Evaluates expr and creates a new PHP class using the arguments. The instance of 
 ```
 Access to an object property or result of chained calls.',
             'docUrl' => '/documentation/php-interop/#php-set-object-properties',
-            'fnSignature' => '(php/-> object call*)',
+            'signature' => '(php/-> object call*)',
             'desc' => 'Access to an object property or result of chained calls.',
         ],
         Symbol::NAME_PHP_OBJECT_STATIC_CALL => [
@@ -193,14 +193,14 @@ Access to an object property or result of chained calls.',
 
 Calls a static method or property from a PHP class. Both methodname and property must be symbols and cannot be an evaluated value.',
             'docUrl' => '/documentation/php-interop/#php-static-method-and-property-call',
-            'fnSignature' => '(php/:: class call*)',
+            'signature' => '(php/:: class call*)',
             'desc' => 'Calls a static method or property from a PHP class. Both methodname and property must be symbols and cannot be an evaluated value.',
         ],
         Symbol::NAME_QUOTE => [
             'doc' => '```phel
 (NAME_QUOTE)
 ```',
-            'fnSignature' => '(NAME_QUOTE)',
+            'signature' => '(NAME_QUOTE)',
             'desc' => 'NAME_QUOTE description',
         ],
         Symbol::NAME_RECUR => [
@@ -209,7 +209,7 @@ Calls a static method or property from a PHP class. Both methodname and property
 Internally recur is implemented as a PHP while loop and therefore prevents the Maximum function nesting level errors..
 ```',
             'docUrl' => '/documentation/global-and-local-bindings/#local-bindings-let',
-            'fnSignature' => '(recur expr*)',
+            'signature' => '(recur expr*)',
             'desc' => 'Internally recur is implemented as a PHP while loop and therefore prevents the Maximum function nesting level errors.',
         ],
         Symbol::NAME_UNQUOTE => [
@@ -219,7 +219,7 @@ Internally recur is implemented as a PHP while loop and therefore prevents the M
 ```
 Values that should be evaluated in a macro are marked with the unquote function (shorthand `,`).',
             'docUrl' => '/documentation/macros/#quasiquote',
-            'fnSignature' => '(unquote my-sym)',
+            'signature' => '(unquote my-sym)',
             'desc' => 'Values that should be evaluated in a macro are marked with the unquote function (shorthand ,).',
         ],
         Symbol::NAME_UNQUOTE_SPLICING => [
@@ -229,7 +229,7 @@ Values that should be evaluated in a macro are marked with the unquote function 
 ```
 Values that should be evaluated in a macro are marked with the unquote function (shorthand `,@`).',
             'docUrl' => '/documentation/macros/#quasiquote',
-            'fnSignature' => '(unquote-splicing my-sym)',
+            'signature' => '(unquote-splicing my-sym)',
             'desc' => 'Values that should be evaluated in a macro are marked with the unquote function (shorthand ,@).',
         ],
         Symbol::NAME_THROW => [
@@ -239,7 +239,7 @@ Values that should be evaluated in a macro are marked with the unquote function 
 Throw an exception.
 See [try-catch](/documentation/control-flow/#try-catch-and-finally).',
             'docUrl' => '',
-            'fnSignature' => '(throw exception)',
+            'signature' => '(throw exception)',
             'desc' => 'Throw an exception.',
         ],
         Symbol::NAME_TRY => [
@@ -248,7 +248,7 @@ See [try-catch](/documentation/control-flow/#try-catch-and-finally).',
 ```
 All expressions are evaluated and if no exception is thrown the value of the last expression is returned. If an exception occurs and a matching catch-clause is provided, its expression is evaluated and the value is returned. If no matching catch-clause can be found the exception is propagated out of the function. Before returning normally or abnormally the optionally finally-clause is evaluated.',
             'docUrl' => '/documentation/control-flow/#try-catch-and-finally',
-            'fnSignature' => '(try expr* catch-clause* finally-clause?)',
+            'signature' => '(try expr* catch-clause* finally-clause?)',
             'desc' => 'All expressions are evaluated and if no exception is thrown the value of the last expression is returned. If an exception occurs and a matching catch-clause is provided, its expression is evaluated and the value is returned. If no matching catch-clause can be found the exception is propagated out of the function. Before returning normally or abnormally the optionally finally-clause is evaluated.',
         ],
         Symbol::NAME_PHP_OBJECT_SET => [
@@ -258,7 +258,7 @@ All expressions are evaluated and if no exception is thrown the value of the las
 ```
 Use `php/oset` to set a value to a class/object property.',
             'docUrl' => '/documentation/php-interop/#php-set-object-properties',
-            'fnSignature' => '(php/oset (php/-> object prop) val)',
+            'signature' => '(php/oset (php/-> object prop) val)',
             'desc' => 'Use `php/oset` to set a value to a class/object property.',
         ],
         Symbol::NAME_LIST => [ # overriding already defined at core.phel:50
@@ -267,7 +267,7 @@ Use `php/oset` to set a value to a class/object property.',
 ```
 Creates a new list. If no argument is provided, an empty list is created.',
             'docUrl' => '/documentation/data-structures/#lists',
-            'fnSignature' => "(list & xs) # '(& xs)",
+            'signature' => "(list & xs) # '(& xs)",
             'desc' => 'Creates a new list. If no argument is provided, an empty list is created.',
         ],
         Symbol::NAME_VECTOR => [ # overridden already defined at core.phel:54
@@ -276,7 +276,7 @@ Creates a new list. If no argument is provided, an empty list is created.',
 ```
 Creates a new vector. If no argument is provided, an empty vector is created.',
             'docUrl' => '/documentation/data-structures/#vectors',
-            'fnSignature' => '(vector & xs) # [& xs]',
+            'signature' => '(vector & xs) # [& xs]',
             'desc' => 'Creates a new vector. If no argument is provided, an empty vector is created.',
         ],
         Symbol::NAME_MAP => [ # overridden already defined at core.phel:58
@@ -285,7 +285,7 @@ Creates a new vector. If no argument is provided, an empty vector is created.',
 ```
 Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even.',
             'docUrl' => '/documentation/data-structures/#maps',
-            'fnSignature' => '(hash-map & xs) # {& xs}',
+            'signature' => '(hash-map & xs) # {& xs}',
             'desc' => 'Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even.',
         ],
         Symbol::NAME_SET_VAR => [
@@ -294,7 +294,7 @@ Creates a new hash map. If no argument is provided, an empty hash map is created
 ```
 Variables provide a way to manage mutable state. Each variable contains a single value. To create a variable use the var function.',
             'docUrl' => '/documentation/global-and-local-bindings/#variables',
-            'fnSignature' => '(var value)',
+            'signature' => '(var value)',
             'desc' => 'Variables provide a way to manage mutable state. Each variable contains a single value. To create a variable use the var function.',
         ],
         Symbol::NAME_DEF_INTERFACE => [ # overridden
@@ -303,7 +303,7 @@ Variables provide a way to manage mutable state. Each variable contains a single
 ```
 An interface in Phel defines an abstract set of functions. It is directly mapped to a PHP interface. An interface can be defined by using the definterface macro.',
             'docUrl' => '/documentation/interfaces/#defining-interfaces',
-            'fnSignature' => '(definterface name & fns)',
+            'signature' => '(definterface name & fns)',
             'desc' => 'An interface in Phel defines an abstract set of functions. It is directly mapped to a PHP interface. An interface can be defined by using the definterface macro.',
         ],
     ];

--- a/src/php/Api/Transfer/PhelFunction.php
+++ b/src/php/Api/Transfer/PhelFunction.php
@@ -10,6 +10,7 @@ final readonly class PhelFunction
         private string $namespace,
         private string $name,
         private string $doc,
+        private string $rawDoc,
         private string $signature,
         private string $description,
         private string $groupKey = '',
@@ -27,6 +28,7 @@ final readonly class PhelFunction
      *     name?: string,
      *     fnName?: string, // @deprecated Use name instead
      *     doc?: string,
+     *     rawDoc?: string,
      *     signature?: string,
      *     fnSignature?: string, // @deprecated Use signature instead
      *     desc?: string,
@@ -44,6 +46,7 @@ final readonly class PhelFunction
             $array['namespace'] ?? $array['fnNs'] ?? '',
             $array['name'] ?? $array['fnName'] ?? '',
             $array['doc'] ?? '',
+            $array['rawDoc'] ?? '',
             $array['signature'] ?? $array['fnSignature'] ?? '',
             $array['desc'] ?? '',
             $array['groupKey'] ?? '',
@@ -70,6 +73,11 @@ final readonly class PhelFunction
     public function doc(): string
     {
         return $this->doc;
+    }
+
+    public function rawDoc(): string
+    {
+        return $this->rawDoc;
     }
 
     public function fnSignature(): string

--- a/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
+++ b/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
@@ -254,6 +254,7 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'NAN',
                 'doc' => 'Constant for Not a Number (NAN) values.',
+                'rawDoc' => 'Constant for Not a Number (NAN) values.',
                 'fnSignature' => '',
                 'desc' => 'Constant for Not a Number (NAN) values.',
                 'groupKey' => 'nan',
@@ -287,6 +288,7 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'array',
                 'doc' => "```phel\n(array & xs)\n```\nCreates a new Array.",
+                'rawDoc' => "(array & xs)\nCreates a new Array.",
                 'fnSignature' => '(array & xs)',
                 'desc' => 'Creates a new Array.',
                 'groupKey' => 'array',
@@ -321,6 +323,7 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'format',
                 'doc' => "```phel\n(array & xs)\n```\nReturns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
+                'rawDoc' => "(array & xs)\nReturns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
                 'fnSignature' => '(array & xs)',
                 'desc' => "Returns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
                 'groupKey' => 'format',


### PR DESCRIPTION
## 🤔 Background

Related to https://github.com/phel-lang/phel-lang/issues/942 by @jasalt 

## 💡 Goal

Enable easy use of the docs without markdown format from `getPhelFunctions()`

## 🔖 Changes

- Change `fnSignature` to `signature`
- Add `rawDoc` as doc without markdown wrapper

## 🖼️  Demo

> Keeping Backwards Compatibility (BC).

<img width="1493" height="934" alt="Screenshot 2025-09-06 at 12 01 24" src="https://github.com/user-attachments/assets/351db867-d912-452c-9bce-f1a505194919" />
