### PR TITLE
Deprecate PhelFunction methods in favor of public props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Improve public Api module
     - Add new methods and remove deprecated ones from PhelFunction
 - Add `*file*` to return the current source file's path
+- Deprecate `PhelFunction` methods in favor of its public properties and remove `rawDoc`
 
 ## [0.21.0](https://github.com/phel-lang/phel-lang/compare/v0.20.0...v0.21.0) - 2025-09-01
 

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -125,7 +125,7 @@ final class DocCommand extends Command
         $normalized = [];
 
         foreach ($phelFunctions as $phelFunction) {
-            $fnName = $phelFunction->namespace() . '/' . $phelFunction->name();
+            $fnName = $phelFunction->namespace . '/' . $phelFunction->name;
             similar_text($fnName, $search, $percent);
             if ($search && $percent < 45) {
                 continue;
@@ -134,11 +134,11 @@ final class DocCommand extends Command
             $normalized[] = [
                 'percent' => round($percent),
                 'name' => $fnName,
-                'signature' => $phelFunction->fnSignature(),
-                'doc' => $phelFunction->doc(),
-                'description' => preg_replace('/\r?\n/', '', $phelFunction->description()),
-                'githubUrl' => $phelFunction->githubUrl(),
-                'docUrl' => $phelFunction->docUrl(),
+                'signature' => $phelFunction->signature,
+                'doc' => $phelFunction->doc,
+                'description' => preg_replace('/\r?\n/', '', $phelFunction->description),
+                'githubUrl' => $phelFunction->githubUrl,
+                'docUrl' => $phelFunction->docUrl,
             ];
         }
 

--- a/src/php/Api/Transfer/PhelFunction.php
+++ b/src/php/Api/Transfer/PhelFunction.php
@@ -9,17 +9,16 @@ use function sprintf;
 final readonly class PhelFunction
 {
     public function __construct(
-        private string $namespace,
-        private string $name,
-        private string $doc,
-        private string $rawDoc,
-        private string $signature,
-        private string $description,
-        private string $groupKey = '',
-        private string $githubUrl = '',
-        private string $docUrl = '',
-        private string $file = '',
-        private int $line = 0,
+        public string $namespace,
+        public string $name,
+        public string $doc,
+        public string $signature,
+        public string $description,
+        public string $groupKey = '',
+        public string $githubUrl = '',
+        public string $docUrl = '',
+        public string $file = '',
+        public int $line = 0,
     ) {
     }
 
@@ -28,7 +27,6 @@ final readonly class PhelFunction
      *     namespace?: string,
      *     name?: string,
      *     doc?: string,
-     *     rawDoc?: string,
      *     signature?: string,
      *     desc?: string,
      *     groupKey?: string,
@@ -44,7 +42,6 @@ final readonly class PhelFunction
             $array['namespace'] ?? '',
             $array['name'] ?? '',
             $array['doc'] ?? '',
-            $array['rawDoc'] ?? '',
             $array['signature'] ?? '',
             $array['desc'] ?? '',
             $array['groupKey'] ?? '',
@@ -53,11 +50,6 @@ final readonly class PhelFunction
             $array['file'] ?? '',
             $array['line'] ?? 0,
         );
-    }
-
-    public function name(): string
-    {
-        return $this->name;
     }
 
     public function nameWithNamespace(): string
@@ -69,56 +61,89 @@ final readonly class PhelFunction
         return sprintf('%s/%s', $this->namespace, $this->name);
     }
 
+    /**
+     * @deprecated in favor of the name attribute
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated in favor of the doc attribute
+     */
     public function doc(): string
     {
         return $this->doc;
     }
 
-    public function rawDoc(): string
-    {
-        return $this->rawDoc;
-    }
-
+    /**
+     * @deprecated in favor of the signature attribute
+     */
     public function fnSignature(): string
     {
         return $this->signature;
     }
 
+    /**
+     * @deprecated in favor of the signature attribute
+     */
     public function signature(): string
     {
         return $this->signature;
     }
 
+    /**
+     * @deprecated in favor of the description attribute
+     */
     public function description(): string
     {
         return $this->description;
     }
 
+    /**
+     * @deprecated in favor of the groupKey attribute
+     */
     public function groupKey(): string
     {
         return $this->groupKey;
     }
 
+    /**
+     * @deprecated in favor of the githubUrl attribute
+     */
     public function githubUrl(): string
     {
         return $this->githubUrl;
     }
 
+    /**
+     * @deprecated in favor of the docUrl attribute
+     */
     public function docUrl(): string
     {
         return $this->docUrl;
     }
 
+    /**
+     * @deprecated in favor of the file attribute
+     */
     public function file(): string
     {
         return $this->file;
     }
 
+    /**
+     * @deprecated in favor of the line attribute
+     */
     public function line(): int
     {
         return $this->line;
     }
 
+    /**
+     * @deprecated in favor of the namespace attribute
+     */
     public function namespace(): string
     {
         return $this->namespace;

--- a/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
+++ b/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
@@ -255,7 +255,6 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'NAN',
                 'doc' => 'Constant for Not a Number (NAN) values.',
-                'rawDoc' => 'Constant for Not a Number (NAN) values.',
                 'signature' => '',
                 'desc' => 'Constant for Not a Number (NAN) values.',
                 'groupKey' => 'nan',
@@ -289,7 +288,6 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'array',
                 'doc' => "```phel\n(array & xs)\n```\nCreates a new Array.",
-                'rawDoc' => "(array & xs)\nCreates a new Array.",
                 'signature' => '(array & xs)',
                 'desc' => 'Creates a new Array.',
                 'groupKey' => 'array',
@@ -324,7 +322,6 @@ final class PhelFnNormalizerTest extends TestCase
             PhelFunction::fromArray([
                 'name' => 'format',
                 'doc' => "```phel\n(array & xs)\n```\nReturns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
-                'rawDoc' => "(array & xs)\nReturns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
                 'signature' => '(array & xs)',
                 'desc' => "Returns a formatted string. See PHP's [sprintf](https://example.com) for more information.",
                 'groupKey' => 'format',


### PR DESCRIPTION

## 🤔 Background

Closes https://github.com/phel-lang/phel-lang/issues/947 by @jasalt 

## 🔖 Changes

- Remove the rawDoc attr and function
- Deprecate PhelFunction methods in favor of public properties