### PR TITLE
Add comma separator between key value pairs in the hash-map printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Improve public Api module
     - Add new methods and remove deprecated ones from PhelFunction
 - Add `*file*` to return the current source file's path
+- Add comma separator between key value pairs in the hash-map printer
 - Return empty string for `__FILE__` and `__DIR__` in the REPL
 - Improve PhelFunction 
     - Deprecate methods in favor of its public properties

--- a/src/php/Printer/TypePrinter/PersistentMapPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentMapPrinter.php
@@ -7,6 +7,8 @@ namespace Phel\Printer\TypePrinter;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Printer\PrinterInterface;
 
+use function sprintf;
+
 /**
  * @implements TypePrinterInterface<PersistentMapInterface>
  */
@@ -24,12 +26,15 @@ final readonly class PersistentMapPrinter implements TypePrinterInterface
         $prefix = '{';
         $suffix = '}';
 
-        $values = [];
+        $pairs = [];
         foreach ($form as $key => $value) {
-            $values[] = $this->printer->print($key);
-            $values[] = $this->printer->print($value);
+            $pairs[] = sprintf(
+                '%s %s',
+                $this->printer->print($key),
+                $this->printer->print($value),
+            );
         }
 
-        return $prefix . implode(' ', $values) . $suffix;
+        return $prefix . implode(', ', $pairs) . $suffix;
     }
 }

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Test;
 
-use Phel;
 use Phel\Printer\Printer;
+
+use function sprintf;
 
 final readonly class TestCommandOptions
 {
@@ -34,13 +35,16 @@ final readonly class TestCommandOptions
 
     public function asPhelHashMap(): string
     {
-        $optionsMap = Phel::map(
-            Phel::keyword(self::FILTER),
-            $this->filter,
-            Phel::keyword(self::TESTDOX),
-            $this->testdox,
-        );
+        $printer = Printer::readable();
 
-        return Printer::readable()->print($optionsMap);
+        $filter = $this->filter === null
+            ? 'nil'
+            : $printer->print($this->filter);
+
+        return sprintf(
+            '{:filter %s :testdox %s}',
+            $filter,
+            $printer->print($this->testdox),
+        );
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/PersistentMapPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/PersistentMapPrinterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Generator;
+use Phel;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Printer\Printer;
+use Phel\Printer\TypePrinter\PersistentMapPrinter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PersistentMapPrinterTest extends TestCase
+{
+    #[DataProvider('printerDataProvider')]
+    public function test_print(string $expected, PersistentMapInterface $map): void
+    {
+        self::assertSame(
+            $expected,
+            (new PersistentMapPrinter(Printer::readable()))->print($map),
+        );
+    }
+
+    public static function printerDataProvider(): Generator
+    {
+        yield 'empty map' => [
+            '{}',
+            Phel::map(),
+        ];
+
+        yield 'map with values' => [
+            '{:a 1, :b 2}',
+            Phel::map(
+                Phel::keyword('a'),
+                1,
+                Phel::keyword('b'),
+                2,
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Closes https://github.com/phel-lang/phel-lang/issues/957 by @jasalt 

## 🖼️  Demo

### BEFORE

<img width="661" height="142" alt="Screenshot 2025-09-15 at 18 37 51" src="https://github.com/user-attachments/assets/5fed531d-41f7-46a0-92c9-ad455d31d77a" />

### AFTER

<img width="804" height="148" alt="Screenshot 2025-09-15 at 18 38 32" src="https://github.com/user-attachments/assets/d18c67c4-d8c5-4b24-83d3-88c0d3c78dac" />
