### PR TITLE
`argv` as Phel vector instead of PHP array

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -45,8 +45,8 @@
   "")
 
 (def argv
-  "Array of arguments passed to script."
-  (php/aget php/$GLOBALS "argv"))
+  "Vector of arguments passed to the script."
+  (php/:: Phel (vector (php/aget php/$GLOBALS "argv"))))
 
 # --------------------------------------------
 # Basic methods for quasiquote and destructure


### PR DESCRIPTION
Current behavior of [`argv`](https://github.com/phel-lang/phel-lang/blob/df802d378328a573624d63d7c6b684498527b1ba/src/phel/core.phel#L47) is a little bit odd, the output being an PHP Array:

```
./vendor/bin/phel repl
Welcome to the Phel Repl (v0.21.0-beta#231768b)
Type "exit" or press Ctrl-D to exit.
phel:1> argv
<PHP-Array ["./vendor/bin/phel", "repl"]>
```

While not essential, this would need to be converted to a Phel vector in user code adding some extra noise.
 
PR changes it to Phel vector:

```
./bin/phel repl
Welcome to the Phel Repl (v0.21.0-beta#1c3900b)
Type "exit" or press Ctrl-D to exit.
phel:1> argv
["./bin/phel" "repl"]
```

As `vector` is not declared in `core.phel` yet, I followed example how `\Phel` class static methods are called in following def's of `list`, `vector` and so on.

Also modified docstring slightly with "the" missing.