### PR TITLE
Use custom if-throw for pre/post metadata conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, assert.exception=1
           coverage: none
           tools: composer
 
@@ -57,7 +56,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, assert.exception=1
           coverage: none
           tools: composer
 
@@ -94,7 +92,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, assert.exception=1
           coverage: none
           tools: composer
 
@@ -131,7 +128,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, assert.exception=1
           coverage: none
           tools: composer
 
@@ -165,7 +161,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, assert.exception=1
           coverage: none
           tools: composer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
     - Use new set shortcut syntax for printer
 - Add `into` function
 - Discarding commas in printer output with new `CommaNode`
+- Use custom if-throw for `:pre/:post` metadata conditions
 - Return empty string for `__FILE__` and `__DIR__` in the REPL
 - Improve PhelFunction 
     - Deprecate methods in favor of its public properties

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -17,6 +17,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
+use RuntimeException;
 
 use function array_slice;
 use function count;
@@ -278,7 +279,7 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
 
         $exception = Phel::list([
             Symbol::create('php/new')->copyLocationFrom($formForMessage),
-            \RuntimeException::class,
+            RuntimeException::class,
             $message,
         ])->copyLocationFrom($formForMessage);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -276,10 +276,20 @@ final class FnSymbol implements SpecialFormAnalyzerInterface
             ])->copyLocationFrom($formForMessage),
         ])->copyLocationFrom($formForMessage);
 
-        return Phel::list([
-            Symbol::create('php/assert')->copyLocationFrom($form),
-            $form,
+        $exception = Phel::list([
+            Symbol::create('php/new')->copyLocationFrom($formForMessage),
+            \RuntimeException::class,
             $message,
+        ])->copyLocationFrom($formForMessage);
+
+        return Phel::list([
+            Symbol::create(Symbol::NAME_IF)->copyLocationFrom($form),
+            $form,
+            null,
+            Phel::list([
+                Symbol::create(Symbol::NAME_THROW)->copyLocationFrom($form),
+                $exception,
+            ])->copyLocationFrom($form),
         ])->copyLocationFrom($form);
     }
 

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -1,11 +1,12 @@
 (ns phel-test\test\core\pre-post-conditions
-  (:require phel\test :refer [deftest is thrown? thrown-with-msg?]))
+  (:require phel\test :refer [deftest is thrown? thrown-with-msg?])
+  (:use RuntimeException))
 
 (deftest test-pre-condition
   (let [divide (fn [x y] {:pre [(not= y 0)]} (/ x y))]
     (is (= 3 (divide 6 2)) "pre condition success")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (not= y 0)"
+         RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre condition failure")))
 
@@ -15,11 +16,11 @@
                  (/ x y))]
     (is (= 3 (divide 6 2)) "multiple pre conditions success")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (number? x)"
+         RuntimeException "Assert failed: (number? x)"
          (divide "foo" 2))
         "pre condition failure: x not number")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (not= y 0)"
+         RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre condition failure: y is zero")))
 
@@ -27,7 +28,7 @@
   (let [get-username (fn [user] {:post [(not (nil? $))]} (get user :name))]
     (is (= "test" (get-username {:id 1 :name "test"})) "post condition success")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (not (nil? $))"
+         RuntimeException "Assert failed: (not (nil? $))"
          (get-username {:id 4 :joined 2000}))
         "post condition failure")))
 
@@ -38,11 +39,11 @@
                  (/ x y))]
     (is (= 3 (divide 6 2)) "pre and post success")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (not= y 0)"
+         RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre failure in pre and post")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (pos? $)"
+         RuntimeException "Assert failed: (pos? $)"
          (divide 6 -2))
         "post failure in pre and post")))
 
@@ -52,6 +53,6 @@
                   method)]
     (is (= "GET" (request {:method "GET"})) "pre condition with destructuring success")
     (is (thrown-with-msg?
-         \RuntimeException "Assert failed: (= method GET)"
+         RuntimeException "Assert failed: (= method GET)"
          (request {:method "POST"}))
         "pre condition with destructuring failure")))

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -5,7 +5,7 @@
   (let [divide (fn [x y] {:pre [(not= y 0)]} (/ x y))]
     (is (= 3 (divide 6 2)) "pre condition success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (not= y 0)"
+         \RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre condition failure")))
 
@@ -15,11 +15,11 @@
                  (/ x y))]
     (is (= 3 (divide 6 2)) "multiple pre conditions success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (number? x)"
+         \RuntimeException "Assert failed: (number? x)"
          (divide "foo" 2))
         "pre condition failure: x not number")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (not= y 0)"
+         \RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre condition failure: y is zero")))
 
@@ -27,7 +27,7 @@
   (let [get-username (fn [user] {:post [(not (nil? $))]} (get user :name))]
     (is (= "test" (get-username {:id 1 :name "test"})) "post condition success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (not (nil? $))"
+         \RuntimeException "Assert failed: (not (nil? $))"
          (get-username {:id 4 :joined 2000}))
         "post condition failure")))
 
@@ -38,11 +38,11 @@
                  (/ x y))]
     (is (= 3 (divide 6 2)) "pre and post success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (not= y 0)"
+         \RuntimeException "Assert failed: (not= y 0)"
          (divide 6 0))
         "pre failure in pre and post")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (pos? $)"
+         \RuntimeException "Assert failed: (pos? $)"
          (divide 6 -2))
         "post failure in pre and post")))
 
@@ -52,6 +52,6 @@
                   method)]
     (is (= "GET" (request {:method "GET"})) "pre condition with destructuring success")
     (is (thrown-with-msg?
-         \AssertionError "Assert failed: (= method GET)"
+         \RuntimeException "Assert failed: (= method GET)"
          (request {:method "POST"}))
         "pre condition with destructuring failure")))


### PR DESCRIPTION
## 🤔 Background

Closes https://github.com/phel-lang/phel-lang/issues/967 

## 💡 Goal

Instead of using native php assert (which requires `zend.assertions=1`), we need to find another way to have such pre/post assertions

## 🔖 Changes

- Use custom if-throw for `:pre/:post` metadata conditions