### PR TITLE
Add composer validation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
 name: CI
 
 jobs:
+  composer-validate:
+    name: Validate composer configuration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
+          tools: composer
+
+      - name: Validate composer configuration
+        run: composer validate --strict --quiet --no-interaction --no-check-all --no-check-lock
+
   coding-guidelines:
     name: Coding Guidelines
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🤔 Background

I forgot to update composer.lock in a release, making the composer hash validation broken and forcing me to create a new release ([0.22.2](https://github.com/phel-lang/phel-lang/releases/tag/v0.22.2)) because of this reason.

## 💡 Goal

Inspired by this line https://github.com/NixOS/nixpkgs/blob/97e5d399726f2ab2d501d6c4b4cf808134e6cadc/pkgs/build-support/php/builders/v2/hooks/php-script-utils.bash#L21 kudos to @drupol for the hint

## 🔖 Changes

- Add a composer validation on CI level to guarantee its status