### PR TITLE
Add format json to doc command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add `catch` and `finally` functions to the API docs
+- Add `--format` json option to `phel doc` command
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -141,7 +141,12 @@ final class DocCommand extends Command
      */
     private function printFunctionsAsJson(OutputInterface $output, array $phelFunctions): void
     {
-        $output->writeln((string) json_encode($phelFunctions, JSON_PRETTY_PRINT));
+        $jsonData = array_map(static function (array $func): array {
+            unset($func['percent']);
+            return $func;
+        }, $phelFunctions);
+
+        $output->writeln(json_encode($jsonData, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

Closes: https://github.com/phel-lang/phel-lang/issues/978 by @JesusValeraDev 

When calling `phel doc`, it returns the information as a table. However, while building other tools that wants to know the outcome of this command, this output as a table is not useful; it would be great to have an optional parameter `--format={table|json}` (default "table")

## 🔖 Changes

- Add `--format` json option to `phel doc` command

## 🖼️  Demo

<img width="991" height="422" alt="Screenshot 2025-09-27 at 17 01 27" src="https://github.com/user-attachments/assets/d144e47e-da8b-438d-a942-145aaa7f1c90" />

