### PR TITLE
Fix doc command on phar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix `doc` command on phar command
 - Add `catch` and `finally` functions to the API docs
 - Add `--format` json option to `phel doc` command
 


### PR DESCRIPTION
## 🤔 Background

Closes https://github.com/phel-lang/phel-lang/issues/981

## 💡 Goal

<!-- The goal of this PR. -->

## 🔖 Changes

- Fix `doc` command on phar command

## 🖼️  Demo 

### Running `phel doc` from phar in a random directory

<img width="1010" height="478" alt="Screenshot 2025-09-28 at 15 01 37" src="https://github.com/user-attachments/assets/0f18c6a1-a88c-4707-81a5-645d589da540" />

### Running `phel doc` from src

<img width="774" height="165" alt="Screenshot 2025-09-28 at 15 02 59" src="https://github.com/user-attachments/assets/f8a9a21e-49c3-470d-8226-1668c8975006" />

