### PR TITLE
Allow ns form with multiple modules within a single :require form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix `doc` command on phar command
 - Add `catch` and `finally` functions to the API docs
 - Add `--format` json option to `phel doc` command
+- Allow `ns` form with multiple modules within a single `:require` form
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/tests/php/Integration/Fixtures/Ns/require-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-multiple.test
@@ -1,0 +1,58 @@
+--PHEL--
+(ns test
+  (:require xyz\core :as c
+            xyz\foo
+            xyz\core2 :as c2))
+
+(def kw ::c/f1)
+(def kw2 ::c2/f3)
+--PHP--
+namespace test;
+require_once __DIR__ . '/phel/core.php';
+require_once __DIR__ . '/xyz/core.php';
+require_once __DIR__ . '/xyz/foo.php';
+require_once __DIR__ . '/xyz/core2.php';
+\Phel::addDefinition(
+  "phel\\core",
+  "*file*",
+  "Ns/require-multiple.test"
+);
+\Phel::addDefinition(
+  "phel\\core",
+  "*ns*",
+  "test"
+);
+\Phel::addDefinition(
+  "test",
+  "kw",
+  \Phel::keyword("f1", "xyz\\core"),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Ns/require-multiple.test",
+      \Phel::keyword("line"), 6,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Ns/require-multiple.test",
+      \Phel::keyword("line"), 6,
+      \Phel::keyword("column"), 15
+    )
+  )
+);
+\Phel::addDefinition(
+  "test",
+  "kw2",
+  \Phel::keyword("f3", "xyz\\core2"),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Ns/require-multiple.test",
+      \Phel::keyword("line"), 7,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Ns/require-multiple.test",
+      \Phel::keyword("line"), 7,
+      \Phel::keyword("column"), 17
+    )
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Right now `:require` in the ns must be one by one like the following: 

```
(ns pong\main
  (:require phel-cli-gui\terminal-gui :as gui)
  (:require chemaclass\pong\logic :as logic))
```

## 💡 Goal

Task: allow defining multiple requires in the same statement:
```
(ns pong\main
  (:require phel-cli-gui\terminal-gui :as gui
            chemaclass\pong\logic :as logic))
```

## 🔖 Changes

- Allow `ns` form with multiple modules within a single `:require` form