### PR TITLE
Add repl --eval option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Allow `ns` form with multiple modules within a single `:require` form
 - Add `--debug` flag to suppress test output and write debug info to ./phel-debug.log
   - Optional Phel file filter using equals syntax: `--debug="core"` or `--debug="boot"`
+- Add `--eval` option to `phel repl` command
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/src/php/Run/Application/EvalModeExecutor.php
+++ b/src/php/Run/Application/EvalModeExecutor.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Compiler\CompilerFacadeInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Compiler\Domain\Lexer\Token;
+use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\ColorStyleInterface;
+use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Symfony\Component\Console\Command\Command;
+use Throwable;
+
+use function array_reverse;
+use function explode;
+use function sprintf;
+
+final readonly class EvalModeExecutor
+{
+    public function __construct(
+        private ReplCommandIoInterface $io,
+        private ColorStyleInterface $style,
+        private PrinterInterface $printer,
+        private CompilerFacadeInterface $compilerFacade,
+    ) {
+    }
+
+    public function execute(string $input): int
+    {
+        if ($input === '') {
+            return Command::SUCCESS;
+        }
+
+        if (!$this->hasBalancedParentheses($input)) {
+            $this->io->writeln($this->style->red('Unbalanced parentheses.'));
+
+            return Command::FAILURE;
+        }
+
+        $options = (new CompileOptions())->setStartingLine(1);
+
+        try {
+            $result = $this->compilerFacade->eval($input, $options);
+            $this->io->writeln($this->printer->print($result));
+
+            return Command::SUCCESS;
+        } catch (UnfinishedParserException $e) {
+            $this->io->writeLocatedException($e, $e->getCodeSnippet());
+
+            return Command::FAILURE;
+        } catch (CompiledCodeIsMalformedException $e) {
+            if ($e->getPrevious() instanceof Throwable) {
+                $e = $e->getPrevious();
+            }
+
+            $exceptionClass = array_reverse(explode('\\', $e::class))[0];
+            $this->io->writeln(sprintf(
+                '%s: %s',
+                $this->style->red($exceptionClass),
+                $e->getMessage() !== '' ? $e->getMessage() : '*no message*',
+            ));
+
+            return Command::FAILURE;
+        } catch (CompilerException $e) {
+            $this->io->writeLocatedException($e->getNestedException(), $e->getCodeSnippet());
+
+            return Command::FAILURE;
+        } catch (Throwable $e) {
+            $this->io->writeStackTrace($e);
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function hasBalancedParentheses(string $input): bool
+    {
+        $tokenStream = $this->compilerFacade->lexString($input);
+
+        $open = 0;
+        $close = 0;
+
+        foreach ($tokenStream as $token) {
+            if ($token->getType() === Token::T_OPEN_PARENTHESIS) {
+                ++$open;
+            } elseif ($token->getType() === Token::T_CLOSE_PARENTHESIS) {
+                ++$close;
+            }
+        }
+
+        return $close >= $open;
+    }
+}

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -130,7 +130,7 @@ final class ReplCommand extends Command
             Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, ReplConstants::REPL_MODE, true);
 
             if ($isEvalMode) {
-                return $this->evalModeExecutor->execute((string)$evalInput);
+                return $this->evalModeExecutor->execute((string)$evalInput) ? self::SUCCESS : self::FAILURE;
             }
 
             $this->loopReadLineAndAnalyze();

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -12,6 +12,7 @@ use Phel\Compiler\CompilerFacadeInterface;
 use Phel\Console\ConsoleFacadeInterface;
 use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
+use Phel\Run\Application\EvalModeExecutor;
 use Phel\Run\Application\NamespaceRunner;
 use Phel\Run\Application\NamespacesLoader;
 use Phel\Run\Domain\Repl\ColorStyle;
@@ -92,5 +93,15 @@ class RunFactory extends AbstractFactory
     public function getConsoleFacade(): ConsoleFacadeInterface
     {
         return $this->getProvidedDependency(RunProvider::FACADE_CONSOLE);
+    }
+
+    public function createEvalModeExecutor(): EvalModeExecutor
+    {
+        return new EvalModeExecutor(
+            $this->createReplCommandIo(),
+            $this->createColorStyle(),
+            $this->createPrinter(),
+            $this->getCompilerFacade(),
+        );
     }
 }

--- a/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -97,6 +99,22 @@ final class ReplTestCommand extends AbstractTestCommand
         $replOutput = $io->getOutputString();
 
         self::assertSame(trim($expectedOutput), trim($replOutput));
+    }
+
+    public function test_eval_option(): void
+    {
+        $io = $this->createReplTestIo();
+        $this->prepareRunFactory($io);
+
+        $repl = $this->createReplCommand();
+        $input = new ArrayInput(['--eval' => '(php/abs -1)']);
+        $result = $repl->run(
+            $input,
+            $this->createStub(OutputInterface::class),
+        );
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertSame(['1'], $io->getRawOutputs());
     }
 
     public static function providerIntegration(): Generator

--- a/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
@@ -92,6 +92,14 @@ final class ReplTestIo implements ReplCommandIoInterface
         return implode('', $this->getOutputs()) . PHP_EOL;
     }
 
+    /**
+     * @return list<string>
+     */
+    public function getRawOutputs(): array
+    {
+        return $this->outputs;
+    }
+
     public function isBracketedPasteSupported(): bool
     {
         return false;


### PR DESCRIPTION
## 🤔 Background

Closes: https://github.com/phel-lang/phel-lang/issues/991

It would be helpful to run phel code in one command for quick testing and check the output.

## 🔖 Changes

- Add `--eval` option to `phel repl` command

<img width="561" height="57" alt="Screenshot 2025-10-04 at 14 41 11" src="https://github.com/user-attachments/assets/32ecfd43-ca89-41b1-9387-d1af96f50b72" />

<img width="548" height="51" alt="Screenshot 2025-10-04 at 14 45 46" src="https://github.com/user-attachments/assets/27a023f7-acf4-4deb-bc45-cf911c1c81e0" />
