### PR TITLE
Set repl as default command instead of help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Add `--debug` flag to suppress test output and write debug info to ./phel-debug.log
   - Optional Phel file filter using equals syntax: `--debug="core"` or `--debug="boot"`
 - Add `--eval` option to `phel repl` command
+- Make `repl` the default command when no args are provided to the executable
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -24,6 +24,7 @@ final class ConsoleBootstrap extends Application
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         $this->setAutoExit(false);
+        $this->setDefaultCommand('repl');
 
         if (!$input instanceof InputInterface) {
             $input = new ArgvInput($this->getFactory()


### PR DESCRIPTION
## 🤔 Background

When no args are provided, you get the `list` by default

<img width="848" height="357" alt="Screenshot 2025-10-04 at 15 03 09" src="https://github.com/user-attachments/assets/9c1d91be-2287-45db-8697-81b36c54b87d" />

<img width="635" height="463" alt="Screenshot 2025-10-04 at 14 59 28" src="https://github.com/user-attachments/assets/04467504-20ea-41ba-a90f-189417b6ec69" />

## 💡 Goal

Make `repl` the default command when no args are provided to the executable.

## 🔖 Changes

The best solution is to make REPL the default command (which we've done), so you should use:
  - `bin/phel` - runs REPL interactively
  - `bin/phel repl --eval "(+ 2 3)"` - runs REPL in eval mode
  - `bin/phel run --debug local/boot.phel` - runs other commands

<img width="601" height="438" alt="Screenshot 2025-10-04 at 14 56 09" src="https://github.com/user-attachments/assets/5ac7efc2-305f-4eec-baad-591522aa4fa6" />

You can still see the current version and all available commands with the `list` command:

<img width="975" height="564" alt="Screenshot 2025-10-04 at 15 01 35" src="https://github.com/user-attachments/assets/2f659715-ccc5-4f30-9124-1c930cc1cd6b" />


