### PR TITLE
Remove deprecated *compile-mode* in favor of *build-mode*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add `phel eval` command
 - Make `repl` the default command when no args are provided to the executable
 - Move Facade Interfaces to Shared Module
+- Remove deprecated `*compile-mode*` in favor of `*build-mode*`
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -23,13 +23,11 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
 {
     public static function enableBuildMode(): void
     {
-        Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, true);
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, true);
     }
 
     public static function disableBuildMode(): void
     {
-        Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::COMPILE_MODE, false);
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, BuildConstants::BUILD_MODE, false);
     }
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -45,7 +45,6 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function __construct()
     {
-        $this->addInternalCompileModeDefinition();
         $this->addInternalBuildModeDefinition();
     }
 
@@ -230,25 +229,6 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         return Phel::hasDefinition($namespace, $symbolName);
-    }
-
-    /**
-     * @deprecated remove when `BuildConstants::COMPILE_MODE` is also removed
-     */
-    private function addInternalCompileModeDefinition(): void
-    {
-        $symbol = Symbol::create(BuildConstants::COMPILE_MODE);
-        $meta = Phel::map(
-            Keyword::create('doc'),
-            'Deprecated! Use *build-mode* instead. Set to true when a file is compiled, false otherwise.',
-        );
-        Phel::addDefinition(
-            CompilerConstants::PHEL_CORE_NAMESPACE,
-            $symbol->getName(),
-            false,
-            $meta,
-        );
-        $this->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol);
     }
 
     private function addInternalBuildModeDefinition(): void

--- a/src/php/Shared/BuildConstants.php
+++ b/src/php/Shared/BuildConstants.php
@@ -6,8 +6,5 @@ namespace Phel\Shared;
 
 interface BuildConstants
 {
-    /** @deprecated Use BuildConstants::BUILD_MODE instead */
-    public const string COMPILE_MODE = '*compile-mode*';
-
     public const string BUILD_MODE = '*build-mode*';
 }

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -32,6 +32,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(360, $groupedFns);
+        self::assertCount(359, $groupedFns);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Deprecated since Feb, 2023 -> https://github.com/phel-lang/phel-lang/pull/570

## 🔖 Changes

- Remove deprecated `*compile-mode*` in favor of `*build-mode*`