### PR TITLE
Allow multiple entries in :use form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Make `repl` the default command when no args are provided to the executable
 - Move Facade Interfaces to Shared Module
 - Remove deprecated `*compile-mode*` in favor of `*build-mode*`
+- Allow multiple entries in `:use` form
 
 ## [0.22.2](https://github.com/phel-lang/phel-lang/compare/v0.22.1...v0.22.2) - 2025-09-23
 

--- a/tests/php/Integration/Fixtures/Ns/use.test
+++ b/tests/php/Integration/Fixtures/Ns/use.test
@@ -1,7 +1,6 @@
 --PHEL--
 (ns test
-  (:use DateTimeImmutable)
-  (:use DateTime :as D))
+  (:use DateTimeImmutable DateTime :as D))
 
 (php/new DateTimeImmutable)
 (php/new D)

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -258,6 +258,9 @@ final class NsSymbolTest extends TestCase
             Phel::list([
                 Keyword::create('use'),
                 Symbol::create('Vendor\\Library'),
+                Symbol::create('Vendor\\Toolkit'),
+                Keyword::create('as'),
+                Symbol::create('Kit'),
             ]),
             Phel::list([
                 Keyword::create('require'),
@@ -284,12 +287,17 @@ final class NsSymbolTest extends TestCase
         self::assertSame(['src/config.phel'], $nsNode->getRequireFiles());
         self::assertSame('my\\project', $this->analyzer->getNamespace());
         self::assertTrue($this->globalEnv->hasUseAlias('my\\project', Symbol::create('Library')));
+        self::assertTrue($this->globalEnv->hasUseAlias('my\\project', Symbol::create('Kit')));
         self::assertTrue($this->globalEnv->hasRequireAlias('my\\project', Symbol::create('package')));
         self::assertSame('vendor\\package', $this->globalEnv->resolveAlias('package'));
 
         $phpClassNode = $this->globalEnv->resolve(Symbol::create('Library'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNode);
         self::assertSame('\\Vendor\\Library', $phpClassNode->getName()->getName());
+
+        $phpClassNodeAlias = $this->globalEnv->resolve(Symbol::create('Kit'), NodeEnvironment::empty());
+        self::assertInstanceOf(PhpClassNameNode::class, $phpClassNodeAlias);
+        self::assertSame('\\Vendor\\Toolkit', $phpClassNodeAlias->getName()->getName());
 
         Phel::addDefinition('vendor\\package', 'foo', 'value', Phel::map());
         $globalVarNode = $this->globalEnv->resolve(Symbol::create('foo'), NodeEnvironment::empty());


### PR DESCRIPTION
## 🤔 Background

Right now, the `:use` suports only one class not multiple
```
(ns examples\php-integration
  (:use DateInterval)
  (:use DateTimeImmutable)
  (:use DateTimeZone))
```

## 💡 Goal

Allow multiple entries in `:use` from the ns form:
```
(ns examples\php-integration
  (:use DateInterval DateTimeImmutable DateTimeZone))
```

## 🔖 Changes

Expanded `:use` analysis to iterate over multiple class symbols, validate keyword options, and reuse a shared alias helper for each import entry.