### PR TITLE
Refactor TrySymbol for better readability

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -19,118 +19,227 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
 {
     use WithAnalyzerTrait;
 
+    private const string STATE_START = 'start';
+
+    private const string STATE_CATCHES = 'catches';
+
+    private const string STATE_DONE = 'done';
+
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): TryNode
     {
-        $state = 'start';
+        $parsedTry = $this->parseTryForm($list);
+        $catchContext = $this->resolveCatchContext($env);
+
+        $finallyNode = $this->analyzeFinallyBlock($parsedTry['finally'], $env);
+        $catchNodes = $this->analyzeCatchBlocks($parsedTry['catches'], $env, $catchContext);
+        $bodyNode = $this->analyzeBodyBlock($parsedTry['body'], $env, $catchContext, $catchNodes, $finallyNode);
+
+        return new TryNode(
+            $env,
+            $bodyNode,
+            $catchNodes,
+            $finallyNode,
+            $list->getStartLocation(),
+        );
+    }
+
+    /**
+     * @return array{
+     *     body: list<mixed>,
+     *     catches: list<PersistentListInterface>,
+     *     finally: PersistentListInterface|null,
+     * }
+     */
+    private function parseTryForm(PersistentListInterface $list): array
+    {
+        $state = self::STATE_START;
         $body = [];
         $catches = [];
-        /** @var PersistentListInterface|null $finally */
         $finally = null;
+
         for ($forms = $list->cdr(); $forms instanceof PersistentListInterface; $forms = $forms->cdr()) {
             /** @var mixed $form */
             $form = $forms->first();
 
-            switch ($state) {
-                case 'start':
-                    if ($form instanceof PersistentListInterface && $this->isSymWithName($form->get(0), 'catch')) {
-                        $state = 'catches';
-                        $catches[] = $form;
-                    } elseif ($form instanceof PersistentListInterface && $this->isSymWithName($form->get(0), 'finally')) {
-                        $state = 'done';
-                        $finally = $form;
-                    } else {
-                        $body[] = $form;
-                    }
-
-                    break;
-
-                case 'catches':
-                    if ($form instanceof PersistentListInterface && $this->isSymWithName($form->get(0), 'catch')) {
-                        $catches[] = $form;
-                    } elseif ($form instanceof PersistentListInterface && $this->isSymWithName($form->get(0), 'finally')) {
-                        $state = 'done';
-                        $finally = $form;
-                    } else {
-                        throw AnalyzerException::withLocation("Invalid 'try form", $list);
-                    }
-
-                    break;
-
-                case 'done':
-                    throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
-
-                default:
-                    throw AnalyzerException::withLocation("Unexpected parser state in 'try", $list);
+            if ($this->isCatchForm($form)) {
+                $state = $this->handleCatchForm($state, $form, $catches, $list);
+            } elseif ($this->isFinallyForm($form)) {
+                $state = $this->handleFinallyForm($state, $form, $finally, $list);
+            } else {
+                $this->handleBodyForm($state, $form, $body, $list);
             }
         }
 
-        if ($finally instanceof PersistentListInterface) {
-            /** @psalm-suppress InvalidOperand */
-            $finally = Phel::list([
-                Symbol::create(Symbol::NAME_DO),
-                ...$finally->rest(),
-            ])->copyLocationFrom($finally);
+        return [
+            'body' => $body,
+            'catches' => $catches,
+            'finally' => $finally,
+        ];
+    }
 
-            $finally = $this->analyzer->analyze(
-                $finally,
-                $env->withStatementContext()->withDisallowRecurFrame(),
-            );
+    private function isCatchForm(mixed $form): bool
+    {
+        return $form instanceof PersistentListInterface
+            && $this->isSymWithName($form->get(0), 'catch');
+    }
+
+    private function isFinallyForm(mixed $form): bool
+    {
+        return $form instanceof PersistentListInterface
+            && $this->isSymWithName($form->get(0), 'finally');
+    }
+
+    /**
+     * @param list<PersistentListInterface> $catches
+     * @param PersistentListInterface       $form
+     *
+     * @param-out non-empty-list<PersistentListInterface> $catches
+     */
+    private function handleCatchForm(string $state, mixed $form, array &$catches, PersistentListInterface $list): string
+    {
+        if ($state === self::STATE_DONE) {
+            throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
         }
 
-        $catchCtx = $env->isContext(NodeEnvironment::CONTEXT_EXPRESSION)
+        $catches[] = $form;
+        return self::STATE_CATCHES;
+    }
+
+    private function handleFinallyForm(string $state, mixed $form, ?PersistentListInterface &$finally, PersistentListInterface $list): string
+    {
+        if ($state === self::STATE_DONE) {
+            throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
+        }
+
+        $finally = $form;
+        return self::STATE_DONE;
+    }
+
+    /**
+     * @param list<mixed> $body
+     */
+    private function handleBodyForm(string $state, mixed $form, array &$body, PersistentListInterface $list): void
+    {
+        if ($state === self::STATE_CATCHES) {
+            throw AnalyzerException::withLocation("Invalid 'try form", $list);
+        }
+
+        if ($state === self::STATE_DONE) {
+            throw AnalyzerException::withLocation("Unexpected form after 'finally", $list);
+        }
+
+        $body[] = $form;
+    }
+
+    private function resolveCatchContext(NodeEnvironmentInterface $env): string
+    {
+        return $env->isContext(NodeEnvironment::CONTEXT_EXPRESSION)
             ? NodeEnvironment::CONTEXT_RETURN
             : $env->getContext();
+    }
 
-        $catchNodes = [];
-        /** @var PersistentListInterface $catch */
-        foreach ($catches as $catch) {
-            $type = $catch->get(1);
-            $name = $catch->get(2);
-
-            if (!($type instanceof Symbol)) {
-                throw AnalyzerException::withLocation("First argument of 'catch must be a Symbol", $catch);
-            }
-
-            if (!($name instanceof Symbol)) {
-                throw AnalyzerException::withLocation("Second argument of 'catch must be a Symbol", $catch);
-            }
-
-            $resolvedType = $this->analyzer->resolve($type, $env);
-
-            if (!$resolvedType instanceof AbstractNode) {
-                throw AnalyzerException::withLocation('Can not resolve type ' . $type->getName(), $catch);
-            }
-
-            $exprs = [Symbol::create(Symbol::NAME_DO), ...$catch->rest()->rest()->rest()->toArray()];
-
-            $catchBody = $this->analyzer->analyze(
-                Phel::list($exprs),
-                $env->withContext($catchCtx)
-                    ->withMergedLocals([$name])
-                    ->withDisallowRecurFrame(),
-            );
-
-            $catchNodes[] = new CatchNode(
-                $env,
-                $resolvedType,
-                $name,
-                $catchBody,
-                $catch->getStartLocation(),
-            );
+    private function analyzeFinallyBlock(?PersistentListInterface $finally, NodeEnvironmentInterface $env): ?AbstractNode
+    {
+        if (!$finally instanceof PersistentListInterface) {
+            return null;
         }
 
-        $body = $this->analyzer->analyze(
-            Phel::list([Symbol::create(Symbol::NAME_DO), ...$body]),
-            $env->withContext($catchNodes !== [] || $finally ? $catchCtx : $env->getContext())
+        /** @psalm-suppress InvalidOperand */
+        $finallyList = Phel::list([
+            Symbol::create(Symbol::NAME_DO),
+            ...$finally->rest(),
+        ])->copyLocationFrom($finally);
+
+        return $this->analyzer->analyze(
+            $finallyList,
+            $env->withStatementContext()->withDisallowRecurFrame(),
+        );
+    }
+
+    /**
+     * @param list<PersistentListInterface> $catches
+     *
+     * @return list<CatchNode>
+     */
+    private function analyzeCatchBlocks(array $catches, NodeEnvironmentInterface $env, string $catchContext): array
+    {
+        $catchNodes = [];
+
+        foreach ($catches as $catch) {
+            $catchNodes[] = $this->analyzeSingleCatch($catch, $env, $catchContext);
+        }
+
+        return $catchNodes;
+    }
+
+    private function analyzeSingleCatch(PersistentListInterface $catch, NodeEnvironmentInterface $env, string $catchContext): CatchNode
+    {
+        $type = $catch->get(1);
+        $name = $catch->get(2);
+
+        $this->validateCatchArguments($type, $name, $catch);
+
+        $resolvedType = $this->resolveCatchType($type, $env, $catch);
+        $catchBody = $this->analyzeCatchBody($catch, $name, $env, $catchContext);
+
+        return new CatchNode(
+            $env,
+            $resolvedType,
+            $name,
+            $catchBody,
+            $catch->getStartLocation(),
+        );
+    }
+
+    private function validateCatchArguments(mixed $type, mixed $name, PersistentListInterface $catch): void
+    {
+        if (!($type instanceof Symbol)) {
+            throw AnalyzerException::withLocation("First argument of 'catch must be a Symbol", $catch);
+        }
+
+        if (!($name instanceof Symbol)) {
+            throw AnalyzerException::withLocation("Second argument of 'catch must be a Symbol", $catch);
+        }
+    }
+
+    private function resolveCatchType(Symbol $type, NodeEnvironmentInterface $env, PersistentListInterface $catch): AbstractNode
+    {
+        $resolvedType = $this->analyzer->resolve($type, $env);
+
+        if (!$resolvedType instanceof AbstractNode) {
+            throw AnalyzerException::withLocation('Can not resolve type ' . $type->getName(), $catch);
+        }
+
+        return $resolvedType;
+    }
+
+    private function analyzeCatchBody(PersistentListInterface $catch, Symbol $name, NodeEnvironmentInterface $env, string $catchContext): AbstractNode
+    {
+        $exprs = [
+            Symbol::create(Symbol::NAME_DO),
+            ...$catch->rest()->rest()->rest()->toArray(),
+            ];
+
+        return $this->analyzer->analyze(
+            Phel::list($exprs),
+            $env->withContext($catchContext)
+                ->withMergedLocals([$name])
                 ->withDisallowRecurFrame(),
         );
+    }
 
-        return new TryNode(
-            $env,
-            $body,
-            $catchNodes,
-            $finally,
-            $list->getStartLocation(),
+    /**
+     * @param list<mixed>     $body
+     * @param list<CatchNode> $catchNodes
+     */
+    private function analyzeBodyBlock(array $body, NodeEnvironmentInterface $env, string $catchContext, array $catchNodes, ?AbstractNode $finally): AbstractNode
+    {
+        $hasCatchOrFinally = $catchNodes !== [] || $finally instanceof AbstractNode;
+        $bodyContext = $hasCatchOrFinally ? $catchContext : $env->getContext();
+
+        return $this->analyzer->analyze(
+            Phel::list([Symbol::create(Symbol::NAME_DO), ...$body]),
+            $env->withContext($bodyContext)->withDisallowRecurFrame(),
         );
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/TrySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/TrySymbolTest.php
@@ -129,30 +129,6 @@ final class TrySymbolTest extends TestCase
         self::assertEquals(NodeEnvironment::empty(), $actual->getEnv());
     }
 
-    public function test_analyze_try_with_map_literal_body(): void
-    {
-        $list = Phel::list([
-            Symbol::create(Symbol::NAME_TRY),
-            Phel::map('a', 1, 'b', 2),
-        ]);
-
-        $actual = $this->analyze($list);
-
-        self::assertInstanceOf(TryNode::class, $actual);
-    }
-
-    public function test_analyze_try_with_empty_vector_literal_body(): void
-    {
-        $list = Phel::list([
-            Symbol::create(Symbol::NAME_TRY),
-            Phel::vector(),
-        ]);
-
-        $actual = $this->analyze($list);
-
-        self::assertInstanceOf(TryNode::class, $actual);
-    }
-
     public function test_analyze_try_with_only_body(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

https://scrutinizer-ci.com/g/phel-lang/phel-lang/code-structure/main/operation/Phel%5CCompiler%5CDomain%5CAnalyzer%5CTypeAnalyzer%5CSpecialForm%5CTrySymbol::analyze

<img width="1135" height="766" alt="Screenshot 2025-10-05 at 16 00 28" src="https://github.com/user-attachments/assets/dd61818e-f7a1-4a90-9fd4-9d2ada1d30d1" />

## 🔖 Changes

Refactor TrySymbol for better readability