### PR TITLE
Allow null on phel static collections arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Allow null on Phel static collections (vector, list, map, set) arguments
+
 ## [0.23.0](https://github.com/phel-lang/phel-lang/compare/v0.22.2...v0.23.0) - 2025-10-05
 
 - Fix `doc` command on phar command

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Phel\Lang\Collections\HashSet\PersistentHashSet;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -57,21 +56,21 @@ final class Phel extends InternalPhel
     /**
      * Create a persistent vector from an array of values.
      *
-     * @param list<mixed> $values
+     * @param list<mixed>|null $values
      */
-    public static function vector(array $values = []): PersistentVectorInterface
+    public static function vector(?array $values = []): PersistentVectorInterface
     {
-        return TypeFactory::getInstance()->persistentVectorFromArray($values);
+        return TypeFactory::getInstance()->persistentVectorFromArray($values ?? []);
     }
 
     /**
      * Create a persistent list from an array of values.
      *
-     * @param list<mixed> $values
+     * @param list<mixed>|null $values
      */
-    public static function list(array $values = []): PersistentListInterface
+    public static function list(?array $values = []): PersistentListInterface
     {
-        return TypeFactory::getInstance()->persistentListFromArray($values);
+        return TypeFactory::getInstance()->persistentListFromArray($values ?? []);
     }
 
     /**
@@ -88,6 +87,10 @@ final class Phel extends InternalPhel
             if (is_array($firstArgument)) {
                 return $typeFactory->persistentMapFromArray($firstArgument);
             }
+
+            if ($firstArgument === null) {
+                return $typeFactory->persistentMapFromArray([]);
+            }
         }
 
         return $typeFactory->persistentMapFromKVs(...$kvs);
@@ -96,11 +99,11 @@ final class Phel extends InternalPhel
     /**
      * Create a persistent hash set from an array of values.
      *
-     * @param list<mixed> $values
+     * @param list<mixed>|null $values
      */
-    public static function set(array $values = []): PersistentHashSetInterface
+    public static function set(?array $values = []): PersistentHashSetInterface
     {
-        return TypeFactory::getInstance()->persistentHashSetFromArray($values);
+        return TypeFactory::getInstance()->persistentHashSetFromArray($values ?? []);
     }
 
     /**

--- a/tests/php/Unit/Phel/PhelConstructorsTest.php
+++ b/tests/php/Unit/Phel/PhelConstructorsTest.php
@@ -38,4 +38,28 @@ final class PhelConstructorsTest extends TestCase
         $set = Phel::set([1, 2]);
         self::assertSame([1, 2], $set->toPhpArray());
     }
+
+    public function test_vector_with_null(): void
+    {
+        $vector = Phel::vector(null);
+        self::assertSame([], $vector->toArray());
+    }
+
+    public function test_list_with_null(): void
+    {
+        $list = Phel::list(null);
+        self::assertSame([], $list->toArray());
+    }
+
+    public function test_map_with_null(): void
+    {
+        $map = Phel::map(null);
+        self::assertSame([], iterator_to_array($map));
+    }
+
+    public function test_set_with_null(): void
+    {
+        $set = Phel::set(null);
+        self::assertSame([], $set->toPhpArray());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

I noticed that when running phel on a web server, it's crashing because GLOBALS does not contain "argv" when I tried:

```phel
  (php/:: Phel (vector (php/aget php/$GLOBALS "argv"))))
```

I get a : **Fatal error: Uncaught TypeError: Phel::vector(): Argument #1 ($values) must be of type array, null given**

## 💡 Goal

Allow passing null as an argument, so this will be similar to an empty array, avoiding fatal errors at runtime.
