### PR TITLE
Fix argv from GLOBALS when does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Allow null on Phel static collections (vector, list, map, set) arguments
+- Fix `argv` from GLOBALS when does not exist
 
 ## [0.23.0](https://github.com/phel-lang/phel-lang/compare/v0.22.2...v0.23.0) - 2025-10-05
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -44,10 +44,6 @@
   "Returns the path to the current source file."
   "")
 
-(def argv
-  "Vector of arguments passed to the script."
-  (php/:: Phel (vector (php/aget php/$GLOBALS "argv"))))
-
 # --------------------------------------------
 # Basic methods for quasiquote and destructure
 # --------------------------------------------
@@ -118,6 +114,14 @@
    :doc "Declare a global symbol before it is defined."}
   (fn [name]
     `(def ,name nil)))
+
+(declare nil?)
+(def argv
+  "Vector of arguments passed to the script."
+  (let [argv-raw (php/aget php/$GLOBALS "argv")]
+    (if (php/=== argv-raw nil)
+      []
+      (php/:: Phel (vector argv-raw)))))
 
 # ------------
 # Meta helpers


### PR DESCRIPTION
## 🔖 Changes

- Avoid calling `Phel::vector(...)` if there is no args from `$GLOBALS`