### PR TITLE
Improve type safety with PHPDoc annotations and generic types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "homepage": "https://phel-lang.org/",
     "require": {
         "php": ">=8.3",
-        "gacela-project/gacela": "^1.11",
+        "gacela-project/gacela": "^1.12",
         "phpunit/php-timer": "^6.0|^7.0|^8.0",
         "symfony/console": "^6.0|^7.0|^8.0"
     },
@@ -37,7 +37,7 @@
         "psalm/plugin-phpunit": "^0.19",
         "rector/rector": "^2.2",
         "symfony/var-dumper": "^7.3",
-        "vimeo/psalm": "^7.0.0-beta11"
+        "vimeo/psalm": "^6.13"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be6db9eea61a31b6b9cd1e87db11bc37",
+    "content-hash": "2735918656cd817509e30323402db215",
     "packages": [
         {
             "name": "gacela-project/container",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/container.git",
-                "reference": "64315ade4f21407a807e48f7d18cf5a96c387cd7"
+                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/container/zipball/64315ade4f21407a807e48f7d18cf5a96c387cd7",
-                "reference": "64315ade4f21407a807e48f7d18cf5a96c387cd7",
+                "url": "https://api.github.com/repos/gacela-project/container/zipball/62a409c918fe0e301b909da1c54aea189bd6e76a",
+                "reference": "62a409c918fe0e301b909da1c54aea189bd6e76a",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/resolver/issues",
-                "source": "https://github.com/gacela-project/container/tree/0.7.0"
+                "source": "https://github.com/gacela-project/container/tree/0.8.0"
             },
             "funding": [
                 {
@@ -72,31 +72,31 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-08-01T22:35:09+00:00"
+            "time": "2025-11-08T22:36:48+00:00"
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "87d099d39d8d0349cd0abd961cda0f026512e263"
+                "reference": "60c49f8ea74a298efb9153441edfdbcce982be23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/87d099d39d8d0349cd0abd961cda0f026512e263",
-                "reference": "87d099d39d8d0349cd0abd961cda0f026512e263",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/60c49f8ea74a298efb9153441edfdbcce982be23",
+                "reference": "60c49f8ea74a298efb9153441edfdbcce982be23",
                 "shasum": ""
             },
             "require": {
-                "gacela-project/container": "^0.7",
+                "gacela-project/container": "^0.8",
                 "php": ">=8.1"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.47",
-                "friendsofphp/php-cs-fixer": "^3.88",
+                "ergebnis/composer-normalize": "^2.48",
+                "friendsofphp/php-cs-fixer": "^3.89",
                 "infection/infection": "^0.29",
-                "phpbench/phpbench": "^1.3",
+                "phpbench/phpbench": "^1.4",
                 "phpmetrics/phpmetrics": "^2.9",
                 "phpstan/phpstan": "^1.12",
                 "phpstan/phpstan-strict-rules": "^1.6",
@@ -148,7 +148,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.11.0"
+                "source": "https://github.com/gacela-project/gacela/tree/1.12.0"
             },
             "funding": [
                 {
@@ -156,7 +156,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-10-12T16:34:24+00:00"
+            "time": "2025-11-09T20:54:47+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -272,16 +272,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.5",
+            "version": "v7.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7"
+                "reference": "c28ad91448f86c5f6d9d2c70f0cf68bf135f252a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
-                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c28ad91448f86c5f6d9d2c70f0cf68bf135f252a",
+                "reference": "c28ad91448f86c5f6d9d2c70f0cf68bf135f252a",
                 "shasum": ""
             },
             "require": {
@@ -346,7 +346,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.5"
+                "source": "https://github.com/symfony/console/tree/v7.3.6"
             },
             "funding": [
                 {
@@ -366,7 +366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-14T15:46:26+00:00"
+            "time": "2025-11-04T01:21:42+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -772,16 +772,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
@@ -835,7 +835,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -847,11 +847,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         },
         {
             "name": "symfony/string",
@@ -1816,79 +1820,6 @@
                 }
             ],
             "time": "2022-12-23T10:58:28+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "composer/pcre",
@@ -3077,16 +3008,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.89.1",
+            "version": "v3.89.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "f34967da2866ace090a2b447de1f357356474573"
+                "reference": "7569658f91e475ec93b99bd5964b059ad1336dcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/f34967da2866ace090a2b447de1f357356474573",
-                "reference": "f34967da2866ace090a2b447de1f357356474573",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7569658f91e475ec93b99bd5964b059ad1336dcf",
+                "reference": "7569658f91e475ec93b99bd5964b059ad1336dcf",
                 "shasum": ""
             },
             "require": {
@@ -3122,7 +3053,7 @@
                 "justinrainbow/json-schema": "^6.5",
                 "keradus/cli-executor": "^2.2",
                 "mikey179/vfsstream": "^1.6.12",
-                "php-coveralls/php-coveralls": "^2.8",
+                "php-coveralls/php-coveralls": "^2.9",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
                 "phpunit/phpunit": "^9.6.25 || ^10.5.53 || ^11.5.34",
@@ -3168,7 +3099,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.89.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.89.2"
             },
             "funding": [
                 {
@@ -3176,20 +3107,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-24T12:05:10+00:00"
+            "time": "2025-11-06T21:12:50+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.0",
+            "version": "6.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "68ba7677532803cc0c5900dd5a4d730537f2b2f3"
+                "reference": "fd8e5c6b1badb998844ad34ce0abcd71a0aeb396"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/68ba7677532803cc0c5900dd5a4d730537f2b2f3",
-                "reference": "68ba7677532803cc0c5900dd5a4d730537f2b2f3",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fd8e5c6b1badb998844ad34ce0abcd71a0aeb396",
+                "reference": "fd8e5c6b1badb998844ad34ce0abcd71a0aeb396",
                 "shasum": ""
             },
             "require": {
@@ -3249,9 +3180,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.1"
             },
-            "time": "2025-10-10T11:34:09+00:00"
+            "time": "2025-11-07T18:30:29+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -3902,24 +3833,24 @@
         },
         {
             "name": "phpbench/container",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/container.git",
-                "reference": "a59b929e00b87b532ca6d0edd8eca0967655af33"
+                "reference": "0c7b2d36c1ea53fe27302fb8873ded7172047196"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/container/zipball/a59b929e00b87b532ca6d0edd8eca0967655af33",
-                "reference": "a59b929e00b87b532ca6d0edd8eca0967655af33",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/0c7b2d36c1ea53fe27302fb8873ded7172047196",
+                "reference": "0c7b2d36c1ea53fe27302fb8873ded7172047196",
                 "shasum": ""
             },
             "require": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0"
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16",
+                "php-cs-fixer/shim": "^3.89",
                 "phpstan/phpstan": "^0.12.52",
                 "phpunit/phpunit": "^8"
             },
@@ -3947,22 +3878,22 @@
             "description": "Simple, configurable, service container.",
             "support": {
                 "issues": "https://github.com/phpbench/container/issues",
-                "source": "https://github.com/phpbench/container/tree/2.2.2"
+                "source": "https://github.com/phpbench/container/tree/2.2.3"
             },
-            "time": "2023-10-30T13:38:26+00:00"
+            "time": "2025-11-06T09:05:13+00:00"
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "bb61ae6c54b3d58642be154eb09f4e73c3511018"
+                "reference": "b641dde59d969ea42eed70a39f9b51950bc96878"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/bb61ae6c54b3d58642be154eb09f4e73c3511018",
-                "reference": "bb61ae6c54b3d58642be154eb09f4e73c3511018",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/b641dde59d969ea42eed70a39f9b51950bc96878",
+                "reference": "b641dde59d969ea42eed70a39f9b51950bc96878",
                 "shasum": ""
             },
             "require": {
@@ -3977,26 +3908,26 @@
                 "phpbench/container": "^2.2",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
                 "seld/jsonlint": "^1.1",
-                "symfony/console": "^6.1 || ^7.0",
-                "symfony/filesystem": "^6.1 || ^7.0",
-                "symfony/finder": "^6.1 || ^7.0",
-                "symfony/options-resolver": "^6.1 || ^7.0",
-                "symfony/process": "^6.1 || ^7.0",
+                "symfony/console": "^6.1 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^6.1 || ^7.0 || ^8.0",
+                "symfony/finder": "^6.1 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^6.1 || ^7.0 || ^8.0",
+                "symfony/process": "^6.1 || ^7.0 || ^8.0",
                 "webmozart/glob": "^4.6"
             },
             "require-dev": {
                 "dantleech/invoke": "^2.0",
                 "ergebnis/composer-normalize": "^2.39",
-                "friendsofphp/php-cs-fixer": "^3.0",
                 "jangregor/phpstan-prophecy": "^1.0",
+                "php-cs-fixer/shim": "^3.9",
                 "phpspec/prophecy": "^1.22",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^10.4 || ^11.0",
                 "rector/rector": "^1.2",
-                "symfony/error-handler": "^6.1 || ^7.0",
-                "symfony/var-dumper": "^6.1 || ^7.0"
+                "symfony/error-handler": "^6.1 || ^7.0 || ^8.0",
+                "symfony/var-dumper": "^6.1 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "ext-xdebug": "For Xdebug profiling extension."
@@ -4039,7 +3970,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.4.2"
+                "source": "https://github.com/phpbench/phpbench/tree/1.4.3"
             },
             "funding": [
                 {
@@ -4047,7 +3978,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-26T14:21:59+00:00"
+            "time": "2025-11-06T19:07:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4697,35 +4628,32 @@
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.19.3",
+            "version": "0.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "07dbf9fec23a694f2c095d8e2d44ccd6992afe38"
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/07dbf9fec23a694f2c095d8e2d44ccd6992afe38",
-                "reference": "07dbf9fec23a694f2c095d8e2d44ccd6992afe38",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
                 "shasum": ""
             },
             "require": {
-                "composer/package-versions-deprecated": "^1.10",
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "ext-simplexml": "*",
                 "php": ">=8.1",
-                "vimeo/psalm": "dev-master || ^6 || ^7"
+                "vimeo/psalm": "dev-master || ^6.10.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<7.5"
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
             },
             "require-dev": {
-                "behat/gherkin": "~4.11.0",
-                "codeception/codeception": "^4.0.3",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
                 "squizlabs/php_codesniffer": "^3.3.1",
-                "weirdan/codeception-psalm-module": "^0.11.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "type": "psalm-plugin",
@@ -4752,9 +4680,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.3"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
-            "time": "2025-03-20T11:21:58+00:00"
+            "time": "2025-03-31T18:49:55+00:00"
         },
         {
             "name": "psr/cache",
@@ -6918,16 +6846,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.3.2",
+            "version": "v7.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd"
+                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edcbb768a186b5c3f25d0643159a787d3e63b7fd",
-                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e9bcfd7837928ab656276fe00464092cc9e1826a",
+                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a",
                 "shasum": ""
             },
             "require": {
@@ -6964,7 +6892,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.3.2"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.6"
             },
             "funding": [
                 {
@@ -6984,7 +6912,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-07T08:17:47+00:00"
+            "time": "2025-11-05T09:52:27+00:00"
         },
         {
             "name": "symfony/finder",
@@ -7635,16 +7563,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "7.0.0-beta11",
+            "version": "6.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "24cb5084ef3db7259d26047ea3a7ddef30f36144"
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/24cb5084ef3db7259d26047ea3a7ddef30f36144",
-                "reference": "24cb5084ef3db7259d26047ea3a7ddef30f36144",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
                 "shasum": ""
             },
             "require": {
@@ -7749,7 +7677,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-07-14T09:59:20+00:00"
+            "time": "2025-08-06T10:10:28+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -7861,9 +7789,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "vimeo/psalm": 10
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/gacela-project/gacela/phpstan-gacela.neon
+
 parameters:
     level: 5
     parallel:

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
@@ -18,15 +19,22 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
 
+    <xi:include href="vendor/gacela-project/gacela/psalm-gacela.xml"/>
+
     <issueHandlers>
-        <DeprecatedConstant errorLevel="suppress" />
-        <DeprecatedClass errorLevel="suppress" />
-        <DeprecatedInterface errorLevel="suppress" />
-        <DeprecatedMethod errorLevel="suppress" />
+        <!-- Suppress overly strict checks -->
+        <MissingOverrideAttribute errorLevel="suppress" />
+        <ClassMustBeFinal errorLevel="suppress" />
         <MissingTemplateParam errorLevel="suppress" />
         <ArgumentTypeCoercion errorLevel="suppress" />
         <LessSpecificReturnStatement errorLevel="suppress" />
+        <MoreSpecificReturnType errorLevel="suppress" />
+        <RiskyTruthyFalsyComparison errorLevel="suppress" />
+        <PossiblyUndefinedMethod errorLevel="suppress" />
+        <InvalidArrayOffset errorLevel="suppress" />
         <NamedArgumentNotAllowed errorLevel="suppress" />
+
+        <!-- Type safety suppressions for dynamic code -->
         <MixedArgument errorLevel="suppress" />
         <MixedArgumentTypeCoercion errorLevel="suppress" />
         <MixedArrayAccess errorLevel="suppress" />
@@ -39,13 +47,5 @@
         <MixedPropertyTypeCoercion errorLevel="suppress" />
         <MixedReturnStatement errorLevel="suppress" />
         <MixedReturnTypeCoercion errorLevel="suppress" />
-        <MoreSpecificReturnType errorLevel="suppress" />
-        <InvalidArrayOffset errorLevel="suppress" />
-        <RiskyTruthyFalsyComparison errorLevel="suppress" />
-        <PossiblyUndefinedMethod errorLevel="suppress" />
-        <MissingOverrideAttribute errorLevel="suppress" />
-        <ClassMustBeFinal errorLevel="suppress" />
-        <TaintedHtml errorLevel="suppress" />
-        <TaintedTextWithQuotes errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -15,7 +15,7 @@ use Phel\Api\Domain\ReplCompleterInterface;
 use Phel\Api\Infrastructure\PhelFnLoader;
 
 /**
- * @method ApiConfig getConfig()
+ * @extends AbstractFactory<ApiConfig>
  */
 final class ApiFactory extends AbstractFactory
 {

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Api\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use InvalidArgumentException;
 use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\PhelFunction;
@@ -14,18 +15,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
 use Symfony\Component\Console\Terminal;
 
 use function in_array;
 use function sprintf;
 
-/**
- * @method ApiFacade getFacade()
- */
+#[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
 final class DocCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     private const string OPTION_NAMESPACES = 'ns';
 

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -8,9 +8,6 @@ use Gacela\Framework\AbstractConfig;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
-/**
- * @method BuildConfig getConfig()
- */
 final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 {
     /**

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -22,7 +22,7 @@ use Phel\Shared\Facade\CommandFacadeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 
 /**
- * @method BuildConfig getConfig()
+ * @extends AbstractFactory<BuildConfig>
  */
 final class BuildFactory extends AbstractFactory
 {

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
@@ -18,12 +19,10 @@ use Throwable;
 
 use function sprintf;
 
-/**
- * @method BuildFacade getFacade()
- */
+#[ServiceMap(method: 'getFacade', className: BuildFacade::class)]
 final class BuildCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     private const string OPTION_CACHE = 'cache';
 

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -23,7 +23,7 @@ use Phel\Printer\Printer;
 use Phel\Run\Domain\Repl\ColorStyle;
 
 /**
- * @method CommandConfig getConfig()
+ * @extends AbstractFactory<CommandConfig>
  */
 final class CommandFactory extends AbstractFactory
 {

--- a/src/php/Command/Infrastructure/ComposerVendorDirectoriesFinder.php
+++ b/src/php/Command/Infrastructure/ComposerVendorDirectoriesFinder.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Command\Infrastructure;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel;
 use Phel\Command\CommandFacade;
 use Phel\Command\Domain\Finder\VendorDirectoriesFinderInterface;
@@ -15,12 +16,10 @@ use function dirname;
 use function glob;
 use function sprintf;
 
-/**
- * @method CommandFacade getFacade()
- */
+#[ServiceMap(method: 'getFacade', className: CommandFacade::class)]
 final class ComposerVendorDirectoriesFinder implements VendorDirectoriesFinderInterface
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     public function __construct(
         private readonly string $vendorDirectory,

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -42,7 +42,7 @@ use Phel\Filesystem\FilesystemFacadeInterface;
 use Phel\Printer\Printer;
 
 /**
- * @method CompilerConfig getConfig()
+ * @extends AbstractFactory<CompilerConfig>
  */
 final class CompilerFactory extends AbstractFactory
 {

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Console\Infrastructure;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Override;
 use Phel\Console\ConsoleFactory;
 use Symfony\Component\Console\Application;
@@ -13,12 +14,10 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @method ConsoleFactory getFactory()
- */
+#[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
 final class ConsoleBootstrap extends Application
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     #[Override]
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int

--- a/src/php/Filesystem/FilesystemFactory.php
+++ b/src/php/Filesystem/FilesystemFactory.php
@@ -12,7 +12,7 @@ use Phel\Filesystem\Domain\NullFilesystem;
 use Phel\Filesystem\Infrastructure\RealFilesystem;
 
 /**
- * @method FilesystemConfig getConfig()
+ * @extends AbstractFactory<FilesystemConfig>
  */
 final class FilesystemFactory extends AbstractFactory
 {

--- a/src/php/Formatter/Infrastructure/Command/FormatCommand.php
+++ b/src/php/Formatter/Infrastructure/Command/FormatCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Formatter\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Formatter\FormatterConfig;
 use Phel\Formatter\FormatterFacade;
 use Symfony\Component\Console\Command\Command;
@@ -14,13 +15,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
 
-/**
- * @method FormatterFacade getFacade()
- * @method FormatterConfig getConfig()
- */
+#[ServiceMap(method: 'getFacade', className: FormatterFacade::class)]
+#[ServiceMap(method: 'getConfig', className: FormatterConfig::class)]
 final class FormatCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     protected function configure(): void
     {

--- a/src/php/Interop/Infrastructure/Command/ExportCommand.php
+++ b/src/php/Interop/Infrastructure/Command/ExportCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Interop\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Interop\InteropFacade;
 use Symfony\Component\Console\Command\Command;
@@ -17,9 +18,10 @@ use function sprintf;
 /**
  * @method InteropFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: InteropFacade::class)]
 final class ExportCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     protected function configure(): void
     {

--- a/src/php/Interop/InteropFactory.php
+++ b/src/php/Interop/InteropFactory.php
@@ -22,7 +22,7 @@ use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
 /**
- * @method InteropConfig getConfig()
+ * @extends AbstractFactory<InteropConfig>
  */
 final class InteropFactory extends AbstractFactory
 {

--- a/src/php/Lang/Equalizer.php
+++ b/src/php/Lang/Equalizer.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use Gacela\Container\Attribute\Singleton;
+
+#[Singleton]
 final class Equalizer implements EqualizerInterface
 {
     /**

--- a/src/php/Lang/Hasher.php
+++ b/src/php/Lang/Hasher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use Gacela\Container\Attribute\Singleton;
 use RuntimeException;
 
 use function gettype;
@@ -16,6 +17,7 @@ use function is_string;
  * This Hasher is inspired by the Clojurescript implementation.
  * These constants are the same hash value as in clojure.
  */
+#[Singleton]
 final class Hasher implements HasherInterface
 {
     private const int NULL_HASH_VALUE = 0;

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Run\RunFacade;
 use Phel\Run\RunFactory;
 use Symfony\Component\Console\Command\Command;
@@ -16,9 +17,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @method RunFacade getFacade()
  * @method RunFactory getFactory()
  */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
+#[ServiceMap(method: 'getFactory', className: RunFactory::class)]
 final class EvalCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     protected function configure(): void
     {

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Run\RunFacade;
 use Symfony\Component\Console\Command\Command;
@@ -17,12 +18,10 @@ use function count;
 use function implode;
 use function sprintf;
 
-/**
- * @method RunFacade getFacade()
- */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
 class NsCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     protected function configure(): void
     {

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel;
 use Phel\Compiler\Domain\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
@@ -31,14 +32,12 @@ use function count;
 use function explode;
 use function sprintf;
 
-/**
- * @method RunFacade getFacade()
- * @method RunFactory getFactory()
- * @method RunConfig getConfig()
- */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
+#[ServiceMap(method: 'getFactory', className: RunFactory::class)]
+#[ServiceMap(method: 'getConfig', className: RunConfig::class)]
 final class ReplCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     private const string ENABLE_BRACKETED_PASTE = "\e[?2004h";
 

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Run\Infrastructure\Service\DebugLineTap;
 use Phel\Run\RunFacade;
@@ -24,9 +25,10 @@ use function sprintf;
 /**
  * @method RunFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
 final class RunCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     protected function configure(): void
     {

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
-use Gacela\Framework\DocBlockResolverAwareTrait;
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
@@ -23,9 +24,10 @@ use function sprintf;
 /**
  * @method RunFacade getFacade()
  */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
 final class TestCommand extends Command
 {
-    use DocBlockResolverAwareTrait;
+    use ServiceResolverAwareTrait;
 
     public const string COMMAND_NAME = 'test';
 

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -24,7 +24,7 @@ use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Facade\ConsoleFacadeInterface;
 
 /**
- * @method RunConfig getConfig()
+ * @extends AbstractFactory<RunConfig>
  */
 class RunFactory extends AbstractFactory
 {


### PR DESCRIPTION

  ## Changes

  ### Factory Classes
  - Removed `#[ServiceMap]` attributes from 7 Factory classes that don't use `ServiceResolverAwareTrait`
  - Added PHPDoc `@method ConfigClass getConfig()` annotations
  - Added generic `@extends AbstractFactory<ConfigClass>` annotations

  Affected classes:
  - `BuildFactory`, `ApiFactory`, `CommandFactory`, `CompilerFactory`, `FilesystemFactory`, `InteropFactory`, `RunFactory`

### Facade Classes
  All 9 Facade classes now have proper generic type annotations:
  ```php
  /**
   * @extends AbstractFacade<ModuleFactory>
   */
```

###  Command Classes

  Classes with ServiceResolverAwareTrait (BuildCommand, NsCommand, etc.) kept their #[ServiceMap] attributes as they use Gacela's dynamic resolution.
