### PR TITLE
Implement lazy map-indexed with support for infinite sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Make `concat` fully lazy with support for infinite sequences
 - Make `mapcat` fully lazy with support for infinite sequences
 - Make `interpose` fully lazy with support for infinite sequences
+- Make `map-indexed` fully lazy with support for infinite sequences
 
 ### Fixed
 - Fix `into` to work correctly with `PersistentList` and other `ConcatInterface` types that don't implement `PushInterface`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1610,7 +1610,6 @@ arrays. Use (php/aunset ds key)"))
           '()
           result)))))
 
-# Redefine mapcat as lazy
 (def mapcat
   "Maps a function over a collection and concatenates the results. Returns a lazy sequence.
 
@@ -1640,6 +1639,23 @@ arrays. Use (php/aunset ds key)"))
       '()
       (let [result (lazy-seq-from-generator
                      (php/:: \Phel\Lang\Generators (interpose sep coll)))]
+        (if (php/=== nil result)
+          '()
+          (with-meta coll result))))))
+
+(def map-indexed
+  "Maps a function over a collection with index. Returns a lazy sequence.
+
+  Applies `f` to each element in `xs`. `f` is a two-argument function where
+  the first argument is the index (0-based) and the second is the element itself.
+  Works with infinite sequences.
+
+  Example: (map-indexed vector [:a :b :c]) ; => ([0 :a] [1 :b] [2 :c])"
+  (fn [f coll]
+    (if (php/=== nil coll)
+      '()
+      (let [result (lazy-seq-from-generator
+                     (php/:: \Phel\Lang\Generators (mapIndexed f coll)))]
         (if (php/=== nil result)
           '()
           (with-meta coll result))))))

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -70,7 +70,7 @@
       (str " " (escape-html name) "=\""  (render-attribute-value name value) "\""))))
 
 (defn- render-attrs [attrs]
-  (apply str (map-indexed render-attribute attrs)))
+  (apply str (for [[name value] :pairs attrs] (render-attribute name value))))
 
 (defn- render-element
   "Renders an Element."

--- a/src/php/Lang/Generators.php
+++ b/src/php/Lang/Generators.php
@@ -161,6 +161,27 @@ final class Generators
     }
 
     /**
+     * Maps a function over an iterable with index.
+     * Applies the function to each element along with its index (0-based).
+     *
+     * @template T
+     * @template U
+     *
+     * @param callable(int, T): U $f        The mapping function that takes index and value
+     * @param iterable<T>         $iterable The input sequence
+     *
+     * @return Generator<int, U>
+     */
+    public static function mapIndexed(callable $f, iterable $iterable): Generator
+    {
+        $index = 0;
+        foreach ($iterable as $value) {
+            yield $f($index, $value);
+            ++$index;
+        }
+    }
+
+    /**
      * Generates a range of numbers [start, end) with given step.
      *
      * @return Generator<int, float|int>

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -469,3 +469,37 @@
   (let [result (interpose 0 [1 2 3])]
     (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
         "interpose should return a lazy sequence")))
+
+# Lazy map-indexed tests
+(deftest test-map-indexed-basic
+  (is (= [[0 "a"] [1 "b"] [2 "c"]] (doall (map-indexed vector ["a" "b" "c"])))
+      "map-indexed should apply function with index and value"))
+
+(deftest test-map-indexed-is-lazy
+  (is (= [[0 1] [1 2] [2 3]] (take 3 (map-indexed vector [1 2 3 4 5])))
+      "map-indexed should be lazy and work with take"))
+
+(deftest test-map-indexed-with-infinite-sequence
+  (is (= [[0 0] [1 1] [2 2] [3 3] [4 4]] (take 5 (map-indexed vector (iterate inc 0))))
+      "map-indexed should work with infinite sequences"))
+
+(deftest test-map-indexed-empty-collection
+  (is (= '() (map-indexed vector []))
+      "map-indexed on empty collection should return empty list"))
+
+(deftest test-map-indexed-single-element
+  (is (= [[0 :x]] (doall (map-indexed vector [:x])))
+      "map-indexed on single element should work correctly"))
+
+(deftest test-map-indexed-custom-function
+  (is (= [0 11 22] (doall (map-indexed (fn [i v] (+ (* i 10) v)) [0 1 2])))
+      "map-indexed should work with custom functions"))
+
+(deftest test-map-indexed-returns-index-first
+  (is (= [0 1 2] (doall (map-indexed (fn [i v] i) ["a" "b" "c"])))
+      "map-indexed should pass index as first argument"))
+
+(deftest test-map-indexed-returns-lazy-seq
+  (let [result (map-indexed vector [1 2 3])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "map-indexed should return a lazy sequence")))


### PR DESCRIPTION
 ## 🤔 Background

  Continuing the lazy sequences implementation effort tracked in #1019. `map-indexed` was previously eager, preventing from working with infinite sequences. Additionally, the html module was misusing `map-indexed` to iterate over hash map pairs.

  ## 🔖 Changes

  **Lazy map-indexed:**
  - Added `Generators::mapIndexed` method for lazy indexed mapping
  - Added lazy `map-indexed` redefinition in core.phel
  - Fixed `render-attrs` in html.phel to use `for` loop with `:pairs` instead of misusing `map-indexed`
  - Added 8 tests covering laziness, infinite sequences, and edge cases