### PR TITLE
Implement lazy interleave with infinite sequence support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Make `mapcat` fully lazy with support for infinite sequences
 - Make `interpose` fully lazy with support for infinite sequences
 - Make `map-indexed` fully lazy with support for infinite sequences
+- Make `interleave` fully lazy with support for infinite sequences
 
 ### Fixed
 - Fix `into` to work correctly with `PersistentList` and other `ConcatInterface` types that don't implement `PushInterface`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1660,6 +1660,26 @@ arrays. Use (php/aunset ds key)"))
           '()
           (with-meta coll result))))))
 
+# Redefine interleave as lazy
+(def interleave
+  "Interleaves multiple collections. Returns a lazy sequence.
+
+  Returns elements by taking one from each collection in turn.
+  Pads with nil when collections have different lengths.
+  Works with infinite sequences.
+
+  Example: (interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)"
+  (fn [& colls]
+    (if (php/=== nil colls)
+      '()
+      (let [result (lazy-seq-from-generator
+                     (php/call_user_func_array
+                       (php/array "\\Phel\\Lang\\Generators" "interleave")
+                       (apply php/array colls)))]
+        (if (php/=== nil result)
+          '()
+          (with-meta (first colls) result))))))
+
 (defn doall
   "Forces realization of a lazy sequence and returns it as a vector.
   Useful when you need to force side effects or ensure computation happens immediately.

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -503,3 +503,41 @@
   (let [result (map-indexed vector [1 2 3])]
     (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
         "map-indexed should return a lazy sequence")))
+
+# Lazy interleave tests
+(deftest test-interleave-two-vectors
+  (is (= [1 :a 2 :b 3 :c] (doall (interleave [1 2 3] [:a :b :c])))
+      "interleave should alternate elements from two vectors"))
+
+(deftest test-interleave-is-lazy
+  (is (= [1 :a 2 :b 3] (take 5 (interleave [1 2 3 4 5] [:a :b :c :d :e])))
+      "interleave should be lazy and work with take"))
+
+(deftest test-interleave-with-infinite-sequence
+  (is (= [0 :x 1 :x 2 :x 3 :x 4 :x] (take 10 (interleave (iterate inc 0) (repeat :x))))
+      "interleave should work with infinite sequences"))
+
+(deftest test-interleave-stops-at-first
+  (is (= [1 :a 2 :b] (doall (interleave [1 2] [:a :b :c :d])))
+      "interleave should stop when first collection is exhausted"))
+
+(deftest test-interleave-three-collections
+  (is (= [1 :a "x" 2 :b "y" 3 :c "z"] (doall (interleave [1 2 3] [:a :b :c] ["x" "y" "z"])))
+      "interleave should work with three collections"))
+
+(deftest test-interleave-empty-collection
+  (is (= '() (interleave))
+      "interleave with no arguments should return empty list"))
+
+(deftest test-interleave-first-empty
+  (is (= [] (doall (interleave [] [1 2 3])))
+      "interleave should return empty when first collection is empty"))
+
+(deftest test-interleave-single-collection
+  (is (= [1 2 3] (doall (interleave [1 2 3])))
+      "interleave with single collection should return that collection"))
+
+(deftest test-interleave-returns-lazy-seq
+  (let [result (interleave [1 2 3] [:a :b :c])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "interleave should return a lazy sequence")))


### PR DESCRIPTION

  ## 🤔 Background

  Continuing the lazy sequences implementation effort tracked in #1019. The `interleave` function was previously eager, using a  loop with eager concat and count, which prevented it from working with infinite sequences.

  ## 💡 Goal

  - Implement lazy `interleave` with support for infinite sequences

  ## 🔖 Changes

  - Added `Generators::interleave` method in `src/php/Lang/Generators.php` for lazy interleaving
  - Added helper `toIterator` method to convert iterables to Iterator
  - Added lazy `interleave` redefinition in `src/phel/core.phel`
  