### PR TITLE
Document flatten as lazy and add comprehensive tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Make `interpose` fully lazy with support for infinite sequences
 - Make `map-indexed` fully lazy with support for infinite sequences
 - Make `interleave` fully lazy with support for infinite sequences
+- Document `flatten` as lazy (already was lazy via `filter` and `tree-seq`)
 
 ### Fixed
 - Fix `into` to work correctly with `PersistentList` and other `ConcatInterface` types that don't implement `PushInterface`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1946,8 +1946,12 @@ arrays. Use (php/aunset ds key)"))
         (with-meta root (persistent ret))))))
 
 (defn flatten
-  "Takes a nested sequential data structure `(tree)`, and returns their contents
-  as a single, flat vector."
+  "Takes a nested sequential data structure (tree) and returns a lazy sequence of all leaf values.
+
+  Walks the tree structure and yields all non-indexed (scalar) values.
+  Returns a lazy sequence that works with infinite nested structures.
+
+  Example: (flatten [[1 2] [3 [4 5]] 6]) ; => (1 2 3 4 5 6)"
   [xs]
   (filter
    (complement indexed?)

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -541,3 +541,37 @@
   (let [result (interleave [1 2 3] [:a :b :c])]
     (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
         "interleave should return a lazy sequence")))
+
+# Lazy flatten tests
+(deftest test-flatten-basic
+  (is (= [1 2 3 4 5 6] (doall (flatten [[1 2] [3 [4 5]] 6])))
+      "flatten should flatten nested vectors"))
+
+(deftest test-flatten-is-lazy
+  (is (= [1 2 3 4 5] (take 5 (flatten [[1 2] [3 4 5 6 7 8]])))
+      "flatten should be lazy and work with take"))
+
+(deftest test-flatten-deeply-nested
+  (is (= [1 2 3 4 5] (doall (flatten [1 [2 [3 [4 [5]]]]])))
+      "flatten should handle deeply nested structures"))
+
+(deftest test-flatten-empty-collection
+  (is (= [] (doall (flatten [])))
+      "flatten on empty collection should return empty vector"))
+
+(deftest test-flatten-already-flat
+  (is (= [1 2 3 4] (doall (flatten [1 2 3 4])))
+      "flatten on already flat collection should return same elements"))
+
+(deftest test-flatten-mixed-types
+  (is (= [1 :a "x" 2 :b "y"] (doall (flatten [[1 :a] ["x" [2]] [:b "y"]])))
+      "flatten should work with mixed types"))
+
+(deftest test-flatten-with-nil
+  (is (= [1 nil 2 3] (doall (flatten [[1 nil] [2 3]])))
+      "flatten should preserve nil values"))
+
+(deftest test-flatten-returns-lazy-seq
+  (let [result (flatten [[1 2] [3 4]])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "flatten should return a lazy sequence")))


### PR DESCRIPTION
## 🤔 Background

  Continuing the lazy sequences implementation effort tracked in #1019. The `flatten` function was already lazy (via `filter` and `tree-seq` composition) but was undocumented and untested for lazy behavior.

  ## 🔖 Changes

  - Updated `flatten` docstring in `src/phel/core.phel` to clarify it returns a lazy sequence
  - Added explanation of how it works: walks tree structure and yields all non-indexed (scalar) values
  - Added example usage to documentation
