### PR TITLE
Make variadic map lazy with support for infinite sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Make `interpose` fully lazy with support for infinite sequences
 - Make `map-indexed` fully lazy with support for infinite sequences
 - Make `interleave` fully lazy with support for infinite sequences
+- Make variadic `map` (multi-collection) fully lazy with support for infinite sequences
 - Document `flatten` as lazy (already was lazy via `filter` and `tree-seq`)
 
 ### Fixed

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1108,14 +1108,14 @@ arrays. Use (php/aunset ds key)"))
         (if (empty? coll)
           []
           (with-meta coll (lazy-seq-from-generator (php/:: Generators (map f coll))))))
-    (let [colls xs]
-      (loop [res (transient [])
-             seq colls]
-        (if (some? empty? seq)
-          (with-meta (first colls) (persistent res))
-          (do
-            (push res (apply f (map first seq)))
-            (recur res (map next seq))))))))
+    (let [colls xs
+          result (lazy-seq-from-generator
+                   (php/call_user_func_array
+                     (php/array "\\Phel\\Lang\\Generators" "mapMulti")
+                     (php/array_merge (php/array f) (apply php/array colls))))]
+      (if (php/=== nil result)
+        []
+        (with-meta (first colls) result)))))
 
 (defn map-indexed
   "Applies `f` to each element in `xs`. `f` is a two-argument function. The first argument

--- a/src/php/Lang/Generators.php
+++ b/src/php/Lang/Generators.php
@@ -222,6 +222,49 @@ final class Generators
     }
 
     /**
+     * Maps a function over multiple iterables.
+     * Applies the function to corresponding elements from each iterable.
+     * Stops when the shortest iterable is exhausted.
+     *
+     * @template T
+     *
+     * @param callable    $f            The mapping function
+     * @param iterable<T> ...$iterables The sequences to map over
+     *
+     * @return Generator<int, mixed>
+     */
+    public static function mapMulti(callable $f, iterable ...$iterables): Generator
+    {
+        if ($iterables === []) {
+            return;
+        }
+
+        $iterators = array_map(self::toIterator(...), $iterables);
+
+        while (true) {
+            $allValid = true;
+            foreach ($iterators as $iterator) {
+                if (!$iterator->valid()) {
+                    $allValid = false;
+                    break;
+                }
+            }
+
+            if (!$allValid) {
+                break;
+            }
+
+            $values = [];
+            foreach ($iterators as $iterator) {
+                $values[] = $iterator->current();
+                $iterator->next();
+            }
+
+            yield $f(...$values);
+        }
+    }
+
+    /**
      * Generates a range of numbers [start, end) with given step.
      *
      * @return Generator<int, float|int>

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -575,3 +575,37 @@
   (let [result (flatten [[1 2] [3 4]])]
     (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
         "flatten should return a lazy sequence")))
+
+# Lazy variadic map tests
+(deftest test-map-two-collections
+  (is (= [[1 :a] [2 :b] [3 :c]] (doall (map vector [1 2 3] [:a :b :c])))
+      "map should work with two collections"))
+
+(deftest test-map-variadic-is-lazy
+  (is (= [[1 :a] [2 :b] [3 :c]] (take 3 (map vector [1 2 3 4 5] [:a :b :c :d :e])))
+      "variadic map should be lazy and work with take"))
+
+(deftest test-map-with-infinite-sequences
+  (is (= [[0 10] [1 11] [2 12] [3 13] [4 14]] (take 5 (map vector (iterate inc 0) (iterate inc 10))))
+      "variadic map should work with infinite sequences"))
+
+(deftest test-map-stops-at-shortest
+  (is (= [[1 :a] [2 :b]] (doall (map vector [1 2] [:a :b :c :d])))
+      "variadic map should stop at shortest collection"))
+
+(deftest test-map-three-collections
+  (is (= [[1 :a "x"] [2 :b "y"] [3 :c "z"]] (doall (map vector [1 2 3] [:a :b :c] ["x" "y" "z"])))
+      "variadic map should work with three collections"))
+
+(deftest test-map-with-function
+  (is (= [11 22 33] (doall (map + [1 2 3] [10 20 30])))
+      "variadic map should apply function to corresponding elements"))
+
+(deftest test-map-empty-collection
+  (is (= [] (doall (map vector [] [1 2 3])))
+      "variadic map with empty first collection should return empty"))
+
+(deftest test-map-variadic-returns-lazy-seq
+  (let [result (map vector [1 2 3] [:a :b :c])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "variadic map should return a lazy sequence")))


### PR DESCRIPTION

  ## 🤔 Background

  The `map` function supports multiple collections (variadic form), where it applies a function to corresponding elements from each collection. Previously, this was implemented eagerly using a loop, which meant it would hang on infinite sequences and couldn't benefit from lazy evaluation.

  ## 💡 Goal

  Make the variadic (multi-collection) form of `map` fully lazy, enabling it to work with infinite sequences and defer
  computation until values are actually needed.

  ## 🔖 Changes

  - Added `Generators::mapMulti` method in `src/php/Lang/Generators.php` to handle lazy mapping over multiple collections
  - Updated `map` function in `src/phel/core.phel` to use the lazy generator for multi-collection case

>  Progress: 24/25 (96%) lazy functions complete in the lazy sequences roadmap (#1019).