### PR TITLE
Make partition lazy and add partition-all with infinite sequence support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Make `map-indexed` fully lazy with support for infinite sequences
 - Make `interleave` fully lazy with support for infinite sequences
 - Make variadic `map` (multi-collection) fully lazy with support for infinite sequences
+- Make `partition` fully lazy with support for infinite sequences
+- Add `partition-all` function with lazy support for infinite sequences
 - Document `flatten` as lazy (already was lazy via `filter` and `tree-seq`)
 
 ### Fixed

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1795,21 +1795,36 @@ arrays. Use (php/aunset ds key)"))
     true (lazy-seq-from-generator (php/:: Generators (dedupe xs)))))
 
 (defn partition
-  "Partition an indexed data structure into vectors of maximum size n. Returns a new vector."
+  "Partitions a collection into chunks of size n. Returns a lazy sequence.
+
+  Only yields complete partitions. If the final partition has fewer than n elements,
+  it is dropped. Works with infinite sequences.
+
+  Example: (partition 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6])"
   [n xs]
-  (if (<= (count xs) n)
-    (if (= (count xs) 0) [] [xs])
-    (let [res (transient [])]
-      (loop [xs xs]
-        (let [[a b] (split-at n xs)]
-          (push res a)
-          (if (>= (count b) n)
-            (recur b)
-            (if (= (count b) 0)
-              (persistent res)
-              (do
-                (push res b)
-                (persistent res)))))))))
+  (let [result (lazy-seq-from-generator
+                 (php/call_user_func_array
+                   (php/array "\\Phel\\Lang\\Generators" "partition")
+                   (php/array n xs)))]
+    (if (php/=== nil result)
+      '()
+      (with-meta xs result))))
+
+(defn partition-all
+  "Partitions a collection into chunks of size n. Returns a lazy sequence.
+
+  Yields all partitions including the final incomplete partition if present.
+  Works with infinite sequences.
+
+  Example: (partition-all 3 [1 2 3 4 5 6 7]) ; => ([1 2 3] [4 5 6] [7])"
+  [n xs]
+  (let [result (lazy-seq-from-generator
+                 (php/call_user_func_array
+                   (php/array "\\Phel\\Lang\\Generators" "partitionAll")
+                   (php/array n xs)))]
+    (if (php/=== nil result)
+      '()
+      (with-meta xs result))))
 
 # -------------
 # Set operation

--- a/src/php/Lang/Generators.php
+++ b/src/php/Lang/Generators.php
@@ -10,6 +10,7 @@ use Iterator;
 use Phel;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 
+use function count;
 use function is_array;
 
 final class Generators
@@ -507,6 +508,66 @@ final class Generators
                 $prev = $value;
                 $first = false;
             }
+        }
+    }
+
+    /**
+     * Partitions an iterable into chunks of size n.
+     * Only yields complete partitions (drops incomplete final partition).
+     *
+     * @template T
+     *
+     * @param int         $n        The partition size
+     * @param iterable<T> $iterable The input sequence
+     *
+     * @return Generator<int, PersistentVectorInterface>
+     */
+    public static function partition(int $n, iterable $iterable): Generator
+    {
+        if ($n <= 0) {
+            return;
+        }
+
+        $partition = [];
+        foreach ($iterable as $value) {
+            $partition[] = $value;
+
+            if (count($partition) === $n) {
+                yield Phel::vector($partition);
+                $partition = [];
+            }
+        }
+    }
+
+    /**
+     * Partitions an iterable into chunks of size n.
+     * Yields all partitions including incomplete final partition.
+     *
+     * @template T
+     *
+     * @param int         $n        The partition size
+     * @param iterable<T> $iterable The input sequence
+     *
+     * @return Generator<int, PersistentVectorInterface>
+     */
+    public static function partitionAll(int $n, iterable $iterable): Generator
+    {
+        if ($n <= 0) {
+            return;
+        }
+
+        $partition = [];
+        foreach ($iterable as $value) {
+            $partition[] = $value;
+
+            if (count($partition) === $n) {
+                yield Phel::vector($partition);
+                $partition = [];
+            }
+        }
+
+        if ($partition !== []) {
+            yield Phel::vector($partition);
         }
     }
 

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -609,3 +609,71 @@
   (let [result (map vector [1 2 3] [:a :b :c])]
     (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
         "variadic map should return a lazy sequence")))
+
+# Tests for partition
+(deftest test-partition-basic
+  (is (= [[1 2 3] [4 5 6]] (doall (partition 3 [1 2 3 4 5 6])))
+      "partition should divide collection into chunks of size n"))
+
+(deftest test-partition-is-lazy
+  (is (= [[1 2] [3 4] [5 6]] (take 3 (partition 2 [1 2 3 4 5 6 7 8 9 10])))
+      "partition should be lazy and work with take"))
+
+(deftest test-partition-with-infinite-sequence
+  (is (= [[0 1] [2 3] [4 5]] (doall (take 3 (partition 2 (iterate inc 0)))))
+      "partition should work with infinite sequences"))
+
+(deftest test-partition-drops-incomplete
+  (is (= [[1 2 3] [4 5 6]] (doall (partition 3 [1 2 3 4 5 6 7])))
+      "partition should drop incomplete final partition"))
+
+(deftest test-partition-empty-collection
+  (is (= [] (doall (partition 3 [])))
+      "partition of empty collection should return empty"))
+
+(deftest test-partition-single-chunk
+  (is (= [[1 2 3]] (doall (partition 3 [1 2 3])))
+      "partition with exact chunk size should return single chunk"))
+
+(deftest test-partition-size-one
+  (is (= [[1] [2] [3]] (doall (partition 1 [1 2 3])))
+      "partition with size 1 should return individual elements"))
+
+(deftest test-partition-returns-lazy-seq
+  (let [result (partition 2 [1 2 3 4])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "partition should return a lazy sequence")))
+
+# Tests for partition-all
+(deftest test-partition-all-basic
+  (is (= [[1 2 3] [4 5 6]] (doall (partition-all 3 [1 2 3 4 5 6])))
+      "partition-all should divide collection into chunks of size n"))
+
+(deftest test-partition-all-is-lazy
+  (is (= [[1 2] [3 4] [5 6]] (take 3 (partition-all 2 [1 2 3 4 5 6 7 8 9 10])))
+      "partition-all should be lazy and work with take"))
+
+(deftest test-partition-all-with-infinite-sequence
+  (is (= [[0 1 2] [3 4 5] [6 7 8]] (doall (take 3 (partition-all 3 (iterate inc 0)))))
+      "partition-all should work with infinite sequences"))
+
+(deftest test-partition-all-keeps-incomplete
+  (is (= [[1 2 3] [4 5 6] [7]] (doall (partition-all 3 [1 2 3 4 5 6 7])))
+      "partition-all should keep incomplete final partition"))
+
+(deftest test-partition-all-empty-collection
+  (is (= [] (doall (partition-all 3 [])))
+      "partition-all of empty collection should return empty"))
+
+(deftest test-partition-all-single-chunk
+  (is (= [[1 2 3]] (doall (partition-all 3 [1 2 3])))
+      "partition-all with exact chunk size should return single chunk"))
+
+(deftest test-partition-all-size-one
+  (is (= [[1] [2] [3]] (doall (partition-all 1 [1 2 3])))
+      "partition-all with size 1 should return individual elements"))
+
+(deftest test-partition-all-returns-lazy-seq
+  (let [result (partition-all 2 [1 2 3 4 5])]
+    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+        "partition-all should return a lazy sequence")))

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -326,11 +326,19 @@
 
 (deftest test-partition
   (is (= [] (partition 2 [])) "partition-2 empty")
-  (is (= [[1]] (partition 2 [1])) "partition-2 one element")
+  (is (= [] (partition 2 [1])) "partition-2 one element drops incomplete")
   (is (= [[1 2]] (partition 2 [1 2])) "partition-2 two elements")
-  (is (= [[1 2] [3]] (partition 2 [1 2 3])) "partition-2 three elements")
+  (is (= [[1 2]] (partition 2 [1 2 3])) "partition-2 three elements drops incomplete")
   (is (= [[1 2] [3 4]] (partition 2 [1 2 3 4])) "partition-2 four elements")
-  (is (= [[1 2] [3 4] [5]] (partition 2 [1 2 3 4 5])) "partition-2 five elements"))
+  (is (= [[1 2] [3 4]] (partition 2 [1 2 3 4 5])) "partition-2 five elements drops incomplete"))
+
+(deftest test-partition-all
+  (is (= [] (partition-all 2 [])) "partition-all-2 empty")
+  (is (= [[1]] (partition-all 2 [1])) "partition-all-2 one element keeps incomplete")
+  (is (= [[1 2]] (partition-all 2 [1 2])) "partition-all-2 two elements")
+  (is (= [[1 2] [3]] (partition-all 2 [1 2 3])) "partition-all-2 three elements keeps incomplete")
+  (is (= [[1 2] [3 4]] (partition-all 2 [1 2 3 4])) "partition-all-2 four elements")
+  (is (= [[1 2] [3 4] [5]] (partition-all 2 [1 2 3 4 5])) "partition-all-2 five elements keeps incomplete"))
 
 (deftest test-phel-php-roundtrip
   (let [data {:a [1 {:b 2}]}]

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -30,6 +30,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(364, $groupedFns);
+        self::assertCount(365, $groupedFns);
     }
 }


### PR DESCRIPTION

  ## 🤔 Background

  The `partition` function was implemented eagerly, which meant it would hang on infinite sequences and couldn't benefit from lazy evaluation. Additionally, Phel was missing `partition-all`, which is useful when you need to include the final incomplete partition.

  In Clojure, `partition` drops incomplete final partitions while `partition-all` keeps them. This PR aligns Phel's behavior with this convention.

  ## 💡 Goal

  Make `partition` fully lazy with proper handling of incomplete partitions, and add `partition-all` function to provide the
  option of keeping incomplete partitions. Both functions should work with infinite sequences.

  ## 🔖 Changes

  - Added `Generators::partition` method in `src/php/Lang/Generators.php` to handle lazy partitioning (drops incomplete
  partitions)
  - Added `Generators::partitionAll` method in `src/php/Lang/Generators.php` to handle lazy partitioning (keeps incomplete partitions)
  - Updated `partition` function in `src/phel/core.phel` to use lazy generator and drop incomplete final partitions (breaking change)
  - Added new `partition-all` function in `src/phel/core.phel` with lazy support for keeping incomplete final partitions
  - Added 16 comprehensive tests covering basic usage, laziness, infinite sequences, and edge cases
  - Updated existing tests to match new `partition` behavior (drops incomplete) and added tests for `partition-all` (keeps incomplete)
  - Updated function count test to reflect new `partition-all` function
  - Updated CHANGELOG.md with both changes

  **Breaking Change**: `partition` now drops incomplete final partitions to match Clojure's behavior. Use `partition-all` if you
  need to keep incomplete partitions.

>  Progress: 25/25 (100%) - Completes the lazy sequences roadmap (#1019).