### PR TITLE
Add read-file-lazy for lazy chunked file reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add `partition-all` function with lazy support for infinite sequences
 - Add `line-seq` function for lazy line-by-line file reading with automatic resource cleanup
 - Add `file-seq` function for lazy recursive directory traversal
+- Add `read-file-lazy` function for lazy chunked file reading with configurable chunk size
 - Document `flatten` as lazy (already was lazy via `filter` and `tree-seq`)
 
 ### Fixed

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2394,6 +2394,30 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
       '()
       result)))
 
+(defn read-file-lazy
+  "Returns a lazy sequence of byte string chunks from a file. The file is read
+  in chunks of the specified size (default 8192 bytes). The file handle is
+  automatically closed when the sequence is fully consumed or if an error occurs.
+
+  Useful for processing large binary files, streaming file content, or reading
+  files where line-based processing doesn't make sense.
+
+  The optional chunk-size parameter controls how many bytes to read at a time.
+  Smaller chunks use less memory but make more system calls; larger chunks are
+  more efficient but use more memory.
+
+  Example: (take 5 (read-file-lazy \"large-file.bin\" 1024))"
+  ([filename]
+   (read-file-lazy filename 8192))
+  ([filename chunk-size]
+   (let [result (lazy-seq-from-generator
+                  (php/call_user_func_array
+                    (php/array "\\Phel\\Lang\\Generators" "readFileChunks")
+                    (php/array filename chunk-size)))]
+     (if (php/=== nil result)
+       '()
+       result))))
+
 # ----------------
 # Threading macros
 # ----------------

--- a/tests/phel/test/core/file-operation.phel
+++ b/tests/phel/test/core/file-operation.phel
@@ -200,3 +200,98 @@
     (php/unlink cycle-link)
     (php/rmdir subdir)
     (php/rmdir target-directory)))
+
+(deftest test-read-file-lazy-basic
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy.txt")
+        content "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+    (spit target-file content)
+    (let [chunks (doall (read-file-lazy target-file 5))]
+      (is (= 6 (count chunks)) "should read file in 6 chunks of 5 bytes")
+      (is (= content (apply str chunks)) "concatenated chunks should equal original content"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-default-chunk-size
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-default.txt")
+        content (apply str (repeat 10000 "x"))]
+    (spit target-file content)
+    (let [chunks (doall (read-file-lazy target-file))]
+      (is (= 2 (count chunks)) "should read 10000 bytes in 2 chunks with default 8192 chunk size")
+      (is (= content (apply str chunks)) "concatenated chunks should equal original content"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-empty-file
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-empty.txt")]
+    (spit target-file "")
+    (is (= [] (doall (read-file-lazy target-file)))
+        "read-file-lazy returns empty sequence for empty file")
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-single-byte
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-single.txt")]
+    (spit target-file "X")
+    (let [chunks (doall (read-file-lazy target-file 1))]
+      (is (= 1 (count chunks)) "single byte should be one chunk")
+      (is (= "X" (first chunks)) "chunk should contain the single byte"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-exact-chunk-size
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-exact.txt")
+        content "12345678901234567890"]
+    (spit target-file content)
+    (let [chunks (doall (read-file-lazy target-file 10))]
+      (is (= 2 (count chunks)) "20 bytes with chunk size 10 should produce 2 chunks")
+      (is (= "1234567890" (first chunks)) "first chunk should be exactly 10 bytes")
+      (is (= "1234567890" (second chunks)) "second chunk should be exactly 10 bytes"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-is-lazy
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-lazy.txt")
+        content (apply str (repeat 1000 "ABCDEFGHIJ"))]
+    (spit target-file content)
+    (let [first-three (take 3 (read-file-lazy target-file 100))]
+      (is (= 3 (count first-three)) "read-file-lazy should be lazy and work with take")
+      (is (= 300 (php/strlen (apply str first-three))) "first 3 chunks should total 300 bytes"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-non-existent-file
+  (is (thrown? \InvalidArgumentException (doall (read-file-lazy "/non/existent/file.bin")))
+      "read-file-lazy throws exception for non-existent file"))
+
+(deftest test-read-file-lazy-directory
+  (is (thrown? \InvalidArgumentException (doall (read-file-lazy (php/sys_get_temp_dir))))
+      "read-file-lazy throws exception for directory"))
+
+(deftest test-read-file-lazy-invalid-chunk-size
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-invalid-chunk.txt")]
+    (spit target-file "content")
+    (is (thrown? \InvalidArgumentException (doall (read-file-lazy target-file 0)))
+        "read-file-lazy throws exception for zero chunk size")
+    (is (thrown? \InvalidArgumentException (doall (read-file-lazy target-file -1)))
+        "read-file-lazy throws exception for negative chunk size")
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-returns-lazy-seq
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-type.txt")]
+    (spit target-file "some content")
+    (let [result (read-file-lazy target-file)]
+      (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+          "read-file-lazy should return a lazy sequence"))
+    (php/unlink target-file)))
+
+(deftest test-read-file-lazy-binary-content
+  (let [target-directory (str (php/sys_get_temp_dir))
+        target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-binary.bin")
+        binary-content (php/pack "C*" 0 1 2 3 4 255 254 253)]
+    (php/file_put_contents target-file binary-content)
+    (let [chunks (doall (read-file-lazy target-file 4))]
+      (is (= 2 (count chunks)) "8 bytes with chunk size 4 should produce 2 chunks")
+      (is (= binary-content (apply str chunks)) "binary content should be preserved"))
+    (php/unlink target-file)))

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -30,6 +30,6 @@ final class ApiFacadeTest extends TestCase
             ApiConfig::allNamespaces(),
         );
 
-        self::assertCount(367, $groupedFns);
+        self::assertCount(368, $groupedFns);
     }
 }


### PR DESCRIPTION


  ## 🤔 Background

  We've been building out lazy file I/O capabilities for Phel, starting with `line-seq` for line-based reading and `file-seq` for directory traversal. However, there wasn't a way to lazily read files in custom-sized chunks, which is essential for processing large binary files, streaming content, or cases where line-based processing doesn't apply.

  ## 💡 Goal

  Add `read-file-lazy` function to enable lazy, memory-efficient reading of files in configurable byte chunks. This completes the core lazy file I/O story alongside `line-seq` and `file-seq`.

  ## 🔖 Changes

  - Add `Generators::readFileChunks` PHP method for chunked file reading with generator-based lazy evaluation
  - Add `read-file-lazy` Phel function with configurable chunk size (default 8192 bytes)
  - Implement automatic resource cleanup with try/finally blocks
  - Add binary mode file reading to preserve byte-level content
  - Add 11 comprehensive tests covering:
    - Basic chunked reading with custom sizes
    - Default chunk size behavior
    - Edge cases (empty files, single byte)
    - Laziness verification
    - Error handling (non-existent files, directories, invalid chunk sizes)
    - Binary content preservation
    - Return type validation

  The function supports both text and binary files, making it useful for log processing, large file analysis, streaming operations, and any scenario requiring memory-efficient file access with custom chunk sizes.