### PR TITLE
Improve docblock examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `compact` function for removing nil values
 
+### Changed
+- Standardize docblock examples with triple backtick code fencing for better IDE rendering and syntax highlighting
+
 ## [0.26.0](https://github.com/phel-lang/phel-lang/compare/v0.25.0...v0.26.0) - 2025-11-16
 
 ### Added

--- a/src/phel/base64.phel
+++ b/src/phel/base64.phel
@@ -5,8 +5,10 @@
   "Encodes a string to Base64.
 
   Example:
+    ```phel
     (encode \"Hello\")
-    # => \"SGVsbG8=\""
+    # => \"SGVsbG8=\"
+    ```"
   [s]
   (php/base64_encode s))
 
@@ -14,8 +16,10 @@
   "Decodes a Base64 string. Optional `strict?` flag validates characters.
 
   Example:
+    ```phel
     (decode \"SGVsbG8=\")
-    # => \"Hello\""
+    # => \"Hello\"
+    ```"
   [s & [strict?]]
   (php/base64_decode s (or strict? false)))
 
@@ -23,8 +27,10 @@
   "Encodes a string to URL-safe Base64 (no padding).
 
   Example:
+    ```phel
     (encode-url \"Hello\")
-    # => \"SGVsbG8\""
+    # => \"SGVsbG8\"
+    ```"
   [s]
   (-> (encode s)
       (s/replace "+" "-")
@@ -35,8 +41,10 @@
   "Decodes a URL-safe Base64 string. Adds padding automatically.
 
   Example:
+    ```phel
     (decode-url \"SGVsbG8\")
-    # => \"Hello\""
+    # => \"Hello\"
+    ```"
   [s & [strict?]]
   (let [s (s/replace s "-" "+")
         s (s/replace s "_" "/")

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -57,32 +57,40 @@
   "Creates a new list from the given arguments. Shortcut: '()
 
   Example:
+    ```phel
     (list 1 2 3)
-    # => (1 2 3)"
+    # => (1 2 3)
+    ```"
   (fn [& xs] (php/:: Phel (list (apply php/array xs)))))
 
 (def vector
   "Creates a new vector from the given arguments. Shortcut: []
 
   Example:
+    ```phel
     (vector 1 2 3)
-    # => [1 2 3]"
+    # => [1 2 3]
+    ```"
   (fn [& xs] (php/:: Phel (vector (apply php/array xs)))))
 
 (def hash-map
   "Creates a new hash map from key-value pairs. Shortcut: {}
 
   Example:
+    ```phel
     (hash-map :a 1 :b 2)
-    # => {:a 1 :b 2}"
+    # => {:a 1 :b 2}
+    ```"
   (fn [& xs] (php/:: Phel (map (apply php/array xs)))))
 
 (def next
   "Returns the sequence after the first element, or nil if empty.
 
   Example:
+    ```phel
     (next [1 2 3])
-    # => [2 3]"
+    # => [2 3]
+    ```"
   (fn [xs]
     (if (php/=== xs nil)
       nil
@@ -105,8 +113,10 @@
   "Returns the first element of a sequence, or nil if empty.
 
   Example:
+    ```phel
     (first [1 2 3])
-    # => 1"
+    # => 1
+    ```"
   (fn [xs]
     (if (php/instanceof xs FirstInterface)
       (php/-> xs (first))
@@ -293,11 +303,13 @@
   With two arguments, creates a symbol in the given namespace.
 
   Examples:
+    ```phel
     (symbol \"foo\")
     # => foo
 
     (symbol \"my-ns\" \"bar\")
-    # => my-ns/bar"
+    # => my-ns/bar
+    ```"
   [name-or-ns & [name]]
   (if name
     (php/:: Symbol (createForNamespace name-or-ns name))
@@ -327,10 +339,12 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Use `persistent` to convert back.
 
   Example:
+    ```phel
     (def t (transient []))
     (conj t 1)
     (persistent t)
     # => [1]
+    ```
 
   See also: persistent"
   [coll]
@@ -340,10 +354,12 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Converts a transient collection back to a persistent collection.
 
   Example:
+    ```phel
     (def t (transient {}))
     (assoc t :a 1)
     (persistent t)
     # => {:a 1}
+    ```
 
   See also: transient"
   [coll]
@@ -357,8 +373,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a new Set from the given arguments. Shortcut: #{}
 
   Example:
+    ```phel
     (set 1 2 3)
-    # => #{1 2 3}"
+    # => #{1 2 3}
+    ```"
   [& xs]
   (php/:: Phel (set (apply php/array xs))))
 
@@ -366,8 +384,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a new Keyword from a given string.
 
   Example:
+    ```phel
     (keyword \"name\")
-    # => :name"
+    # => :name
+    ```"
   [x]
   (php/:: Keyword (create x)))
 
@@ -375,8 +395,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a PHP indexed array from the given values.
 
   Example:
+    ```phel
     (php-indexed-array 1 2 3)
-    # => (PHP array [1, 2, 3])"
+    # => (PHP array [1, 2, 3])
+    ```"
   [& xs]
   (apply php/array xs))
 
@@ -387,8 +409,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
     Key-value pairs (must be even number of arguments)
 
   Example:
+    ```phel
     (php-associative-array \"name\" \"Alice\" \"age\" 30)
-    # => (PHP array [\"name\" => \"Alice\", \"age\" => 30])"
+    # => (PHP array [\"name\" => \"Alice\", \"age\" => 30])
+    ```"
   [& xs]
   (let [cnt (php/count xs)
         res (php/array)]
@@ -414,8 +438,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Prepends an element to the beginning of a collection.
 
   Example:
+    ```phel
     (cons 0 [1 2 3])
-    # => [0 1 2 3]"
+    # => [0 1 2 3]
+    ```"
   [x coll]
   (if (php/is_array coll)
     (do
@@ -437,8 +463,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the second element of a sequence, or nil if not present.
 
   Example:
+    ```phel
     (second [1 2 3])
-    # => 2"
+    # => 2
+    ```"
   [coll]
   (first (next coll)))
 
@@ -446,8 +474,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the sequence after the first element, or empty sequence if none.
 
   Example:
+    ```phel
     (rest [1 2 3])
-    # => [2 3]"
+    # => [2 3]
+    ```"
   [coll]
   (if (php/instanceof coll RestInterface)
     (php/-> coll (rest))
@@ -474,6 +504,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Returns 0 for nil.
 
   Examples:
+    ```phel
     (count [1 2 3])
     # => 3
 
@@ -494,6 +525,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 
     (count nil)
     # => 0
+    ```
 
   See also: empty?, seq"
   [coll]
@@ -515,8 +547,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates then if test is false, else otherwise.
 
   Example:
+    ```phel
     (if-not (< 5 3) \"not less\" \"less\")
-    # => \"not less\""
+    # => \"not less\"
+    ```"
   [test then & [else]]
   `(if ,test ,else ,then))
 
@@ -524,8 +558,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates body if test is true, otherwise returns nil.
 
   Example:
+    ```phel
     (when (> 10 5) \"greater\")
-    # => \"greater\""
+    # => \"greater\"
+    ```"
   [test & body]
   `(if ,test (do ,@body)))
 
@@ -533,8 +569,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates body if test is false, otherwise returns nil.
 
   Example:
+    ```phel
     (when-not (empty? [1 2 3]) \"has items\")
-    # => \"has items\""
+    # => \"has items\"
+    ```"
   [test & body]
   `(if ,test nil (do ,@body)))
 
@@ -542,8 +580,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates test/expression pairs, returning the first matching expression.
 
   Example:
+    ```phel
     (cond (< x 0) \"negative\" (> x 0) \"positive\" \"zero\")
-    # => \"negative\", \"positive\", or \"zero\" depending on x"
+    # => \"negative\", \"positive\", or \"zero\" depending on x
+    ```"
   [& pairs]
   (let [cnt (count pairs)]
     (if (php/=== cnt 0)
@@ -559,11 +599,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates expression and matches it against constant test values, returning the associated result.
 
   Example:
+    ```phel
     (case x
       1 \"one\"
       2 \"two\"
       \"other\")
-    # => \"one\" (when x is 1)"
+    # => \"one\" (when x is 1)
+    ```"
   [e & pairs]
   (if (next pairs)
     (let [v (gensym)]
@@ -581,8 +623,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates expressions left to right, returning the first truthy value or the last value.
 
   Example:
+    ```phel
     (or false nil 42 100)
-    # => 42"
+    # => 42
+    ```"
   [& args]
   (case (count args)
     0 nil
@@ -595,8 +639,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Evaluates expressions left to right, returning the first falsy value or the last value.
 
   Example:
+    ```phel
     (and true 1 \"hello\")
-    # => \"hello\""
+    # => \"hello\"
+    ```"
   [& args]
   (case (count args)
     0 'true
@@ -624,8 +670,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Checks if all values are equal (value equality, not identity).
 
   Example:
+    ```phel
     (= [1 2 3] [1 2 3])
-    # => true"
+    # => true
+    ```"
   [a & more]
   (case (count more)
     0 true
@@ -638,8 +686,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if value is falsy (nil or false), false otherwise.
 
   Example:
+    ```phel
     (not nil)
-    # => true"
+    # => true
+    ```"
   [x]
   (if x false true))
 
@@ -655,8 +705,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Checks if each argument is strictly less than the following argument.
 
   Example:
+    ```phel
     (< 1 2 3 4)
-    # => true"
+    # => true
+    ```"
   {:inline (fn [a b] `(php/< ,a ,b))
    :inline-arity (fn [n] (php/=== n 2))}
   [a & more]
@@ -683,8 +735,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Checks if each argument is strictly greater than the following argument.
 
   Example:
+    ```phel
     (> 4 3 2 1)
-    # => true"
+    # => true
+    ```"
   {:inline (fn [a b] `(php/> ,a ,b))
    :inline-arity (fn [n] (php/=== n 2))}
   [a & more]
@@ -723,8 +777,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if predicate is true for every element in collection, false otherwise.
 
   Example:
+    ```phel
     (all? even? [2 4 6 8])
-    # => true"
+    # => true
+    ```"
   [pred coll]
   (cond
     (php/=== (count coll) 0) true
@@ -750,8 +806,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if predicate is true for at least one element in collection, false otherwise.
 
   Example:
+    ```phel
     (some? even? [1 3 5 6 7])
-    # => true"
+    # => true
+    ```"
   [pred coll]
   (if (empty? coll)
     false
@@ -769,8 +827,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the first truthy value of applying predicate to elements, or nil if none found.
 
   Example:
+    ```phel
     (some #(when (> % 10) %) [5 15 8])
-    # => 15"
+    # => 15
+    ```"
   [pred coll]
   (if (empty? coll)
     nil
@@ -783,8 +843,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Checks if value is exactly true (not just truthy).
 
   Example:
+    ```phel
     (true? 1)
-    # => false"
+    # => false
+    ```"
   [x]
   (id x true))
 
@@ -797,8 +859,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Checks if value is exactly false (not just falsy).
 
   Example:
+    ```phel
     (false? nil)
-    # => false"
+    # => false
+    ```"
   [x]
   (id x false))
 
@@ -806,8 +870,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if value is nil, false otherwise.
 
   Example:
+    ```phel
     (nil? (get {:a 1} :b))
-    # => true"
+    # => true
+    ```"
   [x]
   (id x nil))
 
@@ -821,10 +887,12 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if key is present in collection (checks keys/indices, not values).
 
   Example:
+    ```phel
     (contains? [10 20 30] 1)
     # => true
     (contains? \"hello\" 0)
-    # => true"
+    # => true
+    ```"
   [coll key]
   (cond
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
@@ -985,6 +1053,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   enabling sequence operations like map, filter, and frequencies.
 
   Examples:
+    ```phel
     (seq \"hello\")
     # => [\"h\" \"e\" \"l\" \"l\" \"o\"]
 
@@ -996,6 +1065,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 
     (seq nil)
     # => nil
+    ```
 
   See also: chars, count"
   [coll]
@@ -1032,11 +1102,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Indexed sequences include lists, vectors, and indexed PHP arrays.
 
   Example:
+    ```phel
     (indexed? [1 2 3])
     # => true
 
     (indexed? {:a 1})
-    # => false"
+    # => false
+    ```"
   [x]
   (let [t (type x)]
     (or
@@ -1050,11 +1122,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Associative data structures include hash maps, structs, and associative PHP arrays.
 
   Example:
+    ```phel
     (associative? {:a 1})
     # => true
 
     (associative? [1 2 3])
-    # => false"
+    # => false
+    ```"
   [x]
   (let [t (type x)]
     (or
@@ -1075,8 +1149,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the last element of a sequence.
 
   Example:
+    ```phel
     (peek [1 2 3])
-    # => 3"
+    # => 3
+    ```"
   [coll]
   (php/aget coll (php/- (count coll) 1)))
 
@@ -1102,8 +1178,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Removes up to `n` elements from array `coll` starting at index `offset`.
 
   Example:
+    ```phel
     (remove my-array 1 2)
-    # Removes 2 elements starting at index 1"
+    # Removes 2 elements starting at index 1
+    ```"
   [^:reference coll offset & [n]]
   (cond
     (php-array? coll) (if n (php/array_splice coll offset n) (php/array_splice coll offset))
@@ -1114,8 +1192,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Gets the value at key in a collection. Returns default if not found.
 
   Example:
+    ```phel
     (get {:a 1} :a)
-    # => 1"
+    # => 1
+    ```"
   [ds k & [opt]]
   (cond
     (or (set? ds)
@@ -1147,8 +1227,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Associates a value with a key in a collection.
 
   Example:
+    ```phel
     (assoc {:a 1} :b 2)
-    # => {:a 1 :b 2}"
+    # => {:a 1 :b 2}
+    ```"
   [ds key value]
   (cond
     (php-array? ds)
@@ -1177,8 +1259,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Dissociates `key` from the datastructure `ds`. Returns `ds` without `key`.
 
   Example:
+    ```phel
     (dissoc {:a 1 :b 2} :b)
-    # => {:a 1}"
+    # => {:a 1}
+    ```"
   [ds key]
   (cond
     (php-array? ds)
@@ -1213,10 +1297,12 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Variables provide mutable state that can be updated with `set!` and `swap!`.
 
   Example:
+    ```phel
     (def counter (var 0))
     (swap! counter inc)
     (deref counter)
     # => 1
+    ```
 
   See also: set!, deref, swap!"
   [value]
@@ -1231,10 +1317,12 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Sets a new value to the given variable.
 
   Example:
+    ```phel
     (def x (var 10))
     (set! x 20)
     (deref x)
     # => 20
+    ```
 
   See also: var, deref, swap!"
   [variable value]
@@ -1244,9 +1332,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the current value inside the variable.
 
   Example:
+    ```phel
     (def x (var 42))
     (deref x)
     # => 42
+    ```
 
   See also: var, set!, swap!"
   [variable]
@@ -1258,11 +1348,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Returns the new value after the swap.
 
   Example:
+    ```phel
     (def counter (var 0))
     (swap! counter + 10)
     # => 10
     (swap! counter * 2)
     # => 20
+    ```
 
   See also: var, set!, deref"
   [variable f & args]
@@ -1288,8 +1380,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a lazy sequence of numbers from start to end (exclusive).
 
   Example:
+    ```phel
     (range 5)
-    # => (0 1 2 3 4)"
+    # => (0 1 2 3 4)
+    ```"
   [a & rest]
   (case (count rest)
     0 (lazy-seq-from-generator (php/:: Seq (range 0 a 1)))
@@ -1371,6 +1465,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
      is bound to `initial-value`.
 
   Examples:
+    ```phel
     (for [x :in [1 2 3]] (* x 2))
     # => [2 4 6]
 
@@ -1378,7 +1473,8 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
     # => [\"H\" \"E\" \"L\" \"L\" \"O\"]
 
     (for [x :range [0 5] :when (even? x)] x)
-    # => [0 2 4]"
+    # => [0 2 4]
+    ```"
   [head & body]
   (let [res-sym (gensym "res__")
         acc-sym (gensym "acc__")
@@ -1419,6 +1515,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   stopping when the shortest collection is exhausted.
 
   Examples:
+    ```phel
     (map inc [1 2 3])
     # => (2 3 4)
 
@@ -1433,6 +1530,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
 
     (map list [1 2] [3 4] [5 6])
     # => ((1 3 5) (2 4 6))
+    ```
 
   See also: filter, reduce, map-indexed, mapcat"
   [f & colls]
@@ -1454,8 +1552,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Applies function to each element with its index, returning a lazy sequence.
 
   Example:
+    ```phel
     (map-indexed (fn [i x] [i x]) [\"a\" \"b\" \"c\"])
-    # => ([0 \"a\"] [1 \"b\"] [2 \"c\"])"
+    # => ([0 \"a\"] [1 \"b\"] [2 \"c\"])
+    ```"
   [f coll]
   (let [result (for [[k v] :pairs coll] (f k v))]
     (with-meta coll result)))
@@ -1464,8 +1564,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Applies function to collections and concatenates the results.
 
   Example:
+    ```phel
     (mapcat reverse [[1 2] [3 4]])
-    # => (2 1 4 3)"
+    # => (2 1 4 3)
+    ```"
   [f & colls]
   (let [result (apply concat [] (apply map f colls))]
     (if (empty? colls)
@@ -1476,8 +1578,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Reduces collection to a single value by repeatedly applying function to accumulator and elements.
 
   Example:
+    ```phel
     (reduce + [1 2 3 4])
-    # => 10"
+    # => 10
+    ```"
   [f & args]
   (case (count args)
     1 (let [coll (first args)]
@@ -1497,11 +1601,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Supports persistent and transient collections.
 
   Examples:
+    ```phel
     (into [] '(1 2 3))
     # => [1 2 3]
 
     (into {:a 1} {:b 2 :c 3})
     # => {:a 1 :b 2 :c 3}
+    ```
 
   See also: conj, concat"
   [to & rest]
@@ -1603,11 +1709,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
     "Returns a new collection with values added. Appends to vectors/sets, prepends to lists.
 
     Examples:
+      ```phel
       (conj [1 2] 3)
       # => [1 2 3]
 
       (conj {:a 1} [:b 2])
-      # => {:a 1 :b 2}"
+      # => {:a 1 :b 2}
+      ```"
   ([] [])
   ([coll] coll)
   ([coll value]
@@ -1619,8 +1727,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Extracts a slice of `coll` starting at `offset` with optional `length`.
 
   Example:
+    ```phel
     (slice [1 2 3 4 5] 1 3)
-    # => [2 3 4]"
+    # => [2 3 4]
+    ```"
   [coll & [offset & [length]]]
   (cond
     (php-array? coll) (php/array_slice coll offset length)
@@ -1633,11 +1743,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Returns `opt` (default nil) if the path doesn't exist.
 
   Example:
+    ```phel
     (get-in {:a {:b {:c 42}}} [:a :b :c])
     # => 42
 
     (get-in {:a 1} [:b :c] :not-found)
     # => :not-found
+    ```
 
   See also: assoc-in, update-in"
   [ds ks & [opt]]
@@ -1650,11 +1762,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Creates intermediate maps if they don't exist.
 
   Example:
+    ```phel
     (assoc-in {:a {:b 1}} [:a :c] 2)
     # => {:a {:b 1 :c 2}}
 
     (assoc-in {} [:a :b :c] 42)
     # => {:a {:b {:c 42}}}
+    ```
 
   See also: get-in, update-in, dissoc-in"
   [ds [k & ks] v]
@@ -1675,11 +1789,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Updates a value in a datastructure by applying `f` to the current value.
 
   Example:
+    ```phel
     (update {:count 5} :count inc)
     # => {:count 6}
 
     (update [1 2 3] 1 * 10)
     # => [1 20 3]
+    ```
 
   See also: update-in, assoc"
   [ds k f & args]
@@ -1689,11 +1805,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Updates a value in a nested data structure by applying `f` to the value at path.
 
   Example:
+    ```phel
     (update-in {:a {:b 5}} [:a :b] inc)
     # => {:a {:b 6}}
 
     (update-in {:user {:age 30}} [:user :age] + 5)
     # => {:user {:age 35}}
+    ```
 
   See also: get-in, assoc-in, update"
   [ds [k & ks] f & args]
@@ -1706,8 +1824,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Dissociates a value from a nested data structure at the given path.
 
   Example:
+    ```phel
     (dissoc-in {:a {:b 1 :c 2}} [:a :b])
     # => {:a {:c 2}}
+    ```
 
   See also: dissoc, assoc-in, get-in"
   [ds [k & ks]]
@@ -1731,8 +1851,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Drops the first `n` elements of `coll`. Returns a lazy sequence.
 
   Example:
+    ```phel
     (drop 2 [1 2 3 4 5])
     # => (3 4 5)
+    ```
 
   See also: take, drop-last"
   [n coll]
@@ -1748,8 +1870,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Drops the last `n` elements of `coll`.
 
   Example:
+    ```phel
     (drop-last 2 [1 2 3 4 5])
     # => [1 2 3]
+    ```
 
   See also: drop, butlast"
   [n coll]
@@ -1761,8 +1885,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the last element of `coll` or nil if `coll` is empty or nil.
 
   Example:
+    ```phel
     (last [1 2 3])
     # => 3
+    ```
 
   See also: first, peek, butlast"
   [coll]
@@ -1774,8 +1900,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns all but the last item in `coll`.
 
   Example:
+    ```phel
     (butlast [1 2 3 4])
     # => [1 2 3]
+    ```
 
   See also: last, drop-last"
   [coll]
@@ -1785,8 +1913,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
 
   Example:
+    ```phel
     (drop-while #(< % 5) [1 2 3 4 5 6 3 2 1])
     # => (5 6 3 2 1)
+    ```
 
   See also: take-while, drop"
   [pred coll]
@@ -1814,8 +1944,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Takes the last `n` elements of `coll`.
 
   Example:
+    ```phel
     (take-last 3 [1 2 3 4 5])
     # => [3 4 5]
+    ```
 
   See also: take, drop-last"
   [n coll]
@@ -1825,8 +1957,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.
 
   Example:
+    ```phel
     (take-while #(< % 5) [1 2 3 4 5 6 3 2 1])
     # => (1 2 3 4)
+    ```
 
   See also: drop-while, take"
   [pred coll]
@@ -1839,8 +1973,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns every nth item in `coll`. Returns a lazy sequence.
 
   Example:
+    ```phel
     (take-nth 2 [0 1 2 3 4 5 6 7 8])
     # => (0 2 4 6 8)
+    ```
 
   See also: take, filter"
   [n coll]
@@ -1855,8 +1991,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence of elements where predicate returns true.
 
   Example:
+    ```phel
     (filter even? [1 2 3 4 5 6])
-    # => (2 4 6)"
+    # => (2 4 6)
+    ```"
   [pred coll]
   (let [result (lazy-seq-from-generator (php/:: Seq (filter pred coll)))]
     (if (nil? result)
@@ -1867,8 +2005,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence of non-nil results of applying function to elements.
 
   Example:
+    ```phel
     (keep #(when (even? %) (* % %)) [1 2 3 4 5])
-    # => (4 16)"
+    # => (4 16)
+    ```"
   [pred coll]
   (if (nil? coll)
     []
@@ -1879,8 +2019,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence of non-nil results of `(pred i x)`.
 
   Example:
+    ```phel
     (keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"])
     # => (\"a\" \"c\")
+    ```
 
   See also: keep, map-indexed"
   [pred coll]
@@ -1893,8 +2035,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the first item in `coll` where `(pred item)` evaluates to true.
 
   Example:
+    ```phel
     (find #(> % 5) [1 2 3 6 7 8])
     # => 6
+    ```
 
   See also: find-index, filter, some?"
   [pred coll]
@@ -1909,8 +2053,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns the index of the first item in `coll` where `(pred item)` evaluates to true.
 
   Example:
+    ```phel
     (find-index #(> % 5) [1 2 3 6 7 8])
     # => 3
+    ```
 
   See also: find, filter"
   [pred coll]
@@ -1926,8 +2072,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence with duplicated values removed in `coll`.
 
   Example:
+    ```phel
     (distinct [1 2 1 3 2 4 3])
     # => (1 2 3 4)
+    ```
 
   See also: frequencies, set"
   [coll]
@@ -1941,8 +2089,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Reverses the order of the elements in the given sequence.
 
   Example:
+    ```phel
     (reverse [1 2 3 4])
-    # => [4 3 2 1]"
+    # => [4 3 2 1]
+    ```"
   [coll]
   (let [result
         (for [i :range [(php/- (count coll) 1) -1 -1]
@@ -1954,8 +2104,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a vector with the first items of each col, then the second items, etc.
 
   Example:
+    ```phel
     (interleave [1 2 3] [:a :b :c])
     # => [1 :a 2 :b 3 :c]
+    ```
 
   See also: interpose"
   [& colls]
@@ -1975,8 +2127,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a vector of elements separated by `sep`.
 
   Example:
+    ```phel
     (interpose :x [1 2 3 4])
     # => [1 :x 2 :x 3 :x 4]
+    ```
 
   See also: interleave"
   [sep coll]
@@ -1995,11 +2149,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Works with vectors, lists, sets, and strings.
 
   Examples:
+    ```phel
     (frequencies [:a :b :a :c :b :a])
     # => {:a 3 :b 2 :c 1}
 
     (frequencies \"hello\")
-    # => {\"h\" 1 \"e\" 1 \"l\" 2 \"o\" 1}"
+    # => {\"h\" 1 \"e\" 1 \"l\" 2 \"o\" 1}
+    ```"
   [coll]
   (let [result (for [x :in coll
                      :reduce [res {}]]
@@ -2011,8 +2167,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a sequence of all keys in a map.
 
   Example:
+    ```phel
     (keys {:a 1 :b 2})
-    # => (:a :b)"
+    # => (:a :b)
+    ```"
   [coll]
   (let [result (for [k :keys coll] k)]
     (with-meta coll result)))
@@ -2021,8 +2179,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a sequence of all values in a map.
 
   Example:
+    ```phel
     (values {:a 1 :b 2})
-    # => (1 2)"
+    # => (1 2)
+    ```"
   [coll]
   (let [result (for [x :in coll] x)]
     (with-meta coll result)))
@@ -2031,8 +2191,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Gets the pairs of an associative data structure.
 
   Example:
+    ```phel
     (pairs {:a 1 :b 2})
     # => ([:a 1] [:b 2])
+    ```
 
   See also: keys, values, kvs"
   [coll]
@@ -2043,8 +2205,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a vector of key-value pairs like `[k1 v1 k2 v2 k3 v3 ...]`.
 
   Example:
+    ```phel
     (kvs {:a 1 :b 2})
     # => [:a 1 :b 2]
+    ```
 
   See also: pairs, keys, values"
   [coll]
@@ -2060,8 +2224,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a PHP Array from a sequential data structure.
 
   Example:
+    ```phel
     (to-php-array [1 2 3])
     # => (PHP array [1, 2, 3])
+    ```
 
   See also: php-array-to-map, phel->php"
   [coll]
@@ -2071,8 +2237,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Converts a PHP Array to a Phel map.
 
   Example:
+    ```phel
     (php-array-to-map (php-associative-array \"a\" 1 \"b\" 2))
     # => {\"a\" 1 \"b\" 2}
+    ```
 
   See also: to-php-array, php->phel"
   [arr]
@@ -2086,8 +2254,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Recursively converts a Phel data structure to a PHP array.
 
   Example:
+    ```phel
     (phel->php {:a [1 2 3] :b {:c 4}})
     # => (PHP array [\"a\" => [1, 2, 3], \"b\" => [\"c\" => 4]])
+    ```
 
   See also: php->phel"
   [x]
@@ -2124,8 +2294,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Indexed PHP arrays become vectors, associative PHP arrays become maps.
 
   Example:
+    ```phel
     (php->phel (php-associative-array \"a\" 1 \"b\" 2))
     # => {\"a\" 1 \"b\" 2}
+    ```
 
   See also: phel->php"
   [x]
@@ -2148,8 +2320,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if the value is present in the given collection, otherwise returns false.
 
   Example:
+    ```phel
     (contains-value? {:a 1 :b 2} 2)
     # => true
+    ```
 
   See also: contains?, some?"
   [coll val]
@@ -2159,8 +2333,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a sorted vector. If no comparator is supplied compare is used.
 
   Example:
+    ```phel
     (sort [3 1 4 1 5 9 2 6])
     # => [1 1 2 3 4 5 6 9]
+    ```
 
   See also: sort-by, compare"
   [coll & [comp]]
@@ -2174,8 +2350,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   If no comparator is supplied compare is used.
 
   Example:
+    ```phel
     (sort-by count [\"aaa\" \"c\" \"bb\"])
     # => [\"c\" \"bb\" \"aaa\"]
+    ```
 
   See also: sort, compare"
   [keyfn coll & [comp]]
@@ -2188,8 +2366,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a random permutation of coll.
 
   Example:
+    ```phel
     (shuffle [1 2 3 4 5])
-    # => [3 1 5 2 4] (random order)"
+    # => [3 1 5 2 4] (random order)
+    ```"
   [coll]
   (let [php-array (to-php-array coll)]
     (php/shuffle php-array)
@@ -2201,11 +2381,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   With one argument returns an infinite lazy sequence of x.
 
   Examples:
+    ```phel
     (repeat 3 :a)
     # => [:a :a :a]
 
     (take 5 (repeat :x))
     # => (:x :x :x :x :x)
+    ```
 
   See also: repeatedly, cycle"
   [a & rest]
@@ -2220,11 +2402,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   With one argument returns an infinite lazy sequence of calls to f.
 
   Examples:
+    ```phel
     (repeatedly 3 rand)
     # => [0.234 0.892 0.456] (random values)
 
     (take 3 (repeatedly #(rand-int 10)))
     # => (5 2 8) (random values)
+    ```
 
   See also: repeat, iterate"
   [a & rest]
@@ -2239,9 +2423,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a lazy sequence that evaluates the body only when accessed.
 
   Example:
+    ```phel
     (defn my-range [n]
       (when (> n 0)
-        (lazy-seq (cons n (my-range (dec n))))))"
+        (lazy-seq (cons n (my-range (dec n))))))
+    ```"
   [& body]
   `(php/new \Phel\Lang\Collections\LazySeq\LazySeq
             (php/new \Phel\Lang\Hasher)
@@ -2252,8 +2438,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Concatenates collections into a lazy sequence (expands to concat).
 
   Example:
+    ```phel
     (lazy-cat [1 2] [3 4])
-    # => (1 2 3 4)"
+    # => (1 2 3 4)
+    ```"
   [& colls]
   (apply list 'concat colls))
 
@@ -2261,8 +2449,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns an infinite lazy sequence of x, (f x), (f (f x)), and so on.
 
   Example:
+    ```phel
     (take 5 (iterate inc 0))
     # => (0 1 2 3 4)
+    ```
 
   See also: repeatedly, cycle"
   [f x]
@@ -2272,8 +2462,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns an infinite lazy sequence that cycles through the elements of collection.
 
   Example:
+    ```phel
     (take 7 (cycle [1 2 3]))
     # => (1 2 3 1 2 3 1)
+    ```
 
   See also: iterate, repeat"
   [coll]
@@ -2285,8 +2477,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Concatenates multiple collections into a lazy sequence.
 
   Example:
+    ```phel
     (concat [1 2] [3 4])
-    # => (1 2 3 4)"
+    # => (1 2 3 4)
+    ```"
   (fn [& colls]
     (if (php/=== nil colls)
       '()
@@ -2305,7 +2499,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   All resulting collections are concatenated into a single lazy sequence.
   Works with infinite sequences.
 
-  Example: (mapcat reverse [[1 2] [3 4]]) ; => (2 1 4 3)"
+  Example:
+    ```phel
+    (mapcat reverse [[1 2] [3 4]])
+    # => (2 1 4 3)
+    ```"
   (fn [f coll]
     (if (php/=== nil coll)
       '()
@@ -2321,7 +2519,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Inserts `sep` between each element of the collection.
   Works with infinite sequences.
 
-  Example: (interpose 0 [1 2 3]) ; => (1 0 2 0 3)"
+  Example:
+    ```phel
+    (interpose 0 [1 2 3])
+    # => (1 0 2 0 3)
+    ```"
   (fn [sep coll]
     (if (php/=== nil coll)
       '()
@@ -2338,7 +2540,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   the first argument is the index (0-based) and the second is the element itself.
   Works with infinite sequences.
 
-  Example: (map-indexed vector [:a :b :c]) ; => ([0 :a] [1 :b] [2 :c])"
+  Example:
+    ```phel
+    (map-indexed vector [:a :b :c])
+    # => ([0 :a] [1 :b] [2 :c])
+    ```"
   (fn [f coll]
     (if (php/=== nil coll)
       '()
@@ -2356,7 +2562,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Pads with nil when collections have different lengths.
   Works with infinite sequences.
 
-  Example: (interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)"
+  Example:
+    ```phel
+    (interleave [1 2 3] [:a :b :c])
+    # => (1 :a 2 :b 3 :c)
+    ```"
   (fn [& colls]
     (if (php/=== nil colls)
       '()
@@ -2372,8 +2582,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Forces realization of a lazy sequence and returns it as a vector.
 
   Example:
+    ```phel
     (doall (map println [1 2 3]))
-    # => [nil nil nil]"
+    # => [nil nil nil]
+    ```"
   [coll]
   (if (php/instanceof coll LazySeqInterface)
     (let [arr (php/-> coll (toArray))]
@@ -2386,8 +2598,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Forces realization of a lazy sequence for side effects, returns nil.
 
   Example:
+    ```phel
     (dorun (map println [1 2 3]))
-    # => nil"
+    # => nil
+    ```"
   [coll]
   (if (php/instanceof coll LazySeqInterface)
     (do
@@ -2399,8 +2613,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns true if a lazy sequence has been realized, false otherwise.
 
   Example:
+    ```phel
     (realized? (take 5 (iterate inc 1)))
-    # => false"
+    # => false
+    ```"
   [coll]
   (if (php/instanceof coll LazySeqInterface)
     (php/-> coll (isRealized))
@@ -2410,8 +2626,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a map of the elements of coll keyed by the result of `f` on each element.
 
   Example:
+    ```phel
     (group-by count [\"a\" \"bb\" \"c\" \"ddd\" \"ee\"])
     # => {1 [\"a\" \"c\"] 2 [\"bb\" \"ee\"] 3 [\"ddd\"]}
+    ```
 
   See also: partition-by, frequencies"
   [f coll]
@@ -2427,8 +2645,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Creates a map from two sequential data structures. Returns a new map.
 
   Example:
+    ```phel
     (zipcoll [:a :b :c] [1 2 3])
     # => {:a 1 :b 2 :c 3}
+    ```
 
   See also: zipmap, interleave"
   [a b]
@@ -2440,8 +2660,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   Stops when the shorter of `keys` or `vals` is exhausted.
 
   Example:
+    ```phel
     (zipmap [:a :b :c] [1 2 3])
     # => {:a 1 :b 2 :c 3}
+    ```
 
   See also: zipcoll"
   [keys vals]
@@ -2458,8 +2680,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   If a key appears in more than one collection, later values replace previous ones.
 
   Example:
+    ```phel
     (merge {:a 1 :b 2} {:b 3 :c 4})
-    # => {:a 1 :b 3 :c 4}"
+    # => {:a 1 :b 3 :c 4}
+    ```"
   [& maps]
   (for [map :in maps
         [k v] :pairs map
@@ -2470,8 +2694,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a new map including key value pairs from `m` selected with keys `ks`.
 
   Example:
+    ```phel
     (select-keys {:a 1 :b 2 :c 3} [:a :c])
     # => {:a 1 :c 3}
+    ```
 
   See also: dissoc"
   [m ks]
@@ -2487,8 +2713,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   If map has duplicated values, some keys will be ignored.
 
   Example:
+    ```phel
     (invert {:a 1 :b 2 :c 3})
-    # => {1 :a 2 :b 3 :c}"
+    # => {1 :a 2 :b 3 :c}
+    ```"
   [map]
   (for [[k v] :pairs map
         :reduce [res {}]]
@@ -2498,8 +2726,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a vector of `[(take n coll) (drop n coll)]`.
 
   Example:
+    ```phel
     (split-at 2 [1 2 3 4 5])
     # => [[1 2] [3 4 5]]
+    ```
 
   See also: split-with, take, drop"
   [n coll]
@@ -2509,8 +2739,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a vector of `[(take-while pred coll) (drop-while pred coll)]`.
 
   Example:
+    ```phel
     (split-with #(< % 4) [1 2 3 4 5 6])
     # => [[1 2 3] [4 5 6]]
+    ```
 
   See also: split-at, take-while, drop-while"
   [f coll]
@@ -2520,8 +2752,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence of partitions. Applies `f` to each value in `coll`, splitting them each time the return value changes.
 
   Example:
+    ```phel
     (partition-by #(< % 3) [1 2 3 4 5 1 2])
     # => [[1 2] [3 4 5] [1 2]]
+    ```
 
   See also: group-by, partition"
   [f coll]
@@ -2534,8 +2768,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Returns a lazy sequence with consecutive duplicate values removed in `coll`.
 
   Example:
+    ```phel
     (dedupe [1 1 2 2 2 3 1 1])
     # => (1 2 3 1)
+    ```
 
   See also: distinct"
   [coll]
@@ -2549,11 +2785,13 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   If no values are specified, removes nil values by default.
 
   Example:
+    ```phel
     (compact [1 nil 2 nil 3])
     # => (1 2 3)
 
     (compact [1 0 2 false 3] 0 false)
-    # => (1 2 3)"
+    # => (1 2 3)
+    ```"
   [coll & values]
   (cond
     (nil? coll) []
@@ -2567,8 +2805,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Partitions collection into chunks of size n, dropping incomplete final partition.
 
   Example:
+    ```phel
     (partition 3 [1 2 3 4 5 6 7])
-    # => ([1 2 3] [4 5 6])"
+    # => ([1 2 3] [4 5 6])
+    ```"
   [n coll]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
@@ -2582,8 +2822,10 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
   "Partitions collection into chunks of size n, including incomplete final partition.
 
   Example:
+    ```phel
     (partition-all 3 [1 2 3 4 5 6 7])
-    # => ([1 2 3] [4 5 6] [7])"
+    # => ([1 2 3] [4 5 6] [7])
+    ```"
   [n coll]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
@@ -3107,8 +3349,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Reads entire file or URL into a string.
 
   Example:
+    ```phel
     (slurp \"file.txt\")
-    # => \"file contents\""
+    # => \"file contents\"
+    ```"
   [path & [opts]]
   (let [is-url? (php/preg_match "/^(https?|ftp):\/\//i" path)]
     # Validate for non-URLs
@@ -3153,8 +3397,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Returns a lazy sequence of lines from a file.
 
   Example:
+    ```phel
     (take 10 (line-seq \"large-file.txt\"))
-    # => [\"line1\" \"line2\" ...]"
+    # => [\"line1\" \"line2\" ...]
+    ```"
   [filename]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
@@ -3168,8 +3414,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Returns a lazy sequence of all files and directories in a directory tree.
 
   Example:
+    ```phel
     (filter |(php/str_ends_with $ \".phel\") (file-seq \"src/\"))
-    # => [\"src/file1.phel\" \"src/file2.phel\" ...]"
+    # => [\"src/file1.phel\" \"src/file2.phel\" ...]
+    ```"
   [path]
   (let [result (lazy-seq-from-generator
                 (php/call_user_func_array
@@ -3183,8 +3431,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Returns a lazy sequence of byte chunks from a file.
 
   Example:
+    ```phel
     (take 5 (read-file-lazy \"large-file.bin\" 1024))
-    # => [\"chunk1\" \"chunk2\" ...]"
+    # => [\"chunk1\" \"chunk2\" ...]
+    ```"
   ([filename]
    (read-file-lazy filename 8192))
   ([filename chunk-size]
@@ -3200,8 +3450,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Returns a lazy sequence of rows from a CSV file.
 
   Example:
+    ```phel
     (take 10 (csv-seq \"data.csv\"))
-    # => [[\"col1\" \"col2\"] [\"val1\" \"val2\"] ...]"
+    # => [[\"col1\" \"col2\"] [\"val1\" \"val2\"] ...]
+    ```"
   ([filename]
    (csv-seq filename {}))
   ([filename options]

--- a/src/phel/debug.phel
+++ b/src/phel/debug.phel
@@ -10,8 +10,10 @@
   "Sets the number of digits for trace ID padding.
 
   Example:
+    ```phel
     (set-trace-id-padding! 3)
-    # Uses 3 digits: 001, 002, etc."
+    # Uses 3 digits: 001, 002, etc.
+    ```"
   [estimated-id-padding]
   (swap! *max-trace-digits* (fn [_] estimated-id-padding)))
 
@@ -22,10 +24,12 @@
   "Wraps a function to print each call and result with indentation.
 
   Example:
+    ```phel
     (def add (dotrace \"add\" +))
     (add 2 3)
     # Prints: TRACE t01: (add 2 3)
-    # Prints: TRACE t01: => 5"
+    # Prints: TRACE t01: => 5
+    ```"
   [name f]
   (fn [& args]
     (let [id (next-id)
@@ -46,8 +50,10 @@
   "Resets trace counters to initial values.
 
   Example:
+    ```phel
     (reset-trace-state!)
-    # Trace IDs restart from 01"
+    # Trace IDs restart from 01
+    ```"
   []
   (do
     (set! *trace-level* 0)
@@ -58,9 +64,11 @@
   "Evaluates an expression and prints it with its result.
 
   Example:
+    ```phel
     (dbg (+ 1 2))
     # Prints: (+ 1 2) => 3
-    # => 3"
+    # => 3
+    ```"
   [expr]
   (let [res (gensym)]
     `(let [,res ,expr]
@@ -71,9 +79,11 @@
   "Evaluates an expression and prints it with an optional label.
 
   Example:
+    ```phel
     (spy (+ 1 2))
     # Prints: SPY (+ 1 2) => 3
-    # => 3"
+    # => 3
+    ```"
   ([expr]
    (let [res (gensym)]
      `(let [,res ,expr]
@@ -91,9 +101,11 @@
   "Prints a value and returns it unchanged. Useful in pipelines.
 
   Example:
+    ```phel
     (-> 5 (tap) (* 2))
     # Prints: TAP => 5
-    # => 10"
+    # => 10
+    ```"
   ([value]
    (println (str "TAP => " (print-str value)))
    value)

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -7,8 +7,10 @@
   "Escapes HTML special characters to prevent XSS.
 
   Example:
+    ```phel
     (escape-html \"<div>\")
-    # => \"&lt;div&gt;\""
+    # => \"&lt;div&gt;\"
+    ```"
   [s]
   (php/htmlspecialchars s (bit-or php/ENT_QUOTES php/ENT_SUBSTITUTE)))
 
@@ -159,8 +161,10 @@
   "Compiles Phel vectors to HTML strings.
 
   Example:
+    ```phel
     (html [:div \"Hello\"])
-    # => \"<div>Hello</div>\""
+    # => \"<div>Hello</div>\"
+    ```"
   [& content]
   (apply compile-html content))
 
@@ -177,7 +181,9 @@
   "Returns an HTML doctype declaration.
 
   Example:
+    ```phel
     (doctype :html5)
-    # => \"<!DOCTYPE html>\\n\""
+    # => \"<!DOCTYPE html>\\n\"
+    ```"
   [type]
   (raw-string (get doctypes type (:html5 doctypes))))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -54,8 +54,10 @@
   "Extracts the URI from the `$_SERVER` variable.
 
   Example:
+    ```phel
     (uri-from-globals)
-    # => (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)"
+    # => (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)
+    ```"
   [& [server]]
   (let [server (or server php/$_SERVER)
         scheme (cond
@@ -81,8 +83,10 @@
   "Create a uri struct from a string.
 
   Example:
+    ```phel
     (uri-from-string \"https://example.com/path?foo=bar\")
-    # => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"
+    # => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)
+    ```"
   [url]
   (let [matches (php/array)
         [prefix url] (if (one? (php/preg_match "%^(.*://\\[[0-9:a-f]+\\])(.*?)$%" url matches))
@@ -152,8 +156,10 @@
   "Extracts the files from `$_FILES` and normalizes them to a map of \"uploaded-file\".
 
   Example:
+    ```phel
     (files-from-globals)
-    # => {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}"
+    # => {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}
+    ```"
   [& [files]]
   (normalize-files (or files php/$_FILES)))
 
@@ -165,8 +171,10 @@
   "Extracts all headers from the `$_SERVER` variable.
 
   Example:
+    ```phel
     (headers-from-server)
-    # => {:host \"example.com\" :content-type \"application/json\"}"
+    # => {:host \"example.com\" :content-type \"application/json\"}
+    ```"
   [& [server]]
   (let [headers (transient {})
         server (or server php/$_SERVER)]
@@ -220,8 +228,10 @@
   "Extracts a request from args.
 
   Example:
+    ```phel
     (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES)
-    # => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+    # => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})
+    ```"
   [server get-parameter post-parameter cookies files]
   (let [method (get-method-from-globals server)
         uri (uri-from-globals server)
@@ -246,8 +256,10 @@
   "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE` and `$_FILES`.
 
   Example:
+    ```phel
     (request-from-globals)
-    # => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"
+    # => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})
+    ```"
   []
   (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES))
 
@@ -255,8 +267,10 @@
   "Creates a request struct from a map with optional keys :method, :uri, :headers, etc.
 
   Example:
+    ```phel
     (request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"})
-    # => (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})"
+    # => (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})
+    ```"
   [{:method method
     :uri uri
     :headers headers
@@ -356,8 +370,10 @@
   "Creates a response struct from a map with optional keys :status, :headers, :body, :version, and :reason.
 
   Example:
+    ```phel
     (response-from-map {:status 200 :body \"Hello World\"})
-    # => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+    # => (response 200 {} \"Hello World\" \"1.1\" \"OK\")
+    ```"
   [{:status status :headers headers :body body :version version :reason reason}]
   (let [status (or status 200)
         headers (or headers {})
@@ -372,8 +388,10 @@
   "Create a response from a string.
 
   Example:
+    ```phel
     (response-from-string \"Hello World\")
-    # => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"
+    # => (response 200 {} \"Hello World\" \"1.1\" \"OK\")
+    ```"
   [s]
   (create-response-from-map {:body s}))
 
@@ -422,8 +440,10 @@
   "Emits the response by sending headers and outputting the body.
 
   Example:
+    ```phel
     (emit-response (response-from-string \"Hello World\"))
-    # => nil"
+    # => nil
+    ```"
   [response]
   (emit-status-line response)
   (emit-headers response)

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -5,8 +5,10 @@
   "Checks if a value can be used as a JSON key.
 
   Example:
+    ```phel
     (valid-key? :name)
-    # => true"
+    # => true
+    ```"
   [v]
   (or (int? v) (float? v) (symbol? v) (keyword? v) (string? v)))
 
@@ -24,8 +26,10 @@
   "Converts a Phel value to JSON-compatible format.
 
   Example:
+    ```phel
     (encode-value :name)
-    # => \"name\""
+    # => \"name\"
+    ```"
   [x]
   (cond
     (php/is_iterable x) (encode-value-iterable x)
@@ -38,8 +42,10 @@
   "Encodes a Phel value to a JSON string.
 
   Example:
+    ```phel
     (encode {:name \"Alice\"})
-    # => \"{\\\"name\\\":\\\"Alice\\\"}\""
+    # => \"{\\\"name\\\":\\\"Alice\\\"}\"
+    ```"
   [value & [{:flags flags :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]
@@ -53,8 +59,10 @@
   "Converts a JSON value to Phel format.
 
   Example:
+    ```phel
     (decode-value [1 2 3])
-    # => [1 2 3]"
+    # => [1 2 3]
+    ```"
   [x]
   (cond
     (indexed? x) (for [v :in x] (decode-value v))
@@ -68,8 +76,10 @@
   "Decodes a JSON string to a Phel value.
 
   Example:
+    ```phel
     (decode \"{\\\"name\\\":\\\"Alice\\\"}\")
-    # => {:name \"Alice\"}"
+    # => {:name \"Alice\"}
+    ```"
   [json & [{:flags flags :depth depth}]]
   (let [flags (or flags 0)
         depth (or depth 512)]

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -30,9 +30,11 @@
   "Creates a mock function that returns a fixed value and tracks all calls.
 
   Examples:
+    ```phel
     (def my-mock (mock :return-value))
     (my-mock 1 2 3)  # => :return-value
-    (calls my-mock)  # => [[1 2 3]]"
+    (calls my-mock)  # => [[1 2 3]]
+    ```"
   [return-value]
   (let [call-history (var [])]
     (register-mock!
@@ -45,9 +47,11 @@
   "Creates a mock function with custom behavior that tracks all calls.
 
   Examples:
+    ```phel
     (def my-mock (mock-fn (fn [x] (* x 2))))
     (my-mock 5)      # => 10
-    (calls my-mock)  # => [[5]]"
+    (calls my-mock)  # => [[5]]
+    ```"
   [f]
   (let [call-history (var [])]
     (register-mock!
@@ -60,10 +64,12 @@
   "Wraps an existing function to track calls while preserving original behavior.
 
   Examples:
+    ```phel
     (def original-fn (fn [x] (* x 2)))
     (def spied (spy original-fn))
     (spied 5)        # => 10 (calls original)
-    (calls spied)    # => [[5]]"
+    (calls spied)    # => [[5]]
+    ```"
   [f]
   (mock-fn f))
 
@@ -72,11 +78,13 @@
   After exhausting values, returns the last value.
 
   Examples:
+    ```phel
     (def my-mock (mock-returning [1 2 3]))
     (my-mock)  # => 1
     (my-mock)  # => 2
     (my-mock)  # => 3
-    (my-mock)  # => 3"
+    (my-mock)  # => 3
+    ```"
   [values]
   (let [call-history (var [])
         index (var 0)
@@ -97,8 +105,10 @@
   "Creates a mock that throws an exception when called.
 
   Examples:
+    ```phel
     (def my-mock (mock-throwing (php/new \\RuntimeException \"API unavailable\")))
-    (my-mock)  # throws RuntimeException"
+    (my-mock)  # throws RuntimeException
+    ```"
   [exception]
   (let [call-history (var [])]
     (register-mock!
@@ -120,10 +130,12 @@
   "Returns a list of all argument lists the mock was called with.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1 2)
     (my-mock 3)
-    (calls my-mock)  # => [[1 2] [3]]"
+    (calls my-mock)  # => [[1 2] [3]]
+    ```"
   [mock-fn]
   (let [call-history (get-mock-calls mock-fn)]
     (if call-history
@@ -134,10 +146,12 @@
   "Returns the number of times the mock was called.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1)
     (my-mock 2)
-    (call-count my-mock)  # => 2"
+    (call-count my-mock)  # => 2
+    ```"
   [mock-fn]
   (count (calls mock-fn)))
 
@@ -145,10 +159,12 @@
   "Returns true if the mock was called at least once.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (called? my-mock)     # => false
     (my-mock)
-    (called? my-mock)     # => true"
+    (called? my-mock)     # => true
+    ```"
   [mock-fn]
   (> (call-count mock-fn) 0))
 
@@ -156,10 +172,12 @@
   "Returns true if the mock was called with the exact arguments.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1 2 3)
     (called-with? my-mock 1 2 3)  # => true
-    (called-with? my-mock 1 2)    # => false"
+    (called-with? my-mock 1 2)    # => false
+    ```"
   [mock-fn & expected-args]
   (let [all-calls (calls mock-fn)]
     (some? (fn [call] (= call expected-args)) all-calls)))
@@ -168,11 +186,13 @@
   "Returns true if the mock was called exactly once.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock)
     (called-once? my-mock)  # => true
     (my-mock)
-    (called-once? my-mock)  # => false"
+    (called-once? my-mock)  # => false
+    ```"
   [mock-fn]
   (= 1 (call-count mock-fn)))
 
@@ -180,10 +200,12 @@
   "Returns true if the mock was called exactly n times.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock)
     (my-mock)
-    (called-times? my-mock 2)  # => true"
+    (called-times? my-mock 2)  # => true
+    ```"
   [mock-fn n]
   (= n (call-count mock-fn)))
 
@@ -191,10 +213,12 @@
   "Returns true if the mock was never called.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (never-called? my-mock)  # => true
     (my-mock)
-    (never-called? my-mock)  # => false"
+    (never-called? my-mock)  # => false
+    ```"
   [mock-fn]
   (= 0 (call-count mock-fn)))
 
@@ -202,10 +226,12 @@
   "Returns the arguments from the most recent call.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1 2)
     (my-mock 3 4)
-    (last-call my-mock)  # => [3 4]"
+    (last-call my-mock)  # => [3 4]
+    ```"
   [mock-fn]
   (last (calls mock-fn)))
 
@@ -213,10 +239,12 @@
   "Returns the arguments from the first call.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1 2)
     (my-mock 3 4)
-    (first-call my-mock)  # => [1 2]"
+    (first-call my-mock)  # => [1 2]
+    ```"
   [mock-fn]
   (first (calls mock-fn)))
 
@@ -225,13 +253,15 @@
   The mock can continue to be used and track new calls.
 
   Examples:
+    ```phel
     (def my-mock (mock :result))
     (my-mock 1)
     (call-count my-mock)   # => 1
     (reset-mock! my-mock)
     (call-count my-mock)   # => 0
     (my-mock 2)
-    (call-count my-mock)   # => 1"
+    (call-count my-mock)   # => 1
+    ```"
   [mock-fn]
   (let [mock-data (get (deref mock-registry) mock-fn)]
     (when mock-data
@@ -246,7 +276,9 @@
   Useful for cleanup between test suites in long-running processes.
 
   Examples:
-    (clear-all-mocks!)  # All mocks removed from registry"
+    ```phel
+    (clear-all-mocks!)  # All mocks removed from registry
+    ```"
   []
   (set! mock-registry {}))
 
@@ -259,20 +291,26 @@
   Automatically resets mocks after the body executes.
 
   Works with inline mock creation:
+    ```phel
     (with-mocks [http-get (mock {:status 200})]
       (http-get)
       # Mock is automatically reset after this block)
+    ```
 
   Also works with pre-defined mocks:
+    ```phel
     (let [my-mock (mock :result)]
       (with-mocks [some-fn my-mock]
         (some-fn)))
+    ```
 
   If you need to wrap the mock in a function (e.g., to adapt arguments),
   you'll need to manually reset:
+    ```phel
     (with-mocks [some-fn (fn [& args] (my-mock (transform args)))]
       (some-fn)
-      (reset-mock! my-mock))"
+      (reset-mock! my-mock))
+    ```"
   [bindings & body]
   (let [symbols (take-nth 2 bindings)
         values (take-nth 2 (drop 1 bindings))
@@ -289,21 +327,27 @@
   Automatically resets the underlying mock even when wrapped in an adapter function.
 
   Usage:
+    ```phel
     (with-mock-wrapper [fn-symbol underlying-mock wrapper-fn]
       body...)
+    ```
 
   Example:
+    ```phel
     (let [mock-http (mock {:status 200})]
       (with-mock-wrapper [symfony-service mock-http
                           (fn [args] (mock-http (adapt-args args)))]
         (symfony-service {:key \"value\"})
         (is (called-once? mock-http))))
       # mock-http is automatically reset here
+    ```
 
   Multiple wrappers:
+    ```phel
     (with-mock-wrapper [service-a mock-a (fn [x] (mock-a (inc x)))
                         service-b mock-b (fn [y] (mock-b (dec y)))]
-      ...)"
+      ...)
+    ```"
   [bindings & body]
   (let [grouped (partition 3 bindings)
         symbols (map first grouped)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -19,8 +19,10 @@
   "Returns all namespaces currently loaded in the REPL.
 
   Example:
+    ```phel
     (loaded-namespaces)
-    # => [\"phel\\core\" \"phel\\repl\"]"
+    # => [\"phel\\core\" \"phel\\repl\"]
+    ```"
   []
   (php/:: Phel (getNamespaces)))
 
@@ -37,8 +39,10 @@
   "Resolves the given symbol in the current environment and returns a resolved Symbol with the absolute namespace or nil if it cannot be resolved.
 
   Example:
+    ```phel
     (resolve 'map)
-    # => phel\\core/map"
+    # => phel\\core/map
+    ```"
   [sym]
   (-> (get-global-env)
       (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))
@@ -60,8 +64,10 @@
   "Prints the documentation for the given symbol.
 
   Example:
+    ```phel
     (doc map)
-    # Prints: \"Applies function f to each element...\""
+    # Prints: \"Applies function f to each element...\"
+    ```"
   [sym]
   (let [resolved-sym (resolve sym)]
     (when resolved-sym
@@ -93,8 +99,10 @@
   "Requires a Phel module into the environment.
 
   Example:
+    ```phel
     (require phel\http :as http :refer [request])
-    # => phel\\http"
+    # => phel\\http
+    ```"
   [sym & args]
   (let [options (apply hash-map args)
         alias (extract-alias sym options)
@@ -110,8 +118,10 @@
   "Adds a use statement to the environment.
 
   Example:
+    ```phel
     (use DateTime :as DT)
-    # => DateTime"
+    # => DateTime
+    ```"
   [sym & args]
   (let [options (apply hash-map args)
         alias (extract-alias sym options)]
@@ -136,8 +146,10 @@
   "Prints arguments with colored output.
 
   Example:
+    ```phel
     (print-colorful [1 2 3])
-    # Prints: [1 2 3] (with color)"
+    # Prints: [1 2 3] (with color)
+    ```"
   [& xs]
   (php/print (apply print-colorful-str xs))
   nil)
@@ -146,8 +158,10 @@
   "Prints arguments with colored output followed by a newline.
 
   Example:
+    ```phel
     (println-colorful [1 2 3])
-    # Prints: [1 2 3]\n (with color)"
+    # Prints: [1 2 3]\n (with color)
+    ```"
   [& xs]
   (apply print-colorful xs)
   (php/print "\n")
@@ -157,8 +171,10 @@
   "Compiles a Phel expression string to PHP code.
 
   Example:
+    ```phel
     (compile-str \"(+ 1 2)\")
-    # => \"(1 + 2)\""
+    # => \"(1 + 2)\"
+    ```"
   [s]
   (let [cf (php/new CompilerFacade)
         opts (php/new CompileOptions)

--- a/src/phel/str.phel
+++ b/src/phel/str.phel
@@ -6,8 +6,10 @@
   "Splits string on a regular expression, returning a vector of parts.
 
   Example:
+    ```phel
     (split \"hello world foo bar\" #\"\\s+\")
-    # => [\"hello\" \"world\" \"foo\" \"bar\"]"
+    # => [\"hello\" \"world\" \"foo\" \"bar\"]
+    ```"
   [s re & [limit]]
   (values (php/preg_split re s (or limit -1))))
 
@@ -18,6 +20,7 @@
   Properly handles multibyte UTF-8 characters.
 
   Examples:
+    ```phel
     (chars \"hello\")
     # => [\"h\" \"e\" \"l\" \"l\" \"o\"]
 
@@ -26,6 +29,7 @@
 
     (chars \"\")
     # => []
+    ```
 
   See also: seq, split"
   [s]
@@ -35,8 +39,10 @@
   "Returns a string of all elements in coll, separated by an optional separator.
 
   Example:
+    ```phel
     (join \", \" [\"apple\" \"banana\" \"cherry\"])
-    # => \"apple, banana, cherry\""
+    # => \"apple, banana, cherry\"
+    ```"
   [separator & [coll]]
   (let [[coll separator] (if (nil? coll) [separator ""] [coll separator])]
     (php/implode separator (to-php-array coll))))
@@ -45,8 +51,10 @@
   "Returns the substring of s from start (inclusive) to end (exclusive).
 
   Example:
+    ```phel
     (subs \"hello world\" 0 5)
-    # => \"hello\""
+    # => \"hello\"
+    ```"
   [s start & [end]]
   (let [len (php/mb_strlen s)
         end (or end len)]
@@ -58,8 +66,10 @@
   "Returns s with its characters reversed.
 
   Example:
+    ```phel
     (reverse \"hello\")
-    # => \"olleh\""
+    # => \"olleh\"
+    ```"
   [s]
   (let [chars (php/mb_str_split s)]
     (join (core/reverse chars))))
@@ -68,8 +78,10 @@
   "Returns a string containing n copies of s.
 
   Example:
+    ```phel
     (repeat \"ha\" 3)
-    # => \"hahaha\""
+    # => \"hahaha\"
+    ```"
   [s n]
   (php/str_repeat s n))
 
@@ -77,8 +89,10 @@
   "Replaces all instances of match with replacement in s.
 
   Example:
+    ```phel
     (replace \"hello world\" \"world\" \"there\")
-    # => \"hello there\""
+    # => \"hello there\"
+    ```"
   [s match replacement]
   (let [match (if (and
                    (> (php/mb_strlen match) 1)
@@ -97,8 +111,10 @@
   "Replaces the first instance of match with replacement in s.
 
   Example:
+    ```phel
     (replace-first \"hello world world\" \"world\" \"there\")
-    # => \"hello there world\""
+    # => \"hello there world\"
+    ```"
   [s match replacement]
   (let [match (if (and
                    (> (php/mb_strlen match) 1)
@@ -117,8 +133,10 @@
   "Removes all trailing newline or return characters from string.
 
   Example:
+    ```phel
     (trim-newline \"hello\\n\\n\")
-    # => \"hello\""
+    # => \"hello\"
+    ```"
   [s]
   (loop [index (php/mb_strlen s)]
     (if (zero? index)
@@ -132,8 +150,10 @@
   "Converts first character to upper-case and all other characters to lower-case.
 
   Example:
+    ```phel
     (capitalize \"hELLO wORLD\")
-    # => \"Hello world\""
+    # => \"Hello world\"
+    ```"
   [s]
   (let [first-char (php/mb_substr s 0 1)
         rest (php/mb_substr s 1)]
@@ -144,8 +164,10 @@
   "Converts string to all lower-case.
 
   Example:
+    ```phel
     (lower-case \"HELLO World\")
-    # => \"hello world\""
+    # => \"hello world\"
+    ```"
   [s]
   (php/mb_strtolower s))
 
@@ -153,8 +175,10 @@
   "Converts string to all upper-case.
 
   Example:
+    ```phel
     (upper-case \"hello World\")
-    # => \"HELLO WORLD\""
+    # => \"HELLO WORLD\"
+    ```"
   [s]
   (php/mb_strtoupper s))
 
@@ -162,8 +186,10 @@
   "Removes whitespace from both ends of string.
 
   Example:
+    ```phel
     (trim \"  hello  \")
-    # => \"hello\""
+    # => \"hello\"
+    ```"
   [s]
   (php/preg_replace "/^[\s]+|[\s]+$/u" "" s))
 
@@ -171,8 +197,10 @@
   "Removes whitespace from the left side of string.
 
   Example:
+    ```phel
     (triml \"  hello  \")
-    # => \"hello  \""
+    # => \"hello  \"
+    ```"
   [s]
   (php/preg_replace "/^[\s]+/u" "" s))
 
@@ -180,8 +208,10 @@
   "Removes whitespace from the right side of string.
 
   Example:
+    ```phel
     (trimr \"  hello  \")
-    # => \"  hello\""
+    # => \"  hello\"
+    ```"
   [s]
   (php/preg_replace "/[\s]+$/u" "" s))
 
@@ -189,11 +219,13 @@
   "True if s is nil, empty, or contains only whitespace.
 
   Example:
+    ```phel
     (blank? \"   \")
     # => true
 
     (blank? \"hello\")
-    # => false"
+    # => false
+    ```"
   [s]
   (if s
     (loop [index 0]
@@ -208,8 +240,10 @@
   "True if s starts with substr.
 
   Example:
+    ```phel
     (starts-with? \"hello world\" \"hello\")
-    # => true"
+    # => true
+    ```"
   [s substr]
   (php/str_starts_with s substr))
 
@@ -217,8 +251,10 @@
   "True if s ends with substr.
 
   Example:
+    ```phel
     (ends-with? \"hello world\" \"world\")
-    # => true"
+    # => true
+    ```"
   [s substr]
   (php/str_ends_with s substr))
 
@@ -226,8 +262,10 @@
   "True if s contains substr.
 
   Example:
+    ```phel
     (contains? \"hello world\" \"lo wo\")
-    # => true"
+    # => true
+    ```"
   [s substr]
   (php/str_contains s substr))
 
@@ -235,8 +273,10 @@
   "True if s includes substr.
 
   Example:
+    ```phel
     (includes? \"hello world\" \"world\")
-    # => true"
+    # => true
+    ```"
   [s substr]
   (php/str_contains s substr))
 
@@ -244,8 +284,10 @@
   "Escapes special characters in a replacement string for literal use.
 
   Example:
+    ```phel
     (re-quote-replacement \"$1.00\")
-    # => \"\\$1.00\""
+    # => \"\\$1.00\"
+    ```"
   [replacement]
   (php/preg_replace "/([\\\$])/" "\$1" replacement))
 
@@ -253,8 +295,10 @@
   "Returns a new string with each character escaped according to cmap.
 
   Example:
+    ```phel
     (escape \"hello\" {\"h\" \"H\" \"o\" \"O\"})
-    # => \"HellO\""
+    # => \"HellO\"
+    ```"
   [s cmap]
   (loop [index 0
          buffer ""]
@@ -268,8 +312,10 @@
   "Returns the index of value in s, or nil if not found.
 
   Example:
+    ```phel
     (index-of \"hello world\" \"world\")
-    # => 6"
+    # => 6
+    ```"
   [s value & [from-index]]
   (let [from-index (or from-index 0)
         from-index (let [abs (php/abs from-index)
@@ -286,8 +332,10 @@
   "Returns the last index of value in s, or nil if not found.
 
   Example:
+    ```phel
     (last-index-of \"hello world world\" \"world\")
-    # => 12"
+    # => 12
+    ```"
   [s value & [from-index]]
   (let [max-index (dec (php/mb_strlen s))
         from-index (or from-index max-index)
@@ -310,8 +358,10 @@
   "Splits s on \\n or \\r\\n. Trailing empty lines are not returned.
 
   Example:
+    ```phel
     (split-lines \"hello\\nworld\\ntest\")
-    # => [\"hello\" \"world\" \"test\"]"
+    # => [\"hello\" \"world\" \"test\"]
+    ```"
   [s]
   (split s "/\\r?\\n/"))
 
@@ -319,8 +369,10 @@
   "Returns a string padded on the left side to length len.
 
   Example:
+    ```phel
     (pad-left \"hello\" 10)
-    # => \"     hello\""
+    # => \"     hello\"
+    ```"
   [s len & [pad-str]]
   (php/str_pad s len (or pad-str " ") php/STR_PAD_LEFT))
 
@@ -328,8 +380,10 @@
   "Returns a string padded on the right side to length len.
 
   Example:
+    ```phel
     (pad-right \"hello\" 10)
-    # => \"hello     \""
+    # => \"hello     \"
+    ```"
   [s len & [pad-str]]
   (php/str_pad s len (or pad-str " ") php/STR_PAD_RIGHT))
 
@@ -337,7 +391,9 @@
   "Returns a string padded on both sides to length len.
 
   Example:
+    ```phel
     (pad-both \"hello\" 11)
-    # => \"   hello   \""
+    # => \"   hello   \"
+    ```"
   [s len & [pad-str]]
   (php/str_pad s len (or pad-str " ") php/STR_PAD_BOTH))

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -34,8 +34,10 @@
   "Records test results and prints status indicators.
 
   Example:
+    ```phel
     (report {:state :pass})
-    # Prints: ."
+    # Prints: .
+    ```"
   [data]
   (let [{:state state :type type} data
         ok (= state :pass)
@@ -190,8 +192,10 @@
   "Asserts that an expression is true.
 
   Example:
+    ```phel
     (is (= 4 (+ 2 2)))
-    # Passes if equal"
+    # Passes if equal
+    ```"
   [form & [message]]
   (let [loc (location form) e (gensym)]
     `(try ,(assert-expr form message)
@@ -210,8 +214,10 @@
   "Defines a test function.
 
   Example:
+    ```phel
     (deftest test-add
-      (is (= 4 (+ 2 2))))"
+      (is (= 4 (+ 2 2))))
+    ```"
   [test-name & body]
   `(defn ,test-name {:test true :test-name ,(name test-name)} []
      (binding [*current-test-name* ,(name test-name)]
@@ -304,8 +310,10 @@
   "Prints test results summary.
 
   Example:
+    ```phel
     (print-summary)
-    # Prints: Passed: 10, Failed: 2"
+    # Prints: Passed: 10, Failed: 2
+    ```"
   []
   (println)
   (println)
@@ -344,8 +352,10 @@
   "Runs all tests in the given namespaces.
 
   Example:
+    ```phel
     (run-tests {} 'my-app\test)
-    # Runs all tests"
+    # Runs all tests
+    ```"
   [options & namespaces]
   (set! testdox? (:testdox options))
   (dofor [namespace :in namespaces
@@ -357,8 +367,10 @@
   "Checks if all tests passed.
 
   Example:
+    ```phel
     (successful?)
-    # => true"
+    # => true
+    ```"
   []
   (let [{:failed failed :error error} (get (deref stats) :counts)]
     (zero? (+ failed error))))


### PR DESCRIPTION
## 🤔 Background

IDE and documentation tools render markdown code blocks with syntax highlighting when they are properly fenced with triple backticks.

## 💡 Goal

Improve docblock examples readability and IDE integration by standardizing code example formatting.

## 🔖 Changes

- Wrap all code examples in docblocks with ```phel code fencing across all 10 phel library files (~209 examples updated)
- Updated CHANGELOG.md with the improvement