### PR TITLE
Fix example from deftest function

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -202,7 +202,7 @@
 
 (defmacro deftest
   "Defines a test function."
-  {:example "(deftest test-add"}
+  {:example "(deftest test-add)"}
   [test-name & body]
   `(defn ,test-name {:test true :test-name ,(name test-name)} []
      (binding [*current-test-name* ,(name test-name)]


### PR DESCRIPTION
## 📚 Description

Add missing `)` in the example metadata section.