### PR TITLE
Run tests with PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3', '8.4' ]
+        php: [ '8.3', '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3' , '8.4' ]
+        php: [ '8.3' , '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@v4
 
@@ -220,6 +220,7 @@ jobs:
               echo "" || \
               (echo "❌ ERROR in {}" && exit 1)
             '
+
 
   bash-tests:
     name: Bash tests


### PR DESCRIPTION
## 🤔 Background

The CI was not running compiler tests with PHP 8.5.

## 💡 Goal

Run compiler tests with PHP 8.5 to ensure compatibility.

## 🔖 Changes

- Updated CI workflow to include PHP 8.5 in compiler-tests matrix.