### PR TITLE
Incremental dependency resolution 

### DIFF
--- a/src/php/Build/Application/FileSetDiffCalculator.php
+++ b/src/php/Build/Application/FileSetDiffCalculator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Application;
+
+use Phel\Build\Domain\Graph\FileSetDiff;
+use Phel\Build\Domain\Graph\FileSetSnapshot;
+
+final readonly class FileSetDiffCalculator
+{
+    /**
+     * Calculate the difference between a cached file set and current files.
+     *
+     * @param array<string, int> $currentFiles path => mtime
+     */
+    public function calculate(?FileSetSnapshot $cached, array $currentFiles): FileSetDiff
+    {
+        if (!$cached instanceof FileSetSnapshot) {
+            // No cache - all files are "added"
+            return new FileSetDiff(
+                added: array_keys($currentFiles),
+                modified: [],
+                deleted: [],
+            );
+        }
+
+        $added = [];
+        $modified = [];
+        $deleted = [];
+
+        // Find added and modified files
+        foreach ($currentFiles as $file => $mtime) {
+            if (!$cached->hasFile($file)) {
+                $added[] = $file;
+            } elseif ($cached->getMtime($file) !== $mtime) {
+                $modified[] = $file;
+            }
+        }
+
+        // Find deleted files
+        foreach (array_keys($cached->files) as $file) {
+            if (!isset($currentFiles[$file])) {
+                $deleted[] = $file;
+            }
+        }
+
+        return new FileSetDiff($added, $modified, $deleted);
+    }
+}

--- a/src/php/Build/Application/IncrementalNamespaceExtractor.php
+++ b/src/php/Build/Application/IncrementalNamespaceExtractor.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Application;
+
+use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
+use Phel\Build\Domain\Graph\DependencyGraph;
+use Phel\Build\Domain\Graph\DependencyGraphCacheInterface;
+use Phel\Build\Domain\Graph\FileSetDiff;
+use Phel\Build\Domain\Graph\FileSetSnapshot;
+use Phel\Build\Domain\Graph\GraphNode;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
+
+use function count;
+
+final readonly class IncrementalNamespaceExtractor implements NamespaceExtractorInterface
+{
+    public function __construct(
+        private NamespaceExtractorInterface $innerExtractor,
+        private DependencyGraphCacheInterface $graphCache,
+        private FileSetDiffCalculator $diffCalculator,
+        private NamespaceSorterInterface $namespaceSorter,
+    ) {
+    }
+
+    public function getNamespaceFromFile(string $path): NamespaceInformation
+    {
+        return $this->innerExtractor->getNamespaceFromFile($path);
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<NamespaceInformation>
+     */
+    public function getNamespacesFromDirectories(array $directories): array
+    {
+        // Resolve directories to canonical paths for consistent comparison
+        $resolvedDirectories = $this->resolveDirectories($directories);
+
+        // 1. Lightweight scan: collect file paths + mtimes only (no parsing)
+        $currentFiles = $this->scanFilesWithMtimes($directories);
+
+        // 2. Load cached graph and file set
+        $cachedGraph = $this->graphCache->load();
+        $cachedFileSet = $this->graphCache->loadFileSet();
+
+        // 3. Validate that cached directories match current directories
+        if (!$this->directoriesMatch($cachedFileSet, $resolvedDirectories)) {
+            // Directories changed - rebuild from scratch
+            $graph = $this->buildFullGraph($directories);
+            $fileSet = new FileSetSnapshot($currentFiles, $resolvedDirectories, time());
+            $this->graphCache->save($graph, $fileSet);
+            return $graph->toNamespaceInformationList();
+        }
+
+        // 4. Calculate diff
+        $diff = $this->diffCalculator->calculate($cachedFileSet, $currentFiles);
+
+        // 5. If no changes and cache valid, return immediately
+        if ($diff->isEmpty() && $cachedGraph instanceof DependencyGraph) {
+            return $cachedGraph->toNamespaceInformationList();
+        }
+
+        // 6. Build or update graph
+        if (!$cachedGraph instanceof DependencyGraph || $this->shouldRebuildFully($diff, $cachedFileSet)) {
+            $graph = $this->buildFullGraph($directories);
+        } else {
+            $graph = $this->updateGraphIncrementally($cachedGraph, $diff);
+        }
+
+        // 7. Save and return
+        $fileSet = new FileSetSnapshot($currentFiles, $resolvedDirectories, time());
+        $this->graphCache->save($graph, $fileSet);
+
+        return $graph->toNamespaceInformationList();
+    }
+
+    /**
+     * Scan directories for .phel files and collect their paths and mtimes.
+     * This is faster than full parsing since we only stat files.
+     *
+     * @param list<string> $directories
+     *
+     * @return array<string, int> path => mtime
+     */
+    private function scanFilesWithMtimes(array $directories): array
+    {
+        $files = [];
+
+        foreach ($directories as $directory) {
+            $realpath = $this->resolvePath($directory);
+            if ($realpath === null) {
+                continue;
+            }
+
+            if (!is_dir($realpath)) {
+                continue;
+            }
+
+            try {
+                $directoryIterator = new RecursiveDirectoryIterator($realpath);
+                $iterator = new RecursiveIteratorIterator($directoryIterator);
+                $phelIterator = new RegexIterator($iterator, '/^.+\.phel$/i', RegexIterator::GET_MATCH);
+
+                foreach ($phelIterator as $file) {
+                    $resolvedFile = $this->resolvePath($file[0]);
+                    if ($resolvedFile !== null) {
+                        $mtime = @filemtime($resolvedFile);
+                        if ($mtime !== false) {
+                            $files[$resolvedFile] = $mtime;
+                        }
+                    }
+                }
+            } catch (UnexpectedValueException) {
+                continue;
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Determine if we should rebuild the entire graph instead of updating incrementally.
+     * Rebuilding is more efficient when many files have changed.
+     */
+    private function shouldRebuildFully(FileSetDiff $diff, ?FileSetSnapshot $cached): bool
+    {
+        if (!$cached instanceof FileSetSnapshot) {
+            return true;
+        }
+
+        $totalFiles = count($cached->files);
+        if ($totalFiles === 0) {
+            return true;
+        }
+
+        $changedCount = count($diff->added) + count($diff->modified) + count($diff->deleted);
+
+        // Rebuild if more than 50% of files changed
+        return ($changedCount / $totalFiles) > 0.5;
+    }
+
+    /**
+     * Build the dependency graph from scratch.
+     *
+     * @param list<string> $directories
+     */
+    private function buildFullGraph(array $directories): DependencyGraph
+    {
+        // Use the inner extractor which already handles parsing and sorting
+        $namespaceInfos = $this->innerExtractor->getNamespacesFromDirectories($directories);
+
+        $nodes = [];
+        $topologicalOrder = [];
+
+        foreach ($namespaceInfos as $info) {
+            $mtime = @filemtime($info->getFile()) ?: 0;
+            $nodes[$info->getNamespace()] = new GraphNode(
+                $info->getFile(),
+                $info->getNamespace(),
+                $mtime,
+                $info->getDependencies(),
+            );
+            $topologicalOrder[] = $info->getNamespace();
+        }
+
+        return new DependencyGraph($nodes, $topologicalOrder);
+    }
+
+    /**
+     * Update the graph incrementally based on file changes.
+     */
+    private function updateGraphIncrementally(DependencyGraph $cachedGraph, FileSetDiff $diff): DependencyGraph
+    {
+        $nodes = $cachedGraph->getNodes();
+
+        // Remove deleted files
+        foreach ($diff->deleted as $file) {
+            $namespace = $this->findNamespaceByFile($nodes, $file);
+            if ($namespace !== null) {
+                unset($nodes[$namespace]);
+            }
+        }
+
+        // Update/add changed files
+        foreach ($diff->getChangedFiles() as $file) {
+            $info = $this->innerExtractor->getNamespaceFromFile($file);
+            $mtime = @filemtime($file) ?: 0;
+
+            // Remove old node if namespace changed (e.g., file was renamed)
+            $oldNamespace = $this->findNamespaceByFile($nodes, $file);
+            if ($oldNamespace !== null && $oldNamespace !== $info->getNamespace()) {
+                unset($nodes[$oldNamespace]);
+            }
+
+            $nodes[$info->getNamespace()] = new GraphNode(
+                $info->getFile(),
+                $info->getNamespace(),
+                $mtime,
+                $info->getDependencies(),
+            );
+        }
+
+        // Re-sort the graph
+        $dependencyIndex = [];
+        foreach ($nodes as $namespace => $node) {
+            $dependencyIndex[$namespace] = $node->dependencies;
+        }
+
+        $topologicalOrder = $this->namespaceSorter->sort(
+            array_keys($dependencyIndex),
+            $dependencyIndex,
+        );
+
+        return new DependencyGraph($nodes, $topologicalOrder);
+    }
+
+    /**
+     * Find a namespace in the nodes by its file path.
+     *
+     * @param array<string, GraphNode> $nodes
+     */
+    private function findNamespaceByFile(array $nodes, string $file): ?string
+    {
+        foreach ($nodes as $namespace => $node) {
+            if ($node->file === $file) {
+                return $namespace;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolvePath(string $path): ?string
+    {
+        // Support PHAR paths
+        if (str_starts_with($path, 'phar://')) {
+            return $path;
+        }
+
+        $real = realpath($path);
+        return $real !== false ? $real : null;
+    }
+
+    /**
+     * Resolve a list of directories to their canonical paths.
+     *
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function resolveDirectories(array $directories): array
+    {
+        $resolved = [];
+        foreach ($directories as $directory) {
+            $realpath = $this->resolvePath($directory);
+            if ($realpath !== null) {
+                $resolved[] = $realpath;
+            }
+        }
+
+        sort($resolved);
+
+        return $resolved;
+    }
+
+    /**
+     * Check if the cached file set's directories match the current directories.
+     *
+     * @param list<string> $currentDirectories Resolved/canonical paths
+     */
+    private function directoriesMatch(?FileSetSnapshot $cached, array $currentDirectories): bool
+    {
+        if (!$cached instanceof FileSetSnapshot) {
+            return false;
+        }
+
+        $cachedDirectories = $cached->directories;
+        sort($cachedDirectories);
+
+        return $cachedDirectories === $currentDirectories;
+    }
+}

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -67,4 +67,14 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
     {
         return $this->getCacheDir() . '/namespace-cache.php';
     }
+
+    public function getDependencyGraphCacheFile(): string
+    {
+        return $this->getCacheDir() . '/dependency-graph.php';
+    }
+
+    public function isDependencyGraphCacheEnabled(): bool
+    {
+        return (bool)$this->get(PhelConfig::ENABLE_DEPENDENCY_GRAPH_CACHE, true);
+    }
 }

--- a/src/php/Build/Domain/Graph/DependencyGraph.php
+++ b/src/php/Build/Domain/Graph/DependencyGraph.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Graph;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+
+final readonly class DependencyGraph
+{
+    /**
+     * @param array<string, GraphNode> $nodes            namespace => GraphNode
+     * @param list<string>             $topologicalOrder sorted namespace list
+     */
+    public function __construct(
+        public array $nodes,
+        public array $topologicalOrder,
+    ) {
+    }
+
+    public function getNode(string $namespace): ?GraphNode
+    {
+        return $this->nodes[$namespace] ?? null;
+    }
+
+    public function hasNode(string $namespace): bool
+    {
+        return isset($this->nodes[$namespace]);
+    }
+
+    /**
+     * @return array<string, GraphNode>
+     */
+    public function getNodes(): array
+    {
+        return $this->nodes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getTopologicalOrder(): array
+    {
+        return $this->topologicalOrder;
+    }
+
+    /**
+     * @return list<NamespaceInformation>
+     */
+    public function toNamespaceInformationList(): array
+    {
+        $result = [];
+        foreach ($this->topologicalOrder as $namespace) {
+            $node = $this->nodes[$namespace] ?? null;
+            if ($node !== null) {
+                $result[] = $node->toNamespaceInformation();
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{nodes: array<string, array{file: string, namespace: string, mtime: int, dependencies: list<string>}>, topological_order: list<string>}
+     */
+    public function toArray(): array
+    {
+        $nodes = [];
+        foreach ($this->nodes as $namespace => $node) {
+            $nodes[$namespace] = $node->toArray();
+        }
+
+        return [
+            'nodes' => $nodes,
+            'topological_order' => $this->topologicalOrder,
+        ];
+    }
+
+    /**
+     * @param array{nodes: array<string, array{file: string, namespace: string, mtime: int, dependencies: list<string>}>, topological_order: list<string>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $nodes = [];
+        foreach ($data['nodes'] as $namespace => $nodeData) {
+            $nodes[$namespace] = GraphNode::fromArray($nodeData);
+        }
+
+        return new self($nodes, $data['topological_order']);
+    }
+}

--- a/src/php/Build/Domain/Graph/DependencyGraphCacheInterface.php
+++ b/src/php/Build/Domain/Graph/DependencyGraphCacheInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Graph;
+
+interface DependencyGraphCacheInterface
+{
+    /**
+     * Load the cached dependency graph.
+     * Returns null if cache is missing or invalid.
+     */
+    public function load(): ?DependencyGraph;
+
+    /**
+     * Load the cached file set snapshot.
+     * Returns null if cache is missing or invalid.
+     */
+    public function loadFileSet(): ?FileSetSnapshot;
+
+    /**
+     * Save the dependency graph and file set to cache.
+     */
+    public function save(DependencyGraph $graph, FileSetSnapshot $fileSet): void;
+
+    /**
+     * Clear all cached data.
+     */
+    public function clear(): void;
+}

--- a/src/php/Build/Domain/Graph/FileSetDiff.php
+++ b/src/php/Build/Domain/Graph/FileSetDiff.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Graph;
+
+final readonly class FileSetDiff
+{
+    /**
+     * @param list<string> $added    new files
+     * @param list<string> $modified files with changed mtime
+     * @param list<string> $deleted  files that no longer exist
+     */
+    public function __construct(
+        public array $added,
+        public array $modified,
+        public array $deleted,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->added === []
+            && $this->modified === []
+            && $this->deleted === [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getChangedFiles(): array
+    {
+        return [...$this->added, ...$this->modified];
+    }
+}

--- a/src/php/Build/Domain/Graph/FileSetSnapshot.php
+++ b/src/php/Build/Domain/Graph/FileSetSnapshot.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Graph;
+
+final readonly class FileSetSnapshot
+{
+    /**
+     * @param array<string, int> $files       file path => mtime
+     * @param list<string>       $directories directories that were scanned
+     */
+    public function __construct(
+        public array $files,
+        public array $directories,
+        public int $createdAt,
+    ) {
+    }
+
+    public function hasFile(string $path): bool
+    {
+        return isset($this->files[$path]);
+    }
+
+    public function getMtime(string $path): ?int
+    {
+        return $this->files[$path] ?? null;
+    }
+
+    /**
+     * @return array{files: array<string, int>, directories: list<string>, created_at: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'files' => $this->files,
+            'directories' => $this->directories,
+            'created_at' => $this->createdAt,
+        ];
+    }
+
+    /**
+     * @param array{files: array<string, int>, directories: list<string>, created_at: int} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['files'],
+            $data['directories'],
+            $data['created_at'],
+        );
+    }
+}

--- a/src/php/Build/Domain/Graph/GraphNode.php
+++ b/src/php/Build/Domain/Graph/GraphNode.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Graph;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+
+final readonly class GraphNode
+{
+    /**
+     * @param list<string> $dependencies
+     */
+    public function __construct(
+        public string $file,
+        public string $namespace,
+        public int $mtime,
+        public array $dependencies,
+    ) {
+    }
+
+    public function toNamespaceInformation(): NamespaceInformation
+    {
+        return new NamespaceInformation(
+            $this->file,
+            $this->namespace,
+            $this->dependencies,
+        );
+    }
+
+    /**
+     * @return array{file: string, namespace: string, mtime: int, dependencies: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'file' => $this->file,
+            'namespace' => $this->namespace,
+            'mtime' => $this->mtime,
+            'dependencies' => $this->dependencies,
+        ];
+    }
+
+    /**
+     * @param array{file: string, namespace: string, mtime: int, dependencies: list<string>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['file'],
+            $data['namespace'],
+            $data['mtime'],
+            $data['dependencies'],
+        );
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/PhpDependencyGraphCache.php
+++ b/src/php/Build/Infrastructure/Cache/PhpDependencyGraphCache.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use Phel\Build\Domain\Graph\DependencyGraph;
+use Phel\Build\Domain\Graph\DependencyGraphCacheInterface;
+use Phel\Build\Domain\Graph\FileSetSnapshot;
+
+use function dirname;
+use function function_exists;
+use function is_array;
+
+final class PhpDependencyGraphCache implements DependencyGraphCacheInterface
+{
+    private const string FORMAT_VERSION = '1.0';
+
+    private bool $dirty = false;
+
+    private bool $shutdownRegistered = false;
+
+    private ?DependencyGraph $graph = null;
+
+    private ?FileSetSnapshot $fileSet = null;
+
+    public function __construct(
+        private readonly string $cacheFile,
+        private readonly string $phelVersion = '',
+    ) {
+        $this->loadFromFile();
+    }
+
+    public function load(): ?DependencyGraph
+    {
+        return $this->graph;
+    }
+
+    public function loadFileSet(): ?FileSetSnapshot
+    {
+        return $this->fileSet;
+    }
+
+    public function save(DependencyGraph $graph, FileSetSnapshot $fileSet): void
+    {
+        $this->graph = $graph;
+        $this->fileSet = $fileSet;
+        $this->dirty = true;
+        $this->registerShutdown();
+    }
+
+    public function clear(): void
+    {
+        $this->graph = null;
+        $this->fileSet = null;
+        $this->dirty = false;
+
+        if (file_exists($this->cacheFile)) {
+            @unlink($this->cacheFile);
+        }
+    }
+
+    public function flush(): void
+    {
+        if (!$this->dirty) {
+            return;
+        }
+
+        $dir = dirname($this->cacheFile);
+        if (!is_dir($dir)) {
+            $oldUmask = umask(0);
+            @mkdir($dir, 0755, true);
+            umask($oldUmask);
+        }
+
+        if (!is_dir($dir) || !is_writable($dir)) {
+            return;
+        }
+
+        $handle = @fopen($this->cacheFile, 'c');
+        if ($handle === false) {
+            return;
+        }
+
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+            return;
+        }
+
+        try {
+            ftruncate($handle, 0);
+            rewind($handle);
+            $content = '<?php return ' . var_export($this->toArray(), true) . ';';
+            fwrite($handle, $content);
+            $this->dirty = false;
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            @opcache_invalidate($this->cacheFile, true);
+        }
+    }
+
+    private function getVersion(): string
+    {
+        return self::FORMAT_VERSION . ':' . $this->phelVersion;
+    }
+
+    private function loadFromFile(): void
+    {
+        if (!file_exists($this->cacheFile)) {
+            return;
+        }
+
+        $data = @include $this->cacheFile;
+        if (!is_array($data) || !isset($data['version']) || $data['version'] !== $this->getVersion()) {
+            return;
+        }
+
+        if (isset($data['graph']) && is_array($data['graph'])) {
+            $this->graph = DependencyGraph::fromArray($data['graph']);
+        }
+
+        if (isset($data['file_set']) && is_array($data['file_set'])) {
+            $this->fileSet = FileSetSnapshot::fromArray($data['file_set']);
+        }
+    }
+
+    /**
+     * @return array{version: string, graph: ?array{nodes: array<string, array{file: string, namespace: string, mtime: int, dependencies: list<string>}>, topological_order: list<string>}, file_set: ?array{files: array<string, int>, directories: list<string>, created_at: int}}
+     */
+    private function toArray(): array
+    {
+        return [
+            'version' => $this->getVersion(),
+            'graph' => $this->graph?->toArray(),
+            'file_set' => $this->fileSet?->toArray(),
+        ];
+    }
+
+    private function registerShutdown(): void
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+
+        register_shutdown_function([$this, 'flush']);
+        $this->shutdownRegistered = true;
+    }
+}

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -36,6 +36,8 @@ final class PhelConfig implements JsonSerializable
 
     public const string ENABLE_COMPILED_CODE_CACHE = 'enable-compiled-code-cache';
 
+    public const string ENABLE_DEPENDENCY_GRAPH_CACHE = 'enable-dependency-graph-cache';
+
     public const string CACHE_DIR = 'cache-dir';
 
     /** @var list<string> */
@@ -72,6 +74,8 @@ final class PhelConfig implements JsonSerializable
     private bool $enableNamespaceCache = true;
 
     private bool $enableCompiledCodeCache = true;
+
+    private bool $enableDependencyGraphCache = true;
 
     public function __construct()
     {
@@ -201,6 +205,13 @@ final class PhelConfig implements JsonSerializable
         return $this;
     }
 
+    public function setEnableDependencyGraphCache(bool $flag): self
+    {
+        $this->enableDependencyGraphCache = $flag;
+
+        return $this;
+    }
+
     public function setCacheDir(string $dir): self
     {
         $this->cacheDir = rtrim($dir, DIRECTORY_SEPARATOR);
@@ -225,6 +236,7 @@ final class PhelConfig implements JsonSerializable
             self::ASSERTS_ENABLED => $this->enableAsserts,
             self::ENABLE_NAMESPACE_CACHE => $this->enableNamespaceCache,
             self::ENABLE_COMPILED_CODE_CACHE => $this->enableCompiledCodeCache,
+            self::ENABLE_DEPENDENCY_GRAPH_CACHE => $this->enableDependencyGraphCache,
             self::CACHE_DIR => $this->cacheDir,
         ];
     }

--- a/tests/php/Integration/Build/Graph/IncrementalNamespaceExtractorIntegrationTest.php
+++ b/tests/php/Integration/Build/Graph/IncrementalNamespaceExtractorIntegrationTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Build\Graph;
+
+use Phel\Build\Application\FileSetDiffCalculator;
+use Phel\Build\Application\IncrementalNamespaceExtractor;
+use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
+use Phel\Build\Domain\Graph\DependencyGraph;
+use Phel\Build\Domain\Graph\DependencyGraphCacheInterface;
+use Phel\Build\Domain\Graph\FileSetSnapshot;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use stdClass;
+
+/**
+ * Integration tests for IncrementalNamespaceExtractor verifying caching behavior.
+ */
+final class IncrementalNamespaceExtractorIntegrationTest extends TestCase
+{
+    private string $testDir;
+
+    private CountingGraphCache $graphCache;
+
+    protected function setUp(): void
+    {
+        $this->testDir = sys_get_temp_dir() . '/phel-incremental-test-' . uniqid();
+        mkdir($this->testDir, 0755, true);
+        $this->graphCache = new CountingGraphCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->testDir);
+    }
+
+    public function test_first_call_populates_cache(): void
+    {
+        $this->createPhelFile('a.phel');
+        $this->createPhelFile('b.phel');
+
+        $innerExtractor = $this->createCountingExtractor([
+            new NamespaceInformation($this->testDir . '/a.phel', 'test\\a', []),
+            new NamespaceInformation($this->testDir . '/b.phel', 'test\\b', ['test\\a']),
+        ]);
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $result = $extractor->getNamespacesFromDirectories([$this->testDir]);
+
+        self::assertCount(2, $result);
+        self::assertSame('test\\a', $result[0]->getNamespace());
+        self::assertSame('test\\b', $result[1]->getNamespace());
+
+        // Cache should now be populated
+        self::assertNotNull($this->graphCache->load());
+        self::assertNotNull($this->graphCache->loadFileSet());
+        self::assertSame(1, $this->graphCache->getSaveCount());
+    }
+
+    public function test_second_call_uses_cache_when_no_files_changed(): void
+    {
+        $this->createPhelFile('a.phel');
+
+        $callCount = 0;
+        $innerExtractor = new class($this->testDir, $callCount) implements NamespaceExtractorInterface {
+            /** @var int */
+            private $callCount;
+
+            public function __construct(
+                private readonly string $testDir,
+                int &$callCount,
+            ) {
+                $this->callCount = &$callCount;
+            }
+
+            public function getNamespaceFromFile(string $path): NamespaceInformation
+            {
+                ++$this->callCount;
+                return new NamespaceInformation($path, 'test\\a', []);
+            }
+
+            public function getNamespacesFromDirectories(array $directories): array
+            {
+                ++$this->callCount;
+                return [
+                    new NamespaceInformation($this->testDir . '/a.phel', 'test\\a', []),
+                ];
+            }
+        };
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        // First call - should delegate to inner extractor
+        $result1 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        $callsAfterFirst = $callCount;
+
+        // Second call - should use cache
+        $result2 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        $callsAfterSecond = $callCount;
+
+        // Results should be the same
+        self::assertCount(1, $result1);
+        self::assertCount(1, $result2);
+        self::assertSame($result1[0]->getNamespace(), $result2[0]->getNamespace());
+
+        // Inner extractor should NOT have been called for second request
+        self::assertSame($callsAfterFirst, $callsAfterSecond);
+
+        // Cache should have been saved only once
+        self::assertSame(1, $this->graphCache->getSaveCount());
+    }
+
+    public function test_modified_file_triggers_cache_update(): void
+    {
+        $file = $this->createPhelFile('a.phel');
+
+        $versionHolder = new stdClass();
+        $versionHolder->value = 1;
+
+        $innerExtractor = new readonly class($file, $versionHolder) implements NamespaceExtractorInterface {
+            public function __construct(
+                private string $file,
+                private stdClass $versionHolder,
+            ) {
+            }
+
+            public function getNamespaceFromFile(string $path): NamespaceInformation
+            {
+                return new NamespaceInformation($path, 'test\\v' . $this->versionHolder->value, []);
+            }
+
+            public function getNamespacesFromDirectories(array $directories): array
+            {
+                return [
+                    new NamespaceInformation($this->file, 'test\\v' . $this->versionHolder->value, []),
+                ];
+            }
+        };
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        // First call
+        $result1 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        self::assertSame('test\\v1', $result1[0]->getNamespace());
+
+        // Modify the file (update mtime) and version
+        sleep(1);
+        $versionHolder->value = 2;
+        touch($file);
+
+        // Second call - should detect modification
+        $result2 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        self::assertSame('test\\v2', $result2[0]->getNamespace());
+
+        // Cache should have been saved twice
+        self::assertSame(2, $this->graphCache->getSaveCount());
+    }
+
+    public function test_new_file_triggers_cache_update(): void
+    {
+        $fileA = $this->createPhelFile('a.phel');
+
+        $filesHolder = new stdClass();
+        $filesHolder->files = [$fileA];
+
+        $innerExtractor = new readonly class($filesHolder) implements NamespaceExtractorInterface {
+            public function __construct(
+                private stdClass $filesHolder,
+            ) {
+            }
+
+            public function getNamespaceFromFile(string $path): NamespaceInformation
+            {
+                $ns = basename($path, '.phel');
+
+                return new NamespaceInformation($path, 'test\\' . $ns, []);
+            }
+
+            public function getNamespacesFromDirectories(array $directories): array
+            {
+                $result = [];
+                foreach ($this->filesHolder->files as $file) {
+                    $ns = basename((string) $file, '.phel');
+                    $result[] = new NamespaceInformation($file, 'test\\' . $ns, []);
+                }
+
+                return $result;
+            }
+        };
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        // First call with only file a
+        $result1 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        self::assertCount(1, $result1);
+        self::assertSame('test\\a', $result1[0]->getNamespace());
+
+        // Add new file
+        $fileB = $this->createPhelFile('b.phel');
+        $filesHolder->files[] = $fileB;
+
+        // Second call - should detect new file
+        $result2 = $extractor->getNamespacesFromDirectories([$this->testDir]);
+        self::assertCount(2, $result2);
+
+        $namespaces = array_map(static fn (NamespaceInformation $info): string => $info->getNamespace(), $result2);
+        self::assertContains('test\\a', $namespaces);
+        self::assertContains('test\\b', $namespaces);
+    }
+
+    public function test_get_namespace_from_file_delegates_to_inner(): void
+    {
+        $file = $this->createPhelFile('test.phel');
+        $expectedInfo = new NamespaceInformation($file, 'test\\ns', []);
+
+        $innerExtractor = $this->createCountingExtractor([$expectedInfo]);
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $result = $extractor->getNamespaceFromFile($file);
+
+        self::assertSame('test\\ns', $result->getNamespace());
+    }
+
+    public function test_returns_correct_topological_order(): void
+    {
+        $this->createPhelFile('a.phel');
+        $this->createPhelFile('b.phel');
+        $this->createPhelFile('c.phel');
+
+        // c depends on b, b depends on a
+        $innerExtractor = $this->createCountingExtractor([
+            new NamespaceInformation($this->testDir . '/a.phel', 'test\\a', []),
+            new NamespaceInformation($this->testDir . '/b.phel', 'test\\b', ['test\\a']),
+            new NamespaceInformation($this->testDir . '/c.phel', 'test\\c', ['test\\b']),
+        ]);
+
+        $extractor = new IncrementalNamespaceExtractor(
+            $innerExtractor,
+            $this->graphCache,
+            new FileSetDiffCalculator(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $result = $extractor->getNamespacesFromDirectories([$this->testDir]);
+
+        self::assertCount(3, $result);
+        // Should be in dependency order: a first (no deps), then b (depends on a), then c (depends on b)
+        self::assertSame('test\\a', $result[0]->getNamespace());
+        self::assertSame('test\\b', $result[1]->getNamespace());
+        self::assertSame('test\\c', $result[2]->getNamespace());
+    }
+
+    private function createPhelFile(string $name): string
+    {
+        $path = $this->testDir . '/' . $name;
+        file_put_contents($path, '(ns test)');
+        return $path;
+    }
+
+    /**
+     * @param list<NamespaceInformation> $infos
+     */
+    private function createCountingExtractor(array $infos): NamespaceExtractorInterface
+    {
+        return new class($infos) implements NamespaceExtractorInterface {
+            public int $callCount = 0;
+
+            /**
+             * @param list<NamespaceInformation> $infos
+             */
+            public function __construct(private readonly array $infos)
+            {
+            }
+
+            public function getNamespaceFromFile(string $path): NamespaceInformation
+            {
+                ++$this->callCount;
+                foreach ($this->infos as $info) {
+                    if ($info->getFile() === $path) {
+                        return $info;
+                    }
+                }
+
+                throw new RuntimeException('Unexpected file: ' . $path);
+            }
+
+            public function getNamespacesFromDirectories(array $directories): array
+            {
+                ++$this->callCount;
+                return $this->infos;
+            }
+        };
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+
+        rmdir($dir);
+    }
+}
+
+/**
+ * Simple in-memory cache that counts save operations for testing.
+ */
+final class CountingGraphCache implements DependencyGraphCacheInterface
+{
+    private ?DependencyGraph $graph = null;
+
+    private ?FileSetSnapshot $fileSet = null;
+
+    private int $saveCount = 0;
+
+    public function load(): ?DependencyGraph
+    {
+        return $this->graph;
+    }
+
+    public function loadFileSet(): ?FileSetSnapshot
+    {
+        return $this->fileSet;
+    }
+
+    public function save(DependencyGraph $graph, FileSetSnapshot $fileSet): void
+    {
+        $this->graph = $graph;
+        $this->fileSet = $fileSet;
+        ++$this->saveCount;
+    }
+
+    public function clear(): void
+    {
+        $this->graph = null;
+        $this->fileSet = null;
+    }
+
+    public function getSaveCount(): int
+    {
+        return $this->saveCount;
+    }
+}

--- a/tests/php/Unit/Build/Application/FileSetDiffCalculatorTest.php
+++ b/tests/php/Unit/Build/Application/FileSetDiffCalculatorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Application;
+
+use Phel\Build\Application\FileSetDiffCalculator;
+use Phel\Build\Domain\Graph\FileSetSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class FileSetDiffCalculatorTest extends TestCase
+{
+    private FileSetDiffCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new FileSetDiffCalculator();
+    }
+
+    public function test_no_cache_treats_all_files_as_added(): void
+    {
+        $currentFiles = [
+            '/path/a.phel' => 1000,
+            '/path/b.phel' => 2000,
+        ];
+
+        $diff = $this->calculator->calculate(null, $currentFiles);
+
+        self::assertSame(['/path/a.phel', '/path/b.phel'], $diff->added);
+        self::assertSame([], $diff->modified);
+        self::assertSame([], $diff->deleted);
+        self::assertFalse($diff->isEmpty());
+    }
+
+    public function test_identical_file_sets_return_empty_diff(): void
+    {
+        $cached = new FileSetSnapshot(
+            ['/path/a.phel' => 1000, '/path/b.phel' => 2000],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 1000,
+            '/path/b.phel' => 2000,
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertTrue($diff->isEmpty());
+        self::assertSame([], $diff->added);
+        self::assertSame([], $diff->modified);
+        self::assertSame([], $diff->deleted);
+    }
+
+    public function test_detects_new_file(): void
+    {
+        $cached = new FileSetSnapshot(
+            ['/path/a.phel' => 1000],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 1000,
+            '/path/b.phel' => 2000, // new file
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertSame(['/path/b.phel'], $diff->added);
+        self::assertSame([], $diff->modified);
+        self::assertSame([], $diff->deleted);
+    }
+
+    public function test_detects_modified_file(): void
+    {
+        $cached = new FileSetSnapshot(
+            ['/path/a.phel' => 1000, '/path/b.phel' => 2000],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 1000,
+            '/path/b.phel' => 3000, // modified (different mtime)
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertSame([], $diff->added);
+        self::assertSame(['/path/b.phel'], $diff->modified);
+        self::assertSame([], $diff->deleted);
+    }
+
+    public function test_detects_deleted_file(): void
+    {
+        $cached = new FileSetSnapshot(
+            ['/path/a.phel' => 1000, '/path/b.phel' => 2000],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 1000,
+            // b.phel deleted
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertSame([], $diff->added);
+        self::assertSame([], $diff->modified);
+        self::assertSame(['/path/b.phel'], $diff->deleted);
+    }
+
+    public function test_detects_multiple_changes(): void
+    {
+        $cached = new FileSetSnapshot(
+            [
+                '/path/a.phel' => 1000,
+                '/path/b.phel' => 2000,
+                '/path/c.phel' => 3000,
+            ],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 1000, // unchanged
+            '/path/b.phel' => 2500, // modified
+            // c.phel deleted
+            '/path/d.phel' => 4000, // added
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertSame(['/path/d.phel'], $diff->added);
+        self::assertSame(['/path/b.phel'], $diff->modified);
+        self::assertSame(['/path/c.phel'], $diff->deleted);
+        self::assertFalse($diff->isEmpty());
+    }
+
+    public function test_get_changed_files_returns_added_and_modified(): void
+    {
+        $cached = new FileSetSnapshot(
+            ['/path/a.phel' => 1000],
+            ['/path'],
+            time(),
+        );
+        $currentFiles = [
+            '/path/a.phel' => 2000, // modified
+            '/path/b.phel' => 3000, // added
+        ];
+
+        $diff = $this->calculator->calculate($cached, $currentFiles);
+
+        self::assertCount(2, $diff->getChangedFiles());
+        self::assertContains('/path/a.phel', $diff->getChangedFiles());
+        self::assertContains('/path/b.phel', $diff->getChangedFiles());
+    }
+}

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -39,6 +39,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::ASSERTS_ENABLED => true,
             PhelConfig::ENABLE_NAMESPACE_CACHE => true,
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
+            PhelConfig::ENABLE_DEPENDENCY_GRAPH_CACHE => true,
             PhelConfig::CACHE_DIR => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phel/cache',
         ];
 
@@ -91,6 +92,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::ASSERTS_ENABLED => false,
             PhelConfig::ENABLE_NAMESPACE_CACHE => true,
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
+            PhelConfig::ENABLE_DEPENDENCY_GRAPH_CACHE => true,
             PhelConfig::CACHE_DIR => '.cache',
         ];
 


### PR DESCRIPTION
## 🤔 Background

Related https://github.com/phel-lang/phel-lang/issues/1008#issuecomment-3657854627

### Status Quo

Every call to `getNamespacesFromDirectories()` performed expensive operations:

1. **Directory scanning**: Recursively scanned all source directories for `.phel` files
2. **File parsing**: Parsed each file to extract namespace information and dependencies
3. **Topological sorting**: Re-sorted the entire dependency graph every time

Even with the existing per-file namespace cache, steps 1 and 3 happened on every invocation, causing noticeable delays especially for larger projects.

## 💡 Goal

Cache the full dependency graph and file set to avoid redundant work when files haven't changed. Return cached results immediately when possible, and only update affected nodes incrementally when files change.

## 🔖 Changes

### New Domain Models (`src/php/Build/Domain/Graph/`)
- `GraphNode` - Represents a namespace node with file path, mtime, and dependencies
- `DependencyGraph` - Full graph with nodes and pre-computed topological order
- `FileSetSnapshot` - Snapshot of file paths and mtimes for change detection
- `FileSetDiff` - Contains added/modified/deleted file lists

### Infrastructure (`src/php/Build/Infrastructure/Cache/`)
- `PhpDependencyGraphCache` - File-based cache with:
  - PHP `var_export` serialization for fast loading via `include`
  - File locking (`flock`) for concurrent access safety
  - Version validation (format version + Phel version) for proper cache invalidation

### Application Logic (`src/php/Build/Application/`)
- `FileSetDiffCalculator` - Compares cached file set with current files
- `IncrementalNamespaceExtractor` - Wraps existing extractors with caching logic:
  - Returns cached results immediately when no files changed
  - Validates directories match before using cache (prevents stale data)
  - Incrementally updates only affected nodes when files change
  - Falls back to full rebuild when >50% of files changed

### Configuration
- New `enable-dependency-graph-cache` option in `PhelConfig` (enabled by default)

## 📊 How It Works

```
ON getNamespacesFromDirectories():
  1. Lightweight scan: collect file paths + mtimes only (no parsing)
  2. Load cached graph and file set
  3. Validate directories match (prevents cross-project cache pollution)
  4. Calculate diff (added/modified/deleted files)

  IF no changes AND directories match:
     Return cached topological order immediately ← FAST PATH

  IF changes detected:
     FOR each deleted file: Remove node from graph
     FOR each added/modified file: Parse and update node
     Re-run topological sort
     Save updated graph
     Return new order
```

## 🧪 Testing

```bash
# Clear cache and benchmark
rm -rf /tmp/phel/cache

# Cold run (builds cache)
time ./bin/phel test

# Warm run (uses cache) - should be faster
time ./bin/phel test
```

To disable the feature:
```php
// phel-config.php
return [
    'enable-dependency-graph-cache' => false,
    // ...
];
```