### PR TITLE
Add memoize-lru function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add a persistent namespace cache with mtime invalidation for ~99% faster warm runs
 - Add `cache:clear` command for clearing namespace and compiled code caches
 - Add compiled code cache for significantly faster test execution
+- Add `memoize-lru` function with configurable cache size to prevent unbounded memory growth
 
 ### Changed
 - Standardize docblock examples with triple backtick code fencing for better IDE rendering and syntax highlighting

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2206,6 +2206,46 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`."
             (set! memoize-cache (assoc c args res))
             res))))))
 
+(defn memoize-lru
+  "Returns a memoized version of the function `f` with an LRU (Least Recently Used)
+  cache limited to `max-size` entries. When the cache exceeds `max-size`, the
+  least recently used entry is evicted. This prevents unbounded memory growth
+  in long-running processes.
+
+  Without arguments, uses a default cache size of 128 entries."
+  {:example "(def fib-memo (memoize-lru fib 100))"
+   :see-also ["memoize"]}
+  ([f] (memoize-lru f 128))
+  ([f max-size]
+   (let [cache (var {})       ; {args -> {:value val :accessed time}}
+         tick (var 0)]        ; access counter (monotonically increasing)
+     (fn [& args]
+       (let [c (deref cache)
+             t (swap! tick |(php/+ 1 $))]
+         (if (contains? c args)
+           ;; Cache hit - update access time and return cached value
+           (let [entry (get c args)]
+             (set! cache (assoc c args {:value (get entry :value) :accessed t}))
+             (get entry :value))
+           ;; Cache miss - compute value, add to cache, evict if necessary
+           (let [res (apply f args)
+                 new-entry {:value res :accessed t}
+                 new-cache (assoc c args new-entry)]
+             ;; Evict LRU entry if over capacity
+             (if (php/> (count new-cache) max-size)
+               (let [;; Find the key with the smallest access time
+                     lru-key (reduce
+                               (fn [oldest-key current-key]
+                                 (if (php/< (get (get new-cache current-key) :accessed)
+                                            (get (get new-cache oldest-key) :accessed))
+                                   current-key
+                                   oldest-key))
+                               (first (keys new-cache))
+                               (keys new-cache))]
+                 (set! cache (dissoc new-cache lru-key)))
+               (set! cache new-cache))
+             res)))))))
+
 # -----------------------
 # More sequence operation
 # -----------------------

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -30,3 +30,48 @@
     (is (= 2 (f 1)) "cached call")
     (is (= 3 (f 2)) "different arg")
     (is (= 2 (deref counter)) "function executed twice")))
+
+(deftest test-memoize-lru-basic
+  (let [counter (var 0)
+        f (memoize-lru (fn [x] (swap! counter inc) (+ x 1)) 10)]
+    (is (= 2 (f 1)) "first call returns correct value")
+    (is (= 2 (f 1)) "cached call returns same value")
+    (is (= 3 (f 2)) "different arg returns correct value")
+    (is (= 2 (deref counter)) "function executed only twice")))
+
+(deftest test-memoize-lru-eviction
+  (let [counter (var 0)
+        f (memoize-lru (fn [x] (swap! counter inc) (* x 10)) 3)]
+    ;; Fill the cache with 3 entries
+    (is (= 10 (f 1)) "first entry")
+    (is (= 20 (f 2)) "second entry")
+    (is (= 30 (f 3)) "third entry")
+    (is (= 3 (deref counter)) "three calls executed")
+    ;; Access first entry to make it recently used
+    (is (= 10 (f 1)) "re-access first entry (from cache)")
+    (is (= 3 (deref counter)) "no new call for cached entry")
+    ;; Add fourth entry - should evict entry 2 (least recently used)
+    (is (= 40 (f 4)) "fourth entry triggers eviction")
+    (is (= 4 (deref counter)) "fourth call executed")
+    ;; Entry 1 should still be cached (was recently accessed)
+    (is (= 10 (f 1)) "entry 1 still cached")
+    (is (= 4 (deref counter)) "entry 1 from cache, no new call")
+    ;; Entry 2 should have been evicted
+    (is (= 20 (f 2)) "entry 2 was evicted, recomputed")
+    (is (= 5 (deref counter)) "entry 2 required new call")))
+
+(deftest test-memoize-lru-default-size
+  (let [counter (var 0)
+        f (memoize-lru (fn [x] (swap! counter inc) x))]
+    ;; Test that default size works (should be 128)
+    (is (= 1 (f 1)) "first call works")
+    (is (= 1 (f 1)) "cached call works")
+    (is (= 1 (deref counter)) "only one execution")))
+
+(deftest test-memoize-lru-multi-arg
+  (let [counter (var 0)
+        f (memoize-lru (fn [x y] (swap! counter inc) (+ x y)) 5)]
+    (is (= 3 (f 1 2)) "multi-arg call")
+    (is (= 3 (f 1 2)) "cached multi-arg call")
+    (is (= 7 (f 3 4)) "different multi-arg call")
+    (is (= 2 (deref counter)) "two executions")))


### PR DESCRIPTION
## 📋 Summary

- Add `memoize-lru` function with LRU (Least Recently Used) cache eviction to prevent unbounded memory growth in long-running processes
- The existing `memoize` function caches results indefinitely, which can cause memory leaks when memoizing functions called with many unique arguments
- New function evicts least recently accessed entries when cache exceeds configurable max-size (default: 128 entries)

## 🎯 When to Use `memoize-lru`

### 🔄 Long-Running Processes
Web servers, daemons, REPL sessions where processes run for hours/days. Regular `memoize` accumulates entries forever, eventually exhausting memory.

### 🌐 Functions with Large Input Domains
When a function can be called with many unique arguments (e.g., parsing URLs, processing user IDs, handling API requests).

### ⏱️ Temporal Locality Patterns
When recent inputs are more likely to repeat than old ones:
- User sessions (recent users more active)
- File/resource access (recently accessed files likely accessed again)
- API responses (recent queries more relevant)

### 💾 Memory-Constrained Environments
Embedded/containerized environments with memory limits where you need caching benefits but must cap memory usage.

### ⚡ When to Use Regular `memoize` Instead
- Small, fixed input domains (e.g., `(memoize factorial)` for small n)
- Short-lived processes where memory cleanup happens naturally
- When cache misses are very expensive and you can afford unbounded memory

## 💡 Example

```phel
;; Basic usage with default cache size (128 entries)
(def expensive-memo (memoize-lru expensive-computation))

;; Custom cache size for memory-constrained environments
(def fib-memo (memoize-lru fib 100))

;; LRU behavior: least recently used entries are evicted first
(def f (memoize-lru (fn [x] (* x 10)) 3))
(f 1)  ; cache: {1 -> 10}
(f 2)  ; cache: {1 -> 10, 2 -> 20}
(f 3)  ; cache: {1 -> 10, 2 -> 20, 3 -> 30}
(f 1)  ; cache hit, 1 is now most recently used
(f 4)  ; evicts 2 (LRU), cache: {1 -> 10, 3 -> 30, 4 -> 40}
```

## ✅ Test plan

- [x] Add tests for basic caching behavior
- [x] Add tests for LRU eviction behavior  
- [x] Add tests for default cache size
- [x] Add tests for multi-argument functions
- [x] Run full Phel test suite (1739 tests passing)
- [x] Run PHP unit tests (990 tests passing)
- [x] Run static analysis (Psalm - no errors)