### PR TITLE
fix: defexception macro parse error with apply php/new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- Fix `defexception` macro failing with parse error due to invalid `apply php/new` usage
+
 ## [0.27.0](https://github.com/phel-lang/phel-lang/compare/v0.26.0...v0.27.0) - 2025-12-24
 
 ### Added

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -295,7 +295,9 @@
         is-name (php/:: Symbol (create (php/. name-str "?")))]
     `(do
        (defexception* ,name)
-       (defn ,name ,(php/. "Creates a new " name " exception.") [& args] (apply php/new ,class-name-str args))
+       (defn ,name ,(php/. "Creates a new " name " exception.") [& args]
+         (php/-> (php/new \ReflectionClass ,class-name-str)
+                 (newInstanceArgs (to-php-array args))))
        (defn ,is-name ,(php/. "Checks if `x` is an instance of the " name " exception.") [x] (php/is_a x ,class-name-str)))))
 
 (defmacro comment

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -77,6 +77,18 @@
   (let [x (my-struct true 1 "str" {:a 1} [:b :c])]
     (is (= x (my-struct true 1 "str" {:a 1} [:b :c])) "structs with same data")))
 
+(defexception my-exception)
+
+(deftest test-defexception
+  (let [ex (my-exception "test message" 42)]
+    (is (= "test message" (php/-> ex (getMessage))) "exception: get message")
+    (is (= 42 (php/-> ex (getCode))) "exception: get code")
+    (is (true? (my-exception? ex)) "exception: predicate returns true")
+    (is (false? (my-exception? "not an exception")) "exception: predicate returns false for non-exception"))
+  (let [ex (my-exception)]
+    (is (= "" (php/-> ex (getMessage))) "exception: default message is empty string")
+    (is (= 0 (php/-> ex (getCode))) "exception: default code is 0")))
+
 (deftest test-__FILE__
   (is (true? (>= (php/strpos __FILE__ "tests/phel/test/core.phel") 0)) "__FILE__"))
 


### PR DESCRIPTION
## 🤔 Background

The `defexception` macro was broken in v0.27.0, causing a `ParseError` when trying to define custom exceptions.

**Issue:** When executing `(defexception my-error)` in the REPL or in code, users encountered:

```clojure
phel:1> (defexception newerror)
ParseError: syntax error, unexpected token ","
```

**Root cause:** The macro used `(apply php/new ClassName args)` to instantiate the exception class with variadic arguments. However, `php/new` is a special form that compiles directly to PHP's `new` keyword, which cannot be used as a function or with `apply`.

Fixes #1073

## 💡 Goal

Allow users to define and instantiate custom exceptions without parse errors.

## 🔖 Changes

- **`src/phel/core.phel`**: Replace `(apply php/new ...)` with PHP's reflection API:
  ```clojure
  ;; Before (broken):
  (defn ,name [& args] (apply php/new ,class-name-str args))

  ;; After (working):
  (defn ,name [& args]
    (php/-> (php/new \ReflectionClass ,class-name-str)
            (newInstanceArgs (to-php-array args))))
  ```
  This uses `ReflectionClass::newInstanceArgs()` to dynamically instantiate the exception with variadic arguments.

- **`tests/phel/test/core.phel`**: Added tests for `defexception` covering:
  - Exception creation with message and code arguments
  - Predicate function (`my-exception?`) behavior
  - Default values when no arguments provided

## Example

```clojure
 ;; Define a custom exception
  (defexception my-error)

  ;; Create an instance with optional message and code
  (let [ex (my-error "Something went wrong" 500)]
    (my-error? ex))  ; => true

  ;; Can also create with no args (defaults: message="", code=0)
  (my-error)

  ;; Or just a message
  (my-error "Oops")
```