### PR TITLE
fix: `re-seq` doesn't return capture groups (#1086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Add emoji headers to GitHub release notes in `release.sh`
 
+### Fixed
+- Fix `re-seq` doesn't return capture groups (#1086)
+
 ## [0.28.0](https://github.com/phel-lang/phel-lang/compare/v0.27.0...v0.28.0) - 2026-01-18
 
 ### Added

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2889,8 +2889,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   "Returns a sequence of successive matches of pattern in string."
   [re s]
   (let [matches (php/array)
-        match-result (php/preg_match_all re s matches)]
-    (apply vector (php/aget matches 0))))
+        match-result (php/preg_match_all re s matches)
+        matches (php->phel matches)]
+    (if (= (count matches) 1)
+      (first matches)
+      (doall (apply map vector matches)))))
 
 # -------
 # Binding

--- a/tests/phel/test/core/regex-functions.phel
+++ b/tests/phel/test/core/regex-functions.phel
@@ -5,3 +5,18 @@
   (let [input "Hello, 1 regex 2 test"]
     (is (= ["1" "2"] (re-seq "/\d+/" input)) "regex [0-9]")
     (is (= ["Hello" "1" "regex" "2" "test"] (re-seq "/\w+/" input)) "regex [a-zA-Z0-9_]")))
+
+(deftest test-re-seq-doesnt-match
+  (let [input "Hello, one regex two test"]
+    (is (= [] (re-seq "/\d+/" input)) "regex [0-9] doesn't match")))
+
+(deftest test-re-seq-with-capture
+  (let [input "one=1 two=2 none="
+        expected [["one=1" "one" "1"]
+                  ["two=2" "two" "2"]
+                  ["none=" "none" ""]]]
+    (is (= expected (re-seq "/(\w+)=(\w*)/" input)) "regex with capture")))
+
+(deftest test-re-seq-with-capture-doesnt-match
+  (let [input "one,1 two,2 none,"]
+    (is (= [] (re-seq "/(\w+)=(\w*)/" input)) "regex with capture doesn't match")))


### PR DESCRIPTION
Fix #1086 

## 🤔 Background

Currently, Phel's `re-seq` function ignores capture groups within regular expressions, so capture results cannot be obtained.

## 💡 Goal

Implement capture group support in `re-seq` to match Clojure's behavior, making the function return a sequence of vectors (each containing the full match followed by captured groups) when the regex pattern includes capture groups.

## 🔖 Changes

Modified `re-seq` to check `preg_match` results (`$matches`) and return vectors with capture groups when captures are present
The implementation inspects the structure of `$matches` to determine if capture groups were found, rather than parsing the regex pattern itself
Maintained backward compatibility: patterns without capture groups still return simple string sequences

Updated CHANGELOG.md with this fix in the 'unreleased' section