### PR TITLE
Add cond-> and cond->> conditional threading macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `cond->` macro for conditional thread-first: `(cond-> 1 true inc false (* 42)) ; => 2`
+- Add `cond->>` macro for conditional thread-last: `(cond->> [1 2 3] true (map inc)) ; => [2 3 4]`
 - Add `vec` function to coerce collections to vectors: `(vec '(1 2 3))` => `[1 2 3]`
 - Add `hash-set` function to create sets from arguments (like Clojure's `hash-set`)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2900,6 +2900,40 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
               forms)
        ,gx)))
 
+(defmacro cond->
+  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->`)
+  through each form for which the corresponding test expression is true.
+  Note that, unlike `cond` branching, `cond->` threading does not short-circuit
+  after the first true test expression."
+  {:example "(cond-> 1 true inc false (* 42) true (* 3)) ; => 6"}
+  [expr & clauses]
+  (let [g (gensym)
+        steps (map (fn [pair]
+                     (let [test (first pair)
+                           step (second pair)]
+                       `(if ,test (-> ,g ,step) ,g)))
+                   (partition 2 clauses))]
+    `(let [,g ,expr
+           ,@(interleave (repeat (count steps) g) steps)]
+       ,g)))
+
+(defmacro cond->>
+  "Takes an expression and a set of test/form pairs. Threads `expr` (via `->>`)
+  through each form for which the corresponding test expression is true.
+  Note that, unlike `cond` branching, `cond->>` threading does not short-circuit
+  after the first true test expression."
+  {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => [2 3 4]"}
+  [expr & clauses]
+  (let [g (gensym)
+        steps (map (fn [pair]
+                     (let [test (first pair)
+                           step (second pair)]
+                       `(if ,test (->> ,g ,step) ,g)))
+                   (partition 2 clauses))]
+    `(let [,g ,expr
+           ,@(interleave (repeat (count steps) g) steps)]
+       ,g)))
+
 # ---------------
 # Regex functions
 # ---------------

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -43,6 +43,22 @@
     (is (= "DateTime" (php/get_class dt)))
     (is (= "2026-02-09 13:00:00" (php/-> dt (format "Y-m-d H:i:s"))))))
 
+(deftest test-cond->
+  (is (= 1 (cond-> 1)) "identity when no clauses")
+  (is (= 2 (cond-> 1 true inc)) "threads when test is true")
+  (is (= 1 (cond-> 1 false inc)) "skips when test is false")
+  (is (= 6 (cond-> 1 true inc false (* 42) true (* 3)))
+      "threads selectively based on tests")
+  (is (= 3 (cond-> {:a 1 :b 2} true (assoc :c 3) false (dissoc :a) true count))
+      "works with map operations"))
+
+(deftest test-cond->>
+  (is (= 1 (cond->> 1)) "identity when no clauses")
+  (is (= [2 3 4] (cond->> [1 2 3] true (map inc))) "threads when test is true")
+  (is (= [1 2 3] (cond->> [1 2 3] false (map inc))) "skips when test is false")
+  (is (= [2 4] (cond->> (range 1 6) true (filter even?) false (map inc)))
+      "threads selectively"))
+
 (deftest threading-macros-preserve-form-metadata
   (let [m {:line 1}]
     (let [form (set-meta! '(+ 2) m)


### PR DESCRIPTION
## 🤔 Background

Phel already has `->`, `->>`, `some->`, `some->>`, `as->`, and `doto` threading macros. However, `cond->` and `cond->>` — conditional threading — are missing. These are commonly used in Clojure for selective data transformations.

## 💡 Goal

Add `cond->` and `cond->>` macros that thread an expression through forms only when the corresponding test is true. Unlike `cond` branching, these do not short-circuit — all pairs are evaluated.

## 🔖 Changes

- Add `cond->` macro: conditional thread-first
- Add `cond->>` macro: conditional thread-last
- Add tests for both macros (8 new assertions)
- Update CHANGELOG.md