### PR TITLE
feat(test): add --fail-fast option to stop on first failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add `tap>`, `add-tap`, `remove-tap`, and `reset-taps!` to `phel\debug` for a global tap handler system
 - Add `dir`, `apropos`, and `search-doc` to `phel\repl` for namespace exploration and documentation search
 - Add `defmulti` and `defmethod` macros for runtime polymorphism via dispatch functions
+- Add `--fail-fast` option to `phel test` to stop on first failure or error
 
 ### Changed
 - `assoc` now accepts multiple key-value pairs in a single call (Clojure alignment): `(assoc m :a 1 :b 2 :c 3)`

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -11,6 +11,8 @@
 
 (def- testdox? (var false))
 
+(def- fail-fast? (var false))
+
 (def- *current-test-name* nil)
 
 (def- stats (var {:failed []
@@ -29,6 +31,11 @@
 
 (defn- should-report-println? [total-columns]
   (= (% (get-in (deref stats) [:counts :total]) total-columns) 0))
+
+(defn- should-stop? []
+  (and (deref fail-fast?)
+       (let [{:failed f :error e} (get (deref stats) :counts)]
+         (pos? (+ f e)))))
 
 (defn report
   "Records test results and prints status indicators."
@@ -325,7 +332,8 @@
 
 (defn- run-test [options ns]
   (let [tests (find-test-fns ns options)]
-    (dofor [test :in tests]
+    (dofor [test :in tests
+            :when (not (should-stop?))]
       (test))))
 
 (defn run-tests
@@ -333,8 +341,10 @@
   {:example "(run-tests {} 'my-app\test)"}
   [options & namespaces]
   (set! testdox? (:testdox options))
+  (set! fail-fast? (:fail-fast options))
   (dofor [namespace :in namespaces
-          :let [ns-name (name namespace)]]
+          :let [ns-name (name namespace)]
+          :when (not (should-stop?))]
     (run-test options ns-name))
   (print-summary))
 

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -14,9 +14,12 @@ final readonly class TestCommandOptions
 
     public const string TESTDOX = 'testdox';
 
+    public const string FAIL_FAST = 'fail-fast';
+
     private function __construct(
         private ?string $filter,
         private bool $testdox,
+        private bool $failFast,
     ) {
     }
 
@@ -30,6 +33,7 @@ final readonly class TestCommandOptions
         return new self(
             $options[self::FILTER] ?? null,
             !empty($options[self::TESTDOX]),
+            !empty($options[self::FAIL_FAST]),
         );
     }
 
@@ -42,9 +46,10 @@ final readonly class TestCommandOptions
             : $printer->print($this->filter);
 
         return sprintf(
-            '{:filter %s :testdox %s}',
+            '{:filter %s :testdox %s :fail-fast %s}',
             $filter,
             $printer->print($this->testdox),
+            $printer->print($this->failFast),
         );
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -37,6 +37,8 @@ final class TestCommand extends Command
 
     private const string OPT_TESTDOX = 'testdox';
 
+    private const string OPT_FAIL_FAST = 'fail-fast';
+
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
@@ -58,6 +60,11 @@ final class TestCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Report test execution progress in TestDox format.',
+            )->addOption(
+                self::OPT_FAIL_FAST,
+                null,
+                InputOption::VALUE_NONE,
+                'Stop running tests after the first failure or error.',
             );
     }
 
@@ -116,6 +123,7 @@ final class TestCommand extends Command
             TestCommandOptions::fromArray([
                 TestCommandOptions::FILTER => (string) $input->getOption(self::OPT_FILTER),
                 TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
+                TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
             ])->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -13,41 +13,48 @@ final class TestCommandOptionsTest extends TestCase
     {
         $options = TestCommandOptions::empty();
 
-        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
     public function test_random_filter(): void
     {
         $options = TestCommandOptions::fromArray(['filter' => 'example']);
 
-        self::assertSame('{:filter "example" :testdox false}', $options->asPhelHashMap());
+        self::assertSame('{:filter "example" :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
     public function test_no_testdox(): void
     {
         $options = TestCommandOptions::fromArray([]);
 
-        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
     public function test_false_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => false]);
 
-        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
     public function test_null_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => null]);
 
-        self::assertSame('{:filter nil :testdox false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
     public function test_true_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => 'true']);
 
-        self::assertSame('{:filter nil :testdox true}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox true :fail-fast false}', $options->asPhelHashMap());
+    }
+
+    public function test_fail_fast(): void
+    {
+        $options = TestCommandOptions::fromArray(['fail-fast' => true]);
+
+        self::assertSame('{:filter nil :testdox false :fail-fast true}', $options->asPhelHashMap());
     }
 }


### PR DESCRIPTION
## 🤔 Background

When running a large test suite, waiting for all tests to complete before seeing the first failure wastes time during development.

## 💡 Goal

Add a `--fail-fast` flag to `phel test` that stops execution after the first failure or error, enabling faster feedback loops during TDD.

## 🔖 Changes

- Add `FAIL_FAST` constant and `failFast` property to `TestCommandOptions`
- Add `--fail-fast` CLI option to `TestCommand`
- Add `fail-fast?` var and `should-stop?` helper to Phel test runner
- Add `:when (not (should-stop?))` guards to test loops in `run-test` and `run-tests`
- Update `TestCommandOptionsTest` with the new option in hash map output

### Usage

```bash
./bin/phel test --fail-fast
./bin/phel test --fail-fast tests/phel/
```