### PR TITLE
perf(lang): intern keywords via flyweight pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `assoc` now accepts multiple key-value pairs in a single call (Clojure alignment): `(assoc m :a 1 :b 2 :c 3)`
 - **BREAKING**: `set` now coerces a collection to a set (Clojure alignment): `(set [1 2 3])` => `#{1 2 3}`
 - Use `hash-set` for creating sets from arguments: `(hash-set 1 2 3)` => `#{1 2 3}`
+- Keywords are now interned (flyweight pattern) — same name/namespace returns the same instance, enabling `===` identity checks and reducing GC pressure
 
 ### Fixed
 - Functions used in string concatenation (e.g. `(str "Hello, " name "!")`) no longer crash with a PHP error; they now render as `<function:name>`

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -10,6 +10,9 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
 {
     use MetaTrait;
 
+    /** @var array<string, self> */
+    private static array $internPool = [];
+
     private readonly int $hash;
 
     private function __construct(
@@ -30,7 +33,11 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
 
     public static function create(string $name, ?string $namespace = null): self
     {
-        return new self($namespace, $name);
+        $key = $namespace !== null && $namespace !== ''
+            ? $namespace . '/' . $name
+            : $name;
+
+        return self::$internPool[$key] ??= new self($namespace, $name);
     }
 
     /**
@@ -38,7 +45,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
      */
     public static function createForNamespace(string $namespace, string $name): self
     {
-        return new self($namespace, $name);
+        return self::create($name, $namespace);
     }
 
     public function getName(): string
@@ -72,8 +79,6 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
 
     public function identical(mixed $other): bool
     {
-        return ($other instanceof self)
-            && $this->name === $other->getName()
-            && $this->namespace === $other->getNamespace();
+        return $this === $other;
     }
 }

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -93,6 +93,27 @@ final class KeywordTest extends TestCase
         $this->assertTrue($keyword2->identical($keyword1));
     }
 
+    public function test_interned_same_instance(): void
+    {
+        $keyword1 = Keyword::create('interned');
+        $keyword2 = Keyword::create('interned');
+        $this->assertSame($keyword1, $keyword2);
+    }
+
+    public function test_interned_same_instance_with_namespace(): void
+    {
+        $keyword1 = Keyword::create('interned', 'ns');
+        $keyword2 = Keyword::create('interned', 'ns');
+        $this->assertSame($keyword1, $keyword2);
+    }
+
+    public function test_interned_different_instances_for_different_names(): void
+    {
+        $keyword1 = Keyword::create('a');
+        $keyword2 = Keyword::create('b');
+        $this->assertNotSame($keyword1, $keyword2);
+    }
+
     public function test_to_string(): void
     {
         $keyword = Keyword::create('test');


### PR DESCRIPTION
## 🤔 Background

Every call to `Keyword::create()` allocates a new object and computes `crc32()` for the hash, even when the same keyword (e.g. `:name`, `:type`) is used thousands of times. In Clojure, keywords are interned — the same keyword string always returns the same object instance.

## 💡 Goal

Intern keywords so that `Keyword::create('foo')` always returns the same instance. This enables identity comparison (`===`) instead of string comparison, and reduces GC pressure from duplicate allocations.

## 🔖 Changes

- Add `$internPool` static cache to `Keyword` keyed by `namespace/name`
- `Keyword::create()` now returns cached instances via `??=`
- `Keyword::createForNamespace()` delegates to `create()` for consistent interning
- `identical()` simplified to `$this === $other` (identity check)
- Added tests verifying same-instance identity for interned keywords
- Updated CHANGELOG.md