### PR TITLE
ref: migrate code style from PSR-12 to PER-CS 3.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,8 +8,8 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = Finder::create()
     ->files()
-    ->in(__DIR__.'/src/php')
-    ->in(__DIR__.'/tests/php')
+    ->in(__DIR__ . '/src/php')
+    ->in(__DIR__ . '/tests/php')
     ->exclude(['cache', 'out', 'PhelGenerated']);
 
 return (new Config())
@@ -19,9 +19,10 @@ return (new Config())
     ->setRiskyAllowed(true)
     ->setRules([
         // ------------------------------------------------------------------
-        // Base preset
+        // Base preset: PER Coding Style 3.0
         // ------------------------------------------------------------------
-        '@PSR12' => true,
+        '@PER-CS3.0' => true,
+        '@PER-CS3.0:risky' => true,
 
         // ------------------------------------------------------------------
         // Language level & typing

--- a/src/php/Api/ApiProvider.php
+++ b/src/php/Api/ApiProvider.php
@@ -21,7 +21,7 @@ final class ApiProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_RUN,
-            static fn (Container $container) => $container->getLocator()->get(RunFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(RunFacade::class),
         );
     }
 }

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -24,8 +24,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
         private PhelFnLoaderInterface $phelFnLoader,
         private PhelFnGroupKeyGeneratorInterface $phelFnGroupKeyGenerator,
         private array $allNamespaces = [],
-    ) {
-    }
+    ) {}
 
     /**
      * @param list<string> $namespaces
@@ -47,7 +46,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
                 continue;
             }
 
-            $doc = (string)($meta[Keyword::create('doc')] ?? '');
+            $doc = (string) ($meta[Keyword::create('doc')] ?? '');
             preg_match('#(```phel\n(?<signature>.*)\n```\n)?(?<desc>.*)#s', $doc, $matches);
 
             $signatureBlock = $matches['signature'] ?? '';
@@ -74,7 +73,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
                 description: $description,
                 groupKey: $groupKey,
                 githubUrl: $this->toGithubUrl($file, $line),
-                docUrl: (string)($meta[Keyword::create('docUrl')] ?? ''),
+                docUrl: (string) ($meta[Keyword::create('docUrl')] ?? ''),
                 file: $file,
                 line: $line,
                 meta: $this->metaToArray($meta),
@@ -137,7 +136,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
 
     private function sortingPhelFunctionsCallback(): callable
     {
-        return static fn (PhelFunction $a, PhelFunction $b): int => (($a->namespace <=> $b->namespace) !== 0)
+        return static fn(PhelFunction $a, PhelFunction $b): int => (($a->namespace <=> $b->namespace) !== 0)
             ? $a->namespace <=> $b->namespace
             : ($a->name <=> $b->name);
     }

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -33,8 +33,7 @@ final class ReplCompleter implements ReplCompleterInterface
     public function __construct(
         private readonly PhelFnLoaderInterface $phelFnLoader,
         private readonly array $allNamespaces = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Complete input from either PHP or Phel context.
@@ -79,17 +78,17 @@ final class ReplCompleter implements ReplCompleterInterface
 
         $functions = array_filter(
             self::$phpFunctions,
-            static fn (string $fn): bool => str_starts_with($fn, $prefix),
+            static fn(string $fn): bool => str_starts_with($fn, $prefix),
         );
 
         $classes = array_filter(
             self::$phpClasses,
-            static fn (string $class): bool => str_starts_with($class, $prefix),
+            static fn(string $class): bool => str_starts_with($class, $prefix),
         );
 
         $matches = [
-            ...array_map(static fn (string $fn): string => 'php/' . $fn, $functions),
-            ...array_map(static fn (string $class): string => 'php/' . $class, $classes),
+            ...array_map(static fn(string $fn): string => 'php/' . $fn, $functions),
+            ...array_map(static fn(string $class): string => 'php/' . $class, $classes),
         ];
 
         sort($matches);

--- a/src/php/Api/Infrastructure/Command/DocCommand.php
+++ b/src/php/Api/Infrastructure/Command/DocCommand.php
@@ -60,7 +60,7 @@ final class DocCommand extends Command
         $search = $input->getArgument('search');
         $normalized = $this->normalizeGroupedFunctions($phelFunctions, $search);
 
-        $format = strtolower((string)$input->getOption(self::OPTION_FORMAT));
+        $format = strtolower((string) $input->getOption(self::OPTION_FORMAT));
         if (!in_array($format, self::AVAILABLE_FORMATS, true)) {
             $message = sprintf(
                 'Invalid format "%s". Allowed values: %s',
@@ -157,13 +157,13 @@ final class DocCommand extends Command
     private function calculateWithProportionalToCurrentScreen(): array
     {
         $colCount = (new Terminal())->getWidth();
-        $colCountFloat = (float)$colCount;
+        $colCountFloat = (float) $colCount;
         $proportion1 = 25;
         $proportion2 = 40;
         $proportion3 = 50;
-        $totalProportion = (float)($proportion1 + $proportion2 + $proportion3);
-        $width1 = (int)(((float)$proportion1 / $totalProportion) * $colCountFloat) - 5;
-        $width2 = (int)(((float)$proportion2 / $totalProportion) * $colCountFloat) - 5;
+        $totalProportion = (float) ($proportion1 + $proportion2 + $proportion3);
+        $width1 = (int) (((float) $proportion1 / $totalProportion) * $colCountFloat) - 5;
+        $width2 = (int) (((float) $proportion2 / $totalProportion) * $colCountFloat) - 5;
         $width3 = $colCount - ($width1 + $width2 + 10);
 
         return [$width1, $width2, $width3];
@@ -204,14 +204,14 @@ final class DocCommand extends Command
                 'signatures' => $phelFunction->signatures,
                 'doc' => $phelFunction->doc,
                 'description' => $description,
-                'example' => (string)($phelFunction->meta['example'] ?? ''),
+                'example' => (string) ($phelFunction->meta['example'] ?? ''),
                 'githubUrl' => $phelFunction->githubUrl,
                 'docUrl' => $phelFunction->docUrl,
                 'percent' => (int) round($percent),
             ];
         }
 
-        usort($normalized, static fn (array $a, array $b): int => $b['percent'] <=> $a['percent']);
+        usort($normalized, static fn(array $a, array $b): int => $b['percent'] <=> $a['percent']);
 
         return $normalized;
     }

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -135,9 +135,9 @@ Evaluate expressions after the try body and all matching catches have completed.
             'docUrl' => '/documentation/control-flow/#try-catch-and-finally',
             'signatures' => ['(finally expr*)'],
             'desc' => 'Evaluate expressions after the try body and all matching catches have completed. The finally block runs regardless of whether an exception was thrown.',
-            'example' => '(defn risky-operation [] (throw (php/new \Exception "Error!")))' . PHP_EOL .
-                '(defn cleanup [] (println "Cleanup!"))' . PHP_EOL .
-                '(try (risky-operation) (catch \Exception e nil) (finally (cleanup)))',
+            'example' => '(defn risky-operation [] (throw (php/new \Exception "Error!")))' . PHP_EOL
+                . '(defn cleanup [] (println "Cleanup!"))' . PHP_EOL
+                . '(try (risky-operation) (catch \Exception e nil) (finally (cleanup)))',
         ],
         Symbol::NAME_FN => [
             'doc' => '```phel
@@ -431,8 +431,7 @@ Creates a new vector. If no argument is provided, an empty vector is created. Sh
 
     public function __construct(
         private RunFacadeInterface $runFacade,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<string,array{

--- a/src/php/Api/Transfer/PhelFunction.php
+++ b/src/php/Api/Transfer/PhelFunction.php
@@ -24,8 +24,7 @@ final readonly class PhelFunction
         public string $file = '',
         public int $line = 0,
         public array $meta = [],
-    ) {
-    }
+    ) {}
 
     /**
      * @param  array{

--- a/src/php/Build/Application/CacheClearer.php
+++ b/src/php/Build/Application/CacheClearer.php
@@ -14,8 +14,7 @@ final readonly class CacheClearer
     public function __construct(
         private string $tempDir,
         private string $cacheDir,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<string> List of cleared paths

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -23,8 +23,7 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
         private NamespaceExtractorInterface $innerExtractor,
         private NamespaceCacheInterface $cache,
         private NamespaceSorterInterface $namespaceSorter,
-    ) {
-    }
+    ) {}
 
     public function getNamespaceFromFile(string $path): NamespaceInformation
     {
@@ -80,10 +79,10 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
     {
         foreach ($allLocations as $namespace => $files) {
             if (count($files) > 1) {
-                $fileList = implode("\n", array_map(static fn (string $f): string => '  - ' . $f, $files));
+                $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $files));
                 fwrite(STDERR, sprintf(
-                    "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n" .
-                    "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
+                    "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
+                    . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
                     $namespace,
                     $fileList,
                 ));

--- a/src/php/Build/Application/DependenciesForNamespace.php
+++ b/src/php/Build/Application/DependenciesForNamespace.php
@@ -16,8 +16,7 @@ final readonly class DependenciesForNamespace
 {
     public function __construct(
         private NamespaceExtractorInterface $namespaceExtractor,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NamespaceInformation>

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -20,8 +20,7 @@ final readonly class FileCompiler implements FileCompilerInterface
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceExtractorInterface $namespaceExtractor,
         private FileIoInterface $fileIo,
-    ) {
-    }
+    ) {}
 
     public function compileFile(string $src, string $dest, bool $enableSourceMaps): CompiledFile
     {

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -28,8 +28,7 @@ final readonly class FileEvaluator
         private NamespaceExtractorInterface $namespaceExtractor,
         private ?CompiledCodeCache $compiledCodeCache = null,
         private FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
-    ) {
-    }
+    ) {}
 
     public function evalFile(string $src): CompiledFile
     {

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -33,8 +33,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
         private CompilerFacadeInterface $compilerFacade,
         private NamespaceSorterInterface $namespaceSorter,
         private FileIoInterface $fileIo,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws ExtractorException
@@ -65,7 +64,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
                     $realFile !== false ? $realFile : $path,
                     $node->getNamespace(),
                     array_unique(array_map(
-                        static fn (Symbol $s): string => $s->getFullName(),
+                        static fn(Symbol $s): string => $s->getFullName(),
                         $node->getRequireNs(),
                     )),
                     isPrimaryDefinition: true,
@@ -127,10 +126,10 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     {
         foreach ($allLocations as $namespace => $files) {
             if (count($files) > 1) {
-                $fileList = implode("\n", array_map(static fn (string $f): string => '  - ' . $f, $files));
+                $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $files));
                 fwrite(STDERR, sprintf(
-                    "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n" .
-                    "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
+                    "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
+                    . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
                     $namespace,
                     $fileList,
                 ));

--- a/src/php/Build/Application/ProjectCompiler.php
+++ b/src/php/Build/Application/ProjectCompiler.php
@@ -31,8 +31,7 @@ final readonly class ProjectCompiler
         private CommandFacadeInterface $commandFacade,
         private EntryPointPhpFileInterface $entryPointPhpFile,
         private BuildConfigInterface $config,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<CompiledFile>

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -33,7 +33,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getPhelBuildConfig(): PhelBuildConfig
     {
-        $config = PhelBuildConfig::fromArray((array)$this->get('out', []));
+        $config = PhelBuildConfig::fromArray((array) $this->get('out', []));
 
         // Auto-detect namespace from core.phel if not explicitly configured
         if ($config->getMainPhelNamespace() === '') {
@@ -48,22 +48,22 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function isNamespaceCacheEnabled(): bool
     {
-        return (bool)$this->get(PhelConfig::ENABLE_NAMESPACE_CACHE, true);
+        return (bool) $this->get(PhelConfig::ENABLE_NAMESPACE_CACHE, true);
     }
 
     public function isCompiledCodeCacheEnabled(): bool
     {
-        return (bool)$this->get(PhelConfig::ENABLE_COMPILED_CODE_CACHE, true);
+        return (bool) $this->get(PhelConfig::ENABLE_COMPILED_CODE_CACHE, true);
     }
 
     public function getTempDir(): string
     {
-        return (string)$this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir() . '/phel');
+        return (string) $this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir() . '/phel');
     }
 
     public function getCacheDir(): string
     {
-        $cacheDir = (string)$this->get(PhelConfig::CACHE_DIR, 'cache');
+        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, 'cache');
 
         // If absolute path, use as-is; otherwise relative to app root
         if (str_starts_with($cacheDir, '/') || str_starts_with($cacheDir, 'phar://')) {
@@ -85,7 +85,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
     private function autoDetectMainNamespace(): string
     {
         /** @var list<string> $srcDirs */
-        $srcDirs = (array)$this->get(PhelConfig::SRC_DIRS, PhelConfig::DEFAULT_SRC_DIRS);
+        $srcDirs = (array) $this->get(PhelConfig::SRC_DIRS, PhelConfig::DEFAULT_SRC_DIRS);
         $appRoot = $this->getAppRootDir();
 
         foreach ($srcDirs as $srcDir) {

--- a/src/php/Build/BuildProvider.php
+++ b/src/php/Build/BuildProvider.php
@@ -25,7 +25,7 @@ final class BuildProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMPILER,
-            static fn (Container $container) => $container->getLocator()->get(CompilerFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
         );
     }
 
@@ -33,7 +33,7 @@ final class BuildProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMMAND,
-            static fn (Container $container) => $container->getLocator()->get(CommandFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
         );
     }
 }

--- a/src/php/Build/Domain/Cache/NamespaceCacheEntry.php
+++ b/src/php/Build/Domain/Cache/NamespaceCacheEntry.php
@@ -17,8 +17,7 @@ final readonly class NamespaceCacheEntry
         public string $namespace,
         public array $dependencies,
         public bool $isPrimaryDefinition = true,
-    ) {
-    }
+    ) {}
 
     public function isValid(): bool
     {

--- a/src/php/Build/Domain/Compile/BuildOptions.php
+++ b/src/php/Build/Domain/Compile/BuildOptions.php
@@ -9,8 +9,7 @@ final readonly class BuildOptions
     public function __construct(
         private bool $enableCache,
         private bool $enableSourceMap,
-    ) {
-    }
+    ) {}
 
     public function isCacheEnabled(): bool
     {

--- a/src/php/Build/Domain/Compile/CompiledFile.php
+++ b/src/php/Build/Domain/Compile/CompiledFile.php
@@ -10,8 +10,7 @@ final readonly class CompiledFile
         private string $sourceFile,
         private string $targetFile,
         private string $namespace,
-    ) {
-    }
+    ) {}
 
     public function getSourceFile(): string
     {

--- a/src/php/Build/Domain/Compile/Output/EntryPointPhpFile.php
+++ b/src/php/Build/Domain/Compile/Output/EntryPointPhpFile.php
@@ -15,8 +15,7 @@ final readonly class EntryPointPhpFile implements EntryPointPhpFileInterface
         private PhelBuildConfig $phelBuildConfig,
         private NamespacePathTransformer $namespacePathTransformer,
         private string $appRootDir,
-    ) {
-    }
+    ) {}
 
     public function createFile(): void
     {

--- a/src/php/Build/Domain/Extractor/NamespaceInformation.php
+++ b/src/php/Build/Domain/Extractor/NamespaceInformation.php
@@ -16,8 +16,7 @@ final readonly class NamespaceInformation
         private string $namespace,
         private array $dependencies,
         private bool $isPrimaryDefinition = true,
-    ) {
-    }
+    ) {}
 
     public function getFile(): string
     {

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -31,8 +31,7 @@ final class CompiledCodeCache
         private readonly string $cacheDir,
         private readonly string $phelVersion = '',
         private readonly int $maxEntries = 500,
-    ) {
-    }
+    ) {}
 
     /**
      * Returns the path to the cached compiled PHP file if it exists and is valid.
@@ -369,7 +368,7 @@ final class CompiledCodeCache
         }
 
         // Sort entries by last_accessed (oldest first)
-        uasort($this->entries, static fn ($a, $b): int => $a['last_accessed'] <=> $b['last_accessed']);
+        uasort($this->entries, static fn($a, $b): int => $a['last_accessed'] <=> $b['last_accessed']);
 
         // Calculate how many to evict (10% of max, minimum 1)
         $evictCount = max(1, (int) floor($this->maxEntries / 10));

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -19,8 +19,7 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     public function __construct(
         private ExceptionPrinterInterface $exceptionPrinter,
         private ErrorLogInterface $errorLog,
-    ) {
-    }
+    ) {}
 
     public function writeStackTrace(
         OutputInterface $output,

--- a/src/php/Command/Application/DirectoryFinder.php
+++ b/src/php/Command/Application/DirectoryFinder.php
@@ -14,8 +14,7 @@ final readonly class DirectoryFinder implements DirectoryFinderInterface
         private string $applicationRootDir,
         private CodeDirectories $codeDirectories,
         private VendorDirectoriesFinderInterface $vendorDirectoriesFinder,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<string>

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -31,8 +31,7 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
         private MungeInterface $munge,
         private FilePositionExtractorInterface $filePositionExtractor,
         private ErrorLogInterface $errorLog,
-    ) {
-    }
+    ) {}
 
     public function printError(string $error): void
     {
@@ -60,11 +59,11 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
         $str .= 'in ' . $errorStartLocation->getFile() . ':' . $errorFirstLine . PHP_EOL . PHP_EOL;
 
         $lines = explode(PHP_EOL, $codeSnippet->getCode());
-        $endLineLength = strlen((string)$codeSnippet->getEndLocation()->getLine());
-        $padLength = $endLineLength - strlen((string)$codeFirstLine);
+        $endLineLength = strlen((string) $codeSnippet->getEndLocation()->getLine());
+        $padLength = $endLineLength - strlen((string) $codeFirstLine);
 
         foreach ($lines as $index => $line) {
-            $str .= str_pad((string)($codeFirstLine + $index), $padLength, ' ', STR_PAD_LEFT);
+            $str .= str_pad((string) ($codeFirstLine + $index), $padLength, ' ', STR_PAD_LEFT);
             if ($line !== '') {
                 $str .= '| ' . $line . PHP_EOL;
             } else {

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -26,19 +26,19 @@ final class CommandConfig extends AbstractConfig
         $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
 
         return new CodeDirectories(
-            [__DIR__ . '/../../', ...(array)$this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS)],
-            (array)$this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS),
-            (string)($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
+            [__DIR__ . '/../../', ...(array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS)],
+            (array) $this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS),
+            (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
         );
     }
 
     public function getVendorDir(): string
     {
-        return (string)$this->get(PhelConfig::VENDOR_DIR, self::DEFAULT_VENDOR_DIR);
+        return (string) $this->get(PhelConfig::VENDOR_DIR, self::DEFAULT_VENDOR_DIR);
     }
 
     public function getErrorLogFile(): string
     {
-        return (string)$this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE);
+        return (string) $this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE);
     }
 }

--- a/src/php/Command/CommandProvider.php
+++ b/src/php/Command/CommandProvider.php
@@ -16,7 +16,7 @@ final class CommandProvider extends AbstractProvider
     {
         $container->set(
             self::PHP_CONFIG_READER,
-            static fn (Container $container) => $container->getLocator()->get(PhpConfigReader::class),
+            static fn(Container $container) => $container->getLocator()->get(PhpConfigReader::class),
         );
     }
 }

--- a/src/php/Command/Domain/CodeDirectories.php
+++ b/src/php/Command/Domain/CodeDirectories.php
@@ -14,8 +14,7 @@ final readonly class CodeDirectories
         private array $srcDirs,
         private array $testDirs,
         private string $outputDir,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<string>

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -18,8 +18,7 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
 {
     public function __construct(
         private PrinterInterface $printer,
-    ) {
-    }
+    ) {}
 
     public function parseArgsAsString(array $frameArgs): string
     {
@@ -83,6 +82,6 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
             return 'Resource id #' . get_resource_id($arg);
         }
 
-        return (string)$arg;
+        return (string) $arg;
     }
 }

--- a/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/FilePositionExtractor.php
@@ -12,8 +12,7 @@ final readonly class FilePositionExtractor implements FilePositionExtractorInter
 {
     public function __construct(
         private SourceMapExtractorInterface $sourceMapExtractor,
-    ) {
-    }
+    ) {}
 
     public function getOriginal(string $filename, int $line): FilePosition
     {

--- a/src/php/Command/Domain/Exceptions/Extractor/ReadModel/FilePosition.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/ReadModel/FilePosition.php
@@ -9,8 +9,7 @@ final readonly class FilePosition
     public function __construct(
         private string $filename,
         private int $line,
-    ) {
-    }
+    ) {}
 
     public function filename(): string
     {

--- a/src/php/Command/Domain/Exceptions/Extractor/ReadModel/SourceMapInformation.php
+++ b/src/php/Command/Domain/Exceptions/Extractor/ReadModel/SourceMapInformation.php
@@ -9,8 +9,7 @@ final readonly class SourceMapInformation
     public function __construct(
         private string $filename,
         private string $sourceMap,
-    ) {
-    }
+    ) {}
 
     public function filename(): string
     {

--- a/src/php/Command/Infrastructure/ComposerVendorDirectoriesFinder.php
+++ b/src/php/Command/Infrastructure/ComposerVendorDirectoriesFinder.php
@@ -23,8 +23,7 @@ final class ComposerVendorDirectoriesFinder implements VendorDirectoriesFinderIn
 
     public function __construct(
         private readonly string $vendorDirectory,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<string>

--- a/src/php/Command/Infrastructure/ErrorLog.php
+++ b/src/php/Command/Infrastructure/ErrorLog.php
@@ -10,8 +10,7 @@ final readonly class ErrorLog implements ErrorLogInterface
 {
     public function __construct(
         private string $filepath,
-    ) {
-    }
+    ) {}
 
     public function writeln(string $text): void
     {

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -44,8 +44,7 @@ final class Analyzer implements AnalyzerInterface
     public function __construct(
         private readonly GlobalEnvironmentInterface $globalEnvironment,
         private readonly bool $assertsEnabled = true,
-    ) {
-    }
+    ) {}
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
     {

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -38,8 +38,7 @@ final readonly class CodeCompiler implements CodeCompilerInterface
         private StatementEmitterInterface $statementEmitter,
         private FileEmitterInterface $fileEmitter,
         private EvaluatorInterface $evaluator,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws CompilerException

--- a/src/php/Compiler/Application/EvalCompiler.php
+++ b/src/php/Compiler/Application/EvalCompiler.php
@@ -36,8 +36,7 @@ final readonly class EvalCompiler implements EvalCompilerInterface
         private AnalyzerInterface $analyzer,
         private StatementEmitterInterface $emitter,
         private EvaluatorInterface $evaluator,
-    ) {
-    }
+    ) {}
 
     /**
      * Evaluates a provided Phel code.

--- a/src/php/Compiler/Application/Munge.php
+++ b/src/php/Compiler/Application/Munge.php
@@ -44,8 +44,7 @@ final readonly class Munge implements MungeInterface
     public function __construct(
         private array $mapping = self::DEFAULT_MAPPING,
         private array $nsMapping = self::DEFAULT_NS_MAPPING,
-    ) {
-    }
+    ) {}
 
     public function encode(string $str): string
     {

--- a/src/php/Compiler/Application/NamespaceEnvironmentSerializer.php
+++ b/src/php/Compiler/Application/NamespaceEnvironmentSerializer.php
@@ -15,8 +15,7 @@ final readonly class NamespaceEnvironmentSerializer
 {
     public function __construct(
         private GlobalEnvironmentInterface $globalEnvironment,
-    ) {
-    }
+    ) {}
 
     /**
      * Captures the current GlobalEnvironment state for a namespace
@@ -30,8 +29,8 @@ final readonly class NamespaceEnvironmentSerializer
      */
     public function capture(string $namespace): array
     {
-        $toArray = static fn (array $symbols): array => array_map(
-            static fn (Symbol $symbol): array => [
+        $toArray = static fn(array $symbols): array => array_map(
+            static fn(Symbol $symbol): array => [
                 'ns' => $symbol->getNamespace(),
                 'name' => $symbol->getName(),
             ],

--- a/src/php/Compiler/Application/Reader.php
+++ b/src/php/Compiler/Application/Reader.php
@@ -32,8 +32,7 @@ final class Reader implements ReaderInterface
     public function __construct(
         private readonly ExpressionReaderFactoryInterface $readerFactory,
         private readonly QuasiquoteTransformerInterface $quasiquoteTransformer,
-    ) {
-    }
+    ) {}
 
     /**
      * Reads the next expression from the token stream.

--- a/src/php/Compiler/CompilerConfig.php
+++ b/src/php/Compiler/CompilerConfig.php
@@ -11,6 +11,6 @@ final class CompilerConfig extends AbstractConfig
 {
     public function assertsEnabled(): bool
     {
-        return (bool)$this->get(PhelConfig::ASSERTS_ENABLED, true);
+        return (bool) $this->get(PhelConfig::ASSERTS_ENABLED, true);
     }
 }

--- a/src/php/Compiler/CompilerProvider.php
+++ b/src/php/Compiler/CompilerProvider.php
@@ -16,7 +16,7 @@ final class CompilerProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_FILESYSTEM,
-            static fn (Container $container) => $container->getLocator()->get(FilesystemFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(FilesystemFacade::class),
         );
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Ast/AbstractNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/AbstractNode.php
@@ -12,8 +12,7 @@ abstract class AbstractNode
     public function __construct(
         private readonly NodeEnvironmentInterface $env,
         private readonly ?SourceLocation $startSourceLocation = null,
-    ) {
-    }
+    ) {}
 
     public function getEnv(): NodeEnvironmentInterface
     {

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefInterfaceMethod.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefInterfaceMethod.php
@@ -18,8 +18,7 @@ final readonly class DefInterfaceMethod
         private Symbol $name,
         private array $arguments,
         private ?string $comment = null,
-    ) {
-    }
+    ) {}
 
     public function getName(): Symbol
     {

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefStructInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefStructInterface.php
@@ -12,8 +12,7 @@ final readonly class DefStructInterface
     public function __construct(
         private string $absoluteInterfaceName,
         private array $methods,
-    ) {
-    }
+    ) {}
 
     public function getAbsoluteInterfaceName(): string
     {

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefStructMethod.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefStructMethod.php
@@ -11,8 +11,7 @@ final readonly class DefStructMethod
     public function __construct(
         private Symbol $name,
         private FnNode $fnNode,
-    ) {
-    }
+    ) {}
 
     public function getName(): Symbol
     {

--- a/src/php/Compiler/Domain/Analyzer/Ast/MultiFnNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MultiFnNode.php
@@ -35,7 +35,7 @@ final class MultiFnNode extends AbstractNode
 
     public function getMinArity(): int
     {
-        return min(array_map(static fn (FnNode $n): int => $n->getMinArity(), $this->fnNodes));
+        return min(array_map(static fn(FnNode $n): int => $n->getMinArity(), $this->fnNodes));
     }
 
     /**
@@ -47,7 +47,7 @@ final class MultiFnNode extends AbstractNode
             return null;
         }
 
-        return max(array_map(static fn (FnNode $n): int => $n->getMinArity(), $this->fnNodes));
+        return max(array_map(static fn(FnNode $n): int => $n->getMinArity(), $this->fnNodes));
     }
 
     /**
@@ -57,7 +57,7 @@ final class MultiFnNode extends AbstractNode
     {
         return array_reduce(
             $this->fnNodes,
-            static fn (bool $carry, FnNode $n): bool => $carry || $n->isVariadic(),
+            static fn(bool $carry, FnNode $n): bool => $carry || $n->isVariadic(),
             false,
         );
     }

--- a/src/php/Compiler/Domain/Analyzer/Ast/RecurFrame.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/RecurFrame.php
@@ -15,8 +15,7 @@ final class RecurFrame
      */
     public function __construct(
         private readonly array $params,
-    ) {
-    }
+    ) {}
 
     public function setIsActive(bool $isActive): void
     {

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -37,8 +37,7 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         private array $shadowed,
         private array $recurFrames,
         private string $boundTo = '',
-    ) {
-    }
+    ) {}
 
     public static function empty(): NodeEnvironmentInterface
     {

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -216,7 +216,7 @@ final class AnalyzerException extends AbstractLocatedException
 
         /** @var string $lastSuggestion */
         $lastSuggestion = array_pop($suggestions);
-        $quotedSuggestions = array_map(static fn (string $s): string => sprintf("'%s'", $s), $suggestions);
+        $quotedSuggestions = array_map(static fn(string $s): string => sprintf("'%s'", $s), $suggestions);
 
         return implode(', ', $quotedSuggestions) . sprintf(", or '%s'", $lastSuggestion);
     }

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/GlobalEnvironmentAlreadyInitializedException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/GlobalEnvironmentAlreadyInitializedException.php
@@ -6,6 +6,4 @@ namespace Phel\Compiler\Domain\Analyzer\Exceptions;
 
 use Exception;
 
-final class GlobalEnvironmentAlreadyInitializedException extends Exception
-{
-}
+final class GlobalEnvironmentAlreadyInitializedException extends Exception {}

--- a/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
+++ b/src/php/Compiler/Domain/Analyzer/SymbolSuggestionProvider.php
@@ -37,7 +37,7 @@ final class SymbolSuggestionProvider
             }
         }
 
-        usort($suggestions, static fn (array $a, array $b): int => $a['distance'] <=> $b['distance']);
+        usort($suggestions, static fn(array $a, array $b): int => $a['distance'] <=> $b['distance']);
 
         $result = [];
         $count = 0;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -57,8 +57,7 @@ final class AnalyzePersistentList
     public function __construct(
         private readonly AnalyzerInterface $analyzer,
         private readonly bool $assertsEnabled,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws AbstractLocatedException|AnalyzerException

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
@@ -21,8 +21,7 @@ final readonly class Deconstructor implements DeconstructorInterface
 {
     public function __construct(
         private BindingValidatorInterface $bindingValidator,
-    ) {
-    }
+    ) {}
 
     public function deconstruct(PersistentVectorInterface $form): array
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -23,8 +23,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
 
     public function __construct(
         private readonly Deconstructor $deconstructor,
-    ) {
-    }
+    ) {}
 
     /**
      * @param PersistentMapInterface                   $binding The binding form

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/VectorBindingDeconstructor.php
@@ -38,8 +38,7 @@ final class VectorBindingDeconstructor implements BindingDeconstructorInterface
 
     public function __construct(
         private readonly Deconstructor $deconstructor,
-    ) {
-    }
+    ) {}
 
     /**
      * @param mixed $binding

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -26,8 +26,7 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private MungeInterface $munge,
-    ) {
-    }
+    ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefStructNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -27,8 +27,7 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private bool $assertsEnabled = true,
-    ) {
-    }
+    ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LetSymbol.php
@@ -24,8 +24,7 @@ final readonly class LetSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private DeconstructorInterface $deconstructor,
-    ) {
-    }
+    ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): LetNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/LoopSymbol.php
@@ -25,8 +25,7 @@ final readonly class LoopSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private BindingValidator $bindingValidator,
-    ) {
-    }
+    ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): LetNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpObjectCallSymbol.php
@@ -21,8 +21,7 @@ final readonly class PhpObjectCallSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private bool $isStatic,
-    ) {
-    }
+    ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): PhpObjectCallNode
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/FnSymbolTuple.php
@@ -34,8 +34,7 @@ final class FnSymbolTuple
 
     private function __construct(
         private readonly PersistentListInterface $parentList,
-    ) {
-    }
+    ) {}
 
     public static function createWithTuple(PersistentListInterface $list): self
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/ForeachSymbolTuple.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReadModel/ForeachSymbolTuple.php
@@ -16,8 +16,7 @@ final readonly class ForeachSymbolTuple
         private AbstractNode $listExpr,
         private Symbol $valueSymbol,
         private ?Symbol $keySymbol = null,
-    ) {
-    }
+    ) {}
 
     public function lets(): array
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TrySymbol.php
@@ -218,7 +218,7 @@ final class TrySymbol implements SpecialFormAnalyzerInterface
         $exprs = [
             Symbol::create(Symbol::NAME_DO),
             ...$catch->rest()->rest()->rest()->toArray(),
-            ];
+        ];
 
         return $this->analyzer->analyze(
             Phel::list($exprs),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/WithAnalyzerTrait.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/WithAnalyzerTrait.php
@@ -10,6 +10,5 @@ trait WithAnalyzerTrait
 {
     public function __construct(
         private readonly AnalyzerInterface $analyzer,
-    ) {
-    }
+    ) {}
 }

--- a/src/php/Compiler/Domain/Emitter/EmitterResult.php
+++ b/src/php/Compiler/Domain/Emitter/EmitterResult.php
@@ -11,8 +11,7 @@ final readonly class EmitterResult
         private string $phpCode,
         private string $sourceMap,
         private string $source,
-    ) {
-    }
+    ) {}
 
     public function getPhpCode(): string
     {

--- a/src/php/Compiler/Domain/Emitter/FileEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/FileEmitter.php
@@ -17,8 +17,7 @@ final class FileEmitter implements FileEmitterInterface
     public function __construct(
         private readonly SourceMapGenerator $sourceMapGenerator,
         private readonly OutputEmitterInterface $outputEmitter,
-    ) {
-    }
+    ) {}
 
     public function startFile(string $source): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -35,8 +35,7 @@ final class OutputEmitter implements OutputEmitterInterface
         private readonly PrinterInterface $printer,
         private readonly SourceMapState $sourceMapState,
         private readonly OutputEmitterOptions $options,
-    ) {
-    }
+    ) {}
 
     public function getOptions(): OutputEmitterOptions
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -27,8 +27,7 @@ final readonly class LiteralEmitter
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private PrinterInterface $printer,
-    ) {
-    }
+    ) {}
 
     public function emitLiteral(TypeInterface|array|string|float|bool|int|null $x): void
     {
@@ -66,18 +65,18 @@ final readonly class LiteralEmitter
     private function emitFloat(float $x): void
     {
         /** @psalm-suppress InvalidCast */
-        $float = ((int)$x == $x)
+        $float = ((int) $x == $x)
             // (string) 10.0 will return 10 and not 10.0
             // so, we just add a .0 at the end
             ? ($x) . '.0'
-            : ((string)$x);
+            : ((string) $x);
 
         $this->outputEmitter->emitStr($float);
     }
 
     private function emitInt(int $x): void
     {
-        $this->outputEmitter->emitStr((string)$x);
+        $this->outputEmitter->emitStr((string) $x);
     }
 
     private function emitStr(string $x): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -13,9 +13,7 @@ use function assert;
 
 final readonly class DefExceptionEmitter implements NodeEmitterInterface
 {
-    public function __construct(private OutputEmitterInterface $outputEmitter)
-    {
-    }
+    public function __construct(private OutputEmitterInterface $outputEmitter) {}
 
     public function emit(AbstractNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -19,8 +19,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
-    ) {
-    }
+    ) {}
 
     public function emit(AbstractNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -18,8 +18,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
-    ) {
-    }
+    ) {}
 
     public function emit(AbstractNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -18,8 +18,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
 {
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
-    ) {
-    }
+    ) {}
 
     public function emit(AbstractNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/WithOutputEmitterTrait.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/WithOutputEmitterTrait.php
@@ -8,7 +8,5 @@ use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 
 trait WithOutputEmitterTrait
 {
-    public function __construct(private OutputEmitterInterface $outputEmitter)
-    {
-    }
+    public function __construct(private OutputEmitterInterface $outputEmitter) {}
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptions.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptions.php
@@ -14,8 +14,7 @@ final readonly class OutputEmitterOptions
 
     public function __construct(
         private string $emitMode = self::EMIT_MODE_STATEMENT,
-    ) {
-    }
+    ) {}
 
     public function isFileEmitMode(): bool
     {

--- a/src/php/Compiler/Domain/Emitter/StatementEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/StatementEmitter.php
@@ -14,8 +14,7 @@ final readonly class StatementEmitter implements StatementEmitterInterface
     public function __construct(
         private SourceMapGenerator $sourceMapGenerator,
         private OutputEmitterInterface $outputEmitter,
-    ) {
-    }
+    ) {}
 
     public function emitNode(AbstractNode $node, bool $enableSourceMaps): EmitterResult
     {

--- a/src/php/Compiler/Domain/Evaluator/RequireEvaluator.php
+++ b/src/php/Compiler/Domain/Evaluator/RequireEvaluator.php
@@ -31,8 +31,7 @@ final class RequireEvaluator implements EvaluatorInterface
 
     public function __construct(
         private readonly FilesystemFacadeInterface $filesystemFacade,
-    ) {
-    }
+    ) {}
 
     /**
      * Clears the process-local memory cache.

--- a/src/php/Compiler/Domain/Lexer/Token.php
+++ b/src/php/Compiler/Domain/Lexer/Token.php
@@ -53,8 +53,7 @@ final readonly class Token
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-    ) {
-    }
+    ) {}
 
     public function getType(): int
     {

--- a/src/php/Compiler/Domain/Parser/Exceptions/KeywordParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/KeywordParserException.php
@@ -6,6 +6,4 @@ namespace Phel\Compiler\Domain\Parser\Exceptions;
 
 use RuntimeException;
 
-final class KeywordParserException extends RuntimeException
-{
-}
+final class KeywordParserException extends RuntimeException {}

--- a/src/php/Compiler/Domain/Parser/Exceptions/StringParserException.php
+++ b/src/php/Compiler/Domain/Parser/Exceptions/StringParserException.php
@@ -6,6 +6,4 @@ namespace Phel\Compiler\Domain\Parser\Exceptions;
 
 use RuntimeException;
 
-final class StringParserException extends RuntimeException
-{
-}
+final class StringParserException extends RuntimeException {}

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -30,9 +30,7 @@ final readonly class AtomParser
 
     private const string REGEX_DECIMAL_NUMBER = '/^(?:([+-])?\d+(_\d+)*[\.(_\d+]?|0)$/';
 
-    public function __construct(private GlobalEnvironmentInterface $globalEnvironment)
-    {
-    }
+    public function __construct(private GlobalEnvironmentInterface $globalEnvironment) {}
 
     public function parse(Token $token): AbstractAtomNode
     {
@@ -67,7 +65,7 @@ final readonly class AtomParser
         }
 
         if (is_numeric($word)) {
-            $value = strpbrk($word, '.eE') !== false ? (float)$word : (int)$word;
+            $value = strpbrk($word, '.eE') !== false ? (float) $word : (int) $word;
 
             return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
         }
@@ -121,7 +119,7 @@ final readonly class AtomParser
     private function parseBinaryNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
-        $unsignedInteger = (string)($matches[2] ?? $word);
+        $unsignedInteger = (string) ($matches[2] ?? $word);
         $value = bindec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
@@ -134,7 +132,7 @@ final readonly class AtomParser
     private function parseHexadecimalNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
-        $unsignedInteger = (string)($matches[2] ?? $word);
+        $unsignedInteger = (string) ($matches[2] ?? $word);
         $value = hexdec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
@@ -147,7 +145,7 @@ final readonly class AtomParser
     private function parseOctalNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
-        $unsignedInteger = (string)($matches[2] ?? $word);
+        $unsignedInteger = (string) ($matches[2] ?? $word);
         $value = octdec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
@@ -160,7 +158,7 @@ final readonly class AtomParser
     private function parseDecimalNumber(array $matches, string $word, Token $token): NumberNode
     {
         $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
-        $value = (int)str_replace('_', '', $word);
+        $value = (int) str_replace('_', '', $word);
 
         if ($sign === -1) {
             $value = -$value;

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/ListParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/ListParser.php
@@ -21,9 +21,7 @@ final readonly class ListParser
         Token::T_CLOSE_BRACE => '}',
     ];
 
-    public function __construct(private Parser $parser)
-    {
-    }
+    public function __construct(private Parser $parser) {}
 
     /**
      * @throws UnfinishedParserException

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/MetaParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/MetaParser.php
@@ -11,9 +11,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 
 final readonly class MetaParser
 {
-    public function __construct(private Parser $parser)
-    {
-    }
+    public function __construct(private Parser $parser) {}
 
     public function parse(TokenStream $tokenStream): MetaNode
     {

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/QuoteParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/QuoteParser.php
@@ -10,9 +10,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 
 final readonly class QuoteParser
 {
-    public function __construct(private Parser $parser)
-    {
-    }
+    public function __construct(private Parser $parser) {}
 
     public function parse(TokenStream $tokenStream, int $tokenType): QuoteNode
     {

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -53,7 +53,7 @@ final class StringParser
                 return $this->codePointToUtf8(hexdec((string) $matches[2]));
             }
 
-            return chr((int)octdec((string) $str));
+            return chr((int) octdec((string) $str));
         };
 
         $result = preg_replace_callback(

--- a/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/AbstractAtomNode.php
@@ -22,8 +22,7 @@ abstract class AbstractAtomNode implements NodeInterface
         private readonly SourceLocation $startLocation,
         private readonly SourceLocation $endLocation,
         private readonly mixed $value,
-    ) {
-    }
+    ) {}
 
     public function getCode(): string
     {

--- a/src/php/Compiler/Domain/Parser/ParserNode/BooleanNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/BooleanNode.php
@@ -7,6 +7,4 @@ namespace Phel\Compiler\Domain\Parser\ParserNode;
 /**
  * @extends AbstractAtomNode<bool>
  */
-final class BooleanNode extends AbstractAtomNode
-{
-}
+final class BooleanNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/CommaNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/CommaNode.php
@@ -13,8 +13,7 @@ final readonly class CommaNode implements TriviaNodeInterface
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-    ) {
-    }
+    ) {}
 
     public static function createWithToken(Token $token): self
     {

--- a/src/php/Compiler/Domain/Parser/ParserNode/CommentMacroNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/CommentMacroNode.php
@@ -11,8 +11,7 @@ final readonly class CommentMacroNode implements TriviaNodeInterface
     public function __construct(
         private NodeInterface $node,
         private SourceLocation $startLocation,
-    ) {
-    }
+    ) {}
 
     public function getNode(): NodeInterface
     {

--- a/src/php/Compiler/Domain/Parser/ParserNode/CommentNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/CommentNode.php
@@ -13,8 +13,7 @@ final readonly class CommentNode implements TriviaNodeInterface
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-    ) {
-    }
+    ) {}
 
     public static function createWithToken(Token $token): self
     {

--- a/src/php/Compiler/Domain/Parser/ParserNode/FileNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/FileNode.php
@@ -17,8 +17,7 @@ final class FileNode implements InnerNodeInterface
         private readonly SourceLocation $startLocation,
         private readonly SourceLocation $endLocation,
         private array $children,
-    ) {
-    }
+    ) {}
 
     /**
      * @param list<NodeInterface> $children

--- a/src/php/Compiler/Domain/Parser/ParserNode/KeywordNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/KeywordNode.php
@@ -9,6 +9,4 @@ use Phel\Lang\Keyword;
 /**
  * @extends AbstractAtomNode<Keyword>
  */
-final class KeywordNode extends AbstractAtomNode
-{
-}
+final class KeywordNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/ListNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/ListNode.php
@@ -18,8 +18,7 @@ final class ListNode implements InnerNodeInterface
         private readonly SourceLocation $startLocation,
         private readonly SourceLocation $endLocation,
         private array $children,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NodeInterface>

--- a/src/php/Compiler/Domain/Parser/ParserNode/MetaNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/MetaNode.php
@@ -19,8 +19,7 @@ final class MetaNode implements InnerNodeInterface
         private readonly SourceLocation $startLocation,
         private readonly SourceLocation $endLocation,
         private array $children,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NodeInterface>

--- a/src/php/Compiler/Domain/Parser/ParserNode/NewlineNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/NewlineNode.php
@@ -13,8 +13,7 @@ final readonly class NewlineNode implements TriviaNodeInterface
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-    ) {
-    }
+    ) {}
 
     public static function createWithToken(Token $token): self
     {

--- a/src/php/Compiler/Domain/Parser/ParserNode/NilNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/NilNode.php
@@ -7,6 +7,4 @@ namespace Phel\Compiler\Domain\Parser\ParserNode;
 /**
  * @extends AbstractAtomNode<null>
  */
-final class NilNode extends AbstractAtomNode
-{
-}
+final class NilNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/NumberNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/NumberNode.php
@@ -7,6 +7,4 @@ namespace Phel\Compiler\Domain\Parser\ParserNode;
 /**
  * @extends AbstractAtomNode<float|int>
  */
-final class NumberNode extends AbstractAtomNode
-{
-}
+final class NumberNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/QuoteNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/QuoteNode.php
@@ -15,8 +15,7 @@ final class QuoteNode implements InnerNodeInterface
         private readonly SourceLocation $startLocation,
         private readonly SourceLocation $endLocation,
         private NodeInterface $expression,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NodeInterface>

--- a/src/php/Compiler/Domain/Parser/ParserNode/StringNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/StringNode.php
@@ -7,6 +7,4 @@ namespace Phel\Compiler\Domain\Parser\ParserNode;
 /**
  * @extends AbstractAtomNode<string>
  */
-final class StringNode extends AbstractAtomNode
-{
-}
+final class StringNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/SymbolNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/SymbolNode.php
@@ -9,6 +9,4 @@ use Phel\Lang\Symbol;
 /**
  * @extends AbstractAtomNode<Symbol>
  */
-final class SymbolNode extends AbstractAtomNode
-{
-}
+final class SymbolNode extends AbstractAtomNode {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/TriviaNodeInterface.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/TriviaNodeInterface.php
@@ -7,6 +7,4 @@ namespace Phel\Compiler\Domain\Parser\ParserNode;
 /**
  * This is just an interface to mark nodes as trivia.
  */
-interface TriviaNodeInterface extends NodeInterface
-{
-}
+interface TriviaNodeInterface extends NodeInterface {}

--- a/src/php/Compiler/Domain/Parser/ParserNode/WhitespaceNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/WhitespaceNode.php
@@ -13,8 +13,7 @@ final readonly class WhitespaceNode implements TriviaNodeInterface
         private string $code,
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
-    ) {
-    }
+    ) {}
 
     public static function createWithToken(Token $token): self
     {

--- a/src/php/Compiler/Domain/Parser/ReadModel/CodeSnippet.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/CodeSnippet.php
@@ -13,8 +13,7 @@ final readonly class CodeSnippet
         private SourceLocation $startLocation,
         private SourceLocation $endLocation,
         private string $code,
-    ) {
-    }
+    ) {}
 
     public static function fromNode(NodeInterface $node): self
     {

--- a/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
@@ -11,8 +11,7 @@ final readonly class ReaderResult
     public function __construct(
         private float|bool|int|string|TypeInterface|null $ast,
         private CodeSnippet $codeSnippet,
-    ) {
-    }
+    ) {}
 
     public function getAst(): float|bool|int|string|TypeInterface|null
     {

--- a/src/php/Compiler/Domain/Reader/Exceptions/SpliceNotInListException.php
+++ b/src/php/Compiler/Domain/Reader/Exceptions/SpliceNotInListException.php
@@ -6,6 +6,4 @@ namespace Phel\Compiler\Domain\Reader\Exceptions;
 
 use RuntimeException;
 
-final class SpliceNotInListException extends RuntimeException
-{
-}
+final class SpliceNotInListException extends RuntimeException {}

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListFnReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Symbol;
 
 final readonly class ListFnReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     /**
      * @param array<int, Symbol>|null $fnArgs

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/ListReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 
 final readonly class ListReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     public function read(ListNode $node, NodeInterface $root): PersistentListInterface
     {

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MapReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 
 final readonly class MapReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     public function read(ListNode $node, NodeInterface $root): PersistentMapInterface
     {

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php
@@ -19,9 +19,7 @@ use function is_string;
 
 final readonly class MetaReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     /**
      * @throws ReaderException

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/QuoasiquoteReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/QuoasiquoteReader.php
@@ -17,8 +17,7 @@ final readonly class QuoasiquoteReader
     public function __construct(
         private Reader $reader,
         private QuasiquoteTransformerInterface $quasiquoteTransformer,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws ReaderException

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/SetReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/SetReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 
 final readonly class SetReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     public function read(ListNode $node, NodeInterface $root): PersistentHashSetInterface
     {

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/SymbolReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/SymbolReader.php
@@ -55,7 +55,7 @@ final class SymbolReader
         }
 
         if (preg_match('/\$([1-9]\d*)/', $word, $matches)) {
-            $number = (int)$matches[1];
+            $number = (int) $matches[1];
             if (isset($fnArgs[$number])) {
                 return Symbol::create($fnArgs[$number]->getName());
             }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/VectorReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 
 final readonly class VectorReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     public function read(ListNode $node, NodeInterface $root): PersistentVectorInterface
     {

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/WrapReader.php
@@ -13,9 +13,7 @@ use Phel\Lang\Symbol;
 
 final readonly class WrapReader
 {
-    public function __construct(private Reader $reader)
-    {
-    }
+    public function __construct(private Reader $reader) {}
 
     public function read(QuoteNode $node, string $wrapFn, NodeInterface $root): PersistentListInterface
     {

--- a/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
+++ b/src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php
@@ -29,8 +29,7 @@ final readonly class QuasiquoteTransformer implements QuasiquoteTransformerInter
 {
     public function __construct(
         private GlobalEnvironmentInterface $env,
-    ) {
-    }
+    ) {}
 
     /**
      * @param bool|float|int|string|TypeInterface|null $form The form to quasiqoute

--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -114,7 +114,7 @@ final class PhelBuildConfig implements JsonSerializable
 
     public function shouldCreateEntryPointPhpFile(): bool
     {
-        return (bool)$this->mainPhelNamespace;
+        return (bool) $this->mainPhelNamespace;
     }
 
     private function getDestDir(): string

--- a/src/php/Console/Application/VersionFinder.php
+++ b/src/php/Console/Application/VersionFinder.php
@@ -16,8 +16,7 @@ final class VersionFinder
         private readonly string $tagCommitHash,
         private readonly string $currentCommit,
         private readonly bool $isOfficialRelease = false,
-    ) {
-    }
+    ) {}
 
     public function getVersion(): string
     {

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -45,13 +45,13 @@ final class ConsoleProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_FILESYSTEM,
-            static fn (Container $container) => $container->getLocator()->get(FilesystemFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(FilesystemFacade::class),
         );
     }
 
     private function addCommands(Container $container): void
     {
-        $container->set(self::COMMANDS, static fn (): array => [
+        $container->set(self::COMMANDS, static fn(): array => [
             new InitCommand(),
             new ExportCommand(),
             new FormatCommand(),

--- a/src/php/Filesystem/Application/TempDirFinder.php
+++ b/src/php/Filesystem/Application/TempDirFinder.php
@@ -14,8 +14,7 @@ final class TempDirFinder
     public function __construct(
         private readonly FileIoInterface $fileIo,
         private readonly string $configTempDir,
-    ) {
-    }
+    ) {}
 
     /**
      * Returns the configured temporary directory. If it doesn't exist,

--- a/src/php/Filesystem/Domain/NullFilesystem.php
+++ b/src/php/Filesystem/Domain/NullFilesystem.php
@@ -6,11 +6,7 @@ namespace Phel\Filesystem\Domain;
 
 final class NullFilesystem implements FilesystemInterface
 {
-    public function addFile(string $file): void
-    {
-    }
+    public function addFile(string $file): void {}
 
-    public function clearAll(): void
-    {
-    }
+    public function clearAll(): void {}
 }

--- a/src/php/Filesystem/FilesystemConfig.php
+++ b/src/php/Filesystem/FilesystemConfig.php
@@ -11,11 +11,11 @@ final class FilesystemConfig extends AbstractConfig
 {
     public function shouldKeepGeneratedTempFiles(): bool
     {
-        return (bool)$this->get(PhelConfig::KEEP_GENERATED_TEMP_FILES, false);
+        return (bool) $this->get(PhelConfig::KEEP_GENERATED_TEMP_FILES, false);
     }
 
     public function getTempDir(): string
     {
-        return (string)$this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir());
+        return (string) $this->get(PhelConfig::TEMP_DIR, sys_get_temp_dir());
     }
 }

--- a/src/php/Formatter/Application/Formatter.php
+++ b/src/php/Formatter/Application/Formatter.php
@@ -20,8 +20,7 @@ final readonly class Formatter implements FormatterInterface
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         private array $rules,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws AbstractParserException

--- a/src/php/Formatter/Application/PathsFormatter.php
+++ b/src/php/Formatter/Application/PathsFormatter.php
@@ -22,8 +22,7 @@ final readonly class PathsFormatter
         private FormatterInterface $formatter,
         private PathFilterInterface $pathFilter,
         private FileIoInterface $fileIo,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<string> successful formatted file paths
@@ -64,6 +63,6 @@ final readonly class PathsFormatter
         $formattedCode = $this->formatter->format($code, $filename);
         $this->fileIo->putContents($filename, $formattedCode);
 
-        return (bool)strcmp($formattedCode, $code);
+        return (bool) strcmp($formattedCode, $code);
     }
 }

--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -29,8 +29,7 @@ abstract class AbstractZipper
         protected array $rightSiblings = [],
         protected bool $hasChanged = false,
         protected bool $isEnd = false,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<T>

--- a/src/php/Formatter/FormatterProvider.php
+++ b/src/php/Formatter/FormatterProvider.php
@@ -25,7 +25,7 @@ final class FormatterProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMPILER,
-            static fn (Container $container) => $container->getLocator()->get(CompilerFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
         );
     }
 
@@ -33,7 +33,7 @@ final class FormatterProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMMAND,
-            static fn (Container $container) => $container->getLocator()->get(CommandFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
         );
     }
 }

--- a/src/php/Interop/Application/ExportCodeGenerator.php
+++ b/src/php/Interop/Application/ExportCodeGenerator.php
@@ -19,8 +19,7 @@ final readonly class ExportCodeGenerator
         private WrapperGeneratorInterface $wrapperGenerator,
         private FunctionsToExportFinderInterface $functionsToExportFinder,
         private FileCreatorInterface $fileCreator,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws CompilerException

--- a/src/php/Interop/Domain/DirectoryRemover/DirectoryRemover.php
+++ b/src/php/Interop/Domain/DirectoryRemover/DirectoryRemover.php
@@ -11,9 +11,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 final readonly class DirectoryRemover implements DirectoryRemoverInterface
 {
-    public function __construct(private string $targetDir)
-    {
-    }
+    public function __construct(private string $targetDir) {}
 
     public function removeDir(): void
     {

--- a/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
+++ b/src/php/Interop/Domain/ExportFinder/FunctionsToExportFinder.php
@@ -22,8 +22,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
         private array $exportDirs,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws ExtractorException
@@ -52,7 +51,7 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
             ->getNamespaceFromDirectories($this->exportDirs);
 
         $namespaces = array_map(
-            static fn (NamespaceInformation $info): string => $info->getNamespace(),
+            static fn(NamespaceInformation $info): string => $info->getNamespace(),
             $namespaceFromDirectories,
         );
 
@@ -94,6 +93,6 @@ final readonly class FunctionsToExportFinder implements FunctionsToExportFinderI
         $meta = Phel::getDefinitionMetaData($ns, $fnName)
             ?? Phel::list();
 
-        return (bool)($meta[Keyword::create('export')] ?? false);
+        return (bool) ($meta[Keyword::create('export')] ?? false);
     }
 }

--- a/src/php/Interop/Domain/FileCreator/FileCreator.php
+++ b/src/php/Interop/Domain/FileCreator/FileCreator.php
@@ -13,8 +13,7 @@ final readonly class FileCreator implements FileCreatorInterface
     public function __construct(
         private string $destinationDir,
         private FileIoInterface $io,
-    ) {
-    }
+    ) {}
 
     public function createFromWrapper(Wrapper $wrapper): void
     {

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpClassBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpClassBuilder.php
@@ -11,8 +11,7 @@ final readonly class CompiledPhpClassBuilder
     public function __construct(
         private string $prefixNamespace,
         private CompiledPhpMethodBuilder $methodBuilder,
-    ) {
-    }
+    ) {}
 
     /**
      * @param list<FunctionToExport> $functionsToExport

--- a/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
+++ b/src/php/Interop/Domain/Generator/Builder/CompiledPhpMethodBuilder.php
@@ -14,7 +14,7 @@ final class CompiledPhpMethodBuilder
     public function build(string $phelNs, FunctionToExport $functionToExport): string
     {
         $ref = new ReflectionClass($functionToExport->fn());
-        $boundTo = (string)$ref->getConstant('BOUND_TO');
+        $boundTo = (string) $ref->getConstant('BOUND_TO');
         $refInvoke = $ref->getMethod('__invoke');
 
         return str_replace([

--- a/src/php/Interop/Domain/Generator/WrapperGenerator.php
+++ b/src/php/Interop/Domain/Generator/WrapperGenerator.php
@@ -14,8 +14,7 @@ final readonly class WrapperGenerator implements WrapperGeneratorInterface
     public function __construct(
         private CompiledPhpClassBuilder $classBuilder,
         private WrapperRelativeFilenamePathBuilder $relativeFilenamePathBuilder,
-    ) {
-    }
+    ) {}
 
     /**
      * @param list<FunctionToExport> $functionsToExport

--- a/src/php/Interop/Domain/ReadModel/FunctionToExport.php
+++ b/src/php/Interop/Domain/ReadModel/FunctionToExport.php
@@ -8,9 +8,7 @@ use Phel\Lang\FnInterface;
 
 final readonly class FunctionToExport
 {
-    public function __construct(private FnInterface $fn)
-    {
-    }
+    public function __construct(private FnInterface $fn) {}
 
     public function fn(): FnInterface
     {

--- a/src/php/Interop/Domain/ReadModel/Wrapper.php
+++ b/src/php/Interop/Domain/ReadModel/Wrapper.php
@@ -11,8 +11,7 @@ final readonly class Wrapper
     public function __construct(
         private string $relativeFilenamePath,
         private string $compiledPhp,
-    ) {
-    }
+    ) {}
 
     public function compiledPhp(): string
     {

--- a/src/php/Interop/InteropConfig.php
+++ b/src/php/Interop/InteropConfig.php
@@ -24,12 +24,12 @@ final class InteropConfig extends AbstractConfig
 
     public function prefixNamespace(): string
     {
-        return (string)($this->getExport()[PhelExportConfig::NAMESPACE_PREFIX] ?? self::DEFAULT_EXPORT_NAMESPACE_PREFIX);
+        return (string) ($this->getExport()[PhelExportConfig::NAMESPACE_PREFIX] ?? self::DEFAULT_EXPORT_NAMESPACE_PREFIX);
     }
 
     public function getExportTargetDirectory(): string
     {
-        return (string)($this->getExport()[PhelExportConfig::TARGET_DIRECTORY] ?? self::DEFAULT_EXPORT_TARGET_DIRECTORY);
+        return (string) ($this->getExport()[PhelExportConfig::TARGET_DIRECTORY] ?? self::DEFAULT_EXPORT_TARGET_DIRECTORY);
     }
 
     /**
@@ -38,7 +38,7 @@ final class InteropConfig extends AbstractConfig
     public function getExportDirectories(): array
     {
         return array_map(
-            fn (string $dir): string => $this->getAppRootDir() . '/' . $dir,
+            fn(string $dir): string => $this->getAppRootDir() . '/' . $dir,
             $this->getExport()[PhelExportConfig::FROM_DIRECTORIES] ?? self::DEFAULT_EXPORT_DIRECTORIES,
         );
     }

--- a/src/php/Interop/InteropProvider.php
+++ b/src/php/Interop/InteropProvider.php
@@ -25,7 +25,7 @@ final class InteropProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMMAND,
-            static fn (Container $container) => $container->getLocator()->get(CommandFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
         );
     }
 
@@ -33,7 +33,7 @@ final class InteropProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_BUILD,
-            static fn (Container $container) => $container->getLocator()->get(BuildFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(BuildFacade::class),
         );
     }
 }

--- a/src/php/Lang/Collections/Exceptions/IndexOutOfBoundsException.php
+++ b/src/php/Lang/Collections/Exceptions/IndexOutOfBoundsException.php
@@ -6,6 +6,4 @@ namespace Phel\Lang\Collections\Exceptions;
 
 use Exception;
 
-final class IndexOutOfBoundsException extends Exception
-{
-}
+final class IndexOutOfBoundsException extends Exception {}

--- a/src/php/Lang/Collections/Exceptions/MethodNotSupportedException.php
+++ b/src/php/Lang/Collections/Exceptions/MethodNotSupportedException.php
@@ -6,6 +6,4 @@ namespace Phel\Lang\Collections\Exceptions;
 
 use Exception;
 
-final class MethodNotSupportedException extends Exception
-{
-}
+final class MethodNotSupportedException extends Exception {}

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -27,8 +27,7 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
         private readonly HasherInterface $hasher,
         private readonly ?PersistentMapInterface $meta,
         private readonly PersistentMapInterface $map,
-    ) {
-    }
+    ) {}
 
     /**
      * @param V $key

--- a/src/php/Lang/Collections/HashSet/TransientHashSet.php
+++ b/src/php/Lang/Collections/HashSet/TransientHashSet.php
@@ -18,8 +18,7 @@ final readonly class TransientHashSet implements TransientHashSetInterface, Stri
     public function __construct(
         private HasherInterface $hasher,
         private TransientMapInterface $transientMap,
-    ) {
-    }
+    ) {}
 
     public function __toString(): string
     {

--- a/src/php/Lang/Collections/LazySeq/Chunk.php
+++ b/src/php/Lang/Collections/LazySeq/Chunk.php
@@ -26,8 +26,7 @@ final readonly class Chunk
     public function __construct(
         private array $values,
         private int $offset = 0,
-    ) {
-    }
+    ) {}
 
     /**
      * Gets the value at the specified index within this chunk.

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -43,8 +43,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
         private readonly Chunk $chunk,
         private readonly ?MemoizedThunk $thunk,
         private readonly ?PersistentMapInterface $meta = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Creates a ChunkedSeq from a Generator, realizing elements in chunks.
@@ -78,7 +77,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
         // Create memoized thunk for the rest
         $thunk = new MemoizedThunk(
-            static fn (): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, $chunkSize),
+            static fn(): ?ChunkedSeq => self::fromGenerator($hasher, $equalizer, $generator, $chunkSize),
         );
 
         return new self($hasher, $equalizer, $chunk, $thunk, $meta);
@@ -114,7 +113,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
         $thunk = $remaining === []
             ? null
             : new MemoizedThunk(
-                static fn (): ?ChunkedSeq => self::fromArray($hasher, $equalizer, $remaining, $chunkSize),
+                static fn(): ?ChunkedSeq => self::fromArray($hasher, $equalizer, $remaining, $chunkSize),
             );
 
         return new self($hasher, $equalizer, $chunk, $thunk, $meta);
@@ -137,7 +136,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
     /**
      * @return LazySeqInterface<T>|null
      */
-    public function cdr(): self|null|LazySeqInterface|LazySeq
+    public function cdr(): self|LazySeqInterface|LazySeq|null
     {
         if ($this->chunk->count() > 1) {
             // Still have elements in current chunk
@@ -183,7 +182,7 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
         if (!$cdr instanceof LazySeqInterface) {
             // Return empty LazySeq
-            return new LazySeq($this->hasher, $this->equalizer, static fn (): null => null);
+            return new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
         }
 
         return $cdr;

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -78,7 +78,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
                 return (new self(
                     $hasher,
                     $equalizer,
-                    static fn (): LazySeq => self::fromGenerator($hasher, $equalizer, $generator),
+                    static fn(): LazySeq => self::fromGenerator($hasher, $equalizer, $generator),
                 ))->cons($value);
             },
             $meta,
@@ -141,7 +141,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         return (new self(
             $hasher,
             $equalizer,
-            static fn (): ?LazySeq => self::fromArray($hasher, $equalizer, $array),
+            static fn(): ?LazySeq => self::fromArray($hasher, $equalizer, $array),
             $meta,
         ))->cons($first);
     }
@@ -168,7 +168,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     /**
      * @return LazySeqInterface<T>|null
      */
-    public function cdr(): null|LazySeqInterface|self
+    public function cdr(): LazySeqInterface|self|null
     {
         $seq = $this->realize();
 
@@ -197,7 +197,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         }
 
         /** @phpstan-ignore return.type */
-        return new self($this->hasher, $this->equalizer, static fn (): SeqInterface => $rest);
+        return new self($this->hasher, $this->equalizer, static fn(): SeqInterface => $rest);
     }
 
     /**
@@ -209,7 +209,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
 
         if (!$cdr instanceof LazySeqInterface) {
             // Return empty LazySeq
-            return new self($this->hasher, $this->equalizer, static fn (): null => null);
+            return new self($this->hasher, $this->equalizer, static fn(): null => null);
         }
 
         return $cdr;
@@ -228,13 +228,12 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
             $this->hasher,
             $this->equalizer,
             /** @psalm-suppress InvalidReturnType, InvalidReturnStatement */
-            static fn (): SeqInterface => // Create a simple cons cell
-            new readonly class($x, $self) implements SeqInterface {
+            static fn(): SeqInterface // Create a simple cons cell
+            => new readonly class($x, $self) implements SeqInterface {
                 public function __construct(
                     private mixed $first,
                     private LazySeqInterface $rest,
-                ) {
-                }
+                ) {}
 
                 public function first()
                 {

--- a/src/php/Lang/Collections/LinkedList/EmptyList.php
+++ b/src/php/Lang/Collections/LinkedList/EmptyList.php
@@ -27,8 +27,7 @@ final class EmptyList extends AbstractType implements PersistentListInterface
         private readonly HasherInterface $hasher,
         private readonly EqualizerInterface $equalizer,
         private readonly ?PersistentMapInterface $meta,
-    ) {
-    }
+    ) {}
 
     public function getMeta(): ?PersistentMapInterface
     {

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -36,8 +36,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
         private readonly mixed $first,
         private $rest,
         private readonly int $count,
-    ) {
-    }
+    ) {}
 
     /**
      * @return T

--- a/src/php/Lang/Collections/Map/AbstractPersistentMap.php
+++ b/src/php/Lang/Collections/Map/AbstractPersistentMap.php
@@ -25,8 +25,7 @@ abstract class AbstractPersistentMap extends AbstractType implements PersistentM
         protected HasherInterface $hasher,
         protected EqualizerInterface $equalizer,
         protected ?PersistentMapInterface $meta,
-    ) {
-    }
+    ) {}
 
     /**
      * @param K $key

--- a/src/php/Lang/Collections/Map/ArrayNode.php
+++ b/src/php/Lang/Collections/Map/ArrayNode.php
@@ -25,8 +25,7 @@ final class ArrayNode implements HashMapNodeInterface, Countable
         private readonly EqualizerInterface $equalizer,
         private readonly int $count,
         private array $childNodes,
-    ) {
-    }
+    ) {}
 
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
     {

--- a/src/php/Lang/Collections/Map/Box.php
+++ b/src/php/Lang/Collections/Map/Box.php
@@ -6,9 +6,7 @@ namespace Phel\Lang\Collections\Map;
 
 final class Box
 {
-    public function __construct(private mixed $value)
-    {
-    }
+    public function __construct(private mixed $value) {}
 
     public function getValue(): mixed
     {

--- a/src/php/Lang/Collections/Map/HashCollisionNode.php
+++ b/src/php/Lang/Collections/Map/HashCollisionNode.php
@@ -27,8 +27,7 @@ final class HashCollisionNode implements HashMapNodeInterface
         private readonly int $hash,
         private readonly int $count,
         private array $objects,
-    ) {
-    }
+    ) {}
 
     /**
      * @param K $key

--- a/src/php/Lang/Collections/Map/IndexedNode.php
+++ b/src/php/Lang/Collections/Map/IndexedNode.php
@@ -29,8 +29,7 @@ final readonly class IndexedNode implements HashMapNodeInterface
         private HasherInterface $hasher,
         private EqualizerInterface $equalizer,
         private array $objects,
-    ) {
-    }
+    ) {}
 
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
     {

--- a/src/php/Lang/Collections/Map/TransientArrayMap.php
+++ b/src/php/Lang/Collections/Map/TransientArrayMap.php
@@ -22,8 +22,7 @@ final class TransientArrayMap implements TransientMapInterface
         private readonly HasherInterface $hasher,
         private readonly EqualizerInterface $equalizer,
         private array $array,
-    ) {
-    }
+    ) {}
 
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
     {

--- a/src/php/Lang/Collections/Map/TransientHashMap.php
+++ b/src/php/Lang/Collections/Map/TransientHashMap.php
@@ -29,8 +29,7 @@ final class TransientHashMap implements TransientMapInterface
         private ?HashMapNodeInterface $root,
         private bool $hasNull,
         private $nullValue,
-    ) {
-    }
+    ) {}
 
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
     {

--- a/src/php/Lang/Collections/Map/TransientMapWrapper.php
+++ b/src/php/Lang/Collections/Map/TransientMapWrapper.php
@@ -17,9 +17,7 @@ final class TransientMapWrapper implements TransientMapInterface, Stringable
     /**
      * @param TransientMapInterface<K, V> $internal
      */
-    public function __construct(private TransientMapInterface $internal)
-    {
-    }
+    public function __construct(private TransientMapInterface $internal) {}
 
     public function __toString(): string
     {

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -108,7 +108,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getAllowedKeys(): array
     {
         return array_map(
-            static fn (string $k): Keyword => Phel::keyword($k),
+            static fn(string $k): Keyword => Phel::keyword($k),
             static::ALLOWED_KEYS,
         );
     }

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -28,8 +28,7 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
         protected HasherInterface $hasher,
         protected EqualizerInterface $equalizer,
         protected ?PersistentMapInterface $meta,
-    ) {
-    }
+    ) {}
 
     /**
      * @return T

--- a/src/php/Lang/Generators/FileGenerator.php
+++ b/src/php/Lang/Generators/FileGenerator.php
@@ -193,7 +193,7 @@ final class FileGenerator
             $typeFactory = TypeFactory::getInstance();
             while (($row = fgetcsv($handle, 0, $separator, $enclosure, $escape)) !== false) {
                 /** @psalm-var list<string|null> $row */
-                $cleanRow = array_map(static fn (?string $val): string => $val ?? '', $row);
+                $cleanRow = array_map(static fn(?string $val): string => $val ?? '', $row);
                 yield $typeFactory->persistentVectorFromArray($cleanRow);
             }
         } finally {

--- a/src/php/Lang/Generators/SequenceGenerator.php
+++ b/src/php/Lang/Generators/SequenceGenerator.php
@@ -252,8 +252,8 @@ final class SequenceGenerator
     public static function range(int|float $start, int|float $end, int|float $step): Generator
     {
         $cmp = $step < 0
-            ? static fn (int|float $i, int|float $e): bool => $i > $e
-            : static fn (int|float $i, int|float $e): bool => $i < $e;
+            ? static fn(int|float $i, int|float $e): bool => $i > $e
+            : static fn(int|float $i, int|float $e): bool => $i < $e;
 
         for ($i = $start; $cmp($i, $end); $i += $step) {
             yield $i;
@@ -721,6 +721,6 @@ final class SequenceGenerator
             return new ArrayIterator($iterable);
         }
 
-        return (static fn () => yield from $iterable)();
+        return (static fn() => yield from $iterable)();
     }
 }

--- a/src/php/Lang/Hasher.php
+++ b/src/php/Lang/Hasher.php
@@ -83,7 +83,7 @@ final class Hasher implements HasherInterface
     private function hashFloat(float $value): int
     {
         if (is_finite($value)) {
-            return (int)($value);
+            return (int) ($value);
         }
 
         if ($value === INF) {

--- a/src/php/Lang/SourceLocation.php
+++ b/src/php/Lang/SourceLocation.php
@@ -10,8 +10,7 @@ final class SourceLocation
         private string $file,
         private int $line,
         private int $column,
-    ) {
-    }
+    ) {}
 
     public function getFile(): string
     {

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -95,8 +95,7 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
     public function __construct(
         private readonly ?string $namespace,
         private readonly string $name,
-    ) {
-    }
+    ) {}
 
     public static function create(string $name): self
     {

--- a/src/php/Lang/TypeInterface.php
+++ b/src/php/Lang/TypeInterface.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
-interface TypeInterface extends MetaInterface, SourceLocationInterface, EqualsInterface, HashableInterface
-{
-}
+interface TypeInterface extends MetaInterface, SourceLocationInterface, EqualsInterface, HashableInterface {}

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -44,8 +44,7 @@ final readonly class Printer implements PrinterInterface
     public function __construct(
         private bool $readable,
         private bool $withColor = false,
-    ) {
-    }
+    ) {}
 
     public static function readable(): self
     {

--- a/src/php/Printer/TypePrinter/ArrayPrinter.php
+++ b/src/php/Printer/TypePrinter/ArrayPrinter.php
@@ -17,8 +17,7 @@ final readonly class ArrayPrinter implements TypePrinterInterface
     public function __construct(
         private PrinterInterface $printer,
         private bool $withColor = false,
-    ) {
-    }
+    ) {}
 
     /**
      * @param array $form

--- a/src/php/Printer/TypePrinter/LazySeqPrinter.php
+++ b/src/php/Printer/TypePrinter/LazySeqPrinter.php
@@ -10,9 +10,7 @@ use Phel\Printer\PrinterInterface;
 
 final readonly class LazySeqPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param LazySeqInterface $form

--- a/src/php/Printer/TypePrinter/NumberPrinter.php
+++ b/src/php/Printer/TypePrinter/NumberPrinter.php
@@ -18,7 +18,7 @@ final class NumberPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        return $this->color((string)$form);
+        return $this->color((string) $form);
     }
 
     private function color(string $str): string

--- a/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentHashSetPrinter.php
@@ -12,9 +12,7 @@ use Phel\Printer\PrinterInterface;
  */
 final readonly class PersistentHashSetPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param PersistentHashSetInterface $form

--- a/src/php/Printer/TypePrinter/PersistentListPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentListPrinter.php
@@ -12,9 +12,7 @@ use Phel\Printer\PrinterInterface;
  */
 final readonly class PersistentListPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param PersistentListInterface $form

--- a/src/php/Printer/TypePrinter/PersistentMapPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentMapPrinter.php
@@ -14,9 +14,7 @@ use function sprintf;
  */
 final readonly class PersistentMapPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param PersistentMapInterface $form

--- a/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
+++ b/src/php/Printer/TypePrinter/PersistentVectorPrinter.php
@@ -12,9 +12,7 @@ use Phel\Printer\PrinterInterface;
  */
 final readonly class PersistentVectorPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param PersistentVectorInterface $form

--- a/src/php/Printer/TypePrinter/StringPrinter.php
+++ b/src/php/Printer/TypePrinter/StringPrinter.php
@@ -28,8 +28,7 @@ final readonly class StringPrinter implements TypePrinterInterface
     public function __construct(
         private bool $readable,
         private bool $withColor = false,
-    ) {
-    }
+    ) {}
 
     public static function nonReadable(bool $withColor = false): self
     {

--- a/src/php/Printer/TypePrinter/StructPrinter.php
+++ b/src/php/Printer/TypePrinter/StructPrinter.php
@@ -12,9 +12,7 @@ use Phel\Printer\PrinterInterface;
  */
 final readonly class StructPrinter implements TypePrinterInterface
 {
-    public function __construct(private PrinterInterface $printer)
-    {
-    }
+    public function __construct(private PrinterInterface $printer) {}
 
     /**
      * @param AbstractPersistentStruct $form

--- a/src/php/Printer/TypePrinter/WithColorTrait.php
+++ b/src/php/Printer/TypePrinter/WithColorTrait.php
@@ -6,7 +6,5 @@ namespace Phel\Printer\TypePrinter;
 
 trait WithColorTrait
 {
-    public function __construct(private bool $withColor = false)
-    {
-    }
+    public function __construct(private bool $withColor = false) {}
 }

--- a/src/php/Run/Application/EvalExecutor.php
+++ b/src/php/Run/Application/EvalExecutor.php
@@ -25,8 +25,7 @@ final readonly class EvalExecutor
         private ColorStyleInterface $style,
         private PrinterInterface $printer,
         private CompilerFacadeInterface $compilerFacade,
-    ) {
-    }
+    ) {}
 
     public function execute(string $input): bool
     {

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -21,8 +21,7 @@ final class NamespaceLoader
         private readonly BuildFacadeInterface $buildFacade,
         private readonly CommandFacadeInterface $commandFacade,
         private readonly string $defaultReplStartupFile,
-    ) {
-    }
+    ) {}
 
     public static function reset(): void
     {

--- a/src/php/Run/Application/NamespaceRunner.php
+++ b/src/php/Run/Application/NamespaceRunner.php
@@ -13,8 +13,7 @@ final readonly class NamespaceRunner implements NamespaceRunnerInterface
     public function __construct(
         private CommandFacadeInterface $commandFacade,
         private BuildFacadeInterface $buildFacade,
-    ) {
-    }
+    ) {}
 
     public function run(string $namespace): void
     {

--- a/src/php/Run/Application/NamespacesLoader.php
+++ b/src/php/Run/Application/NamespacesLoader.php
@@ -15,8 +15,7 @@ final readonly class NamespacesLoader implements NamespacesLoaderInterface
     public function __construct(
         private CommandFacadeInterface $commandFacade,
         private BuildFacadeInterface $buildFacade,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NamespaceInformation>

--- a/src/php/Run/Domain/Repl/InputResult.php
+++ b/src/php/Run/Domain/Repl/InputResult.php
@@ -15,9 +15,7 @@ final readonly class InputResult
 
     private const string LAST_RESULT_PLACEHOLDER = '$_';
 
-    private function __construct(private mixed $lastResult)
-    {
-    }
+    private function __construct(private mixed $lastResult) {}
 
     public static function fromAny(mixed $result): self
     {
@@ -62,6 +60,6 @@ final readonly class InputResult
             return 'nil';
         }
 
-        return (string)$this->lastResult;
+        return (string) $this->lastResult;
     }
 }

--- a/src/php/Run/Domain/Repl/ReplCommandFallbackIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandFallbackIo.php
@@ -19,16 +19,11 @@ final readonly class ReplCommandFallbackIo implements ReplCommandIoInterface
 {
     public function __construct(
         private CommandFacadeInterface $commandFacade,
-    ) {
-    }
+    ) {}
 
-    public function readHistory(): void
-    {
-    }
+    public function readHistory(): void {}
 
-    public function addHistory(string $line): void
-    {
-    }
+    public function addHistory(string $line): void {}
 
     public function readline(?string $prompt = null): ?string
     {

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -14,8 +14,7 @@ final readonly class NamespaceCollector
     public function __construct(
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<NamespaceInformation>
@@ -52,13 +51,13 @@ final readonly class NamespaceCollector
             );
 
             return array_map(
-                static fn (NamespaceInformation $info): string => $info->getNamespace(),
+                static fn(NamespaceInformation $info): string => $info->getNamespace(),
                 $namespaces,
             );
         }
 
         return array_map(
-            fn (string $filename): string => $this
+            fn(string $filename): string => $this
                 ->buildFacade
                 ->getNamespaceFromFile($filename)
                 ->getNamespace(),

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -20,8 +20,7 @@ final readonly class TestCommandOptions
         private ?string $filter,
         private bool $testdox,
         private bool $failFast,
-    ) {
-    }
+    ) {}
 
     public static function empty(): self
     {

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -42,7 +42,7 @@ final class EvalCommand extends Command
 
         $result = $this->getFactory()
             ->createEvalExecutor()
-            ->execute((string)$expression);
+            ->execute((string) $expression);
 
         return $result ? self::SUCCESS : self::FAILURE;
     }

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -168,11 +168,11 @@ final class RunCommand extends Command
         $output->writeln(
             <<<EOF
             <error>No rendered output after running namespace: "{$identifier}"</>
-            
+
             <comment>Please verify that at least one of the following applies:
             - The file exists
             - The namespace exists</>
-            
+
             You can ignore this message with `-q|--quiet`
             EOF
         );

--- a/src/php/Run/Infrastructure/Service/DebugLineTap.php
+++ b/src/php/Run/Infrastructure/Service/DebugLineTap.php
@@ -130,7 +130,7 @@ final class DebugLineTap
 
     private function formatTimestamp(): string
     {
-        $milliseconds = ((int)(microtime(true) * 1000.0)) % 1000;
+        $milliseconds = ((int) (microtime(true) * 1000.0)) % 1000;
 
         return date('H:i:s.') . sprintf('%03d', $milliseconds);
     }
@@ -141,7 +141,7 @@ final class DebugLineTap
         $header = sprintf(
             "=== Phel Debug Trace - Started at %s (PID: %s) ===\n",
             date('Y-m-d H:i:s'),
-            $pid === false ? 'unknown' : (string)$pid,
+            $pid === false ? 'unknown' : (string) $pid,
         );
 
         if ($this->phelFileFilter !== null) {

--- a/src/php/Run/RunProvider.php
+++ b/src/php/Run/RunProvider.php
@@ -45,7 +45,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMMAND,
-            static fn (Container $container) => $container->getLocator()->get(CommandFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
         );
     }
 
@@ -53,7 +53,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_COMPILER,
-            static fn (Container $container) => $container->getLocator()->get(CompilerFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
         );
     }
 
@@ -61,7 +61,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_FORMATTER,
-            static fn (Container $container) => $container->getLocator()->get(FormatterFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(FormatterFacade::class),
         );
     }
 
@@ -69,7 +69,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_INTEROP,
-            static fn (Container $container) => $container->getLocator()->get(InteropFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(InteropFacade::class),
         );
     }
 
@@ -77,7 +77,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_BUILD,
-            static fn (Container $container) => $container->getLocator()->get(BuildFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(BuildFacade::class),
         );
     }
 
@@ -85,7 +85,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_API,
-            static fn (Container $container) => $container->getLocator()->get(ApiFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(ApiFacade::class),
         );
     }
 
@@ -93,7 +93,7 @@ final class RunProvider extends AbstractProvider
     {
         $container->set(
             self::FACADE_CONSOLE,
-            static fn (Container $container) => $container->getLocator()->get(ConsoleFacade::class),
+            static fn(Container $container) => $container->getLocator()->get(ConsoleFacade::class),
         );
     }
 }

--- a/src/php/Shared/ColorStyle.php
+++ b/src/php/Shared/ColorStyle.php
@@ -20,8 +20,7 @@ final class ColorStyle implements ColorStyleInterface
 
     private function __construct(
         private array $styles,
-    ) {
-    }
+    ) {}
 
     public static function withStyles(array $styles = []): self
     {

--- a/tests/php/Benchmark/Lang/Collections/Vector/SimpleImmutableVectorBench.php
+++ b/tests/php/Benchmark/Lang/Collections/Vector/SimpleImmutableVectorBench.php
@@ -65,9 +65,7 @@ final class SimpleImmutableVectorBench
         $seedData = range(0, $size - 1);
 
         $this->vector = new readonly class($seedData) {
-            public function __construct(private array $data)
-            {
-            }
+            public function __construct(private array $data) {}
 
             public function append($value): self
             {

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -42,7 +42,7 @@ final class ApiFacadeTest extends TestCase
     {
         $loadedNamespaces = array_unique(array_column($functions, 'namespace'));
         $expectedNamespaces = array_map(
-            static fn (string $ns): string => str_replace('phel\\', '', $ns),
+            static fn(string $ns): string => str_replace('phel\\', '', $ns),
             ApiConfig::allNamespaces(),
         );
 

--- a/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
+++ b/tests/php/Integration/Interop/Command/Export/ExportCommandTest.php
@@ -49,7 +49,7 @@ final class ExportCommandTest extends TestCase
     {
         $output = $this->createStub(OutputInterface::class);
         $output->method('writeln')
-            ->willReturnCallback(static fn (string $str): int => print $str . PHP_EOL);
+            ->willReturnCallback(static fn(string $str): int => print $str . PHP_EOL);
 
         return $output;
     }

--- a/tests/php/Integration/ParseAndPrintTest.php
+++ b/tests/php/Integration/ParseAndPrintTest.php
@@ -53,7 +53,7 @@ final class ParseAndPrintTest extends TestCase
     private function printTrees(array $parseTrees): string
     {
         return implode('', array_map(
-            static fn (NodeInterface $t): string => $t->getCode(),
+            static fn(NodeInterface $t): string => $t->getCode(),
             $parseTrees,
         ));
     }

--- a/tests/php/Integration/Printer/PrinterTest.php
+++ b/tests/php/Integration/Printer/PrinterTest.php
@@ -104,6 +104,6 @@ final class PrinterTest extends TestCase
         $tokenStream = $this->compilerFacade->lexString($string);
         $parseTree = $this->compilerFacade->parseNext($tokenStream);
 
-        return (string)$this->compilerFacade->read($parseTree)->getAst();
+        return (string) $this->compilerFacade->read($parseTree)->getAst();
     }
 }

--- a/tests/php/Integration/Run/Command/AbstractTestCommand.php
+++ b/tests/php/Integration/Run/Command/AbstractTestCommand.php
@@ -54,9 +54,7 @@ abstract class AbstractTestCommand extends TestCase
                 $this->write($messages, true, $options);
             }
 
-            public function setVerbosity(int $level): void
-            {
-            }
+            public function setVerbosity(int $level): void {}
 
             public function getVerbosity(): int
             {
@@ -83,18 +81,14 @@ abstract class AbstractTestCommand extends TestCase
                 return false;
             }
 
-            public function setDecorated(bool $decorated): void
-            {
-            }
+            public function setDecorated(bool $decorated): void {}
 
             public function isDecorated(): bool
             {
                 return false;
             }
 
-            public function setFormatter(OutputFormatterInterface $formatter): void
-            {
-            }
+            public function setFormatter(OutputFormatterInterface $formatter): void {}
 
             public function getFormatter(): OutputFormatterInterface
             {

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -27,9 +27,9 @@ final class DoctorCommandTest extends TestCase
     {
         $output = $this->createStub(OutputInterface::class);
         $output->method('writeln')
-            ->willReturnCallback(static fn (string $str): int => print $str . PHP_EOL);
+            ->willReturnCallback(static fn(string $str): int => print $str . PHP_EOL);
         $output->method('write')
-            ->willReturnCallback(static fn (string $str): int => print $str);
+            ->willReturnCallback(static fn(string $str): int => print $str);
 
         return $output;
     }

--- a/tests/php/Integration/Run/Command/Repl/InputLine.php
+++ b/tests/php/Integration/Run/Command/Repl/InputLine.php
@@ -11,8 +11,7 @@ final readonly class InputLine implements Stringable
     public function __construct(
         private string $prompt,
         private string $content,
-    ) {
-    }
+    ) {}
 
     public function __toString(): string
     {

--- a/tests/php/Integration/Run/Command/Repl/ReplCwdNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCwdNamespaceTest.php
@@ -113,9 +113,7 @@ PHEL);
         Gacela::overrideExistingResolvedClass(
             RunFactory::class,
             new class($io) extends RunFactory {
-                public function __construct(private readonly ReplCommandIoInterface $io)
-                {
-                }
+                public function __construct(private readonly ReplCommandIoInterface $io) {}
 
                 public function createColorStyle(): ColorStyleInterface
                 {

--- a/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestCommand.php
@@ -177,9 +177,7 @@ final class ReplTestCommand extends AbstractTestCommand
         Gacela::overrideExistingResolvedClass(
             RunFactory::class,
             new class($io) extends RunFactory {
-                public function __construct(private readonly ReplCommandIoInterface $io)
-                {
-                }
+                public function __construct(private readonly ReplCommandIoInterface $io) {}
 
                 public function createColorStyle(): ColorStyleInterface
                 {

--- a/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
@@ -25,16 +25,11 @@ final class ReplTestIo implements ReplCommandIoInterface
 
     public function __construct(
         private readonly ExceptionPrinterInterface $exceptionPrinter,
-    ) {
-    }
+    ) {}
 
-    public function readHistory(): void
-    {
-    }
+    public function readHistory(): void {}
 
-    public function addHistory(string $line): void
-    {
-    }
+    public function addHistory(string $line): void {}
 
     public function readline(?string $prompt = null): ?string
     {

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -119,7 +119,7 @@ final class RunCommandTest extends AbstractTestCommand
     {
         $input = $this->createStub(InputInterface::class);
         $input->method('getArgument')->willReturnCallback(
-            static fn (string $name): string|array => match ($name) {
+            static fn(string $name): string|array => match ($name) {
                 'path' => $path,
                 'argv' => $argv,
                 default => '',

--- a/tests/php/Integration/Run/Command/RunAutoDetect/RunAutoDetectTest.php
+++ b/tests/php/Integration/Run/Command/RunAutoDetect/RunAutoDetectTest.php
@@ -39,7 +39,7 @@ final class RunAutoDetectTest extends AbstractTestCommand
     {
         $input = $this->createStub(InputInterface::class);
         $input->method('getArgument')->willReturnCallback(
-            static fn (string $name): string|array|null => match ($name) {
+            static fn(string $name): string|array|null => match ($name) {
                 'path' => null,
                 'argv' => $argv,
                 default => '',

--- a/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
+++ b/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
@@ -63,8 +63,8 @@ MSG;
     private function stubColorStyle(): ColorStyleInterface
     {
         $colorStyle = $this->createStub(ColorStyleInterface::class);
-        $colorStyle->method('blue')->willReturnCallback(static fn (string $msg): string => $msg);
-        $colorStyle->method('red')->willReturnCallback(static fn (string $msg): string => $msg);
+        $colorStyle->method('blue')->willReturnCallback(static fn(string $msg): string => $msg);
+        $colorStyle->method('red')->willReturnCallback(static fn(string $msg): string => $msg);
 
         return $colorStyle;
     }

--- a/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
+++ b/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
@@ -63,7 +63,7 @@ final class ExceptionArgsPrinterTest extends TestCase
         $resource = tmpfile();
         yield 'resource' => [
             [$resource],
-            (string)$resource,
+            (string) $resource,
         ];
     }
 
@@ -75,7 +75,7 @@ final class ExceptionArgsPrinterTest extends TestCase
     private function stubPrinter(): PrinterInterface
     {
         $printer = $this->createMock(PrinterInterface::class);
-        $printer->method('print')->willReturnCallback(static fn ($arg): string => $arg);
+        $printer->method('print')->willReturnCallback(static fn($arg): string => $arg);
 
         return $printer;
     }

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -77,7 +77,7 @@ final class AnalyzePersistentListTest extends TestCase
     {
         $list = Phel::list([
             Symbol::create(Symbol::NAME_QUOTE),
-             'any text',
+            'any text',
         ]);
         self::assertInstanceOf(QuoteNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -34,7 +34,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-global-fn',
-            static fn ($a, $b): int => $a + $b,
+            static fn($a, $b): int => $a + $b,
             Phel::map('min-arity', 2, 'is-variadic', false),
         );
 
@@ -42,7 +42,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-variadic-fn',
-            static fn ($a, ...$rest): int => $a,
+            static fn($a, ...$rest): int => $a,
             Phel::map('min-arity', 1, 'is-variadic', true),
         );
 
@@ -50,7 +50,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-bounded-fn',
-            static fn ($a, $b = null): int => $a,
+            static fn($a, $b = null): int => $a,
             Phel::map('min-arity', 1, 'is-variadic', false, 'max-arity', 2),
         );
 
@@ -58,7 +58,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-macro',
-            static fn ($a) => $a,
+            static fn($a) => $a,
             Phel::map(Keyword::create('macro'), true),
         );
 
@@ -66,7 +66,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-failed-macro',
-            static fn ($a) => throw new Exception('my-failed-macro message'),
+            static fn($a) => throw new Exception('my-failed-macro message'),
             Phel::map(Keyword::create('macro'), true),
         );
 
@@ -74,10 +74,10 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-inline-fn',
-            static fn ($a): int => 1,
+            static fn($a): int => 1,
             Phel::map(
                 Keyword::create('inline'),
-                static fn ($a): int => 2,
+                static fn($a): int => 2,
             ),
         );
 
@@ -85,12 +85,12 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             'user',
             'my-inline-fn-with-arity',
-            static fn ($a, $b): int => 1,
+            static fn($a, $b): int => 1,
             Phel::map(
                 Keyword::create('inline'),
-                static fn ($a, $b): int => 2,
+                static fn($a, $b): int => 2,
                 Keyword::create('inline-arity'),
-                static fn ($n): bool => $n === 2,
+                static fn($n): bool => $n === 2,
             ),
         );
 
@@ -308,9 +308,9 @@ final class InvokeSymbolTest extends TestCase
                     Symbol::create('my-inline-fn-with-arity'),
                     Phel::map(
                         Keyword::create('inline'),
-                        static fn ($a, $b): int => 2,
+                        static fn($a, $b): int => 2,
                         Keyword::create('inline-arity'),
-                        static fn ($n): bool => $n === 2,
+                        static fn($n): bool => $n === 2,
                     ),
                 ),
                 [
@@ -332,7 +332,7 @@ final class InvokeSymbolTest extends TestCase
         Phel::addDefinition(
             $mungedNs,
             $macroName,
-            static fn ($x) => $x,
+            static fn($x) => $x,
             Phel::map(Keyword::create('macro'), true),
         );
 

--- a/tests/php/Unit/Compiler/Exceptions/ErrorCodeTest.php
+++ b/tests/php/Unit/Compiler/Exceptions/ErrorCodeTest.php
@@ -13,7 +13,7 @@ final class ErrorCodeTest extends TestCase
 {
     public function test_error_code_values_are_unique(): void
     {
-        $values = array_map(static fn (ErrorCode $code): string => $code->value, ErrorCode::cases());
+        $values = array_map(static fn(ErrorCode $code): string => $code->value, ErrorCode::cases());
 
         self::assertCount(count($values), array_unique($values), 'Error codes should be unique');
     }

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -104,7 +104,7 @@ final class LazySeqTest extends TestCase
         $lazySeq = new LazySeq(
             $this->hasher,
             $this->equalizer,
-            static fn (): null => null,
+            static fn(): null => null,
         );
 
         $this->assertNull($lazySeq->first());

--- a/tests/php/Unit/Lang/Collections/ModuloHasher.php
+++ b/tests/php/Unit/Lang/Collections/ModuloHasher.php
@@ -10,8 +10,7 @@ final readonly class ModuloHasher implements HasherInterface
 {
     public function __construct(
         private int $modulo = 10000,
-    ) {
-    }
+    ) {}
 
     public function hash(mixed $value): int
     {

--- a/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
@@ -15,7 +15,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_mapcat_skips_null_results(): void
     {
         $result = SequenceGenerator::mapcat(
-            static fn ($x): ?array => $x > 0 ? [$x, $x] : null,
+            static fn($x): ?array => $x > 0 ? [$x, $x] : null,
             [1, -1, 2, -2, 3],
         );
 
@@ -25,7 +25,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_mapcat_preserves_null_values_in_collections(): void
     {
         $result = SequenceGenerator::mapcat(
-            static fn ($x): array => [$x, null],
+            static fn($x): array => [$x, null],
             [1, 2, 3],
         );
 
@@ -35,7 +35,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_mapcat_with_string_iterable(): void
     {
         $result = SequenceGenerator::mapcat(
-            static fn ($char): ?array => $char === 'a' ? [$char, $char] : null,
+            static fn($char): ?array => $char === 'a' ? [$char, $char] : null,
             'abac',
         );
 
@@ -45,7 +45,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_mapcat_all_null_results_returns_empty(): void
     {
         $result = SequenceGenerator::mapcat(
-            static fn ($x): null => null,
+            static fn($x): null => null,
             [1, 2, 3],
         );
 
@@ -136,9 +136,9 @@ final class SequenceGeneratorTest extends TestCase
 
     public function test_compact_handles_objects(): void
     {
-        $obj1 = (object)['id' => 1];
-        $obj2 = (object)['id' => 2];
-        $obj3 = (object)['id' => 3];
+        $obj1 = (object) ['id' => 1];
+        $obj2 = (object) ['id' => 2];
+        $obj3 = (object) ['id' => 3];
 
         $result = SequenceGenerator::compact([$obj1, $obj2, $obj3], $obj2);
 
@@ -151,9 +151,9 @@ final class SequenceGeneratorTest extends TestCase
     public function test_compact_single_value_optimization_with_objects(): void
     {
         // Test single-value path with object
-        $obj1 = (object)['id' => 1];
-        $obj2 = (object)['id' => 2];
-        $obj3 = (object)['id' => 3];
+        $obj1 = (object) ['id' => 1];
+        $obj2 = (object) ['id' => 2];
+        $obj3 = (object) ['id' => 3];
 
         $result = SequenceGenerator::compact([$obj1, $obj2, $obj3], $obj2);
 
@@ -166,8 +166,8 @@ final class SequenceGeneratorTest extends TestCase
     public function test_compact_multiple_values_with_mixed_scalars_and_objects(): void
     {
         // Test hash lookup path with mixed types
-        $obj1 = (object)['id' => 1];
-        $obj2 = (object)['id' => 2];
+        $obj1 = (object) ['id' => 1];
+        $obj2 = (object) ['id' => 2];
 
         $result = SequenceGenerator::compact(
             [1, $obj1, null, 2, $obj2, false, 3],
@@ -183,10 +183,10 @@ final class SequenceGeneratorTest extends TestCase
     public function test_compact_multiple_objects_removal(): void
     {
         // Test multiple object removals
-        $obj1 = (object)['id' => 1];
-        $obj2 = (object)['id' => 2];
-        $obj3 = (object)['id' => 3];
-        $obj4 = (object)['id' => 4];
+        $obj1 = (object) ['id' => 1];
+        $obj2 = (object) ['id' => 2];
+        $obj3 = (object) ['id' => 3];
+        $obj4 = (object) ['id' => 4];
 
         $result = SequenceGenerator::compact(
             [$obj1, $obj2, $obj3, $obj4],
@@ -287,7 +287,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_basic(): void
     {
         $result = SequenceGenerator::map(
-            static fn ($x): int => $x * 2,
+            static fn($x): int => $x * 2,
             [1, 2, 3],
         );
 
@@ -297,7 +297,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_empty_iterable(): void
     {
         $result = SequenceGenerator::map(
-            static fn ($x): int => $x * 2,
+            static fn($x): int => $x * 2,
             [],
         );
 
@@ -307,7 +307,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_with_string(): void
     {
         $result = SequenceGenerator::map(
-            static fn ($char): string => strtoupper((string) $char),
+            static fn($char): string => strtoupper((string) $char),
             'abc',
         );
 
@@ -336,7 +336,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_indexed_basic(): void
     {
         $result = SequenceGenerator::mapIndexed(
-            static fn (int $idx, $val): string => sprintf('%d:%s', $idx, $val),
+            static fn(int $idx, $val): string => sprintf('%d:%s', $idx, $val),
             ['a', 'b', 'c'],
         );
 
@@ -346,7 +346,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_indexed_empty(): void
     {
         $result = SequenceGenerator::mapIndexed(
-            static fn (int $idx, $val): string => sprintf('%d:%s', $idx, $val),
+            static fn(int $idx, $val): string => sprintf('%d:%s', $idx, $val),
             [],
         );
 
@@ -358,7 +358,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_multi_basic(): void
     {
         $result = SequenceGenerator::mapMulti(
-            static fn ($a, $b): int => $a + $b,
+            static fn($a, $b): int => $a + $b,
             [1, 2, 3],
             [10, 20, 30],
         );
@@ -369,7 +369,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_multi_stops_at_shortest(): void
     {
         $result = SequenceGenerator::mapMulti(
-            static fn ($a, $b): int => $a + $b,
+            static fn($a, $b): int => $a + $b,
             [1, 2, 3, 4, 5],
             [10, 20],
         );
@@ -380,7 +380,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_multi_empty_iterables(): void
     {
         $result = SequenceGenerator::mapMulti(
-            static fn ($a, $b): int => $a + $b,
+            static fn($a, $b): int => $a + $b,
         );
 
         self::assertSame([], iterator_to_array($result, false));
@@ -389,7 +389,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_map_multi_three_iterables(): void
     {
         $result = SequenceGenerator::mapMulti(
-            static fn ($a, $b, $c): int => $a + $b + $c,
+            static fn($a, $b, $c): int => $a + $b + $c,
             [1, 2],
             [10, 20],
             [100, 200],
@@ -403,7 +403,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_filter_basic(): void
     {
         $result = SequenceGenerator::filter(
-            static fn ($x): bool => $x > 2,
+            static fn($x): bool => $x > 2,
             [1, 2, 3, 4, 5],
         );
 
@@ -413,7 +413,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_filter_none_match(): void
     {
         $result = SequenceGenerator::filter(
-            static fn ($x): bool => $x > 10,
+            static fn($x): bool => $x > 10,
             [1, 2, 3],
         );
 
@@ -423,7 +423,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_filter_all_match(): void
     {
         $result = SequenceGenerator::filter(
-            static fn ($x): bool => $x > 0,
+            static fn($x): bool => $x > 0,
             [1, 2, 3],
         );
 
@@ -433,7 +433,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_filter_with_string(): void
     {
         $result = SequenceGenerator::filter(
-            static fn ($char): bool => $char !== 'b',
+            static fn($char): bool => $char !== 'b',
             'abc',
         );
 
@@ -445,7 +445,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_keep_basic(): void
     {
         $result = SequenceGenerator::keep(
-            static fn ($x): ?int => $x > 2 ? $x * 10 : null,
+            static fn($x): ?int => $x > 2 ? $x * 10 : null,
             [1, 2, 3, 4, 5],
         );
 
@@ -455,7 +455,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_keep_all_null(): void
     {
         $result = SequenceGenerator::keep(
-            static fn ($x): null => null,
+            static fn($x): null => null,
             [1, 2, 3],
         );
 
@@ -465,7 +465,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_keep_preserves_falsy_non_null(): void
     {
         $result = SequenceGenerator::keep(
-            static fn ($x): mixed => $x % 2 === 0 ? 0 : null,
+            static fn($x): mixed => $x % 2 === 0 ? 0 : null,
             [1, 2, 3, 4],
         );
 
@@ -477,7 +477,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_keep_indexed_basic(): void
     {
         $result = SequenceGenerator::keepIndexed(
-            static fn (int $idx, $val): ?string => $idx % 2 === 0 ? $val : null,
+            static fn(int $idx, $val): ?string => $idx % 2 === 0 ? $val : null,
             ['a', 'b', 'c', 'd', 'e'],
         );
 
@@ -487,7 +487,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_keep_indexed_empty(): void
     {
         $result = SequenceGenerator::keepIndexed(
-            static fn (int $idx, $val): ?string => $val,
+            static fn(int $idx, $val): ?string => $val,
             [],
         );
 
@@ -538,7 +538,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_take_while_basic(): void
     {
         $result = SequenceGenerator::takeWhile(
-            static fn ($x): bool => $x < 4,
+            static fn($x): bool => $x < 4,
             [1, 2, 3, 4, 5],
         );
 
@@ -548,7 +548,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_take_while_none_match(): void
     {
         $result = SequenceGenerator::takeWhile(
-            static fn ($x): bool => $x < 0,
+            static fn($x): bool => $x < 0,
             [1, 2, 3],
         );
 
@@ -558,7 +558,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_take_while_all_match(): void
     {
         $result = SequenceGenerator::takeWhile(
-            static fn ($x): bool => $x > 0,
+            static fn($x): bool => $x > 0,
             [1, 2, 3],
         );
 
@@ -616,7 +616,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_drop_while_basic(): void
     {
         $result = SequenceGenerator::dropWhile(
-            static fn ($x): bool => $x < 3,
+            static fn($x): bool => $x < 3,
             [1, 2, 3, 4, 5],
         );
 
@@ -626,7 +626,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_drop_while_none_match(): void
     {
         $result = SequenceGenerator::dropWhile(
-            static fn ($x): bool => $x < 0,
+            static fn($x): bool => $x < 0,
             [1, 2, 3],
         );
 
@@ -636,7 +636,7 @@ final class SequenceGeneratorTest extends TestCase
     public function test_drop_while_all_match(): void
     {
         $result = SequenceGenerator::dropWhile(
-            static fn ($x): bool => $x > 0,
+            static fn($x): bool => $x > 0,
             [1, 2, 3],
         );
 
@@ -772,9 +772,9 @@ final class SequenceGeneratorTest extends TestCase
 
     public function test_distinct_with_objects(): void
     {
-        $obj1 = (object)['id' => 1];
-        $obj2 = (object)['id' => 2];
-        $obj3 = (object)['id' => 1]; // Same content but different object
+        $obj1 = (object) ['id' => 1];
+        $obj2 = (object) ['id' => 2];
+        $obj3 = (object) ['id' => 1]; // Same content but different object
 
         $result = SequenceGenerator::distinct([$obj1, $obj2, $obj1, $obj3]);
 

--- a/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/AnonymousClassPrinterTest.php
@@ -11,8 +11,7 @@ final class AnonymousClassPrinterTest extends TestCase
 {
     public function test_print(): void
     {
-        $class = new class() {
-        };
+        $class = new class() {};
 
         self::assertSame(
             '<PHP-AnonymousClass>',

--- a/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ArrayPrinterTest.php
@@ -18,7 +18,7 @@ final class ArrayPrinterTest extends TestCase
         $printer = new class() implements PrinterInterface {
             public function print($form): string
             {
-                return (string)$form;
+                return (string) $form;
             }
         };
 

--- a/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/ObjectPrinterTest.php
@@ -30,7 +30,7 @@ final class ObjectPrinterTest extends TestCase
 
         yield 'array to object cast' => [
             '<PHP-Object(stdClass)>',
-            (object)[],
+            (object) [],
         ];
     }
 }


### PR DESCRIPTION
## 🤔 Background

The project uses PSR-12 as the base coding style preset, but PSR-12 has been superseded by [PER Coding Style 3.0](https://www.php-fig.org/per/coding-style/) — the latest PHP-FIG standard.

## 💡 Goal

Migrate the code style base preset from `@PSR12` to `@PER-CS3.0` (including risky rules) in php-cs-fixer.

## 🔖 Changes

- Updated `.php-cs-fixer.dist.php` base preset from `@PSR12` to `@PER-CS3.0` + `@PER-CS3.0:risky`
- Auto-formatted 208 files — main differences:
  - Space after casts: `(bool)$x` → `(bool) $x`
  - Single-line empty method bodies: `function foo() {}` instead of multi-line
- All static analysis (psalm, phpstan, rector) and tests (1457) pass