### PR TITLE
fix: v0.30.0 phar and cache path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Fix PHAR: deduplicate stdlib source directory in namespace resolution
+- Fix PHAR: pre-compile all stdlib modules during phar build
+- Fix cache: resolve compiled paths from current cache dir, not stored paths
+
 ## [0.30.0](https://github.com/phel-lang/phel-lang/compare/v0.29.0...v0.30.0) - 2026-03-25
 
 ### Added

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -22,7 +22,7 @@ final class PharBuilder
     private array $excludeDirs = [
         '', '.', '..',
         '.git', '.github', '.idea', '.claude', '.vscode',
-        'docs', 'tests', 'docker', 'local', 'build', 'tools', 'examples', 'fixtures',
+        'docs', 'tests', 'docker', 'local', 'build', 'tools', 'examples', 'fixtures', 'out',
         '.phel-cache', '.phpunit.cache',
     ];
 
@@ -126,12 +126,96 @@ final class PharBuilder
     }
 
     /**
+     * Pre-compile all stdlib .phel modules into cache/compiled/ so the PHAR
+     * ships ready-to-run code. Without this, modules other than phel\core
+     * would fail to compile at runtime when phar.readonly=On.
+     */
+    public function preCompileStdlib(): void
+    {
+        $cacheDir = $this->root . '/cache';
+        $compiledDir = $cacheDir . '/compiled';
+
+        // Clean previous compiled cache to avoid stale entries
+        if (is_dir($compiledDir)) {
+            $files = glob($compiledDir . '/*');
+            if ($files !== false) {
+                foreach ($files as $file) {
+                    @unlink($file);
+                }
+            }
+        }
+
+        // Build the project using Phel's build command — this compiles all
+        // stdlib modules through the normal pipeline, populating the temp cache.
+        $exitCode = 0;
+        passthru(
+            sprintf('cd %s && php bin/phel build --quiet 2>&1', escapeshellarg($this->root)),
+            $exitCode,
+        );
+
+        if ($exitCode !== 0) {
+            echo "⚠️  phel build exited with code {$exitCode}, attempting to continue\n";
+        }
+
+        // Copy the compiled cache from the temp dir to the project-local cache/
+        // so the files get bundled into the PHAR.
+        $tempCacheDir = sys_get_temp_dir() . '/phel/cache';
+
+        if (!is_dir($tempCacheDir . '/compiled')) {
+            echo "⚠️  No compiled cache found at {$tempCacheDir}/compiled\n";
+            return;
+        }
+
+        if (!is_dir($compiledDir)) {
+            mkdir($compiledDir, 0755, true);
+        }
+
+        // Copy only stdlib compiled files (phel_* prefix)
+        $compiledFiles = glob($tempCacheDir . '/compiled/phel_*');
+        if ($compiledFiles === false) {
+            return;
+        }
+
+        $copiedCount = 0;
+        foreach ($compiledFiles as $file) {
+            $basename = basename($file);
+            if (copy($file, $compiledDir . '/' . $basename)) {
+                $copiedCount++;
+            }
+        }
+
+        // Copy the compiled index (filtered to only stdlib entries)
+        $indexFile = $tempCacheDir . '/compiled-index.php';
+        if (file_exists($indexFile)) {
+            $indexData = @include $indexFile;
+            if (is_array($indexData) && isset($indexData['entries'])) {
+                $stdlibEntries = [];
+                foreach ($indexData['entries'] as $namespace => $entry) {
+                    if (str_starts_with($namespace, 'phel\\')) {
+                        // Rewrite compiled_path to be relative to phar cache dir
+                        $entry['compiled_path'] = $compiledDir . '/' . basename($entry['compiled_path']);
+                        $stdlibEntries[$namespace] = $entry;
+                    }
+                }
+                $indexData['entries'] = $stdlibEntries;
+                file_put_contents(
+                    $cacheDir . '/compiled-index.php',
+                    '<?php return ' . var_export($indexData, true) . ';',
+                );
+            }
+        }
+
+        echo "📦  Pre-compiled {$copiedCount} stdlib module(s) into cache/compiled/\n";
+    }
+
+    /**
      * Build the PHAR archive
      */
     public function build(): void
     {
         $this->validate();
         $this->prepareReleaseConfig();
+        $this->preCompileStdlib();
         $this->cleanup();
 
         try {

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -55,15 +55,20 @@ final class CompiledCodeCache
             return null;
         }
 
+        // Resolve the compiled path from the current cache dir rather than
+        // using the stored absolute path. This ensures cache hits work inside
+        // a PHAR where the original build-time paths no longer exist.
+        $compiledPath = $this->getCompiledPath($namespace);
+
         // Validate compiled file still exists
-        if (!file_exists($entry['compiled_path'])) {
+        if (!file_exists($compiledPath)) {
             return null;
         }
 
         // Update last_accessed timestamp for LRU tracking
         $this->entries[$namespace]['last_accessed'] = time();
 
-        return $entry['compiled_path'];
+        return $compiledPath;
     }
 
     /**
@@ -171,7 +176,7 @@ final class CompiledCodeCache
             return;
         }
 
-        $compiledPath = $this->entries[$namespace]['compiled_path'];
+        $compiledPath = $this->getCompiledPath($namespace);
         if (file_exists($compiledPath)) {
             @unlink($compiledPath);
         }
@@ -380,8 +385,9 @@ final class CompiledCodeCache
                 break;
             }
 
-            if (file_exists($entry['compiled_path'])) {
-                @unlink($entry['compiled_path']);
+            $compiledPath = $this->getCompiledPath($namespace);
+            if (file_exists($compiledPath)) {
+                @unlink($compiledPath);
             }
 
             $envPath = $this->getEnvironmentPath($namespace);

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -380,7 +380,7 @@ final class CompiledCodeCache
 
         // Evict oldest entries
         $evicted = 0;
-        foreach ($this->entries as $namespace => $entry) {
+        foreach (array_keys($this->entries) as $namespace) {
             if ($evicted >= $evictCount) {
                 break;
             }

--- a/src/php/Run/Application/NamespacesLoader.php
+++ b/src/php/Run/Application/NamespacesLoader.php
@@ -27,9 +27,13 @@ final readonly class NamespacesLoader implements NamespacesLoaderInterface
             ...$this->commandFacade->getVendorSourceDirectories(),
         ];
 
-        // Add core Phel files directory when running from PHAR
+        // Add core Phel files directory when running from PHAR,
+        // but only if not already present (avoids duplicate namespace registration)
         if (str_starts_with(__FILE__, 'phar://')) {
-            $directories[] = Phar::running(true) . '/src/phel';
+            $pharSrcDir = Phar::running(true) . '/src/phel';
+            if (!in_array($pharSrcDir, $directories, true)) {
+                $directories[] = $pharSrcDir;
+            }
         }
 
         return $this->buildFacade->getNamespaceFromDirectories($directories);

--- a/src/php/Run/Application/NamespacesLoader.php
+++ b/src/php/Run/Application/NamespacesLoader.php
@@ -10,6 +10,8 @@ use Phel\Run\Domain\NamespacesLoaderInterface;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
+use function in_array;
+
 final readonly class NamespacesLoader implements NamespacesLoaderInterface
 {
     public function __construct(


### PR DESCRIPTION
## 🤔 Background

The v0.30.0 release had several issues when running from a PHAR: duplicate stdlib namespace registration, absolute build-time paths in the cache preventing lookups, and only `phel\core` being pre-compiled while other stdlib modules failed at runtime with `phar.readonly=On`.

## 💡 Goal

Fix all PHAR and cache-related bugs introduced or exposed in v0.30.0 so that the phar distribution works correctly out of the box.

## 🔖 Changes

- **Deduplicate stdlib source directory in phar namespace resolution**: `NamespacesLoader` now checks if `src/phel` is already present before adding it, preventing every stdlib module from being registered twice
- **Resolve compiled paths from current cache dir, not stored paths**: `CompiledCodeCache` uses `getCompiledPath()` to resolve paths relative to the current `cacheDir` instead of relying on stored absolute build-time paths (fixes `get()`, `invalidate()`, and `evictLRU()`)
- **Pre-compile all stdlib modules during phar build**: the build now runs `phel build` to compile all stdlib modules, copies compiled files into the project cache, filters the index to `phel\*` entries only, and excludes `out/` from the phar
- **Code style fix**: add missing `use function in_array` import in `NamespacesLoader`

Closes #1118