### PR TITLE
feat(repl): capture stdout during eval in EvalResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add stdout capture to `EvalResult` via `$output` field, separating printed output from return values for nREPL support
 - Add `structuredEval()` to `RunFacade` returning structured `EvalResult` with error details for external tooling
 - Add alias-based and referred-symbol completion to `ReplCompleter`
 - Auto-inject REPL utilities (`doc`, `require`, `use`) on `(in-ns ...)` namespace changes

--- a/src/php/Run/Domain/Repl/EvalResult.php
+++ b/src/php/Run/Domain/Repl/EvalResult.php
@@ -18,21 +18,22 @@ final readonly class EvalResult
         public bool $incomplete,
         public mixed $value,
         public ?EvalError $error,
+        public string $output,
     ) {}
 
-    public static function success(mixed $value): self
+    public static function success(mixed $value, string $output = ''): self
     {
-        return new self(success: true, incomplete: false, value: $value, error: null);
+        return new self(success: true, incomplete: false, value: $value, error: null, output: $output);
     }
 
-    public static function incomplete(): self
+    public static function incomplete(string $output = ''): self
     {
-        return new self(success: false, incomplete: true, value: null, error: null);
+        return new self(success: false, incomplete: true, value: null, error: null, output: $output);
     }
 
-    public static function failure(EvalError $error): self
+    public static function failure(EvalError $error, string $output = ''): self
     {
-        return new self(success: false, incomplete: false, value: null, error: $error);
+        return new self(success: false, incomplete: false, value: null, error: $error, output: $output);
     }
 
     public static function fromEval(
@@ -40,13 +41,19 @@ final readonly class EvalResult
         string $phelCode,
         CompileOptions $compileOptions = new CompileOptions(),
     ): self {
+        ob_start();
+
         try {
             $result = $compilerFacade->eval($phelCode, $compileOptions);
+            $output = (string) ob_get_clean();
 
-            return self::success($result);
+            return self::success($result, $output);
         } catch (UnfinishedParserException) {
-            return self::incomplete();
+            $output = (string) ob_get_clean();
+
+            return self::incomplete($output);
         } catch (CompilerException $e) {
+            $output = (string) ob_get_clean();
             $nested = $e->getNestedException();
             $snippet = $e->getCodeSnippet();
             $startLoc = $nested->getStartLocation();
@@ -64,8 +71,9 @@ final readonly class EvalResult
                 codeSnippet: $snippet->getCode(),
                 stackTrace: $nested->getTraceAsString(),
                 phase: 'compile',
-            ));
+            ), $output);
         } catch (CompiledCodeIsMalformedException $e) {
+            $output = (string) ob_get_clean();
             $prev = $e->getPrevious() instanceof Throwable ? $e->getPrevious() : $e;
 
             return self::failure(new EvalError(
@@ -80,8 +88,10 @@ final readonly class EvalResult
                 codeSnippet: null,
                 stackTrace: $prev->getTraceAsString(),
                 phase: 'eval',
-            ));
+            ), $output);
         } catch (Throwable $e) {
+            $output = (string) ob_get_clean();
+
             return self::failure(new EvalError(
                 exceptionClass: array_reverse(explode('\\', $e::class))[0],
                 message: $e->getMessage(),
@@ -94,7 +104,7 @@ final readonly class EvalResult
                 codeSnippet: null,
                 stackTrace: $e->getTraceAsString(),
                 phase: 'runtime',
-            ));
+            ), $output);
         }
     }
 }

--- a/tests/php/Unit/Run/Domain/Repl/EvalResultTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/EvalResultTest.php
@@ -28,6 +28,16 @@ final class EvalResultTest extends TestCase
         self::assertFalse($result->incomplete);
         self::assertSame(42, $result->value);
         self::assertNull($result->error);
+        self::assertSame('', $result->output);
+    }
+
+    public function test_success_result_with_output(): void
+    {
+        $result = EvalResult::success(null, "hello\n");
+
+        self::assertTrue($result->success);
+        self::assertNull($result->value);
+        self::assertSame("hello\n", $result->output);
     }
 
     public function test_incomplete_result(): void
@@ -38,6 +48,7 @@ final class EvalResultTest extends TestCase
         self::assertTrue($result->incomplete);
         self::assertNull($result->value);
         self::assertNull($result->error);
+        self::assertSame('', $result->output);
     }
 
     public function test_from_eval_success(): void
@@ -49,6 +60,23 @@ final class EvalResultTest extends TestCase
 
         self::assertTrue($result->success);
         self::assertSame(42, $result->value);
+        self::assertSame('', $result->output);
+    }
+
+    public function test_from_eval_captures_printed_output(): void
+    {
+        $facade = $this->createMock(CompilerFacadeInterface::class);
+        $facade->method('eval')->willReturnCallback(static function (): mixed {
+            echo "hello\n";
+
+            return null;
+        });
+
+        $result = EvalResult::fromEval($facade, '(println "hello")');
+
+        self::assertTrue($result->success);
+        self::assertNull($result->value);
+        self::assertSame("hello\n", $result->output);
     }
 
     public function test_from_eval_incomplete(): void
@@ -132,5 +160,40 @@ final class EvalResultTest extends TestCase
         self::assertSame('RuntimeException', $result->error->exceptionClass);
         self::assertSame('division by zero', $result->error->message);
         self::assertSame('runtime', $result->error->phase);
+        self::assertSame('', $result->output);
+    }
+
+    public function test_from_eval_captures_output_on_failure(): void
+    {
+        $facade = $this->createMock(CompilerFacadeInterface::class);
+        $facade->method('eval')->willReturnCallback(static function (): never {
+            echo 'partial output';
+            throw new RuntimeException('boom');
+        });
+
+        $result = EvalResult::fromEval($facade, '(do (print "partial output") (/ 1 0))');
+
+        self::assertFalse($result->success);
+        self::assertNotNull($result->error);
+        self::assertSame('partial output', $result->output);
+    }
+
+    public function test_from_eval_preserves_nested_output_buffering(): void
+    {
+        $facade = $this->createMock(CompilerFacadeInterface::class);
+        $facade->method('eval')->willReturnCallback(static function (): mixed {
+            echo 'inner';
+
+            return null;
+        });
+
+        ob_start();
+        echo 'outer-before:';
+        $result = EvalResult::fromEval($facade, '(print "inner")');
+        echo ':outer-after';
+        $outerOutput = ob_get_clean();
+
+        self::assertSame('inner', $result->output);
+        self::assertSame('outer-before::outer-after', $outerOutput);
     }
 }


### PR DESCRIPTION
## 🤔 Background

nREPL servers need to separate printed output (`out`) from return values (`value`). Currently `eval()` lets `print`/`println` output go straight to PHP's stdout, making it impossible for external tools to capture what was printed vs what was returned.

## 💡 Goal

Add output capture to `EvalResult::fromEval()` so `structuredEval()` returns both the value and any captured stdout.

## 🔖 Changes

- Added `string $output` field to `EvalResult` capturing any stdout produced during eval via `ob_start()`/`ob_get_clean()`
- Updated all factory methods (`success()`, `incomplete()`, `failure()`) to accept output
- Output is captured even when eval fails (partial output before exception)
- Nested output buffering is preserved (outer `ob_start` callers unaffected)
- 4 new tests covering output capture, failure output, and buffer nesting