### PR TITLE
feat(repl): add load-file function for evaluating source files in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Store parameter names as `:arglists` in function metadata during compilation for IDE signature help and nREPL support
 - Add `symbol-info` macro and `get-symbol-info` function to `phel\repl` for structured metadata lookup (doc, location, arity, deprecation)
 - Add stdout capture to `EvalResult` via `$output` field, separating printed output from return values for nREPL support
+- Add `load-file` REPL function to evaluate an entire Phel source file within the REPL session context
 - Add `structuredEval()` to `RunFacade` returning structured `EvalResult` with error details for external tooling
 - Add alias-based and referred-symbol completion to `ReplCompleter`
 - Auto-inject REPL utilities (`doc`, `require`, `use`) on `(in-ns ...)` namespace changes

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -142,6 +142,18 @@
         res (php/-> cf (compile s opts))]
     (php/-> res (getCode))))
 
+(defn load-file
+  "Loads and evaluates a Phel source file in the current REPL session.
+  Reads the file content and evaluates it using the compiler, preserving
+  the current REPL namespace context. Returns the result of the last expression."
+  {:example "(load-file \"src/my-module.phel\")"}
+  [path]
+  (let [content (php/file_get_contents path)]
+    (when content
+      (let [cf (php/new CompilerFacade)
+            opts (php/-> (php/new CompileOptions) (setSource path))]
+        (php/-> cf (eval content opts))))))
+
 (defn- munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
@@ -29,6 +29,7 @@ final class ReplReferInjector
                 Symbol::create('print-colorful'),
                 Symbol::create('println-colorful'),
                 Symbol::create('symbol-info'),
+                Symbol::create('load-file'),
             ],
             $replSymbol,
         );

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -1,7 +1,7 @@
 # This is the startup script that is launch in the REPL.
 (ns user
   (:require phel\repl :refer [doc require use print-colorful println-colorful
-                               dir apropos search-doc symbol-info])
+                               dir apropos search-doc symbol-info load-file])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
                                prewalk-replace keywordize-keys stringify-keys]))

--- a/tests/php/Integration/Repl/LoadFileTest.php
+++ b/tests/php/Integration/Repl/LoadFileTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Repl;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Infrastructure\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+final class LoadFileTest extends TestCase
+{
+    private string $tempFile = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Phel::bootstrap(__DIR__);
+        Phel::addDefinition('phel\\repl', 'src-dirs', [__DIR__ . '/../../../../src']);
+
+        $build = new BuildFacade();
+        $build->evalFile(__DIR__ . '/../../../../src/phel/core.phel');
+        $build->evalFile(__DIR__ . '/../../../../src/phel/repl.phel');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== '' && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_load_file_evaluates_phel_source(): void
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'phel_') . '.phel';
+        file_put_contents($this->tempFile, '(+ 1 2)');
+
+        $facade = new CompilerFacade();
+        $result = $facade->eval(
+            '(phel\\repl/load-file "' . addslashes($this->tempFile) . '")',
+            new CompileOptions(),
+        );
+
+        self::assertSame(3, $result);
+    }
+
+    public function test_load_file_returns_last_expression(): void
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'phel_') . '.phel';
+        file_put_contents($this->tempFile, "(+ 1 1)\n(+ 2 3)");
+
+        $facade = new CompilerFacade();
+        $result = $facade->eval(
+            '(phel\\repl/load-file "' . addslashes($this->tempFile) . '")',
+            new CompileOptions(),
+        );
+
+        self::assertSame(5, $result);
+    }
+
+    public function test_load_file_returns_nil_for_nonexistent_file(): void
+    {
+        $facade = new CompilerFacade();
+        $result = @$facade->eval(
+            '(phel\\repl/load-file "/tmp/nonexistent_phel_file_' . uniqid() . '.phel")',
+            new CompileOptions(),
+        );
+
+        self::assertNull($result);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

nREPL's `load-file` op needs to evaluate an entire file within the REPL session context. Currently there's no public API for this — `BuildFacade::evalFile()` goes through the build pipeline without maintaining REPL context.

## 💡 Goal

Add a `load-file` function to the REPL that reads and evaluates a Phel source file, returning the result of its last expression.

## 🔖 Changes

- New public `load-file` function in `repl.phel`: reads file content via `php/file_get_contents`, evaluates through `CompilerFacade::eval()` with file path context
- Added to `startup.phel` `:refer` list and `ReplReferInjector` auto-injection
- Returns `nil` gracefully for non-existent files
- 3 integration tests: basic eval, last-expression return, missing file handling