### PR TITLE
feat(repl): add source function to retrieve definition source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `source` macro and `get-source-code` function to `phel\repl` for retrieving definition source code from file metadata
 - Store parameter names as `:arglists` in function metadata during compilation for IDE signature help and nREPL support
 - Add `symbol-info` macro and `get-symbol-info` function to `phel\repl` for structured metadata lookup (doc, location, arity, deprecation)
 - Add stdout capture to `EvalResult` via `$output` field, separating printed output from return values for nREPL support

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -237,6 +237,32 @@
               (conj results (str (php/-> munge (decodeNs ns)) "/" decoded)))))))
     (sort (persistent results))))
 
+(defn get-source-code
+  "Returns the source code of the definition identified by namespace and name
+  strings, or nil if the source file cannot be found or metadata is missing."
+  {:example "(get-source-code \"phel\\core\" \"map\")"
+   :see-also ["source" "get-symbol-info"]}
+  [ns-str name-str]
+  (let [info (get-symbol-info ns-str name-str)]
+    (when info
+      (let [file (get info :file)
+            start-line (get info :line)
+            end-line (get info :end-line)]
+        (when (and file start-line end-line (php/file_exists file))
+          (let [content (php/file_get_contents file)
+                lines (php/explode "\n" content)
+                extracted (php/array_slice lines (php/- start-line 1) (php/+ (php/- end-line start-line) 1))]
+            (php/implode "\n" extracted)))))))
+
+(defmacro source
+  "Returns the source code of the given symbol as a string, or nil if unavailable."
+  {:example "(source map)"
+   :see-also ["doc" "symbol-info"]}
+  [sym]
+  (let [resolved-sym (resolve sym)]
+    (when resolved-sym
+      `(get-source-code ,(namespace resolved-sym) ,(name resolved-sym)))))
+
 (defn search-doc
   "Searches docstrings across all loaded namespaces for the given string.
   Prints matching function names and their documentation."

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
@@ -30,6 +30,7 @@ final class ReplReferInjector
                 Symbol::create('println-colorful'),
                 Symbol::create('symbol-info'),
                 Symbol::create('load-file'),
+                Symbol::create('source'),
             ],
             $replSymbol,
         );

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -1,7 +1,7 @@
 # This is the startup script that is launch in the REPL.
 (ns user
   (:require phel\repl :refer [doc require use print-colorful println-colorful
-                               dir apropos search-doc symbol-info load-file])
+                               dir apropos search-doc symbol-info load-file source])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
                                prewalk-replace keywordize-keys stringify-keys]))

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info])
+  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code])
   (:require phel\str :as s)
   (:require phel\test :refer [deftest is]))
 
@@ -62,3 +62,21 @@
 (deftest test-get-symbol-info-private-flag
   (let [info (get-symbol-info "phel\\core" "map")]
     (is (= false (get info :private)) "public function has :private false")))
+
+# ------
+# source
+# ------
+
+(deftest test-get-source-code-returns-string-for-known-symbol
+  (let [src (get-source-code "phel\\core" "map")]
+    (is (string? src) "get-source-code returns a string for a known symbol")
+    (is (> (php/strlen src) 0) "get-source-code returns a non-empty string")
+    (is (s/contains? src "defn") "source code contains 'defn'")))
+
+(deftest test-get-source-code-returns-nil-for-unknown-symbol
+  (is (nil? (get-source-code "phel\\core" "zzz_nonexistent_zzz"))
+      "get-source-code returns nil for unknown symbol"))
+
+(deftest test-get-source-code-contains-function-name
+  (let [src (get-source-code "phel\\core" "map")]
+    (is (s/contains? src "map") "source code contains the function name")))


### PR DESCRIPTION
## 🤔 Background

nREPL's `source` op needs to return the source code of a definition. Phel already stores `:start-location` and `:end-location` in function metadata but had no function to read and extract the relevant lines from the source file.

## 💡 Goal

Add a `source` macro that retrieves the source code of any definition directly in the REPL.

## 🔖 Changes

- `get-source-code` function: takes namespace + name strings, reads metadata locations, extracts lines from source file
- `source` macro: resolves unquoted symbol at compile time, delegates to `get-source-code`
- Added to `startup.phel` and `ReplReferInjector` for REPL availability
- 3 Phel tests: known symbol returns source containing "defn", unknown returns nil, source contains function name