### PR TITLE
feat(repl): add find-fn for structured function search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `find-fn` function to `phel\repl` for structured function search across all loaded namespaces, returning maps with `:ns`, `:name`, `:doc`, `:private`, `:min-arity`, `:max-arity`, `:is-variadic`
 - Add structured stack frames (`StackFrame` objects) to `EvalError` for nREPL stacktrace middleware support
 - Add `source` macro and `get-source-code` function to `phel\repl` for retrieving definition source code from file metadata
 - Store parameter names as `:arglists` in function metadata during compilation for IDE signature help and nREPL support

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -7,6 +7,7 @@
   (:use Phel\Compiler\Infrastructure\CompileOptions)
   (:use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton)
   (:use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment)
+  (:use Phel\Lang\FnInterface)
   (:use Phel\Printer\Printer))
 
 (def build-facade (php/new BuildFacade))
@@ -236,6 +237,38 @@
                        (php/str_contains decoded search))
               (conj results (str (php/-> munge (decodeNs ns)) "/" decoded)))))))
     (sort (persistent results))))
+
+(defn find-fn
+  "Searches for functions whose name or docstring contains the search string.
+  Returns a vector of maps with :ns, :name, :doc, :private, :min-arity, :max-arity, :is-variadic."
+  {:example "(find-fn \"map\") ; => [{:ns \"phel\\core\" :name \"map\" ...} ...]"
+   :see-also ["apropos" "search-doc" "get-symbol-info"]}
+  [search]
+  (let [munge (php/new Munge)
+        search-lower (php/strtolower search)
+        results (transient [])]
+    (foreach [ns (loaded-namespaces)]
+      (let [defs (php/:: Phel (getDefinitionInNamespace ns))
+            fn-names (php/array_keys defs)]
+        (foreach [fn-name fn-names]
+          (let [definition (php/:: Phel (getDefinition ns fn-name))]
+            (when (php/instanceof definition FnInterface)
+              (let [meta (php/:: Phel (getDefinitionMetaData ns fn-name))
+                    decoded-name (php/-> munge (decodeNs fn-name))
+                    decoded-ns (php/-> munge (decodeNs ns))
+                    doc (or (get meta :doc) "")
+                    name-lower (php/strtolower decoded-name)
+                    doc-lower (php/strtolower doc)]
+                (when (or (php/str_contains name-lower search-lower)
+                          (php/str_contains doc-lower search-lower))
+                  (conj results {:ns decoded-ns
+                                 :name decoded-name
+                                 :doc doc
+                                 :private (or (get meta :private) false)
+                                 :min-arity (get meta "min-arity")
+                                 :max-arity (get meta "max-arity")
+                                 :is-variadic (or (get meta "is-variadic") false)}))))))))
+    (persistent results)))
 
 (defn get-source-code
   "Returns the source code of the definition identified by namespace and name

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code])
+  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code find-fn])
   (:require phel\str :as s)
   (:require phel\test :refer [deftest is]))
 
@@ -80,3 +80,30 @@
 (deftest test-get-source-code-contains-function-name
   (let [src (get-source-code "phel\\core" "map")]
     (is (s/contains? src "map") "source code contains the function name")))
+
+# -------
+# find-fn
+# -------
+
+(deftest test-find-fn-returns-non-empty-vector
+  (let [results (find-fn "map")]
+    (is (> (count results) 0) "find-fn finds functions matching 'map'")
+    (is (indexed? results) "find-fn returns a vector")))
+
+(deftest test-find-fn-results-have-required-keys
+  (let [results (find-fn "map")
+        first-result (first results)]
+    (is (not (nil? (get first-result :ns))) "result contains :ns key")
+    (is (not (nil? (get first-result :name))) "result contains :name key")
+    (is (string? (get first-result :doc)) "result contains :doc as string")
+    (is (not (nil? (get first-result :private))) "result contains :private key")
+    (is (not (nil? (get first-result :is-variadic))) "result contains :is-variadic key")))
+
+(deftest test-find-fn-no-matches
+  (let [results (find-fn "zzz-nonexistent-xxx")]
+    (is (= 0 (count results)) "find-fn returns empty vector for no matches")))
+
+(deftest test-find-fn-searches-docstrings
+  (let [results (find-fn "concatenat")
+        names (for [r :in results] (get r :name))]
+    (is (> (count results) 0) "find-fn finds functions by docstring match")))


### PR DESCRIPTION
## 🤔 Background

`apropos` returns a sorted vector of symbol name strings. For nREPL and IDE integration, a search that returns structured data (namespace, doc, arity) is more useful — clients shouldn't need to make a second call to get metadata for each match.

## 💡 Goal

Add `find-fn` that searches function names AND docstrings, returning structured result maps.

## 🔖 Changes

- `find-fn` function: case-insensitive search across all loaded namespaces, filters to `FnInterface` instances
- Returns vector of hash-maps with `:ns`, `:name`, `:doc`, `:private`, `:min-arity`, `:max-arity`, `:is-variadic`
- Searches in both function names and docstrings
- 4 Phel tests: non-empty results, required keys, no matches, docstring matching