### PR TITLE
feat(repl): add ns-list for human-readable namespace listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `ns-list` function to `phel\repl` returning a sorted vector of human-readable namespace names (decodes munged underscores back to hyphens)
 - Add GlobalEnvironment snapshot/restore to rollback state on REPL eval errors, preventing dirty state from partial evaluations
 - Add `find-fn` function to `phel\repl` for structured function search across all loaded namespaces, returning maps with `:ns`, `:name`, `:doc`, `:private`, `:min-arity`, `:max-arity`, `:is-variadic`
 - Add structured stack frames (`StackFrame` objects) to `EvalError` for nREPL stacktrace middleware support

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -24,6 +24,16 @@
   []
   (php/:: Phel (getNamespaces)))
 
+(defn ns-list
+  "Returns a sorted vector of all loaded namespace names, decoded to
+  human-readable form (hyphens restored instead of underscores)."
+  {:example "(ns-list) ; => [\"phel\\core\" \"phel\\repl\" ...]"
+   :see-also ["loaded-namespaces" "dir" "ns-publics"]}
+  []
+  (let [munge (php/new Munge)]
+    (sort (for [ns :in (loaded-namespaces)]
+            (php/-> munge (decodeNs ns))))))
+
 (defn- eval-file [file]
   (php/-> build-facade (evalFile file)))
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
@@ -32,6 +32,7 @@ final class ReplReferInjector
                 Symbol::create('load-file'),
                 Symbol::create('source'),
                 Symbol::create('test-ns'),
+                Symbol::create('ns-list'),
             ],
             $replSymbol,
         );

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -2,7 +2,7 @@
 (ns user
   (:require phel\repl :refer [doc require use print-colorful println-colorful
                                dir apropos search-doc symbol-info load-file source
-                               test-ns])
+                               test-ns ns-list])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
                                prewalk-replace keywordize-keys stringify-keys]))

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers find-fn test-ns])
+  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers find-fn test-ns ns-list loaded-namespaces])
   (:require phel\str :as s)
   (:require phel\test :refer [deftest is]))
 
@@ -173,3 +173,24 @@
     (is (> (get result :pass) 0) "test-framework tests have passing tests")
     (is (= 0 (get result :fail)) "test-framework tests have no failures")
     (is (= 0 (get result :error)) "test-framework tests have no errors")))
+
+# -------
+# ns-list
+# -------
+
+(deftest test-ns-list-returns-vector
+  (let [results (ns-list)]
+    (is (indexed? results) "ns-list returns a vector")))
+
+(deftest test-ns-list-contains-known-namespaces
+  (let [results (ns-list)]
+    (is (some? |(= $ "phel\\core") results) "ns-list contains phel\\core")
+    (is (some? |(= $ "phel\\repl") results) "ns-list contains phel\\repl")))
+
+(deftest test-ns-list-is-sorted
+  (let [results (ns-list)]
+    (is (= results (sort results)) "ns-list returns sorted results")))
+
+(deftest test-ns-list-count-matches-loaded-namespaces
+  (is (= (count (ns-list)) (count (loaded-namespaces)))
+      "ns-list count matches loaded-namespaces count"))


### PR DESCRIPTION
## 🤔 Background

The existing `loaded-namespaces` function returns munged names (hyphens converted to underscores for PHP compatibility). nREPL clients need clean, human-readable namespace names for the `ns-list` op.

## 💡 Goal

Add an `ns-list` function that returns a sorted vector of all loaded namespace names decoded to human-readable form (e.g., `"phel-test\test\core"` instead of `"phel_test\test\core"`).

## 🔖 Changes

- Add `ns-list` function to `src/phel/repl.phel` using `Munge.decodeNs` to decode namespace names, following the same pattern as `apropos`, `dir`, and `find-fn`
- Add `ns-list` to REPL startup refers in `src/php/Run/Domain/Repl/startup.phel`
- Add `ns-list` to `ReplReferInjector.php` for auto-injection on `(in-ns ...)` changes
- Add 4 tests in `tests/phel/test/repl.phel`: returns vector, contains known namespaces, is sorted, count matches `loaded-namespaces`
- Update CHANGELOG.md under Unreleased