### PR TITLE
feat(repl): add eval-str function for evaluating code strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `eval-str` function to `phel\repl` for evaluating Phel code strings and returning the result
 - Add GlobalEnvironment snapshot/restore to rollback state on REPL eval errors, preventing dirty state from partial evaluations
 - Add `find-fn` function to `phel\repl` for structured function search across all loaded namespaces, returning maps with `:ns`, `:name`, `:doc`, `:private`, `:min-arity`, `:max-arity`, `:is-variadic`
 - Add structured stack frames (`StackFrame` objects) to `EvalError` for nREPL stacktrace middleware support

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -144,6 +144,16 @@
         res (php/-> cf (compile s opts))]
     (php/-> res (getCode))))
 
+(defn eval-str
+  "Evaluates a string of Phel code and returns the result.
+  If the string contains multiple expressions, returns the result of the last one."
+  {:example "(eval-str \"(+ 1 2)\") ; => 3"
+   :see-also ["compile-str" "load-file"]}
+  [s]
+  (let [cf (php/new CompilerFacade)
+        opts (php/new CompileOptions)]
+    (php/-> cf (eval s opts))))
+
 (defn load-file
   "Loads and evaluates a Phel source file in the current REPL session.
   Reads the file content and evaluates it using the compiler, preserving

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReplReferInjector.php
@@ -32,6 +32,7 @@ final class ReplReferInjector
                 Symbol::create('load-file'),
                 Symbol::create('source'),
                 Symbol::create('test-ns'),
+                Symbol::create('eval-str'),
             ],
             $replSymbol,
         );

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -2,7 +2,7 @@
 (ns user
   (:require phel\repl :refer [doc require use print-colorful println-colorful
                                dir apropos search-doc symbol-info load-file source
-                               test-ns])
+                               test-ns eval-str])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
                                prewalk-replace keywordize-keys stringify-keys]))

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers find-fn test-ns])
+  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers find-fn test-ns eval-str])
   (:require phel\str :as s)
   (:require phel\test :refer [deftest is]))
 
@@ -173,3 +173,23 @@
     (is (> (get result :pass) 0) "test-framework tests have passing tests")
     (is (= 0 (get result :fail)) "test-framework tests have no failures")
     (is (= 0 (get result :error)) "test-framework tests have no errors")))
+
+# --------
+# eval-str
+# --------
+
+(deftest test-eval-str-arithmetic
+  (is (= 3 (eval-str "(+ 1 2)")) "eval-str evaluates arithmetic"))
+
+(deftest test-eval-str-string-concatenation
+  (is (= "hello world" (eval-str "(str \"hello\" \" \" \"world\")"))
+      "eval-str evaluates string concatenation"))
+
+(deftest test-eval-str-def-defines-var
+  (do (eval-str "(def test-eval-var 42)")
+    (is (= 42 (eval-str "test-eval-var"))
+        "eval-str def defines a var accessible in subsequent eval")))
+
+(deftest test-eval-str-multiple-expressions
+  (is (= 10 (eval-str "(+ 1 2) (+ 3 7)"))
+      "eval-str with multiple expressions returns last result"))


### PR DESCRIPTION
## 🤔 Background

An external nREPL server project currently calls `CompilerFacade` directly from Phel code to evaluate strings. A clean Phel-level `eval-str` function simplifies this and provides a public API for programmatic code evaluation.

## 💡 Goal

Add an `eval-str` function to `phel\repl` that takes a string of Phel code, evaluates it using `CompilerFacade::eval()`, and returns the result.

## 🔖 Changes

- Add `eval-str` function to `src/phel/repl.phel` — mirrors `compile-str` but calls `eval` instead of `compile`
- Register `eval-str` in `ReplReferInjector.php` for auto-injection on `(in-ns ...)`
- Add `eval-str` to REPL startup `:refer` list in `startup.phel`
- Add 4 tests in `tests/phel/test/repl.phel`: arithmetic, string concatenation, def + subsequent access, multiple expressions
- Update `CHANGELOG.md` under `## Unreleased`