### PR TITLE
Fix `phel --help` showing only REPL subcommand help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Auto-inject REPL utilities (`doc`, `require`, `use`) on `(in-ns ...)` namespace changes
 
 ### Fixed
+- Fix `phel --help` showing only REPL help instead of top-level help with all commands (#1141)
 - Fix `(str false)` returns `"false"` and `(str true)` returns `"true"` (matching Clojure semantics) (#1122)
 - Fix REPL: `*ns*` now preserves hyphens instead of munging to underscores (#766)
 - Fix REPL: `(ns ...)` form requires no longer silently fail when `src-dirs` is empty (#766)

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_slice;
+use function in_array;
+
 #[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
 final class ConsoleBootstrap extends Application
 {
@@ -23,12 +26,19 @@ final class ConsoleBootstrap extends Application
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         $this->setAutoExit(false);
+
+        $sanitizedArgs = $this->getFactory()
+            ->createArgvInputSanitizer()
+            ->sanitize($_SERVER['argv'] ?? []);
+
         $this->setDefaultCommand('repl');
 
+        if ($this->isTopLevelHelp($sanitizedArgs)) {
+            $sanitizedArgs = $this->replaceHelpWithList($sanitizedArgs);
+        }
+
         if (!$input instanceof InputInterface) {
-            $input = new ArgvInput($this->getFactory()
-                ->createArgvInputSanitizer()
-                ->sanitize($_SERVER['argv'] ?? []));
+            $input = new ArgvInput($sanitizedArgs);
         }
 
         $exitCode = parent::run($input, $output);
@@ -50,5 +60,51 @@ final class ConsoleBootstrap extends Application
         }
 
         return $commands;
+    }
+
+    /**
+     * Detect when --help/-h is requested without an explicit command,
+     * so we show top-level help listing all commands instead of repl help.
+     */
+    private function isTopLevelHelp(array $argv): bool
+    {
+        $args = array_slice($argv, 1);
+
+        $hasHelp = in_array('--help', $args, true) || in_array('-h', $args, true);
+        if (!$hasHelp) {
+            return false;
+        }
+
+        foreach ($args as $arg) {
+            if ($arg === '--help') {
+                continue;
+            }
+
+            if ($arg === '-h') {
+                continue;
+            }
+
+            if (!str_starts_with((string) $arg, '-')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Strip --help/-h flags and insert 'list' as the command,
+     * so Symfony Console executes the list command directly.
+     */
+    private function replaceHelpWithList(array $argv): array
+    {
+        $filtered = array_values(array_filter(
+            $argv,
+            static fn($arg): bool => $arg !== '--help' && $arg !== '-h',
+        ));
+
+        array_splice($filtered, 1, 0, ['list']);
+
+        return $filtered;
     }
 }


### PR DESCRIPTION
## 🤔 Background

As reported in #1141, since `repl` was made the default subcommand, running `phel --help` or `phel -h` shows only the REPL subcommand documentation instead of the top-level help listing all available commands.

## 💡 Goal

Ensure `phel --help` displays the full command list (init, test, eval, run, etc.) while preserving `repl` as the default when no command is given.

## 🔖 Changes

- Detect when `--help`/`-h` is passed without an explicit command and skip setting `repl` as the default, so Symfony Console falls back to `list` (top-level help)
- Extract `$sanitizedArgs` once to avoid duplicate sanitizer calls


<img width="971" height="639" alt="Screenshot 2026-03-28 at 12 35 37" src="https://github.com/user-attachments/assets/31100cff-5a88-4f8e-9263-fb22607ee364" />


Closes #1141