### PR TITLE
feat: add utility functions (update-keys, update-vals, parse-*, abs, inf?, random-uuid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `update-keys`, `update-vals` map utility functions (#1150)
+- Add `parse-long`, `parse-double`, `parse-boolean` safe parsing functions (#1150)
+- Add `abs`, `inf?`, `random-uuid` utility functions (#1150)
 - Add Clojure-style anonymous function shorthand `#(...)` with `%`, `%1`, `%2`, `%&` parameter placeholders as alternative to `|(...)` syntax (#1146)
 - Deprecation warnings for `#` line comments (use `;` instead) and `#| |#` multiline comments (use `(comment ...)` instead) (#1146)
 - Add `eval-capturing` function to `phel\repl` for evaluating code strings while capturing stdout separately from return values, enabling nREPL transport support

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2633,6 +2633,19 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [x]
   (php/is_nan x))
 
+(defn inf?
+  "Checks if `x` is infinite."
+  {:example "(inf? php/INF) ; => true"
+   :see-also ["nan?"]}
+  [x]
+  (php/is_infinite x))
+
+(defn abs
+  "Returns the absolute value of `x`."
+  {:example "(abs -5) ; => 5"}
+  [x]
+  (php/abs x))
+
 (defn rand
   "Returns a random number between 0 and 1."
   []
@@ -3233,3 +3246,72 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
       (if (= e f)
         e
         (recur e)))))
+
+;; --- Map utilities ---
+
+(defn update-keys
+  "Returns a map with `f` applied to each key."
+  {:example "(update-keys {:a 1 :b 2} name) ; => {\"a\" 1 \"b\" 2}"
+   :see-also ["update-vals" "keys" "update"]}
+  [m f]
+  (for [[k v] :pairs m
+        :reduce [acc {}]]
+    (assoc acc (f k) v)))
+
+(defn update-vals
+  "Returns a map with `f` applied to each value."
+  {:example "(update-vals {:a 1 :b 2} inc) ; => {:a 2 :b 3}"
+   :see-also ["update-keys" "values" "update"]}
+  [m f]
+  (for [[k v] :pairs m
+        :reduce [acc {}]]
+    (assoc acc k (f v))))
+
+;; --- Safe parsing ---
+
+(defn parse-long
+  "Parses a string as an integer. Returns nil if parsing fails."
+  {:example "(parse-long \"123\") ; => 123"
+   :see-also ["parse-double"]}
+  [s]
+  (when (string? s)
+    (let [trimmed (php/trim s)]
+      (when (= 1 (php/preg_match "/^[+-]?[0-9]+$/" trimmed))
+        (php/intval trimmed)))))
+
+(defn parse-double
+  "Parses a string as a float. Returns nil if parsing fails."
+  {:example "(parse-double \"3.14\") ; => 3.14"
+   :see-also ["parse-long"]}
+  [s]
+  (when (string? s)
+    (let [trimmed (php/trim s)]
+      (when (php/is_numeric trimmed)
+        (php/floatval trimmed)))))
+
+(defn parse-boolean
+  "Parses a string as a boolean. Returns true for \"true\", false for \"false\", nil otherwise."
+  {:example "(parse-boolean \"true\") ; => true"}
+  [s]
+  (when (string? s)
+    (let [lower (php/strtolower (php/trim s))]
+      (cond
+        (= lower "true") true
+        (= lower "false") false))))
+
+(defn random-uuid
+  "Returns a random UUID v4 string."
+  {:example "(random-uuid) ; => \"550e8400-e29b-41d4-a716-446655440000\""}
+  []
+  (let [bytes (php/random_bytes 16)]
+    ;; Set version 4 (bits 12-15 of time_hi_and_version)
+    (php/aset bytes 6 (php/chr (bit-or (bit-and (php/ord (php/aget bytes 6)) 0x0f) 0x40)))
+    ;; Set variant (bits 6-7 of clock_seq_hi_and_reserved)
+    (php/aset bytes 8 (php/chr (bit-or (bit-and (php/ord (php/aget bytes 8)) 0x3f) 0x80)))
+    (let [hex (php/bin2hex bytes)]
+      (php/.
+        (php/substr hex 0 8) "-"
+        (php/substr hex 8 4) "-"
+        (php/substr hex 12 4) "-"
+        (php/substr hex 16 4) "-"
+        (php/substr hex 20 12)))))

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -1,0 +1,70 @@
+(ns phel-test\test\core\utility-functions
+  (:require phel\test :refer [deftest is]))
+
+;; --- Math predicates & functions ---
+
+(deftest test-inf?
+  (is (true? (inf? php/INF)) "(inf? INF)")
+  (is (true? (inf? (- php/INF))) "(inf? -INF)")
+  (is (false? (inf? 0)) "(inf? 0)")
+  (is (false? (inf? 1.5)) "(inf? 1.5)")
+  (is (false? (inf? php/NAN)) "(inf? NAN)"))
+
+(deftest test-abs
+  (is (= 5 (abs -5)) "(abs -5)")
+  (is (= 5 (abs 5)) "(abs 5)")
+  (is (= 0 (abs 0)) "(abs 0)")
+  (is (= 3.14 (abs -3.14)) "(abs -3.14)"))
+
+;; --- Map utilities ---
+
+(deftest test-update-keys
+  (is (= {"a" 1 "b" 2} (update-keys {:a 1 :b 2} name)) "update-keys with name")
+  (is (= {} (update-keys {} identity)) "update-keys on empty map"))
+
+(deftest test-update-vals
+  (is (= {:a 2 :b 3} (update-vals {:a 1 :b 2} inc)) "update-vals with inc")
+  (is (= {:a "1" :b "2"} (update-vals {:a 1 :b 2} str)) "update-vals with str")
+  (is (= {} (update-vals {} identity)) "update-vals on empty map"))
+
+;; --- Safe parsing ---
+
+(deftest test-parse-long
+  (is (= 123 (parse-long "123")) "parse-long positive")
+  (is (= -42 (parse-long "-42")) "parse-long negative")
+  (is (= 0 (parse-long "0")) "parse-long zero")
+  (is (= 123 (parse-long "  123  ")) "parse-long with whitespace")
+  (is (nil? (parse-long "abc")) "parse-long non-numeric")
+  (is (nil? (parse-long "12.5")) "parse-long float string")
+  (is (nil? (parse-long "")) "parse-long empty string")
+  (is (nil? (parse-long nil)) "parse-long nil"))
+
+(deftest test-parse-double
+  (is (= 3.14 (parse-double "3.14")) "parse-double float")
+  (is (= 42.0 (parse-double "42")) "parse-double integer string")
+  (is (= -1.5 (parse-double "-1.5")) "parse-double negative")
+  (is (= 0.0 (parse-double "0")) "parse-double zero")
+  (is (nil? (parse-double "abc")) "parse-double non-numeric")
+  (is (nil? (parse-double "")) "parse-double empty string")
+  (is (nil? (parse-double nil)) "parse-double nil"))
+
+(deftest test-parse-boolean
+  (is (true? (parse-boolean "true")) "parse-boolean true")
+  (is (false? (parse-boolean "false")) "parse-boolean false")
+  (is (true? (parse-boolean "TRUE")) "parse-boolean TRUE")
+  (is (false? (parse-boolean "FALSE")) "parse-boolean FALSE")
+  (is (true? (parse-boolean "  true  ")) "parse-boolean with whitespace")
+  (is (nil? (parse-boolean "yes")) "parse-boolean invalid")
+  (is (nil? (parse-boolean "1")) "parse-boolean 1")
+  (is (nil? (parse-boolean "")) "parse-boolean empty")
+  (is (nil? (parse-boolean nil)) "parse-boolean nil"))
+
+;; --- UUID ---
+
+(deftest test-random-uuid
+  (let [uuid (random-uuid)]
+    (is (string? uuid) "random-uuid returns a string")
+    (is (= 36 (php/strlen uuid)) "random-uuid has 36 characters")
+    (is (truthy? (php/preg_match "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/" uuid))
+        "random-uuid matches UUID v4 format")
+    (is (not= uuid (random-uuid)) "random-uuid generates unique values")))


### PR DESCRIPTION
## 🤔 Background

Phel is missing several utility functions that are standard in Clojure 1.11+. These are pure Phel functions with no compiler changes needed.

## 💡 Goal

Add `update-keys`, `update-vals`, safe parsing functions (`parse-long`, `parse-double`, `parse-boolean`), and math/utility helpers (`abs`, `inf?`, `random-uuid`).

Note: `nan?` already exists — not duplicated.

## 🔖 Changes

- `update-keys` / `update-vals` — transform map keys or values with a function
- `parse-long` — safe integer parsing, returns nil on failure
- `parse-double` — safe float parsing, returns nil on failure
- `parse-boolean` — parses "true"/"false" strings, nil otherwise
- `abs` — absolute value via `php/abs`
- `inf?` — infinite check via `php/is_infinite`
- `random-uuid` — UUID v4 generation
- Full test coverage in `tests/phel/test/core/utility-functions.phel`
- CHANGELOG updated

Closes #1150