### PR TITLE
feat: add hierarchy system with hierarchy-aware multimethod dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add hierarchy system: `derive`, `underive`, `isa?`, `parents`, `ancestors`, `descendants`, `make-hierarchy` for keyword taxonomies with hierarchy-aware multimethod dispatch (#1156)
 - Add `@` reader syntax as shorthand for `(deref ...)`, e.g. `@my-var` expands to `(deref my-var)` (#1164)
 - Add `re-find`, `re-matches` regex functions (#1153)
 - Add `add-watch`, `remove-watch`, `set-validator!`, `get-validator` for variable state observation and constraints (#1154)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3140,6 +3140,130 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        (definterface* ,name ,@fns)
        ,@defs)))
 
+;; ---------
+;; Hierarchy
+;; ---------
+
+(def ^:private *hierarchy*
+  "Global hierarchy for keyword/symbol taxonomies."
+  (var {:parents {}}))
+
+(defn make-hierarchy
+  "Creates a fresh, empty hierarchy."
+  {:doc "Returns a new hierarchy map with no parent relationships."
+   :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
+  []
+  {:parents {}})
+
+(defn- compute-ancestors
+  "Computes all transitive ancestors of tag from a parents map."
+  [parents-map tag]
+  (let [direct (get parents-map tag)]
+    (if (nil? direct)
+      (hash-set)
+      (reduce
+        (fn [acc p]
+          (union acc (hash-set p) (compute-ancestors parents-map p)))
+        (hash-set)
+        direct))))
+
+(defn isa?
+  "Returns true if child equals parent, or child is a descendant of parent
+  in the global hierarchy."
+  {:example "(do (derive :square :shape) (isa? :square :shape)) ; => true"
+   :see-also ["derive" "parents" "ancestors" "descendants"]}
+  [child parent]
+  (or (= child parent)
+      (contains? (compute-ancestors (get @*hierarchy* :parents) child) parent)))
+
+(defn derive
+  "Establishes a parent/child relationship between child and parent keywords
+  in the global hierarchy. Throws on cyclic derivation."
+  {:example "(derive :square :shape)"
+   :see-also ["underive" "isa?" "parents" "ancestors" "descendants"]}
+  [child parent]
+  (when (isa? parent child)
+    (throw (php/new \InvalidArgumentException
+                    (str "Cyclic derivation: " parent " already isa " child))))
+  (swap! *hierarchy*
+    (fn [h]
+      (let [parents-map (get h :parents)
+            old-parents (get parents-map child (hash-set))
+            new-parents (union old-parents (hash-set parent))]
+        {:parents (assoc parents-map child new-parents)})))
+  nil)
+
+(defn underive
+  "Removes a parent/child relationship from the global hierarchy."
+  {:example "(underive :square :shape)"
+   :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
+  [child parent]
+  (swap! *hierarchy*
+    (fn [h]
+      (let [parents-map (get h :parents)
+            old-parents (get parents-map child (hash-set))
+            new-parents (difference old-parents (hash-set parent))
+            new-map (if (empty? new-parents)
+                      (dissoc parents-map child)
+                      (assoc parents-map child new-parents))]
+        {:parents new-map})))
+  nil)
+
+(defn parents
+  "Returns the set of immediate parents of tag in the global hierarchy, or nil."
+  {:see-also ["ancestors" "descendants" "derive" "isa?"]}
+  [tag]
+  (let [p (get (get @*hierarchy* :parents) tag)]
+    (when (and p (not (empty? p))) p)))
+
+(defn ancestors
+  "Returns the set of all transitive ancestors of tag, or nil."
+  {:see-also ["parents" "descendants" "derive" "isa?"]}
+  [tag]
+  (let [a (compute-ancestors (get @*hierarchy* :parents) tag)]
+    (when (not (empty? a)) a)))
+
+(defn descendants
+  "Returns the set of all descendants of tag, or nil."
+  {:see-also ["parents" "ancestors" "derive" "isa?"]}
+  [tag]
+  (let [parents-map (get @*hierarchy* :parents)
+        all-children (keys parents-map)
+        result (reduce
+                 (fn [acc child]
+                   (if (contains? (compute-ancestors parents-map child) tag)
+                     (union acc (hash-set child))
+                     acc))
+                 (hash-set)
+                 all-children)]
+    (when (not (empty? result)) result)))
+
+(defn find-hierarchy-method
+  "Finds the best matching method for dispatch-val using the global hierarchy.
+  Returns the method function or nil. Used internally by defmulti."
+  [methods dispatch-val]
+  (let [method-keys (keys methods)
+        candidates (reduce
+                     (fn [acc k]
+                       (if (and (not= k :default)
+                                (not= k dispatch-val)
+                                (isa? dispatch-val k))
+                         (conj acc k)
+                         acc))
+                     []
+                     method-keys)]
+    (when (not (empty? candidates))
+      (if (= 1 (count candidates))
+        (get methods (first candidates))
+        (let [best (reduce
+                     (fn [best k]
+                       (if (isa? k best)
+                         k
+                         best))
+                     (first candidates)
+                     (rest candidates))]
+          (get methods best))))))
+
 ;; ------------
 ;; Multimethods
 ;; ------------
@@ -3164,11 +3288,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                method (get methods dispatch-val)]
            (if method
              (apply method args)
-             (let [default-method (get methods :default)]
-               (if default-method
-                 (apply default-method args)
-                 (throw (php/new \InvalidArgumentException
-                                 (str "No method for dispatch value: " dispatch-val)))))))))))
+             (let [hierarchy-method (find-hierarchy-method methods dispatch-val)]
+               (if hierarchy-method
+                 (apply hierarchy-method args)
+                 (let [default-method (get methods :default)]
+                   (if default-method
+                     (apply default-method args)
+                     (throw (php/new \InvalidArgumentException
+                                     (str "No method for dispatch value: " dispatch-val)))))))))))))
 
 (defmacro defmethod
   "Registers a method implementation for a multimethod.

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -1,0 +1,116 @@
+(ns phel-test\test\core\hierarchy
+  (:require phel\test :refer [deftest is]))
+
+;; Each test uses unique keyword prefixes to avoid state leaking between tests.
+
+;; --- derive / isa? ---
+
+(deftest test-derive-and-isa
+  (derive :d1-square :d1-shape)
+  (is (true? (isa? :d1-square :d1-shape)) "child isa parent")
+  (is (false? (isa? :d1-shape :d1-square)) "parent is not child")
+  (is (true? (isa? :d1-square :d1-square)) "identity: x isa x"))
+
+(deftest test-transitive-isa
+  (derive :t1-b :t1-a)
+  (derive :t1-c :t1-b)
+  (is (true? (isa? :t1-c :t1-a)) "transitive: c isa a via b")
+  (is (true? (isa? :t1-c :t1-b)) "direct: c isa b")
+  (is (false? (isa? :t1-a :t1-c)) "not reverse"))
+
+(deftest test-multiple-parents
+  (derive :mp-child :mp-parent1)
+  (derive :mp-child :mp-parent2)
+  (is (true? (isa? :mp-child :mp-parent1)) "isa first parent")
+  (is (true? (isa? :mp-child :mp-parent2)) "isa second parent"))
+
+(deftest test-cyclic-derivation-throws
+  (derive :cy-a :cy-b)
+  (is (thrown? \InvalidArgumentException (derive :cy-b :cy-a))
+      "cyclic derivation throws"))
+
+;; --- parents ---
+
+(deftest test-parents
+  (derive :p1-child :p1-parent)
+  (let [p (parents :p1-child)]
+    (is (not (nil? p)) "parents returns non-nil")
+    (is (contains? p :p1-parent) "contains the parent")))
+
+(deftest test-parents-nil-for-root
+  (is (nil? (parents :p2-nonexistent)) "no parents returns nil"))
+
+;; --- ancestors ---
+
+(deftest test-ancestors
+  (derive :a1-b :a1-a)
+  (derive :a1-c :a1-b)
+  (let [anc (ancestors :a1-c)]
+    (is (not (nil? anc)) "ancestors returns non-nil")
+    (is (contains? anc :a1-b) "contains direct parent")
+    (is (contains? anc :a1-a) "contains transitive ancestor")))
+
+(deftest test-ancestors-nil-for-root
+  (is (nil? (ancestors :a2-nonexistent)) "no ancestors returns nil"))
+
+;; --- descendants ---
+
+(deftest test-descendants
+  (derive :dc-child :dc-root)
+  (derive :dc-grandchild :dc-child)
+  (let [desc (descendants :dc-root)]
+    (is (not (nil? desc)) "descendants returns non-nil")
+    (is (contains? desc :dc-child) "contains child")
+    (is (contains? desc :dc-grandchild) "contains grandchild")))
+
+(deftest test-descendants-nil-for-leaf
+  (is (nil? (descendants :dc2-nonexistent)) "no descendants returns nil"))
+
+;; --- underive ---
+
+(deftest test-underive
+  (derive :u1-child :u1-parent)
+  (is (true? (isa? :u1-child :u1-parent)) "isa before underive")
+  (underive :u1-child :u1-parent)
+  (is (false? (isa? :u1-child :u1-parent)) "not isa after underive"))
+
+(deftest test-underive-preserves-other-parents
+  (derive :u2-child :u2-p1)
+  (derive :u2-child :u2-p2)
+  (underive :u2-child :u2-p1)
+  (is (false? (isa? :u2-child :u2-p1)) "removed parent gone")
+  (is (true? (isa? :u2-child :u2-p2)) "other parent preserved"))
+
+;; --- make-hierarchy ---
+
+(deftest test-make-hierarchy
+  (let [h (make-hierarchy)]
+    (is (= {:parents {}} h) "fresh hierarchy is empty map")))
+
+;; --- multimethod with hierarchy dispatch ---
+
+;; Multimethods must be top-level (defmulti expands to def)
+(derive :mh-circle :mh-shape)
+(derive :mh-square :mh-shape)
+(defmulti mh-draw :type)
+(defmethod mh-draw :mh-shape [_] "generic shape")
+(defmethod mh-draw :mh-circle [_] "circle")
+
+(deftest test-multimethod-hierarchy-dispatch
+  (is (= "circle" (mh-draw {:type :mh-circle})) "exact match preferred")
+  (is (= "generic shape" (mh-draw {:type :mh-square})) "hierarchy dispatch"))
+
+(derive :ms-rect :ms-shape)
+(derive :ms-colored-rect :ms-rect)
+(defmulti ms-render :type)
+(defmethod ms-render :ms-shape [_] "shape")
+(defmethod ms-render :ms-rect [_] "rect")
+
+(deftest test-multimethod-hierarchy-prefers-specific
+  (is (= "rect" (ms-render {:type :ms-colored-rect})) "prefers most specific ancestor"))
+
+(defmulti mf-process :kind)
+(defmethod mf-process :default [m] "default")
+
+(deftest test-multimethod-default-fallback-with-hierarchy
+  (is (= "default" (mf-process {:kind :mf-unknown})) "falls back to default"))


### PR DESCRIPTION
## 🤔 Background

Phel's multimethods (`defmulti`/`defmethod`) only support exact dispatch value matching. There's no way to express that `:square` IS-A `:shape`, so dispatch can't inherit behavior through a taxonomy. Clojure solves this with its hierarchy system.

## 💡 Goal

Add Clojure's ad-hoc hierarchy system so keywords can form parent/child taxonomies, and multimethods dispatch through the hierarchy when no exact match exists.

## 🔖 Changes

**Hierarchy functions** (added to `core.phel` before `defmulti`):

| Function | Purpose |
|----------|---------|
| `make-hierarchy` | Create a fresh empty hierarchy |
| `derive` | Establish parent/child relationship |
| `underive` | Remove parent/child relationship |
| `isa?` | Check if child equals or descends from parent (transitive) |
| `parents` | Get immediate parents set |
| `ancestors` | Get all transitive ancestors set |
| `descendants` | Get all descendants set |

**Multimethod integration**: Updated `defmulti` dispatch to:
1. Try exact match (existing behavior)
2. Search for hierarchy-based match via `find-hierarchy-method`
3. Among multiple matches, prefer the most specific (the one that `isa?` all others)
4. Fall back to `:default`

**Design decisions**:
- Store only `:parents` map in hierarchy — ancestors/descendants computed on demand (simpler, correct underive without transitive closure rebuild)
- Global hierarchy via private `*hierarchy*` var — sufficient for the common case
- 17 tests covering derive, transitive isa?, multiple parents, cycle detection, underive, and multimethod hierarchy dispatch

Closes #1156