### PR TITLE
fix(compiler): emit namespaced php/ functions as fully qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Emit `php/...` calls to namespaced PHP functions (e.g. `php/Amp\File\write`) as fully qualified names so they resolve against the global namespace from compiled/cached files (#1180)
+
 ### Deprecated
 - `|(...)` short function syntax with `$` placeholders; use `#(...)` with `%` placeholders instead
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
@@ -10,6 +10,8 @@ use Phel\Lang\SourceLocation;
 
 use function in_array;
 use function is_callable;
+use function ltrim;
+use function str_contains;
 
 final class PhpVarNode extends AbstractNode
 {
@@ -68,6 +70,23 @@ final class PhpVarNode extends AbstractNode
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Returns the name suitable for emitting as a PHP function reference.
+     *
+     * Namespaced PHP functions (containing a backslash) are returned as
+     * fully qualified names with a single leading backslash so they resolve
+     * against the global namespace, regardless of any active `namespace ...;`
+     * declaration in the emitted PHP file.
+     */
+    public function getAbsoluteName(): string
+    {
+        if (!str_contains($this->name, '\\')) {
+            return $this->name;
+        }
+
+        return '\\' . ltrim($this->name, '\\');
     }
 
     public function isInfix(): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
@@ -60,7 +60,7 @@ final class ApplyEmitter implements NodeEmitterInterface
 
     private function phpVarNodeButNoInfix(ApplyNode $node, PhpVarNode $fnNode): void
     {
-        $this->outputEmitter->emitStr($fnNode->getName(), $fnNode->getStartSourceLocation());
+        $this->outputEmitter->emitStr($fnNode->getAbsoluteName(), $fnNode->getStartSourceLocation());
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         $this->emitArguments($node);
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -77,7 +77,7 @@ final class CallEmitter implements NodeEmitterInterface
 
     private function emitPhpFunctionName(PhpVarNode $fnNode): void
     {
-        $name = $fnNode->getName();
+        $name = $fnNode->getAbsoluteName();
 
         if ($name === 'echo') {
             $name = 'print';

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpVarEmitter.php
@@ -20,13 +20,15 @@ final class PhpVarEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
 
+        $name = $node->getAbsoluteName();
+
         if ($node->isCallable()) {
             $this->outputEmitter->emitStr(
-                '(function(...$args) { return ' . $node->getName() . '(...$args);' . '})',
+                '(function(...$args) { return ' . $name . '(...$args);' . '})',
                 $node->getStartSourceLocation(),
             );
         } else {
-            $this->outputEmitter->emitStr($node->getName(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr($name, $node->getStartSourceLocation());
         }
 
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/tests/php/Integration/Fixtures/Call/php-namespaced-function-call.test
+++ b/tests/php/Integration/Fixtures/Call/php-namespaced-function-call.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/Amp\now)
+--PHP--
+\Amp\now();

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -91,4 +91,18 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('yield 1 => 2;');
     }
 
+    public function test_namespaced_php_function_is_emitted_as_fully_qualified(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp\\File\\write');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
+    }
+
 }


### PR DESCRIPTION
## 🤔 Background

When the test runner re-uses its compiled cache, the cached PHP file starts with a `namespace app\core;` declaration. PHP's function resolution then prepends the active namespace to any unqualified call, so a Phel form like `(php/Amp\File\write "foo.txt" "data")` was emitted as `Amp\File\write(...)` and looked up as `app\core\Amp\File\write(...)`, producing:

```
Call to undefined function app\core\amp\file\write() // file: /tmp/phel/cache/compiled/app_core.php
```

`phel run` worked because that path uses the statement emitter, which never emits a `namespace ...;` declaration around the eval'd code, so the call ran in the global namespace.

## 💡 Goal

`(php/...)` calls to namespaced PHP functions should always resolve against the global namespace, regardless of the active PHP namespace in the emitted file.

## 🔖 Changes

- `PhpVarNode::getAbsoluteName()` returns the name with a single leading backslash whenever it contains a namespace separator (idempotent — will not double-prefix names that already start with `\`).
- `CallEmitter`, `ApplyEmitter`, and `PhpVarEmitter` now use `getAbsoluteName()` when emitting the PHP function name. Plain (non-namespaced) names like `substr`, `print`, `echo`, `yield`, and infix operators are untouched.
- New integration fixture `Call/php-namespaced-function-call.test` and a unit test in `CallEmitterTest` lock the behavior in.
- `CHANGELOG.md` entry under `## Unreleased`.

Closes #1180