### PR TITLE
feat(core): add 1-arg some? for Clojure compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- 1-arg `(some? x)` form returning `true` when `x` is not `nil`, matching Clojure semantics; the existing 2-arg `(some? pred coll)` form keeps working unchanged (#1184)
 - Accept Clojure-style vector entries in `:require`, e.g. `(:require [phel\str :as s :refer [upper-case]])`, including multiple vector entries in a single `:require` clause, for `.cljc` interop (#1183)
 - Accept `.` as an alternate namespace separator in `(ns ...)`, `(in-ns ...)`, `:require`, and `:use` forms, enabling Clojure-style namespaces (e.g. `(ns my.cljc.file)`) for `.cljc` interop (#1177)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -696,14 +696,16 @@ Otherwise, it tries to call `__toString`."
 (declare name)
 
 (defn some?
-  "Returns true if predicate is true for at least one element in collection, false otherwise."
-  {:example "(some? even? [1 3 5 6 7]) ; => true"}
-  [pred coll]
-  (if (empty? coll)
-    false
-    (if (truthy? (pred (first coll)))
-      true
-      (recur pred (next coll)))))
+  "With 1 arg, returns true if `x` is not nil (Clojure semantics).
+   With 2 args, returns true if `pred` is true for at least one element in `coll`."
+  {:example "(some? 1) ; => true\n(some? even? [1 3 5 6 7]) ; => true"}
+  ([x] (not (nil? x)))
+  ([pred coll]
+   (if (empty? coll)
+     false
+     (if (truthy? (pred (first coll)))
+       true
+       (recur pred (next coll))))))
 
 (defn not-any?
   "Returns true if `(pred x)` is logical false for every `x` in `coll`

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -154,6 +154,14 @@
 (deftest test-some?-empty-element
   (is (false? (some? #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 
+(deftest test-some?-1-arg-clojure-semantics
+  (is (true? (some? 0))           "0 is not nil")
+  (is (true? (some? false))       "false is not nil (nil-test, not truthy-test)")
+  (is (true? (some? ""))          "empty string is not nil")
+  (is (true? (some? []))          "empty vector is not nil")
+  (is (false? (some? nil))        "nil returns false")
+  (is (true? (some? "anything"))  "string value is not nil"))
+
 (deftest test-not-any?
   (is (false? (not-any? pos? [1 -1 3])) "not-any? one pos")
   (is (true? (not-any? pos? [])) "not-any? empty list")


### PR DESCRIPTION
## 🤔 Background

In Clojure, [`some?`](https://clojuredocs.org/clojure.core/some_q) is a 1-arg predicate that returns \`true\` iff its argument is not \`nil\`. In Phel, \`some?\` is a 2-arg function \`(some? pred coll)\` — same semantic as Clojure's \`some\` (which Phel also has, at \`src/phel/core.phel:714\`).

Porting Clojure code to Phel breaks on this mismatch:

```clojure
(some? (:ns &env))
;; Phel: [PHEL002] Wrong number of arguments to function "phel\core\some?". Got: 1. Expected: 2
```

This continues the broader Clojure-alignment direction (after #1183 and #1177).

## 💡 Goal

Support the Clojure 1-arg form \`(some? x)\` while keeping Phel's existing 2-arg form working unchanged for backward compatibility.

## 🔖 Changes

- \`some?\` is now multi-arity:
  - \`(some? x)\` — Clojure semantics: returns \`true\` iff \`x\` is not \`nil\`. **Crucially \`(some? false) => true\`** because it's a nil-test, not a truthy-test.
  - \`(some? pred coll)\` — unchanged: returns \`true\` if any element in \`coll\` matches \`pred\`.
- Updated docstring and \`:example\` to cover both arities.
- Added \`test-some?-1-arg-clojure-semantics\` in \`tests/phel/test/core/boolean-operation.phel\` covering \`nil\`, \`false\`, \`0\`, \`""\`, \`[]\`, and a string. The crucial assertion is \`(some? false) => true\`.
- Existing 2-arg tests (\`test-some?\`, \`test-some?-empty-element\`) still pass unchanged.
- 2-arg form is **not** deprecated in this PR — separate decision.

Closes #1184