### PR TITLE
feat(core): add boolean coercion function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `(boolean x)` coercion function returning `false` for `nil`/`false` and `true` otherwise, matching Clojure semantics (#1186)
 - Clojure-compatible `&form` and `&env` implicit symbols inside every `defmacro` body: `&form` is the original macro call form, `&env` is a map of locals in scope at the call site, enabling dialect detection patterns like `(:ns &env)` for `.cljc` interop (#1185)
 - 1-arg `(some? x)` form returning `true` when `x` is not `nil`, matching Clojure semantics; the existing 2-arg `(some? pred coll)` form keeps working unchanged (#1184)
 - Accept Clojure-style vector entries in `:require`, e.g. `(:require [phel\str :as s :refer [upper-case]])`, including multiple vector entries in a single `:require` clause, for `.cljc` interop (#1183)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -877,6 +877,13 @@ Otherwise, it tries to call `__toString`."
   [x]
   (= (type x) :boolean))
 
+(defn boolean
+  "Coerces `x` to a boolean. Returns `false` if `x` is `nil` or `false`,
+   `true` otherwise."
+  {:example "(boolean nil) ; => false"}
+  [x]
+  (if x true false))
+
 (defn php-array?
   "Returns true if `x` is a PHP Array, false otherwise."
   [x]

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -186,6 +186,16 @@
   (is (false? (truthy? nil)) "(truthy? nil)")
   (is (false? (truthy? false)) "(truthy? false)"))
 
+(deftest test-boolean
+  (is (true? (boolean true)) "(boolean true)")
+  (is (true? (boolean [])) "(boolean [])")
+  (is (true? (boolean 10)) "(boolean 10)")
+  (is (true? (boolean 0)) "(boolean 0)")
+  (is (true? (boolean "")) "(boolean \"\")")
+  (is (true? (boolean :a)) "(boolean :a)")
+  (is (false? (boolean nil)) "(boolean nil)")
+  (is (false? (boolean false)) "(boolean false)"))
+
 (deftest test-false?
   (is (true? (false? false)) "(false? false)")
   (is (false? (false? nil)) "(false? nil)")


### PR DESCRIPTION
## 🤔 Background

Closes #1186

Clojure ships `(boolean x)` as a boolean coercion primitive, returning `false` for `nil`/`false` and `true` for every other value. Phel already had the predicate `boolean?` but no coercion counterpart, so cross-dialect code such as the `when-var-exists` macro from the [clojure-test-suite](https://github.com/jank-lang/clojure-test-suite/blob/main/test/clojure/core_test/portability.cljc#L7) failed with `Cannot resolve symbol 'boolean'`.

## 💡 Goal

Add `(boolean x)` to `phel\core` with Clojure-aligned semantics so `.cljc` code that coerces to boolean compiles cleanly under Phel.

## 🔖 Changes

- Added `boolean` in `src/phel/core.phel` right after `boolean?`, implemented as `(if x true false)` — `nil` and `false` coerce to `false`, everything else (including `0`, `""`, `[]`, keywords, etc.) coerces to `true`, matching Clojure.
- Added `test-boolean` covering the full truthiness matrix (true/false/nil, numeric zero, empty string, empty vector, keyword) in `tests/phel/test/core/boolean-operation.phel`.
- Recorded the addition under `## Unreleased` → `### Added` in `CHANGELOG.md`.