### PR TITLE
feat(core): expose resolve globally in phel\core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `(resolve sym)` is now available globally in `phel\core`, no longer requiring `(:require phel\repl :refer [resolve])`, matching Clojure semantics (#1187)
 - `(boolean x)` coercion function returning `false` for `nil`/`false` and `true` otherwise, matching Clojure semantics (#1186)
 - Clojure-compatible `&form` and `&env` implicit symbols inside every `defmacro` body: `&form` is the original macro call form, `&env` is a map of locals in scope at the call site, enabling dialect detection patterns like `(:ns &env)` for `.cljc` interop (#1185)
 - 1-arg `(some? x)` form returning `true` when `x` is not `nil`, matching Clojure semantics; the existing 2-arg `(some? pred coll)` form keeps working unchanged (#1184)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3846,6 +3846,13 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 (defn- get-global-var-node [sym]
   (php/-> (get-global-env) (resolve sym (php/:: NodeEnvironment (empty)))))
 
+(defn resolve
+  "Resolves the given symbol in the current environment and returns a resolved Symbol with the absolute namespace or nil if it cannot be resolved."
+  {:example "(resolve 'map) ; => phel\\core/map"}
+  [sym]
+  (-> (get-global-env)
+      (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))
+
 (defn- inline-call? [meta arity]
   (and (:inline meta)
        (let [af (:inline-arity meta)]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -56,13 +56,6 @@
       (when-not (php/in_array (php/-> dep (getNamespace)) (loaded-namespaces))
         (eval-file (php/-> dep (getFile)))))))
 
-(defn resolve
-  "Resolves the given symbol in the current environment and returns a resolved Symbol with the absolute namespace or nil if it cannot be resolved."
-  {:example "(resolve 'map) ; => phel\\core/map"}
-  [sym]
-  (-> (get-global-env)
-      (php/-> (resolveAsSymbol sym (php/:: NodeEnvironment (empty))))))
-
 (defn- clean-doc [str]
   (php/trim (php/str_replace (php/array "```phel\n" "```") "" str)))
 

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -68,3 +68,27 @@
     (is (truthy? (php/preg_match "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/" uuid))
         "random-uuid matches UUID v4 format")
     (is (not= uuid (random-uuid)) "random-uuid generates unique values")))
+
+;; --- resolve ---
+
+(deftest test-resolve-known-symbol
+  (let [sym (resolve 'map)]
+    (is (not (nil? sym)) "resolve returns non-nil for known symbol")
+    (is (= "phel\\core" (namespace sym)) "resolve returns correct namespace")
+    (is (= "map" (name sym)) "resolve returns correct name")))
+
+(deftest test-resolve-unknown-symbol
+  (is (nil? (resolve 'definitely-not-a-real-symbol-zzz))
+      "resolve returns nil for unknown symbol"))
+
+(deftest test-resolve-special-char-symbol
+  (let [sym (resolve '+)]
+    (is (not (nil? sym)) "resolve handles special-char names")
+    (is (= "phel\\core" (namespace sym)) "+ resolves to phel\\core")
+    (is (= "+" (name sym)) "+ resolves with correct name")))
+
+(deftest test-resolve-itself-in-core
+  (let [sym (resolve 'resolve)]
+    (is (not (nil? sym)) "resolve resolves itself")
+    (is (= "phel\\core" (namespace sym)) "resolve lives in phel\\core")
+    (is (= "resolve" (name sym)) "resolve has correct name")))


### PR DESCRIPTION
## 🤔 Background

`resolve` currently lives in `phel\repl`, so any code that wants to call it must include `(:require phel\repl :refer [resolve])`. Clojure exposes `resolve` directly from `clojure.core`, which makes it globally available without any require.

This forces `.cljc` interop code (e.g. the [clojure-test-suite portability tests](https://github.com/jank-lang/clojure-test-suite/blob/ac33a6c9dbed0b4e8fc45dbc401faf7f02f246c1/test/clojure/core_test/portability.cljc)) to add Phel-specific `:require` clauses just to call `resolve`, adding friction to cross-dialect code.

## 💡 Goal

Make `resolve` available globally — no `:require` needed — to match Clojure semantics. Continues the project's steady Clojure-compatibility additions.

## 🔖 Changes

- Move `(defn resolve ...)` from `src/phel/repl.phel` to `src/phel/core.phel`
- `phel\core` already imports `GlobalEnvironmentSingleton`, `NodeEnvironment`, and `Symbol`, so no new `:use` clauses are needed
- Internal callers in `phel\repl` (`doc`, `symbol-info`, `source`) call `(resolve sym)` unqualified and now resolve to `phel\core/resolve` transparently
- Add tests in `tests/phel/test/core/utility-functions.phel` covering known symbols, unknown symbols, special-character names (`+`), and self-resolution
- Update `CHANGELOG.md` under `## Unreleased` → `### Added`

Closes #1187