### PR TITLE
ref(compiler): extract SymbolResolver and MagicConstantResolver from GlobalEnvironment

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -7,20 +7,15 @@ namespace Phel\Compiler\Domain\Analyzer\Environment;
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
-use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Exceptions\DuplicateDefinitionException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
-use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Shared\BuildConstants;
 use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
-use RuntimeException;
 
 use function array_key_exists;
-use function dirname;
 
 final class GlobalEnvironment implements GlobalEnvironmentInterface
 {
@@ -43,8 +38,11 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     private int $allowPrivateAccessCounter = 0;
 
+    private readonly SymbolResolver $symbolResolver;
+
     public function __construct()
     {
+        $this->symbolResolver = new SymbolResolver($this, new MagicConstantResolver());
         $this->addInternalBuildModeDefinition();
     }
 
@@ -150,6 +148,14 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         return $this->useAliases[$namespace] ?? [];
     }
 
+    /**
+     * @return array<string, Symbol>
+     */
+    public function getInterfaces(string $namespace): array
+    {
+        return $this->interfaces[$namespace] ?? [];
+    }
+
     public function resolveAsSymbol(Symbol $name, NodeEnvironment $env): ?Symbol
     {
         $node = $this->resolve($name, $env);
@@ -162,35 +168,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
     {
-        $strName = $name->getName();
-
-        if ($strName === '__DIR__') {
-            return new LiteralNode(
-                $env,
-                $this->resolveMagicDir($name->getStartLocation()),
-            );
-        }
-
-        if ($strName === '__FILE__') {
-            return new LiteralNode(
-                $env,
-                $this->resolveMagicFile($name->getStartLocation()),
-            );
-        }
-
-        if ($strName[0] === '\\') {
-            return new PhpClassNameNode($env, $name, $name->getStartLocation());
-        }
-
-        if (isset($this->useAliases[$this->ns][$strName])) {
-            $alias = $this->useAliases[$this->ns][$strName];
-            $alias->copyLocationFrom($name);
-            return new PhpClassNameNode($env, $alias, $name->getStartLocation());
-        }
-
-        return ($name->getNamespace() !== null)
-            ? $this->resolveWithAlias($name, $env)
-            : $this->resolveWithoutAlias($name, $env);
+        return $this->symbolResolver->resolve($name, $env);
     }
 
     public function resolveAlias(string $alias): ?string
@@ -210,6 +188,11 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     public function removeLevelToAllowPrivateAccess(): void
     {
         --$this->allowPrivateAccessCounter;
+    }
+
+    public function isPrivateAccessAllowed(): bool
+    {
+        return $this->allowPrivateAccessCounter > 0;
     }
 
     public function addInterface(string $namespace, Symbol $name): void
@@ -307,130 +290,6 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             $meta,
         );
         $this->addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, $symbol);
-    }
-
-    private function resolveMagicFile(?SourceLocation $sl): ?string
-    {
-        return $this->resolveMagicSourceString($sl)
-            ?? $this->resolveRealpath($sl);
-    }
-
-    private function resolveMagicDir(?SourceLocation $sl): ?string
-    {
-        return $this->resolveMagicSourceString($sl)
-            ?? $this->resolveRealpathDirname($sl);
-    }
-
-    private function resolveMagicSourceString(?SourceLocation $sl): ?string
-    {
-        return ($sl instanceof SourceLocation && $sl->getFile() === 'string') ? '' : null;
-    }
-
-    private function resolveRealpath(?SourceLocation $sl): ?string
-    {
-        if (!$sl instanceof SourceLocation) {
-            return null;
-        }
-
-        $realpath = realpath($sl->getFile());
-
-        return $realpath === false ? null : $realpath;
-    }
-
-    private function resolveRealpathDirname(?SourceLocation $sl): ?string
-    {
-        if (!$sl instanceof SourceLocation) {
-            return null;
-        }
-
-        $realpath = realpath(dirname($sl->getFile()));
-
-        return $realpath === false ? null : $realpath;
-    }
-
-    private function resolveWithAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
-    {
-        $alias = $name->getNamespace();
-        if ($alias === null) {
-            throw new RuntimeException('resolveWithAlias called with a Symbol without namespace');
-        }
-
-        $finalName = Symbol::create($name->getName());
-        $ns = $this->resolveAlias($alias) ?? $alias;
-
-        return $this->resolveInterfaceOrDefinition($finalName, $env, $ns);
-    }
-
-    private function resolveWithoutAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
-    {
-        $currentNs = $this->ns;
-        if (isset($this->refers[$this->ns][$name->getName()])) {
-            $currentNs = $this->refers[$this->ns][$name->getName()]->getName();
-
-            return $this->resolveInterfaceOrDefinition($name, $env, $currentNs)
-                ?? $this->resolveInterfaceOrDefinition($name, $env, CompilerConstants::PHEL_CORE_NAMESPACE);
-        }
-
-        return $this->resolveInterfaceOrDefinitionForCurrentNs($name, $env, $currentNs)
-            ?? $this->resolveInterfaceOrDefinition($name, $env, CompilerConstants::PHEL_CORE_NAMESPACE);
-    }
-
-    /**
-     * It also includes private definitions from the current namespace.
-     */
-    private function resolveInterfaceOrDefinitionForCurrentNs(
-        Symbol $name,
-        NodeEnvironmentInterface $env,
-        string $ns,
-    ): ?AbstractNode {
-        if (isset($this->interfaces[$ns][$name->getName()])) {
-            return new PhpClassNameNode(
-                $env,
-                Symbol::createForNamespace($ns, $name->getName()),
-                $name->getStartLocation(),
-            );
-        }
-
-        $def = $this->getDefinition($ns, $name);
-        if ($def instanceof PersistentMapInterface) {
-            return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
-        }
-
-        return null;
-    }
-
-    /**
-     * It ignores private definitions (if they're not allowed) from the namespace.
-     */
-    private function resolveInterfaceOrDefinition(
-        Symbol $name,
-        NodeEnvironmentInterface $env,
-        string $ns,
-    ): ?AbstractNode {
-        if (isset($this->interfaces[$ns][$name->getName()])) {
-            return new PhpClassNameNode(
-                $env,
-                Symbol::createForNamespace($ns, $name->getName()),
-                $name->getStartLocation(),
-            );
-        }
-
-        $def = $this->getDefinition($ns, $name);
-        if (!$def instanceof PersistentMapInterface) {
-            return null;
-        }
-
-        if (!$this->isPrivateDefinitionAllowed($def)) {
-            return null;
-        }
-
-        return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
-    }
-
-    private function isPrivateDefinitionAllowed(PersistentMapInterface $meta): bool
-    {
-        return $this->allowPrivateAccessCounter > 0
-            || !$meta[Keyword::create('private')];
     }
 
     private function mungeEncodeNs(string $ns): string

--- a/src/php/Compiler/Domain/Analyzer/Environment/MagicConstantResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/MagicConstantResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+use Phel\Lang\SourceLocation;
+
+use function dirname;
+
+final class MagicConstantResolver
+{
+    public function resolveFile(?SourceLocation $sl): ?string
+    {
+        return $this->resolveSourceString($sl)
+            ?? $this->resolveRealpath($sl);
+    }
+
+    public function resolveDir(?SourceLocation $sl): ?string
+    {
+        return $this->resolveSourceString($sl)
+            ?? $this->resolveRealpathDirname($sl);
+    }
+
+    private function resolveSourceString(?SourceLocation $sl): ?string
+    {
+        return ($sl instanceof SourceLocation && $sl->getFile() === 'string') ? '' : null;
+    }
+
+    private function resolveRealpath(?SourceLocation $sl): ?string
+    {
+        if (!$sl instanceof SourceLocation) {
+            return null;
+        }
+
+        $realpath = realpath($sl->getFile());
+
+        return $realpath === false ? null : $realpath;
+    }
+
+    private function resolveRealpathDirname(?SourceLocation $sl): ?string
+    {
+        if (!$sl instanceof SourceLocation) {
+            return null;
+        }
+
+        $realpath = realpath(dirname($sl->getFile()));
+
+        return $realpath === false ? null : $realpath;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use RuntimeException;
+
+final readonly class SymbolResolver
+{
+    public function __construct(
+        private GlobalEnvironment $globalEnv,
+        private MagicConstantResolver $magicConstantResolver,
+    ) {}
+
+    public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
+    {
+        $strName = $name->getName();
+
+        if ($strName === '__DIR__') {
+            return new LiteralNode(
+                $env,
+                $this->magicConstantResolver->resolveDir($name->getStartLocation()),
+            );
+        }
+
+        if ($strName === '__FILE__') {
+            return new LiteralNode(
+                $env,
+                $this->magicConstantResolver->resolveFile($name->getStartLocation()),
+            );
+        }
+
+        if ($strName[0] === '\\') {
+            return new PhpClassNameNode($env, $name, $name->getStartLocation());
+        }
+
+        $useAliasNode = $this->resolveFromUseAlias($name, $env);
+        if ($useAliasNode instanceof AbstractNode) {
+            return $useAliasNode;
+        }
+
+        return ($name->getNamespace() !== null)
+            ? $this->resolveWithAlias($name, $env)
+            : $this->resolveWithoutAlias($name, $env);
+    }
+
+    private function resolveFromUseAlias(Symbol $name, NodeEnvironmentInterface $env): ?PhpClassNameNode
+    {
+        $currentNs = $this->globalEnv->getNs();
+        $useAliases = $this->globalEnv->getUseAliases($currentNs);
+        $strName = $name->getName();
+
+        if (!isset($useAliases[$strName])) {
+            return null;
+        }
+
+        $alias = $useAliases[$strName];
+        $alias->copyLocationFrom($name);
+
+        return new PhpClassNameNode($env, $alias, $name->getStartLocation());
+    }
+
+    private function resolveWithAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
+    {
+        $alias = $name->getNamespace();
+        if ($alias === null) {
+            throw new RuntimeException('resolveWithAlias called with a Symbol without namespace');
+        }
+
+        $finalName = Symbol::create($name->getName());
+        $ns = $this->globalEnv->resolveAlias($alias) ?? $alias;
+
+        return $this->resolveInterfaceOrDefinition($finalName, $env, $ns);
+    }
+
+    private function resolveWithoutAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
+    {
+        $currentNs = $this->globalEnv->getNs();
+        $refers = $this->globalEnv->getRefers($currentNs);
+
+        if (isset($refers[$name->getName()])) {
+            $referNs = $refers[$name->getName()]->getName();
+
+            return $this->resolveInterfaceOrDefinition($name, $env, $referNs)
+                ?? $this->resolveInterfaceOrDefinition($name, $env, CompilerConstants::PHEL_CORE_NAMESPACE);
+        }
+
+        return $this->resolveInterfaceOrDefinitionForCurrentNs($name, $env, $currentNs)
+            ?? $this->resolveInterfaceOrDefinition($name, $env, CompilerConstants::PHEL_CORE_NAMESPACE);
+    }
+
+    /**
+     * It also includes private definitions from the current namespace.
+     */
+    private function resolveInterfaceOrDefinitionForCurrentNs(
+        Symbol $name,
+        NodeEnvironmentInterface $env,
+        string $ns,
+    ): ?AbstractNode {
+        $interfaceNode = $this->resolveInterface($name, $env, $ns);
+        if ($interfaceNode instanceof PhpClassNameNode) {
+            return $interfaceNode;
+        }
+
+        $def = $this->globalEnv->getDefinition($ns, $name);
+        if ($def instanceof PersistentMapInterface) {
+            return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
+        }
+
+        return null;
+    }
+
+    /**
+     * It ignores private definitions (if they're not allowed) from the namespace.
+     */
+    private function resolveInterfaceOrDefinition(
+        Symbol $name,
+        NodeEnvironmentInterface $env,
+        string $ns,
+    ): ?AbstractNode {
+        $interfaceNode = $this->resolveInterface($name, $env, $ns);
+        if ($interfaceNode instanceof PhpClassNameNode) {
+            return $interfaceNode;
+        }
+
+        $def = $this->globalEnv->getDefinition($ns, $name);
+        if (!$def instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        if (!$this->isPrivateDefinitionAllowed($def)) {
+            return null;
+        }
+
+        return new GlobalVarNode($env, $ns, $name, $def, $name->getStartLocation());
+    }
+
+    private function resolveInterface(
+        Symbol $name,
+        NodeEnvironmentInterface $env,
+        string $ns,
+    ): ?PhpClassNameNode {
+        $interfaces = $this->globalEnv->getInterfaces($ns);
+        if (!isset($interfaces[$name->getName()])) {
+            return null;
+        }
+
+        return new PhpClassNameNode(
+            $env,
+            Symbol::createForNamespace($ns, $name->getName()),
+            $name->getStartLocation(),
+        );
+    }
+
+    private function isPrivateDefinitionAllowed(PersistentMapInterface $meta): bool
+    {
+        if ($this->globalEnv->isPrivateAccessAllowed()) {
+            return true;
+        }
+
+        return !$meta[Keyword::create('private')];
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/MagicConstantResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/MagicConstantResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
+use Phel\Lang\SourceLocation;
+use PHPUnit\Framework\TestCase;
+
+final class MagicConstantResolverTest extends TestCase
+{
+    public function test_resolve_file_returns_realpath_for_existing_file(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation(__FILE__, 0, 0);
+
+        self::assertSame(__FILE__, $resolver->resolveFile($sl));
+    }
+
+    public function test_resolve_file_returns_null_when_source_location_missing(): void
+    {
+        $resolver = new MagicConstantResolver();
+
+        self::assertNull($resolver->resolveFile(null));
+    }
+
+    public function test_resolve_file_returns_empty_string_for_string_source(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation('string', 0, 0);
+
+        self::assertSame('', $resolver->resolveFile($sl));
+    }
+
+    public function test_resolve_file_returns_null_when_realpath_fails(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation('/this/path/really/should/not/exist/phel-xyz.phel', 0, 0);
+
+        self::assertNull($resolver->resolveFile($sl));
+    }
+
+    public function test_resolve_dir_returns_realpath_dirname_for_existing_file(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation(__FILE__, 0, 0);
+
+        self::assertSame(__DIR__, $resolver->resolveDir($sl));
+    }
+
+    public function test_resolve_dir_returns_null_when_source_location_missing(): void
+    {
+        $resolver = new MagicConstantResolver();
+
+        self::assertNull($resolver->resolveDir(null));
+    }
+
+    public function test_resolve_dir_returns_empty_string_for_string_source(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation('string', 0, 0);
+
+        self::assertSame('', $resolver->resolveDir($sl));
+    }
+
+    public function test_resolve_dir_returns_null_when_realpath_fails(): void
+    {
+        $resolver = new MagicConstantResolver();
+        $sl = new SourceLocation('/this/path/really/should/not/exist/phel-xyz.phel', 0, 0);
+
+        self::assertNull($resolver->resolveDir($sl));
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\SymbolResolver;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolResolverTest extends TestCase
+{
+    private GlobalEnvironment $globalEnv;
+
+    private SymbolResolver $resolver;
+
+    protected function setUp(): void
+    {
+        Phel::clear();
+        $this->globalEnv = new GlobalEnvironment();
+        $this->resolver = new SymbolResolver($this->globalEnv, new MagicConstantResolver());
+    }
+
+    public function test_resolve_magic_dir_constant(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+        $sym = Symbol::create('__DIR__');
+        $sym->setStartLocation(new SourceLocation(__FILE__, 0, 0));
+
+        self::assertEquals(
+            new LiteralNode($nodeEnv, __DIR__),
+            $this->resolver->resolve($sym, $nodeEnv),
+        );
+    }
+
+    public function test_resolve_magic_file_constant(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+        $sym = Symbol::create('__FILE__');
+        $sym->setStartLocation(new SourceLocation(__FILE__, 0, 0));
+
+        self::assertEquals(
+            new LiteralNode($nodeEnv, __FILE__),
+            $this->resolver->resolve($sym, $nodeEnv),
+        );
+    }
+
+    public function test_resolve_absolute_php_class(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\Exception')),
+            $this->resolver->resolve(Symbol::create('\\Exception'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_via_use_alias(): void
+    {
+        $this->globalEnv->setNs('foo');
+        $this->globalEnv->addUseAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('bar')),
+            $this->resolver->resolve(Symbol::create('b'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_qualified_symbol_via_require_alias(): void
+    {
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+        $this->globalEnv->setNs('foo');
+        $this->globalEnv->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'bar', Symbol::create('x'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_qualified_symbol_without_alias_uses_namespace_as_is(): void
+    {
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+        $this->globalEnv->setNs('foo');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'bar', Symbol::create('x'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_unqualified_via_refer(): void
+    {
+        $this->globalEnv->addDefinition('foo', Symbol::create('x'));
+        $this->globalEnv->setNs('bar');
+        $this->globalEnv->addRefer('bar', Symbol::create('x'), Symbol::create('foo'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'foo', Symbol::create('x'), Phel::map()),
+            $this->resolver->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_unqualified_falls_back_to_current_ns(): void
+    {
+        $this->globalEnv->setNs('bar');
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'bar', Symbol::create('x'), Phel::map()),
+            $this->resolver->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_unqualified_falls_back_to_phel_core(): void
+    {
+        $this->globalEnv->addDefinition('phel\\core', Symbol::create('x'));
+        $this->globalEnv->setNs('bar');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\core', Symbol::create('x'), Phel::map()),
+            $this->resolver->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_returns_null_when_symbol_is_unknown(): void
+    {
+        self::assertNotInstanceOf(
+            AbstractNode::class,
+            $this->resolver->resolve(Symbol::create('foo'), NodeEnvironment::empty()),
+        );
+    }
+
+    public function test_resolve_ignores_private_definition_by_default(): void
+    {
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+        Phel::addDefinition('bar', 'x', null, Phel::map(Keyword::create('private'), true));
+        $this->globalEnv->setNs('foo');
+
+        self::assertNotInstanceOf(
+            AbstractNode::class,
+            $this->resolver->resolve(Symbol::createForNamespace('bar', 'x'), NodeEnvironment::empty()),
+        );
+    }
+
+    public function test_resolve_allows_private_definition_when_access_level_active(): void
+    {
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+        Phel::addDefinition('bar', 'x', null, Phel::map(Keyword::create('private'), true));
+        $this->globalEnv->setNs('foo');
+        $this->globalEnv->addLevelToAllowPrivateAccess();
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertInstanceOf(
+            GlobalVarNode::class,
+            $this->resolver->resolve(Symbol::createForNamespace('bar', 'x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_current_ns_exposes_own_private_definitions(): void
+    {
+        $this->globalEnv->setNs('bar');
+        $this->globalEnv->addDefinition('bar', Symbol::create('x'));
+        Phel::addDefinition('bar', 'x', null, Phel::map(Keyword::create('private'), true));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode(
+                $nodeEnv,
+                'bar',
+                Symbol::create('x'),
+                Phel::map(Keyword::create('private'), true),
+            ),
+            $this->resolver->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_interface_in_current_ns(): void
+    {
+        $this->globalEnv->setNs('bar');
+        $this->globalEnv->addInterface('bar', Symbol::create('x'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::createForNamespace('bar', 'x')),
+            $this->resolver->resolve(Symbol::create('x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_interface_via_alias(): void
+    {
+        $this->globalEnv->addInterface('bar', Symbol::create('x'));
+        $this->globalEnv->setNs('foo');
+        $this->globalEnv->addRequireAlias('foo', Symbol::create('b'), Symbol::create('bar'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::createForNamespace('bar', 'x')),
+            $this->resolver->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`GlobalEnvironment` sat at 440 lines with cyclomatic complexity ~69 and an
F rating on Scrutinizer. It mixed three unrelated concerns: namespace state
registries (definitions, refers, require/use aliases, interfaces), the
resolve chain that walks those registries to turn a `Symbol` into an
`AbstractNode`, and the stateless file/dir magic-constant helpers used by
`__FILE__` / `__DIR__`.

That god-class shape made the resolve logic hard to reason about in
isolation and impossible to reuse, and every bug fix to the resolution
chain dragged the whole state class along with it.

## 💡 Goal

Break `GlobalEnvironment` into three focused collaborators while keeping
the public `GlobalEnvironmentInterface` byte-for-byte identical, so the
REPL snapshot/restore mechanism and every existing analyzer caller keeps
working unchanged.

Target: drop `GlobalEnvironment` below ~300 lines, give the resolve chain
its own tested class, and isolate the magic-constant helpers so they can
be unit tested without booting the global environment.

## 🔖 Changes

- **New `SymbolResolver`** (`src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php`)
  owns the resolve chain as a clean pipeline: magic constant → absolute PHP
  class (leading `\`) → use alias → qualified/unqualified dispatch →
  refer/phel\\core fallback → private-access gating. It reads state from
  `GlobalEnvironment` via the existing public getters plus a narrow new
  `getInterfaces()` / `isPrivateAccessAllowed()` pair added to the class
  (not the interface).
- **New `MagicConstantResolver`** (`src/php/Compiler/Domain/Analyzer/Environment/MagicConstantResolver.php`)
  is a pure stateless helper exposing `resolveFile()` and `resolveDir()`.
  Encapsulates the `string` source-location special case and the
  `realpath` failure path.
- **`GlobalEnvironment` slimmed from 440 → 299 lines.** State, registry
  mutators/accessors, snapshot/restore, `getAllDefinitions()`, the
  duplicate-definition guard, and the private-access counter stay put.
  `resolve()` and `resolveAsSymbol()` still exist on the public interface
  and now delegate to an internally-constructed `SymbolResolver`.
- `GlobalEnvironmentInterface` is unchanged.
- New focused tests:
  - `SymbolResolverTest` (15 tests) covers magic constants, absolute PHP
    classes, use alias, qualified/unqualified dispatch, refer, phel\\core
    fallback, private access (blocked + allowed), and current-ns private
    exposure.
  - `MagicConstantResolverTest` (8 tests) covers `resolveFile` /
    `resolveDir` with realpath success, null source location, `string`
    source, and realpath failure.
- Existing `GlobalEnvironmentTest` (39 tests) passes unchanged, which is
  the primary behavioural contract check.

No changes to `CHANGELOG.md`: internal refactor with no user-visible
effects.

**Test results:** `composer test` green — 1649 PHPUnit tests + 2289 Phel
core tests, zero failures. `composer test-quality` green (cs-fixer, psalm
level 1, phpstan level 5, rector).