### PR TITLE
ref(formatter): extract private helpers from AbstractZipper

### DIFF
--- a/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
+++ b/src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php
@@ -88,10 +88,6 @@ abstract class AbstractZipper
 
         $leftSiblings = $this->leftSiblings;
         $lastIndex = array_key_last($leftSiblings);
-        if ($lastIndex === null) {
-            throw ZipperException::cannotGoLeftOnTheLeftmostNode();
-        }
-
         /** @var T $left */
         $left = $leftSiblings[$lastIndex];
         unset($leftSiblings[$lastIndex]);
@@ -182,19 +178,7 @@ abstract class AbstractZipper
         assert($this->parent instanceof self);
 
         if ($this->hasChanged) {
-            $newParent = $this->makeNode(
-                $this->parent->getNode(),
-                [...$this->leftSiblings, $this->node, ...$this->rightSiblings],
-            );
-
-            return $this->createNewInstance(
-                $newParent,
-                $this->parent->parent,
-                $this->parent->lefts(),
-                $this->parent->rights(),
-                true,
-                $this->parent->isEnd(),
-            );
+            return $this->reconstructParentFromChange();
         }
 
         /** @var static<T> $parent */
@@ -258,17 +242,7 @@ abstract class AbstractZipper
             return $this->right();
         }
 
-        $up = $this;
-        while ($up->isLast() && !$up->isTop()) {
-            $up = $up->up();
-        }
-
-        if ($up->isTop()) {
-            $up->isEnd = true;
-            return $up;
-        }
-
-        return $up->right();
+        return $this->backtrackToNextSibling();
     }
 
     public function prev(): static
@@ -387,36 +361,9 @@ abstract class AbstractZipper
 
         assert($this->parent instanceof self);
 
-        if (!$this->isFirst()) {
-            $leftSiblings = $this->leftSiblings;
-            $left = array_pop($leftSiblings);
-            if ($left === null) {
-                throw new RuntimeException('Unable to remove node: missing left sibling.');
-            }
-
-            $loc = $this->createNewInstance(
-                $left,
-                $this->parent,
-                $leftSiblings,
-                $this->rightSiblings,
-                true,
-                false,
-            );
-            while ($loc->isBranch() && $loc->hasChildren()) {
-                $loc = $loc->down()->rightMost();
-            }
-
-            return $loc;
-        }
-
-        return $this->createNewInstance(
-            $this->makeNode($this->parent->getNode(), $this->rightSiblings),
-            $this->parent->parent,
-            $this->parent->lefts(),
-            $this->parent->rights(),
-            true,
-            $this->parent->isEnd(),
-        );
+        return $this->isFirst()
+            ? $this->removeFirstChild()
+            : $this->removeNonFirstSibling();
     }
 
     public function isEnd(): bool
@@ -458,4 +405,115 @@ abstract class AbstractZipper
         bool $hasChanged,
         bool $isEnd,
     ): static;
+
+    /**
+     * Rebuilds the parent node from the current (changed) siblings and
+     * returns a new zipper positioned at that parent, preserving the
+     * parent's own lefts/rights/end state and marking the result as changed.
+     *
+     * @return static<T>
+     */
+    private function reconstructParentFromChange(): static
+    {
+        assert($this->parent instanceof self);
+
+        $newParent = $this->makeNode(
+            $this->parent->getNode(),
+            [...$this->leftSiblings, $this->node, ...$this->rightSiblings],
+        );
+
+        /** @var static<T> $newInstance */
+        $newInstance = $this->createNewInstance(
+            $newParent,
+            $this->parent->parent,
+            $this->parent->lefts(),
+            $this->parent->rights(),
+            true,
+            $this->parent->isEnd(),
+        );
+
+        return $newInstance;
+    }
+
+    /**
+     * Walks up the tree while the current location is the last sibling,
+     * stopping at the next ancestor that has a right sibling. If the walk
+     * reaches the root, marks the zipper as ended and returns it.
+     *
+     * @return static<T>
+     */
+    private function backtrackToNextSibling(): static
+    {
+        $up = $this;
+        while ($up->isLast() && !$up->isTop()) {
+            $up = $up->up();
+        }
+
+        if ($up->isTop()) {
+            $up->isEnd = true;
+            /** @var static<T> $up */
+            return $up;
+        }
+
+        /** @var static<T> $next */
+        $next = $up->right();
+        return $next;
+    }
+
+    /**
+     * Handles removal when the current location is not the first child:
+     * pops the last left sibling to become the new location and then
+     * descends to the rightmost leaf under that subtree.
+     *
+     * @return static<T>
+     */
+    private function removeNonFirstSibling(): static
+    {
+        assert($this->parent instanceof self);
+
+        $leftSiblings = $this->leftSiblings;
+        $left = array_pop($leftSiblings);
+        if ($left === null) {
+            throw new RuntimeException('Unable to remove node: missing left sibling.');
+        }
+
+        $loc = $this->createNewInstance(
+            $left,
+            $this->parent,
+            $leftSiblings,
+            $this->rightSiblings,
+            true,
+            false,
+        );
+        while ($loc->isBranch() && $loc->hasChildren()) {
+            $loc = $loc->down()->rightMost();
+        }
+
+        /** @var static<T> $loc */
+        return $loc;
+    }
+
+    /**
+     * Handles removal when the current location is the first child:
+     * rebuilds the parent node from the remaining right siblings and
+     * returns a zipper positioned at that new parent.
+     *
+     * @return static<T>
+     */
+    private function removeFirstChild(): static
+    {
+        assert($this->parent instanceof self);
+
+        /** @var static<T> $newInstance */
+        $newInstance = $this->createNewInstance(
+            $this->makeNode($this->parent->getNode(), $this->rightSiblings),
+            $this->parent->parent,
+            $this->parent->lefts(),
+            $this->parent->rights(),
+            true,
+            $this->parent->isEnd(),
+        );
+
+        return $newInstance;
+    }
 }


### PR DESCRIPTION
## 🤔 Background

`src/php/Formatter/Domain/Rules/Zipper/AbstractZipper.php` carries the bulk of the formatter's tree navigation logic (it is the base class for `ParseTreeZipper`). Scrutinizer flags it with an `F` rating: 462 lines, aggregate cyclomatic complexity around 60. The hot spots are `remove()`, `next()`, and `up()`, each of which mixes a guard chain with a distinct data-shuffling branch.

The zipper pattern has inherent complexity — it is a navigation DSL. Splitting the class into strategy objects would break the `static` return contract and fight the `@psalm-consistent-constructor` pattern, so that is explicitly out of scope here.

## 💡 Goal

Make the three worst methods easier to read and lower their per-method cyclomatic complexity by extracting the distinct branches into named private helpers. This is a **conservative** refactor — the public API, the abstract hooks (`getChildren`, `isBranch`, `makeNode`, `createNewInstance`), and the generic `@template T` contract are all unchanged. Behaviour is byte-identical (verified by re-formatting `src/phel/core.phel` against `main` — the output is exactly the same).

## 🔖 Changes

- `remove()` is reduced to a guard + ternary, delegating to two new helpers:
  - `removeFirstChild()` — rebuilds the parent from `rightSiblings` when the removed node is the first child.
  - `removeNonFirstSibling()` — pops the last left sibling and descends to the rightmost leaf.
- `next()` delegates its backtracking loop to `backtrackToNextSibling()`, which walks up until it finds a right sibling or marks the zipper as ended.
- `up()` delegates the `hasChanged` branch to `reconstructParentFromChange()`, leaving the clean clone path inline.
- Dropped the redundant `array_key_last() === null` check in `left()` — it was already guarded by `isFirst()` at the top of the method (psalm level 1 accepts the removal).

### Honest expectations

The file **grew** from 462 to 519 lines because each extracted helper carries its own docblock plus the `@var static<T>` annotations that phpstan level 5 requires to preserve the generic binding through `createNewInstance()` calls. Scrutinizer's metric of interest is cyclomatic complexity, not LOC:

- `remove()`: CC 5 → 2
- `next()`: CC 5 → 4
- `up()`: CC 3 → 3 (unchanged guard shape; body is now a 1-line delegation)
- New helpers each have CC 2–3

This is a **modest** improvement, not a jump from F to A. The zipper's total surface area is still complex by design. Larger structural refactors (strategy classes, separate navigator/modifier splits) were deliberately rejected because they break the `static` return contract that subclasses like `ParseTreeZipper` rely on.

## ✅ Verification

- `composer test-compiler` — 1626 PHPUnit tests pass
- `composer test-quality` — php-cs-fixer, psalm (level 1), phpstan (level 5), rector all clean
- `composer test` — full suite, 2289 tests pass
- Formatter end-to-end check: `./bin/phel format` on `src/phel/core.phel` produces byte-identical output vs. `main`