### PR TITLE
feat(compiler): auto-alias clojure.* namespaces to phel.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching (#1207)
 - Accept `~` and `~@` as reader macros for `unquote` and `unquote-splicing` inside syntax-quote (alongside the existing `,` and `,@`), matching Clojure's syntax for `.cljc` interop (#1201)
 - `integer?` Clojure compatibility alias function for `int?`
 - `phel\test/assert-expr` is now an open multimethod (was a closed private function), letting users extend the `is` macro with custom assertion forms via `(defmethod phel\test/assert-expr 'my-form [form message] ...)`, matching Clojure's `clojure.test/assert-expr` (#1188)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -22,6 +22,8 @@ use function preg_match;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+use function str_starts_with;
+use function substr;
 
 /**
  * (ns name (:require ...) (:use ...)).
@@ -289,9 +291,7 @@ TXT;
             );
         }
 
-        $this->registerRequire($ns, $requireSymbol, $aliasValue, $referValue, $import);
-
-        return $requireSymbol;
+        return $this->registerRequire($ns, $requireSymbol, $aliasValue, $referValue, $import);
     }
 
     /**
@@ -359,9 +359,7 @@ TXT;
             );
         }
 
-        $this->registerRequire($ns, $requireSymbol, $aliasValue, $referValue, $import);
-
-        return $requireSymbol;
+        return $this->registerRequire($ns, $requireSymbol, $aliasValue, $referValue, $import);
     }
 
     /**
@@ -411,12 +409,20 @@ TXT;
         ?Symbol $aliasValue,
         ?PersistentVectorInterface $referValue,
         PersistentListInterface $import,
-    ): void {
-        $alias = $this->createAliasFromSymbol($aliasValue, $requireSymbol);
+    ): Symbol {
+        $resolvedSymbol = $this->remapClojureNamespace($requireSymbol);
+
+        $alias = $this->createAliasFromSymbol($aliasValue, $resolvedSymbol);
         $referSymbols = $this->extractRefer($referValue, $import);
 
-        $this->analyzer->addRequireAlias($ns, $alias, $requireSymbol);
-        $this->analyzer->addRefers($ns, $referSymbols, $requireSymbol);
+        $this->analyzer->addRequireAlias($ns, $alias, $resolvedSymbol);
+        $this->analyzer->addRefers($ns, $referSymbols, $resolvedSymbol);
+
+        if ($resolvedSymbol->getName() !== $requireSymbol->getName()) {
+            $this->analyzer->addRequireAlias($ns, $requireSymbol, $resolvedSymbol);
+        }
+
+        return $resolvedSymbol;
     }
 
     private function analyzeRequireFile(PersistentListInterface $import): string
@@ -466,6 +472,25 @@ TXT;
         return Symbol::createForNamespace(
             $symbol->getNamespace(),
             $this->normalizeNamespaceSeparators($name),
+        )->copyLocationFrom($symbol);
+    }
+
+    /**
+     * Remaps `clojure\*` namespaces to `phel\*` for Clojure compatibility.
+     *
+     * If a required namespace starts with `clojure\`, the prefix is replaced
+     * with `phel\` so that e.g. `clojure\test` resolves to `phel\test`.
+     */
+    private function remapClojureNamespace(Symbol $symbol): Symbol
+    {
+        $name = $symbol->getName();
+        if (!str_starts_with($name, 'clojure\\')) {
+            return $symbol;
+        }
+
+        return Symbol::createForNamespace(
+            $symbol->getNamespace(),
+            'phel\\' . substr($name, 8),
         )->copyLocationFrom($symbol);
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -761,6 +761,178 @@ final class NsSymbolTest extends TestCase
         self::assertSame('\\Vendor\\Toolkit', $kitNode->getName()->getName());
     }
 
+    public function test_clojure_namespace_remapped_to_phel_in_require(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('phel\\test'),
+        ], $nsNode->getRequireNs());
+    }
+
+    public function test_clojure_namespace_auto_alias_points_to_phel(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+            ]),
+        ]);
+
+        (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('test')));
+        self::assertSame('phel\\test', $this->globalEnv->resolveAlias('test'));
+    }
+
+    public function test_clojure_namespace_with_explicit_as_alias(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+                Keyword::create('as'),
+                Symbol::create('t'),
+            ]),
+        ]);
+
+        (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('t')));
+        self::assertSame('phel\\test', $this->globalEnv->resolveAlias('t'));
+    }
+
+    public function test_clojure_namespace_with_refer(): void
+    {
+        Phel::addDefinition('phel\\test', 'deftest', 'value', Phel::map());
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+                Keyword::create('refer'),
+                Phel::vector([
+                    Symbol::create('deftest'),
+                ]),
+            ]),
+        ]);
+
+        (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        $node = $this->globalEnv->resolve(Symbol::create('deftest'), NodeEnvironment::empty());
+        self::assertInstanceOf(GlobalVarNode::class, $node);
+        self::assertSame('phel\\test', $node->getNamespace());
+    }
+
+    public function test_clojure_namespace_original_registered_as_alias(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+            ]),
+        ]);
+
+        (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('clojure\\test')));
+        self::assertSame('phel\\test', $this->globalEnv->resolveAlias('clojure\\test'));
+    }
+
+    public function test_clojure_namespace_via_dot_syntax(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app.core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure.test'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('phel\\test'),
+        ], $nsNode->getRequireNs());
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('test')));
+        self::assertSame('phel\\test', $this->globalEnv->resolveAlias('test'));
+    }
+
+    public function test_clojure_namespace_vector_form_with_as_and_refer(): void
+    {
+        Phel::addDefinition('phel\\test', 'is', 'value', Phel::map());
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app.core'),
+            Phel::list([
+                Keyword::create('require'),
+                Phel::vector([
+                    Symbol::create('clojure.test'),
+                    Keyword::create('as'),
+                    Symbol::create('t'),
+                    Keyword::create('refer'),
+                    Phel::vector([
+                        Symbol::create('is'),
+                    ]),
+                ]),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('phel\\test'),
+        ], $nsNode->getRequireNs());
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('t')));
+        self::assertSame('phel\\test', $this->globalEnv->resolveAlias('t'));
+
+        $isNode = $this->globalEnv->resolve(Symbol::create('is'), NodeEnvironment::empty());
+        self::assertInstanceOf(GlobalVarNode::class, $isNode);
+        self::assertSame('phel\\test', $isNode->getNamespace());
+    }
+
+    public function test_non_clojure_namespace_not_remapped(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('vendor\\package'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('vendor\\package'),
+        ], $nsNode->getRequireNs());
+        self::assertSame('vendor\\package', $this->globalEnv->resolveAlias('package'));
+    }
+
     public function test_backslash_only_namespaces_still_work_unchanged(): void
     {
         // Regression: confirm the canonical \\-form still produces identical output


### PR DESCRIPTION
## 🤔 Background

Clojure test suites (like [clojure-test-suite](https://github.com/jasalt/clojure-test-suite)) use `(:require [clojure.test ...])`. Currently Phel requires manually patching these to `phel.test`. Other Clojure dialects (e.g. Basilisp) handle this transparently by auto-aliasing `clojure.*` namespaces to their dialect equivalents.

## 💡 Goal

When a `clojure.*` namespace is required and the corresponding `phel.*` namespace exists, Phel should automatically alias the former to the latter — matching Basilisp's behavior and enabling Clojure test suites to run without manual patching.

## 🔖 Changes

- Add `remapClojureNamespace()` in `NsSymbol` that rewrites `clojure\*` → `phel\*` during `:require` analysis
- `registerRequire()` now applies the remapping before registering aliases/refers, and also registers the original `clojure\*` name as an alias so fully-qualified references (e.g. `clojure.test/deftest`) resolve correctly
- Both flat and vector `:require` forms supported (e.g. `clojure.test` and `[clojure.test :as t :refer [deftest is]]`)
- 8 new unit tests covering: remapping, auto-alias, explicit `:as`, `:refer`, original-as-alias, dot syntax, vector form, and non-clojure passthrough
- Changelog updated under `## Unreleased`

Closes #1207