### PR TITLE
feat(repl): allow require and use to accept quoted symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)
 - Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching (#1207)
 - Accept `~` and `~@` as reader macros for `unquote` and `unquote-splicing` inside syntax-quote (alongside the existing `,` and `,@`), matching Clojure's syntax for `.cljc` interop (#1201)
 - `integer?` Clojure compatibility alias function for `int?`

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -77,6 +77,11 @@
     (when resolved-sym
       `(println (find-doc ~(namespace resolved-sym) ~(name resolved-sym))))))
 
+(defn- unquote-sym [sym]
+  (if (and (list? sym) (= 'quote (first sym)))
+    (second sym)
+    sym))
+
 (defn- extract-alias [sym options]
   (if (:as options)
     (:as options)
@@ -101,9 +106,10 @@
 
 (defmacro require
   "Requires a Phel module into the environment."
-  {:example "(require phel\http :as http :refer [request]) ; => phel\\http"}
+  {:example "(require 'phel\\http :as http :refer [request]) ; => phel\\http"}
   [sym & args]
-  (let [options (apply hash-map args)
+  (let [sym (unquote-sym sym)
+        options (apply hash-map args)
         alias (extract-alias sym options)
         refers (or (:refer options) [])]
     `(require-namespace '~sym '~alias '~refers)))
@@ -117,7 +123,8 @@
   "Adds a use statement to the environment."
   {:example "(use DateTime :as DT) ; => DateTime"}
   [sym & args]
-  (let [options (apply hash-map args)
+  (let [sym (unquote-sym sym)
+        options (apply hash-map args)
         alias (extract-alias sym options)]
     `(use-namespace '~sym '~alias)))
 

--- a/tests/php/Integration/Run/Command/Repl/FixturesWithCoreLib/require-quoted-namespace.test
+++ b/tests/php/Integration/Run/Command/Repl/FixturesWithCoreLib/require-quoted-namespace.test
@@ -1,0 +1,4 @@
+phel:1> (require 'phel\html :as h)
+phel\html
+phel:2> (h/html [:div])
+<div></div>


### PR DESCRIPTION
## 🤔 Background

In Clojure, `require` expects a quoted symbol: `(require 'clojure.string)`. Phel's REPL only accepted unquoted symbols, crashing with `PersistentList::getName()` when a quoted form was passed. This blocks nREPL clients (e.g. Emacs CIDER) that auto-evaluate `(require 'clojure.stacktrace)`.

## 💡 Goal

Accept both quoted and unquoted symbols in the REPL's `require` and `use` macros, matching Clojure semantics.

## 🔖 Changes

- Add `unquote-sym` helper that unwraps `(quote sym)` forms back to bare symbols
- Update `require` and `use` macros to call `unquote-sym` before processing
- Add REPL integration test fixture for quoted `require`

Closes #1211

<img width="392" height="122" alt="Screenshot 2026-04-09 at 16 26 36" src="https://github.com/user-attachments/assets/19577bcd-72ca-48e0-9a2b-b9d852d7015a" />
