### PR TITLE
Fix macroexpand applying inline expansion to non-macro forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Accept `name#` as an auto-gensym suffix inside syntax-quote (alongside the existing `name$`), matching Clojure's `clojure.core/gensym` reader macro (#1195)
 
 ### Fixed
+- `macroexpand` no longer applies inline expansion to non-macro forms; `(macroexpand '(+ 1 2))` now correctly returns `(+ 1 2)` instead of `(do (assert-non-nil 1 2) (+ 1 2))` (#1208)
 - Lexer no longer swallows a reader conditional (`#?(...)`) following a gensym-suffixed symbol (e.g. `report-success# #?(:phel ...)`), which previously surfaced as a misleading "Unterminated list (BRACKETS)" parse error (#1195)
 - Emit `php/...` calls to namespaced PHP functions (e.g. `php/Amp\File\write`) as fully qualified names so they resolve against the global namespace from compiled/cached files (#1180)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3965,20 +3965,13 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
       (if (symbol? op)
         (let [node (get-global-var-node op)]
           (if (php/instanceof node GlobalVarNode)
-            (let [meta (php/-> node (getMeta))
-                  ns (php/-> node (getNamespace))
-                  name (php/-> (php/-> node (getName)) (getName))
-                  args (rest form)]
-              (cond
-                (inline-call? meta (count args))
-                (apply (:inline meta) args)
-                (:macro meta)
-                (let [macro-fn (php/:: Phel (getDefinition ns name))]
-                  ;; Macros receive `&form` (the call form) and `&env`
-                  ;; (lexical bindings map) as the first two implicit args.
-                  ;; Outside of analyzer context pass an empty env map.
+            (let [meta (php/-> node (getMeta))]
+              (if (:macro meta)
+                (let [ns (php/-> node (getNamespace))
+                      name (php/-> (php/-> node (getName)) (getName))
+                      macro-fn (php/:: Phel (getDefinition ns name))
+                      args (rest form)]
                   (apply macro-fn form {} args))
-                :else
                 form))
             form))
         form))

--- a/src/php/Compiler/Application/MacroExpander.php
+++ b/src/php/Compiler/Application/MacroExpander.php
@@ -9,11 +9,9 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
-use function count;
 use function is_callable;
 
 /**
@@ -46,22 +44,6 @@ final readonly class MacroExpander
             return $form;
         }
 
-        $meta = $node->getMeta();
-        $args = $form->rest()->toArray();
-        $arity = count($args);
-
-        // Check for inline expansion first
-        $inlineFn = $meta[Keyword::create('inline')];
-        if ($inlineFn !== null) {
-            $arityFn = $meta[Keyword::create('inline-arity')];
-            $shouldInline = $arityFn === null || $arityFn($arity);
-
-            if ($shouldInline && is_callable($inlineFn)) {
-                return $inlineFn(...$args);
-            }
-        }
-
-        // Check for macro expansion
         if (!$node->isMacro()) {
             return $form;
         }
@@ -73,6 +55,8 @@ final readonly class MacroExpander
         if (!is_callable($fn)) {
             return $form;
         }
+
+        $args = $form->rest()->toArray();
 
         // Macros receive `&form` (the call form) and `&env` (lexical bindings map)
         // as the first two arguments. This path has no surrounding analyzer env,

--- a/tests/phel/test/core/macroexpand.phel
+++ b/tests/phel/test/core/macroexpand.phel
@@ -6,9 +6,9 @@
          (macroexpand-1 '(when true 1 2)))))
 
 (deftest test-macroexpand-threading
-  (is (= (print-str '(do (assert-non-nil 1 2) (+ 1 2)))
-         (print-str (macroexpand '(-> 1 (+ 2)))))))
+  (is (= '(+ 1 2)
+         (macroexpand '(-> 1 (+ 2))))))
 
 (deftest test-macroexpand-inline
-  (is (= (print-str '(do (assert-non-nil 1) (+ 1 1)))
-         (print-str (macroexpand-1 '(inc 1))))))
+  (is (= '(inc 1)
+         (macroexpand-1 '(inc 1)))))

--- a/tests/php/Unit/Compiler/Application/MacroExpanderTest.php
+++ b/tests/php/Unit/Compiler/Application/MacroExpanderTest.php
@@ -179,7 +179,7 @@ final class MacroExpanderTest extends TestCase
         self::assertNull($this->macroExpander->macroexpand(null));
     }
 
-    public function test_macroexpand1_handles_inline_expansion(): void
+    public function test_macroexpand1_returns_inline_function_unchanged(): void
     {
         $form = Phel::list([
             Symbol::createForNamespace('user', 'my-inline'),
@@ -188,9 +188,7 @@ final class MacroExpanderTest extends TestCase
 
         $result = $this->macroExpander->macroexpand1($form);
 
-        // Inline expands to (php/+ 5 1)
-        $expected = Phel::list([Symbol::createForNamespace('php', '+'), 5, 1]);
-        self::assertTrue($expected->equals($result));
+        self::assertSame($form, $result);
     }
 
     public function test_macroexpand1_with_symbol_form(): void


### PR DESCRIPTION
## 🤔 Background

`macroexpand` and `macroexpand-1` were incorrectly applying inline expansion to non-macro forms. For example, `(macroexpand '(+ 1 2))` returned `(do (assert-non-nil 1 2) (+ 1 2))` instead of `(+ 1 2)`. The `+` function has `:inline` metadata (a compiler optimization), but it is not a macro — `macroexpand` should only expand macros.

## 💡 Goal

Make `macroexpand` only expand actual macros, leaving inline functions untouched. Inline expansion is a compiler optimization that belongs in the analyzer phase (`InvokeSymbol`), not in `macroexpand`.

## 🔖 Changes

- Removed inline expansion logic from PHP-side `MacroExpander::macroexpand1()` — only macros are expanded now
- Removed `inline-call?` branch from Phel-side `macroexpand-1` in `core.phel` — replaced `cond` with simple `if` on `:macro` metadata
- Updated PHP unit test to expect inline functions returned unchanged
- Fixed Phel tests to reflect correct `macroexpand` behavior
- Updated CHANGELOG

Closes #1208