### PR TITLE
fix(compiler): only remap clojure namespaces when phel equivalent exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)
-- Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching (#1207)
+- Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching; only remaps when the target `phel.*` namespace exists, so user-defined `clojure.*` namespaces are left untouched (#1207, #1210)
 - Accept `~` and `~@` as reader macros for `unquote` and `unquote-splicing` inside syntax-quote (alongside the existing `,` and `,@`), matching Clojure's syntax for `.cljc` interop (#1201)
 - `integer?` Clojure compatibility alias function for `int?`
 - `phel\test/assert-expr` is now an open multimethod (was a closed private function), letting users extend the `is` macro with custom assertion forms via `(defmethod phel\test/assert-expr 'my-form [form message] ...)`, matching Clojure's `clojure.test/assert-expr` (#1188)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 
 use function count;
@@ -478,8 +479,12 @@ TXT;
     /**
      * Remaps `clojure\*` namespaces to `phel\*` for Clojure compatibility.
      *
-     * If a required namespace starts with `clojure\`, the prefix is replaced
-     * with `phel\` so that e.g. `clojure\test` resolves to `phel\test`.
+     * If a required namespace starts with `clojure\` and the corresponding
+     * `phel\*` namespace exists in the Registry, the prefix is replaced
+     * so that e.g. `clojure\test` resolves to `phel\test`.
+     *
+     * User-defined `clojure\*` namespaces (e.g. `clojure\core-test\portability`)
+     * are left untouched when no matching `phel\*` namespace is registered.
      */
     private function remapClojureNamespace(Symbol $symbol): Symbol
     {
@@ -488,9 +493,16 @@ TXT;
             return $symbol;
         }
 
+        $targetNs = 'phel\\' . substr($name, 8);
+        $mungedNs = str_replace('-', '_', $targetNs);
+
+        if (Registry::getInstance()->getDefinitionInNamespace($mungedNs) === []) {
+            return $symbol;
+        }
+
         return Symbol::createForNamespace(
             $symbol->getNamespace(),
-            'phel\\' . substr($name, 8),
+            $targetNs,
         )->copyLocationFrom($symbol);
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -34,6 +34,9 @@ final class NsSymbolTest extends TestCase
         Registry::getInstance()->clear();
         $this->globalEnv = new GlobalEnvironment();
         $this->analyzer = new Analyzer($this->globalEnv);
+
+        // Seed the Registry so clojure\* → phel\* remapping finds the target namespace
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
     }
 
     public function test_first_argument_must_be_symbol(): void
@@ -763,8 +766,6 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_remapped_to_phel_in_require(): void
     {
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -784,8 +785,6 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_auto_alias_points_to_phel(): void
     {
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -803,8 +802,6 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_with_explicit_as_alias(): void
     {
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -848,8 +845,6 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_original_registered_as_alias(): void
     {
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -867,8 +862,6 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_via_dot_syntax(): void
     {
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app.core'),

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -763,6 +763,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_remapped_to_phel_in_require(): void
     {
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -782,6 +784,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_auto_alias_points_to_phel(): void
     {
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -799,6 +803,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_with_explicit_as_alias(): void
     {
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -842,6 +848,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_original_registered_as_alias(): void
     {
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -859,6 +867,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_via_dot_syntax(): void
     {
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app.core'),
@@ -911,6 +921,113 @@ final class NsSymbolTest extends TestCase
         $isNode = $this->globalEnv->resolve(Symbol::create('is'), NodeEnvironment::empty());
         self::assertInstanceOf(GlobalVarNode::class, $isNode);
         self::assertSame('phel\\test', $isNode->getNamespace());
+    }
+
+    public function test_clojure_namespace_not_remapped_when_phel_equivalent_missing(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\core-test\\portability'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('clojure\\core-test\\portability'),
+        ], $nsNode->getRequireNs());
+        self::assertSame('clojure\\core-test\\portability', $this->globalEnv->resolveAlias('portability'));
+    }
+
+    public function test_clojure_namespace_not_remapped_via_dot_syntax_when_phel_equivalent_missing(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app.core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure.core-test.portability'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('clojure\\core-test\\portability'),
+        ], $nsNode->getRequireNs());
+        self::assertSame('clojure\\core-test\\portability', $this->globalEnv->resolveAlias('portability'));
+    }
+
+    public function test_clojure_namespace_not_remapped_in_vector_form_when_phel_equivalent_missing(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app.core'),
+            Phel::list([
+                Keyword::create('require'),
+                Phel::vector([
+                    Symbol::create('clojure.core-test.portability'),
+                    Keyword::create('as'),
+                    Symbol::create('p'),
+                ]),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('clojure\\core-test\\portability'),
+        ], $nsNode->getRequireNs());
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('p')));
+        self::assertSame('clojure\\core-test\\portability', $this->globalEnv->resolveAlias('p'));
+    }
+
+    public function test_clojure_namespace_no_spurious_original_alias_when_not_remapped(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\custom\\lib'),
+            ]),
+        ]);
+
+        (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        // When no remap happens, resolvedSymbol === requireSymbol,
+        // so the original clojure\* name should NOT be registered as a separate alias
+        self::assertTrue($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('lib')));
+        self::assertFalse($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('clojure\\custom\\lib')));
+    }
+
+    public function test_clojure_remap_uses_munged_namespace_for_registry_lookup(): void
+    {
+        // Register with munged name (dashes → underscores), matching how the compiler stores it
+        Phel::addDefinition('phel\\my_lib', '__ns_marker', true, Phel::map());
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\my-lib'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        // Should remap because phel\my_lib exists (munged form of phel\my-lib)
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('phel\\my-lib'),
+        ], $nsNode->getRequireNs());
     }
 
     public function test_non_clojure_namespace_not_remapped(): void


### PR DESCRIPTION
## 🤔 Background

PR #1210 introduced automatic `clojure.*` to `phel.*` namespace remapping to enable Clojure test suites to run without manual patching. However, as reported in [#1210 (comment)](https://github.com/phel-lang/phel-lang/pull/1210#discussion_r3061421031), the remapping was too eager. It rewrote all `clojure\*` prefixes, including user-defined namespaces like `clojure.core-test.portability` that have no `phel\*` counterpart, causing `Cannot resolve symbol` errors.

## 💡 Goal

Only remap `clojure.*` to `phel.*` when the target `phel.*` namespace actually exists in the Registry. User-defined `clojure.*` namespaces (e.g. `clojure.core-test.portability`) should pass through untouched.

## 🔖 Changes

- `remapClojureNamespace()` in `NsSymbol` now checks `Registry::getDefinitionInNamespace()` (with munged namespace name) before remapping. If the target `phel\*` namespace has no definitions, the original `clojure\*` name is kept
- Registry seeded with `phel\test` in test `setUp()` so all remap tests have a realistic environment
- 4 new tests covering the fix behavior:
  - Dot syntax passthrough when phel equivalent is missing
  - Vector form passthrough with `:as` when phel equivalent is missing
  - No extra alias registered when remap is skipped
  - Dashed namespace names resolved via munged Registry key
- Changelog entry for #1207 updated to mention the guard

Closes #1210