### PR TITLE
fix(compiler): pre-scan source namespaces for robust clojure remap

### DIFF
--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -50,6 +50,10 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
      */
     public function getNamespacesFromDirectories(array $directories): array
     {
+        // Delegate pre-scan to the inner extractor so NsSymbol knows
+        // which clojure\* namespaces are user-defined source files.
+        $this->innerExtractor->preRegisterDeclaredNamespaces($directories);
+
         $allFiles = $this->findAllPhelFiles($directories);
 
         /** @var array<string, NamespaceInformation> $namespaces */
@@ -70,6 +74,11 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
         $this->warnAboutDuplicateNamespaces($primaryDefinitions);
 
         return $this->sortNamespaceInformationList(array_values($namespaces));
+    }
+
+    public function preRegisterDeclaredNamespaces(array $directories): void
+    {
+        $this->innerExtractor->preRegisterDeclaredNamespaces($directories);
     }
 
     /**

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -17,6 +17,8 @@ use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use RecursiveDirectoryIterator;
@@ -98,6 +100,11 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
      */
     public function getNamespacesFromDirectories(array $directories): array
     {
+        // Pre-scan: register all declared namespace names so NsSymbol
+        // can distinguish user-defined clojure\* namespaces from
+        // references to phel standard library equivalents.
+        $this->preRegisterDeclaredNamespaces($directories);
+
         /** @var array<string, NamespaceInformation> $namespaces */
         $namespaces = [];
         /** @var array<string, list<string>> $primaryDefinitions */
@@ -117,6 +124,29 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
         $this->warnAboutDuplicateNamespaces($primaryDefinitions);
 
         return $this->sortNamespaceInformationList(array_values($namespaces));
+    }
+
+    /**
+     * Lightweight pre-scan: extracts only the declared namespace name from
+     * each source file and registers it on the Registry. This runs before
+     * the full extraction so that NsSymbol::remapClojureNamespace() can
+     * tell user-defined clojure\* namespaces apart from references to
+     * phel standard library equivalents.
+     *
+     * @param list<string> $directories
+     */
+    public function preRegisterDeclaredNamespaces(array $directories): void
+    {
+        $registry = Registry::getInstance();
+
+        foreach ($directories as $directory) {
+            foreach ($this->findAllPhelFiles($directory) as $file) {
+                $name = $this->extractNamespaceNameOnly($file);
+                if ($name !== null) {
+                    $registry->addDeclaredNamespace($name);
+                }
+            }
+        }
     }
 
     /**
@@ -193,6 +223,74 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Extracts the namespace name from a file without running the full
+     * analyzer. Only lexes, parses, and reads the first form.
+     */
+    private function extractNamespaceNameOnly(string $path): ?string
+    {
+        try {
+            $content = $this->fileIo->getContents($path);
+            $tokenStream = $this->compilerFacade->lexString($content);
+
+            do {
+                $parseTree = $this->compilerFacade->parseNext($tokenStream);
+            } while ($parseTree instanceof TriviaNodeInterface);
+
+            if (!$parseTree instanceof NodeInterface) {
+                return null;
+            }
+
+            $readerResult = $this->compilerFacade->read($parseTree);
+            $ast = $readerResult->getAst();
+
+            if (!$ast instanceof PersistentListInterface) {
+                return null;
+            }
+
+            $first = $ast->get(0);
+            $second = $ast->get(1);
+
+            if (!$first instanceof Symbol || !$second instanceof Symbol) {
+                return null;
+            }
+
+            if ($first->getName() !== Symbol::NAME_NS && $first->getName() !== Symbol::NAME_IN_NS) {
+                return null;
+            }
+
+            return str_replace('.', '\\', $second->getName());
+        } catch (AbstractParserException|ReaderException|LexerValueException) {
+            return null;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findAllPhelFiles(string $directory): array
+    {
+        $realpath = $this->resolvePath($directory);
+        if ($realpath === null || !is_dir($realpath)) {
+            return [];
+        }
+
+        try {
+            $directoryIterator = new RecursiveDirectoryIterator($realpath);
+            $iterator = new RecursiveIteratorIterator($directoryIterator);
+            $phelIterator = new RegexIterator($iterator, '/^.+\.(phel|cljc)$/i', RegexIterator::GET_MATCH);
+
+            $files = [];
+            foreach ($phelIterator as $file) {
+                $files[] = $file[0];
+            }
+
+            return $files;
+        } catch (UnexpectedValueException) {
+            return [];
+        }
     }
 
     private function resolvePath(string $path): ?string

--- a/src/php/Build/Domain/Extractor/NamespaceExtractorInterface.php
+++ b/src/php/Build/Domain/Extractor/NamespaceExtractorInterface.php
@@ -14,4 +14,13 @@ interface NamespaceExtractorInterface
      * @return list<NamespaceInformation>
      */
     public function getNamespacesFromDirectories(array $directories): array;
+
+    /**
+     * Lightweight pre-scan: registers all declared namespace names from
+     * source files on the Registry, so NsSymbol can distinguish
+     * user-defined clojure\* namespaces from phel standard library references.
+     *
+     * @param list<string> $directories
+     */
+    public function preRegisterDeclaredNamespaces(array $directories): void;
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -479,12 +479,10 @@ TXT;
     /**
      * Remaps `clojure\*` namespaces to `phel\*` for Clojure compatibility.
      *
-     * If a required namespace starts with `clojure\` and the corresponding
-     * `phel\*` namespace exists in the Registry, the prefix is replaced
-     * so that e.g. `clojure\test` resolves to `phel\test`.
-     *
-     * User-defined `clojure\*` namespaces (e.g. `clojure\core-test\portability`)
-     * are left untouched when no matching `phel\*` namespace is registered.
+     * A `clojure\*` require is remapped to `phel\*` unless a source file
+     * declares that exact `clojure\*` namespace (detected via pre-scan).
+     * In REPL mode (no pre-scan), falls back to checking the Registry
+     * for the target `phel\*` namespace.
      */
     private function remapClojureNamespace(Symbol $symbol): Symbol
     {
@@ -493,11 +491,21 @@ TXT;
             return $symbol;
         }
 
-        $targetNs = 'phel\\' . substr($name, 8);
-        $mungedNs = str_replace('-', '_', $targetNs);
+        $registry = Registry::getInstance();
 
-        if (Registry::getInstance()->getDefinitionInNamespace($mungedNs) === []) {
+        // If a source file declares this exact clojure\* namespace, don't remap
+        if ($registry->hasDeclaredNamespace($name)) {
             return $symbol;
+        }
+
+        $targetNs = 'phel\\' . substr($name, 8);
+
+        // When no pre-scan ran (REPL), fall back to Registry definitions check
+        if (!$registry->hasDeclaredNamespaces()) {
+            $mungedNs = str_replace('-', '_', $targetNs);
+            if ($registry->getDefinitionInNamespace($mungedNs) === []) {
+                return $symbol;
+            }
         }
 
         return Symbol::createForNamespace(

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -19,6 +19,9 @@ final class Registry
     /** @var array<string, array<string, mixed>> */
     private array $definitionsMetaData = [];
 
+    /** @var array<string, true> Namespace names declared by source files (populated by pre-scan) */
+    private array $declaredNamespaces = [];
+
     private static ?Registry $instance = null;
 
     private function __construct()
@@ -39,6 +42,7 @@ final class Registry
     {
         $this->definitions = [];
         $this->definitionsMetaData = [];
+        $this->declaredNamespaces = [];
     }
 
     public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): void
@@ -93,5 +97,20 @@ final class Registry
     public function getNamespaces(): array
     {
         return array_keys($this->definitions);
+    }
+
+    public function addDeclaredNamespace(string $ns): void
+    {
+        $this->declaredNamespaces[$ns] = true;
+    }
+
+    public function hasDeclaredNamespace(string $ns): bool
+    {
+        return isset($this->declaredNamespaces[$ns]);
+    }
+
+    public function hasDeclaredNamespaces(): bool
+    {
+        return $this->declaredNamespaces !== [];
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -35,8 +35,11 @@ final class NsSymbolTest extends TestCase
         $this->globalEnv = new GlobalEnvironment();
         $this->analyzer = new Analyzer($this->globalEnv);
 
-        // Seed the Registry so clojure\* → phel\* remapping finds the target namespace
-        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+        // Simulate the NamespaceExtractor pre-scan: register standard library
+        // namespaces as declared so clojure→phel remapping knows which
+        // clojure\* names are NOT user-defined source files.
+        Registry::getInstance()->addDeclaredNamespace('phel\\core');
+        Registry::getInstance()->addDeclaredNamespace('phel\\test');
     }
 
     public function test_first_argument_must_be_symbol(): void
@@ -916,8 +919,10 @@ final class NsSymbolTest extends TestCase
         self::assertSame('phel\\test', $isNode->getNamespace());
     }
 
-    public function test_clojure_namespace_not_remapped_when_phel_equivalent_missing(): void
+    public function test_clojure_namespace_not_remapped_when_declared_as_source_namespace(): void
     {
+        Registry::getInstance()->addDeclaredNamespace('clojure\\core-test\\portability');
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -936,8 +941,10 @@ final class NsSymbolTest extends TestCase
         self::assertSame('clojure\\core-test\\portability', $this->globalEnv->resolveAlias('portability'));
     }
 
-    public function test_clojure_namespace_not_remapped_via_dot_syntax_when_phel_equivalent_missing(): void
+    public function test_clojure_namespace_not_remapped_via_dot_syntax_when_declared(): void
     {
+        Registry::getInstance()->addDeclaredNamespace('clojure\\core-test\\portability');
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app.core'),
@@ -956,8 +963,10 @@ final class NsSymbolTest extends TestCase
         self::assertSame('clojure\\core-test\\portability', $this->globalEnv->resolveAlias('portability'));
     }
 
-    public function test_clojure_namespace_not_remapped_in_vector_form_when_phel_equivalent_missing(): void
+    public function test_clojure_namespace_not_remapped_in_vector_form_when_declared(): void
     {
+        Registry::getInstance()->addDeclaredNamespace('clojure\\core-test\\portability');
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app.core'),
@@ -983,6 +992,8 @@ final class NsSymbolTest extends TestCase
 
     public function test_clojure_namespace_no_spurious_original_alias_when_not_remapped(): void
     {
+        Registry::getInstance()->addDeclaredNamespace('clojure\\custom\\lib');
+
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -1000,11 +1011,10 @@ final class NsSymbolTest extends TestCase
         self::assertFalse($this->globalEnv->hasRequireAlias('app\\core', Symbol::create('clojure\\custom\\lib')));
     }
 
-    public function test_clojure_remap_uses_munged_namespace_for_registry_lookup(): void
+    public function test_clojure_remap_works_when_pre_scan_ran(): void
     {
-        // Register with munged name (dashes → underscores), matching how the compiler stores it
-        Phel::addDefinition('phel\\my_lib', '__ns_marker', true, Phel::map());
-
+        // setUp already registered phel\test as declared; clojure\my-lib is NOT
+        // declared, so it should remap unconditionally
         $list = Phel::list([
             Symbol::create(Symbol::NAME_NS),
             Symbol::create('app\\core'),
@@ -1016,10 +1026,60 @@ final class NsSymbolTest extends TestCase
 
         $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
 
-        // Should remap because phel\my_lib exists (munged form of phel\my-lib)
         self::assertEquals([
             Symbol::create('phel\\core'),
             Symbol::create('phel\\my-lib'),
+        ], $nsNode->getRequireNs());
+    }
+
+    public function test_clojure_remap_falls_back_to_registry_in_repl_mode(): void
+    {
+        // Simulate REPL: no pre-scan, so no declared namespaces
+        Registry::getInstance()->clear();
+        $this->globalEnv = new GlobalEnvironment();
+        $this->analyzer = new Analyzer($this->globalEnv);
+
+        // Add phel\test to the Registry (as it would be after loading)
+        Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\test'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('phel\\test'),
+        ], $nsNode->getRequireNs());
+    }
+
+    public function test_clojure_not_remapped_in_repl_when_target_missing(): void
+    {
+        // Simulate REPL: no pre-scan, no declared namespaces, no Registry definitions
+        Registry::getInstance()->clear();
+        $this->globalEnv = new GlobalEnvironment();
+        $this->analyzer = new Analyzer($this->globalEnv);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('app\\core'),
+            Phel::list([
+                Keyword::create('require'),
+                Symbol::create('clojure\\unknown\\ns'),
+            ]),
+        ]);
+
+        $nsNode = (new NsSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertEquals([
+            Symbol::create('phel\\core'),
+            Symbol::create('clojure\\unknown\\ns'),
         ], $nsNode->getRequireNs());
     }
 


### PR DESCRIPTION
## 🤔 Background

PR #1215 fixed the eager clojure→phel remapping by checking the Registry before remapping. However, during the namespace extraction phase (before any file is compiled), the Registry is empty, so the check has a timing gap: `clojure.test` might not get remapped to `phel\test` during extraction, which could break dependency ordering in edge cases.

## 💡 Goal

Make the clojure→phel remap decision work correctly regardless of compilation phase. User-defined `clojure.*` namespaces (e.g. `clojure.core-test.portability`) should never be remapped, while references to phel standard library equivalents (e.g. `clojure.test`) should always remap.

## 🔖 Changes

- `Registry`: add declared namespace tracking (`addDeclaredNamespace`, `hasDeclaredNamespace`, `hasDeclaredNamespaces`) cleared on `clear()`
- `NamespaceExtractorInterface`: add `preRegisterDeclaredNamespaces()` method
- `NamespaceExtractor`: lightweight pre-scan (lex/parse/read only, no analyzer) before full extraction; registers all declared namespace names on the Registry
- `CachedNamespaceExtractor`: delegates pre-scan to inner extractor
- `NsSymbol::remapClojureNamespace()`: two-tier logic:
  1. If pre-scan ran: check if `clojure\*` is a declared source namespace (don't remap if so), otherwise remap unconditionally
  2. If no pre-scan (REPL mode): fall back to existing Registry definitions check
- Tests updated to use declared namespaces instead of Registry definitions; new tests for REPL fallback path and REPL unknown namespace

Closes #1210