### PR TITLE
feat(core): add condp macro for Clojure compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)
 - Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching; only remaps when the target `phel.*` namespace exists, so user-defined `clojure.*` namespaces are left untouched (#1207, #1210)
 - Accept `~` and `~@` as reader macros for `unquote` and `unquote-splicing` inside syntax-quote (alongside the existing `,` and `,@`), matching Clojure's syntax for `.cljc` interop (#1201)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -537,6 +537,44 @@ Otherwise, it tries to call `__toString`."
            (case ~v ~@(next (next pairs))))))
     (first pairs)))
 
+(defn- condp-emit [gpred gexpr clauses]
+  (let [cnt (count clauses)]
+    (cond
+      (php/=== cnt 0)
+      (list 'throw (list 'php/new '\InvalidArgumentException
+                         "No matching clause in condp"))
+      (php/=== cnt 1)
+      (first clauses)
+      :else
+      (if (if (php/>= cnt 3) (= :>> (second clauses)) false)
+        (let [gres (gensym)]
+          (list 'let [gres (list gpred (first clauses) gexpr)]
+                (list 'if gres
+                      (list (first (next (next clauses))) gres)
+                      (condp-emit gpred gexpr (apply list (next (next (next clauses))))))))
+        (list 'if (list gpred (first clauses) gexpr)
+              (second clauses)
+              (condp-emit gpred gexpr (apply list (next (next clauses)))))))))
+
+(defmacro condp
+  "Takes a binary predicate, an expression, and a set of clauses.
+  Each clause takes the form of either:
+    test-expr result-expr
+    test-expr :>> result-fn
+  For each clause, (pred test-expr expr) is evaluated. If it returns
+  logical true, the clause is a match. If a binary clause is a match,
+  result-expr is returned. If a ternary clause with :>> is a match,
+  the result of (pred test-expr expr) is passed to result-fn and the
+  return value is the result. If no clause matches, the default value
+  is returned (if provided), otherwise an exception is thrown."
+  {:example "(condp = 1 1 \"one\" 2 \"two\" \"other\") ; => \"one\""}
+  [pred expr & clauses]
+  (let [gpred (gensym)
+        gexpr (gensym)]
+    `(let [~gpred ~pred
+           ~gexpr ~expr]
+       ~(condp-emit gpred gexpr clauses))))
+
 ;; -----------------
 ;; Boolean operation
 ;; -----------------

--- a/tests/phel/test/core/control-structures.phel
+++ b/tests/phel/test/core/control-structures.phel
@@ -27,3 +27,12 @@
   (is (= 2 (case true true 2)) "case one successful test without default")
   (is (= 2 (case true true 2 1)) "case one successful test with default")
   (is (= :one (case (+ 1 0) 1 :one)) "case with expression"))
+
+(deftest test-condp
+  (is (= "one" (condp = 1 1 "one" 2 "two")) "condp basic match first")
+  (is (= "two" (condp = 2 1 "one" 2 "two")) "condp basic match second")
+  (is (= "default" (condp = 99 1 "one" 2 "two" "default")) "condp with default")
+  (is (thrown? \InvalidArgumentException (condp = 99 1 "one" 2 "two")) "condp no match no default throws")
+  (is (= "neg" (condp < 0 10 "pos" -10 "neg")) "condp with < predicate")
+  (is (= 3 (condp some [1 2 3 4] #{0 6 7} :>> inc #{4 5 9} :>> dec)) "condp :>> threading first match")
+  (is (= 2 (condp some [1 2 3 4] #{0 6 7} :>> inc #{1 2 3} :>> inc)) "condp :>> second clause match"))


### PR DESCRIPTION
## 🤔 Background

Clojure's `condp` is one of its most commonly used conditional macros, and its absence in Phel is a frequent stumbling block for Clojure developers. This is part of the Clojure compatibility initiative tracked in #1217.

## 💡 Goal

Add a `condp` macro to `phel\core` matching Clojure's semantics, including `:>>` result threading support.

## 🔖 Changes

- Add private `condp-emit` helper function that recursively builds the nested `if` tree for clause matching
- Add public `condp` macro supporting:
  - Binary predicate dispatch: `(condp = x 1 "one" 2 "two")`
  - Default fallback clause (odd trailing form)
  - `:>>` result threading: `(condp some coll #{4 5} :>> dec)`
  - Throws `InvalidArgumentException` when no clause matches and no default
- Add 7 test cases covering basic matching, defaults, exceptions, custom predicates, and `:>>` threading
- Update CHANGELOG.md

Closes #1217