### PR TITLE
feat(core): add seq? predicate for lazy sequence checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)
 - Automatic namespace aliasing: `clojure.*` namespaces in `:require` resolve to `phel.*` automatically (e.g. `clojure.test` → `phel\test`), enabling Clojure test suites to run without manual patching; only remaps when the target `phel.*` namespace exists, so user-defined `clojure.*` namespaces are left untouched (#1207, #1210)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -949,6 +949,12 @@ Otherwise, it tries to call `__toString`."
   [x]
   (= (type x) :php/object))
 
+(defn seq?
+  "Returns true if `x` is a seq (implements LazySeqInterface), false otherwise."
+  {:see-also ["seq" "lazy-seq"]}
+  [x]
+  (php/instanceof x LazySeqInterface))
+
 (defn empty?
   "Returns true if x would be 0, \"\" or empty collection, false otherwise."
   [x]
@@ -983,7 +989,7 @@ Otherwise, it tries to call `__toString`."
     nil
 
     ;; For lazy sequences, don't force them - just check if first element exists
-    (php/instanceof coll LazySeqInterface)
+    (seq? coll)
     (if (php/=== nil (php/-> coll (first))) nil coll)
 
     ;; For other countable collections, check count (won't force lazy seqs)
@@ -1043,7 +1049,7 @@ Otherwise, it tries to call `__toString`."
     (nil? coll)
     nil
 
-    (php/instanceof coll LazySeqInterface)
+    (seq? coll)
     (loop [s coll last-val nil]
       (if (nil? (seq s))
         last-val
@@ -1080,7 +1086,7 @@ Otherwise, it tries to call `__toString`."
       k
       opt)
 
-    (php/instanceof ds LazySeqInterface)
+    (seq? ds)
     (loop [i k
            s ds]
       (if (or (nil? s) (php/< i 0))
@@ -2339,7 +2345,7 @@ Otherwise, it tries to call `__toString`."
   "Forces realization of a lazy sequence and returns it as a vector."
   {:example "(doall (map println [1 2 3])) ; => [nil nil nil]"}
   [coll]
-  (if (php/instanceof coll LazySeqInterface)
+  (if (seq? coll)
     (let [arr (php/-> coll (toArray))]
       (if (php/empty arr)
         nil
@@ -2350,7 +2356,7 @@ Otherwise, it tries to call `__toString`."
   "Forces realization of a lazy sequence for side effects, returns nil."
   {:example "(dorun (map println [1 2 3])) ; => nil"}
   [coll]
-  (if (php/instanceof coll LazySeqInterface)
+  (if (seq? coll)
     (do
       (doseq [x :in coll] x)
       nil)
@@ -2362,7 +2368,7 @@ Otherwise, it tries to call `__toString`."
    :see-also ["delay" "force" "lazy-seq"]}
   [coll]
   (cond
-    (php/instanceof coll LazySeqInterface) (php/-> coll (isRealized))
+    (seq? coll) (php/-> coll (isRealized))
     (php/instanceof coll Delay) (php/-> coll (isRealized))
     true))
 

--- a/tests/phel/test/core/file-operation.phel
+++ b/tests/phel/test/core/file-operation.phel
@@ -113,7 +113,7 @@
         target-file (str target-directory php/DIRECTORY_SEPARATOR "test-line-seq-type.txt")]
     (spit target-file "line1\nline2")
     (let [result (line-seq target-file)]
-      (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+      (is (true? (seq? result))
           "line-seq should return a lazy sequence"))
     (php/unlink target-file)))
 
@@ -173,7 +173,7 @@
     (php/mkdir target-directory)
     (spit target-file "content")
     (let [result (file-seq target-directory)]
-      (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+      (is (true? (seq? result))
           "file-seq should return a lazy sequence"))
     (php/unlink target-file)
     (php/rmdir target-directory)))
@@ -312,7 +312,7 @@
         target-file (str target-directory php/DIRECTORY_SEPARATOR "test-read-file-lazy-type.txt")]
     (spit target-file "some content")
     (let [result (read-file-lazy target-file)]
-      (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+      (is (true? (seq? result))
           "read-file-lazy should return a lazy sequence"))
     (php/unlink target-file)))
 
@@ -432,7 +432,7 @@
         target-file (str target-directory php/DIRECTORY_SEPARATOR "test-csv-seq-type.csv")]
     (spit target-file "a,b,c\n1,2,3")
     (let [result (csv-seq target-file)]
-      (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+      (is (true? (seq? result))
           "csv-seq should return a lazy sequence"))
     (php/unlink target-file)))
 

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -433,7 +433,7 @@
 
 (deftest test-mapcat-returns-lazy-seq
   (let [result (mapcat identity [[1 2] [3 4]])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "mapcat should return a lazy sequence")))
 
 ;; Lazy interpose tests
@@ -467,7 +467,7 @@
 
 (deftest test-interpose-returns-lazy-seq
   (let [result (interpose 0 [1 2 3])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "interpose should return a lazy sequence")))
 
 ;; Lazy map-indexed tests
@@ -501,7 +501,7 @@
 
 (deftest test-map-indexed-returns-lazy-seq
   (let [result (map-indexed vector [1 2 3])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "map-indexed should return a lazy sequence")))
 
 ;; Lazy interleave tests
@@ -539,7 +539,7 @@
 
 (deftest test-interleave-returns-lazy-seq
   (let [result (interleave [1 2 3] [:a :b :c])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "interleave should return a lazy sequence")))
 
 ;; Lazy flatten tests
@@ -573,7 +573,7 @@
 
 (deftest test-flatten-returns-lazy-seq
   (let [result (flatten [[1 2] [3 4]])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "flatten should return a lazy sequence")))
 
 ;; Lazy variadic map tests
@@ -607,7 +607,7 @@
 
 (deftest test-map-variadic-returns-lazy-seq
   (let [result (map vector [1 2 3] [:a :b :c])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "variadic map should return a lazy sequence")))
 
 ;; Tests for partition
@@ -641,7 +641,7 @@
 
 (deftest test-partition-returns-lazy-seq
   (let [result (partition 2 [1 2 3 4])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "partition should return a lazy sequence")))
 
 ;; Tests for partition-all
@@ -675,7 +675,7 @@
 
 (deftest test-partition-all-returns-lazy-seq
   (let [result (partition-all 2 [1 2 3 4 5])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "partition-all should return a lazy sequence")))
 
 ;; Helper functions for lazy-seq tests
@@ -760,7 +760,7 @@
 
 (deftest test-lazy-cat-returns-lazy-seq
   (let [result (lazy-cat [1 2] [3 4])]
-    (is (true? (php/instanceof result \Phel\Lang\Collections\LazySeq\LazySeqInterface))
+    (is (true? (seq? result))
         "lazy-cat should return a lazy sequence")))
 
 (deftest test-lazy-cat-three-collections

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -116,3 +116,10 @@
   (is (true? (associative? (php-associative-array "a" 1 "b" 2))) "associative? on associative array")
   (is (false? (associative? [])) "associative? on vector")
   (is (false? (associative? (php/array))) "associative? on php array"))
+
+(deftest test-seq?
+  (is (true? (seq? (take 5 (iterate inc 1)))) "seq? on lazy sequence")
+  (is (false? (seq? [])) "seq? on vector")
+  (is (false? (seq? '())) "seq? on list")
+  (is (false? (seq? {})) "seq? on map")
+  (is (false? (seq? nil)) "seq? on nil"))


### PR DESCRIPTION
## 🤔 Background

Clojure provides `seq?` to check if a value is a seq. Phel currently lacks this predicate and uses raw `(php/instanceof x LazySeqInterface)` calls throughout the core library and tests.

## 💡 Goal

Add an idiomatic `seq?` predicate function matching Clojure semantics and replace all raw `php/instanceof LazySeqInterface` calls with it.

Closes #1231

## 🔖 Changes

- Added `seq?` function in `phel\core` using `(php/instanceof x LazySeqInterface)`, placed alongside other type predicates
- Replaced 6 raw `(php/instanceof ... LazySeqInterface)` calls in core (`seq`, `peek`, `get`, `doall`, `dorun`, `realized?`) with `(seq? ...)`
- Replaced 13 raw `(php/instanceof ... \Phel\Lang\Collections\LazySeq\LazySeqInterface)` calls in test files with `(seq? ...)`
- Added `test-seq?` in `type-operation.phel` covering lazy sequences, vectors, lists, maps, and nil
- Updated CHANGELOG.md unreleased section