### PR TITLE
feat(core): add if-some, when-some, when-first macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `if-some`, `when-some`, `when-first` macros for nil-aware binding, matching Clojure semantics (#1218)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3858,6 +3858,58 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
          (let [~form temp-sym]
            ~@body)))))
 
+(defmacro if-some
+  "Binds name to the value of test. If test is not nil, evaluates then with binding-form
+  bound to the value of test, if not, yields else. Unlike if-let, false and 0 are not
+  treated as falsy — only nil triggers the else branch."
+  {:see-also ["if-let" "when-some"]}
+  [bindings then & [else]]
+  (let [err #(throw (php/new \InvalidArgumentException %))]
+    (when-not
+      (vector? bindings)
+      (err (str "if-some requires a vector for its bindings, "
+                (type bindings) " given")))
+    (when-not
+      (= 2 (count bindings))
+      (err (str "if-some requires bindings to have 2 elements, "
+                (count bindings) " given"))))
+
+  (let [form (bindings 0) tst (bindings 1) temp-sym (gensym)]
+    `(let [temp-sym ~tst]
+       (if (not (nil? temp-sym))
+         (let [~form temp-sym]
+           ~then)
+         ~else))))
+
+(defmacro when-some
+  "Binds name to the value of test. When test is not nil, evaluates body with
+  binding-form bound to the value of test. Unlike when-let, false and 0 are not
+  treated as falsy — only nil causes the body to be skipped."
+  {:see-also ["when-let" "if-some"]}
+  [bindings & body]
+  `(if-some ~bindings (do ~@body) nil))
+
+(defmacro when-first
+  "Binds name to the first element of coll. When the collection is non-empty
+  (first returns non-nil), evaluates body with the binding."
+  {:see-also ["when-some" "first"]}
+  [bindings & body]
+  (let [err #(throw (php/new \InvalidArgumentException %))]
+    (when-not
+      (vector? bindings)
+      (err (str "when-first requires a vector for its bindings, "
+                (type bindings) " given")))
+    (when-not
+      (= 2 (count bindings))
+      (err (str "when-first requires bindings to have 2 elements, "
+                (count bindings) " given"))))
+
+  (let [sym (bindings 0) coll (bindings 1) temp-sym (gensym)]
+    `(let [temp-sym (first ~coll)]
+       (when (not (nil? temp-sym))
+         (let [~sym temp-sym]
+           ~@body)))))
+
 (defmacro time
   "Evaluates expr and prints the time it took. Returns the value of expr."
   [expr]

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -117,6 +117,40 @@
   (is (= 2 (when-let [[a b] '(1 2)] b)))
   (is (= nil (when-let [a false] (throw (php/new \Exception))))))
 
+(deftest test-if-some
+  (is (= "found" (if-some [x 1] "found" "missing"))
+      "if-some with non-nil value")
+  (is (= "found" (if-some [x false] "found" "missing"))
+      "if-some with false (not nil)")
+  (is (= 0 (if-some [x 0] x "missing"))
+      "if-some with 0 (not nil)")
+  (is (= "missing" (if-some [x nil] "found" "missing"))
+      "if-some with nil")
+  (is (= nil (if-some [x nil] "found"))
+      "if-some with nil and no else")
+  (is (= "found" (if-some [x ""] "found" "missing"))
+      "if-some with empty string (not nil)"))
+
+(deftest test-when-some
+  (is (= 1 (when-some [x 1] x))
+      "when-some with non-nil value")
+  (is (= false (when-some [x false] x))
+      "when-some with false (not nil)")
+  (is (= 0 (when-some [x 0] x))
+      "when-some with 0 (not nil)")
+  (is (nil? (when-some [x nil] x))
+      "when-some with nil"))
+
+(deftest test-when-first
+  (is (= 1 (when-first [x [1 2 3]] x))
+      "when-first with non-empty vector")
+  (is (nil? (when-first [x []] x))
+      "when-first with empty vector")
+  (is (nil? (when-first [x '()] x))
+      "when-first with empty list")
+  (is (= :a (when-first [x [:a :b]] x))
+      "when-first with keyword vector"))
+
 (deftest test-time
   (is (= 2 (+ 1 1)) "time returns expr value")
   (let [output-print (with-output-buffer (time (+ 1 1)))]


### PR DESCRIPTION
## 🤔 Background

Clojure provides `if-some`, `when-some`, and `when-first` for nil-aware binding. Unlike `if-let`/`when-let` which check truthiness, these check for non-nil — so `false` and `0` are valid values that don't trigger the else branch.

## 💡 Goal

Add three nil-aware binding macros matching Clojure semantics.

Closes #1218

## 🔖 Changes

- Added `if-some` macro: binds value, executes then-branch if not nil (false/0 are valid)
- Added `when-some` macro: like `if-some` without else branch
- Added `when-first` macro: binds first element of collection, executes body if non-nil
- All three include input validation matching `if-let`/`when-let` patterns
- Tests cover nil, false, 0, empty string, empty collections, and keyword edge cases