### PR TITLE
feat(core): add rename-keys function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `rename-keys` function for renaming map keys according to a key map (#1220)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2429,6 +2429,16 @@ Otherwise, it tries to call `__toString`."
                  (assoc acc k v))]
     (with-meta m result)))
 
+(defn rename-keys
+  "Returns the map with keys renamed according to kmap.
+  Keys not present in kmap are left unchanged."
+  {:example "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; => {:x 1 :y 2 :c 3}"
+   :see-also ["select-keys" "keys" "vals"]}
+  [m kmap]
+  (for [[k v] :pairs m
+        :reduce [acc {}]]
+    (put acc (get kmap k k) v)))
+
 (defn invert
   "Returns a new map where the keys and values are swapped.
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -305,6 +305,20 @@
   (is (= {:a 1} (select-keys {:a 1 :b 2 :c 3} [:a nil])) "select-keys with nil key in ks")
   (is (= {:a 1 nil 4} (select-keys {:a 1 :b 2 :c 3 nil 4} [:a nil])) "select-keys with nil key in m"))
 
+(deftest test-rename-keys
+  (is (= {:x 1 :y 2 :c 3} (rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}))
+      "rename-keys renames matching keys")
+  (is (= {:a 1} (rename-keys {:a 1} {}))
+      "rename-keys with empty kmap")
+  (is (= {} (rename-keys {} {:a :b}))
+      "rename-keys with empty map")
+  (is (= {:a 1} (rename-keys {:a 1} {:z :q}))
+      "rename-keys when kmap key not in map")
+  (is (= {:b 1} (rename-keys {:a 1} {:a :b}))
+      "rename-keys single key")
+  (is (= {:x 1 :y 2} (rename-keys {:a 1 :b 2} {:a :x :b :y}))
+      "rename-keys all keys"))
+
 (deftest test-simple-deep-merge
   (is (= {:a 1 :b 3 :c 4} (deep-merge {:a 1 :b 2} {:b 3 :c 4}))))
 


### PR DESCRIPTION
## 🤔 Background

Clojure provides `rename-keys` (in `clojure.set`) for renaming map keys. Since Phel already has `select-keys` in core, `rename-keys` belongs alongside it.

## 💡 Goal

Add `rename-keys` function matching Clojure semantics.

Closes #1220

## 🔖 Changes

- Added `rename-keys` function in `phel\core` next to `select-keys`
- Uses `for` comprehension with `get` fallback for clean O(n) implementation
- Keys present in kmap are renamed; others pass through unchanged
- Tests cover: basic rename, empty map, empty kmap, missing kmap keys, full rename