### PR TITLE
feat(core): add min-key and max-key functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `min-key` and `max-key` functions for finding extremes by a derived value (#1221)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3001,6 +3001,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [& numbers]
   (extreme > numbers))
 
+(defn min-key
+  "Returns the arg for which (k arg) is smallest."
+  {:example "(min-key count \"bb\" \"aaa\" \"b\") ; => \"b\""
+   :see-also ["max-key" "min" "sort-by"]}
+  [k x & more]
+  (reduce (fn [best item] (if (< (k item) (k best)) item best)) x more))
+
+(defn max-key
+  "Returns the arg for which (k arg) is largest."
+  {:example "(max-key count \"bb\" \"aaa\" \"b\") ; => \"aaa\""
+   :see-also ["min-key" "max" "sort-by"]}
+  [k x & more]
+  (reduce (fn [best item] (if (> (k item) (k best)) item best)) x more))
+
 (defn coerce-in
   "Returns `v` if it is in the range, or `min` if `v` is less than `min`, or `max` if `v` is greater than `max`."
   [v min max]

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -99,6 +99,22 @@
 (deftest test-max
   (is (= 3 (max 1 2 3)) "(max 1 2 3)"))
 
+(deftest test-min-key
+  (is (= {:a 1} (min-key :a {:a 1} {:a 3} {:a 2}))
+      "min-key with keyword key")
+  (is (= "b" (min-key count "bb" "aaa" "b"))
+      "min-key with function key")
+  (is (= 5 (min-key identity 5))
+      "min-key with single arg"))
+
+(deftest test-max-key
+  (is (= {:a 3} (max-key :a {:a 1} {:a 3} {:a 2}))
+      "max-key with keyword key")
+  (is (= "aaa" (max-key count "bb" "aaa" "b"))
+      "max-key with function key")
+  (is (= 5 (max-key identity 5))
+      "max-key with single arg"))
+
 (deftest test-coerce-in
   (is (= 0.5 (coerce-in 0.5 0 1)) "(coerce-in 0.5 0 1)")
   (is (= 1 (coerce-in 1.5 0 1)) "(coerce-in 1.5 0 1)")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `min-key` and `max-key` for finding extremes by a derived value. These are commonly used utilities missing from Phel.

## 💡 Goal

Add `min-key` and `max-key` functions matching Clojure semantics.

Closes #1221

## 🔖 Changes

- Added `min-key` function: returns the arg for which `(k arg)` is smallest
- Added `max-key` function: returns the arg for which `(k arg)` is largest
- Both support single and variadic arguments via `reduce`
- Tests cover keyword keys, function keys, and single-arg cases