### PR TITLE
feat: add fnil function

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2628,6 +2628,19 @@ Otherwise, it tries to call `__toString`."
   [f & args]
   #(apply f (concat [] args %&)))
 
+(defn fnil
+  "Returns a function that replaces nil arguments with defaults before calling f."
+  {:see-also ["partial" "comp"]}
+  ([f default]
+   (fn [x & args]
+     (apply f (if (nil? x) default x) args)))
+  ([f d1 d2]
+   (fn [x y & args]
+     (apply f (if (nil? x) d1 x) (if (nil? y) d2 y) args)))
+  ([f d1 d2 d3]
+   (fn [x y z & args]
+     (apply f (if (nil? x) d1 x) (if (nil? y) d2 y) (if (nil? z) d3 z) args))))
+
 (defn memoize
   "Returns a memoized version of the function `f`. The memoized function
   caches the return value for each set of arguments."

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -75,3 +75,19 @@
     (is (= 3 (f 1 2)) "cached multi-arg call")
     (is (= 7 (f 3 4)) "different multi-arg call")
     (is (= 2 (deref counter)) "two executions")))
+
+(deftest test-fnil-one-arg
+  (let [safe-inc (fnil inc 0)]
+    (is (= 1 (safe-inc nil)) "nil replaced with default")
+    (is (= 6 (safe-inc 5)) "non-nil passes through")))
+
+(deftest test-fnil-two-args
+  (let [safe-add (fnil + 0 0)]
+    (is (= 0 (safe-add nil nil)) "both nil replaced")
+    (is (= 5 (safe-add 5 nil)) "first non-nil, second nil")
+    (is (= 3 (safe-add nil 3)) "first nil, second non-nil")))
+
+(deftest test-fnil-three-args
+  (let [f (fnil (fn [a b c] (+ a b c)) 1 2 3)]
+    (is (= 6 (f nil nil nil)) "all three nil")
+    (is (= 15 (f 10 nil nil)) "only first non-nil")))


### PR DESCRIPTION
Added `fnil` to `phel\core`, matching Clojure's [`fnil`](https://clojuredocs.org/clojure.core/fnil). Creates a nil-safe wrapper around a function, replacing nil arguments with defaults before calling `f`.

```phel
(def safe-inc (fnil inc 0))
(safe-inc nil)  ;; => 1
(safe-inc 5)    ;; => 6
```

Supports 1-arg, 2-arg, and 3-arg default variants. Placed near `partial`, `comp`, and `juxt` in the HOF section of core.phel.

Tests cover all three arity variants, nil replacement, and non-nil passthrough.

Fixes #1225

---

This contribution was developed with AI assistance (Claude Code).