### PR TITLE
feat(core): add assert macro for precondition checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `assert` macro for precondition checking with optional custom message (#1222)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3866,6 +3866,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
      (println "Elapsed time:" (* 1000 (- (php/microtime true) start#)) "msecs")
      ret#))
 
+(defmacro assert
+  "Throws an exception if expr is falsy. Optional message string.
+  Used for precondition checking in application code."
+  {:see-also ["when" "throw"]}
+  [expr & [message]]
+  (let [msg (if message
+              `(str "Assert failed: " ~message)
+              `(str "Assert failed: " (quote ~expr)))]
+    `(when (not ~expr)
+       (throw (php/new \InvalidArgumentException ~msg)))))
+
 (defn name
   "Returns the name string of a string, keyword or symbol."
   [x]

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -124,6 +124,21 @@
     (is (s/contains? output-print "Elapsed time:"))
     (is (s/contains? output-print "msecs"))))
 
+(deftest test-assert-passes
+  (assert true)
+  (assert (= 1 1))
+  (assert "non-nil string")
+  (is (= 1 1) "assert does not throw on truthy values"))
+
+(deftest test-assert-fails
+  (is (thrown? \InvalidArgumentException (assert false))
+      "assert throws on false")
+  (is (thrown? \InvalidArgumentException (assert nil))
+      "assert throws on nil")
+  (is (thrown-with-msg? \InvalidArgumentException "Assert failed: must be positive"
+        (assert false "must be positive"))
+      "assert includes custom message"))
+
 (deftest test-name
   (is (= "string" (name "string")) "name on string")
   (is (= "symbol" (name 'symbol)) "name on symbol")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `assert` for precondition checking in application code. Phel has assertion helpers in `phel\test` but no general-purpose `assert` macro for runtime preconditions.

## 💡 Goal

Add `assert` macro matching Clojure semantics.

Closes #1222

## 🔖 Changes

- Added `assert` macro: throws `InvalidArgumentException` when expr is falsy
- Supports optional custom message string
- Default message includes the quoted expression for debugging
- Tests cover truthy pass-through, false/nil throwing, and custom messages