### PR TITLE
feat(core): add vary-meta function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `vary-meta` function to apply a function to an object's metadata (#1223)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -193,6 +193,15 @@
   (fn [obj meta]
     (php/-> obj (withMeta meta))))
 
+(def vary-meta
+  {:doc "Returns an object with (apply f (meta obj) args) as its new metadata."
+   :see-also ["meta" "with-meta"]}
+  (fn [obj f & args]
+    (let [m (if (php/instanceof obj MetaInterface)
+              (php/-> obj (getMeta))
+              nil)]
+      (php/-> obj (withMeta (apply f m args))))))
+
 (def with-meta
   {:private true
    :doc "Returns `target` with the metadata from `source` when both implement `MetaInterface`."}

--- a/tests/phel/test/core/meta.phel
+++ b/tests/phel/test/core/meta.phel
@@ -44,6 +44,14 @@
     (is (= m (meta (interleave data [4 5 6]))) "interleave preserves metadata")
     (is (= m (meta (frequencies data))) "frequencies preserves metadata")))
 
+(deftest test-vary-meta
+  (is (= {:a 1 :b 2} (meta (vary-meta (set-meta! [] {:a 1}) put :b 2)))
+      "vary-meta adds key to existing metadata")
+  (is (= {:count 1} (meta (vary-meta (set-meta! [] {:count 0}) update-in [:count] inc)))
+      "vary-meta with update-in")
+  (is (= {:a 1} (meta (vary-meta (set-meta! [] {:a 1 :b 2}) dissoc :b)))
+      "vary-meta with dissoc"))
+
 (deftest associative-functions-preserve-meta
   (let [m {:foo "bar"}
         data (set-meta! {:a 1 :b 2} m)]


### PR DESCRIPTION
## 🤔 Background

Clojure provides `vary-meta` to apply a function to an object's metadata. Phel has `meta` and `set-meta!` but lacks `vary-meta`, which is commonly used in macro-heavy code for metadata transformations.

## 💡 Goal

Add `vary-meta` function matching Clojure semantics.

Closes #1223

## 🔖 Changes

- Added `vary-meta` function using raw PHP interop to get/set metadata at runtime
- Supports variadic args passed through to the function via `apply`
- Tests cover `put`, `update-in`, and `dissoc` operations on metadata