### PR TITLE
feat(core): add fnil function for nil-safe wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `fnil` function for nil-safe function wrapping with default values (#1225)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2628,6 +2628,24 @@ Otherwise, it tries to call `__toString`."
   [f & args]
   #(apply f (concat [] args %&)))
 
+(defn fnil
+  "Returns a function that replaces nil arguments with the provided defaults
+  before calling f. The number of defaults determines how many leading arguments
+  are nil-checked."
+  {:example "(let [safe-inc (fnil inc 0)] (safe-inc nil)) ; => 1"
+   :see-also ["partial" "comp"]}
+  [f & defaults]
+  (let [n (count defaults)]
+    (fn [& args]
+      (let [patched (for [i :range [0 (count args)]
+                          :reduce [acc []]]
+                      (let [arg (get args i)]
+                        (conj acc
+                          (if (and (php/< i n) (nil? arg))
+                            (get defaults i)
+                            arg))))]
+        (apply f patched)))))
+
 (defn memoize
   "Returns a memoized version of the function `f`. The memoized function
   caches the return value for each set of arguments."

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -18,6 +18,28 @@
 (deftest test-partial
   (is (= 3 ((partial + 2) 1)) "partial of add"))
 
+(deftest test-fnil-one-default
+  (let [safe-inc (fnil inc 0)]
+    (is (= 1 (safe-inc nil))
+        "fnil replaces nil with default")
+    (is (= 6 (safe-inc 5))
+        "fnil passes non-nil through")))
+
+(deftest test-fnil-two-defaults
+  (let [safe-add (fnil + 0 0)]
+    (is (= 0 (safe-add nil nil))
+        "fnil replaces both nil args")
+    (is (= 5 (safe-add 5 nil))
+        "fnil replaces only nil args")
+    (is (= 3 (safe-add nil 3))
+        "fnil replaces first nil arg")))
+
+(deftest test-fnil-with-update-in
+  (let [m {:a 1}
+        result (update-in m [:b] (fnil inc 0))]
+    (is (= 1 (get result :b))
+        "fnil works with update-in for missing keys")))
+
 (deftest test-constantly
   (let [f (constantly 42)]
     (is (= 42 (f)) "constantly without args")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `fnil` to create nil-safe function wrappers, commonly used with `update-in` for safely incrementing missing map keys. Phel lacks this utility.

## 💡 Goal

Add `fnil` function matching Clojure semantics.

Closes #1225

## 🔖 Changes

- Added `fnil` function accepting a function and variadic defaults
- Replaces nil arguments (up to the number of defaults) before calling the wrapped function
- Non-nil values pass through unchanged
- Tests cover 1-default, 2-default, and `update-in` integration scenarios