### PR TITLE
feat(test): add testing macro for grouping assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `testing` macro in `phel\test` for grouping assertions with context strings, matching Clojure's `clojure.test/testing` (#1237)
 - `seq?` predicate function to check if a value is a seq (implements `LazySeqInterface`), matching Clojure semantics (#1231)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - Allow `require` and `use` to accept quoted symbols in the REPL (e.g. `(require 'phel\str)`), matching Clojure semantics and enabling nREPL client compatibility (#1211)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -235,6 +235,13 @@
      (binding [*current-test-name* ~(name test-name)]
               ~@body)))
 
+(defmacro testing
+  "Adds a testing context string. Used inside deftest to describe a group of assertions.
+  The context string is prepended to failure messages for better diagnostics."
+  {:example "(deftest test-math\n  (testing \"addition\"\n    (is (= 2 (+ 1 1)))))"}
+  [context & body]
+  `(do ~@body))
+
 ;; ---------------------
 ;; error/failure printer
 ;; ---------------------

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -15,6 +15,10 @@
 
 (def- *current-test-name* nil)
 
+(def *testing-contexts*
+  "Stack of testing context strings, most recent first."
+  [])
+
 (def- stats (var {:failed []
                   :counts {:failed 0
                            :error 0
@@ -37,11 +41,22 @@
        (let [{:failed f :error e} (get (deref stats) :counts)]
          (pos? (+ f e)))))
 
+(defn- testing-contexts-str []
+  "Returns the current testing context as a string prefix, or nil."
+  (when (not (empty? *testing-contexts*))
+    (str (s/join " > " *testing-contexts*) " - ")))
+
 (defn report
   "Records test results and prints status indicators."
   {:example "(report {:state :pass})"}
   [data]
-  (let [{:state state :type type} data
+  (let [ctx (testing-contexts-str)
+        data (if (and ctx (:message data))
+               (put data :message (str ctx (:message data)))
+               (if ctx
+                 (put data :message (s/join " > " *testing-contexts*))
+                 data))
+        {:state state :type type} data
         ok (= state :pass)
         total-columns 80]
     (if (deref testdox?)
@@ -240,7 +255,8 @@
   The context string is prepended to failure messages for better diagnostics."
   {:example "(deftest test-math\n  (testing \"addition\"\n    (is (= 2 (+ 1 1)))))"}
   [context & body]
-  `(do ~@body))
+  `(binding [*testing-contexts* (conj *testing-contexts* ~context)]
+     ~@body))
 
 ;; ---------------------
 ;; error/failure printer

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\test-framework
-  (:require phel\test :refer [deftest is get-stats reset-stats restore-stats]))
+  (:require phel\test :refer [deftest is testing get-stats reset-stats restore-stats]))
 
 ;; Behavior coverage for the `is` macro and its built-in dispatch arms.
 ;;
@@ -211,3 +211,16 @@
     (let [failure (first (get snapshot :failed))]
       (is (= "intentional failure" (get failure :message))
           "failure preserves the user-provided message"))))
+
+;; ---------------------------------------------------------------------------
+;; testing macro — context wrapper for grouping assertions
+;; ---------------------------------------------------------------------------
+
+(deftest test-testing-executes-body
+  (testing "arithmetic"
+    (is (= 4 (+ 2 2)) "testing macro executes body assertions")))
+
+(deftest test-testing-nested
+  (testing "outer"
+    (testing "inner"
+      (is (= 1 1) "nested testing blocks execute"))))

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -224,3 +224,15 @@
   (testing "outer"
     (testing "inner"
       (is (= 1 1) "nested testing blocks execute"))))
+
+(deftest test-testing-context-in-failure-message
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer
+            (testing "math basics"
+              (is (= 1 2) "addition")))
+        snapshot (get-stats)]
+    (restore-stats saved)
+    (let [failure (first (get snapshot :failed))]
+      (is (= "math basics - addition" (get failure :message))
+          "testing context is prepended to failure message"))))


### PR DESCRIPTION
## 🤔 Background

Clojure's `clojure.test/testing` is widely used to group assertions with context strings. Its absence causes `Cannot resolve symbol 'testing'` errors when running Clojure test suites in Phel (e.g. clojure-test-suite).

## 💡 Goal

Add `testing` macro to `phel\test` for Clojure compatibility.

Closes #1237

## 🔖 Changes

- Added `testing` macro to `phel\test` that executes its body (context string for readability)
- Tests cover basic usage and nested `testing` blocks