### PR TITLE
feat(compiler): support :strs in map destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `:strs` support in map destructuring for string-key lookups, matching Clojure semantics (#1227)
 - `fnil` function for nil-safe function wrapping with default values (#1225)
 - `vary-meta` function to apply a function to an object's metadata (#1223)
 - `assert` macro for precondition checking with optional custom message (#1222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
-- `:strs` support in map destructuring for string-key lookups, matching Clojure semantics (#1227)
+- `:strs` support in map destructuring for string key lookup (#1227)
 - `fnil` function for nil-safe function wrapping with default values (#1225)
 - `vary-meta` function to apply a function to an object's metadata (#1223)
 - `assert` macro for precondition checking with optional custom message (#1222)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -32,12 +32,18 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
     public function deconstruct(array &$bindings, $binding, $value): void
     {
         $keys = null;
+        $strs = null;
         $asSymbol = null;
         $normalBindings = [];
 
         foreach ($binding as $key => $bindTo) {
             if ($key instanceof Keyword && $key->getName() === 'keys') {
                 $keys = $bindTo;
+                continue;
+            }
+
+            if ($key instanceof Keyword && $key->getName() === 'strs') {
+                $strs = $bindTo;
                 continue;
             }
 
@@ -60,6 +66,14 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
                 if ($sym instanceof Symbol) {
                     $keyword = Keyword::create($sym->getName());
                     $this->bindingIteration($bindings, $binding, $keyword, $sym);
+                }
+            }
+        }
+
+        if ($strs instanceof PersistentVectorInterface) {
+            foreach ($strs as $sym) {
+                if ($sym instanceof Symbol) {
+                    $this->bindingIteration($bindings, $binding, $sym->getName(), $sym);
                 }
             }
         }

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -19,6 +19,18 @@
   (is (= 3 (let [{:keys [a b]} {:a 1 :b 2}] (+ a b))) "destructure hash map with :keys")
   (is (= {:a 1 :b 2} (let [{:keys [a b] :as user} {:a 1 :b 2}] user)) "destructure hash map with :keys and :as"))
 
+(deftest destructure-hash-map-strs
+  (is (= "Alice" (let [{:strs [name]} {"name" "Alice"}] name))
+      ":strs extracts string key")
+  (is (= 30 (let [{:strs [name age]} {"name" "Alice" "age" 30}] age))
+      ":strs extracts multiple string keys")
+  (is (nil? (let [{:strs [a b]} {"a" 1}] b))
+      ":strs returns nil for missing key")
+  (is (= {"x" 1 "y" 2} (let [{:strs [x] :as m} {"x" 1 "y" 2}] m))
+      ":strs combined with :as binds the full map")
+  (is (= "Bob" ((fn [{:strs [name]}] name) {"name" "Bob"}))
+      ":strs works in fn parameter destructuring"))
+
 ;; ----------------------------
 ;; Basic methods for quasiquote
 ;; ----------------------------

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -189,6 +189,109 @@ final class MapBindingDeconstructorTest extends TestCase
         ], $bindings);
     }
 
+    public function test_deconstruct_strs(): void
+    {
+        // Test for binding like this (let [{:strs [name age]} x])
+        // This will be destructured to this:
+        // (let [__phel_1 x
+        //       __phel_2 (get __phel_1 "name")
+        //       name __phel_2
+        //       __phel_3 (get __phel_1 "age")
+        //       age __phel_3])
+
+        $binding = Phel::map(
+            Keyword::create('strs'),
+            Phel::vector([
+                Symbol::create('name'),
+                Symbol::create('age'),
+            ]),
+        );
+        $value = Symbol::create('x');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // __phel_1 x
+            [
+                Symbol::create('__phel_1'),
+                $value,
+            ],
+            // __phel_2 (get __phel_1 "name")
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    'name',
+                ]),
+            ],
+            // name __phel_2
+            [
+                Symbol::create('name'),
+                Symbol::create('__phel_2'),
+            ],
+            // __phel_3 (get __phel_1 "age")
+            [
+                Symbol::create('__phel_3'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    'age',
+                ]),
+            ],
+            // age __phel_3
+            [
+                Symbol::create('age'),
+                Symbol::create('__phel_3'),
+            ],
+        ], $bindings);
+    }
+
+    public function test_deconstruct_strs_with_as(): void
+    {
+        // Test for binding like this (let [{:strs [name] :as m} x])
+        // This will be destructured to this:
+        // (let [m x
+        //       __phel_1 (get m "name")
+        //       name __phel_1])
+
+        $binding = Phel::map(
+            Keyword::create('strs'),
+            Phel::vector([
+                Symbol::create('name'),
+            ]),
+            Keyword::create('as'),
+            Symbol::create('m'),
+        );
+        $value = Symbol::create('x');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // m x
+            [
+                Symbol::create('m'),
+                $value,
+            ],
+            // __phel_1 (get m "name")
+            [
+                Symbol::create('__phel_1'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('m'),
+                    'name',
+                ]),
+            ],
+            // name __phel_1
+            [
+                Symbol::create('name'),
+                Symbol::create('__phel_1'),
+            ],
+        ], $bindings);
+    }
+
     public function test_deconstruct_keys_with_as(): void
     {
         // Test for binding like this (let [{:keys [a] :as m} x])


### PR DESCRIPTION
## 🤔 Background

Phel currently supports `:keys` for keyword-based map destructuring but lacks `:strs` for string-based destructuring. This is a gap compared to Clojure, which supports both. String-key destructuring is particularly useful for PHP interop scenarios like working with JSON-decoded data or PHP arrays that use string keys.

## 💡 Goal

Add `:strs` support in map destructuring so that `{:strs [name age]}` looks up `"name"` and `"age"` as string keys in the map, matching Clojure's behavior.

## 🔖 Changes

- Added `:strs` keyword detection in `MapBindingDeconstructor`, parallel to existing `:keys` handling
- For each symbol in the `:strs` vector, uses `$sym->getName()` (a plain string) as the lookup key instead of wrapping it in `Keyword::create()`
- Works with `:as` for binding the whole map, same as `:keys`
- Added `test_deconstruct_strs` and `test_deconstruct_strs_with_as` unit tests following the existing test patterns

Closes #1227