### PR TITLE
feat(compiler): support :or defaults in map destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `:or` defaults in map destructuring, matching Clojure semantics (#1219)
 - `fnil` function for nil-safe function wrapping with default values (#1225)
 - `vary-meta` function to apply a function to an object's metadata (#1223)
 - `assert` macro for precondition checking with optional custom message (#1222)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -13,6 +13,8 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
+use function array_key_exists;
+
 /**
  * @implements BindingDeconstructorInterface<PersistentMapInterface>
  */
@@ -20,6 +22,9 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     private Symbol $mapSymbol;
+
+    /** @var array<string, bool|float|int|string|TypeInterface|null> */
+    private array $orDefaults = [];
 
     public function __construct(
         private readonly Deconstructor $deconstructor,
@@ -33,6 +38,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
     {
         $keys = null;
         $asSymbol = null;
+        $orMap = null;
         $normalBindings = [];
 
         foreach ($binding as $key => $bindTo) {
@@ -46,7 +52,21 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
                 continue;
             }
 
+            if ($key instanceof Keyword && $key->getName() === 'or') {
+                $orMap = $bindTo;
+                continue;
+            }
+
             $normalBindings[] = [$key, $bindTo];
+        }
+
+        $this->orDefaults = [];
+        if ($orMap instanceof PersistentMapInterface) {
+            foreach ($orMap as $sym => $default) {
+                if ($sym instanceof Symbol) {
+                    $this->orDefaults[$sym->getName()] = $default;
+                }
+            }
         }
 
         $this->mapSymbol = $asSymbol instanceof Symbol
@@ -76,10 +96,35 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
         TypeInterface|string|float|int|bool|null $bindTo,
     ): void {
         $accessSymbol = Symbol::gen()->copyLocationFrom($binding);
-        $accessValue = $this->createAccessValue($binding, $key);
+        $default = $this->findDefault($bindTo);
+        $accessValue = $default !== null
+            ? $this->createAccessValueWithDefault($binding, $key, $default[0])
+            : $this->createAccessValue($binding, $key);
         $bindings[] = [$accessSymbol, $accessValue];
 
         $this->deconstructor->deconstructBindings($bindings, $bindTo, $accessSymbol);
+    }
+
+    /**
+     * Returns [default] if the binding symbol has an :or default, null otherwise.
+     * Wrapped in an array to distinguish "no default" from "default is null".
+     *
+     * @return array{bool|float|int|string|TypeInterface|null}|null
+     */
+    private function findDefault(
+        TypeInterface|string|float|int|bool|null $bindTo,
+    ): ?array {
+        if (!$bindTo instanceof Symbol) {
+            return null;
+        }
+
+        $name = $bindTo->getName();
+
+        if (!array_key_exists($name, $this->orDefaults)) {
+            return null;
+        }
+
+        return [$this->orDefaults[$name]];
     }
 
     private function createAccessValue(
@@ -90,6 +135,28 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
             (Symbol::create(Symbol::NAME_PHP_ARRAY_GET))->copyLocationFrom($binding),
             $this->mapSymbol,
             $key,
+        ])->copyLocationFrom($binding);
+    }
+
+    /**
+     * Generates: (if (contains? mapSym key) (php/aget mapSym key) default)
+     */
+    private function createAccessValueWithDefault(
+        PersistentMapInterface $binding,
+        float|bool|int|string|TypeInterface|null $key,
+        float|bool|int|string|TypeInterface|null $default,
+    ): PersistentListInterface {
+        $containsCheck = Phel::list([
+            Symbol::create('contains?')->copyLocationFrom($binding),
+            $this->mapSymbol,
+            $key,
+        ])->copyLocationFrom($binding);
+
+        return Phel::list([
+            Symbol::create(Symbol::NAME_IF)->copyLocationFrom($binding),
+            $containsCheck,
+            $this->createAccessValue($binding, $key),
+            $default,
         ])->copyLocationFrom($binding);
     }
 }

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -19,6 +19,38 @@
   (is (= 3 (let [{:keys [a b]} {:a 1 :b 2}] (+ a b))) "destructure hash map with :keys")
   (is (= {:a 1 :b 2} (let [{:keys [a b] :as user} {:a 1 :b 2}] user)) "destructure hash map with :keys and :as"))
 
+(deftest destructure-hash-map-or-defaults
+  ;; :or with :keys — default applied when key is absent
+  (is (= 42 (let [{:keys [a b] :or {b 42}} {:a 1}] b))
+      ":or provides default for absent key")
+  (is (= 1 (let [{:keys [a b] :or {b 42}} {:a 1}] a))
+      "present key unaffected by :or")
+  ;; :or not applied when key exists in map
+  (is (= 99 (let [{:keys [b] :or {b 42}} {:b 99}] b))
+      ":or not applied when key is present")
+  ;; :or with nil value present — nil wins (Clojure semantics: contains? check)
+  (is (nil? (let [{:keys [a] :or {a "default"}} {:a nil}] a))
+      ":or not applied when key present with nil value")
+  ;; :or with explicit key bindings
+  (is (= 99 (let [{:a x :or {x 99}} {}] x))
+      ":or works with explicit key bindings")
+  ;; :or combined with :as
+  (is (= {:a 1} (let [{:keys [a b] :or {b 42} :as m} {:a 1}] m))
+      ":as binds the original map regardless of :or")
+  ;; :or with multiple defaults
+  (is (= [10 20] (let [{:keys [a b] :or {a 10 b 20}} {}] [a b]))
+      ":or applies multiple defaults")
+  ;; :or for extra keys is ignored
+  (is (= 1 (let [{:keys [a] :or {a 10 z 99}} {:a 1}] a))
+      ":or for unreferenced keys has no effect")
+  ;; :or works in fn destructuring
+  (is (= 42 ((fn [{:keys [x] :or {x 42}}] x) {}))
+      ":or works in fn parameter destructuring")
+  ;; :or works in defn destructuring
+  (is (= 7 (let [f (fn [{:keys [a b] :or {b 3}}] (+ a b))]
+              (f {:a 4})))
+      ":or works in defn-style destructuring"))
+
 ;; ----------------------------
 ;; Basic methods for quasiquote
 ;; ----------------------------

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -232,4 +232,128 @@ final class MapBindingDeconstructorTest extends TestCase
             ],
         ], $bindings);
     }
+
+    public function test_deconstruct_keys_with_or(): void
+    {
+        // Test for binding like this (let [{:keys [a b] :or {b 42}} x])
+        // This will be destructured to this:
+        // (let [__phel_1 x
+        //       __phel_2 (php/aget __phel_1 :a)
+        //       a __phel_2
+        //       __phel_3 (if (contains? __phel_1 :b) (php/aget __phel_1 :b) 42)
+        //       b __phel_3])
+
+        $binding = Phel::map(
+            Keyword::create('keys'),
+            Phel::vector([
+                Symbol::create('a'),
+                Symbol::create('b'),
+            ]),
+            Keyword::create('or'),
+            Phel::map(
+                Symbol::create('b'),
+                42,
+            ),
+        );
+        $value = Symbol::create('x');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // __phel_1 x
+            [
+                Symbol::create('__phel_1'),
+                $value,
+            ],
+            // __phel_2 (php/aget __phel_1 :a)
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    Keyword::create('a'),
+                ]),
+            ],
+            // a __phel_2
+            [
+                Symbol::create('a'),
+                Symbol::create('__phel_2'),
+            ],
+            // __phel_3 (if (contains? __phel_1 :b) (php/aget __phel_1 :b) 42)
+            [
+                Symbol::create('__phel_3'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_IF),
+                    Phel::list([
+                        Symbol::create('contains?'),
+                        Symbol::create('__phel_1'),
+                        Keyword::create('b'),
+                    ]),
+                    Phel::list([
+                        Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                        Symbol::create('__phel_1'),
+                        Keyword::create('b'),
+                    ]),
+                    42,
+                ]),
+            ],
+            // b __phel_3
+            [
+                Symbol::create('b'),
+                Symbol::create('__phel_3'),
+            ],
+        ], $bindings);
+    }
+
+    public function test_deconstruct_explicit_keys_with_or(): void
+    {
+        // Test for binding like this (let [{:a x :or {x 99}} val])
+        // Explicit key binding with :or default
+
+        $binding = Phel::map(
+            Keyword::create('a'),
+            Symbol::create('x'),
+            Keyword::create('or'),
+            Phel::map(
+                Symbol::create('x'),
+                99,
+            ),
+        );
+        $value = Symbol::create('val');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // __phel_1 val
+            [
+                Symbol::create('__phel_1'),
+                $value,
+            ],
+            // __phel_2 (if (contains? __phel_1 :a) (php/aget __phel_1 :a) 99)
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_IF),
+                    Phel::list([
+                        Symbol::create('contains?'),
+                        Symbol::create('__phel_1'),
+                        Keyword::create('a'),
+                    ]),
+                    Phel::list([
+                        Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                        Symbol::create('__phel_1'),
+                        Keyword::create('a'),
+                    ]),
+                    99,
+                ]),
+            ],
+            // x __phel_2
+            [
+                Symbol::create('x'),
+                Symbol::create('__phel_2'),
+            ],
+        ], $bindings);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Phel's map destructuring supports `:keys` and `:as` but does not support `:or` for default values. This is a frequently used feature in Clojure and its absence forces verbose fallback patterns like chaining `if`/`nil?` checks after destructuring.

## 💡 Goal

Add `:or` defaults to map destructuring, matching Clojure semantics. Defaults apply only when a key is **absent** from the map (uses `contains?` check), not when the key is present with a `nil` value.

Closes #1219

## 🔖 Changes

- Extended `MapBindingDeconstructor` to extract `:or` keyword and build a defaults lookup
- For keys with defaults, generates `(if (contains? map key) (php/aget map key) default)` instead of plain `(php/aget map key)`
- Works in `let`, `fn`, `defn`, `loop`, `for` — anywhere map destructuring is used
- Combined with `:keys` and `:as` seamlessly
- Unit tests for the deconstructor (keys with `:or`, explicit key bindings with `:or`)
- Phel integration tests covering: absent keys, present keys, nil values, multiple defaults, `:as` combination, `fn` parameter destructuring