### PR TITLE
feat(compiler): support :strs in map destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `:strs` support in map destructuring for string key lookup (#1227)
 - `fnil` function for nil-safe function wrapping with default values (#1225)
 - `vary-meta` function to apply a function to an object's metadata (#1223)
 - `assert` macro for precondition checking with optional custom message (#1222)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -32,12 +32,18 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
     public function deconstruct(array &$bindings, $binding, $value): void
     {
         $keys = null;
+        $strs = null;
         $asSymbol = null;
         $normalBindings = [];
 
         foreach ($binding as $key => $bindTo) {
             if ($key instanceof Keyword && $key->getName() === 'keys') {
                 $keys = $bindTo;
+                continue;
+            }
+
+            if ($key instanceof Keyword && $key->getName() === 'strs') {
+                $strs = $bindTo;
                 continue;
             }
 
@@ -60,6 +66,14 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
                 if ($sym instanceof Symbol) {
                     $keyword = Keyword::create($sym->getName());
                     $this->bindingIteration($bindings, $binding, $keyword, $sym);
+                }
+            }
+        }
+
+        if ($strs instanceof PersistentVectorInterface) {
+            foreach ($strs as $sym) {
+                if ($sym instanceof Symbol) {
+                    $this->bindingIteration($bindings, $binding, $sym->getName(), $sym);
                 }
             }
         }

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -19,6 +19,18 @@
   (is (= 3 (let [{:keys [a b]} {:a 1 :b 2}] (+ a b))) "destructure hash map with :keys")
   (is (= {:a 1 :b 2} (let [{:keys [a b] :as user} {:a 1 :b 2}] user)) "destructure hash map with :keys and :as"))
 
+(deftest destructure-hash-map-strs
+  (is (= "Alice" (let [{:strs [name]} {"name" "Alice"}] name))
+      ":strs extracts string key")
+  (is (= 30 (let [{:strs [name age]} {"name" "Alice" "age" 30}] age))
+      ":strs extracts multiple string keys")
+  (is (nil? (let [{:strs [a b]} {"a" 1}] b))
+      ":strs returns nil for missing key")
+  (is (= {"x" 1 "y" 2} (let [{:strs [x] :as m} {"x" 1 "y" 2}] m))
+      ":strs combined with :as binds the full map")
+  (is (= "Bob" ((fn [{:strs [name]}] name) {"name" "Bob"}))
+      ":strs works in fn parameter destructuring"))
+
 ;; ----------------------------
 ;; Basic methods for quasiquote
 ;; ----------------------------

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -232,4 +232,103 @@ final class MapBindingDeconstructorTest extends TestCase
             ],
         ], $bindings);
     }
+
+    public function test_deconstruct_strs(): void
+    {
+        // Test for binding like this (let [{:strs [a b]} x])
+        // This will be destructured to this:
+        // (let [__phel_1 x
+        //       __phel_2 (php/aget __phel_1 "a")
+        //       a __phel_2
+        //       __phel_3 (php/aget __phel_1 "b")
+        //       b __phel_3])
+
+        $binding = Phel::map(
+            Keyword::create('strs'),
+            Phel::vector([
+                Symbol::create('a'),
+                Symbol::create('b'),
+            ]),
+        );
+        $value = Symbol::create('x');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // __phel_1 x
+            [
+                Symbol::create('__phel_1'),
+                $value,
+            ],
+            // __phel_2 (php/aget __phel_1 "a")
+            [
+                Symbol::create('__phel_2'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    'a',
+                ]),
+            ],
+            // a __phel_2
+            [
+                Symbol::create('a'),
+                Symbol::create('__phel_2'),
+            ],
+            // __phel_3 (php/aget __phel_1 "b")
+            [
+                Symbol::create('__phel_3'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('__phel_1'),
+                    'b',
+                ]),
+            ],
+            // b __phel_3
+            [
+                Symbol::create('b'),
+                Symbol::create('__phel_3'),
+            ],
+        ], $bindings);
+    }
+
+    public function test_deconstruct_strs_with_as(): void
+    {
+        // Test for binding like this (let [{:strs [x] :as m} val])
+
+        $binding = Phel::map(
+            Keyword::create('strs'),
+            Phel::vector([
+                Symbol::create('x'),
+            ]),
+            Keyword::create('as'),
+            Symbol::create('m'),
+        );
+        $value = Symbol::create('val');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, $value);
+
+        self::assertEquals([
+            // m val
+            [
+                Symbol::create('m'),
+                $value,
+            ],
+            // __phel_1 (php/aget m "x")
+            [
+                Symbol::create('__phel_1'),
+                Phel::list([
+                    Symbol::create(Symbol::NAME_PHP_ARRAY_GET),
+                    Symbol::create('m'),
+                    'x',
+                ]),
+            ],
+            // x __phel_1
+            [
+                Symbol::create('x'),
+                Symbol::create('__phel_1'),
+            ],
+        ], $bindings);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Phel's map destructuring supports `:keys` (keyword-based) but not `:strs` (string-based). This is needed for PHP interop where data often has string keys (JSON decoding, PHP arrays, etc.).

## 💡 Goal

Add `:strs` support in map destructuring, matching Clojure semantics.

Closes #1227

## 🔖 Changes

- Extended `MapBindingDeconstructor` to recognize `:strs` keyword
- For each symbol in `:strs [name age]`, looks up the string `"name"`, `"age"` instead of keywords `:name`, `:age`
- Works in `let`, `fn`, `defn`, `loop`, `for`
- Combinable with `:as`
- Unit tests for the deconstructor (`:strs` basic, `:strs` with `:as`)
- Phel integration tests covering: string key extraction, missing keys, `:as` combination, `fn` parameter destructuring