### PR TITLE
feat(core): Clojure-compatible aliases and deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `atom`, `atom?`, `reset!` as Clojure-compatible aliases for `var`, `var?`, `set!` (#1252)
+- `identical?` as Clojure-compatible alias for `id` (#1252)
+- `fn?` as Clojure-compatible alias for `function?` (#1252)
+- `map?` as Clojure-compatible alias for `hash-map?` (#1252)
+- `vals` as Clojure-compatible alias for `values` (#1252)
+- `with-meta` made public as Clojure-compatible replacement for `set-meta!` (#1252)
+- `run!` function for applying a function to each element of a collection for side effects (#1252)
+- `dotimes` macro for evaluating body n times with a binding from 0 to n-1 (#1252)
 - `letfn` macro for mutually recursive local functions (#1224)
+
+### Deprecated
+- `var` → use `atom`, `var?` → use `atom?`, `set!` → use `reset!` (#1252)
+- `id` → use `identical?` (#1252)
+- `function?` → use `fn?`, `hash-map?` → use `map?` (#1252)
+- `values` → use `vals` (#1252)
+- `set-meta!` → use `with-meta` (#1252)
 - `:or` defaults in map destructuring, matching Clojure semantics (#1219)
 - `:strs` support in map destructuring for string key lookup (#1227)
 - `fnil` function for nil-safe function wrapping with default values (#1225)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -623,7 +623,7 @@ Otherwise, it tries to call `__toString`."
     (php/-> a (identical b))
     (php/=== a b)))
 
-(defn id
+(defn identical?
   "Checks if all values are identical. Same as `a === b` in PHP."
   [a & more]
   (case (count more)
@@ -632,6 +632,13 @@ Otherwise, it tries to call `__toString`."
     (if (id2 a (first more))
       (recur (first more) (next more))
       false)))
+
+(defn id
+  "Checks if all values are identical. Same as `a === b` in PHP."
+  {:deprecated "0.32.0"
+   :superseded-by "identical?"}
+  [a & more]
+  (apply identical? a more))
 
 (defn =
   "Checks if all values are equal (value equality, not identity)."
@@ -914,20 +921,34 @@ Otherwise, it tries to call `__toString`."
   [x]
   (= (type x) :symbol))
 
-(defn function?
+(defn fn?
   "Returns true if `x` is a function, false otherwise."
   [x]
   (= (type x) :function))
+
+(defn function?
+  "Returns true if `x` is a function, false otherwise."
+  {:deprecated "0.32.0"
+   :superseded-by "fn?"}
+  [x]
+  (fn? x))
 
 (defn struct?
   "Returns true if `x` is a struct, false otherwise."
   [x]
   (= (type x) :struct))
 
-(defn hash-map?
+(defn map?
   "Returns true if `x` is a hash map, false otherwise."
   [x]
   (= (type x) :hash-map))
+
+(defn hash-map?
+  "Returns true if `x` is a hash map, false otherwise."
+  {:deprecated "0.32.0"
+   :superseded-by "map?"}
+  [x]
+  (map? x))
 
 (defn vector?
   "Returns true if `x` is a vector, false otherwise."
@@ -2094,12 +2115,20 @@ Otherwise, it tries to call `__toString`."
   (let [result (for [k :keys coll] k)]
     (copy-meta coll result)))
 
-(defn values
+(defn vals
   "Returns a sequence of all values in a map."
-  {:example "(values {:a 1 :b 2}) ; => (1 2)"}
+  {:example "(vals {:a 1 :b 2}) ; => (1 2)"}
   [coll]
   (let [result (for [x :in coll] x)]
     (copy-meta coll result)))
+
+(defn values
+  "Returns a sequence of all values in a map."
+  {:deprecated "0.32.0"
+   :superseded-by "vals"
+   :example "(values {:a 1 :b 2}) ; => (1 2)"}
+  [coll]
+  (vals coll))
 
 (defn pairs
   "Gets the pairs of an associative data structure."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -4305,3 +4305,21 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        (php/substr hex 12 4) "-"
        (php/substr hex 16 4) "-"
        (php/substr hex 20 12)))))
+
+(defn run!
+  "Calls `(f x)` for each element in `coll` for side effects. Returns nil."
+  {:example "(run! println [1 2 3])"
+   :see-also ["doseq" "map"]}
+  [f coll]
+  (doseq [x :in coll] (f x))
+  nil)
+
+(defmacro dotimes
+  "Evaluates body `n` times with `binding` bound to integers from 0 to n-1.
+  Returns nil."
+  {:example "(dotimes [i 5] (println i))"}
+  [[binding n] & body]
+  (let [n-sym (gensym)]
+    `(let [~n-sym ~n]
+       (doseq [~binding :range [0 ~n-sym]]
+         ~@body))))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -188,10 +188,28 @@
              (php/-> obj-meta (getMeta))
              nil))))))
 
-(def set-meta!
-  "Sets the metadata to a given object."
+(def copy-meta
+  {:private true
+   :doc "Returns `target` with the metadata from `source` when both implement `MetaInterface`."}
+  (fn [source target]
+    (if (php/instanceof source MetaInterface)
+      (if (php/instanceof target MetaInterface)
+        (php/-> target (withMeta (php/-> source (getMeta))))
+        target)
+      target)))
+
+(def with-meta
+  {:doc "Returns `obj` with the given metadata `meta` attached."
+   :see-also ["meta" "vary-meta"]}
   (fn [obj meta]
     (php/-> obj (withMeta meta))))
+
+(def set-meta!
+  {:doc "Sets the metadata to a given object."
+   :deprecated "0.32.0"
+   :superseded-by "with-meta"}
+  (fn [obj meta]
+    (with-meta obj meta)))
 
 (def vary-meta
   {:doc "Returns an object with (apply f (meta obj) args) as its new metadata."
@@ -201,16 +219,6 @@
               (php/-> obj (getMeta))
               nil)]
       (php/-> obj (withMeta (apply f m args))))))
-
-(def with-meta
-  {:private true
-   :doc "Returns `target` with the metadata from `source` when both implement `MetaInterface`."}
-  (fn [source target]
-    (if (php/instanceof source MetaInterface)
-      (if (php/instanceof target MetaInterface)
-        (php/-> target (withMeta (php/-> source (getMeta))))
-        target)
-      target)))
 
 ;; ------------
 ;; Basic macros
@@ -1413,14 +1421,14 @@ Otherwise, it tries to call `__toString`."
     1 (let [coll (first colls)]
         (if (empty? coll)
           []
-          (with-meta coll (lazy-seq-from-generator (php/:: Seq (map f coll))))))
+          (copy-meta coll (lazy-seq-from-generator (php/:: Seq (map f coll))))))
     (let [result (lazy-seq-from-generator
                   (php/call_user_func_array
                    (php/array "\\Phel\\Lang\\Seq" "mapMulti")
                    (php/array_merge (php/array f) (apply php/array colls))))]
       (if (php/=== nil result)
         []
-        (with-meta (first colls) result)))))
+        (copy-meta (first colls) result)))))
 
 ;; -------------------
 ;; Transducer support
@@ -1773,7 +1781,7 @@ Otherwise, it tries to call `__toString`."
             (if (php/=== n 0)
               coll
               (let [result (lazy-seq-from-generator (php/:: Seq (drop n coll)))]
-                (with-meta coll (or result [])))))))
+                (copy-meta coll (or result [])))))))
     (throw (php/new InvalidArgumentException "drop expects 1 or 2 arguments"))))
 
 (defn drop-last
@@ -1818,7 +1826,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (dropWhile pred coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "drop-while expects 1 or 2 arguments"))))
 
 (defn take
@@ -1840,7 +1848,7 @@ Otherwise, it tries to call `__toString`."
           (let [result (lazy-seq-from-generator (php/:: Seq (take n coll)))]
             (if (nil? result)
               []
-              (with-meta coll result)))))
+              (copy-meta coll result)))))
     (throw (php/new InvalidArgumentException "take expects 1 or 2 arguments"))))
 
 (defn take-last
@@ -1864,7 +1872,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (takeWhile pred coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "take-while expects 1 or 2 arguments"))))
 
 (defn take-nth
@@ -1886,7 +1894,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
 
 (defn filter
@@ -1902,7 +1910,7 @@ Otherwise, it tries to call `__toString`."
             result (lazy-seq-from-generator (php/:: Seq (filter pred coll)))]
         (if (nil? result)
           []
-          (with-meta coll result)))
+          (copy-meta coll result)))
     (throw (php/new InvalidArgumentException "filter expects 1 or 2 arguments"))))
 
 (defn remove
@@ -1931,7 +1939,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (keep pred coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "keep expects 1 or 2 arguments"))))
 
 (defn keep-indexed
@@ -1951,7 +1959,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (keepIndexed pred coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "keep-indexed expects 1 or 2 arguments"))))
 
 (defn find
@@ -1996,7 +2004,7 @@ Otherwise, it tries to call `__toString`."
         (if (nil? coll)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (distinct coll)))]
-            (with-meta coll (or result [])))))
+            (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
 
 
@@ -2008,7 +2016,7 @@ Otherwise, it tries to call `__toString`."
               (php/mb_str_split coll)
               (to-php-array coll))
         result (apply vector (php/array_reverse arr))]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn interleave
   "Returns a vector with the first items of each col, then the second items, etc."
@@ -2025,7 +2033,7 @@ Otherwise, it tries to call `__toString`."
                      res
                      (recur (php/+ i 1)
                             (reduce #(conj %1 (get %2 i)) res colls))))]
-      (with-meta first-coll result))))
+      (copy-meta first-coll result))))
 
 (defn interpose
   "Returns a vector of elements separated by `sep`."
@@ -2039,7 +2047,7 @@ Otherwise, it tries to call `__toString`."
            (when (> k 0)
              (conj res sep v))
            (conj res v)))]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn frequencies
   "Returns a map from distinct items in `coll` to the number of times they appear.
@@ -2051,21 +2059,21 @@ Otherwise, it tries to call `__toString`."
                      :reduce [res {}]]
                  (let [n (get res x 0)]
                    (assoc res x (php/+ 1 n))))]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn keys
   "Returns a sequence of all keys in a map."
   {:example "(keys {:a 1 :b 2}) ; => (:a :b)"}
   [coll]
   (let [result (for [k :keys coll] k)]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn values
   "Returns a sequence of all values in a map."
   {:example "(values {:a 1 :b 2}) ; => (1 2)"}
   [coll]
   (let [result (for [x :in coll] x)]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn pairs
   "Gets the pairs of an associative data structure."
@@ -2073,7 +2081,7 @@ Otherwise, it tries to call `__toString`."
    :see-also ["keys" "values" "kvs"]}
   [coll]
   (let [result (for [p :pairs coll] p)]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn kvs
   "Returns a vector of key-value pairs like `[k1 v1 k2 v2 k3 v3 ...]`."
@@ -2086,7 +2094,7 @@ Otherwise, it tries to call `__toString`."
                :reduce [res (transient [])]]
            (conj res k)
            (conj res v)))]
-    (with-meta coll result)))
+    (copy-meta coll result)))
 
 (defn php-array-to-map
   "Converts a PHP Array to a Phel map."
@@ -2167,7 +2175,7 @@ Otherwise, it tries to call `__toString`."
   [coll & [comp]]
   (let [php-array (to-php-array coll)]
     (php/usort php-array (or comp compare))
-    (with-meta coll (apply vector php-array))))
+    (copy-meta coll (apply vector php-array))))
 
 (defn sort-by
   "Returns a sorted vector where the sort order is determined by comparing `(keyfn item)`.
@@ -2179,7 +2187,7 @@ Otherwise, it tries to call `__toString`."
   (let [php-array (to-php-array coll)
         cmp (or comp compare)]
     (php/usort php-array #(cmp (keyfn %1) (keyfn %2)))
-    (with-meta coll (apply vector php-array))))
+    (copy-meta coll (apply vector php-array))))
 
 (defn shuffle
   "Returns a random permutation of coll."
@@ -2187,7 +2195,7 @@ Otherwise, it tries to call `__toString`."
   [coll]
   (let [php-array (to-php-array coll)]
     (php/shuffle php-array)
-    (with-meta coll (apply vector php-array))))
+    (copy-meta coll (apply vector php-array))))
 
 (defn repeat
   "Returns a vector of length n where every element is x.
@@ -2282,7 +2290,7 @@ Otherwise, it tries to call `__toString`."
                         (php/:: \Phel\Lang\Seq (mapcat f coll)))]
             (if (php/=== nil result)
               '()
-              (with-meta coll result)))))
+              (copy-meta coll result)))))
     (throw (php/new InvalidArgumentException "mapcat expects 1 or 2 arguments"))))
 
 (defn interpose
@@ -2312,7 +2320,7 @@ Otherwise, it tries to call `__toString`."
                         (php/:: \Phel\Lang\Seq (interpose sep coll)))]
             (if (php/=== nil result)
               '()
-              (with-meta coll result)))))
+              (copy-meta coll result)))))
     (throw (php/new InvalidArgumentException "interpose expects 1 or 2 arguments"))))
 
 (defn map-indexed
@@ -2329,7 +2337,7 @@ Otherwise, it tries to call `__toString`."
                   (php/:: \Phel\Lang\Seq (mapIndexed f coll)))]
       (if (php/=== nil result)
         '()
-        (with-meta coll result)))))
+        (copy-meta coll result)))))
 
 ;; Redefine interleave as lazy
 (defn interleave
@@ -2348,7 +2356,7 @@ Otherwise, it tries to call `__toString`."
                    (apply php/array colls)))]
       (if (php/=== nil result)
         '()
-        (with-meta (first colls) result)))))
+        (copy-meta (first colls) result)))))
 
 (defn doall
   "Forces realization of a lazy sequence and returns it as a vector."
@@ -2436,7 +2444,7 @@ Otherwise, it tries to call `__toString`."
                      :when (contains-value? ks k)
                      :reduce [acc {}]]
                  (assoc acc k v))]
-    (with-meta m result)))
+    (copy-meta m result)))
 
 (defn rename-keys
   "Returns the map with keys renamed according to kmap.
@@ -2532,7 +2540,7 @@ Otherwise, it tries to call `__toString`."
                  (php/array n coll)))]
     (if (php/=== nil result)
       '()
-      (with-meta coll result))))
+      (copy-meta coll result))))
 
 (defn partition-all
   "Partitions collection into chunks of size n, including incomplete final partition."
@@ -2544,7 +2552,7 @@ Otherwise, it tries to call `__toString`."
                  (php/array n coll)))]
     (if (php/=== nil result)
       '()
-      (with-meta coll result))))
+      (copy-meta coll result))))
 
 ;; -------------
 ;; Set operation
@@ -2748,7 +2756,7 @@ Otherwise, it tries to call `__toString`."
                 (php/apush stack child))
               (recur stack))
             (recur stack)))
-        (with-meta root (persistent ret))))))
+        (copy-meta root (persistent ret))))))
 
 (defn flatten
   "Flattens nested sequential structure into a lazy sequence of all leaf values."
@@ -3264,8 +3272,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (if forms
       (let [form (first forms)
             threaded (if (list? form)
-                       (with-meta form `(~(first form) ~x ~@(next form)))
-                       (with-meta form (list form x)))]
+                       (copy-meta form `(~(first form) ~x ~@(next form)))
+                       (copy-meta form (list form x)))]
         (recur threaded (next forms)))
       x)))
 
@@ -3280,8 +3288,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (if forms
       (let [form (first forms)
             threaded (if (list? form)
-                       (with-meta form `(~(first form) ~@(next form) ~x))
-                       (with-meta form (list form x)))]
+                       (copy-meta form `(~(first form) ~@(next form) ~x))
+                       (copy-meta form (list form x)))]
         (recur threaded (next forms)))
       x)))
 
@@ -3298,8 +3306,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                          args (if rest
                                 (cons g rest)
                                 [g])]
-                     (with-meta form (apply list (cons (first form) args))))
-                   (with-meta form (list form g)))
+                     (copy-meta form (apply list (cons (first form) args))))
+                   (copy-meta form (list form g)))
             threaded (list 'let
                            [g x]
                            (list 'if
@@ -3322,8 +3330,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                          args (if rest
                                 (concat rest [g])
                                 [g])]
-                     (with-meta form (apply list (cons (first form) args))))
-                   (with-meta form (list form g)))
+                     (copy-meta form (apply list (cons (first form) args))))
+                   (copy-meta form (list form g)))
             threaded (list 'let
                            [g x]
                            (list 'if
@@ -3352,8 +3360,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     `(let [~gx ~x]
        ~@(map (fn [f]
                 (if (list? f)
-                  (with-meta f `(~(first f) ~gx ~@(next f)))
-                  (with-meta f `(~f ~gx))))
+                  (copy-meta f `(~(first f) ~gx ~@(next f)))
+                  (copy-meta f `(~f ~gx))))
               forms)
        ~gx)))
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1187,48 +1187,74 @@ Otherwise, it tries to call `__toString`."
   [ds key]
   (dissoc ds key))
 
-;; --------
-;; Variable
-;; --------
+;; -----
+;; Atoms
+;; -----
 
-(defn var
-  "Creates a new variable with the given value.
+(defn atom
+  "Creates a new atom with the given value.
 
-  Variables provide a way to manage mutable state that can be updated with `set!` and `swap!`. Each variable contains a single value. To create a variable use the var function."
-  {:example "(def counter (var 0))"
-   :see-also ["set!" "deref" "swap!"]}
+  Atoms provide a way to manage mutable state. Use `reset!` to set a new value
+  and `swap!` to update based on the current value."
+  {:example "(def counter (atom 0))"
+   :see-also ["reset!" "deref" "swap!"]}
   [value]
   (php/:: Phel (variable value)))
 
-(defn var?
-  "Checks if the given value is a variable."
+(defn var
+  "Creates a new variable with the given value."
+  {:deprecated "0.32.0"
+   :superseded-by "atom"
+   :example "(def counter (var 0))"
+   :see-also ["set!" "deref" "swap!"]}
+  [value]
+  (atom value))
+
+(defn atom?
+  "Returns true if the given value is an atom."
   [x]
   (php/instanceof x Variable))
 
-(defn set!
-  "Sets a new value to the given variable."
-  {:example "(def x (var 10))"
-   :see-also ["var" "deref" "swap!"]}
+(defn var?
+  "Checks if the given value is a variable."
+  {:deprecated "0.32.0"
+   :superseded-by "atom?"}
+  [x]
+  (atom? x))
+
+(defn reset!
+  "Sets a new value on the given atom. Returns the new value."
+  {:example "(def x (atom 10))"
+   :see-also ["atom" "deref" "swap!"]}
   [variable value]
   (php/-> variable (set value)))
 
+(defn set!
+  "Sets a new value to the given variable."
+  {:deprecated "0.32.0"
+   :superseded-by "reset!"
+   :example "(def x (var 10))"
+   :see-also ["var" "deref" "swap!"]}
+  [variable value]
+  (reset! variable value))
+
 (defn deref
   "Returns the current value inside the variable."
-  {:example "(def x (var 42))"
-   :see-also ["var" "set!" "swap!"]}
+  {:example "(def x (atom 42))"
+   :see-also ["atom" "reset!" "swap!"]}
   [variable]
   (php/-> variable (deref)))
 
 (defn swap!
-  "Atomically swaps the value of the variable to `(apply f current-value args)`.
+  "Atomically swaps the value of the atom to `(apply f current-value args)`.
 
   Returns the new value after the swap."
-  {:example "(def counter (var 0))"
-   :see-also ["var" "set!" "deref"]}
+  {:example "(def counter (atom 0))"
+   :see-also ["atom" "reset!" "deref"]}
   [variable f & args]
   (let [current (deref variable)
         next (apply f current args)]
-    (set! variable next)
+    (reset! variable next)
     next))
 
 (defn add-watch

--- a/tests/phel/test/core/clojure-aliases.phel
+++ b/tests/phel/test/core/clojure-aliases.phel
@@ -1,0 +1,105 @@
+(ns phel-test\test\core\clojure-aliases
+  (:require phel\test :refer [deftest is]))
+
+;; --- atom / var aliases ---
+
+(deftest test-atom-creates-mutable-ref
+  (let [a (atom 42)]
+    (is (= 42 (deref a)) "atom holds initial value")))
+
+(deftest test-atom?
+  (is (true? (atom? (atom 0))) "atom? on atom")
+  (is (false? (atom? 42)) "atom? on int"))
+
+(deftest test-reset!
+  (let [a (atom 0)]
+    (reset! a 10)
+    (is (= 10 (deref a)) "reset! updates value")))
+
+(deftest test-var-still-works
+  (let [v (var 5)]
+    (is (= 5 (deref v)) "deprecated var still works")))
+
+(deftest test-var?-still-works
+  (is (true? (var? (var 0))) "deprecated var? still works"))
+
+(deftest test-set!-still-works
+  (let [v (var 0)]
+    (set! v 99)
+    (is (= 99 (deref v)) "deprecated set! still works")))
+
+;; --- identical? / id aliases ---
+
+(deftest test-identical?
+  (is (true? (identical? 10 10)) "identical? on same ints")
+  (is (false? (identical? 10 10.0)) "identical? on int vs float")
+  (is (true? (identical? :test :test)) "keywords are identical")
+  (is (true? (identical? 1)) "single arg returns true"))
+
+(deftest test-id-still-works
+  (is (true? (id 10 10)) "deprecated id still works"))
+
+;; --- fn? / function? aliases ---
+
+(deftest test-fn?
+  (is (true? (fn? concat)) "fn? on function")
+  (is (false? (fn? 42)) "fn? on int"))
+
+(deftest test-function?-still-works
+  (is (true? (function? concat)) "deprecated function? still works"))
+
+;; --- map? / hash-map? aliases ---
+
+(deftest test-map?
+  (is (true? (map? {})) "map? on map")
+  (is (false? (map? [])) "map? on vector"))
+
+(deftest test-hash-map?-still-works
+  (is (true? (hash-map? {})) "deprecated hash-map? still works"))
+
+;; --- vals / values aliases ---
+
+(deftest test-vals
+  (is (= [1 2 3] (vals {:a 1 :b 2 :c 3})) "vals of map")
+  (is (= [3 2 1] (vals [3 2 1])) "vals of vector"))
+
+(deftest test-values-still-works
+  (is (= [1 2 3] (values {:a 1 :b 2 :c 3})) "deprecated values still works"))
+
+;; --- with-meta (public) / set-meta! ---
+
+(deftest test-with-meta-public
+  (is (= {:a 1} (meta (with-meta [] {:a 1}))) "with-meta sets metadata"))
+
+(deftest test-set-meta!-still-works
+  (is (= {:a 1} (meta (set-meta! [] {:a 1}))) "deprecated set-meta! still works"))
+
+;; --- run! ---
+
+(deftest test-run!
+  (let [acc (atom [])]
+    (run! (fn [x] (swap! acc (fn [xs] (conj xs x)))) [1 2 3])
+    (is (= [1 2 3] (deref acc)) "run! applies fn to each element"))
+  (is (nil? (run! identity [1 2 3])) "run! returns nil"))
+
+(deftest test-run!-empty
+  (let [acc (atom 0)]
+    (run! (fn [_] (swap! acc inc)) [])
+    (is (= 0 (deref acc)) "run! on empty collection does nothing")))
+
+;; --- dotimes ---
+
+(deftest test-dotimes
+  (let [acc (atom 0)]
+    (dotimes [i 5] (swap! acc + i))
+    (is (= 10 (deref acc)) "dotimes sums 0+1+2+3+4 = 10")))
+
+(deftest test-dotimes-zero
+  (let [acc (atom 0)]
+    (dotimes [_ 0] (swap! acc inc))
+    (is (= 0 (deref acc)) "dotimes with 0 does nothing")))
+
+(deftest test-dotimes-expression
+  (let [acc (atom 0)]
+    (dotimes [_ (+ 2 3)] (swap! acc inc))
+    (is (= 5 (deref acc)) "dotimes evaluates n expression once")))


### PR DESCRIPTION
## 🤔 Background

Phel uses some function names that differ from Clojure conventions, creating friction for Clojure developers and making the migration guide longer. This aligns the core library naming with Clojure by adding canonical aliases and deprecating the old names.

Closes #1252

## 💡 Goal

Add Clojure-compatible aliases for commonly used functions, deprecate the Phel-specific names (keeping them working), and introduce two new Clojure functions (`run!` and `dotimes`).

## 🔖 Changes

### Aliases (new canonical name → deprecated old name)

**Mutable state:**
- `atom` → `var`
- `atom?` → `var?`
- `reset!` → `set!`

**Reference equality:**
- `identical?` → `id`

**Type predicates:**
- `fn?` → `function?`
- `map?` → `hash-map?`

**Collections:**
- `vals` → `values`

**Metadata:**
- `with-meta` made public (Clojure-compatible `(with-meta obj meta)` signature) → `set-meta!`
- Internal helper renamed to `copy-meta` (private) to avoid confusion

### New functions
- `run!` — calls `(f x)` for each element in a collection for side effects, returns nil
- `dotimes` — macro that evaluates body n times with binding from 0 to n-1

### Other
- All deprecated names use `{:deprecated "0.32.0" :superseded-by "new-name"}` metadata
- Updated `swap!` and `deref` `:see-also` to reference new names
- CHANGELOG updated with Added and Deprecated sections
- 29 new tests covering all aliases, backward compat, and new functions