### PR TITLE
feat(test): add `are` macro for template-based multiple assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `are` macro in `phel\test` for template-based multiple assertions, matching Clojure's `clojure.test/are` (#1255)
 - Clojure-to-Phel migration guide covering naming, interop, namespaces, and feature differences (#1229)
 - `atom`, `atom?`, `reset!` as Clojure-compatible aliases for `var`, `var?`, `set!` (#1252)
 - `identical?` as Clojure-compatible alias for `id` (#1252)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -258,6 +258,20 @@
   `(binding [*testing-contexts* (conj *testing-contexts* ~context)]
      ~@body))
 
+(defmacro are
+  "Checks multiple assertions with a template expression.
+  `argv` is a vector of template variables, `expr` is the assertion template,
+  and the remaining `args` are partitioned by `(count argv)` to fill the template."
+  {:see-also ["is" "deftest" "testing"]
+   :example "(are [x y] (= x y)\n  2 (+ 1 1)\n  4 (* 2 2))"}
+  [argv expr & args]
+  (let [n (count argv)
+        groups (partition n args)
+        assertions (for [group :in groups
+                         :let [bindings (vec (interleave argv group))]]
+                     `(let [~@bindings] (is ~expr)))]
+    `(do ~@assertions)))
+
 ;; ---------------------
 ;; error/failure printer
 ;; ---------------------

--- a/tests/phel/test/are.phel
+++ b/tests/phel/test/are.phel
@@ -1,0 +1,122 @@
+(ns phel-test\test\are
+  (:require phel\test :refer [deftest is are testing get-stats reset-stats restore-stats]))
+
+;; ---------------------------------------------------------------------------
+;; Basic 2-variable usage — the canonical use case
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-two-variables
+  (are [x y] (= x y)
+    2 (+ 1 1)
+    4 (* 2 2)
+    0 (- 1 1)))
+
+;; ---------------------------------------------------------------------------
+;; Single variable
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-single-variable
+  (are [x] (true? x)
+    true
+    (= 1 1)
+    (< 1 2)))
+
+;; ---------------------------------------------------------------------------
+;; Three variables
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-three-variables
+  (are [x y z] (= z (+ x y))
+    1 2 3
+    4 5 9
+    0 0 0
+    -1 1 0))
+
+;; ---------------------------------------------------------------------------
+;; Works inside testing context
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-inside-testing
+  (testing "arithmetic identities"
+    (are [x y] (= x y)
+      0 (* 0 1)
+      1 (* 1 1))))
+
+;; ---------------------------------------------------------------------------
+;; Works alongside regular `is` assertions
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-mixed-with-is
+  (is (= 1 1) "regular is before are")
+  (are [x] (pos? x)
+    1
+    42
+    100)
+  (is (= 2 2) "regular is after are"))
+
+;; ---------------------------------------------------------------------------
+;; Failure recording — each group produces an independent assertion
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-records-individual-failures
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer
+            (are [x y] (= x y)
+              1 1
+              2 3
+              4 4
+              5 6))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 2 (:pass counts)) "two groups pass")
+    (is (= 2 (:failed counts)) "two groups fail")))
+
+;; ---------------------------------------------------------------------------
+;; Incomplete trailing group is silently dropped (matches Clojure behavior)
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-drops-incomplete-trailing-group
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer
+            (are [x y] (= x y)
+              1 1
+              2 2
+              3))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 2 (:pass counts)) "only complete groups are asserted")
+    (is (= 0 (:failed counts)) "no failures from dropped group")))
+
+;; ---------------------------------------------------------------------------
+;; Works with non-equality predicates
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-with-predicate-template
+  (are [x y] (< x y)
+    1 2
+    0 100
+    -5 -4))
+
+;; ---------------------------------------------------------------------------
+;; Works with nil values in arguments
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-with-nil-values
+  (are [x] (nil? x)
+    nil
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Zero args produces no assertions
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-zero-args
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer
+            (are [x y] (= x y)))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 0 (:total counts)) "no assertions generated")))


### PR DESCRIPTION
## 🤔 Background

Clojure's `are` is a test helper macro that runs the same assertion template over multiple groups of values. It's missing from `phel\test`, blocking the Clojure test suite compatibility effort (the forked clojure-test-suite fails with `Cannot resolve symbol 'are'`).

## 💡 Goal

Add `are` macro to `phel\test`, matching Clojure's `clojure.test/are` semantics.

## 🔖 Changes

- **`src/phel/test.phel`**: Added `are` defmacro after `testing`. Uses `partition` to chunk args by variable count, `interleave` to pair variables with values, and `let` bindings for substitution. No new dependencies.
- **`tests/phel/test/are.phel`**: Comprehensive test suite covering 1/2/3 variables, `testing` context integration, mixed with `is`, individual failure counting, incomplete trailing group dropped (matches Clojure), nil values, and zero-args edge case.
- **`CHANGELOG.md`**: Added entry under `## Unreleased > ### Added`.

Closes #1255