### PR TITLE
feat: dot namespace separator & clojure aliasing for FQN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
 - `are` macro in `phel\test` for template-based multiple assertions, matching Clojure's `clojure.test/are` (#1255)
 - Clojure-to-Phel migration guide covering naming, interop, namespaces, and feature differences (#1229)
 - `atom`, `atom?`, `reset!` as Clojure-compatible aliases for `var`, `var?`, `set!` (#1252)

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use RuntimeException;
@@ -77,9 +78,29 @@ final readonly class SymbolResolver
         }
 
         $finalName = Symbol::create($name->getName());
-        $ns = $this->globalEnv->resolveAlias($alias) ?? $alias;
+
+        $normalizedAlias = str_replace('.', '\\', $alias);
+        $normalizedAlias = $this->remapClojureAlias($normalizedAlias);
+
+        $ns = $this->globalEnv->resolveAlias($normalizedAlias) ?? $normalizedAlias;
 
         return $this->resolveInterfaceOrDefinition($finalName, $env, $ns);
+    }
+
+    private function remapClojureAlias(string $alias): string
+    {
+        if (!str_starts_with($alias, 'clojure\\')) {
+            return $alias;
+        }
+
+        $targetNs = 'phel\\' . substr($alias, 8);
+        $mungedNs = str_replace('-', '_', $targetNs);
+
+        if (Registry::getInstance()->getDefinitionInNamespace($mungedNs) === []) {
+            return $alias;
+        }
+
+        return $targetNs;
     }
 
     private function resolveWithoutAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -14,6 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\SymbolResolver;
 use Phel\Lang\Keyword;
+use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
@@ -223,6 +224,101 @@ final class SymbolResolverTest extends TestCase
         self::assertEquals(
             new PhpClassNameNode($nodeEnv, Symbol::createForNamespace('bar', 'x')),
             $this->resolver->resolve(Symbol::createForNamespace('b', 'x'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_fqn_with_dot_namespace_separator(): void
+    {
+        $this->globalEnv->addDefinition('phel\\stacktrace', Symbol::create('print-cause-trace'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\stacktrace', Symbol::create('print-cause-trace'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('phel.stacktrace', 'print-cause-trace'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_dot_namespace_via_require_alias(): void
+    {
+        $this->globalEnv->addDefinition('phel\\stacktrace', Symbol::create('print-cause-trace'));
+        $this->globalEnv->setNs('app\\core');
+        $this->globalEnv->addRequireAlias('app\\core', Symbol::create('phel\\stacktrace'), Symbol::create('phel\\stacktrace'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\stacktrace', Symbol::create('print-cause-trace'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('phel.stacktrace', 'print-cause-trace'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_backslash_fqn_remaps_to_phel(): void
+    {
+        Registry::getInstance()->addDefinition('phel\\stacktrace', '__ns_marker', true);
+        $this->globalEnv->addDefinition('phel\\stacktrace', Symbol::create('print-cause-trace'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\stacktrace', Symbol::create('print-cause-trace'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('clojure\\stacktrace', 'print-cause-trace'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_dot_fqn_normalizes_and_remaps(): void
+    {
+        Registry::getInstance()->addDefinition('phel\\stacktrace', '__ns_marker', true);
+        $this->globalEnv->addDefinition('phel\\stacktrace', Symbol::create('print-cause-trace'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\stacktrace', Symbol::create('print-cause-trace'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('clojure.stacktrace', 'print-cause-trace'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_fqn_not_remapped_when_phel_missing(): void
+    {
+        $this->globalEnv->addDefinition('clojure\\custom-lib', Symbol::create('my-fn'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'clojure\\custom-lib', Symbol::create('my-fn'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('clojure\\custom-lib', 'my-fn'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_backslash_fqn_still_works(): void
+    {
+        $this->globalEnv->addDefinition('phel\\stacktrace', Symbol::create('print-cause-trace'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\stacktrace', Symbol::create('print-cause-trace'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('phel\\stacktrace', 'print-cause-trace'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_fqn_uses_munged_registry_lookup(): void
+    {
+        Registry::getInstance()->addDefinition('phel\\my_lib', '__ns_marker', true);
+        $this->globalEnv->addDefinition('phel\\my-lib', Symbol::create('some-fn'));
+        $this->globalEnv->setNs('app\\core');
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'phel\\my-lib', Symbol::create('some-fn'), Phel::map()),
+            $this->resolver->resolve(Symbol::createForNamespace('clojure.my-lib', 'some-fn'), $nodeEnv),
         );
     }
 }


### PR DESCRIPTION
## 🤔 Background

nREPL clients (e.g. Cider) use Clojure-style fully qualified names like `clojure.stacktrace/print-cause-trace`. Phel already supports dot separators and Clojure aliasing in `ns` declarations (#1182, #1215), but those normalizations were not applied when FQN symbols are used in code — only during namespace declaration parsing.

## 💡 Goal

Enable all FQN forms to resolve correctly at symbol usage time:

| FQN form | Before | After |
|----------|--------|-------|
| `phel\stacktrace/fn` | ✅ Works | ✅ Works |
| `phel.stacktrace/fn` | ❌ Fails | ✅ Works |
| `clojure\stacktrace/fn` | ❌ Fails | ✅ Works |
| `clojure.stacktrace/fn` | ❌ Fails | ✅ Works |

## 🔖 Changes

- Apply dot-to-backslash normalization in `SymbolResolver::resolveWithAlias()` so dot-separated FQN namespaces resolve to their canonical backslash form
- Add Clojure-to-Phel namespace remapping at symbol resolution time (mirrors existing logic in `NsSymbol` for `ns` declarations)
- Add 7 unit tests covering all 4 FQN forms from the issue plus edge cases (missing phel namespace, munged registry lookup, regression guard)
- Update CHANGELOG

Closes #1251