### PR TITLE
feat(core): support 0-arity `range` returning infinite lazy sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `range` with 0 arguments now returns an infinite lazy sequence starting at 0, matching Clojure's `(range)` (#1259)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
 - `are` macro in `phel\test` for template-based multiple assertions, matching Clojure's `clojure.test/are` (#1255)
 - Clojure-to-Phel migration guide covering naming, interop, namespaces, and feature differences (#1229)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1324,14 +1324,18 @@ Otherwise, it tries to call `__toString`."
                       generator)))
 
 (defn range
-  "Creates a lazy sequence of numbers from start to end (exclusive)."
-  {:example "(range 5) ; => (0 1 2 3 4)"}
-  [a & rest]
-  (case (count rest)
-    0 (lazy-seq-from-generator (php/:: Seq (range 0 a 1)))
-    1 (lazy-seq-from-generator (php/:: Seq (range a (get rest 0) 1)))
-    2 (lazy-seq-from-generator (php/:: Seq (range a (get rest 0) (get rest 1))))
-    (throw (php/new InvalidArgumentException "Range function expects one, two or three arguments"))))
+  "Creates a lazy sequence of numbers. With no arguments returns an infinite
+  sequence starting at 0. With one argument returns (0..n). With two (start..end).
+  With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX."
+  {:example "(range 5) ; => (0 1 2 3 4)"
+   :see-also ["iterate" "repeat"]}
+  [& args]
+  (case (count args)
+    0 (lazy-seq-from-generator (php/:: Seq (infiniteRange)))
+    1 (lazy-seq-from-generator (php/:: Seq (range 0 (get args 0) 1)))
+    2 (lazy-seq-from-generator (php/:: Seq (range (get args 0) (get args 1) 1)))
+    3 (lazy-seq-from-generator (php/:: Seq (range (get args 0) (get args 1) (get args 2))))
+    (throw (php/new InvalidArgumentException "Range function expects zero to three arguments"))))
 
 (def- for-options (hash-set :reduce))
 

--- a/src/php/Lang/Generators/InfiniteGenerator.php
+++ b/src/php/Lang/Generators/InfiniteGenerator.php
@@ -82,6 +82,17 @@ final class InfiniteGenerator
     }
 
     /**
+     * @return Generator<int, int>
+     */
+    public static function range(): Generator
+    {
+        $i = 0;
+        while (true) {
+            yield $i++;
+        }
+    }
+
+    /**
      * @template T
      *
      * @param iterable<T>|string|null $value

--- a/src/php/Lang/Seq.php
+++ b/src/php/Lang/Seq.php
@@ -138,6 +138,14 @@ final class Seq
     }
 
     /**
+     * @return Generator<int, int>
+     */
+    public static function infiniteRange(): Generator
+    {
+        return InfiniteGenerator::range();
+    }
+
+    /**
      * @return Generator<int, float|int>
      */
     public static function range(int|float $start, int|float $end, int|float $step): Generator

--- a/tests/phel/test/core/for-loop.phel
+++ b/tests/phel/test/core/for-loop.phel
@@ -2,6 +2,7 @@
   (:require phel\test :refer [deftest is]))
 
 (deftest test-range
+  (is (= [0 1 2 3 4] (take 5 (range))) "(range) infinite")
   (is (= [0 1 2] (range 3)) "(range 3)")
   (is (= [1 2] (range 1 3)) "(range 1 3)")
   (is (= [0 2] (range 0 4 2)) "(range 0 4 2)")

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -9,6 +9,14 @@
   (is (= [:x :x :x] (take 3 (repeatedly (fn [] :x))))
       "(take 3 (repeatedly (fn [] :x)))"))
 
+(deftest test-range-infinite
+  (is (= [0 1 2 3 4] (take 5 (range)))
+      "(take 5 (range)) should return first 5 natural numbers")
+  (is (= [0 1 2 3 4 5 6 7 8 9] (take 10 (range)))
+      "(take 10 (range)) should return 0..9")
+  (is (some? (and (range)))
+      "range with no args should return truthy value"))
+
 (deftest test-iterate
   (is (= [1 2 4 8] (take 4 (iterate (fn [x] (* 2 x)) 1)))
       "(take 4 (iterate (fn [x] (* 2 x)) 1))"))


### PR DESCRIPTION
## 🤔 Background

Clojure's `(range)` returns an infinite lazy sequence `(0 1 2 3 ...)`. Phel currently requires at least 1 argument and errors with `Wrong number of arguments`. This blocks Clojure compatibility — specifically [jasalt's clojure-test-suite](https://github.com/jasalt/clojure-test-suite/blob/06945eb/test/clojure/core_test/and.cljc#L38) which tests `(is (some? (and (range))))`.

## 💡 Goal

Support `(range)` with 0 arguments, returning an infinite lazy sequence starting at 0, matching Clojure's behavior.

## 🔖 Changes

- Added `InfiniteGenerator::range()` — infinite PHP generator yielding `0, 1, 2, ...`
- Added `Seq::infiniteRange()` — delegates to the new generator (separate name to avoid collision with existing `range(start, end, step)`)
- Updated `range` in `core.phel` — changed signature from `[a & rest]` to `[& args]` to handle 0-arity, dispatching to `Seq::infiniteRange()`
- Updated docstring with all arities and PHP_INT_MAX limitation note
- Added tests in `for-loop.phel` and `infinite-seqs.phel` (including the exact `(some? (and (range)))` case from the clojure-test-suite)
- Updated CHANGELOG.md

Closes #1259