### PR TITLE
feat(core): add sorted collections (sorted-map, sorted-set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)
 - `range` with 0 arguments now returns an infinite lazy sequence starting at 0, matching Clojure's `(range)` (#1259)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
 - `are` macro in `phel\test` for template-based multiple assertions, matching Clojure's `clojure.test/are` (#1255)

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -109,6 +109,52 @@ final class Phel extends InternalPhel
     }
 
     /**
+     * Create a persistent sorted map from key-value pairs.
+     */
+    public static function sortedMap(mixed ...$kvs): PersistentMapInterface
+    {
+        $typeFactory = TypeFactory::getInstance();
+        if (\count($kvs) === 1 && \is_array($kvs[0])) {
+            return $typeFactory->persistentSortedMapFromArray($kvs[0]);
+        }
+
+        return $typeFactory->persistentSortedMapFromArray($kvs);
+    }
+
+    /**
+     * Create a persistent sorted map with a custom comparator.
+     */
+    public static function sortedMapBy(callable $comparator, mixed ...$kvs): PersistentMapInterface
+    {
+        $typeFactory = TypeFactory::getInstance();
+        if (\count($kvs) === 1 && \is_array($kvs[0])) {
+            return $typeFactory->persistentSortedMapFromArray($kvs[0], $comparator);
+        }
+
+        return $typeFactory->persistentSortedMapFromArray($kvs, $comparator);
+    }
+
+    /**
+     * Create a persistent sorted set from an array of values.
+     *
+     * @param list<mixed>|null $values
+     */
+    public static function sortedSet(?array $values = []): PersistentHashSetInterface
+    {
+        return TypeFactory::getInstance()->persistentSortedSetFromArray($values ?? []);
+    }
+
+    /**
+     * Create a persistent sorted set with a custom comparator.
+     *
+     * @param list<mixed>|null $values
+     */
+    public static function sortedSetBy(callable $comparator, ?array $values = []): PersistentHashSetInterface
+    {
+        return TypeFactory::getInstance()->persistentSortedSetFromArray($values ?? [], $comparator);
+    }
+
+    /**
      * @template T
      *
      * @param T $value The initial value of the variable

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -401,6 +401,37 @@ Otherwise, it tries to call `__toString`."
   [& xs]
   (php/:: Phel (set (apply php/array xs))))
 
+(defn sorted-map
+  "Creates a new sorted map. Keys are in natural sorted order.
+  The number of parameters must be even."
+  {:example "(sorted-map :c 3 :a 1 :b 2) ; keys iterate as :a :b :c"
+   :see-also ["sorted-map-by" "hash-map"]}
+  [& xs]
+  (php/:: Phel (sortedMap (apply php/array xs))))
+
+(defn sorted-map-by
+  "Creates a new sorted map using the given comparator for key ordering.
+  The comparator takes two arguments and returns a negative integer,
+  zero, or a positive integer."
+  {:example "(sorted-map-by (fn [a b] (compare b a)) :a 1 :b 2) ; keys iterate as :b :a"
+   :see-also ["sorted-map" "compare"]}
+  [comp & xs]
+  (php/:: Phel (sortedMapBy comp (apply php/array xs))))
+
+(defn sorted-set
+  "Creates a new sorted set. Elements are in natural sorted order."
+  {:example "(sorted-set 3 1 2) ; iterates as 1 2 3"
+   :see-also ["sorted-set-by" "hash-set"]}
+  [& xs]
+  (php/:: Phel (sortedSet (apply php/array xs))))
+
+(defn sorted-set-by
+  "Creates a new sorted set using the given comparator for element ordering."
+  {:example "(sorted-set-by (fn [a b] (compare b a)) 3 1 2) ; iterates as 3 2 1"
+   :see-also ["sorted-set" "compare"]}
+  [comp & xs]
+  (php/:: Phel (sortedSetBy comp (apply php/array xs))))
+
 (defn keyword
   "Creates a new Keyword from a given string."
   {:example "(keyword \"name\") ; => :name"}

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -10,7 +10,6 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Map\TransientMapWrapper;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
-use Phel\Lang\NamedInterface;
 use RuntimeException;
 use Traversable;
 
@@ -27,18 +26,21 @@ use function count;
  */
 final class PersistentSortedMap extends AbstractPersistentMap
 {
+    private readonly Closure $effectiveComparator;
+
     /**
-     * @param array<int, mixed>           $array      Flat [k, v, k, v, ...] array in sorted key order
-     * @param ?Closure(mixed, mixed): int $comparator
+     * @param array<int, mixed>           $array          Flat [k, v, k, v, ...] in sorted key order
+     * @param ?Closure(mixed, mixed): int $userComparator Original user comparator (null = natural order)
      */
     public function __construct(
         HasherInterface $hasher,
         EqualizerInterface $equalizer,
         ?PersistentMapInterface $meta,
         private readonly array $array,
-        private readonly ?Closure $comparator = null,
+        private readonly ?Closure $userComparator = null,
     ) {
         parent::__construct($hasher, $equalizer, $meta);
+        $this->effectiveComparator = SortedArrayHelper::resolveComparator($userComparator);
     }
 
     /**
@@ -46,7 +48,9 @@ final class PersistentSortedMap extends AbstractPersistentMap
      */
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer, ?callable $comparator = null): self
     {
-        return new self($hasher, $equalizer, null, [], self::toClosure($comparator));
+        $closure = $comparator !== null ? SortedArrayHelper::resolveComparator($comparator) : null;
+
+        return new self($hasher, $equalizer, null, [], $closure);
     }
 
     /**
@@ -70,17 +74,17 @@ final class PersistentSortedMap extends AbstractPersistentMap
 
     public function withMeta(?PersistentMapInterface $meta): static
     {
-        return new self($this->hasher, $this->equalizer, $meta, $this->array, $this->comparator);
+        return new self($this->hasher, $this->equalizer, $meta, $this->array, $this->userComparator);
     }
 
     public function contains($key): bool
     {
-        return $this->binarySearchIndex($key) >= 0;
+        return SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator) >= 0;
     }
 
     public function put($key, $value): PersistentMapInterface
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
 
         if ($idx >= 0) {
             if ($this->equalizer->equals($this->array[$idx + 1], $value)) {
@@ -90,19 +94,19 @@ final class PersistentSortedMap extends AbstractPersistentMap
             $newArray = $this->array;
             $newArray[$idx + 1] = $value;
 
-            return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+            return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->userComparator);
         }
 
         $insertAt = -($idx + 1);
         $newArray = $this->array;
         array_splice($newArray, $insertAt, 0, [$key, $value]);
 
-        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->userComparator);
     }
 
     public function remove($key): self
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
 
         if ($idx < 0) {
             return $this;
@@ -111,12 +115,12 @@ final class PersistentSortedMap extends AbstractPersistentMap
         $newArray = $this->array;
         array_splice($newArray, $idx, 2);
 
-        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->userComparator);
     }
 
     public function find($key)
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
         if ($idx < 0) {
             return null;
         }
@@ -143,66 +147,18 @@ final class PersistentSortedMap extends AbstractPersistentMap
                 $this->hasher,
                 $this->equalizer,
                 $this->array,
-                $this->comparator,
+                $this->userComparator,
             ),
         );
     }
 
     /**
-     * @return ?callable(mixed, mixed): int
-     */
-    public function getComparator(): ?callable
-    {
-        return $this->comparator;
-    }
-
-    private static function toClosure(?callable $comparator): ?Closure
-    {
-        if ($comparator === null) {
-            return null;
-        }
-
-        return $comparator instanceof Closure ? $comparator : Closure::fromCallable($comparator);
-    }
-
-    /**
-     * Default comparator that handles NamedInterface objects (Keywords, Symbols)
-     * by comparing their full names, and falls back to <=> for everything else.
-     */
-    private static function defaultCompare(mixed $a, mixed $b): int
-    {
-        if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
-            return $a->getFullName() <=> $b->getFullName();
-        }
-
-        return $a <=> $b;
-    }
-
-    /**
-     * Binary search for a key in the sorted array.
+     * Returns the user-provided comparator, or null for natural order.
      *
-     * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
+     * @return ?Closure(mixed, mixed): int
      */
-    private function binarySearchIndex(mixed $key): int
+    public function getComparator(): ?Closure
     {
-        /** @var Closure(mixed, mixed): int $comparator */
-        $comparator = $this->comparator ?? static fn(mixed $a, mixed $b): int => self::defaultCompare($a, $b);
-        $low = 0;
-        $high = (int) (count($this->array) / 2) - 1;
-
-        while ($low <= $high) {
-            $mid = intdiv($low + $high, 2);
-            $cmp = $comparator($this->array[$mid * 2], $key);
-
-            if ($cmp < 0) {
-                $low = $mid + 1;
-            } elseif ($cmp > 0) {
-                $high = $mid - 1;
-            } else {
-                return $mid * 2;
-            }
-        }
-
-        return -(($low * 2) + 1);
+        return $this->userComparator;
     }
 }

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\SortedMap;
+
+use Closure;
+use Phel\Lang\Collections\Map\AbstractPersistentMap;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapWrapper;
+use Phel\Lang\EqualizerInterface;
+use Phel\Lang\HasherInterface;
+use Phel\Lang\NamedInterface;
+use RuntimeException;
+use Traversable;
+
+use function count;
+
+/**
+ * Sorted map implementation based on a flat array maintained in sorted key order.
+ * Uses binary search for O(log n) lookups and O(n) inserts/removes.
+ *
+ * @template K
+ * @template V
+ *
+ * @extends AbstractPersistentMap<K, V>
+ */
+final class PersistentSortedMap extends AbstractPersistentMap
+{
+    /**
+     * @param array<int, mixed>           $array      Flat [k, v, k, v, ...] array in sorted key order
+     * @param ?Closure(mixed, mixed): int $comparator
+     */
+    public function __construct(
+        HasherInterface $hasher,
+        EqualizerInterface $equalizer,
+        ?PersistentMapInterface $meta,
+        private readonly array $array,
+        private readonly ?Closure $comparator = null,
+    ) {
+        parent::__construct($hasher, $equalizer, $meta);
+    }
+
+    /**
+     * @param ?callable(mixed, mixed): int $comparator
+     */
+    public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer, ?callable $comparator = null): self
+    {
+        return new self($hasher, $equalizer, null, [], self::toClosure($comparator));
+    }
+
+    /**
+     * @param array<int, mixed>            $kvs
+     * @param ?callable(mixed, mixed): int $comparator
+     */
+    public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $kvs, ?callable $comparator = null): self
+    {
+        if (count($kvs) % 2 !== 0) {
+            throw new RuntimeException('A even number of elements must be provided');
+        }
+
+        $result = self::empty($hasher, $equalizer, $comparator)->asTransient();
+        for ($i = 0, $l = count($kvs); $i < $l; $i += 2) {
+            $result->put($kvs[$i], $kvs[$i + 1]);
+        }
+
+        /** @var self */
+        return $result->persistent();
+    }
+
+    public function withMeta(?PersistentMapInterface $meta): static
+    {
+        return new self($this->hasher, $this->equalizer, $meta, $this->array, $this->comparator);
+    }
+
+    public function contains($key): bool
+    {
+        return $this->binarySearchIndex($key) >= 0;
+    }
+
+    public function put($key, $value): PersistentMapInterface
+    {
+        $idx = $this->binarySearchIndex($key);
+
+        if ($idx >= 0) {
+            if ($this->equalizer->equals($this->array[$idx + 1], $value)) {
+                return $this;
+            }
+
+            $newArray = $this->array;
+            $newArray[$idx + 1] = $value;
+
+            return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+        }
+
+        $insertAt = -($idx + 1);
+        $newArray = $this->array;
+        array_splice($newArray, $insertAt, 0, [$key, $value]);
+
+        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+    }
+
+    public function remove($key): self
+    {
+        $idx = $this->binarySearchIndex($key);
+
+        if ($idx < 0) {
+            return $this;
+        }
+
+        $newArray = $this->array;
+        array_splice($newArray, $idx, 2);
+
+        return new self($this->hasher, $this->equalizer, $this->meta, $newArray, $this->comparator);
+    }
+
+    public function find($key)
+    {
+        $idx = $this->binarySearchIndex($key);
+        if ($idx < 0) {
+            return null;
+        }
+
+        return $this->array[$idx + 1];
+    }
+
+    public function count(): int
+    {
+        return (int) (count($this->array) / 2);
+    }
+
+    public function getIterator(): Traversable
+    {
+        for ($i = 0, $cnt = count($this->array); $i < $cnt; $i += 2) {
+            yield $this->array[$i] => $this->array[$i + 1];
+        }
+    }
+
+    public function asTransient(): TransientMapWrapper
+    {
+        return new TransientMapWrapper(
+            new TransientSortedMap(
+                $this->hasher,
+                $this->equalizer,
+                $this->array,
+                $this->comparator,
+            ),
+        );
+    }
+
+    /**
+     * @return ?callable(mixed, mixed): int
+     */
+    public function getComparator(): ?callable
+    {
+        return $this->comparator;
+    }
+
+    private static function toClosure(?callable $comparator): ?Closure
+    {
+        if ($comparator === null) {
+            return null;
+        }
+
+        return $comparator instanceof Closure ? $comparator : Closure::fromCallable($comparator);
+    }
+
+    /**
+     * Default comparator that handles NamedInterface objects (Keywords, Symbols)
+     * by comparing their full names, and falls back to <=> for everything else.
+     */
+    private static function defaultCompare(mixed $a, mixed $b): int
+    {
+        if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
+            return $a->getFullName() <=> $b->getFullName();
+        }
+
+        return $a <=> $b;
+    }
+
+    /**
+     * Binary search for a key in the sorted array.
+     *
+     * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
+     */
+    private function binarySearchIndex(mixed $key): int
+    {
+        /** @var Closure(mixed, mixed): int $comparator */
+        $comparator = $this->comparator ?? static fn(mixed $a, mixed $b): int => self::defaultCompare($a, $b);
+        $low = 0;
+        $high = (int) (count($this->array) / 2) - 1;
+
+        while ($low <= $high) {
+            $mid = intdiv($low + $high, 2);
+            $cmp = $comparator($this->array[$mid * 2], $key);
+
+            if ($cmp < 0) {
+                $low = $mid + 1;
+            } elseif ($cmp > 0) {
+                $high = $mid - 1;
+            } else {
+                return $mid * 2;
+            }
+        }
+
+        return -(($low * 2) + 1);
+    }
+}

--- a/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
+++ b/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\SortedMap;
+
+use Closure;
+use Phel\Lang\NamedInterface;
+
+use function count;
+
+/**
+ * Shared binary search and comparator logic for sorted collections.
+ */
+final class SortedArrayHelper
+{
+    private static ?Closure $defaultComparator = null;
+
+    /**
+     * Default comparator: compares NamedInterface objects (Keywords, Symbols)
+     * by full name, everything else via spaceship operator.
+     */
+    public static function defaultCompare(mixed $a, mixed $b): int
+    {
+        if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
+            return $a->getFullName() <=> $b->getFullName();
+        }
+
+        return $a <=> $b;
+    }
+
+    /**
+     * Resolves a user-provided comparator into a non-null Closure.
+     * Returns the default comparator when null is given.
+     */
+    public static function resolveComparator(?callable $comparator): Closure
+    {
+        if ($comparator === null) {
+            return self::$defaultComparator ??= static fn(mixed $a, mixed $b): int => self::defaultCompare($a, $b);
+        }
+
+        return $comparator instanceof Closure ? $comparator : Closure::fromCallable($comparator);
+    }
+
+    /**
+     * Binary search for a key in a sorted flat [k, v, k, v, ...] array.
+     *
+     * @param array<int, mixed> $array      The flat sorted array
+     * @param mixed             $key        The key to search for
+     * @param Closure           $comparator Non-null comparator function
+     *
+     * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
+     */
+    public static function binarySearch(array $array, mixed $key, Closure $comparator): int
+    {
+        $low = 0;
+        $high = (int) (count($array) / 2) - 1;
+
+        while ($low <= $high) {
+            $mid = intdiv($low + $high, 2);
+            $cmp = $comparator($array[$mid * 2], $key);
+
+            if ($cmp < 0) {
+                $low = $mid + 1;
+            } elseif ($cmp > 0) {
+                $high = $mid - 1;
+            } else {
+                return $mid * 2;
+            }
+        }
+
+        return -(($low * 2) + 1);
+    }
+}

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\SortedMap;
+
+use Closure;
+use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
+use Phel\Lang\EqualizerInterface;
+use Phel\Lang\HasherInterface;
+use Phel\Lang\NamedInterface;
+
+use function count;
+
+/**
+ * @template K
+ * @template V
+ *
+ * @implements TransientMapInterface<K, V>
+ */
+final class TransientSortedMap implements TransientMapInterface
+{
+    /**
+     * @param array<int, mixed>           $array      Flat [k, v, k, v, ...] array in sorted key order
+     * @param ?Closure(mixed, mixed): int $comparator
+     */
+    public function __construct(
+        private readonly HasherInterface $hasher,
+        private readonly EqualizerInterface $equalizer,
+        private array $array,
+        private readonly ?Closure $comparator = null,
+    ) {}
+
+    public function contains($key): bool
+    {
+        return $this->binarySearchIndex($key) >= 0;
+    }
+
+    public function put($key, $value): self
+    {
+        $idx = $this->binarySearchIndex($key);
+
+        if ($idx >= 0) {
+            if ($this->equalizer->equals($this->array[$idx + 1], $value)) {
+                return $this;
+            }
+
+            $this->array[$idx + 1] = $value;
+
+            return $this;
+        }
+
+        $insertAt = -($idx + 1);
+        array_splice($this->array, $insertAt, 0, [$key, $value]);
+
+        return $this;
+    }
+
+    public function remove($key): self
+    {
+        $idx = $this->binarySearchIndex($key);
+
+        if ($idx < 0) {
+            return $this;
+        }
+
+        array_splice($this->array, $idx, 2);
+
+        return $this;
+    }
+
+    public function find($key)
+    {
+        $idx = $this->binarySearchIndex($key);
+        if ($idx < 0) {
+            return null;
+        }
+
+        return $this->array[$idx + 1];
+    }
+
+    public function count(): int
+    {
+        return (int) (count($this->array) / 2);
+    }
+
+    /**
+     * @param K $offset
+     *
+     * @return V|null
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->find($offset);
+    }
+
+    /**
+     * @param K $offset
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->contains($offset);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new MethodNotSupportedException('Method offsetSet is not supported on TransientSortedMap');
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new MethodNotSupportedException('Method offsetUnset is not supported on TransientSortedMap');
+    }
+
+    public function persistent(): PersistentMapInterface
+    {
+        return new PersistentSortedMap($this->hasher, $this->equalizer, null, $this->array, $this->comparator);
+    }
+
+    /**
+     * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
+     */
+    private static function defaultCompare(mixed $a, mixed $b): int
+    {
+        if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
+            return $a->getFullName() <=> $b->getFullName();
+        }
+
+        return $a <=> $b;
+    }
+
+    private function binarySearchIndex(mixed $key): int
+    {
+        /** @var Closure(mixed, mixed): int $comparator */
+        $comparator = $this->comparator ?? static fn(mixed $a, mixed $b): int => self::defaultCompare($a, $b);
+        $low = 0;
+        $high = (int) (count($this->array) / 2) - 1;
+
+        while ($low <= $high) {
+            $mid = intdiv($low + $high, 2);
+            $cmp = $comparator($this->array[$mid * 2], $key);
+
+            if ($cmp < 0) {
+                $low = $mid + 1;
+            } elseif ($cmp > 0) {
+                $high = $mid - 1;
+            } else {
+                return $mid * 2;
+            }
+        }
+
+        return -(($low * 2) + 1);
+    }
+}

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -10,7 +10,6 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Map\TransientMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
-use Phel\Lang\NamedInterface;
 
 use function count;
 
@@ -22,25 +21,29 @@ use function count;
  */
 final class TransientSortedMap implements TransientMapInterface
 {
+    private readonly Closure $effectiveComparator;
+
     /**
-     * @param array<int, mixed>           $array      Flat [k, v, k, v, ...] array in sorted key order
-     * @param ?Closure(mixed, mixed): int $comparator
+     * @param array<int, mixed>           $array          Flat [k, v, k, v, ...] in sorted key order
+     * @param ?Closure(mixed, mixed): int $userComparator Original user comparator (null = natural order)
      */
     public function __construct(
         private readonly HasherInterface $hasher,
         private readonly EqualizerInterface $equalizer,
         private array $array,
-        private readonly ?Closure $comparator = null,
-    ) {}
+        private readonly ?Closure $userComparator = null,
+    ) {
+        $this->effectiveComparator = SortedArrayHelper::resolveComparator($userComparator);
+    }
 
     public function contains($key): bool
     {
-        return $this->binarySearchIndex($key) >= 0;
+        return SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator) >= 0;
     }
 
     public function put($key, $value): self
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
 
         if ($idx >= 0) {
             if ($this->equalizer->equals($this->array[$idx + 1], $value)) {
@@ -60,7 +63,7 @@ final class TransientSortedMap implements TransientMapInterface
 
     public function remove($key): self
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
 
         if ($idx < 0) {
             return $this;
@@ -73,7 +76,7 @@ final class TransientSortedMap implements TransientMapInterface
 
     public function find($key)
     {
-        $idx = $this->binarySearchIndex($key);
+        $idx = SortedArrayHelper::binarySearch($this->array, $key, $this->effectiveComparator);
         if ($idx < 0) {
             return null;
         }
@@ -116,41 +119,6 @@ final class TransientSortedMap implements TransientMapInterface
 
     public function persistent(): PersistentMapInterface
     {
-        return new PersistentSortedMap($this->hasher, $this->equalizer, null, $this->array, $this->comparator);
-    }
-
-    /**
-     * @return int The array index (even) if found, or -(insertionPoint) - 1 if not found
-     */
-    private static function defaultCompare(mixed $a, mixed $b): int
-    {
-        if ($a instanceof NamedInterface && $b instanceof NamedInterface) {
-            return $a->getFullName() <=> $b->getFullName();
-        }
-
-        return $a <=> $b;
-    }
-
-    private function binarySearchIndex(mixed $key): int
-    {
-        /** @var Closure(mixed, mixed): int $comparator */
-        $comparator = $this->comparator ?? static fn(mixed $a, mixed $b): int => self::defaultCompare($a, $b);
-        $low = 0;
-        $high = (int) (count($this->array) / 2) - 1;
-
-        while ($low <= $high) {
-            $mid = intdiv($low + $high, 2);
-            $cmp = $comparator($this->array[$mid * 2], $key);
-
-            if ($cmp < 0) {
-                $low = $mid + 1;
-            } elseif ($cmp > 0) {
-                $high = $mid - 1;
-            } else {
-                return $mid * 2;
-            }
-        }
-
-        return -(($low * 2) + 1);
+        return new PersistentSortedMap($this->hasher, $this->equalizer, null, $this->array, $this->userComparator);
     }
 }

--- a/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\SortedSet;
+
+use Phel\Lang\AbstractType;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\SortedMap\PersistentSortedMap;
+use Phel\Lang\HasherInterface;
+use Traversable;
+
+/**
+ * @template V
+ *
+ * @implements PersistentHashSetInterface<V>
+ *
+ * @extends AbstractType<PersistentSortedSet<V>>
+ */
+final class PersistentSortedSet extends AbstractType implements PersistentHashSetInterface
+{
+    private int $hashCache = 0;
+
+    public function __construct(
+        private readonly HasherInterface $hasher,
+        private readonly ?PersistentMapInterface $meta,
+        private readonly PersistentMapInterface $map,
+    ) {}
+
+    /**
+     * @param V $key
+     *
+     * @return ?V
+     */
+    public function __invoke(mixed $key)
+    {
+        return $this->map->find($key);
+    }
+
+    public function getMeta(): ?PersistentMapInterface
+    {
+        return $this->meta;
+    }
+
+    public function withMeta(?PersistentMapInterface $meta): static
+    {
+        return new self($this->hasher, $meta, $this->map);
+    }
+
+    /**
+     * @param V $key
+     */
+    public function contains($key): bool
+    {
+        return $this->map->contains($key);
+    }
+
+    /**
+     * @param V $value
+     */
+    public function add($value): PersistentHashSetInterface
+    {
+        $newMap = $this->map->put($value, $value);
+        if ($newMap === $this->map) {
+            return $this;
+        }
+
+        /** @var PersistentSortedMap $newMap */
+        return new self($this->hasher, $this->meta, $newMap);
+    }
+
+    /**
+     * @param V $value
+     */
+    public function remove($value): PersistentHashSetInterface
+    {
+        $newMap = $this->map->remove($value);
+        if ($newMap === $this->map) {
+            return $this;
+        }
+
+        return new self($this->hasher, $this->meta, $newMap);
+    }
+
+    public function count(): int
+    {
+        return $this->map->count();
+    }
+
+    public function equals(mixed $other): bool
+    {
+        if (!$other instanceof self) {
+            return false;
+        }
+
+        if ($this->count() !== $other->count()) {
+            return false;
+        }
+
+        foreach ($this as $value) {
+            if (!$other->contains($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function hash(): int
+    {
+        if ($this->hashCache === 0) {
+            foreach ($this->map as $value) {
+                $this->hashCache += $this->hasher->hash($value);
+            }
+        }
+
+        return $this->hashCache;
+    }
+
+    public function getIterator(): Traversable
+    {
+        foreach ($this->map as $value) {
+            yield $value;
+        }
+    }
+
+    public function asTransient(): TransientSortedSet
+    {
+        return new TransientSortedSet($this->hasher, $this->map->asTransient());
+    }
+
+    public function toPhpArray(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    /**
+     * @param array<int, mixed> $xs
+     */
+    public function concat($xs): PersistentHashSetInterface
+    {
+        $map = $this->asTransient();
+        foreach ($xs as $x) {
+            $map->add($x);
+        }
+
+        return $map->persistent();
+    }
+}

--- a/src/php/Lang/Collections/SortedSet/TransientSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/TransientSortedSet.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\SortedSet;
+
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
+use Phel\Lang\HasherInterface;
+use Stringable;
+
+/**
+ * @template V
+ *
+ * @implements TransientHashSetInterface<V>
+ */
+final readonly class TransientSortedSet implements TransientHashSetInterface, Stringable
+{
+    public function __construct(
+        private HasherInterface $hasher,
+        private TransientMapInterface $transientMap,
+    ) {}
+
+    public function __toString(): string
+    {
+        return '<TransientSortedSet count=' . $this->transientMap->count() . '>';
+    }
+
+    public function count(): int
+    {
+        return $this->transientMap->count();
+    }
+
+    public function contains($key): bool
+    {
+        return $this->transientMap->contains($key);
+    }
+
+    /**
+     * @param V $value
+     */
+    public function add($value): TransientHashSetInterface
+    {
+        $this->transientMap->put($value, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param V $value
+     */
+    public function remove($value): TransientHashSetInterface
+    {
+        $this->transientMap->remove($value);
+
+        return $this;
+    }
+
+    public function persistent(): PersistentHashSetInterface
+    {
+        return new PersistentSortedSet($this->hasher, null, $this->transientMap->persistent());
+    }
+}

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -11,6 +11,8 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentArrayMap;
 use Phel\Lang\Collections\Map\PersistentHashMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\SortedMap\PersistentSortedMap;
+use Phel\Lang\Collections\SortedSet\TransientSortedSet;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 
@@ -74,6 +76,28 @@ final class TypeFactory
     public function persistentVectorFromArray(array $values): PersistentVectorInterface
     {
         return PersistentVector::fromArray($this->hasher, $this->equalizer, $values);
+    }
+
+    /**
+     * @param ?callable(mixed, mixed): int $comparator
+     */
+    public function persistentSortedMapFromArray(array $kvs = [], ?callable $comparator = null): PersistentMapInterface
+    {
+        return PersistentSortedMap::fromArray($this->hasher, $this->equalizer, $kvs, $comparator);
+    }
+
+    /**
+     * @param ?callable(mixed, mixed): int $comparator
+     */
+    public function persistentSortedSetFromArray(array $values = [], ?callable $comparator = null): PersistentHashSetInterface
+    {
+        $map = PersistentSortedMap::empty($this->hasher, $this->equalizer, $comparator);
+        $transient = new TransientSortedSet($this->hasher, $map->asTransient());
+        foreach ($values as $value) {
+            $transient->add($value);
+        }
+
+        return $transient->persistent();
     }
 
     public function getEqualizer(): EqualizerInterface

--- a/tests/phel/test/core/sorted-collections.phel
+++ b/tests/phel/test/core/sorted-collections.phel
@@ -1,0 +1,99 @@
+(ns phel-test\test\core\sorted-collections
+  (:require phel\test :refer [deftest is]))
+
+;; ---- sorted-map ----
+
+(deftest test-sorted-map-empty
+  (is (= 0 (count (sorted-map))) "empty sorted map"))
+
+(deftest test-sorted-map-count
+  (is (= 3 (count (sorted-map :a 1 :b 2 :c 3))) "sorted map count"))
+
+(deftest test-sorted-map-key-order
+  (let [m (sorted-map :c 3 :a 1 :b 2)]
+    (is (= [:a :b :c] (keys m)) "keys in sorted order")
+    (is (= [1 2 3] (vals m)) "values in key-sorted order")))
+
+(deftest test-sorted-map-get
+  (let [m (sorted-map :a 1 :b 2)]
+    (is (= 1 (get m :a)) "get existing key")
+    (is (nil? (get m :z)) "get missing key")
+    (is (contains? m :a) "contains existing")
+    (is (not (contains? m :z)) "contains missing")))
+
+(deftest test-sorted-map-put-maintains-order
+  (let [m (sorted-map :b 2 :a 1)]
+    (is (= [:a :b :c] (keys (put m :c 3))) "put maintains order")))
+
+(deftest test-sorted-map-remove-maintains-order
+  (let [m (sorted-map :c 3 :b 2 :a 1)]
+    (is (= [:a :c] (keys (unset m :b))) "unset maintains order")))
+
+(deftest test-sorted-map-is-map
+  (is (hash-map? (sorted-map :a 1)) "hash-map? returns true for sorted map"))
+
+(deftest test-sorted-map-merge
+  (let [m1 (sorted-map 1 "a" 3 "c")
+        m2 (sorted-map 2 "b" 4 "d")
+        merged (php/-> m1 (merge m2))]
+    (is (= [1 2 3 4] (keys merged)) "map merge maintains order")))
+
+(deftest test-sorted-map-persistent
+  (let [m1 (sorted-map :a 1)
+        m2 (put m1 :b 2)]
+    (is (= 1 (count m1)) "original unchanged")
+    (is (= 2 (count m2)) "new map has both entries")))
+
+;; ---- sorted-map-by ----
+
+(deftest test-sorted-map-by-reverse
+  (let [m (sorted-map-by (fn [a b] (compare b a)) 1 "a" 2 "b" 3 "c")]
+    (is (= [3 2 1] (keys m)) "reverse sorted order")))
+
+(deftest test-sorted-map-by-operations
+  (let [m (sorted-map-by (fn [a b] (compare b a)) 1 "a" 2 "b")]
+    (is (= "a" (get m 1)) "get works with custom comparator")
+    (is (= [3 2 1] (keys (put m 3 "c"))) "put maintains custom order")))
+
+;; ---- sorted-set ----
+
+(deftest test-sorted-set-empty
+  (is (= 0 (count (sorted-set))) "empty sorted set"))
+
+(deftest test-sorted-set-order
+  (let [s (sorted-set 3 1 2)]
+    (is (= [1 2 3] (into [] s)) "elements in sorted order")))
+
+(deftest test-sorted-set-contains
+  (let [s (sorted-set 3 1 2)]
+    (is (contains? s 1) "contains existing")
+    (is (not (contains? s 4)) "contains missing")
+    (is (= 3 (count s)) "count")))
+
+(deftest test-sorted-set-conj
+  (let [s (sorted-set 3 1)]
+    (is (= [1 2 3] (into [] (conj s 2))) "conj maintains order")))
+
+(deftest test-sorted-set-is-set
+  (is (set? (sorted-set 1)) "set? returns true for sorted set"))
+
+(deftest test-sorted-set-duplicates
+  (let [s (sorted-set 1 2 3 2 1)]
+    (is (= 3 (count s)) "duplicates removed")
+    (is (= [1 2 3] (into [] s)) "sorted without duplicates")))
+
+(deftest test-sorted-set-persistent
+  (let [s1 (sorted-set 1)
+        s2 (conj s1 2)]
+    (is (= 1 (count s1)) "original unchanged")
+    (is (= 2 (count s2)) "new set has both elements")))
+
+;; ---- sorted-set-by ----
+
+(deftest test-sorted-set-by-reverse
+  (let [s (sorted-set-by (fn [a b] (compare b a)) 3 1 2)]
+    (is (= [3 2 1] (into [] s)) "reverse sorted order")))
+
+(deftest test-sorted-set-by-operations
+  (let [s (sorted-set-by (fn [a b] (compare b a)) 3 1)]
+    (is (= [3 2 1] (into [] (conj s 2))) "conj maintains custom order")))

--- a/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/PersistentSortedMapTest.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\Collections\SortedMap;
+
+use Phel\Lang\Collections\Map\PersistentArrayMap;
+use Phel\Lang\Collections\SortedMap\PersistentSortedMap;
+use PhelTest\Unit\Lang\Collections\ModuloHasher;
+use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class PersistentSortedMapTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        self::assertCount(0, $h);
+        self::assertFalse($h->contains('test'));
+        self::assertFalse($h->contains(null));
+        self::assertNull($h->find('test'));
+    }
+
+    public function test_can_not_create_from_array_with_uneven_values(): void
+    {
+        $this->expectException(RuntimeException::class);
+        PersistentSortedMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['test']);
+    }
+
+    public function test_put_key_value(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+
+        self::assertCount(1, $h);
+        self::assertTrue($h->contains(1));
+        self::assertSame('test', $h->find(1));
+    }
+
+    public function test_put_same_key_value_twice(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test')
+            ->put(1, 'test');
+
+        self::assertCount(1, $h);
+        self::assertTrue($h->contains(1));
+        self::assertSame('test', $h->find(1));
+    }
+
+    public function test_put_same_key_different_value(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test')
+            ->put(1, 'foo');
+
+        self::assertCount(1, $h);
+        self::assertTrue($h->contains(1));
+        self::assertSame('foo', $h->find(1));
+    }
+
+    public function test_put_returns_same_instance_when_value_unchanged(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+        $h2 = $h->put(1, 'test');
+
+        self::assertSame($h, $h2);
+    }
+
+    public function test_remove_existing_key(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test')
+            ->remove(1);
+
+        self::assertCount(0, $h);
+        self::assertFalse($h->contains(1));
+        self::assertNull($h->find(1));
+    }
+
+    public function test_remove_non_existing_key(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->remove(1);
+
+        self::assertCount(0, $h);
+        self::assertFalse($h->contains(1));
+        self::assertNull($h->find(1));
+    }
+
+    public function test_remove_returns_same_instance_when_key_not_found(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+        $h2 = $h->remove(2);
+
+        self::assertSame($h, $h2);
+    }
+
+    public function test_remove_non_existing_key_in_child(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(2, 'test')
+            ->remove(1);
+
+        self::assertCount(1, $h);
+        self::assertTrue($h->contains(2));
+        self::assertSame('test', $h->find(2));
+        self::assertFalse($h->contains(1));
+        self::assertNull($h->find(1));
+    }
+
+    public function test_merge(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+
+        $h2 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(2, 'bar');
+
+        $merged = $h1->merge($h2);
+
+        self::assertCount(2, $merged);
+        self::assertSame('test', $merged->find(1));
+        self::assertSame('bar', $merged->find(2));
+    }
+
+    public function test_equals(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'foo')
+            ->put(2, 'bar');
+
+        $h2 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(2, 'bar')
+            ->put(1, 'foo');
+
+        $this->assertTrue($h1->equals($h2));
+        $this->assertTrue($h2->equals($h1));
+    }
+
+    public function test_equals_different_keys(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'foo')
+            ->put(2, 'bar');
+
+        $h2 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(3, 'bar')
+            ->put(4, 'foo');
+
+        $this->assertFalse($h1->equals($h2));
+        $this->assertFalse($h2->equals($h1));
+    }
+
+    public function test_equals_different_length(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'foo')
+            ->put(2, 'bar')
+            ->put(3, 'foobar');
+
+        $h2 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(2, 'bar')
+            ->put(1, 'foo');
+
+        $this->assertFalse($h1->equals($h2));
+        $this->assertFalse($h2->equals($h1));
+    }
+
+    public function test_equals_different_values(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'foo')
+            ->put(2, 'bar');
+
+        $h2 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'bar')
+            ->put(2, 'foo');
+
+        $this->assertFalse($h1->equals($h2));
+        $this->assertFalse($h2->equals($h1));
+    }
+
+    public function test_equals_different_type(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'foo')
+            ->put(2, 'bar');
+
+        $this->assertFalse($h1->equals([1 => 'foo', 2 => 'bar']));
+    }
+
+    public function test_iteration_order_is_sorted(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(3, 'c')
+            ->put(1, 'a')
+            ->put(2, 'b');
+
+        $keys = [];
+        $values = [];
+        foreach ($h as $k => $v) {
+            $keys[] = $k;
+            $values[] = $v;
+        }
+
+        $this->assertSame([1, 2, 3], $keys);
+        $this->assertSame(['a', 'b', 'c'], $values);
+    }
+
+    public function test_iteration_order_with_custom_comparator(): void
+    {
+        $reverseComparator = static fn($a, $b): int => $b <=> $a;
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer(), $reverseComparator)
+            ->put(1, 'a')
+            ->put(3, 'c')
+            ->put(2, 'b');
+
+        $keys = [];
+        foreach ($h as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame([3, 2, 1], $keys);
+    }
+
+    public function test_from_array_maintains_sorted_order(): void
+    {
+        $h = PersistentSortedMap::fromArray(
+            new ModuloHasher(),
+            new SimpleEqualizer(),
+            [3, 'c', 1, 'a', 2, 'b'],
+        );
+
+        $keys = [];
+        foreach ($h as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame([1, 2, 3], $keys);
+    }
+
+    public function test_from_array_with_custom_comparator(): void
+    {
+        $reverseComparator = static fn($a, $b): int => $b <=> $a;
+        $h = PersistentSortedMap::fromArray(
+            new ModuloHasher(),
+            new SimpleEqualizer(),
+            [3, 'c', 1, 'a', 2, 'b'],
+            $reverseComparator,
+        );
+
+        $keys = [];
+        foreach ($h as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame([3, 2, 1], $keys);
+    }
+
+    public function test_iteration_on_empty(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        $result = [];
+        foreach ($h as $k => $v) {
+            $result[$k] = $v;
+        }
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_hash_on_empty_map(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        $this->assertSame(1, $h->hash());
+    }
+
+    public function test_hash_on_single_entry_map(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 10);
+
+        $this->assertSame(1 + (1 ^ 10), $h->hash());
+    }
+
+    public function test_add_meta_data(): void
+    {
+        $meta = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->withMeta($meta);
+
+        $this->assertEquals($meta, $h->getMeta());
+    }
+
+    public function test_with_meta_preserves_comparator(): void
+    {
+        $reverseComparator = static fn($a, $b): int => $b <=> $a;
+        $meta = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer(), $reverseComparator)
+            ->put(1, 'a')
+            ->put(2, 'b')
+            ->withMeta($meta);
+
+        $h2 = $h->put(3, 'c');
+
+        $keys = [];
+        foreach ($h2 as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame([3, 2, 1], $keys);
+    }
+
+    public function test_invoke_returns_value(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+
+        self::assertSame('test', $h(1));
+        self::assertNull($h(2));
+    }
+
+    public function test_offset_get(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+
+        self::assertSame('test', $h[1]);
+        self::assertNull($h[2]);
+    }
+
+    public function test_offset_exists(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'test');
+
+        self::assertArrayHasKey(1, $h);
+        self::assertArrayNotHasKey(2, $h);
+    }
+
+    public function test_persistent_after_put(): void
+    {
+        $h1 = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put(1, 'a');
+        $h2 = $h1->put(2, 'b');
+
+        self::assertCount(1, $h1);
+        self::assertCount(2, $h2);
+        self::assertNull($h1->find(2));
+        self::assertSame('b', $h2->find(2));
+    }
+
+    public function test_transient_round_trip(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $t = $h->asTransient();
+        $t->put(3, 'c');
+        $t->put(1, 'a');
+        $t->put(2, 'b');
+
+        $result = $t->persistent();
+
+        $keys = [];
+        foreach ($result as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame([1, 2, 3], $keys);
+        $this->assertCount(3, $result);
+    }
+
+    public function test_get_comparator(): void
+    {
+        $comp = static fn($a, $b): int => $b <=> $a;
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer(), $comp);
+
+        self::assertSame($comp, $h->getComparator());
+    }
+
+    public function test_get_comparator_returns_null_for_natural_order(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        self::assertNull($h->getComparator());
+    }
+
+    public function test_string_keys_sorted(): void
+    {
+        $h = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer())
+            ->put('c', 3)
+            ->put('a', 1)
+            ->put('b', 2);
+
+        $keys = [];
+        foreach ($h as $k => $v) {
+            $keys[] = $k;
+        }
+
+        $this->assertSame(['a', 'b', 'c'], $keys);
+    }
+}

--- a/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedMap/SortedArrayHelperTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\Collections\SortedMap;
+
+use Closure;
+use Phel\Lang\Collections\SortedMap\SortedArrayHelper;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class SortedArrayHelperTest extends TestCase
+{
+    // ---- defaultCompare ----
+
+    public function test_default_compare_integers(): void
+    {
+        self::assertSame(-1, SortedArrayHelper::defaultCompare(1, 2));
+        self::assertSame(0, SortedArrayHelper::defaultCompare(2, 2));
+        self::assertSame(1, SortedArrayHelper::defaultCompare(3, 2));
+    }
+
+    public function test_default_compare_strings(): void
+    {
+        self::assertSame(-1, SortedArrayHelper::defaultCompare('a', 'b'));
+        self::assertSame(0, SortedArrayHelper::defaultCompare('b', 'b'));
+        self::assertSame(1, SortedArrayHelper::defaultCompare('c', 'b'));
+    }
+
+    public function test_default_compare_keywords_by_name(): void
+    {
+        $a = Keyword::create('alpha');
+        $b = Keyword::create('beta');
+        $c = Keyword::create('gamma');
+
+        self::assertLessThan(0, SortedArrayHelper::defaultCompare($a, $b));
+        self::assertSame(0, SortedArrayHelper::defaultCompare($a, $a));
+        self::assertGreaterThan(0, SortedArrayHelper::defaultCompare($c, $b));
+    }
+
+    public function test_default_compare_namespaced_keywords(): void
+    {
+        $a = Keyword::create('name', 'a');
+        $b = Keyword::create('name', 'b');
+
+        self::assertLessThan(0, SortedArrayHelper::defaultCompare($a, $b));
+        self::assertGreaterThan(0, SortedArrayHelper::defaultCompare($b, $a));
+    }
+
+    public function test_default_compare_symbols_by_name(): void
+    {
+        $a = Symbol::create('alpha');
+        $b = Symbol::create('beta');
+
+        self::assertLessThan(0, SortedArrayHelper::defaultCompare($a, $b));
+        self::assertGreaterThan(0, SortedArrayHelper::defaultCompare($b, $a));
+    }
+
+    // ---- resolveComparator ----
+
+    public function test_resolve_null_returns_default_comparator(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+
+        self::assertInstanceOf(Closure::class, $comp);
+        self::assertSame(-1, $comp(1, 2));
+    }
+
+    public function test_resolve_null_returns_singleton(): void
+    {
+        $comp1 = SortedArrayHelper::resolveComparator(null);
+        $comp2 = SortedArrayHelper::resolveComparator(null);
+
+        self::assertSame($comp1, $comp2);
+    }
+
+    public function test_resolve_closure_returns_same_closure(): void
+    {
+        $custom = static fn(int $a, int $b): int => $b <=> $a;
+        $result = SortedArrayHelper::resolveComparator($custom);
+
+        self::assertSame($custom, $result);
+    }
+
+    public function test_resolve_callable_converts_to_closure(): void
+    {
+        $result = SortedArrayHelper::resolveComparator(strcmp(...));
+
+        self::assertInstanceOf(Closure::class, $result);
+    }
+
+    // ---- binarySearch ----
+
+    public function test_search_empty_array(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+
+        self::assertSame(-1, SortedArrayHelper::binarySearch([], 1, $comp));
+    }
+
+    public function test_search_finds_existing_key(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $array = [1, 'a', 2, 'b', 3, 'c'];
+
+        self::assertSame(0, SortedArrayHelper::binarySearch($array, 1, $comp));
+        self::assertSame(2, SortedArrayHelper::binarySearch($array, 2, $comp));
+        self::assertSame(4, SortedArrayHelper::binarySearch($array, 3, $comp));
+    }
+
+    public function test_search_returns_negative_for_missing_key(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $array = [1, 'a', 3, 'c', 5, 'e'];
+
+        // Missing key 2: insertion point is index 2 → returns -(2+1) = -3
+        self::assertSame(-3, SortedArrayHelper::binarySearch($array, 2, $comp));
+        // Missing key 4: insertion point is index 4 → returns -(4+1) = -5
+        self::assertSame(-5, SortedArrayHelper::binarySearch($array, 4, $comp));
+    }
+
+    public function test_search_insertion_point_at_start(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $array = [2, 'b', 3, 'c'];
+
+        // Key 1 inserts at index 0 → returns -(0+1) = -1
+        self::assertSame(-1, SortedArrayHelper::binarySearch($array, 1, $comp));
+    }
+
+    public function test_search_insertion_point_at_end(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $array = [1, 'a', 2, 'b'];
+
+        // Key 3 inserts at index 4 → returns -(4+1) = -5
+        self::assertSame(-5, SortedArrayHelper::binarySearch($array, 3, $comp));
+    }
+
+    public function test_search_with_custom_comparator(): void
+    {
+        $reverse = static fn(int $a, int $b): int => $b <=> $a;
+        $array = [3, 'c', 2, 'b', 1, 'a']; // reverse sorted
+
+        self::assertSame(0, SortedArrayHelper::binarySearch($array, 3, $reverse));
+        self::assertSame(2, SortedArrayHelper::binarySearch($array, 2, $reverse));
+        self::assertSame(4, SortedArrayHelper::binarySearch($array, 1, $reverse));
+    }
+
+    public function test_search_single_element(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $array = [5, 'e'];
+
+        self::assertSame(0, SortedArrayHelper::binarySearch($array, 5, $comp));
+        self::assertSame(-1, SortedArrayHelper::binarySearch($array, 3, $comp));
+        self::assertSame(-3, SortedArrayHelper::binarySearch($array, 7, $comp));
+    }
+
+    public function test_search_with_keywords(): void
+    {
+        $comp = SortedArrayHelper::resolveComparator(null);
+        $a = Keyword::create('a');
+        $b = Keyword::create('b');
+        $c = Keyword::create('c');
+        $array = [$a, 1, $b, 2, $c, 3];
+
+        self::assertSame(0, SortedArrayHelper::binarySearch($array, $a, $comp));
+        self::assertSame(2, SortedArrayHelper::binarySearch($array, $b, $comp));
+        self::assertSame(4, SortedArrayHelper::binarySearch($array, $c, $comp));
+    }
+}

--- a/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
+++ b/tests/php/Unit/Lang/Collections/SortedSet/PersistentSortedSetTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\Collections\SortedSet;
+
+use Phel\Lang\Collections\Map\PersistentArrayMap;
+use Phel\Lang\Collections\SortedMap\PersistentSortedMap;
+use Phel\Lang\Collections\SortedSet\PersistentSortedSet;
+use PhelTest\Unit\Lang\Collections\ModuloHasher;
+use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
+use PHPUnit\Framework\TestCase;
+
+final class PersistentSortedSetTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $s = $this->emptySet();
+
+        self::assertCount(0, $s);
+        self::assertFalse($s->contains(1));
+    }
+
+    public function test_add_value(): void
+    {
+        $s = $this->emptySet()->add(1);
+
+        self::assertCount(1, $s);
+        self::assertTrue($s->contains(1));
+    }
+
+    public function test_add_duplicate(): void
+    {
+        $s = $this->emptySet()->add(1)->add(1);
+
+        self::assertCount(1, $s);
+    }
+
+    public function test_add_returns_same_instance_when_duplicate(): void
+    {
+        $s = $this->emptySet()->add(1);
+        $s2 = $s->add(1);
+
+        self::assertSame($s, $s2);
+    }
+
+    public function test_remove_existing(): void
+    {
+        $s = $this->emptySet()->add(1)->remove(1);
+
+        self::assertCount(0, $s);
+        self::assertFalse($s->contains(1));
+    }
+
+    public function test_remove_non_existing(): void
+    {
+        $s = $this->emptySet()->add(1);
+        $s2 = $s->remove(2);
+
+        self::assertSame($s, $s2);
+    }
+
+    public function test_iteration_order_is_sorted(): void
+    {
+        $s = $this->emptySet()->add(3)->add(1)->add(2);
+
+        $values = [];
+        foreach ($s as $v) {
+            $values[] = $v;
+        }
+
+        $this->assertSame([1, 2, 3], $values);
+    }
+
+    public function test_custom_comparator_reverse_order(): void
+    {
+        $s = $this->emptySet(static fn($a, $b): int => $b <=> $a)
+            ->add(1)->add(3)->add(2);
+
+        $values = [];
+        foreach ($s as $v) {
+            $values[] = $v;
+        }
+
+        $this->assertSame([3, 2, 1], $values);
+    }
+
+    public function test_equals(): void
+    {
+        $s1 = $this->emptySet()->add(1)->add(2)->add(3);
+        $s2 = $this->emptySet()->add(3)->add(1)->add(2);
+
+        $this->assertTrue($s1->equals($s2));
+    }
+
+    public function test_equals_different_elements(): void
+    {
+        $s1 = $this->emptySet()->add(1)->add(2);
+        $s2 = $this->emptySet()->add(3)->add(4);
+
+        $this->assertFalse($s1->equals($s2));
+    }
+
+    public function test_equals_different_count(): void
+    {
+        $s1 = $this->emptySet()->add(1)->add(2);
+        $s2 = $this->emptySet()->add(1);
+
+        $this->assertFalse($s1->equals($s2));
+    }
+
+    public function test_hash(): void
+    {
+        $s1 = $this->emptySet()->add(1)->add(2);
+        $s2 = $this->emptySet()->add(2)->add(1);
+
+        $this->assertSame($s1->hash(), $s2->hash());
+    }
+
+    public function test_invoke(): void
+    {
+        $s = $this->emptySet()->add(1)->add(2);
+
+        self::assertSame(1, $s(1));
+        self::assertNull($s(3));
+    }
+
+    public function test_with_meta(): void
+    {
+        $meta = PersistentArrayMap::empty(new ModuloHasher(), new SimpleEqualizer());
+        $s = $this->emptySet()->withMeta($meta);
+
+        $this->assertEquals($meta, $s->getMeta());
+    }
+
+    public function test_to_php_array(): void
+    {
+        $s = $this->emptySet()->add(3)->add(1)->add(2);
+
+        $this->assertSame([1, 2, 3], $s->toPhpArray());
+    }
+
+    public function test_concat(): void
+    {
+        $s = $this->emptySet()->add(1);
+        $s2 = $s->concat([3, 2]);
+
+        $values = [];
+        foreach ($s2 as $v) {
+            $values[] = $v;
+        }
+
+        $this->assertSame([1, 2, 3], $values);
+        self::assertCount(3, $s2);
+    }
+
+    public function test_transient_round_trip(): void
+    {
+        $s = $this->emptySet();
+        $t = $s->asTransient();
+        $t->add(3);
+        $t->add(1);
+        $t->add(2);
+
+        $result = $t->persistent();
+
+        $values = [];
+        foreach ($result as $v) {
+            $values[] = $v;
+        }
+
+        $this->assertSame([1, 2, 3], $values);
+    }
+
+    public function test_persistent_immutability(): void
+    {
+        $s1 = $this->emptySet()->add(1);
+        $s2 = $s1->add(2);
+
+        self::assertCount(1, $s1);
+        self::assertCount(2, $s2);
+    }
+
+    private function emptySet(?callable $comparator = null): PersistentSortedSet
+    {
+        $map = PersistentSortedMap::empty(new ModuloHasher(), new SimpleEqualizer(), $comparator);
+
+        return new PersistentSortedSet(new ModuloHasher(), null, $map);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Clojure provides sorted collections (`sorted-map`, `sorted-set`) that maintain key/element ordering and enable deterministic iteration. Phel currently lacks these, limiting use cases like ordered config rendering, range queries, and priority-based data.

## 💡 Goal

Add `sorted-map`, `sorted-map-by`, `sorted-set`, and `sorted-set-by` constructor functions to Phel, matching Clojure's sorted collection semantics.

Closes #1228

## 🔖 Changes

- **`PersistentSortedMap`** — extends `AbstractPersistentMap`, array-based sorted map with binary search for O(log n) lookups. Maintains key order via comparator (defaults to natural order with `NamedInterface` support for keywords/symbols).
- **`TransientSortedMap`** — mutable variant for efficient bulk building via `transient`/`persistent!`.
- **`PersistentSortedSet`** — implements `PersistentHashSetInterface`, wraps a `PersistentSortedMap` internally (same pattern as `PersistentHashSet`).
- **`TransientSortedSet`** — mutable variant wrapping transient map.
- **`TypeFactory`** — added `persistentSortedMapFromArray()` and `persistentSortedSetFromArray()` factory methods.
- **`Phel.php`** — added `sortedMap()`, `sortedMapBy()`, `sortedSet()`, `sortedSetBy()` static API.
- **`core.phel`** — added `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` constructor functions with docstrings and examples.
- **Tests** — 33 PHPUnit tests for sorted map, 18 for sorted set, 30 Phel-level integration tests.
- **CHANGELOG** — updated Unreleased section.