### PR TITLE
feat(test): add do-report to phel\test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `do-report` in `phel\test` for Clojure-compatible custom assertion reporting (#1260)
 - `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)
 - `range` with 0 arguments now returns an infinite lazy sequence starting at 0, matching Clojure's `(range)` (#1259)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -68,6 +68,15 @@
     (when-not ok
       (swap! stats update-in [:failed] push data))))
 
+(defn do-report
+  "Add file and line information to a test result and call report.
+  If you are writing a custom assert-expr method, call this function
+  to pass test results to report."
+  {:see-also ["report" "assert-expr"]
+   :example "(do-report {:state :pass :type :any :message \"ok\"})"}
+  [m]
+  (report m))
+
 
 ;; ---------------------------
 ;; `is` macro and its asserts

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\test-framework
-  (:require phel\test :refer [deftest is testing get-stats reset-stats restore-stats]))
+  (:require phel\test :refer [deftest is testing get-stats reset-stats restore-stats do-report]))
 
 ;; Behavior coverage for the `is` macro and its built-in dispatch arms.
 ;;
@@ -236,3 +236,46 @@
     (let [failure (first (get snapshot :failed))]
       (is (= "math basics - addition" (get failure :message))
           "testing context is prepended to failure message"))))
+
+;; ---------------------------------------------------------------------------
+;; do-report — Clojure-compatible entry point that delegates to report
+;; ---------------------------------------------------------------------------
+
+(deftest test-do-report-pass-increments-pass-count
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer (do-report {:state :pass :type :any :message "ok"}))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 1 (:pass counts)) "do-report with :pass increments pass count")
+    (is (= 1 (:total counts)) "do-report with :pass increments total")
+    (is (= 0 (:failed counts)) "do-report with :pass does not increment failed")))
+
+(deftest test-do-report-failure-records-failure
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer (do-report {:state :failed :type :any :message "nope"}))
+        snapshot (get-stats)]
+    (restore-stats saved)
+    (is (= 1 (:failed (get snapshot :counts))) "do-report with :failed increments failed count")
+    (is (= 1 (count (get snapshot :failed))) "do-report with :failed records failure data")
+    (let [failure (first (get snapshot :failed))]
+      (is (= "nope" (get failure :message)) "do-report preserves message"))))
+
+(deftest test-do-report-preserves-location
+  (let [saved (get-stats)
+        loc {:file "test.phel" :line 42 :column 1}
+        _ (reset-stats)
+        _ (with-output-buffer (do-report {:state :failed :type :any :location loc}))
+        snapshot (get-stats)]
+    (restore-stats saved)
+    (let [failure (first (get snapshot :failed))]
+      (is (= loc (get failure :location)) "do-report preserves :location in result"))))
+
+(deftest test-do-report-works-without-location
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer (do-report {:state :pass :type :any}))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 1 (:pass counts)) "do-report works without :location key")))


### PR DESCRIPTION
## 🤔 Background

The clojure-test-suite fails because `t/do-report` cannot be resolved — Phel's test module doesn't have this function. In Clojure, `do-report` is the standard entry point for custom `assert-expr` methods to pass test results to `report`.

## 💡 Goal

Add `do-report` to `phel\test` for Clojure compatibility, enabling the clojure-test-suite and custom assertion authors to use the idiomatic Clojure API.

## 🔖 Changes

- Add public `do-report` function that delegates to `report` (location info is already embedded at macro expansion time by assert-expr methods)
- Add 4 tests covering pass/fail paths, location preservation, and missing-location handling
- Update CHANGELOG.md

Closes #1260