### PR TITLE
fix(repl): support dot separator and clojure alias in require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Accept `name#` as an auto-gensym suffix inside syntax-quote (alongside the existing `name$`), matching Clojure's `clojure.core/gensym` reader macro (#1195)
 
 ### Fixed
+- REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)
 - REPL `(require 'foo)` now throws `RuntimeException` when the namespace cannot be found on source paths, instead of silently succeeding (#1246)
 - Allow PHP reserved keywords (e.g. `and`, `list`, `class`) in namespace names, matching Clojure compatibility — PHP 8.0+ supports keywords in namespace parts (#1230)
 - `macroexpand` and `macroexpand-1` are now functions (were macros), matching Clojure semantics: quoted forms expand correctly (`(macroexpand '(when 1 2))` → `(if 1 (do 2))`), and unquoted forms evaluate eagerly (`(macroexpand (when 1 2))` → `2`) (#1209)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -1,6 +1,7 @@
 (ns phel\repl
   (:use Phel)
   (:use Phel\Lang\Symbol)
+  (:use Phel\Lang\Registry)
   (:use Phel\Build\BuildFacade)
   (:use Phel\Command\CommandFacade)
   (:use Phel\Compiler\Application\Munge)
@@ -96,9 +97,35 @@
 (defn- set-ns [namespace]
   (set-var *ns* namespace))
 
+(defn- normalize-ns-name
+  "Converts dot separators to backslashes in a namespace string."
+  [ns-str]
+  (php/str_replace "." "\\" ns-str))
+
+(defn- remap-clojure-ns-name
+  "Remaps clojure\\* namespace strings to phel\\* when the target exists in the Registry."
+  [ns-str]
+  (if (php/str_starts_with ns-str "clojure\\")
+    (let [target (str "phel\\" (php/substr ns-str 8))
+          munged (php/str_replace "-" "_" target)]
+      (if (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged)))
+        ns-str
+        target))
+    ns-str))
+
+(defn- normalize-require-symbol
+  "Normalizes a require symbol: converts dots to backslashes and remaps clojure\\* to phel\\*."
+  [sym]
+  (let [original (name sym)
+        normalized (remap-clojure-ns-name (normalize-ns-name original))]
+    (if (php/=== normalized original)
+      sym
+      (php/:: Symbol (create normalized)))))
+
 (defn- require-namespace
   [namespace alias refers]
-  (let [env (get-global-env)
+  (let [namespace (normalize-require-symbol namespace)
+        env (get-global-env)
         current-ns *ns*]
     (php/-> env (addRequireAlias current-ns alias namespace))
     (foreach [r refers]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -97,30 +97,20 @@
 (defn- set-ns [namespace]
   (set-var *ns* namespace))
 
-(defn- normalize-ns-name
-  "Converts dot separators to backslashes in a namespace string."
-  [ns-str]
-  (php/str_replace "." "\\" ns-str))
-
-(defn- remap-clojure-ns-name
-  "Remaps clojure\\* namespace strings to phel\\* when the target exists in the Registry."
-  [ns-str]
-  (if (php/str_starts_with ns-str "clojure\\")
-    (let [target (str "phel\\" (php/substr ns-str 8))
-          munged (php/str_replace "-" "_" target)]
-      (if (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged)))
-        ns-str
-        target))
-    ns-str))
-
 (defn- normalize-require-symbol
   "Normalizes a require symbol: converts dots to backslashes and remaps clojure\\* to phel\\*."
   [sym]
-  (let [original (name sym)
-        normalized (remap-clojure-ns-name (normalize-ns-name original))]
-    (if (php/=== normalized original)
+  (let [ns-str (php/str_replace "." "\\" (name sym))
+        ns-str (if (php/str_starts_with ns-str "clojure\\")
+                 (let [target (str "phel\\" (php/substr ns-str 8))
+                       munged (php/str_replace "-" "_" target)]
+                   (if (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged)))
+                     ns-str
+                     target))
+                 ns-str)]
+    (if (php/=== ns-str (name sym))
       sym
-      (php/:: Symbol (create normalized)))))
+      (php/:: Symbol (create ns-str)))))
 
 (defn- require-namespace
   [namespace alias refers]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -97,20 +97,24 @@
 (defn- set-ns [namespace]
   (set-var *ns* namespace))
 
+(defn- normalize-ns-str
+  "Converts dots to backslashes and remaps clojure\\* to phel\\* when the target exists."
+  [ns-str]
+  (let [ns-str (php/str_replace "." "\\" ns-str)]
+    (if-not (php/str_starts_with ns-str "clojure\\")
+      ns-str
+      (let [target (str "phel\\" (php/substr ns-str 8))
+            munged (php/str_replace "-" "_" target)
+            exists (not (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged))))]
+        (if exists target ns-str)))))
+
 (defn- normalize-require-symbol
-  "Normalizes a require symbol: converts dots to backslashes and remaps clojure\\* to phel\\*."
+  "Normalizes a require symbol, returning the original if unchanged."
   [sym]
-  (let [ns-str (php/str_replace "." "\\" (name sym))
-        ns-str (if (php/str_starts_with ns-str "clojure\\")
-                 (let [target (str "phel\\" (php/substr ns-str 8))
-                       munged (php/str_replace "-" "_" target)]
-                   (if (php/empty (php/-> (php/:: Registry (getInstance)) (getDefinitionInNamespace munged)))
-                     ns-str
-                     target))
-                 ns-str)]
-    (if (php/=== ns-str (name sym))
+  (let [normalized (normalize-ns-str (name sym))]
+    (if (php/=== normalized (name sym))
       sym
-      (php/:: Symbol (create ns-str)))))
+      (php/:: Symbol (create normalized)))))
 
 (defn- require-namespace
   [namespace alias refers]

--- a/tests/php/Integration/Repl/RequireNamespaceTest.php
+++ b/tests/php/Integration/Repl/RequireNamespaceTest.php
@@ -57,4 +57,46 @@ final class RequireNamespaceTest extends TestCase
         $facade = new CompilerFacade();
         $facade->eval('(phel\\repl/require nonexistent\\foo)', new CompileOptions());
     }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_require_with_dot_separator(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::addDefinition('phel\\repl', 'src-dirs', [__DIR__ . '/../../../../src']);
+
+        $srcDir = __DIR__ . '/../../../../src';
+        $build = new BuildFacade();
+        $deps = $build->getDependenciesForNamespace([$srcDir], ['phel\\repl']);
+        foreach ($deps as $dep) {
+            $build->evalFile($dep->getFile());
+        }
+
+        $facade = new CompilerFacade();
+        $result = $facade->eval('(phel\\repl/require phel.str)', new CompileOptions());
+
+        self::assertInstanceOf(Symbol::class, $result);
+        self::assertSame('phel\\str', $result->getFullName());
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_require_with_clojure_alias(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::addDefinition('phel\\repl', 'src-dirs', [__DIR__ . '/../../../../src']);
+
+        $srcDir = __DIR__ . '/../../../../src';
+        $build = new BuildFacade();
+        $deps = $build->getDependenciesForNamespace([$srcDir], ['phel\\repl']);
+        foreach ($deps as $dep) {
+            $build->evalFile($dep->getFile());
+        }
+
+        $facade = new CompilerFacade();
+        $result = $facade->eval('(phel\\repl/require clojure.str)', new CompileOptions());
+
+        self::assertInstanceOf(Symbol::class, $result);
+        self::assertSame('phel\\str', $result->getFullName());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

The compiler's `(ns)` form correctly normalizes dot separators to backslashes and remaps `clojure\*` namespaces to `phel\*` (via `NsSymbol.php`). However, the REPL's `require` macro bypasses this pipeline and passes raw symbols directly to `require-namespace`, so `(require phel.str)` and `(require clojure.str)` fail with "Could not locate namespace".

> Also affects nREPL clients (jasalt/phel-nrepl#4) where Cider tries `(require 'clojure.stacktrace)` for error diagnostics.

## 💡 Goal

Make the REPL `require` macro handle dot namespace separators and Clojure namespace aliasing, matching the compiler's behavior.

## 🔖 Changes

- Add `normalize-ns-name` helper to convert dots to backslashes in namespace strings
- Add `remap-clojure-ns-name` helper to remap `clojure\*` to `phel\*` when the target exists in the Registry
- Add `normalize-require-symbol` to compose both normalizations and return a proper Symbol
- Apply normalization at the start of `require-namespace` so all downstream code sees canonical names
- Add integration tests for dot separator and Clojure alias require

Closes #1263