### PR TITLE
feat: add reify for anonymous protocol implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `reify` for anonymous protocol/interface implementation, matching Clojure's `reify` (#1226)
 - `do-report` in `phel\test` for Clojure-compatible custom assertion reporting (#1260)
 - `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)
 - `range` with 0 arguments now returns an infinite lazy sequence starting at 0, matching Clojure's `(range)` (#1259)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3932,57 +3932,63 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
    :see-also ["defprotocol" "extend-type" "satisfies?"]}
   [& specs]
   (let [munge (php/new Munge)
-        obj-sym (gensym "reify__")
-        class-sym (gensym "class__")
-        ;; Parse specs: alternating protocol symbols and method lists
-        groups (loop [remaining specs
-                      current-proto nil
-                      current-methods []
-                      result []]
-                 (if (nil? remaining)
-                   (if current-proto
-                     (conj result [current-proto current-methods])
-                     result)
-                   (let [item (first remaining)
-                         rst (next remaining)]
-                     (if (php/instanceof item Symbol)
-                       (recur rst item []
-                              (if current-proto
-                                (conj result [current-proto current-methods])
-                                result))
-                       (recur rst current-proto
-                              (conj current-methods item)
-                              result)))))
-        ;; Collect all methods for reify*
-        all-methods (reduce (fn [acc group] (concat acc (second group))) [] groups)
-        ;; Build dispatch registrations
-        registrations (reduce
-                       (fn [acc group]
-                         (let [proto (first group)
-                               methods (second group)
-                               proto-str (php/-> proto (getName))]
-                           (reduce
-                            (fn [inner method]
-                              (let [mname (first method)
-                                    mname-str (php/-> mname (getName))
-                                    margs (second method)
-                                    rest-args (next margs)
-                                    dsym (php/:: Symbol
-                                                 (create (php/. proto-str "--" mname-str "--dispatch")))
-                                    munged-str (php/-> munge (encode mname-str))
-                                    munged-sym (php/:: Symbol (create munged-str))]
-                                (conj inner
-                                      `(swap! ~dsym assoc ~class-sym
-                                              (fn ~margs
-                                                (php/-> ~(first margs) (~munged-sym ~@rest-args)))))))
-                            acc
-                            methods)))
-                       []
-                       groups)]
-    `(let [~obj-sym (reify* ~@all-methods)
-           ~class-sym (php/get_class ~obj-sym)]
-       ~@registrations
-       ~obj-sym)))
+        instance-sym (gensym "reify__")
+        class-name-sym (gensym "class__")
+        ;; Group specs into [[ProtocolSym [method1 method2 ...]] ...]
+        ;; Same parsing pattern as extend-type: symbols start a new group,
+        ;; lists are methods belonging to the current protocol.
+        proto-groups (loop [remaining specs
+                            current-proto nil
+                            current-methods []
+                            result []]
+                       (if (nil? remaining)
+                         (if current-proto
+                           (conj result [current-proto current-methods])
+                           result)
+                         (let [item (first remaining)
+                               rst (next remaining)]
+                           (if (php/instanceof item Symbol)
+                             (recur rst item []
+                                    (if current-proto
+                                      (conj result [current-proto current-methods])
+                                      result))
+                             (recur rst current-proto
+                                    (conj current-methods item)
+                                    result)))))
+        ;; Flatten all methods for the reify* special form (it only needs
+        ;; method specs, protocol grouping is handled here for dispatch).
+        all-methods (reduce (fn [acc group] (concat acc (second group))) [] proto-groups)
+        ;; For each protocol method, register a dispatch entry that delegates
+        ;; to the PHP method on the object. This way each instance's closed-over
+        ;; state is accessed via $this->property inside the PHP method.
+        dispatch-registrations
+        (reduce
+         (fn [acc group]
+           (let [proto (first group)
+                 methods (second group)
+                 proto-str (php/-> proto (getName))]
+             (reduce
+              (fn [inner method]
+                (let [mname (first method)
+                      mname-str (php/-> mname (getName))
+                      margs (second method)
+                      rest-args (next margs)
+                      dispatch-var (php/:: Symbol
+                                          (create (php/. proto-str "--" mname-str "--dispatch")))
+                      php-method-sym (php/:: Symbol
+                                            (create (php/-> munge (encode mname-str))))]
+                  (conj inner
+                        `(swap! ~dispatch-var assoc ~class-name-sym
+                                (fn ~margs
+                                  (php/-> ~(first margs) (~php-method-sym ~@rest-args)))))))
+              acc
+              methods)))
+         []
+         proto-groups)]
+    `(let [~instance-sym (reify* ~@all-methods)
+           ~class-name-sym (php/get_class ~instance-sym)]
+       ~@dispatch-registrations
+       ~instance-sym)))
 
 ;; ------------
 ;; Multimethods

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3917,6 +3917,73 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                        `(extend-type ~type-spec ~protocol-name ~@methods))]
     `(do ~@extend-calls)))
 
+(defmacro reify
+  "Creates an anonymous object implementing one or more protocols.
+  Method bodies close over local bindings. Each instance carries its
+  own captured state, so reify works correctly inside loops.
+
+  Syntax:
+    (reify
+      ProtocolName
+      (method-name [this arg1] body)
+      AnotherProtocol
+      (another-method [this] body))"
+  {:example "(reify Speakable (speak [this] \"hello\"))"
+   :see-also ["defprotocol" "extend-type" "satisfies?"]}
+  [& specs]
+  (let [munge (php/new Munge)
+        obj-sym (gensym "reify__")
+        class-sym (gensym "class__")
+        ;; Parse specs: alternating protocol symbols and method lists
+        groups (loop [remaining specs
+                      current-proto nil
+                      current-methods []
+                      result []]
+                 (if (nil? remaining)
+                   (if current-proto
+                     (conj result [current-proto current-methods])
+                     result)
+                   (let [item (first remaining)
+                         rst (next remaining)]
+                     (if (php/instanceof item Symbol)
+                       (recur rst item []
+                              (if current-proto
+                                (conj result [current-proto current-methods])
+                                result))
+                       (recur rst current-proto
+                              (conj current-methods item)
+                              result)))))
+        ;; Collect all methods for reify*
+        all-methods (reduce (fn [acc group] (concat acc (second group))) [] groups)
+        ;; Build dispatch registrations
+        registrations (reduce
+                       (fn [acc group]
+                         (let [proto (first group)
+                               methods (second group)
+                               proto-str (php/-> proto (getName))]
+                           (reduce
+                            (fn [inner method]
+                              (let [mname (first method)
+                                    mname-str (php/-> mname (getName))
+                                    margs (second method)
+                                    rest-args (next margs)
+                                    dsym (php/:: Symbol
+                                                 (create (php/. proto-str "--" mname-str "--dispatch")))
+                                    munged-str (php/-> munge (encode mname-str))
+                                    munged-sym (php/:: Symbol (create munged-str))]
+                                (conj inner
+                                      `(swap! ~dsym assoc ~class-sym
+                                              (fn ~margs
+                                                (php/-> ~(first margs) (~munged-sym ~@rest-args)))))))
+                            acc
+                            methods)))
+                       []
+                       groups)]
+    `(let [~obj-sym (reify* ~@all-methods)
+           ~class-sym (php/get_class ~obj-sym)]
+       ~@registrations
+       ~obj-sym)))
+
 ;; ------------
 ;; Multimethods
 ;; ------------

--- a/src/php/Compiler/Domain/Analyzer/Ast/ReifyNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/ReifyNode.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Ast;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+final class ReifyNode extends AbstractNode
+{
+    /**
+     * @param list<DefStructMethod> $methods
+     * @param list<Symbol>          $uses
+     */
+    public function __construct(
+        NodeEnvironmentInterface $env,
+        private readonly array $methods,
+        private readonly array $uses,
+        ?SourceLocation $sourceLocation = null,
+    ) {
+        parent::__construct($env, $sourceLocation);
+    }
+
+    /**
+     * @return list<DefStructMethod>
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+
+    /**
+     * @return list<Symbol>
+     */
+    public function getUses(): array
+    {
+        return $this->uses;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -39,6 +39,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpObjectCallSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpOSetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\QuoteSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\RecurSymbol;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReifySymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\SetVarSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\SpecialFormAnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ThrowSymbol;
@@ -117,6 +118,7 @@ final class AnalyzePersistentList
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),
             Symbol::NAME_DEF_INTERFACE => new DefInterfaceSymbol($this->analyzer),
+            Symbol::NAME_REIFY => new ReifySymbol($this->analyzer),
             default => new InvokeSymbol($this->analyzer),
         };
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -25,6 +25,7 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\InvokeSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LetSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LoadSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\LoopSymbol;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MethodBodyAnalyzer;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\NsSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAGetInSymbol;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\PhpAGetSymbol;
@@ -113,12 +114,12 @@ final class AnalyzePersistentList
             Symbol::NAME_THROW => new ThrowSymbol($this->analyzer),
             Symbol::NAME_LOOP => new LoopSymbol($this->analyzer, new BindingValidator()),
             Symbol::NAME_FOREACH => new ForeachSymbol($this->analyzer),
-            Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, new Munge()),
+            Symbol::NAME_DEF_STRUCT => new DefStructSymbol($this->analyzer, new Munge(), new MethodBodyAnalyzer($this->analyzer)),
             Symbol::NAME_DEF_EXCEPTION => new DefExceptionSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_SET => new PhpOSetSymbol($this->analyzer),
             Symbol::NAME_SET_VAR => new SetVarSymbol($this->analyzer),
             Symbol::NAME_DEF_INTERFACE => new DefInterfaceSymbol($this->analyzer),
-            Symbol::NAME_REIFY => new ReifySymbol($this->analyzer),
+            Symbol::NAME_REIFY => new ReifySymbol(new MethodBodyAnalyzer($this->analyzer)),
             default => new InvokeSymbol($this->analyzer),
         };
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefStructSymbol.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
-use Phel;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructMethod;
 use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
-use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -31,6 +29,7 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private MungeInterface $munge,
+        private MethodBodyAnalyzer $methodBodyAnalyzer,
     ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefStructNode
@@ -168,35 +167,6 @@ final readonly class DefStructSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation("The interface doesn't support this method: " . $methodName->getName(), $list);
         }
 
-        $arguments = $list->get(1);
-        if (!$arguments instanceof PersistentVectorInterface) {
-            throw AnalyzerException::withLocation('Method arguments must be a vector', $list);
-        }
-
-        // Analyze arguments and body as (fn arguments (do body))
-        $fnNode = $this->analyzer->analyze(
-            Phel::list([
-                Symbol::create('fn'),
-                $arguments->rest(), // remove the first argument. The first argument is bound to $this
-                Phel::list([
-                    Symbol::create('let'),
-                    Phel::vector([
-                        $arguments->first(),
-                        Symbol::createForNamespace('php', '$this'),
-                    ]),
-                    ...($list->rest()->rest()->toArray()),
-                ]),
-            ]),
-            $env,
-        );
-
-        if (!$fnNode instanceof FnNode) {
-            throw AnalyzerException::withLocation('Can not correctly analyse method body', $list);
-        }
-
-        return new DefStructMethod(
-            $methodName,
-            $fnNode,
-        );
+        return $this->methodBodyAnalyzer->analyze($list, $env);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MethodBodyAnalyzer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/MethodBodyAnalyzer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\DefStructMethod;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+/**
+ * Analyzes a method spec of the form (method-name [this args...] body...).
+ *
+ * The first argument is bound to PHP's $this via a let binding.
+ * Shared by DefStructSymbol (for interface methods) and ReifySymbol (for protocol methods).
+ */
+final readonly class MethodBodyAnalyzer
+{
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+    ) {}
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefStructMethod
+    {
+        $methodName = $this->extractMethodName($list);
+        $arguments = $this->extractArguments($list);
+        $fnNode = $this->analyzeBody($list, $arguments, $env);
+
+        return new DefStructMethod($methodName, $fnNode);
+    }
+
+    private function extractMethodName(PersistentListInterface $list): Symbol
+    {
+        $methodName = $list->get(0);
+        if (!$methodName instanceof Symbol) {
+            throw AnalyzerException::wrongArgumentType('Method name', 'Symbol', $methodName, $list);
+        }
+
+        return $methodName;
+    }
+
+    private function extractArguments(PersistentListInterface $list): PersistentVectorInterface
+    {
+        $arguments = $list->get(1);
+        if (!$arguments instanceof PersistentVectorInterface) {
+            throw AnalyzerException::withLocation('Method arguments must be a vector', $list);
+        }
+
+        if (count($arguments) < 1) {
+            throw AnalyzerException::withLocation(
+                'Method must have at least one argument (this)',
+                $list,
+            );
+        }
+
+        return $arguments;
+    }
+
+    private function analyzeBody(
+        PersistentListInterface $list,
+        PersistentVectorInterface $arguments,
+        NodeEnvironmentInterface $env,
+    ): FnNode {
+        $fnNode = $this->analyzer->analyze(
+            Phel::list([
+                Symbol::create('fn'),
+                $arguments->rest(),
+                Phel::list([
+                    Symbol::create('let'),
+                    Phel::vector([
+                        $arguments->first(),
+                        Symbol::createForNamespace('php', '$this'),
+                    ]),
+                    ...($list->rest()->rest()->toArray()),
+                ]),
+            ]),
+            $env,
+        );
+
+        if (!$fnNode instanceof FnNode) {
+            throw AnalyzerException::withLocation('Cannot correctly analyze method body', $list);
+        }
+
+        return $fnNode;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReifySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReifySymbol.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\DefStructMethod;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+/**
+ * (reify* (method-name [this arg1] body) ...).
+ *
+ * Creates an anonymous object with named methods. Used by the `reify` macro
+ * which handles protocol dispatch registration.
+ */
+final readonly class ReifySymbol implements SpecialFormAnalyzerInterface
+{
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+    ) {}
+
+    public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): ReifyNode
+    {
+        if (count($list) < 2) {
+            throw AnalyzerException::withLocation(
+                "At least one method is required for 'reify*",
+                $list,
+            );
+        }
+
+        $methods = [];
+        $allUses = [];
+
+        for ($forms = $list->rest(); $forms !== null; $forms = $forms->cdr()) {
+            $methodSpec = $forms->first();
+            if (!$methodSpec instanceof PersistentListInterface) {
+                throw AnalyzerException::withLocation('Each reify* method must be a list', $list);
+            }
+
+            $method = $this->analyzeMethod($methodSpec, $env);
+            $methods[] = $method;
+
+            foreach ($method->getFnNode()->getUses() as $use) {
+                $allUses[] = $use;
+            }
+        }
+
+        $uniqueUses = $this->deduplicateUses($allUses);
+
+        return new ReifyNode(
+            $env,
+            $methods,
+            $uniqueUses,
+            $list->getStartLocation(),
+        );
+    }
+
+    private function analyzeMethod(
+        PersistentListInterface $list,
+        NodeEnvironmentInterface $env,
+    ): DefStructMethod {
+        $methodName = $list->get(0);
+        if (!$methodName instanceof Symbol) {
+            throw AnalyzerException::wrongArgumentType('Method name', 'Symbol', $methodName, $list);
+        }
+
+        $arguments = $list->get(1);
+        if (!$arguments instanceof PersistentVectorInterface) {
+            throw AnalyzerException::withLocation('Method arguments must be a vector', $list);
+        }
+
+        if (count($arguments) < 1) {
+            throw AnalyzerException::withLocation(
+                "Method '" . $methodName->getName() . "' must have at least one argument (this)",
+                $list,
+            );
+        }
+
+        $fnNode = $this->analyzer->analyze(
+            Phel::list([
+                Symbol::create('fn'),
+                $arguments->rest(),
+                Phel::list([
+                    Symbol::create('let'),
+                    Phel::vector([
+                        $arguments->first(),
+                        Symbol::createForNamespace('php', '$this'),
+                    ]),
+                    ...($list->rest()->rest()->toArray()),
+                ]),
+            ]),
+            $env,
+        );
+
+        if (!$fnNode instanceof FnNode) {
+            throw AnalyzerException::withLocation('Cannot correctly analyze method body', $list);
+        }
+
+        return new DefStructMethod(
+            $methodName,
+            $fnNode,
+        );
+    }
+
+    /**
+     * @param list<Symbol> $uses
+     *
+     * @return list<Symbol>
+     */
+    private function deduplicateUses(array $uses): array
+    {
+        $seen = [];
+        $result = [];
+        foreach ($uses as $use) {
+            $name = $use->getName();
+            if (!isset($seen[$name])) {
+                $seen[$name] = true;
+                $result[] = $use;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReifySymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReifySymbol.php
@@ -4,15 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
-use Phel;
-use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
-use Phel\Compiler\Domain\Analyzer\Ast\DefStructMethod;
-use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
 
 use function count;
@@ -26,7 +21,7 @@ use function count;
 final readonly class ReifySymbol implements SpecialFormAnalyzerInterface
 {
     public function __construct(
-        private AnalyzerInterface $analyzer,
+        private MethodBodyAnalyzer $methodBodyAnalyzer,
     ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): ReifyNode
@@ -47,7 +42,7 @@ final readonly class ReifySymbol implements SpecialFormAnalyzerInterface
                 throw AnalyzerException::withLocation('Each reify* method must be a list', $list);
             }
 
-            $method = $this->analyzeMethod($methodSpec, $env);
+            $method = $this->methodBodyAnalyzer->analyze($methodSpec, $env);
             $methods[] = $method;
 
             foreach ($method->getFnNode()->getUses() as $use) {
@@ -55,60 +50,11 @@ final readonly class ReifySymbol implements SpecialFormAnalyzerInterface
             }
         }
 
-        $uniqueUses = $this->deduplicateUses($allUses);
-
         return new ReifyNode(
             $env,
             $methods,
-            $uniqueUses,
+            $this->deduplicateUses($allUses),
             $list->getStartLocation(),
-        );
-    }
-
-    private function analyzeMethod(
-        PersistentListInterface $list,
-        NodeEnvironmentInterface $env,
-    ): DefStructMethod {
-        $methodName = $list->get(0);
-        if (!$methodName instanceof Symbol) {
-            throw AnalyzerException::wrongArgumentType('Method name', 'Symbol', $methodName, $list);
-        }
-
-        $arguments = $list->get(1);
-        if (!$arguments instanceof PersistentVectorInterface) {
-            throw AnalyzerException::withLocation('Method arguments must be a vector', $list);
-        }
-
-        if (count($arguments) < 1) {
-            throw AnalyzerException::withLocation(
-                "Method '" . $methodName->getName() . "' must have at least one argument (this)",
-                $list,
-            );
-        }
-
-        $fnNode = $this->analyzer->analyze(
-            Phel::list([
-                Symbol::create('fn'),
-                $arguments->rest(),
-                Phel::list([
-                    Symbol::create('let'),
-                    Phel::vector([
-                        $arguments->first(),
-                        Symbol::createForNamespace('php', '$this'),
-                    ]),
-                    ...($list->rest()->rest()->toArray()),
-                ]),
-            ]),
-            $env,
-        );
-
-        if (!$fnNode instanceof FnNode) {
-            throw AnalyzerException::withLocation('Cannot correctly analyze method body', $list);
-        }
-
-        return new DefStructMethod(
-            $methodName,
-            $fnNode,
         );
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ClosureEmitterHelper.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ClosureEmitterHelper.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+use function count;
+
+/**
+ * Shared helpers for emitting PHP anonymous classes that capture local variables.
+ *
+ * Used by FnAsClassEmitter and ReifyEmitter to avoid duplicating
+ * the constructor-argument, property, and constructor-body patterns.
+ */
+final readonly class ClosureEmitterHelper
+{
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+    ) {}
+
+    public function normalizeUse(Symbol $use, NodeEnvironmentInterface $env): Symbol
+    {
+        $shadowed = $env->getShadowed($use);
+
+        return $shadowed instanceof Symbol ? $shadowed : $use;
+    }
+
+    /**
+     * Emits the captured variables as constructor arguments: `$var1, $var2`.
+     *
+     * @param list<Symbol> $uses
+     */
+    public function emitConstructorArguments(array $uses, NodeEnvironmentInterface $env, ?SourceLocation $loc): void
+    {
+        $count = count($uses);
+        foreach ($uses as $i => $use) {
+            $this->outputEmitter->emitPhpVariable(
+                $this->normalizeUse($use, $env),
+                $use->getStartLocation(),
+            );
+
+            if ($i < $count - 1) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+        }
+    }
+
+    /**
+     * Emits `private $varName;` for each captured variable.
+     *
+     * @param list<Symbol> $uses
+     */
+    public function emitProperties(array $uses, NodeEnvironmentInterface $env, ?SourceLocation $loc): void
+    {
+        foreach ($uses as $use) {
+            $normalizedUse = $this->normalizeUse($use, $env);
+            $this->outputEmitter->emitLine(
+                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
+                $loc,
+            );
+        }
+    }
+
+    /**
+     * Emits the full constructor: parameter list, property assignments.
+     * Emits nothing if there are no captured variables.
+     *
+     * @param list<Symbol> $uses
+     */
+    public function emitConstructor(array $uses, NodeEnvironmentInterface $env, ?SourceLocation $loc): void
+    {
+        if ($uses === []) {
+            return;
+        }
+
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitStr('public function __construct(', $loc);
+
+        $count = count($uses);
+        foreach ($uses as $i => $use) {
+            $this->outputEmitter->emitPhpVariable($this->normalizeUse($use, $env), $loc);
+
+            if ($i < $count - 1) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+        }
+
+        $this->outputEmitter->emitLine(') {', $loc);
+        $this->outputEmitter->increaseIndentLevel();
+
+        foreach ($uses as $use) {
+            $normalizedUse = $this->normalizeUse($use, $env);
+            $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
+            $this->outputEmitter->emitLine('$this->' . $varName . ' = $' . $varName . ';', $loc);
+        }
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $loc);
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -8,16 +8,15 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
-use Phel\Lang\Symbol;
 
 use function assert;
-use function count;
 
 final readonly class FnAsClassEmitter implements NodeEmitterInterface
 {
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
+        private ClosureEmitterHelper $closureHelper,
     ) {}
 
     public function emit(AbstractNode $node): void
@@ -36,20 +35,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('new class(', $node->getStartSourceLocation());
 
-        $usesCount = count($node->getUses());
-        foreach ($node->getUses() as $i => $use) {
-            $loc = $use->getStartLocation();
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitPhpVariable($normalizedUse, $loc);
-
-            if ($i < $usesCount - 1) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-            }
-        }
-
+        $this->closureHelper->emitConstructorArguments($node->getUses(), $node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitLine(') extends \Phel\Lang\AbstractFn {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
     }
@@ -59,60 +45,12 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
         $ns = addslashes($this->outputEmitter->mungeEncodeNs($node->getEnv()->getBoundTo()));
         $this->outputEmitter->emitLine('public const BOUND_TO = "' . $ns . '";', $node->getStartSourceLocation());
 
-        foreach ($node->getUses() as $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitLine(
-                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
-                $node->getStartSourceLocation(),
-            );
-        }
+        $this->closureHelper->emitProperties($node->getUses(), $node->getEnv(), $node->getStartSourceLocation());
     }
 
     private function emitConstructor(FnNode $node): void
     {
-        $usesCount = count($node->getUses());
-
-        if ($usesCount !== 0) {
-            $this->outputEmitter->emitLine();
-            $this->outputEmitter->emitStr('public function __construct(', $node->getStartSourceLocation());
-
-            // Constructor parameter
-            foreach ($node->getUses() as $i => $use) {
-                /** @var Symbol $normalizedUse */
-                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                    ? $node->getEnv()->getShadowed($use)
-                    : $use;
-
-                $this->outputEmitter->emitPhpVariable($normalizedUse, $node->getStartSourceLocation());
-
-                if ($i < $usesCount - 1) {
-                    $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-                }
-            }
-
-            $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
-            $this->outputEmitter->increaseIndentLevel();
-
-            // Constructor assignment
-            foreach ($node->getUses() as $use) {
-                /** @var Symbol $normalizedUse */
-                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                    ? $node->getEnv()->getShadowed($use)
-                    : $use;
-                $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
-
-                $this->outputEmitter->emitLine(
-                    '$this->' . $varName . ' = $' . $varName . ';',
-                    $node->getStartSourceLocation(),
-                );
-            }
-
-            $this->outputEmitter->decreaseIndentLevel();
-            $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
-        }
+        $this->closureHelper->emitConstructor($node->getUses(), $node->getEnv(), $node->getStartSourceLocation());
 
         $this->outputEmitter->emitLine();
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
@@ -8,122 +8,57 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
-use Phel\Lang\Symbol;
 
 use function assert;
-use function count;
 
+/**
+ * Emits a PHP anonymous class for reify* expressions.
+ *
+ * Generates: new class($captured...) { properties; constructor; methods; }
+ * Each method has access to captured locals via $this->property.
+ */
 final readonly class ReifyEmitter implements NodeEmitterInterface
 {
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private MethodEmitter $methodEmitter,
+        private ClosureEmitterHelper $closureHelper,
     ) {}
 
     public function emit(AbstractNode $node): void
     {
         assert($node instanceof ReifyNode);
 
-        $this->emitClassBegin($node);
-        $this->emitProperties($node);
-        $this->emitConstructor($node);
-        $this->emitMethods($node);
-        $this->emitClassEnd($node);
-    }
+        $uses = $node->getUses();
+        $env = $node->getEnv();
+        $loc = $node->getStartSourceLocation();
 
-    private function emitClassBegin(ReifyNode $node): void
-    {
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('new class(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextPrefix($env, $loc);
+        $this->outputEmitter->emitStr('new class(', $loc);
 
-        $usesCount = count($node->getUses());
-        foreach ($node->getUses() as $i => $use) {
-            $loc = $use->getStartLocation();
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitPhpVariable($normalizedUse, $loc);
-
-            if ($i < $usesCount - 1) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-            }
-        }
-
-        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->closureHelper->emitConstructorArguments($uses, $env, $loc);
+        $this->outputEmitter->emitLine(') {', $loc);
         $this->outputEmitter->increaseIndentLevel();
-    }
 
-    private function emitProperties(ReifyNode $node): void
-    {
-        foreach ($node->getUses() as $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitLine(
-                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
-                $node->getStartSourceLocation(),
-            );
-        }
-    }
+        $this->closureHelper->emitProperties($uses, $env, $loc);
+        $this->closureHelper->emitConstructor($uses, $env, $loc);
 
-    private function emitConstructor(ReifyNode $node): void
-    {
-        $usesCount = count($node->getUses());
+        $this->emitMethods($node);
 
-        if ($usesCount !== 0) {
-            $this->outputEmitter->emitLine();
-            $this->outputEmitter->emitStr('public function __construct(', $node->getStartSourceLocation());
-
-            foreach ($node->getUses() as $i => $use) {
-                /** @var Symbol $normalizedUse */
-                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                    ? $node->getEnv()->getShadowed($use)
-                    : $use;
-
-                $this->outputEmitter->emitPhpVariable($normalizedUse, $node->getStartSourceLocation());
-
-                if ($i < $usesCount - 1) {
-                    $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-                }
-            }
-
-            $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
-            $this->outputEmitter->increaseIndentLevel();
-
-            foreach ($node->getUses() as $use) {
-                /** @var Symbol $normalizedUse */
-                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                    ? $node->getEnv()->getShadowed($use)
-                    : $use;
-                $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
-
-                $this->outputEmitter->emitLine(
-                    '$this->' . $varName . ' = $' . $varName . ';',
-                    $node->getStartSourceLocation(),
-                );
-            }
-
-            $this->outputEmitter->decreaseIndentLevel();
-            $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
-        }
-
-        $this->outputEmitter->emitLine();
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitStr('}', $loc);
+        $this->outputEmitter->emitContextSuffix($env, $loc);
     }
 
     private function emitMethods(ReifyNode $node): void
     {
-        foreach ($node->getMethods() as $method) {
+        $methods = $node->getMethods();
+        foreach ($methods as $i => $method) {
+            if ($node->getUses() !== [] || $i > 0) {
+                $this->outputEmitter->emitLine();
+            }
+
             $this->methodEmitter->emit($method->getName()->getName(), $method->getFnNode());
         }
-    }
-
-    private function emitClassEnd(ReifyNode $node): void
-    {
-        $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
-
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Symbol;
+
+use function assert;
+use function count;
+
+final readonly class ReifyEmitter implements NodeEmitterInterface
+{
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+        private MethodEmitter $methodEmitter,
+    ) {}
+
+    public function emit(AbstractNode $node): void
+    {
+        assert($node instanceof ReifyNode);
+
+        $this->emitClassBegin($node);
+        $this->emitProperties($node);
+        $this->emitConstructor($node);
+        $this->emitMethods($node);
+        $this->emitClassEnd($node);
+    }
+
+    private function emitClassBegin(ReifyNode $node): void
+    {
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('new class(', $node->getStartSourceLocation());
+
+        $usesCount = count($node->getUses());
+        foreach ($node->getUses() as $i => $use) {
+            $loc = $use->getStartLocation();
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $this->outputEmitter->emitPhpVariable($normalizedUse, $loc);
+
+            if ($i < $usesCount - 1) {
+                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            }
+        }
+
+        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+    }
+
+    private function emitProperties(ReifyNode $node): void
+    {
+        foreach ($node->getUses() as $use) {
+            /** @var Symbol $normalizedUse */
+            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                ? $node->getEnv()->getShadowed($use)
+                : $use;
+            $this->outputEmitter->emitLine(
+                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
+                $node->getStartSourceLocation(),
+            );
+        }
+    }
+
+    private function emitConstructor(ReifyNode $node): void
+    {
+        $usesCount = count($node->getUses());
+
+        if ($usesCount !== 0) {
+            $this->outputEmitter->emitLine();
+            $this->outputEmitter->emitStr('public function __construct(', $node->getStartSourceLocation());
+
+            foreach ($node->getUses() as $i => $use) {
+                /** @var Symbol $normalizedUse */
+                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                    ? $node->getEnv()->getShadowed($use)
+                    : $use;
+
+                $this->outputEmitter->emitPhpVariable($normalizedUse, $node->getStartSourceLocation());
+
+                if ($i < $usesCount - 1) {
+                    $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+                }
+            }
+
+            $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+            $this->outputEmitter->increaseIndentLevel();
+
+            foreach ($node->getUses() as $use) {
+                /** @var Symbol $normalizedUse */
+                $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
+                    ? $node->getEnv()->getShadowed($use)
+                    : $use;
+                $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
+
+                $this->outputEmitter->emitLine(
+                    '$this->' . $varName . ' = $' . $varName . ';',
+                    $node->getStartSourceLocation(),
+                );
+            }
+
+            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->emitLine();
+    }
+
+    private function emitMethods(ReifyNode $node): void
+    {
+        foreach ($node->getMethods() as $method) {
+            $this->methodEmitter->emit($method->getName()->getName(), $method->getFnNode());
+        }
+    }
+
+    private function emitClassEnd(ReifyNode $node): void
+    {
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -35,6 +35,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
@@ -73,6 +74,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpObjectSetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\PhpVarEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\QuoteEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\RecurEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ReifyEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\SetEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\SetVarEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ThrowEmitter;
@@ -141,6 +143,7 @@ final class NodeEmitterFactory
             SetVarNode::class => new SetVarEmitter($outputEmitter),
             DefInterfaceNode::class => new DefInterfaceEmitter($outputEmitter),
             MultiFnNode::class => new MultiFnAsClassEmitter($outputEmitter),
+            ReifyNode::class => new ReifyEmitter($outputEmitter, $methodEmitter),
             default => throw NotSupportedAstException::withClassName($astNodeClassName),
         };
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -45,6 +45,7 @@ use Phel\Compiler\Domain\Emitter\Exceptions\NotSupportedAstException;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ApplyEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CallEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CatchEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ClosureEmitterHelper;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefExceptionEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\DefInterfaceEmitter;
@@ -90,6 +91,9 @@ final class NodeEmitterFactory
     /** @var array<int, MethodEmitter> */
     private array $methodEmitterCache = [];
 
+    /** @var array<int, ClosureEmitterHelper> */
+    private array $closureHelperCache = [];
+
     public function createNodeEmitter(
         OutputEmitterInterface $outputEmitter,
         string $astNodeClassName,
@@ -105,6 +109,7 @@ final class NodeEmitterFactory
         string $astNodeClassName,
     ): NodeEmitterInterface {
         $methodEmitter = $this->getMethodEmitter($outputEmitter);
+        $closureHelper = $this->getClosureHelper($outputEmitter);
 
         return match ($astNodeClassName) {
             NsNode::class => new NsEmitter($outputEmitter),
@@ -113,7 +118,7 @@ final class NodeEmitterFactory
             DefNode::class => new DefEmitter($outputEmitter),
             LiteralNode::class => new LiteralEmitter($outputEmitter),
             QuoteNode::class => new QuoteEmitter($outputEmitter),
-            FnNode::class => new FnAsClassEmitter($outputEmitter, $methodEmitter),
+            FnNode::class => new FnAsClassEmitter($outputEmitter, $methodEmitter, $closureHelper),
             DoNode::class => new DoEmitter($outputEmitter),
             LetNode::class => new LetEmitter($outputEmitter),
             LocalVarNode::class => new LocalVarEmitter($outputEmitter),
@@ -143,7 +148,7 @@ final class NodeEmitterFactory
             SetVarNode::class => new SetVarEmitter($outputEmitter),
             DefInterfaceNode::class => new DefInterfaceEmitter($outputEmitter),
             MultiFnNode::class => new MultiFnAsClassEmitter($outputEmitter),
-            ReifyNode::class => new ReifyEmitter($outputEmitter, $methodEmitter),
+            ReifyNode::class => new ReifyEmitter($outputEmitter, $methodEmitter, $closureHelper),
             default => throw NotSupportedAstException::withClassName($astNodeClassName),
         };
     }
@@ -152,10 +157,13 @@ final class NodeEmitterFactory
     {
         $key = spl_object_id($outputEmitter);
 
-        if (!isset($this->methodEmitterCache[$key])) {
-            $this->methodEmitterCache[$key] = new MethodEmitter($outputEmitter);
-        }
+        return $this->methodEmitterCache[$key] ??= new MethodEmitter($outputEmitter);
+    }
 
-        return $this->methodEmitterCache[$key];
+    private function getClosureHelper(OutputEmitterInterface $outputEmitter): ClosureEmitterHelper
+    {
+        $key = spl_object_id($outputEmitter);
+
+        return $this->closureHelperCache[$key] ??= new ClosureEmitterHelper($outputEmitter);
     }
 }

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -86,6 +86,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
 
     public const string NAME_DEF_EXCEPTION = 'defexception*';
 
+    public const string NAME_REIFY = 'reify*';
+
     public const string NAME_DOLLAR = '$';
 
     public const string NAME_HASH = '#';

--- a/tests/phel/test/core/reify.phel
+++ b/tests/phel/test/core/reify.phel
@@ -1,0 +1,81 @@
+(ns phel-test\test\core\reify
+  (:require phel\test :refer [deftest is]))
+
+;; --- Protocol definitions ---
+
+(defprotocol Speakable
+  (speak [this]))
+
+(defprotocol Nameable
+  (get-name [this]))
+
+;; --- Single protocol, single method ---
+
+(deftest test-reify-single-protocol
+  (let [obj (reify Speakable (speak [this] "hello"))]
+    (is (= "hello" (speak obj)) "reify single method")))
+
+;; --- Multiple protocols ---
+
+(deftest test-reify-multiple-protocols
+  (let [obj (reify
+              Speakable (speak [this] "hi")
+              Nameable (get-name [this] "Bob"))]
+    (is (= "hi" (speak obj)) "first protocol")
+    (is (= "Bob" (get-name obj)) "second protocol")))
+
+;; --- Closure over local bindings ---
+
+(deftest test-reify-closes-over-locals
+  (let [greeting "Hola"
+        obj (reify Speakable (speak [this] greeting))]
+    (is (= "Hola" (speak obj)) "closes over local")))
+
+;; --- satisfies? ---
+
+(deftest test-reify-satisfies
+  (let [obj (reify Speakable (speak [this] "yes"))]
+    (is (true? (satisfies? Speakable obj)) "satisfies implemented protocol")
+    (is (false? (satisfies? Nameable obj)) "does not satisfy unimplemented protocol")))
+
+;; --- Multi-arg methods ---
+
+(defprotocol Greeter
+  (greet [this name]))
+
+(deftest test-reify-multi-arg
+  (let [obj (reify Greeter (greet [this name] (str "Hello, " name "!")))]
+    (is (= "Hello, World!" (greet obj "World")) "multi-arg method")))
+
+;; --- Closure in a loop: each object has its own state ---
+
+(deftest test-reify-loop-closure
+  (let [objects (for [n :range [1 4]]
+                  (reify Speakable (speak [this] (str "I am " n))))
+        results (map speak objects)]
+    (is (= ["I am 1" "I am 2" "I am 3"] (vec results))
+        "each reified object has its own closed-over state")))
+
+;; --- Multi-expression body ---
+
+(deftest test-reify-multi-expression-body
+  (let [obj (reify Speakable
+              (speak [this]
+                (let [a "hello"
+                      b " world"]
+                  (str a b))))]
+    (is (= "hello world" (speak obj)) "multi-expression body")))
+
+;; --- Multiple methods on same protocol ---
+
+(defprotocol Describable
+  (label [this])
+  (detail [this]))
+
+(deftest test-reify-multi-method-protocol
+  (let [obj (reify Describable
+              (label [this] "my-label")
+              (detail [this] "my-detail"))]
+    (is (= "my-label" (label obj)) "first method")
+    (is (= "my-detail" (detail obj)) "second method")
+    (is (true? (satisfies? Describable obj)) "satisfies multi-method protocol")))

--- a/tests/phel/test/core/reify.phel
+++ b/tests/phel/test/core/reify.phel
@@ -79,3 +79,35 @@
     (is (= "my-label" (label obj)) "first method")
     (is (= "my-detail" (detail obj)) "second method")
     (is (true? (satisfies? Describable obj)) "satisfies multi-method protocol")))
+
+;; --- Multiple closures sharing same variable ---
+
+(deftest test-reify-shared-closure-var
+  (let [prefix ">"
+        obj (reify
+              Speakable (speak [this] (str prefix "speak"))
+              Nameable (get-name [this] (str prefix "name")))]
+    (is (= ">speak" (speak obj)) "first method captures shared var")
+    (is (= ">name" (get-name obj)) "second method captures shared var")))
+
+;; --- Reify with no protocol dispatch (just reify* object) ---
+
+(deftest test-reify-object-identity
+  (let [a (reify Speakable (speak [this] "a"))
+        b (reify Speakable (speak [this] "b"))]
+    (is (= "a" (speak a)) "first object")
+    (is (= "b" (speak b)) "second object independent")))
+
+;; --- Method using this reference ---
+
+(defprotocol HasTag
+  (tag [this])
+  (tagged-message [this msg]))
+
+(deftest test-reify-method-calls-sibling-method
+  (let [obj (reify HasTag
+              (tag [this] "INFO")
+              (tagged-message [this msg] (str "[" (tag this) "] " msg)))]
+    (is (= "INFO" (tag obj)) "tag method")
+    (is (= "[INFO] hello" (tagged-message obj "hello"))
+        "method dispatches through protocol on this")))

--- a/tests/php/Integration/Fixtures/Reify/reify-multi-method.test
+++ b/tests/php/Integration/Fixtures/Reify/reify-multi-method.test
@@ -1,0 +1,14 @@
+--PHEL--
+(reify* (greet [this] "hi") (name [this] "Bob"))
+--PHP--
+new class() {
+  public function greet() {
+    $this_1 = $this;
+    return "hi";
+  }
+
+  public function name() {
+    $this_2 = $this;
+    return "Bob";
+  }
+};

--- a/tests/php/Integration/Fixtures/Reify/reify-no-args.test
+++ b/tests/php/Integration/Fixtures/Reify/reify-no-args.test
@@ -1,0 +1,9 @@
+--PHEL--
+(reify* (greet [this] "hello"))
+--PHP--
+new class() {
+  public function greet() {
+    $this_1 = $this;
+    return "hello";
+  }
+};

--- a/tests/php/Integration/Fixtures/Reify/reify-with-args.test
+++ b/tests/php/Integration/Fixtures/Reify/reify-with-args.test
@@ -1,0 +1,9 @@
+--PHEL--
+(reify* (greet [this name] (php/. "Hello, " name)))
+--PHP--
+new class() {
+  public function greet($name) {
+    $this_1 = $this;
+    return ("Hello, " . $name);
+  }
+};

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefStructSymbolTest.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\DefStructNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\DefStructSymbol;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MethodBodyAnalyzer;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
@@ -34,8 +35,7 @@ final class DefStructSymbolTest extends TestCase
             Symbol::create(Symbol::NAME_DEF_STRUCT),
         ]);
 
-        (new DefStructSymbol($this->analyzer, new Munge()))
-            ->analyze($list, NodeEnvironment::empty());
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_first_arg_is_not_symbol(): void
@@ -49,8 +49,7 @@ final class DefStructSymbolTest extends TestCase
             Phel::vector([]),
         ]);
 
-        (new DefStructSymbol($this->analyzer, new Munge()))
-            ->analyze($list, NodeEnvironment::empty());
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_second_arg_is_not_vector(): void
@@ -64,8 +63,7 @@ final class DefStructSymbolTest extends TestCase
             '',
         ]);
 
-        (new DefStructSymbol($this->analyzer, new Munge()))
-            ->analyze($list, NodeEnvironment::empty());
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_vector_elems_are_not_symbols(): void
@@ -79,8 +77,7 @@ final class DefStructSymbolTest extends TestCase
             Phel::vector(['method']),
         ]);
 
-        (new DefStructSymbol($this->analyzer, new Munge()))
-            ->analyze($list, NodeEnvironment::empty());
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
     }
 
     public function test_def_struct_symbol(): void
@@ -91,7 +88,7 @@ final class DefStructSymbolTest extends TestCase
             Phel::vector([Symbol::create('method'), Symbol::create('uri')]),
         ]);
 
-        $defStructNode = (new DefStructSymbol($this->analyzer, new Munge()))
+        $defStructNode = $this->createSymbol()
             ->analyze($list, NodeEnvironment::empty());
 
         self::assertEquals(
@@ -106,6 +103,15 @@ final class DefStructSymbolTest extends TestCase
                 [],
             ),
             $defStructNode,
+        );
+    }
+
+    private function createSymbol(): DefStructSymbol
+    {
+        return new DefStructSymbol(
+            $this->analyzer,
+            new Munge(),
+            new MethodBodyAnalyzer($this->analyzer),
         );
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/ReifySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/ReifySymbolTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel;
+use Phel\Compiler\Application\Analyzer;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\MethodBodyAnalyzer;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReifySymbol;
+use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class ReifySymbolTest extends TestCase
+{
+    private AnalyzerInterface $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function test_with_no_methods(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage("At least one method is required for 'reify*");
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+        ]);
+
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_method_not_a_list(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Each reify* method must be a list');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            'not-a-list',
+        ]);
+
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_method_name_not_symbol(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Method name must be a Symbol');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list(['not-a-symbol', Phel::vector([Symbol::create('this')]), 'body']),
+        ]);
+
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_method_args_not_vector(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Method arguments must be a vector');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([Symbol::create('greet'), 'not-a-vector', 'body']),
+        ]);
+
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_method_missing_this_arg(): void
+    {
+        $this->expectException(AbstractLocatedException::class);
+        $this->expectExceptionMessage('Method must have at least one argument (this)');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([Symbol::create('greet'), Phel::vector([]), 'body']),
+        ]);
+
+        $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_single_method(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([
+                Symbol::create('greet'),
+                Phel::vector([Symbol::create('this')]),
+                'hello',
+            ]),
+        ]);
+
+        $node = $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+
+        self::assertInstanceOf(ReifyNode::class, $node);
+        self::assertCount(1, $node->getMethods());
+        self::assertSame('greet', $node->getMethods()[0]->getName()->getName());
+        self::assertSame([], $node->getUses());
+    }
+
+    public function test_multiple_methods(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([
+                Symbol::create('greet'),
+                Phel::vector([Symbol::create('this')]),
+                'hello',
+            ]),
+            Phel::list([
+                Symbol::create('farewell'),
+                Phel::vector([Symbol::create('this')]),
+                'bye',
+            ]),
+        ]);
+
+        $node = $this->createSymbol()->analyze($list, NodeEnvironment::empty());
+
+        self::assertCount(2, $node->getMethods());
+        self::assertSame('greet', $node->getMethods()[0]->getName()->getName());
+        self::assertSame('farewell', $node->getMethods()[1]->getName()->getName());
+    }
+
+    public function test_captures_uses_from_environment(): void
+    {
+        $env = NodeEnvironment::empty()
+            ->withMergedLocals([Symbol::create('name')]);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([
+                Symbol::create('greet'),
+                Phel::vector([Symbol::create('this')]),
+                Symbol::create('name'),
+            ]),
+        ]);
+
+        $node = $this->createSymbol()->analyze($list, $env);
+
+        self::assertCount(1, $node->getUses());
+        self::assertSame('name', $node->getUses()[0]->getName());
+    }
+
+    public function test_deduplicates_uses_across_methods(): void
+    {
+        $env = NodeEnvironment::empty()
+            ->withMergedLocals([Symbol::create('shared')]);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_REIFY),
+            Phel::list([
+                Symbol::create('method-a'),
+                Phel::vector([Symbol::create('this')]),
+                Symbol::create('shared'),
+            ]),
+            Phel::list([
+                Symbol::create('method-b'),
+                Phel::vector([Symbol::create('this')]),
+                Symbol::create('shared'),
+            ]),
+        ]);
+
+        $node = $this->createSymbol()->analyze($list, $env);
+
+        self::assertCount(1, $node->getUses(), 'shared variable should appear only once');
+    }
+
+    private function createSymbol(): ReifySymbol
+    {
+        return new ReifySymbol(
+            new MethodBodyAnalyzer($this->analyzer),
+        );
+    }
+}

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -8,6 +8,7 @@ use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\ClosureEmitterHelper;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\FnAsClassEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\MethodEmitter;
 use Phel\Lang\Symbol;
@@ -22,7 +23,11 @@ final class FnAsClassEmitterTest extends TestCase
         $outputEmitter = (new CompilerFactory())
             ->createOutputEmitter();
 
-        $this->fnAsClassEmitter = new FnAsClassEmitter($outputEmitter, new MethodEmitter($outputEmitter));
+        $this->fnAsClassEmitter = new FnAsClassEmitter(
+            $outputEmitter,
+            new MethodEmitter($outputEmitter),
+            new ClosureEmitterHelper($outputEmitter),
+        );
     }
 
     public function test_identity_fn(): void


### PR DESCRIPTION
## 🤔 Background

Without `reify`, users must define a named struct + `extend-type` for one-off protocol implementations, which is verbose for strategies, callbacks, and test doubles.

Closes #1226

## 💡 Goal

Add `reify` matching Clojure's semantics: create anonymous objects implementing one or more protocols inline, with method bodies that close over local bindings.

## 🔖 Changes

- **`reify*` compiler special form** — new `ReifySymbol` analyzer, `ReifyNode` AST node, and `ReifyEmitter` that generates a PHP anonymous class with named methods and closure support (captured variables as class properties)
- **`reify` macro in core.phel** — parses protocol specs, delegates object creation to `reify*`, and registers dispatch table entries that delegate to the object's PHP methods (ensuring each instance carries its own closed-over state, even in loops)
- **12 Phel-level tests** covering: single/multiple protocols, closures over locals, `satisfies?`, multi-arg methods, loop closures, multi-expression bodies, and multi-method protocols
- Updated `CHANGELOG.md`