### PR TITLE
fix(run): remove output buffering to support long-running processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Accept `name#` as an auto-gensym suffix inside syntax-quote (alongside the existing `name$`), matching Clojure's `clojure.core/gensym` reader macro (#1195)
 
 ### Fixed
+- `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)
 - REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)
 - REPL `(require 'foo)` now throws `RuntimeException` when the namespace cannot be found on source paths, instead of silently succeeding (#1246)
 - Allow PHP reserved keywords (e.g. `and`, `list`, `class`) in namespace names, matching Clojure compatibility — PHP 8.0+ supports keywords in namespace parts (#1230)

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -10,8 +10,8 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Phel;
 use Phel\Run\Infrastructure\Service\DebugLineTap;
 use Phel\Run\RunFacade;
-use RuntimeException;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -107,14 +107,10 @@ final class RunCommand extends Command
             // Set up normalized runtime args before executing the script
             Phel::setupRuntimeArgs($path, $userArgv);
 
-            $result = file_exists($path) ? $this->executeFile($path) : $this->executeNamespace($path);
-
-            $identifier = $path;
-
-            if ($result === '') {
-                $this->renderNoResultOutput($output, $identifier);
+            if (file_exists($path)) {
+                $this->getFacade()->runFile($path);
             } else {
-                $output->write($result);
+                $this->getFacade()->runNamespace($path);
             }
 
             if ($input->getOption('with-time')) {
@@ -135,46 +131,4 @@ final class RunCommand extends Command
         return self::FAILURE;
     }
 
-    private function executeNamespace(string $namespace): string
-    {
-        ob_start();
-        $this->getFacade()->runNamespace($namespace);
-
-        $buffer = ob_get_clean();
-
-        if ($buffer === false) {
-            throw new RuntimeException('Unable to capture namespace execution output.');
-        }
-
-        return $buffer;
-    }
-
-    private function executeFile(string $filename): string
-    {
-        ob_start();
-        $this->getFacade()->runFile($filename);
-
-        $buffer = ob_get_clean();
-
-        if ($buffer === false) {
-            throw new RuntimeException('Unable to capture file execution output.');
-        }
-
-        return $buffer;
-    }
-
-    private function renderNoResultOutput(OutputInterface $output, string $identifier): void
-    {
-        $output->writeln(
-            <<<EOF
-            <error>No rendered output after running namespace: "{$identifier}"</>
-
-            <comment>Please verify that at least one of the following applies:
-            - The file exists
-            - The namespace exists</>
-
-            You can ignore this message with `-q|--quiet`
-            EOF
-        );
-    }
 }

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -109,8 +109,11 @@ final class RunCommand extends Command
 
             if (file_exists($path)) {
                 $this->getFacade()->runFile($path);
-            } else {
+            } elseif ($this->namespaceExists($path)) {
                 $this->getFacade()->runNamespace($path);
+            } else {
+                $output->writeln(sprintf('<error>Namespace "%s" not found in any source directory.</error>', $path));
+                return self::FAILURE;
             }
 
             if ($input->getOption('with-time')) {
@@ -131,4 +134,19 @@ final class RunCommand extends Command
         return self::FAILURE;
     }
 
+    private function namespaceExists(string $namespace): bool
+    {
+        $deps = $this->getFacade()->getDependenciesForNamespace(
+            $this->getFacade()->getAllPhelDirectories(),
+            [$namespace],
+        );
+
+        foreach ($deps as $info) {
+            if ($info->getNamespace() === $namespace) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -12,12 +12,12 @@ final class RunCommandTest extends AbstractTestCommand
 {
     public function test_file_not_found(): void
     {
-        $this->expectOutputRegex('~No rendered output after running namespace: "non-existing-file.phel"~');
-
-        $this->createRunCommand()->run(
+        $exitCode = $this->createRunCommand()->run(
             $this->stubInput('non-existing-file.phel'),
             $this->stubOutput(),
         );
+
+        self::assertSame(0, $exitCode);
     }
 
     public function test_run_by_namespace(): void

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -12,12 +12,14 @@ final class RunCommandTest extends AbstractTestCommand
 {
     public function test_file_not_found(): void
     {
+        $this->expectOutputRegex('~Namespace "non-existing-file.phel" not found~');
+
         $exitCode = $this->createRunCommand()->run(
             $this->stubInput('non-existing-file.phel'),
             $this->stubOutput(),
         );
 
-        self::assertSame(0, $exitCode);
+        self::assertSame(1, $exitCode);
     }
 
     public function test_run_by_namespace(): void


### PR DESCRIPTION
## 🤔 Background

`phel run` wrapped all program execution in `ob_start()`/`ob_get_clean()`, capturing output to a string before printing it. For long-running processes (e.g. AMPHP async servers), `ob_get_clean()` is never reached, so all `println`/`print` output silently accumulates in the buffer and never appears on screen.

Reported in discussion #793 — Phel's `println` appeared broken in AMPHP contexts, but the root cause was the output buffering in `RunCommand`, not the print functions themselves.

## 💡 Goal

Let `print`/`println` flush to stdout immediately so long-running Phel programs (async servers, event loops) display output in real time.

## 🔖 Changes

- Removed `ob_start`/`ob_get_clean` wrapping from `RunCommand::execute()` — output now flows directly to stdout
- Removed the "No rendered output" warning (it conflated missing namespaces with silent programs)
- Updated `RunCommandTest::test_file_not_found` to assert exit code instead of the removed warning message