### PR TITLE
feat(async): add phel\async module for AMPHP concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `phel\async` module with `async`, `await`, `delay`, `await-all`, `await-any`, and `->closure` for AMPHP-based concurrency (#793)
 - `reify` for anonymous protocol/interface implementation, matching Clojure's `reify` (#1226)
 - `do-report` in `phel\test` for Clojure-compatible custom assertion reporting (#1260)
 - `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require-dev": {
         "ext-readline": "*",
+        "amphp/amp": "^3.1",
         "ergebnis/composer-normalize": "^2.50",
         "friendsofphp/php-cs-fixer": "^3.94",
         "phpbench/phpbench": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec94593ca3e9e0b0bc37fd359f3dd02b",
+    "content-hash": "493c4bdec99828d30dd3829737ee5d73",
     "packages": [
         {
             "name": "gacela-project/container",
@@ -7822,5 +7822,5 @@
     "platform-overrides": {
         "php": "8.3.16"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/examples/11_async-concurrency.phel
+++ b/docs/examples/11_async-concurrency.phel
@@ -1,0 +1,60 @@
+(ns examples\async-concurrency
+  (:require phel\async :refer [async await await-all delay]))
+
+;; Async concurrency with Phel and AMPHP (amphp/amp).
+;; Run: ./bin/phel run docs/examples/11_async-concurrency.phel
+
+;; --- 1. Basic async/await ---
+
+(println "--- Basic async/await ---")
+
+(let [future (async (+ 21 21))]
+  (println "The answer is:" (await future)))
+
+;; --- 2. Concurrent work ---
+
+(defn fetch-data
+  "Simulates an async I/O operation with a delay."
+  [label ms]
+  (async
+    (delay (/ ms 1000))
+    (str label " (took " ms "ms)")))
+
+(println)
+(println "--- Concurrent fetches ---")
+
+(let [start (php/microtime true)
+      results (await-all [(fetch-data "user-profile" 50)
+                          (fetch-data "notifications" 80)
+                          (fetch-data "feed" 60)])
+      elapsed (php/round (* 1000 (- (php/microtime true) start)))]
+  (for [r :in results]
+    (println " " r))
+  (println (str "  Total wall time: " elapsed "ms (concurrent, not 190ms serial)")))
+
+;; --- 3. First-to-finish race ---
+
+(println)
+(println "--- Race: first to respond wins ---")
+
+(let [winner (phel\async/await-any
+               [(fetch-data "server-eu" 30)
+                (fetch-data "server-us" 70)
+                (fetch-data "server-asia" 50)])]
+  (println "  Winner:" winner))
+
+;; --- 4. Error handling ---
+
+(println)
+(println "--- Error handling ---")
+
+(let [risky (async
+              (delay 0.01)
+              (throw (php/new \RuntimeException "network timeout")))]
+  (try
+    (await risky)
+    (catch \RuntimeException e
+      (println "  Caught:" (php/-> e (getMessage))))))
+
+(println)
+(println "Done!")

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,7 +1,7 @@
 (ns phel\async)
 
 ;; Thin convenience layer over AMPHP (amphp/amp).
-;; amphp/amp is a dev dependency; consuming projects need `composer require amphp/amp`.
+;; Requires `composer require amphp/amp` in the consuming project.
 
 (defn ->closure
   "Converts a Phel function to a PHP Closure.

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,7 +1,7 @@
 (ns phel\async)
 
 ;; Thin convenience layer over AMPHP (amphp/amp).
-;; Requires `composer require amphp/amp` in the consuming project.
+;; amphp/amp is a dev dependency; consuming projects need `composer require amphp/amp`.
 
 (defn ->closure
   "Converts a Phel function to a PHP Closure.

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,0 +1,52 @@
+(ns phel\async)
+
+;; Thin convenience layer over AMPHP (amphp/amp).
+;; Requires `composer require amphp/amp` in the consuming project.
+
+(defn ->closure
+  "Converts a Phel function to a PHP Closure.
+  Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject
+  Phel's `AbstractFn` even though it is callable. This bridges the gap."
+  {:doc "Converts a callable (e.g. Phel function) to a PHP \\Closure."
+   :example "(->closure (fn [x] (* x 2)))"}
+  [f]
+  (php/:: \Closure (fromCallable f)))
+
+(defmacro async
+  "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
+  The body is wrapped in a Closure so AMPHP accepts it."
+  {:doc "Runs body asynchronously. Returns a Future."
+   :example "(async (do-something))"}
+  [& body]
+  `(php/amp\async (->closure (fn [] ~@body))))
+
+(defn await
+  "Blocks the current fiber until the Future resolves and returns its value."
+  {:doc "Awaits an Amp\\Future, returning its resolved value."
+   :example "(await (async (+ 1 2)))"}
+  [future]
+  (php/-> future (await)))
+
+(defn delay
+  "Suspends the current fiber for the given number of seconds (float)."
+  {:doc "Suspends the current fiber for `seconds`."
+   :example "(delay 0.5)"}
+  [seconds]
+  (php/amp\delay seconds))
+
+(defn await-all
+  "Awaits all Futures in the given collection. Returns a vector of results."
+  {:doc "Awaits all Futures, returning a vector of their resolved values."
+   :example "(await-all [(async 1) (async 2)])"}
+  [futures]
+  (let [php-futures (to-php-array futures)]
+    (for [v :in (php/amp\future\await php-futures)]
+      v)))
+
+(defn await-any
+  "Awaits the first Future to resolve. Returns its value."
+  {:doc "Returns the value of the first Future to resolve."
+   :example "(await-any [(async 1) (async 2)])"}
+  [futures]
+  (let [php-futures (to-php-array futures)]
+    (php/amp\future\awaitfirst php-futures)))

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,16 +1,60 @@
 (ns phel-test\test\async
   (:require phel\test :refer [deftest is])
-  (:require phel\async))
+  (:require phel\async :refer [async await await-all await-any delay ->closure]))
 
-;; These tests verify macro expansion and pure functions only.
-;; Runtime async behavior requires amphp/amp to be installed.
+;; --- Pure function tests ---
 
 (deftest test-closure-conversion
   (let [f (fn [x] (* x 2))
-        c (phel\async/->closure f)]
+        c (->closure f)]
     (is (= true (php/instanceof c \Closure)) "->closure returns a PHP Closure")
     (is (= 6 (c 3)) "Closure preserves function behavior")))
 
 (deftest test-async-macro-expands
   (let [expanded (macroexpand-1 '(phel\async/async (+ 1 2)))]
     (is (= 'php/amp\async (first expanded)) "async expands to php/amp\\async call")))
+
+;; --- Runtime integration tests (amphp/amp) ---
+
+(deftest test-async-await-basic
+  (let [future (async (+ 1 2))]
+    (is (= 3 (await future)) "async/await round-trips a simple value")))
+
+(deftest test-async-await-with-side-effects
+  (let [result (atom nil)]
+    (await (async (reset! result 42)))
+    (is (= 42 @result) "async body runs and produces side effects")))
+
+(deftest test-async-multiple-futures
+  (let [f1 (async 10)
+        f2 (async 20)
+        f3 (async 30)]
+    (is (= 10 (await f1)))
+    (is (= 20 (await f2)))
+    (is (= 30 (await f3)))))
+
+(deftest test-async-with-delay
+  (let [future (async (delay 0.01) :done)]
+    (is (= :done (await future)) "delay suspends then resumes the fiber")))
+
+(deftest test-await-all
+  (let [results (await-all [(async 1) (async 2) (async 3)])]
+    (is (= [1 2 3] results) "await-all collects all results in order")))
+
+(deftest test-await-any
+  (let [result (await-any [(async 42)])]
+    (is (= 42 result) "await-any returns the first resolved value")))
+
+(deftest test-async-concurrent-execution
+  (let [start (php/microtime true)
+        results (await-all [(async (delay 0.05) :a)
+                            (async (delay 0.05) :b)
+                            (async (delay 0.05) :c)])
+        elapsed (- (php/microtime true) start)]
+    (is (= [:a :b :c] results) "all futures resolve correctly")
+    (is (< elapsed 0.15) "concurrent execution is faster than sequential")))
+
+(deftest test-async-error-propagation
+  (let [future (async (throw (php/new \RuntimeException "boom")))]
+    (is (thrown? \RuntimeException (await future))
+        "exceptions in async body propagate through await")))

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,0 +1,16 @@
+(ns phel-test\test\async
+  (:require phel\test :refer [deftest is])
+  (:require phel\async))
+
+;; These tests verify macro expansion and pure functions only.
+;; Runtime async behavior requires amphp/amp to be installed.
+
+(deftest test-closure-conversion
+  (let [f (fn [x] (* x 2))
+        c (phel\async/->closure f)]
+    (is (= true (php/instanceof c \Closure)) "->closure returns a PHP Closure")
+    (is (= 6 (c 3)) "Closure preserves function behavior")))
+
+(deftest test-async-macro-expands
+  (let [expanded (macroexpand-1 '(phel\async/async (+ 1 2)))]
+    (is (= 'php/amp\async (first expanded)) "async expands to php/amp\\async call")))


### PR DESCRIPTION
## 🤔 Background

Discussion #793 explored using PHP 8.1 Fibers and AMPHP with Phel. @jasalt demonstrated working examples but noted that the raw `php/amp\async` + `callable->closure` boilerplate was verbose. With the `println` output fix now merged (#1267), this adds the convenience layer.

## 💡 Goal

Provide idiomatic Phel wrappers for AMPHP's async primitives, reducing boilerplate and making concurrent Phel code readable.

## 🔖 Changes

- New `phel\async` module with:
  - `async` macro — wraps body in a fiber-backed Future (handles Closure conversion automatically)
  - `await` — blocks until a Future resolves
  - `delay` — suspends the current fiber for N seconds
  - `await-all` / `await-any` — multi-future coordination
  - `->closure` — converts Phel functions to PHP `\Closure` (needed by AMPHP and other PHP libs with `\Closure` type hints)
- Tests for closure conversion and macro expansion
- Requires `amphp/amp` in the consuming project (not a Phel dependency)