### PR TITLE
fix(emitter): prevent return before yield in return context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - Accept `name#` as an auto-gensym suffix inside syntax-quote (alongside the existing `name$`), matching Clojure's `clojure.core/gensym` reader macro (#1195)
 
 ### Fixed
+- `(php/yield ...)` in return position no longer emits `return yield ...;`, which broke PHP generator semantics (#793)
 - `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)
 - REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)
 - REPL `(require 'foo)` now throws `RuntimeException` when the namespace cannot be found on source paths, instead of silently succeeding (#1246)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -20,8 +20,12 @@ final class CallEmitter implements NodeEmitterInterface
     {
         assert($node instanceof CallNode);
 
-        $this->emitContextPrefix($node);
         $fnNode = $node->getFn();
+        $isYield = $fnNode instanceof PhpVarNode && $fnNode->getName() === 'yield';
+
+        if (!$isYield) {
+            $this->emitContextPrefix($node);
+        }
 
         if ($fnNode instanceof PhpVarNode && $fnNode->isInfix()) {
             $this->emitPhpVarNodeInfix($node, $fnNode);

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -1,0 +1,33 @@
+--PHEL--
+(defn yield_no_return []
+    (php/yield 1)
+    (php/yield 2))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "yield_no_return",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\yield_no_return";
+
+    public function __invoke() {
+      yield 1;
+      yield 2;
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(yield_no_return)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Yield/yield-return-context.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Yield/yield-return-context.test",
+      \Phel::keyword("line"), 3,
+      \Phel::keyword("column"), 18
+    ),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
+);

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -91,6 +91,46 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('yield 1 => 2;');
     }
 
+    public function test_yield_in_return_context_omits_return_keyword(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty()->withReturnContext(), 'yield');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty()->withReturnContext(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('yield "abc";');
+    }
+
+    public function test_yield_key_value_in_return_context_omits_return_keyword(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty()->withReturnContext(), 'yield');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 1),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 2),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty()->withReturnContext(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('yield 1 => 2;');
+    }
+
+    public function test_non_yield_in_return_context_emits_return(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty()->withReturnContext(), 'print');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'abc'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty()->withReturnContext(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('return print("abc");');
+    }
+
     public function test_namespaced_php_function_is_emitted_as_fully_qualified(): void
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp\\File\\write');


### PR DESCRIPTION
## 🤔 Background

When `(php/yield ...)` is the last expression of a function body, the emitter wraps it in `return`, producing `return yield 1;`. In PHP, this changes generator semantics — the yielded value becomes the generator's return value (accessible via `$gen->getReturn()`), which is unexpected. Users had to work around this by appending `nil` after yield calls.

Reported in discussion #793 by @jasalt.

## 💡 Goal

Make `yield` emit correctly regardless of position in the function body.

## 🔖 Changes

- `CallEmitter::emit()` now skips the `return` prefix for yield calls
- 3 new unit tests: yield in return context, yield key-value in return context, and non-yield in return context (proving `return` is still emitted for normal calls)
- 1 new integration fixture: `yield-return-context.test`