### PR TITLE
ref(emitter): emit native PHP closures for anonymous fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this project will be documented in this file.
 - Accept `.` as an alternate namespace separator in `(ns ...)`, `(in-ns ...)`, `:require`, and `:use` forms, enabling Clojure-style namespaces (e.g. `(ns my.cljc.file)`) for `.cljc` interop (#1177)
 - Accept `name#` as an auto-gensym suffix inside syntax-quote (alongside the existing `name$`), matching Clojure's `clojure.core/gensym` reader macro (#1195)
 
+### Changed
+- Anonymous `fn` now emits native PHP closures instead of `AbstractFn` subclasses, making them compatible with PHP libraries that type-hint `\Closure` (e.g. AMPHP) without needing `->closure` conversion (#793)
+
 ### Fixed
 - `(php/yield ...)` in return position no longer emits `return yield ...;`, which broke PHP generator semantics (#793)
 - `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -13,12 +13,11 @@
   (php/:: \Closure (fromCallable f)))
 
 (defmacro async
-  "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
-  The body is wrapped in a Closure so AMPHP accepts it."
+  "Runs body asynchronously in a new fiber. Returns an Amp\\Future."
   {:doc "Runs body asynchronously. Returns a Future."
    :example "(async (do-something))"}
   [& body]
-  `(php/amp\async (->closure (fn [] ~@body))))
+  `(php/amp\async (fn [] ~@body)))
 
 (defn await
   "Blocks the current fiber until the Future resolves and returns its value."

--- a/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
@@ -16,6 +16,8 @@ final class FnNode extends AbstractNode
      * @param list<Symbol> $params
      * @param list<Symbol> $uses
      */
+    private bool $isDefinition = false;
+
     public function __construct(
         NodeEnvironmentInterface $env,
         private readonly array $params,
@@ -26,6 +28,18 @@ final class FnNode extends AbstractNode
         ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
+    }
+
+    public function markAsDefinition(): self
+    {
+        $this->isDefinition = true;
+
+        return $this;
+    }
+
+    public function isDefinition(): bool
+    {
+        return $this->isDefinition;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -71,6 +71,10 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         }
 
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol);
+        if ($initNode instanceof FnNode) {
+            $initNode->markAsDefinition();
+        }
+
         $skip = $isMacro ? self::MACRO_IMPLICIT_PARAMS : 0;
         if ($initNode instanceof FnNode) {
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -8,8 +8,10 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
+use Phel\Lang\Symbol;
 
 use function assert;
+use function count;
 
 final readonly class FnAsClassEmitter implements NodeEmitterInterface
 {
@@ -23,6 +25,58 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
     {
         assert($node instanceof FnNode);
 
+        if ($this->isAnonymous($node)) {
+            $this->emitAsClosure($node);
+        } else {
+            $this->emitAsClass($node);
+        }
+    }
+
+    private function isAnonymous(FnNode $node): bool
+    {
+        return $node->getEnv()->getBoundTo() === '';
+    }
+
+    private function emitAsClosure(FnNode $node): void
+    {
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('(function(', $node->getStartSourceLocation());
+
+        $this->methodEmitter->emitParameters($node);
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        $this->emitUseClause($node);
+        $this->outputEmitter->emitLine(' {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $this->methodEmitter->emitBody($node);
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitStr('})', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    private function emitUseClause(FnNode $node): void
+    {
+        $uses = $node->getUses();
+        if ($uses === []) {
+            return;
+        }
+
+        $this->outputEmitter->emitStr(' use(', $node->getStartSourceLocation());
+        foreach ($uses as $i => $use) {
+            $shadowed = $node->getEnv()->getShadowed($use);
+            $normalizedUse = $shadowed instanceof Symbol ? $shadowed : $use;
+            $this->outputEmitter->emitStr('$' . $this->outputEmitter->mungeEncode($normalizedUse->getName()), $node->getStartSourceLocation());
+            if ($i < count($uses) - 1) {
+                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+            }
+        }
+
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+    }
+
+    private function emitAsClass(FnNode $node): void
+    {
         $this->emitClassBegin($node);
         $this->emitProperties($node);
         $this->emitConstructor($node);

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -25,16 +25,11 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
     {
         assert($node instanceof FnNode);
 
-        if ($this->isAnonymous($node)) {
-            $this->emitAsClosure($node);
-        } else {
+        if ($node->isDefinition()) {
             $this->emitAsClass($node);
+        } else {
+            $this->emitAsClosure($node);
         }
-    }
-
-    private function isAnonymous(FnNode $node): bool
-    {
-        return $node->getEnv()->getBoundTo() === '';
     }
 
     private function emitAsClosure(FnNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -18,17 +18,20 @@ final class MethodEmitter
     public function emit(string $methodName, FnNode $node): void
     {
         $this->emitMethodBegin($methodName, $node);
-        $this->emitMethodParameters($node);
+        $this->emitMethodParameterList($node);
+        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+        $this->emitMethodParametersExtraction($node);
+        $this->emitMethodVariadicParameters($node);
         $this->emitMethodBody($node);
         $this->emitMethodEnd($node);
     }
 
-    private function emitMethodBegin(string $methodName, FnNode $node): void
-    {
-        $this->outputEmitter->emitStr('public function ' . $this->outputEmitter->mungeEncode($methodName) . '(', $node->getStartSourceLocation());
-    }
-
-    private function emitMethodParameters(FnNode $node): void
+    /**
+     * Emits just the parameter list (without surrounding parens or braces).
+     * Used by FnAsClassEmitter for both class and closure emission paths.
+     */
+    public function emitParameters(FnNode $node): void
     {
         $paramsCount = count($node->getParams());
 
@@ -45,12 +48,26 @@ final class MethodEmitter
                 $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
             }
         }
+    }
 
-        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
-        $this->outputEmitter->increaseIndentLevel();
-
-        $this->emitMethodParametersExtraction($node);
+    /**
+     * Emits the function body: variadic wrapping, recur loop, and the body node.
+     * Used by FnAsClassEmitter for the closure emission path.
+     */
+    public function emitBody(FnNode $node): void
+    {
         $this->emitMethodVariadicParameters($node);
+        $this->emitMethodBody($node);
+    }
+
+    private function emitMethodBegin(string $methodName, FnNode $node): void
+    {
+        $this->outputEmitter->emitStr('public function ' . $this->outputEmitter->mungeEncode($methodName) . '(', $node->getStartSourceLocation());
+    }
+
+    private function emitMethodParameterList(FnNode $node): void
+    {
+        $this->emitParameters($node);
     }
 
     private function emitMethodParametersExtraction(FnNode $node): void

--- a/tests/php/Integration/Fixtures/Call/anonymous-fn-call.test
+++ b/tests/php/Integration/Fixtures/Call/anonymous-fn-call.test
@@ -1,10 +1,6 @@
 --PHEL--
 ((fn [x] (php/+ x x)) 1)
 --PHP--
-(new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    return ($x + $x);
-  }
-})(1);
+((function($x) {
+  return ($x + $x);
+}))(1);

--- a/tests/php/Integration/Fixtures/Call/hash-fn-call.test
+++ b/tests/php/Integration/Fixtures/Call/hash-fn-call.test
@@ -1,10 +1,6 @@
 --PHEL--
 (#(php/+ % %) 1)
 --PHP--
-(new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__short_fn_1_1) {
-    return ($__short_fn_1_1 + $__short_fn_1_1);
-  }
-})(1);
+((function($__short_fn_1_1) {
+  return ($__short_fn_1_1 + $__short_fn_1_1);
+}))(1);

--- a/tests/php/Integration/Fixtures/Call/local-call.test
+++ b/tests/php/Integration/Fixtures/Call/local-call.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [f] (f 1))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($f) {
-    return ($f)(1);
-  }
-};
+(function($f) {
+  return ($f)(1);
+});

--- a/tests/php/Integration/Fixtures/Do/empty-do-in-fn.test
+++ b/tests/php/Integration/Fixtures/Do/empty-do-in-fn.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [] (do))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    return null;
-  }
-};
+(function() {
+  return null;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-destructure.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-destructure.test
@@ -1,17 +1,13 @@
 --PHEL--
 (fn [[x y]] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__phel_1) {
-    $__phel_2_7 = $__phel_1;
-    $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
-    $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);
-    $x_10 = $__phel_3_8;
-    $__phel_5_11 = (\Phel::getDefinition("phel\\core", "first"))($__phel_4_9);
-    $__phel_6_12 = (\Phel::getDefinition("phel\\core", "next"))($__phel_4_9);
-    $y_13 = $__phel_5_11;
-    return 1;
-  }
-};
+(function($__phel_1) {
+  $__phel_2_7 = $__phel_1;
+  $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
+  $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);
+  $x_10 = $__phel_3_8;
+  $__phel_5_11 = (\Phel::getDefinition("phel\\core", "first"))($__phel_4_9);
+  $__phel_6_12 = (\Phel::getDefinition("phel\\core", "next"))($__phel_4_9);
+  $y_13 = $__phel_5_11;
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-ignore-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-ignore-arg.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [_] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__phel_1) {
-    return 1;
-  }
-};
+(function($__phel_1) {
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-one-arg.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [x] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    return 1;
-  }
-};
+(function($x) {
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-this-parameter.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-this-parameter.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [this] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__phel_this) {
-    return 1;
-  }
-};
+(function($__phel_this) {
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-two-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-two-args.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [x y] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x, $y) {
-    return 1;
-  }
-};
+(function($x, $y) {
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-destructure.test
@@ -1,18 +1,14 @@
 --PHEL--
 (fn [& [x y]] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::vector($__phel_1);
-    $__phel_2_7 = $__phel_1;
-    $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
-    $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);
-    $x_10 = $__phel_3_8;
-    $__phel_5_11 = (\Phel::getDefinition("phel\\core", "first"))($__phel_4_9);
-    $__phel_6_12 = (\Phel::getDefinition("phel\\core", "next"))($__phel_4_9);
-    $y_13 = $__phel_5_11;
-    return 1;
-  }
-};
+(function(...$__phel_1) {
+  $__phel_1 = \Phel::vector($__phel_1);
+  $__phel_2_7 = $__phel_1;
+  $__phel_3_8 = (\Phel::getDefinition("phel\\core", "first"))($__phel_2_7);
+  $__phel_4_9 = (\Phel::getDefinition("phel\\core", "next"))($__phel_2_7);
+  $x_10 = $__phel_3_8;
+  $__phel_5_11 = (\Phel::getDefinition("phel\\core", "first"))($__phel_4_9);
+  $__phel_6_12 = (\Phel::getDefinition("phel\\core", "next"))($__phel_4_9);
+  $y_13 = $__phel_5_11;
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-ignore.test
@@ -1,11 +1,7 @@
 --PHEL--
 (fn [&] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::vector($__phel_1);
-    return 1;
-  }
-};
+(function(...$__phel_1) {
+  $__phel_1 = \Phel::vector($__phel_1);
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic-underscore.test
@@ -1,11 +1,7 @@
 --PHEL--
 (fn [& _] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$__phel_1) {
-    $__phel_1 = \Phel::vector($__phel_1);
-    return 1;
-  }
-};
+(function(...$__phel_1) {
+  $__phel_1 = \Phel::vector($__phel_1);
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-variadic.test
@@ -1,11 +1,7 @@
 --PHEL--
 (fn [& xs] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$xs) {
-    $xs = \Phel::vector($xs);
-    return 1;
-  }
-};
+(function(...$xs) {
+  $xs = \Phel::vector($xs);
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-zero-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-zero-args.test
@@ -1,10 +1,6 @@
 --PHEL--
 (fn [] 1)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    return 1;
-  }
-};
+(function() {
+  return 1;
+});

--- a/tests/php/Integration/Fixtures/Fn/hash-fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/hash-fn-one-arg.test
@@ -1,10 +1,6 @@
 --PHEL--
 #(php/+ % %)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__short_fn_1_1) {
-    return ($__short_fn_1_1 + $__short_fn_1_1);
-  }
-};
+(function($__short_fn_1_1) {
+  return ($__short_fn_1_1 + $__short_fn_1_1);
+});

--- a/tests/php/Integration/Fixtures/Fn/hash-fn-two-args.test
+++ b/tests/php/Integration/Fixtures/Fn/hash-fn-two-args.test
@@ -1,10 +1,6 @@
 --PHEL--
 #(php/+ %1 %2)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__short_fn_1_1, $__short_fn_2_2) {
-    return ($__short_fn_1_1 + $__short_fn_2_2);
-  }
-};
+(function($__short_fn_1_1, $__short_fn_2_2) {
+  return ($__short_fn_1_1 + $__short_fn_2_2);
+});

--- a/tests/php/Integration/Fixtures/Fn/hash-fn-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/hash-fn-variadic.test
@@ -1,11 +1,7 @@
 --PHEL--
 #(php/+ %1 %&)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($__short_fn_1_1, ...$__short_fn_rest_2) {
-    $__short_fn_rest_2 = \Phel::vector($__short_fn_rest_2);
-    return ($__short_fn_1_1 + $__short_fn_rest_2);
-  }
-};
+(function($__short_fn_1_1, ...$__short_fn_rest_2) {
+  $__short_fn_rest_2 = \Phel::vector($__short_fn_rest_2);
+  return ($__short_fn_1_1 + $__short_fn_rest_2);
+});

--- a/tests/php/Integration/Fixtures/Fn/hash-fn-zero-args.test
+++ b/tests/php/Integration/Fixtures/Fn/hash-fn-zero-args.test
@@ -1,10 +1,6 @@
 --PHEL--
 #(php/+ 1 2)
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    return (1 + 2);
-  }
-};
+(function() {
+  return (1 + 2);
+});

--- a/tests/php/Integration/Fixtures/Fn/issue-443.test
+++ b/tests/php/Integration/Fixtures/Fn/issue-443.test
@@ -11,34 +11,6 @@ $a_10 = $__phel_2_8;
 $__phel_4_11 = (\Phel::getDefinition("phel\\core", "first"))($__phel_3_9);
 $__phel_5_12 = (\Phel::getDefinition("phel\\core", "next"))($__phel_3_9);
 $b_13 = $__phel_4_11;
-$f_14 = new class($__phel_1_7, $__phel_2_8, $__phel_3_9, $a_10, $__phel_4_11, $__phel_5_12, $b_13) extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = ".f";
-  private $__phel_1_7;
-  private $__phel_2_8;
-  private $__phel_3_9;
-  private $a_10;
-  private $__phel_4_11;
-  private $__phel_5_12;
-  private $b_13;
-
-  public function __construct($__phel_1_7, $__phel_2_8, $__phel_3_9, $a_10, $__phel_4_11, $__phel_5_12, $b_13) {
-    $this->__phel_1_7 = $__phel_1_7;
-    $this->__phel_2_8 = $__phel_2_8;
-    $this->__phel_3_9 = $__phel_3_9;
-    $this->a_10 = $a_10;
-    $this->__phel_4_11 = $__phel_4_11;
-    $this->__phel_5_12 = $__phel_5_12;
-    $this->b_13 = $b_13;
-  }
-
-  public function __invoke($matches) {
-    $__phel_1_7 = $this->__phel_1_7;
-    $__phel_2_8 = $this->__phel_2_8;
-    $__phel_3_9 = $this->__phel_3_9;
-    $a_10 = $this->a_10;
-    $__phel_4_11 = $this->__phel_4_11;
-    $__phel_5_12 = $this->__phel_5_12;
-    $b_13 = $this->b_13;
-    return $matches;
-  }
-};
+$f_14 = (function($matches) use($__phel_1_7, $__phel_2_8, $__phel_3_9, $a_10, $__phel_4_11, $__phel_5_12, $b_13) {
+  return $matches;
+});

--- a/tests/php/Integration/Fixtures/Fn/issue-471.test
+++ b/tests/php/Integration/Fixtures/Fn/issue-471.test
@@ -4,11 +4,7 @@
   (f 1 1))
 --PHP--
 $b_1 = 10;
-$f_2 = new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = ".f";
-
-  public function __invoke($a, $b) {
-    return ($a + $b);
-  }
-};
+$f_2 = (function($a, $b) {
+  return ($a + $b);
+});
 ($f_2)(1, 1);

--- a/tests/php/Integration/Fixtures/Fn/nested-fn.test
+++ b/tests/php/Integration/Fixtures/Fn/nested-fn.test
@@ -1,22 +1,8 @@
 --PHEL--
 (fn [x] (fn [y] 1))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    return new class($x) extends \Phel\Lang\AbstractFn {
-      public const BOUND_TO = "";
-      private $x;
-
-      public function __construct($x) {
-        $this->x = $x;
-      }
-
-      public function __invoke($y) {
-        $x = $this->x;
-        return 1;
-      }
-    };
-  }
-};
+(function($x) {
+  return (function($y) use($x) {
+    return 1;
+  });
+});

--- a/tests/php/Integration/Fixtures/Fn/nested-override-var.test
+++ b/tests/php/Integration/Fixtures/Fn/nested-override-var.test
@@ -1,22 +1,8 @@
 --PHEL--
 (fn [x y] (fn [y] 1))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x, $y) {
-    return new class($x) extends \Phel\Lang\AbstractFn {
-      public const BOUND_TO = "";
-      private $x;
-
-      public function __construct($x) {
-        $this->x = $x;
-      }
-
-      public function __invoke($y) {
-        $x = $this->x;
-        return 1;
-      }
-    };
-  }
-};
+(function($x, $y) {
+  return (function($y) use($x) {
+    return 1;
+  });
+});

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -4,16 +4,12 @@
     (foreach [b [1 2 3]]
       (println b))))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    $b_1 = 10;
-    return (function() use($b_1) {
-      foreach (\Phel\Lang\Seq::toIterable(\Phel::vector([1, 2, 3])) as $b) {
-        (\Phel::getDefinition("phel\\core", "println"))($b);
-      }
-      return null;
-    })();
-  }
-};
+(function() {
+  $b_1 = 10;
+  return (function() use($b_1) {
+    foreach (\Phel\Lang\Seq::toIterable(\Phel::vector([1, 2, 3])) as $b) {
+      (\Phel::getDefinition("phel\\core", "println"))($b);
+    }
+    return null;
+  })();
+});

--- a/tests/php/Integration/Fixtures/Let/let-shadowed.test
+++ b/tests/php/Integration/Fixtures/Let/let-shadowed.test
@@ -1,13 +1,9 @@
 --PHEL--
 (fn [x] (do (let [x 1 y 2] (php/+ x y)) x))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    $x_1 = 1;
-    $y_2 = 2;
-    ($x_1 + $y_2);
-    return $x;
-  }
-};
+(function($x) {
+  $x_1 = 1;
+  $y_2 = 2;
+  ($x_1 + $y_2);
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
@@ -4,20 +4,16 @@
     x
     (recur (php/- x 1))))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
+(function($x) {
+  while (true) {
+    if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
+      return $x;
+    } else {
+      $__phel_1 = ($x - 1);
+      $x = $__phel_1;
+      continue;
 
-  public function __invoke($x) {
-    while (true) {
-      if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
-        return $x;
-      } else {
-        $__phel_1 = ($x - 1);
-        $x = $__phel_1;
-        continue;
-
-      }
-      break;
     }
+    break;
   }
-};
+});

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
@@ -4,22 +4,18 @@
     x
     (recur (php/- x 1) (php/+ y 1))))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
+(function($x, $y) {
+  while (true) {
+    if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
+      return $x;
+    } else {
+      $__phel_1 = ($x - 1);
+      $__phel_2 = ($y + 1);
+      $x = $__phel_1;
+      $y = $__phel_2;
+      continue;
 
-  public function __invoke($x, $y) {
-    while (true) {
-      if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
-        return $x;
-      } else {
-        $__phel_1 = ($x - 1);
-        $__phel_2 = ($y + 1);
-        $x = $__phel_1;
-        $y = $__phel_2;
-        continue;
-
-      }
-      break;
     }
+    break;
   }
-};
+});

--- a/tests/php/Integration/Fixtures/Recur/recur-zero-args.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-zero-args.test
@@ -1,13 +1,9 @@
 --PHEL--
 (fn [] (recur))
 --PHP--
-new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    while (true) {
-      continue;
-      break;
-    }
+(function() {
+  while (true) {
+    continue;
+    break;
   }
-};
+});

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -82,13 +82,9 @@ final class ApplyEmitterTest extends TestCase
         $applyNode = new ApplyNode(NodeEnvironment::empty(), $fnNode, $args);
         $this->applyEmitter->emit($applyNode);
 
-        $this->expectOutputString('(new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$x) {
-    $x = \Phel::vector($x);
-    return x;
-  }
-};)(...((\Phel::vector([1])) ?? []));');
+        $this->expectOutputString('((function(...$x) {
+  $x = \Phel::vector($x);
+  return x;
+});)(...((\Phel::vector([1])) ?? []));');
     }
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -147,14 +147,14 @@ final class FnAsClassEmitterTest extends TestCase
     public function test_named_fn_still_emits_class(): void
     {
         $env = NodeEnvironment::empty()->withBoundTo('user\\my-fn');
-        $fnNode = new FnNode(
+        $fnNode = (new FnNode(
             $env,
             params: [Symbol::create('x')],
             body: PhpVarNode::withReturnContext('$x'),
             uses: [],
             isVariadic: false,
             recurs: false,
-        );
+        ))->markAsDefinition();
 
         $this->fnAsClassEmitter->emit($fnNode);
 

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -43,13 +43,9 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    return $x;
-  }
-};');
+        $this->expectOutputString('(function($x) {
+  return $x;
+});');
     }
 
     public function test_without_parameters(): void
@@ -65,13 +61,9 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke() {
-    return $x;
-  }
-};');
+        $this->expectOutputString('(function() {
+  return $x;
+});');
     }
 
     public function test_with_uses(): void
@@ -87,22 +79,9 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class($use1, $use2) extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-  private $use1;
-  private $use2;
-
-  public function __construct($use1, $use2) {
-    $this->use1 = $use1;
-    $this->use2 = $use2;
-  }
-
-  public function __invoke($x) {
-    $use1 = $this->use1;
-    $use2 = $this->use2;
-    return $x;
-  }
-};');
+        $this->expectOutputString('(function($x) use($use1, $use2) {
+  return $x;
+});');
     }
 
     public function test_is_variadic(): void
@@ -118,14 +97,10 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$x) {
-    $x = \Phel::vector($x);
-    return $x;
-  }
-};');
+        $this->expectOutputString('(function(...$x) {
+  $x = \Phel::vector($x);
+  return $x;
+});');
     }
 
     public function test_is_recurs(): void
@@ -141,15 +116,11 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke($x) {
-    while (true) {
-      return $x;break;
-    }
+        $this->expectOutputString('(function($x) {
+  while (true) {
+    return $x;break;
   }
-};');
+});');
     }
 
     public function test_variadic_and_recurs(): void
@@ -165,14 +136,33 @@ final class FnAsClassEmitterTest extends TestCase
 
         $this->fnAsClassEmitter->emit($fnNode);
 
-        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
-  public const BOUND_TO = "";
-
-  public function __invoke(...$x) {
-    $x = \Phel::vector($x);
-    while (true) {
-      return $x;break;
+        $this->expectOutputString('(function(...$x) {
+  $x = \Phel::vector($x);
+  while (true) {
+    return $x;break;
+  }
+});');
     }
+
+    public function test_named_fn_still_emits_class(): void
+    {
+        $env = NodeEnvironment::empty()->withBoundTo('user\\my-fn');
+        $fnNode = new FnNode(
+            $env,
+            params: [Symbol::create('x')],
+            body: PhpVarNode::withReturnContext('$x'),
+            uses: [],
+            isVariadic: false,
+            recurs: false,
+        );
+
+        $this->fnAsClassEmitter->emit($fnNode);
+
+        $this->expectOutputString('new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "user\\\\my_fn";
+
+  public function __invoke($x) {
+    return $x;
   }
 };');
     }


### PR DESCRIPTION
## 🤔 Background

PHP libraries like AMPHP type-hint `\Closure` and reject Phel's `AbstractFn` even though it's callable. Until now, users needed `(->closure my-fn)` to convert. This was the last actionable item from discussion #793.

## 💡 Goal

Make anonymous `fn` work natively with any PHP library that expects `\Closure`, with zero boilerplate.

## 🔖 Changes

- `FnAsClassEmitter` now emits `(function(...) use(...) { ... })` for anonymous fns (where `BOUND_TO` is empty)
- Named `defn` functions keep using `AbstractFn` subclasses (they need metadata, BOUND_TO, interface support)
- `MethodEmitter` exposes `emitParameters()` and `emitBody()` for reuse by the closure path
- Simplified the `async` macro: no longer needs `->closure` wrapping
- Updated 25 integration fixtures and 2 unit test files to match new output
- Net result: -61 lines (simpler generated PHP)