### PR TITLE
feat(async): add pmap for fiber-based parallel map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `pmap` in `phel\async` for fiber-based parallel map, matching Clojure's `pmap` signature (IO-parallel via AMPHP) (#793)
 - `phel\async` module with `async`, `await`, `delay`, `await-all`, `await-any`, and `->closure` for AMPHP-based concurrency (#793)
 - `amphp/amp` promoted to a runtime dependency so `phel\async` works out of the box (including from the PHAR), without requiring consumers to install it separately
 - `reify` for anonymous protocol/interface implementation, matching Clojure's `reify` (#1226)

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -48,3 +48,22 @@
   [futures]
   (let [php-futures (to-php-array futures)]
     (php/amp\future\awaitfirst php-futures)))
+
+(defn pmap
+  "Like `map`, but applies `f` to elements in parallel via fibers.
+
+  Returns a vector of results in the original order. With multiple
+  collections, applies `f` to corresponding elements from each collection,
+  stopping when the shortest collection is exhausted.
+
+  Best for IO-bound work (HTTP, DB, file IO). Because PHP fibers are
+  cooperative on a single thread, `pmap` does not speed up CPU-bound
+  computations — unlike Clojure's thread-based `pmap`."
+  {:doc "Parallel map via AMPHP fibers. IO-parallel, not CPU-parallel."
+   :example "(pmap inc [1 2 3]) ; => [2 3 4]"
+   :see-also ["map" "async" "await-all"]}
+  [f & colls]
+  (case (count colls)
+    0 (throw (php/new \InvalidArgumentException "pmap expects at least one collection"))
+    1 (await-all (map #(async (f %)) (first colls)))
+    (await-all (apply map (fn [& args] (async (apply f args))) colls))))

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,6 +1,6 @@
 (ns phel-test\test\async
   (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [async await await-all await-any delay ->closure]))
+  (:require phel\async :refer [async await await-all await-any delay pmap ->closure]))
 
 ;; --- Pure function tests ---
 
@@ -58,3 +58,38 @@
   (let [future (async (throw (php/new \RuntimeException "boom")))]
     (is (thrown? \RuntimeException (await future))
         "exceptions in async body propagate through await")))
+
+;; --- pmap tests ---
+
+(deftest test-pmap-single-collection
+  (is (= [2 3 4] (pmap inc [1 2 3])) "pmap applies f to each element"))
+
+(deftest test-pmap-preserves-order
+  (is (= [10 20 30 40 50] (pmap #(* % 10) [1 2 3 4 5]))
+      "pmap preserves the original order of results"))
+
+(deftest test-pmap-empty-collection
+  (is (= [] (pmap inc [])) "pmap on empty collection returns empty vector"))
+
+(deftest test-pmap-two-collections
+  (is (= [11 22 33] (pmap + [1 2 3] [10 20 30]))
+      "pmap applies f to corresponding elements of two collections"))
+
+(deftest test-pmap-multi-collections
+  (is (= [111 222 333] (pmap + [1 2 3] [10 20 30] [100 200 300]))
+      "pmap applies f to corresponding elements of N collections"))
+
+(deftest test-pmap-stops-at-shortest
+  (is (= [11 22] (pmap + [1 2 3 4] [10 20]))
+      "pmap stops at the shortest collection, like map"))
+
+(deftest test-pmap-no-collection-throws
+  (is (thrown? \InvalidArgumentException (pmap inc))
+      "pmap requires at least one collection"))
+
+(deftest test-pmap-is-concurrent
+  (let [start (php/microtime true)
+        results (pmap (fn [x] (delay 0.05) x) [:a :b :c :d])
+        elapsed (- (php/microtime true) start)]
+    (is (= [:a :b :c :d] results) "pmap returns all results")
+    (is (< elapsed 0.15) "pmap runs work concurrently via fibers")))


### PR DESCRIPTION
## 🤔 Background

Follow-up to #793. Now that `phel\async` ships `async` / `await-all` on top of AMPHP (runtime dep as of #1271), a fiber-based `pmap` is a natural next step — it was requested by @jasalt [in the discussion](https://github.com/phel-lang/phel-lang/discussions/793#discussioncomment-16520304).

His earlier attempt with `amphp/parallel` hit `Serialization of 'Phel\Lang\AbstractFn@anonymous' is not allowed`. That's the multi-process/CPU-parallel story, which has real blockers (see below). This PR delivers the IO-parallel story via fibers, which covers the common case (fan out HTTP, DB, or file IO).

## 💡 Goal

Give Phel a Clojure-compatible `pmap` in `phel\async` so users can drop it in wherever they already use `map` when the work is IO-bound.

Developer experience mirrors [`clojure.core/pmap`](https://clojuredocs.org/clojure.core/pmap):

```clojure
(pmap fetch-url urls)
(pmap + [1 2 3] [10 20 30])           ; => [11 22 33]
(pmap + [1 2 3] [10 20 30] [100 200]) ; stops at shortest, like map
```

## 🔖 Changes

- `src/phel/async.phel`: add `pmap` with variadic collections, dispatching on arity via `case` (matches existing Phel idiom). Single-collection path uses `#(async (f %))`; multi-collection path threads `async` through an `apply map`.
- `tests/phel/test/async.phel`: cover single collection, order preservation, empty input, two-collection, N-collection, stops-at-shortest, zero-collection throws, and a concurrency smoke test using `delay` to prove results come back faster than sequential execution.
- `CHANGELOG.md`: entry under `## Unreleased`.

### Deliberate differences from Clojure

| Clojure | Phel | Why |
|---|---|---|
| Lazy seq | Eager vector | Fibers are cheap; laziness adds complexity for little gain and Phel idioms lean vector. |
| Semi-lazy window sized to CPU count | All futures spawned at once | No thread pool to protect. For huge N or rate-limited APIs, a bounded variant can land later. |
| Threads via `future` | Fibers via `async` | PHP reality — documented in the docstring so nobody expects CPU speedup. |

### Why this PR intentionally doesn't do CPU-parallel

Fiber `pmap` and a hypothetical process-based `ppmap` have **genuinely different contracts** (not just different implementations of the same one), and a user has to pick consciously — conflating them would cause runtime errors depending on what kind of function they passed:

| | Fiber `pmap` (this PR) | Process `ppmap` (future) |
|---|---|---|
| Parallelism | IO only (cooperative, 1 thread) | Real CPU (N worker processes) |
| `f` can be | Any closure, any captures | Named function only — closures don't serialize |
| Shared state | Atoms, dynamic bindings work | None — workers don't share memory |
| Errors | Normal exception propagation | Serialized across IPC |
| Cost per call | ~µs (fiber spawn) | ~ms (worker startup / channel round-trip) |

Three concrete blockers for `ppmap` today (tracked as a follow-up issue):

1. **Phel Lang types are not serializable.** No class in `src/php/Lang` implements `__serialize` / `__unserialize`. `PersistentVector`, `Keyword`, etc. can't round-trip through an amphp/parallel worker channel without forcing users to convert to PHP arrays/scalars at the boundary.
2. **Closures aren't serializable.** Even with the native PHP `Closure` emission from #1270, stock `Closure` can't be serialized. Options are `laravel/serializable-closure` (partial support) or requiring users to pass fully qualified named functions.
3. **Worker bootstrap.** amphp/parallel workers would need to require the Composer autoloader, bootstrap the Phel runtime, and load the user's namespace before running anything — a full subsystem including source discovery, stdio routing, and error marshalling.

Closes part of #793. `ppmap` tracked in a separate issue.