### PR TITLE
feat(core): add NaN? alias matching Clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - `(resolve sym)` is now available globally in `phel\core`, no longer requiring `(:require phel\repl :refer [resolve])`, matching Clojure semantics (#1187)
 - `:or` defaults in map destructuring, matching Clojure semantics (#1219)
 - `:strs` support in map destructuring for string key lookup (#1227)
+- `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases
 - `atom`, `atom?`, `reset!` as aliases for `var`, `var?`, `set!` (#1252)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3093,6 +3093,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [x]
   (php/is_nan x))
 
+(defn NaN?
+  "Checks if `x` is not a number. Alias for `nan?`, matching Clojure's `NaN?`."
+  {:see-also ["nan?" "inf?"]}
+  [x]
+  (nan? x))
+
 (defn inf?
   "Checks if `x` is infinite."
   {:example "(inf? php/INF) ; => true"

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -93,6 +93,12 @@
   (is (true? (nan? NAN)) "(nan? NAN)")
   (is (false? (nan? 9)) "(nan? 8)"))
 
+(deftest test-NaN?
+  (is (true? (NaN? (php/acos 8))) "(NaN? (php/acos 8)")
+  (is (true? (NaN? php/NAN)) "(NaN? (php/NAN))")
+  (is (true? (NaN? NAN)) "(NaN? NAN)")
+  (is (false? (NaN? 9)) "(NaN? 8)"))
+
 (deftest test-min
   (is (= 1 (min 1 2 3)) "(min 1 2 3)"))
 


### PR DESCRIPTION
## 🤔 Background

Clojure exposes the predicate `NaN?` (with Clojure's camel-cased spelling) to check if a value is `NaN`. Phel already ships `nan?` (lowercase) which wraps PHP's `is_nan`, but `.cljc` files and Clojure test suites that use `NaN?` currently fail to compile against Phel because Phel's reader is case-sensitive and does not know the capitalised name.

Closes #1284

## 💡 Goal

Add `NaN?` as a Clojure-compatible alias for `nan?` so that code written for Clojure's `NaN?` runs on Phel unchanged, without renaming or deprecating the existing `nan?`.

## 🔖 Changes

- Added `NaN?` in `src/phel/core.phel` as a thin one-line wrapper around `nan?`, matching the metadata style of neighbouring predicates (`nan?`, `inf?`).
- Added a `test-NaN?` block in `tests/phel/test/core/math-operation.phel` mirroring the existing `test-nan?` cases: `(php/acos 8)`, `php/NAN`, `NAN`, and a non-NaN integer.
- Updated `CHANGELOG.md` under `## Unreleased` → `### Added` → `#### Core Language`.