### PR TITLE
feat(core): add float and double coercion functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - `(resolve sym)` is now available globally in `phel\core`, no longer requiring `(:require phel\repl :refer [resolve])`, matching Clojure semantics (#1187)
 - `:or` defaults in map destructuring, matching Clojure semantics (#1219)
 - `:strs` support in map destructuring for string key lookup (#1227)
+- `float` and `double` coercion functions, returning a PHP float (PHP has no float/double distinction); matches Clojure's `(float x)` / `(double x)` for `.cljc` interop (#1282)
 
 #### Clojure-Compatible Aliases
 - `atom`, `atom?`, `reset!` as aliases for `var`, `var?`, `set!` (#1252)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3106,6 +3106,23 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [x]
   (php/abs x))
 
+(defn float
+  "Coerces `x` to a float. In PHP there is no distinction between float and
+   double; both map to the same native PHP float type. Delegates to PHP's
+   `floatval`, so non-numeric strings return `0.0` and `nil` returns `0.0`."
+  {:example "(float 1) ; => 1.0"
+   :see-also ["double" "int?" "number?"]}
+  [x]
+  (php/floatval x))
+
+(defn double
+  "Coerces `x` to a double. In PHP there is no distinction between float and
+   double; both map to the same native PHP float type. Alias for `float`."
+  {:example "(double 1) ; => 1.0"
+   :see-also ["float" "int?" "number?"]}
+  [x]
+  (php/floatval x))
+
 (defn rand
   "Returns a random number between 0 and 1."
   []

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -133,6 +133,24 @@
   (is (= 2.5 (median [4 1 3 2])) "(median [4 1 3 2])")
   (is (thrown? \InvalidArgumentException (median [])) "(median [])"))
 
+(deftest test-float
+  (is (= 1.0 (float 1)) "(float 1)")
+  (is (true? (float? (float 1))) "(float 1) is float")
+  (is (= 1.5 (float 1.5)) "(float 1.5)")
+  (is (= -3.0 (float -3)) "(float -3)")
+  (is (= 0.0 (float 0)) "(float 0)")
+  (is (= 3.14 (float "3.14")) "(float \"3.14\")")
+  (is (= 0.0 (float nil)) "(float nil)"))
+
+(deftest test-double
+  (is (= 1.0 (double 1)) "(double 1)")
+  (is (true? (float? (double 1))) "(double 1) is float")
+  (is (= 1.5 (double 1.5)) "(double 1.5)")
+  (is (= -3.0 (double -3)) "(double -3)")
+  (is (= 0.0 (double 0)) "(double 0)")
+  (is (= 3.14 (double "3.14")) "(double \"3.14\")")
+  (is (= 0.0 (double nil)) "(double nil)"))
+
 (deftest test-numbers-with-underscore
   (is (= 1337 0b10100111001) "binary number")
   (is (= 1337 0b101_0011_1001) "binary number with underscores")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `(float x)` and `(double x)` for coercing numeric values to floating-point. On the JVM they target different precisions, but PHP's `float` type is already double-precision — there is no distinction between `float` and `double` at the language level. Phel is missing both, which makes `.cljc` interop and porting Clojure snippets awkward.

## 💡 Goal

Add `float` and `double` to `phel\core` so Clojure code and idioms translate directly. Since PHP has a single float type, both functions perform the same coercion: delegate to PHP's `floatval`. `double` is effectively an alias for `float`.

## 🔖 Changes

- Add `(defn float [x] (php/floatval x))` in `src/phel/core.phel` next to `abs`, with docstring explaining the PHP float/double equivalence and `floatval` semantics (non-numeric strings and `nil` coerce to `0.0`).
- Add `(defn double [x] (php/floatval x))` as a Clojure-compatible alias.
- Add `test-float` and `test-double` to `tests/phel/test/core/math-operation.phel` covering int, float, negative, zero, numeric string, and `nil` inputs, plus `float?` type checks on the results.
- Update `CHANGELOG.md` under `## Unreleased` → `### Added` → `#### Core Language`.

Closes #1282