### PR TITLE
feat(core): add disj function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - `(resolve sym)` is now available globally in `phel\core`, no longer requiring `(:require phel\repl :refer [resolve])`, matching Clojure semantics (#1187)
 - `:or` defaults in map destructuring, matching Clojure semantics (#1219)
 - `:strs` support in map destructuring for string key lookup (#1227)
+- `disj` function for removing keys from a set (hash-set or sorted-set), variadic over keys, matching Clojure's `disj` (#1285)
 
 #### Clojure-Compatible Aliases
 - `atom`, `atom?`, `reset!` as aliases for `var`, `var?`, `set!` (#1252)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1751,6 +1751,26 @@ Otherwise, it tries to call `__toString`."
   ([coll value & more]
    (reduce conj-single (conj-single coll value) more)))
 
+(defn- disj-single
+  [coll k]
+  (cond
+    (php/=== coll nil) nil
+    (set? coll) (php/-> coll (remove k))
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "Cannot disj on type " (type coll))))))
+
+(defn disj
+  "Returns a new set that does not contain the given key(s). Works on hash-sets and sorted-sets.
+  Removing a non-existent key is a no-op. Returns `nil` when called on `nil`."
+  {:example "(disj #{1 2 3} 2) ; => #{1 3}"
+   :see-also ["conj" "hash-set" "sorted-set"]}
+  ([set] set)
+  ([set k]
+   (disj-single set k))
+  ([set k & ks]
+   (reduce disj-single (disj-single set k) ks)))
+
 (defn slice
   "Extracts a slice of `coll` starting at `offset` with optional `length`."
   {:example "(slice [1 2 3 4 5] 1 3) ; => [2 3 4]"}

--- a/tests/phel/test/core/set-operation.phel
+++ b/tests/phel/test/core/set-operation.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\core\set-operation
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is thrown?]))
 
 (deftest test-set-union
   (is (= (hash-set) (union)) "set 0-ary union")
@@ -35,3 +35,15 @@
   (is (superset? (hash-set 1 2 3) (hash-set 1 2 3)) "equal sets are supersets")
   (is (= false (superset? (hash-set 1 2) (hash-set 1 2 3))) "subset is not superset")
   (is (= false (superset? (hash-set 1 2 3) (hash-set 4))) "disjoint is not superset"))
+
+(deftest test-disj
+  (is (= (hash-set 1 2 3) (disj (hash-set 1 2 3))) "disj with no keys is a no-op")
+  (is (= (hash-set 1 3) (disj (hash-set 1 2 3) 2)) "disj removes a single key")
+  (is (= (hash-set 1) (disj (hash-set 1 2 3) 2 3)) "disj removes multiple keys")
+  (is (= (hash-set 1 2) (disj (hash-set 1 2) 99)) "disj non-existent key is a no-op")
+  (is (= (hash-set) (disj (hash-set))) "disj on empty set")
+  (is (= (hash-set) (disj (hash-set 1) 1)) "disj removing only element yields empty set")
+  (is (= (sorted-set 1 3) (disj (sorted-set 1 2 3) 2)) "disj works on sorted-set")
+  (is (= (sorted-set 1) (disj (sorted-set 1 2 3) 2 3)) "disj removes multiple keys from sorted-set")
+  (is (nil? (disj nil 1)) "disj on nil returns nil")
+  (is (thrown? \InvalidArgumentException (disj [1 2 3] 1)) "disj on vector throws InvalidArgumentException"))


### PR DESCRIPTION
## 🤔 Background

Clojure's [`disj`](https://clojuredocs.org/clojure.core/disj) (disjoin) returns a new set without one or more given keys. Phel already exposes `conj` for sets, but until now there was no symmetric operation to remove members, forcing users to reach for `difference` with a singleton set or construct a new set by filtering.

Closes #1285.

## 💡 Goal

Provide a Clojure-compatible `disj` in `phel\core` that works uniformly over hash-sets and sorted-sets, supports variadic key removal, and is a no-op on missing keys or `nil`.

## 🔖 Changes

- Add `disj` to `src/phel/core.phel` with the three Clojure-compatible arities:
  - `(disj set)` returns the set unchanged
  - `(disj set k)` returns a new set without `k`
  - `(disj set k & ks)` returns a new set without all listed keys
- Back the implementation with a private `disj-single` helper that dispatches via `set?` and calls the underlying `PersistentHashSetInterface::remove` method, so it works for both `hash-set` and `sorted-set` (both implement that interface).
- `(disj nil k)` returns `nil`, matching Clojure's nil-handling.
- Calling `disj` on a non-set collection throws `InvalidArgumentException`, mirroring how `conj-single` reports unsupported types.
- Tests in `tests/phel/test/core/set-operation.phel` covering no-op, single-key, multi-key, non-existent key, empty set, sorted-set, `nil` input, and the negative vector case via `thrown?`.
- CHANGELOG entry under `## Unreleased` → `### Added` → `#### Core Language`.

The transient variant `disj!` mentioned in #1285 is intentionally deferred to a follow-up PR to keep this one focused.