### PR TITLE
feat(core): add sorted? predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 #### Core Language
 - `reify` for anonymous protocol/interface implementation, matching Clojure's `reify` (#1226)
 - `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)
+- `sorted?` predicate for checking whether a collection is a sorted-map or sorted-set, matching Clojure's `sorted?` (#1274)
 - `range` with 0 arguments now returns an infinite lazy sequence starting at 0, matching Clojure's `(range)` (#1259)
 - `letfn` macro for mutually recursive local functions (#1224)
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -15,6 +15,8 @@
   (:use Phel\Lang\Collections\LinkedList\PersistentListInterface)
   (:use Phel\Lang\Collections\Map\PersistentMapInterface)
   (:use Phel\Lang\Collections\Map\TransientMapInterface)
+  (:use Phel\Lang\Collections\SortedMap\PersistentSortedMap)
+  (:use Phel\Lang\Collections\SortedSet\PersistentSortedSet)
   (:use Phel\Lang\Collections\Struct\AbstractPersistentStruct)
   (:use Phel\Lang\Collections\Vector\PersistentVectorInterface)
   (:use Phel\Lang\Collections\Vector\TransientVectorInterface)
@@ -1104,6 +1106,14 @@ Otherwise, it tries to call `__toString`."
   "Returns true if `x` is a set, false otherwise."
   [x]
   (= (type x) :set))
+
+(defn sorted?
+  "Returns true if `coll` is a sorted collection (sorted-map or sorted-set), false otherwise."
+  {:example "(sorted? (sorted-set 1 2 3)) ; => true"
+   :see-also ["sorted-map" "sorted-set"]}
+  [coll]
+  (or (php/instanceof coll PersistentSortedMap)
+      (php/instanceof coll PersistentSortedSet)))
 
 ;; ------------------
 ;; Sequence operation

--- a/tests/phel/test/core/sorted-collections.phel
+++ b/tests/phel/test/core/sorted-collections.phel
@@ -97,3 +97,17 @@
 (deftest test-sorted-set-by-operations
   (let [s (sorted-set-by (fn [a b] (compare b a)) 3 1)]
     (is (= [3 2 1] (into [] (conj s 2))) "conj maintains custom order")))
+
+;; ---- sorted? ----
+
+(deftest test-sorted?
+  (is (sorted? (sorted-map :a 1)) "sorted-map is sorted")
+  (is (sorted? (sorted-set 1 2)) "sorted-set is sorted")
+  (is (sorted? (sorted-map-by (fn [a b] (compare b a)) :a 1 :b 2)) "sorted-map-by is sorted")
+  (is (sorted? (sorted-set-by (fn [a b] (compare b a)) 1 2)) "sorted-set-by is sorted")
+  (is (not (sorted? {:a 1})) "hash-map is not sorted")
+  (is (not (sorted? #{1 2})) "hash-set is not sorted")
+  (is (not (sorted? [1 2])) "vector is not sorted")
+  (is (not (sorted? '(1 2))) "list is not sorted")
+  (is (not (sorted? nil)) "nil is not sorted")
+  (is (not (sorted? 42)) "number is not sorted"))


### PR DESCRIPTION
## 🤔 Background

Clojure ships `sorted?` as a core predicate that returns `true` when a collection implements the `Sorted` interface. Phel already offers `sorted-map`, `sorted-map-by`, `sorted-set`, and `sorted-set-by`, but there is no first-class way to ask whether a given value is one of the resulting sorted collections — users have to reach for `php/instanceof` or compare types manually.

## 💡 Goal

Add a `sorted?` predicate that matches Clojure's `sorted?` semantics: return `true` for sorted-maps and sorted-sets, and `false` for every other value (hash-maps, hash-sets, vectors, lists, lazy seqs, `nil`, primitives, ...).

Closes #1274

## 🔖 Changes

- Add `sorted?` in `src/phel/core.phel` next to `set?`, implemented as `(or (php/instanceof coll PersistentSortedMap) (php/instanceof coll PersistentSortedSet))`
- Import `PersistentSortedMap` and `PersistentSortedSet` in the `phel\core` namespace `(:use ...)` list
- Add a `test-sorted?` deftest in `tests/phel/test/core/sorted-collections.phel` covering sorted-map, sorted-set, sorted-map-by, sorted-set-by, hash-map, hash-set, vector, list, `nil`, and a number
- Document the new predicate under `## Unreleased` → `### Added` → `#### Core Language` in `CHANGELOG.md`