### PR TITLE
fix(lang): short-circuit lazy-seq equals on identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix inside syntax-quote; use `name#` instead, matching Clojure's reader macro (#1203)
 
 ### Fixed
+- `=` on lazy sequences now short-circuits on object identity, so `(let [r (range)] (= r (deref (atom r))))` returns `true` instantly instead of trying to realize the infinite sequence and crashing with a PHP integer-overflow allocation error (#1286)
 - `(php/yield ...)` in return position no longer emits `return yield ...;`, which broke PHP generator semantics (#793)
 - `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)
 - REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -283,6 +283,11 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
 
     public function equals(mixed $other): bool
     {
+        // Short-circuit on identity — avoids realizing infinite lazy-seqs when comparing against self.
+        if ($this === $other) {
+            return true;
+        }
+
         $thisArray = $this->toArray();
 
         // Check if other is a sequence or indexable collection

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -370,6 +370,11 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
 
     public function equals(mixed $other): bool
     {
+        // Short-circuit on identity — avoids realizing infinite lazy-seqs when comparing against self.
+        if ($this === $other) {
+            return true;
+        }
+
         $thisArray = $this->toArray();
 
         // Check if other is a sequence or indexable collection

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -836,3 +836,10 @@
       "lazy-cat should work with finite lazy sequences")
   (is (= [1 2 3 4 5 6] (lazy-cat [1 2 3] [4 5 6]))
       "lazy-cat should work with vectors"))
+
+(deftest test-equals-infinite-range-to-self
+  (let [r (range)]
+    (is (true? (= r (deref (atom r))))
+        "identity equality on infinite range via atom/deref should not realize the sequence")
+    (is (true? (= r r))
+        "identity equality on infinite range directly should not realize the sequence")))

--- a/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/ChunkedSeqTest.php
@@ -178,6 +178,36 @@ final class ChunkedSeqTest extends TestCase
         $this->assertSame(31, $rest->first());
     }
 
+    public function test_equals_infinite_chunked_seq_to_self(): void
+    {
+        $generator = (static function (): Generator {
+            $i = 0;
+            while (true) {
+                yield $i++;
+            }
+        })();
+
+        $chunkedSeq = ChunkedSeq::fromGenerator($this->hasher, $this->equalizer, $generator, 32);
+
+        // Must short-circuit on identity and not attempt to realize the infinite sequence.
+        $this->assertTrue($chunkedSeq->equals($chunkedSeq));
+    }
+
+    public function test_equals_finite_chunked_seq_to_self(): void
+    {
+        $chunkedSeq = ChunkedSeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3], 32);
+
+        $this->assertTrue($chunkedSeq->equals($chunkedSeq));
+    }
+
+    public function test_equals_finite_chunked_seq_to_structurally_equal_copy(): void
+    {
+        $a = ChunkedSeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3], 32);
+        $b = ChunkedSeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3], 32);
+
+        $this->assertTrue($a->equals($b));
+    }
+
     public function test_performance_chunks_realize_in_batches(): void
     {
         $realizationCount = 0;

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -206,6 +206,36 @@ final class LazySeqTest extends TestCase
         $this->assertSame(3, $result);
     }
 
+    public function test_equals_infinite_lazy_seq_to_self(): void
+    {
+        $generator = (static function (): Generator {
+            $i = 0;
+            while (true) {
+                yield $i++;
+            }
+        })();
+
+        $lazySeq = LazySeq::fromGenerator($this->hasher, $this->equalizer, $generator);
+
+        // Must short-circuit on identity and not attempt to realize the infinite sequence.
+        $this->assertTrue($lazySeq->equals($lazySeq));
+    }
+
+    public function test_equals_finite_lazy_seq_to_self(): void
+    {
+        $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3]);
+
+        $this->assertTrue($lazySeq->equals($lazySeq));
+    }
+
+    public function test_equals_finite_lazy_seq_to_structurally_equal_copy(): void
+    {
+        $a = LazySeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3]);
+        $b = LazySeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3]);
+
+        $this->assertTrue($a->equals($b));
+    }
+
     public function test_realizes_lazily_on_demand(): void
     {
         $values = [1, 2, 3, 4, 5];


### PR DESCRIPTION
## 🤔 Background

Comparing a lazy sequence to itself (directly or via `atom`/`deref`) caused Phel to try to realize the sequence element-by-element, which for infinite sequences like `(range)` crashed PHP with an integer-overflow allocation error:

```
PHP Fatal error: Possible integer overflow in memory allocation (2147483648 * 32 + 32) in ChunkedSeq.php on line 220
```

Repro from #1286:

```phel
(let [r (range)]
  (= r (deref (atom r)))) ;; hangs / crashes in Phel, returns true instantly in Clojure
```

Root cause: both `LazySeq::equals()` and `ChunkedSeq::equals()` unconditionally call `$this->toArray()` on both sides, and `Variable::deref()` hands back the same PHP object it stores — so the failing repro actually compares a lazy-seq to itself, and the realization never terminates.

## 💡 Goal

Match Clojure's behaviour for the identity case: `(= r r)` and `(= r (deref (atom r)))` should return `true` instantly without realizing the sequence.

## 🔖 Changes

- Add an identity short-circuit (`$this === $other`) at the top of `LazySeq::equals()` and `ChunkedSeq::equals()`, with an inline comment explaining why it is load-bearing so it does not get removed as "dead code".
- Unit tests in `LazySeqTest` and `ChunkedSeqTest` covering: identity on infinite lazy-seq, identity on finite lazy-seq, and structural equality on a distinct finite copy (regression).
- Integration test in `tests/phel/test/core/infinite-seqs.phel` reproducing the issue via `(deref (atom r))` and `(= r r)` directly.
- `CHANGELOG.md` entry under `## Unreleased` → `### Fixed`.

Note: this is intentionally a minimum-blast-radius fix. It does not try to make structural `equals` safe for infinite sequences (e.g. `(= (range) (range))`) — Clojure also hangs/OOMs on that case, and a bail-out heuristic could introduce subtle correctness issues.

Closes #1286