### PR TITLE
fix(test): are no longer evaluates list literal cells eagerly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix inside syntax-quote; use `name#` instead, matching Clojure's reader macro (#1203)
 
 ### Fixed
+- `are` macro no longer eagerly evaluates list literals in table cells (e.g. `()`), which previously caused `Value of type null is not callable`; cells are now substituted into the expression template via symbolic replacement, matching Clojure's `clojure.template/do-template` semantics (#1280)
 - `(php/yield ...)` in return position no longer emits `return yield ...;`, which broke PHP generator semantics (#793)
 - `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)
 - REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -267,18 +267,48 @@
   `(binding [*testing-contexts* (conj *testing-contexts* ~context)]
      ~@body))
 
+(defn- quote-if-empty-list
+  "Wraps an empty-list cell in `(quote ())` so it survives compilation as
+  literal data. Phel's evaluator cannot apply an empty list as a call, so a
+  bare `()` placed in value position (e.g. as an `are` template cell) must be
+  quoted for the generated code to compile. Non-empty lists and other values
+  are returned unchanged — the caller can quote explicitly if needed."
+  [value]
+  (if (and (list? value) (empty? value))
+    `(quote ~value)
+    value))
+
+(defn- substitute-symbols
+  "Recursively replaces every occurrence of a key in `smap` within `form` with
+  its corresponding value, walking lists, vectors, hash-maps, and hash-sets.
+  Used by `are` to expand template cells at macro-expansion time rather than
+  let-binding them at runtime."
+  [smap form]
+  (cond
+    (contains? smap form) (quote-if-empty-list (get smap form))
+    (list? form) (apply list (map #(substitute-symbols smap %) form))
+    (vector? form) (apply vector (map #(substitute-symbols smap %) form))
+    (hash-map? form) (apply hash-map
+                            (interleave (keys form)
+                                        (map #(substitute-symbols smap %) (vals form))))
+    (set? form) (into (hash-set) (map #(substitute-symbols smap %) form))
+    :else form))
+
 (defmacro are
   "Checks multiple assertions with a template expression.
   `argv` is a vector of template variables, `expr` is the assertion template,
-  and the remaining `args` are partitioned by `(count argv)` to fill the template."
+  and the remaining `args` are partitioned by `(count argv)` to fill the template.
+  Template variables are substituted lexically at macro-expansion time, so
+  literal collection cells (e.g. `()`, `[]`, `{}`) are preserved as data and
+  are not evaluated as code."
   {:see-also ["is" "deftest" "testing"]
    :example "(are [x y] (= x y)\n  2 (+ 1 1)\n  4 (* 2 2))"}
   [argv expr & args]
   (let [n (count argv)
         groups (partition n args)
         assertions (for [group :in groups
-                         :let [bindings (vec (interleave argv group))]]
-                     `(let [~@bindings] (is ~expr)))]
+                         :let [smap (zipmap argv group)]]
+                     `(is ~(substitute-symbols smap expr)))]
     `(do ~@assertions)))
 
 ;; ---------------------

--- a/tests/phel/test/are.phel
+++ b/tests/phel/test/are.phel
@@ -120,3 +120,36 @@
         counts (get (get-stats) :counts)]
     (restore-stats saved)
     (is (= 0 (:total counts)) "no assertions generated")))
+
+;; ---------------------------------------------------------------------------
+;; Literal list cells — regression for #1280
+;; An empty list `()` in a template cell must not be evaluated as a call;
+;; cells are substituted into the expression template at macro-expansion time.
+;; Before the fix this threw "Value of type null is not callable" because `()`
+;; was bound in a runtime `let` and Phel cannot apply an empty list.
+;; ---------------------------------------------------------------------------
+
+(deftest test-are-empty-list-cell
+  (are [expected coll] (= expected coll)
+    () ()
+    () (list)))
+
+(deftest test-are-literal-list-cell
+  (are [expected coll] (= expected coll)
+    '(1 2 3) '(1 2 3)
+    '(:a :b) (list :a :b)))
+
+(deftest test-are-nested-literal-list-in-vector
+  ;; Vector cells must not trigger eager evaluation of the argv symbols they
+  ;; contain when the expression is expanded.
+  (are [expected coll] (= expected coll)
+    [[:x] 2] [[:x] 2]
+    [:a :b] [:a :b]))
+
+(deftest test-are-form-cell-still-evaluates
+  ;; A non-literal form like `(range 10)` in a cell must still evaluate at
+  ;; runtime — only the argv symbols are substituted, other lists are left
+  ;; alone so they compile as ordinary expressions.
+  (are [expected n coll] (= expected (vec (take-nth n coll)))
+    [0 2 4 6 8] 2 (range 10)
+    [] 2 nil))


### PR DESCRIPTION
## 🤔 Background

`phel\test/are` expanded each template row into a runtime `let`-binding, so any cell that was a list literal (e.g. `()`) was fed to the Phel evaluator and blew up with `Value of type null is not callable`. The repro from #1280:

```phel
(are [expected n coll] (= expected (take-nth n coll))
  (range 0 10 1) 1 (range 10)
  () 2 nil)
```

failed because the `()` cell ended up in `(let [expected ()] ...)` — Phel cannot apply an empty list. Clojure's `clojure.test/are` sidesteps this by delegating to `clojure.template/do-template`, which performs lexical substitution at macro-expansion time instead of binding cells at runtime.

## 💡 Goal

Align `are` with Clojure-style lexical template substitution so literal collection cells survive as data.

## 🔖 Changes

- Replace runtime `let`-binding with macro-expansion-time symbolic substitution: a small private `substitute-symbols` walker recurses through the template expression and swaps `argv` symbols for their cell values before the expression is handed to `is`. Keeps `phel\test` self-contained (no new dependency on `phel\walk`).
- Wrap an empty-list cell in `(quote ())` during substitution so the generated code compiles — Phel cannot evaluate `()` in value position, whereas `'()` is a valid literal. Non-empty lists (`(range 10)`, `'(1 2 3)`, etc.) are left untouched, so form cells continue to evaluate at runtime.
- Expand `tests/phel/test/are.phel` with regression cases:
  - `test-are-empty-list-cell` — the exact failing shape from #1280
  - `test-are-literal-list-cell` — `'(1 2 3)` / `(list :a :b)` cells
  - `test-are-nested-literal-list-in-vector` — vector cells with nested data
  - `test-are-form-cell-still-evaluates` — adapted #1280 repro with `(range 10)` as a cell, asserting that non-literal forms still evaluate
- Document the new semantics in the `are` docstring.
- `CHANGELOG.md`: add entry under `## Unreleased` → `### Fixed`.

Closes #1280