### PR TITLE
fix(lexer): allow trailing/mid quote in symbol names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.
 - `macroexpand` and `macroexpand-1` are now functions (were macros), matching Clojure semantics: quoted forms expand correctly (`(macroexpand '(when 1 2))` → `(if 1 (do 2))`), and unquoted forms evaluate eagerly (`(macroexpand (when 1 2))` → `2`) (#1209)
 - `macroexpand` no longer applies inline expansion to non-macro forms; `(macroexpand '(+ 1 2))` now correctly returns `(+ 1 2)` instead of `(do (assert-non-nil 1 2) (+ 1 2))` (#1208)
 - Lexer no longer swallows a reader conditional (`#?(...)`) following a gensym-suffixed symbol (e.g. `report-success# #?(:phel ...)`), which previously surfaced as a misleading "Unterminated list (BRACKETS)" parse error (#1195)
+- Lexer now accepts `'` inside and at the end of symbol names (e.g. `a'`, `foo''`, `a'b`), matching Clojure's convention where `'` denotes a "transformed" variant; leading `'` is still the quote reader macro (`'foo` → `(quote foo)`) (#1275)
 - Emit `php/...` calls to namespaced PHP functions (e.g. `php/Amp\File\write`) as fully qualified names so they resolve against the global namespace from compiled/cached files (#1180)
 
 ## [0.31.0](https://github.com/phel-lang/phel-lang/compare/v0.30.0...v0.31.0) - 2026-04-03

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -44,7 +44,7 @@ final class Lexer implements LexerInterface
         "(\|\()", // short fn (index: 18)
         '(#\()', // hash fn (index: 19)
         '("(?:[^"\\\\]++|\\\\.)*+")', // String (index: 20)
-        "([^\(\)\[\]\{\}',`@ \n\r\t\#]+\#?)", // Atom (index: 21), trailing # allowed for gensym syntax (e.g. foo#)
+        "([^\(\)\[\]\{\},`@ \n\r\t\#]+\#?)", // Atom (index: 21), trailing # allowed for gensym syntax (e.g. foo#); leading ' is claimed by the quote rule above so only mid/trailing ' reaches here (e.g. a', foo'')
         '(@)', // deref (index: 22)
         '(#"(?:[^"\\\\]++|\\\\.)*+")', // regex literal (index: 23)
         '(#\?\()', // reader conditional (index: 24 = T_READER_COND)

--- a/tests/phel/test/special-forms.phel
+++ b/tests/phel/test/special-forms.phel
@@ -12,3 +12,10 @@
 (deftest test-def-duplication
   (let [form (read-string "(do (def a \"first\") (def a \"second\") a)")]
     (is (= "second" (eval form)))))
+
+(deftest test-symbol-with-trailing-quote
+  (let [form (read-string "(let [a 1 a' (+ a 1) a'' (+ a' 1)] [a a' a''])")]
+    (is (= [1 2 3] (eval form)) "symbols may contain `'` in the middle and at the end")))
+
+(deftest test-leading-quote-still-quotes-symbol
+  (is (= 'foo (eval (read-string "'foo"))) "leading `'` is still the quote reader macro"))

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def a' 42)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "a\'",
+  42,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-trailing-quote-in-name.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-trailing-quote-in-name.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 11
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -526,6 +526,87 @@ final class LexerTest extends TestCase
         self::assertSame('#?(', $tokens[2]->getCode());
     }
 
+    public function test_atom_with_trailing_quote_is_single_token(): void
+    {
+        $tokens = $this->lex("a'");
+
+        self::assertSame(Token::T_ATOM, $tokens[0]->getType());
+        self::assertSame("a'", $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_atom_with_multiple_trailing_quotes(): void
+    {
+        $tokens = $this->lex("a''");
+
+        self::assertSame(Token::T_ATOM, $tokens[0]->getType());
+        self::assertSame("a''", $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_atom_with_interior_quote(): void
+    {
+        $tokens = $this->lex("a'b");
+
+        self::assertSame(Token::T_ATOM, $tokens[0]->getType());
+        self::assertSame("a'b", $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_leading_quote_still_quotes_symbol(): void
+    {
+        $tokens = $this->lex("'foo");
+
+        self::assertSame(Token::T_QUOTE, $tokens[0]->getType());
+        self::assertSame("'", $tokens[0]->getCode());
+        self::assertSame(Token::T_ATOM, $tokens[1]->getType());
+        self::assertSame('foo', $tokens[1]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[2]->getType());
+    }
+
+    public function test_leading_quote_on_list(): void
+    {
+        $tokens = $this->lex("'(1 2)");
+
+        self::assertSame(Token::T_QUOTE, $tokens[0]->getType());
+        self::assertSame("'", $tokens[0]->getCode());
+        self::assertSame(Token::T_OPEN_PARENTHESIS, $tokens[1]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[2]->getType());
+        self::assertSame('1', $tokens[2]->getCode());
+        self::assertSame(Token::T_WHITESPACE, $tokens[3]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[4]->getType());
+        self::assertSame('2', $tokens[4]->getCode());
+        self::assertSame(Token::T_CLOSE_PARENTHESIS, $tokens[5]->getType());
+        self::assertSame(Token::T_EOF, $tokens[6]->getType());
+    }
+
+    public function test_trailing_quote_in_def_list(): void
+    {
+        $tokens = $this->lex("(def a' 123)");
+
+        self::assertSame(Token::T_OPEN_PARENTHESIS, $tokens[0]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[1]->getType());
+        self::assertSame('def', $tokens[1]->getCode());
+        self::assertSame(Token::T_WHITESPACE, $tokens[2]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[3]->getType());
+        self::assertSame("a'", $tokens[3]->getCode());
+        self::assertSame(Token::T_WHITESPACE, $tokens[4]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[5]->getType());
+        self::assertSame('123', $tokens[5]->getCode());
+        self::assertSame(Token::T_CLOSE_PARENTHESIS, $tokens[6]->getType());
+        self::assertSame(Token::T_EOF, $tokens[7]->getType());
+    }
+
+    public function test_symbol_with_trailing_quote_and_hash(): void
+    {
+        // `a'#` — trailing hash still captured via the atom's `\#?` suffix.
+        $tokens = $this->lex("a'#");
+
+        self::assertSame(Token::T_ATOM, $tokens[0]->getType());
+        self::assertSame("a'#", $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
     private function lex(string $string): array
     {
         $lexer = $this->compilerFactory->createLexer();


### PR DESCRIPTION
## 🤔 Background

Phel's lexer rejected symbols containing `'` anywhere except as a leading reader macro. Clojure allows `'` inside and at the end of symbol names, and it's a common convention where `a'` denotes a "transformed" variant of `a`.

```
phel:1> (def a' 123)
Unterminated list
```

The atom regex in `Lexer::REGEXPS` excluded `'` from the valid-symbol character class, so `a'` tokenised as `T_ATOM("a")` + `T_QUOTE("'")`, leaving the list unterminated.

## 💡 Goal

Allow `'` inside and at the end of symbol names (matching Clojure) without breaking the leading quote reader macro (`'foo` → `(quote foo)`).

## 🔖 Changes

- Remove `'` from the negated character class in the atom regex in `src/php/Compiler/Application/Lexer.php`. The quote rule still matches earlier in the pattern order, so a **leading** `'` is always claimed by `T_QUOTE` first — only mid/trailing `'` now reaches the atom rule.
- Unit tests in `tests/php/Unit/Compiler/Lexer/LexerTest.php` covering:
  - `a'`, `a''`, `a'b` → single `T_ATOM`
  - `(def a' 123)` → full token sequence
  - Regression guards: `'foo` and `'(1 2)` still lex as `T_QUOTE` + atom/list
  - `a'#` still captures the gensym `#` suffix
- Integration fixture `tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test` for end-to-end `(def a' 42)` compilation.
- Phel-level tests in `tests/phel/test/special-forms.phel` exercising `let`-bound `a'`/`a''` and verifying the quote reader macro still works.
- `CHANGELOG.md` entry under `## Unreleased` → `### Fixed`.

Closes #1275