### PR TITLE
fix(parser): clamp negative hex/bin/oct overflow to PHP_INT_MIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix inside syntax-quote; use `name#` instead, matching Clojure's reader macro (#1203)
 
 ### Fixed
+- `-0x8000000000000000` (and equivalent `-0b...`, `-0o...` at 64-bit minimum) now parses correctly to the int `PHP_INT_MIN` instead of crashing with `ParseError: syntax error, unexpected floating-point number ".0"`; previously `hexdec` silently overflowed to a float, which the emitter then wrote as `-9223372036854775808.0` and PHP's own parser rejected (#1278)
 - `(php/yield ...)` in return position no longer emits `return yield ...;`, which broke PHP generator semantics (#793)
 - `phel run` no longer buffers output, so `println` and `print` flush immediately — fixes silent output in long-running processes like AMPHP servers (#793)
 - REPL `require` now supports dot namespace separator and Clojure aliasing, e.g. `(require phel.str)` and `(require clojure.str)` work correctly (#1263)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -76,6 +76,16 @@ final readonly class LiteralEmitter
 
     private function emitInt(int $x): void
     {
+        // PHP's own parser cannot represent PHP_INT_MIN as a literal: `-9223372036854775808`
+        // is parsed as `-(9223372036854775808)`, and the unsigned magnitude overflows int
+        // to a float, yielding `-9.2e18` instead of the expected int. Emit an expression
+        // that stays int-valued at evaluation time.
+        if ($x === PHP_INT_MIN) {
+            $this->outputEmitter->emitStr('(-9223372036854775807 - 1)');
+
+            return;
+        }
+
         $this->outputEmitter->emitStr((string) $x);
     }
 

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -16,6 +16,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
+use function is_float;
 use function sprintf;
 
 final readonly class AtomParser
@@ -123,7 +124,7 @@ final readonly class AtomParser
         $value = bindec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
-            $value = -$value;
+            $value = $this->normalizeNegativeOverflow(-$value);
         }
 
         return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
@@ -136,7 +137,7 @@ final readonly class AtomParser
         $value = hexdec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
-            $value = -$value;
+            $value = $this->normalizeNegativeOverflow(-$value);
         }
 
         return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
@@ -149,10 +150,26 @@ final readonly class AtomParser
         $value = octdec(str_replace('_', '', $unsignedInteger));
 
         if ($sign === -1) {
-            $value = -$value;
+            $value = $this->normalizeNegativeOverflow(-$value);
         }
 
         return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
+    }
+
+    /**
+     * When a bin/hex/oct literal equals the 64-bit minimum (e.g. `-0x8000000000000000`),
+     * `bindec`/`hexdec`/`octdec` silently overflow the unsigned magnitude to a float.
+     * Negating that float yields `(float) PHP_INT_MIN`, which the emitter then writes
+     * as `-9223372036854775808.0` — a literal PHP itself cannot parse. Clamp that
+     * single representable edge case back to the actual int `PHP_INT_MIN`.
+     */
+    private function normalizeNegativeOverflow(float|int $value): float|int
+    {
+        if (is_float($value) && $value === (float) PHP_INT_MIN) {
+            return PHP_INT_MIN;
+        }
+
+        return $value;
     }
 
     private function parseDecimalNumber(array $matches, string $word, Token $token): NumberNode

--- a/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
+++ b/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x -0x8000000000000000)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  (-9223372036854775807 - 1),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/negative-hex-int-min.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/negative-hex-int-min.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 27
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -258,6 +258,85 @@ final class AtomParserTest extends TestCase
         );
     }
 
+    /**
+     * Regression test for https://github.com/phel-lang/phel-lang/issues/1278
+     */
+    public function test_parse_negative_hexadecimal_php_int_min(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 19);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '-0x8000000000000000', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(PHP_INT_MIN, $node->getValue());
+    }
+
+    public function test_parse_negative_hexadecimal_max_positive_int(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 19);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '-0x7FFFFFFFFFFFFFFF', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(-PHP_INT_MAX, $node->getValue());
+    }
+
+    public function test_parse_negative_hexadecimal_32_bit_min(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 11);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '-0x80000000', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(-2147483648, $node->getValue());
+    }
+
+    /**
+     * Regression test for https://github.com/phel-lang/phel-lang/issues/1278
+     */
+    public function test_parse_negative_binary_php_int_min(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 67);
+        $node = $parser->parse(
+            new Token(
+                Token::T_ATOM,
+                '-0b1000000000000000000000000000000000000000000000000000000000000000',
+                $start,
+                $end,
+            ),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(PHP_INT_MIN, $node->getValue());
+    }
+
+    /**
+     * Regression test for https://github.com/phel-lang/phel-lang/issues/1278
+     */
+    public function test_parse_negative_octal_php_int_min(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 24);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '-01000000000000000000000', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(PHP_INT_MIN, $node->getValue());
+    }
+
     public function test_parse_numeric_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());


### PR DESCRIPTION
## 🤔 Background

`-0x8000000000000000` (PHP_INT_MIN as a hex literal) crashed at the PHP parsing phase with:

```
ParseError: syntax error, unexpected floating-point number ".0", expecting ";"
```

The same bug affected the equivalent negative binary (`-0b1000…`, 64 ones) and octal (`-01000000000000000000000`) literals. Meanwhile, `-0x7FFFFFFFFFFFFFFF`, `0x7FFFFFFFFFFFFFFF`, and `php/PHP_INT_MIN` all worked fine — reported in #1278.

Two compounding causes lived on the compiler path:

1. `AtomParser::parseHexadecimalNumber` (and its binary/octal siblings) used `hexdec`/`bindec`/`octdec`, which silently overflow the unsigned magnitude `0x8000000000000000` to a float. Negating that float gave `(float) PHP_INT_MIN`, so the `NumberNode` stored a float instead of an int.
2. Even after forcing an int, `LiteralEmitter::emitInt` emitted `-9223372036854775808` — a literal PHP itself cannot parse as an int: PHP parses it as `-(9223372036854775808)`, where the unsigned magnitude overflows positive int to a float, flipping the whole expression to `-9.22e18`.

## 💡 Goal

Make `-0x8000000000000000` (and `-0b…`/`-0o…` equivalents) parse and emit as the actual int `PHP_INT_MIN`, without special-casing any other value. Closes #1278.

## 🔖 Changes

- `src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php`: extracted a shared `normalizeNegativeOverflow()` helper used by `parseBinaryNumber`, `parseHexadecimalNumber`, and `parseOctalNumber`. It clamps the single overflow edge case (`(float) PHP_INT_MIN` after negation) back to the int `PHP_INT_MIN`. Positive overflow is untouched — it remains a float as before.
- `src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php`: `emitInt()` now emits `PHP_INT_MIN` as `(-9223372036854775807 - 1)` so the compiled PHP stays int-valued at runtime. Every other int is emitted unchanged.
- `tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php`: added five tests — `test_parse_negative_hexadecimal_php_int_min`, `test_parse_negative_hexadecimal_max_positive_int`, `test_parse_negative_hexadecimal_32_bit_min`, `test_parse_negative_binary_php_int_min`, `test_parse_negative_octal_php_int_min`.
- `tests/php/Integration/Fixtures/Def/negative-hex-int-min.test`: integration fixture compiling `(def x -0x8000000000000000)` through the full pipeline and asserting the exact emitted PHP.
- `CHANGELOG.md`: entry under `## Unreleased → ### Fixed` referencing #1278.