### PR TITLE
feat(parser): add radix number literals (NrXXX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `amphp/amp` promoted to a runtime dependency so `phel\async` works out of the box (including from the PHAR), without requiring consumers to install it separately (#793)
 
 #### Reader & Compiler
+- Clojure-style radix number literals: `NrXXX` where `N` is the base (2–36) and `XXX` are digits valid for that base, case-insensitive for bases > 10 (e.g. `2r1111` = 15, `16rFF` = 255, `36rZZ` = 1295). Negative form `-2r1111` also supported (#1281)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
 - Accept `.` as an alternate namespace separator in `(ns ...)`, `(in-ns ...)`, `:require`, and `:use` forms, enabling Clojure-style namespaces (e.g. `(ns my.cljc.file)`) for `.cljc` interop (#1177)
 - Accept Clojure-style vector entries in `:require`, e.g. `(:require [phel\str :as s :refer [upper-case]])`, including multiple vector entries in a single `:require` clause, for `.cljc` interop (#1183)

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -17,7 +17,9 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function is_float;
+use function ord;
 use function sprintf;
+use function strlen;
 
 final readonly class AtomParser
 {
@@ -28,6 +30,8 @@ final readonly class AtomParser
     private const string REGEX_HEXADECIMAL_NUMBER = '/^([+-])?0[xX]([0-9a-fA-F]+(?:_[0-9a-fA-F]+)*)$/';
 
     private const string REGEX_OCTAL_NUMBER = '/^([+-])?0([0-7]+(?:_[0-7]+)*)$/';
+
+    private const string REGEX_RADIX_NUMBER = '/^([+-])?(2|[3-9]|[12]\d|3[0-6])[rR]([0-9a-zA-Z]+(?:_[0-9a-zA-Z]+)*)$/';
 
     private const string REGEX_DECIMAL_NUMBER = '/^(?:([+-])?\d+(_\d+)*[\.(_\d+]?|0)$/';
 
@@ -63,6 +67,12 @@ final readonly class AtomParser
 
         if (preg_match(self::REGEX_OCTAL_NUMBER, $word, $matches)) {
             return $this->parseOctalNumber($matches, $word, $token);
+        }
+
+        if (preg_match(self::REGEX_RADIX_NUMBER, $word, $matches)
+            && $this->isValidDigitsForBase($matches[3], (int) $matches[2])
+        ) {
+            return $this->parseRadixNumber($matches, $word, $token);
         }
 
         if (is_numeric($word)) {
@@ -154,6 +164,59 @@ final readonly class AtomParser
         }
 
         return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
+    }
+
+    /**
+     * Parses Clojure-style radix literals of the form `NrXXX` where `N` is the
+     * base (2–36) and `XXX` are digits valid for that base (case-insensitive
+     * for bases greater than 10). Examples: `2r1111`, `16rFF`, `36rZZ`.
+     */
+    private function parseRadixNumber(array $matches, string $word, Token $token): NumberNode
+    {
+        $sign = (isset($matches[1]) && $matches[1] === '-') ? -1 : 1;
+        $base = (int) $matches[2];
+        $digits = str_replace('_', '', (string) $matches[3]);
+
+        // `base_convert` returns a string; for values that fit, this is the
+        // decimal integer representation. For values that overflow PHP_INT_MAX
+        // it falls back to a scientific-notation string (cast to float below).
+        $decimal = base_convert($digits, $base, 10);
+        $value = str_contains($decimal, '.') || str_contains($decimal, 'E')
+            ? (float) $decimal
+            : (int) $decimal;
+
+        if ($sign === -1) {
+            $value = $this->normalizeNegativeOverflow(-$value);
+        }
+
+        return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
+    }
+
+    /**
+     * Explicit per-digit validation against the base. `base_convert` is
+     * permissive: it silently treats out-of-range digits as zero, so we must
+     * reject them ourselves to keep the radix parser strict.
+     */
+    private function isValidDigitsForBase(string $digits, int $base): bool
+    {
+        $digits = strtolower(str_replace('_', '', $digits));
+        $length = strlen($digits);
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $digits[$i];
+            if ($char >= '0' && $char <= '9') {
+                $digitValue = ord($char) - ord('0');
+            } elseif ($char >= 'a' && $char <= 'z') {
+                $digitValue = ord($char) - ord('a') + 10;
+            } else {
+                return false;
+            }
+
+            if ($digitValue >= $base) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -165,3 +165,15 @@
   (is (= 1337 02471) "octal number")
   (is (= 1337 024_71) "octal number with underscores")
   (is (= 1337 1_337) "decimal number with underscores"))
+
+(deftest test-radix-literals
+  (is (= 15 2r1111) "base 2")
+  (is (= 15 2R1111) "uppercase radix marker")
+  (is (= 511 8r777) "base 8")
+  (is (= 255 16rFF) "base 16 uppercase")
+  (is (= 255 16rff) "base 16 lowercase")
+  (is (= 35 36rZ) "base 36 single digit")
+  (is (= 1295 36rZZ) "base 36 two digits")
+  (is (= -15 -2r1111) "negative radix literal")
+  (is (= 15 +2r1111) "explicit positive radix literal")
+  (is (= 240 2r1111_0000) "radix literal with underscores"))

--- a/tests/php/Integration/Fixtures/Def/radix-binary.test
+++ b/tests/php/Integration/Fixtures/Def/radix-binary.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x 2r1111)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  15,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-binary.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-binary.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 14
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/radix-hex.test
+++ b/tests/php/Integration/Fixtures/Def/radix-hex.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x 16rFF)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  255,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-hex.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-hex.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 13
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/radix-negative.test
+++ b/tests/php/Integration/Fixtures/Def/radix-negative.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x -2r1111)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  -15,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-negative.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/radix-negative.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 15
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -409,6 +409,151 @@ final class AtomParserTest extends TestCase
         );
     }
 
+    public function test_parse_binary_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 6);
+        $node = $parser->parse(new Token(Token::T_ATOM, '2r1111', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(15, $node->getValue());
+    }
+
+    public function test_parse_octal_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+        $node = $parser->parse(new Token(Token::T_ATOM, '8r777', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(511, $node->getValue());
+    }
+
+    public function test_parse_hexadecimal_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+        $node = $parser->parse(new Token(Token::T_ATOM, '16rFF', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(255, $node->getValue());
+    }
+
+    public function test_parse_base_36_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 4);
+        $node = $parser->parse(new Token(Token::T_ATOM, '36rZ', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(35, $node->getValue());
+    }
+
+    public function test_parse_base_36_double_digit_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+        $node = $parser->parse(new Token(Token::T_ATOM, '36rZZ', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(1295, $node->getValue());
+    }
+
+    public function test_parse_radix_number_is_case_insensitive(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 5);
+
+        $lower = $parser->parse(new Token(Token::T_ATOM, '16rff', $start, $end));
+        $upper = $parser->parse(new Token(Token::T_ATOM, '16rFF', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $lower);
+        self::assertInstanceOf(NumberNode::class, $upper);
+        self::assertSame(255, $lower->getValue());
+        self::assertSame(255, $upper->getValue());
+    }
+
+    public function test_parse_uppercase_radix_marker(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 6);
+        $node = $parser->parse(new Token(Token::T_ATOM, '2R1111', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(15, $node->getValue());
+    }
+
+    public function test_parse_negative_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 7);
+        $node = $parser->parse(new Token(Token::T_ATOM, '-2r1111', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(-15, $node->getValue());
+    }
+
+    public function test_parse_positive_signed_radix_number(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 7);
+        $node = $parser->parse(new Token(Token::T_ATOM, '+2r1111', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(15, $node->getValue());
+    }
+
+    public function test_parse_radix_number_with_underscores(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 11);
+        $node = $parser->parse(new Token(Token::T_ATOM, '2r1111_0000', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(240, $node->getValue());
+    }
+
+    public function test_parse_radix_number_with_leading_zero(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 6);
+        $node = $parser->parse(new Token(Token::T_ATOM, '8r0777', $start, $end));
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(511, $node->getValue());
+    }
+
+    public function test_invalid_digit_for_base_falls_through_to_symbol(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 3);
+        $node = $parser->parse(new Token(Token::T_ATOM, '2r2', $start, $end));
+
+        self::assertInstanceOf(SymbolNode::class, $node);
+    }
+
+    public function test_base_greater_than_36_not_matched(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 4);
+        $node = $parser->parse(new Token(Token::T_ATOM, '37r0', $start, $end));
+
+        self::assertInstanceOf(SymbolNode::class, $node);
+    }
+
     public function test_parse_symbol(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());


### PR DESCRIPTION
## 🤔 Background

Clojure supports `NrXXX` radix number literals — an integer written in a base `N` between 2 and 36 followed by the letter `r` and the digits for that base. For example, `2r1111` = 15, `16rFF` = 255, `36rZZ` = 1295.

Phel currently rejects these literals with `[PHEL001] Cannot resolve symbol '2r1111'` because the lexer tokenises `2r1111` as a single `T_ATOM`, and the atom parser has no matching number regex — so it falls through to the symbol path and fails to resolve.

Closes #1281

## 💡 Goal

Let Phel parse and evaluate Clojure-style radix literals, bringing it closer in line with Clojure's reader and enabling `.cljc` interop for numeric code that uses this form.

## 🔖 Changes

- `AtomParser` gains a `REGEX_RADIX_NUMBER` constant and a `parseRadixNumber` method, wired in between the octal and decimal dispatch in `parse()`
- Digits are validated explicitly against the base (`isValidDigitsForBase`) because `php`'s `base_convert` silently coerces out-of-range digits, which would otherwise accept garbage like `2r2`
- Case-insensitive radix marker (`2r1111` and `2R1111` both work) and case-insensitive digits for bases > 10 (`16rff` = `16rFF` = 255)
- Negative form `-2r1111` and explicit positive form `+2r1111` both supported; `normalizeNegativeOverflow` is reused for the PHP_INT_MIN edge case
- Underscores allowed as digit separators (e.g. `2r1111_0000` = 240), matching the style of the existing binary/hex/octal parsers
- Unit tests cover every edge case: base 2/8/16/36, upper/lowercase radix marker, case-insensitive digits, negative and positive signs, underscores, leading zeros, invalid-digit fall-through, and the base > 36 rejection
- Integration fixtures under `tests/php/Integration/Fixtures/Def/` exercise end-to-end compilation for `2r1111`, `16rFF`, and `-2r1111`
- Phel-level `test-radix-literals` added to `math-operation.phel` alongside the existing underscore-literal tests
- `CHANGELOG.md` entry under `Unreleased → Reader & Compiler`