### PR TITLE
feat(analyzer): accept optional name in fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `amphp/amp` promoted to a runtime dependency so `phel\async` works out of the box (including from the PHAR), without requiring consumers to install it separately (#793)
 
 #### Reader & Compiler
+- `fn` accepts an optional name symbol as the first argument (e.g. `(fn my-name [x] x)` and `(fn my-name ([x] ...) ([x y] ...))`), matching Clojure's `(fn name? ...)` signature for `.cljc` interop. The name is currently discarded (not bound in the body); self-binding for named-fn recursion is deferred to a follow-up (#1279)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
 - Accept `.` as an alternate namespace separator in `(ns ...)`, `(in-ns ...)`, `:require`, and `:use` forms, enabling Clojure-style namespaces (e.g. `(ns my.cljc.file)`) for `.cljc` interop (#1177)
 - Accept Clojure-style vector entries in `:require`, e.g. `(:require [phel\str :as s :refer [upper-case]])`, including multiple vector entries in a single `:require` clause, for `.cljc` interop (#1183)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -23,9 +23,13 @@ use function array_slice;
 use function count;
 
 /**
- * (fn [params] body).
+ * (fn name? [params] body) or (fn name? ([params] body)+).
  *
- * Creates an anonymous function (closure).
+ * Creates an anonymous function (closure). The optional name symbol
+ * (Clojure-style `(fn name ...)`) is accepted for `.cljc` interop but is
+ * currently discarded — it is not bound in the function body. Full
+ * Clojure-style self-binding for named-fn recursion is tracked as a
+ * follow-up to #1279.
  */
 final readonly class FnSymbol implements SpecialFormAnalyzerInterface
 {
@@ -39,6 +43,8 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         if (count($list) < 2) {
             throw AnalyzerException::withLocation("'fn requires at least one argument", $list);
         }
+
+        $list = $this->stripOptionalName($list);
 
         $second = $list->get(1);
         if ($second instanceof PersistentVectorInterface) {
@@ -82,6 +88,35 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         }
 
         return new MultiFnNode($env, $fnNodes, $list->getStartLocation());
+    }
+
+    /**
+     * Clojure's `fn` allows an optional leading name symbol:
+     *   `(fn name? [params] body)` or `(fn name? ([params] body)+)`.
+     *
+     * Phel accepts the name for `.cljc` interop but currently discards it —
+     * the compiled closure is anonymous, identical to the unnamed form. This
+     * strips the name up front so the rest of the pipeline is unchanged. The
+     * rebuilt list reuses the source location of the original so error
+     * reporting still points at the user's form.
+     */
+    private function stripOptionalName(PersistentListInterface $list): PersistentListInterface
+    {
+        if (!($list->get(1) instanceof Symbol)) {
+            return $list;
+        }
+
+        $elements = [];
+        $count = count($list);
+        for ($i = 0; $i < $count; ++$i) {
+            if ($i === 1) {
+                continue;
+            }
+
+            $elements[] = $list->get($i);
+        }
+
+        return Phel::list($elements)->copyLocationFrom($list);
     }
 
     private function analyzeSingle(PersistentListInterface $list, NodeEnvironmentInterface $env): FnNode

--- a/tests/phel/test/multi-arity-fn.phel
+++ b/tests/phel/test/multi-arity-fn.phel
@@ -21,3 +21,15 @@
   (is (= [1 2 []] (f-var-dis 1 2)) "two args no rest")
   (is (= [1 2 [3 4]] (f-var-dis 1 2 3 4)) "variadic with rest")
   (is (thrown? \InvalidArgumentException (f-var-dis)) "no matching arity"))
+
+(deftest named-fn-single-arity
+  (is (= 42 ((fn foo [x] x) 42)) "named single-arity fn")
+  (is (= 42 ((fn foo [] 42))) "named zero-arity fn"))
+
+(deftest named-fn-multi-arity
+  (is (= [1 2] ((fn foo ([x] x) ([x y] [x y])) 1 2)) "named multi-arity two-arg")
+  (is (= 1 ((fn foo ([x] x) ([x y] [x y])) 1)) "named multi-arity one-arg"))
+
+(deftest named-fn-variadic
+  (is (= [2 3] ((fn foo [x & xs] xs) 1 2 3)) "named variadic collects rest")
+  (is (= [] ((fn foo [x & xs] xs) 1)) "named variadic with no rest"))

--- a/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
@@ -1,0 +1,28 @@
+--PHEL--
+(fn foo ([x] x) ([x y] y))
+--PHP--
+new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "";
+  private $fn0;
+  private $fn1;
+
+  public function __construct() {
+    $this->fn0 = (function($x) {
+      return $x;
+    });;
+    $this->fn1 = (function($x, $y) {
+      return $y;
+    });;
+  }
+
+  public function __invoke(...$args) {
+    $argc = \count($args);
+    switch ($argc) {
+      case 1:
+        return ($this->fn0)($args[0]);
+      case 2:
+        return ($this->fn1)($args[0], $args[1]);
+      }
+      throw new \InvalidArgumentException("No matching function arity");
+    }
+  };

--- a/tests/php/Integration/Fixtures/Fn/fn-named-single-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-single-arity.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn foo [x] x)
+--PHP--
+(function($x) {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-named-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-variadic.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn foo [x & xs] xs)
+--PHP--
+(function($x, ...$xs) {
+  $xs = \Phel::vector($xs);
+  return $xs;
+});

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/FnSymbolTest.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
@@ -58,10 +59,12 @@ final class FnSymbolTest extends TestCase
         $this->expectException(AbstractLocatedException::class);
         $this->expectExceptionMessage("Second argument of 'fn must be a vector");
 
-        // This is the same as: (fn anything)
+        // This is the same as: (fn 42) — a leading non-Symbol, non-vector,
+        // non-list form should still be rejected. (A leading Symbol would be
+        // accepted as the optional Clojure-style name.)
         $list = Phel::list([
             Symbol::create(Symbol::NAME_FN),
-            Symbol::create('anything'),
+            42,
         ]);
 
         $this->analyze($list);
@@ -347,6 +350,114 @@ final class FnSymbolTest extends TestCase
         self::assertInstanceOf(PhpNewNode::class, $exceptionExpr);
         self::assertInstanceOf(LiteralNode::class, $exceptionExpr->getClassExpr());
         self::assertSame(RuntimeException::class, $exceptionExpr->getClassExpr()->getValue());
+    }
+
+    public function test_named_single_arity_fn_is_analyzed_as_unnamed(): void
+    {
+        // (fn foo [x] x)
+        $namedList = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Symbol::create('foo'),
+            Phel::vector([Symbol::create('x')]),
+            Symbol::create('x'),
+        ]);
+
+        // (fn [x] x)
+        $unnamedList = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Phel::vector([Symbol::create('x')]),
+            Symbol::create('x'),
+        ]);
+
+        $named = $this->analyze($namedList);
+        $unnamed = $this->analyze($unnamedList);
+
+        self::assertInstanceOf(FnNode::class, $named);
+        self::assertEquals($unnamed->getParams(), $named->getParams());
+        self::assertSame($unnamed->isVariadic(), $named->isVariadic());
+    }
+
+    public function test_named_multi_arity_fn_is_analyzed_as_unnamed(): void
+    {
+        // (fn foo ([x] x) ([x y] y))
+        $namedList = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Symbol::create('foo'),
+            Phel::list([
+                Phel::vector([Symbol::create('x')]),
+                Symbol::create('x'),
+            ]),
+            Phel::list([
+                Phel::vector([Symbol::create('x'), Symbol::create('y')]),
+                Symbol::create('y'),
+            ]),
+        ]);
+
+        $node = (new FnSymbol($this->analyzer))->analyze($namedList, NodeEnvironment::empty());
+
+        self::assertInstanceOf(MultiFnNode::class, $node);
+        self::assertCount(2, $node->getFnNodes());
+        self::assertSame(1, $node->getMinArity());
+    }
+
+    public function test_named_zero_arity_fn(): void
+    {
+        // (fn foo [] 42)
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Symbol::create('foo'),
+            Phel::vector([]),
+            42,
+        ]);
+
+        $node = $this->analyze($list);
+
+        self::assertInstanceOf(FnNode::class, $node);
+        self::assertSame([], $node->getParams());
+        self::assertFalse($node->isVariadic());
+    }
+
+    public function test_named_variadic_fn(): void
+    {
+        // (fn foo [x & xs] xs)
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Symbol::create('foo'),
+            Phel::vector([
+                Symbol::create('x'),
+                Symbol::create('&'),
+                Symbol::create('xs'),
+            ]),
+            Symbol::create('xs'),
+        ]);
+
+        $node = $this->analyze($list);
+
+        self::assertInstanceOf(FnNode::class, $node);
+        self::assertTrue($node->isVariadic());
+        self::assertEquals(
+            [Symbol::create('x'), Symbol::create('xs')],
+            $node->getParams(),
+        );
+    }
+
+    public function test_name_shadowing_core_fn_is_still_accepted(): void
+    {
+        // (fn map [x] x) — name is discarded, not resolved against core defs.
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_FN),
+            Symbol::create('map'),
+            Phel::vector([Symbol::create('x')]),
+            Symbol::create('x'),
+        ]);
+
+        $node = $this->analyze($list);
+
+        self::assertInstanceOf(FnNode::class, $node);
+        self::assertEquals(
+            [Symbol::create('x')],
+            $node->getParams(),
+        );
     }
 
     private function analyze(PersistentListInterface $list): AbstractNode


### PR DESCRIPTION
## 🤔 Background

Clojure's `fn` special form accepts an optional leading name symbol:
`(fn name? [params] body)` and `(fn name? ([params] body)+)`. The name is used
for documentation, debugging, and — in Clojure — to enable self-recursive
reference inside the function body. Phel rejected this syntax outright:

```
phel:1> (fn add [a b] (+ a b))
Second argument of 'fn must be a vector
```

This blocks `.cljc` interop (the cross-dialect Clojure/ClojureScript file
format), because those files routinely use named-fn syntax — e.g. `(fn fact
[...] ...)` — even where the name is purely cosmetic.

Closes #1279

## 💡 Goal

Accept Clojure-style named `fn` so `.cljc` files that rely on the syntax
compile without error, while keeping the fix minimal and non-invasive.

## 🔖 Changes

- `FnSymbol::analyze` now detects an optional leading `Symbol` at index 1 and
  strips it from the list before delegating to the existing single- and
  multi-arity paths. Because the rest of the pipeline is unchanged,
  `(fn name ([x] ...) ([x y] ...))` just becomes `(fn ([x] ...) ([x y] ...))`
  — multi-arity handling falls out for free, no duplication.
- The rebuilt list reuses the original source location (via
  `copyLocationFrom`) so error reporting still points at the user's form.
- **The name is currently discarded**, not bound inside the body. The
  compiled closure is byte-for-byte identical to the unnamed equivalent —
  that's the regression guarantee and it's covered by the new integration
  fixtures. **Full Clojure-style self-binding for named-fn recursion
  (`(fn fact [n] (fact (dec n)))`) is explicitly out of scope here and
  deferred to a follow-up issue** — it needs an emitter change
  (`$name = function (...) use (&$name) { ... };` or equivalent) and is a
  meaningful design call. A user writing such self-recursive named-fn code
  with this PR will get a clear "cannot resolve symbol" error at compile
  time rather than silent breakage.
- Unit tests in `FnSymbolTest` covering: named single-arity (equivalence
  with unnamed), named multi-arity, named zero-arity, named variadic, and
  name-shadowing-a-core-fn (name is discarded, not resolved).
- Integration fixtures `fn-named-single-arity.test`,
  `fn-named-multi-arity.test`, and `fn-named-variadic.test` — the expected
  `--PHP--` blocks are identical to their unnamed counterparts.
- Phel-level end-to-end tests in `tests/phel/test/multi-arity-fn.phel`
  exercising named single-arity, multi-arity, variadic, and zero-arity
  invocation.
- `CHANGELOG.md` entry under `Unreleased → Added → Reader & Compiler`.