### PR TITLE
feat(lexer): Clojure-style ##Inf/##NaN literals and #tag dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - `amphp/amp` promoted to a runtime dependency so `phel\async` works out of the box (including from the PHAR), without requiring consumers to install it separately (#793)
 
 #### Reader & Compiler
+- Clojure-style symbolic number literals `##Inf`, `##-Inf`, `##NaN` matching PHP's `INF`, `-INF`, `NAN` for `.cljc` interop (#1276)
+- Generic `#<tag>` tagged-literal dispatch (e.g. `#cpp`, `#uuid`, `#inst`) — the tag and the following form are read as a `TaggedLiteralNode`. Unknown tags in unselected `#?` reader-conditional branches parse without error (enabling `.cljc` files that use foreign tags like `#cpp` inside non-`:phel` branches); unknown tags in selected branches raise a clear reader error (#1277)
 - `fn` accepts an optional name symbol as the first argument (e.g. `(fn my-name [x] x)` and `(fn my-name ([x] ...) ([x y] ...))`), matching Clojure's `(fn name? ...)` signature for `.cljc` interop. The name is currently discarded (not bound in the body); self-binding for named-fn recursion is deferred to a follow-up (#1279)
 - Clojure-style radix number literals: `NrXXX` where `N` is the base (2–36) and `XXX` are digits valid for that base, case-insensitive for bases > 10 (e.g. `2r1111` = 15, `16rFF` = 255, `36rZZ` = 1295). Negative form `-2r1111` also supported (#1281)
 - Dot namespace separator and Clojure aliasing for fully qualified names, enabling `phel.core/fn`, `clojure.core/fn` in code (#1251)
@@ -76,8 +78,10 @@ All notable changes to this project will be documented in this file.
 - Migrate all Phel source and test files from `|(...)` to `#(...)` short function syntax
 - Migrate all in-repo Phel source, tests, and docs from `,` / `,@` to `~` / `~@` for `unquote` / `unquote-splicing` (#1203)
 - Migrate `time` macro in `phel\core` from `name$` to `name#` auto-gensym suffix (#1203)
+- Migrated internal `tests/phel/` usage of the deprecated `#|...|#` multiline comment syntax to `;;` line comments (#1276)
 
 ### Deprecated
+- `#|...|#` multiline comments and bare `#` line comments are deprecated (have been since v0.30 but are now announced for removal). Use `;;` for line comments and `#_` to skip a single form. Removal planned for Phel v0.33 (#1276)
 - `var` → `atom`, `var?` → `atom?`, `set!` → `reset!` (#1252)
 - `id` → `identical?` (#1252)
 - `function?` → `fn?`, `hash-map?` → `map?` (#1252)

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -28,7 +28,7 @@ final class Lexer implements LexerInterface
         "([ \t]+)", // Whitespace (index: 2)
         "(\r?\n)", // Newline (index: 3)
         '(#_)', // Inline comment (index: 4)
-        "(#(?![_{\\|(\x22?])[^\n]*\n?|;[^\n]*\n?)", // Comment (# or ; excludes #_ #{ #( #" #?) (index: 5)
+        "(#(?![_{\\|(\x22?#a-zA-Z])[^\n]*\n?|;[^\n]*\n?)", // Comment (# or ; excludes #_ #{ #( #" #? ## #<letter>) (index: 5)
         '(#\{)', // open hash brace (index: 6)
         '(,@|~@)', // unquote-splicing (index: 7), accepts `,@` or Clojure-style `~@`
         "(\()", // open parenthesis (index: 8)
@@ -49,6 +49,8 @@ final class Lexer implements LexerInterface
         '(#"(?:[^"\\\\]++|\\\\.)*+")', // regex literal (index: 23)
         '(#\?\()', // reader conditional (index: 24 = T_READER_COND)
         '(#\?@\()', // reader conditional splicing (index: 25 = T_READER_COND_SPLICING)
+        '(##(?:-?Inf|NaN)(?![A-Za-z0-9_\-]))', // symbolic number literal (index: 26 = T_SYMBOLIC_NUMBER) - Clojure-style ##Inf, ##-Inf, ##NaN
+        '(#[A-Za-z][A-Za-z0-9_\-]*)', // tagged literal start (index: 27 = T_TAGGED_LITERAL) - e.g. #cpp, #uuid, #inst
     ];
 
     private const string MULTILINE_COMMENT_BEGIN = '#|';
@@ -98,7 +100,7 @@ final class Lexer implements LexerInterface
                 $endLocation = $this->createSourceLocation($source);
 
                 @trigger_error(
-                    sprintf('Using "#| |#" for multiline comments is deprecated, use "(comment ...)" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                    sprintf('"#| ... |#" multiline comments are deprecated and will be removed in Phel v0.33. Use ";;" for line comments or "#_" to skip a single form (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
                     E_USER_DEPRECATED,
                 );
 
@@ -115,7 +117,7 @@ final class Lexer implements LexerInterface
 
                 if ($tokenType === Token::T_COMMENT && str_starts_with($matches[0], '#')) {
                     @trigger_error(
-                        sprintf('Using "#" for line comments is deprecated, use ";" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
+                        sprintf('Bare "#" line comments are deprecated and will be removed in Phel v0.33. Use ";" or ";;" instead (at %s:%d:%d)', $source, $startLocation->getLine(), $startLocation->getColumn()),
                         E_USER_DEPRECATED,
                     );
                 }

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -23,9 +23,11 @@ use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\MetaNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NewlineNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\NumberNode;
 use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 use Phel\Compiler\Domain\Parser\ParserNode\ReaderCondSplicingNode;
 use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\WhitespaceNode;
 
@@ -45,6 +47,8 @@ final readonly class Parser implements ParserInterface
         Token::T_REGEX,
         Token::T_READER_COND,
         Token::T_READER_COND_SPLICING,
+        Token::T_SYMBOLIC_NUMBER,
+        Token::T_TAGGED_LITERAL,
     ];
 
     private SplStack $quasiquoteStack;
@@ -158,6 +162,8 @@ final readonly class Parser implements ParserInterface
                 Token::T_CARET => $this->parseMetaNode($tokenStream),
                 Token::T_READER_COND => $this->parseReaderCondNode($tokenStream, $token),
                 Token::T_READER_COND_SPLICING => $this->parseReaderCondSplicingNode($tokenStream, $token),
+                Token::T_SYMBOLIC_NUMBER => $this->parseSymbolicNumberNode($token),
+                Token::T_TAGGED_LITERAL => $this->parseTaggedLiteralNode($tokenStream, $token),
                 Token::T_EOF => throw $this->createUnfinishedParserException($tokenStream, $token, 'Unterminated list (EOF)'),
                 default => throw $this->createUnexceptedParserException($tokenStream, $token, 'Unhandled syntax token: ' . $token->getCode()),
             };
@@ -202,6 +208,51 @@ final readonly class Parser implements ParserInterface
         } while ($ignored instanceof TriviaNodeInterface);
 
         return new CommentMacroNode($ignored, $token->getStartLocation());
+    }
+
+    /**
+     * Produces a NumberNode with value PHP INF/-INF/NAN from a symbolic
+     * number literal token (`##Inf`, `##-Inf`, `##NaN`). The lexer only
+     * emits these three exact forms, so no other code paths are reachable.
+     */
+    private function parseSymbolicNumberNode(Token $token): NumberNode
+    {
+        $value = match ($token->getCode()) {
+            '##-Inf' => -INF,
+            '##NaN' => NAN,
+            default => INF, // '##Inf'
+        };
+
+        return new NumberNode(
+            $token->getCode(),
+            $token->getStartLocation(),
+            $token->getEndLocation(),
+            $value,
+        );
+    }
+
+    /**
+     * @throws UnexpectedParserException
+     * @throws UnfinishedParserException
+     */
+    private function parseTaggedLiteralNode(TokenStream $tokenStream, Token $token): TaggedLiteralNode
+    {
+        // Tag name is everything after the leading '#'
+        $tag = substr($token->getCode(), 1);
+
+        // The stream is already past the tag token at this point because
+        // T_TAGGED_LITERAL is in TOKENS_THAT_SHOULD_STREAM_NEXT.
+        // Read the next non-trivia form as the tagged value.
+        do {
+            $form = $this->readExpression($tokenStream);
+        } while ($form instanceof TriviaNodeInterface);
+
+        return new TaggedLiteralNode(
+            $tag,
+            $form,
+            $token->getStartLocation(),
+            $form->getEndLocation(),
+        );
     }
 
     /**

--- a/src/php/Compiler/Application/Reader.php
+++ b/src/php/Compiler/Application/Reader.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\MetaNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Phel\Compiler\Domain\Parser\ReadModel\ReaderResult;
@@ -23,6 +24,8 @@ use Phel\Lang\MetaInterface;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use RuntimeException;
+
+use function sprintf;
 
 final class Reader implements ReaderInterface
 {
@@ -82,6 +85,22 @@ final class Reader implements ReaderInterface
 
         if ($node instanceof MetaNode) {
             return $this->readMetaNode($node, $root);
+        }
+
+        // Phel does not (yet) register any tagged-literal handlers. Reaching
+        // this point means a `#<tag>` form survived parsing in a code path
+        // that is actually emitted — i.e. the selected `#?` branch or
+        // top-level code. Unselected branches of `#?` are discarded by the
+        // parser, so unknown tags inside `:jank`/`:clj`/... never reach here.
+        if ($node instanceof TaggedLiteralNode) {
+            throw ReaderException::forNode(
+                $node,
+                $root,
+                sprintf(
+                    "Unknown tagged literal '#%s'. Phel has no built-in handler for this tag; it may only appear inside a non-selected reader-conditional branch (e.g. :clj, :jank).",
+                    $node->getTag(),
+                ),
+            );
         }
 
         throw ReaderException::forNode($node, $root, 'Unterminated list');

--- a/src/php/Compiler/Domain/Lexer/Token.php
+++ b/src/php/Compiler/Domain/Lexer/Token.php
@@ -56,6 +56,10 @@ final readonly class Token
 
     public const int T_READER_COND_SPLICING = 25;
 
+    public const int T_SYMBOLIC_NUMBER = 26;
+
+    public const int T_TAGGED_LITERAL = 27;
+
     public const int T_EOF = 100;
 
     public function __construct(

--- a/src/php/Compiler/Domain/Parser/ParserNode/TaggedLiteralNode.php
+++ b/src/php/Compiler/Domain/Parser/ParserNode/TaggedLiteralNode.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Parser\ParserNode;
+
+use Phel\Lang\SourceLocation;
+
+/**
+ * Represents a Clojure-style tagged literal: `#<tag> <form>`.
+ *
+ * The tag is an identifier (e.g. `cpp`, `uuid`, `inst`) and the form is
+ * the next parseable expression. Phel does not register any tags natively
+ * — the node is emitted so that unknown tags inside non-selected reader
+ * conditional branches parse cleanly. Known-tag dispatch can be layered
+ * on top of this node later.
+ */
+final readonly class TaggedLiteralNode implements NodeInterface
+{
+    public function __construct(
+        private string $tag,
+        private NodeInterface $form,
+        private SourceLocation $startLocation,
+        private SourceLocation $endLocation,
+    ) {}
+
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    public function getForm(): NodeInterface
+    {
+        return $this->form;
+    }
+
+    public function getCode(): string
+    {
+        return '#' . $this->tag . $this->form->getCode();
+    }
+
+    public function getStartLocation(): SourceLocation
+    {
+        return $this->startLocation;
+    }
+
+    public function getEndLocation(): SourceLocation
+    {
+        return $this->endLocation;
+    }
+}

--- a/tests/phel/test/comments.phel
+++ b/tests/phel/test/comments.phel
@@ -1,15 +1,20 @@
 (ns phel-test\test\comments
   (:require phel\test :refer [deftest is]))
 
-(deftest test-multiline-comment
-  (is (= 3 (+ 1 #|
-                 multiline
-                 comment
-               |# 2)) "multiline comment"))
+(deftest test-line-comment
+  ;; line comments compile away cleanly
+  (is (= 3 (+ 1 ;; trailing comment
+                2)) "line comment"))
 
-(deftest test-nested-multiline-comment
-  (is (= 6 (+ 1 #|
-                 2
-                 #| nested |#
-                 4
-               |# 5)) "nested multiline comment"))
+(deftest test-double-semicolon-comment
+  ;; standalone comment lines above an expression
+  (is (= 6 (+ 1
+              ;; a comment
+              ;; another comment
+              5)) "double-semicolon comments"))
+
+(deftest test-tagged-literal-in-unselected-reader-conditional-branch
+  ;; `#cpp` is a foreign tag that would error if reached at read time; the
+  ;; reader-conditional selects `:phel` so the `:jank` branch is discarded.
+  (is (= 42 #?(:phel 42 :jank (#cpp (foo bar)) :default 0))
+      "unknown tagged literal inside an unselected branch is dropped"))

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -99,6 +99,14 @@
   (is (true? (NaN? NAN)) "(NaN? NAN)")
   (is (false? (NaN? 9)) "(NaN? 8)"))
 
+(deftest test-symbolic-number-literals
+  (is (true? (inf? ##Inf)) "(inf? ##Inf)")
+  (is (true? (inf? ##-Inf)) "(inf? ##-Inf)")
+  (is (true? (nan? ##NaN)) "(nan? ##NaN)")
+  (is (= ##-Inf (- 0 ##Inf)) "(- 0 ##Inf) equals ##-Inf")
+  (is (= ##Inf php/INF) "##Inf equals php/INF")
+  (is (true? (neg? ##-Inf)) "##-Inf is negative"))
+
 (deftest test-min
   (is (= 1 (min 1 2 3)) "(min 1 2 3)"))
 

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -23,6 +23,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\NumberNode;
 use Phel\Compiler\Domain\Parser\ParserNode\QuoteNode;
 use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
 use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
 use Phel\Compiler\Domain\Parser\ParserNode\WhitespaceNode;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Keyword;
@@ -710,6 +711,71 @@ final class ParserTest extends TestCase
         $this->expectExceptionMessage('not allowed at the top level');
 
         $this->parse('#?@(:phel [1 2])');
+    }
+
+    public function test_symbolic_number_inf(): void
+    {
+        /** @var NumberNode $node */
+        $node = $this->parse('##Inf');
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(INF, $node->getValue());
+        self::assertSame('##Inf', $node->getCode());
+    }
+
+    public function test_symbolic_number_negative_inf(): void
+    {
+        /** @var NumberNode $node */
+        $node = $this->parse('##-Inf');
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(-INF, $node->getValue());
+        self::assertSame('##-Inf', $node->getCode());
+    }
+
+    public function test_symbolic_number_nan(): void
+    {
+        /** @var NumberNode $node */
+        $node = $this->parse('##NaN');
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertNan($node->getValue());
+        self::assertSame('##NaN', $node->getCode());
+    }
+
+    public function test_tagged_literal_wraps_next_form(): void
+    {
+        /** @var TaggedLiteralNode $node */
+        $node = $this->parse('#cpp (foo bar)');
+        self::assertInstanceOf(TaggedLiteralNode::class, $node);
+        self::assertSame('cpp', $node->getTag());
+        self::assertInstanceOf(ListNode::class, $node->getForm());
+    }
+
+    public function test_tagged_literal_with_atom_form(): void
+    {
+        /** @var TaggedLiteralNode $node */
+        $node = $this->parse('#uuid "abc-123"');
+        self::assertInstanceOf(TaggedLiteralNode::class, $node);
+        self::assertSame('uuid', $node->getTag());
+        self::assertInstanceOf(StringNode::class, $node->getForm());
+    }
+
+    public function test_tagged_literal_inside_unselected_reader_conditional_parses_cleanly(): void
+    {
+        // `#cpp` lands in the :jank branch which is not selected. The entire
+        // reader conditional should resolve to the :phel branch value (42)
+        // without raising a parser error.
+        $node = $this->parse('#?(:phel 42 :jank (#cpp (foo bar)))');
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(42, $node->getValue());
+    }
+
+    public function test_tagged_literal_in_selected_branch_reaches_parser(): void
+    {
+        // Conversely, if #cpp is in the :phel branch, it should reach the
+        // parser output as a TaggedLiteralNode (the error fires at Reader
+        // time, not parse time).
+        /** @var TaggedLiteralNode $node */
+        $node = $this->parse('#?(:phel (#cpp 1) :default 0)');
+        self::assertInstanceOf(ListNode::class, $node);
     }
 
     private function parse(string $string): NodeInterface

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x ##Inf)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  INF,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 13
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x ##NaN)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  NAN,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-nan.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-nan.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 13
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x ##-Inf)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  -INF,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-neg-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/symbolic-number-neg-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 14
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
+++ b/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x #?(:phel 42 :jank (#cpp (foo bar)) :default 0))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  42,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/tagged-literal-in-reader-conditional.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/tagged-literal-in-reader-conditional.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 54
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Lexer/LexerTest.php
+++ b/tests/php/Unit/Compiler/Lexer/LexerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Lexer;
 
 use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\Token;
 use Phel\Lang\SourceLocation;
 use PHPUnit\Framework\TestCase;
@@ -294,6 +295,7 @@ final class LexerTest extends TestCase
         }
 
         self::assertNotNull($warning);
+        self::assertStringContainsString('v0.33', $warning);
         self::assertStringContainsString('";"', $warning);
     }
 
@@ -329,7 +331,8 @@ final class LexerTest extends TestCase
         }
 
         self::assertNotNull($warning);
-        self::assertStringContainsString('(comment ...)', $warning);
+        self::assertStringContainsString('v0.33', $warning);
+        self::assertStringContainsString(';;', $warning);
     }
 
     public function test_pipe_fn_emits_deprecation(): void
@@ -605,6 +608,144 @@ final class LexerTest extends TestCase
         self::assertSame(Token::T_ATOM, $tokens[0]->getType());
         self::assertSame("a'#", $tokens[0]->getCode());
         self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_double_hash_inf_lexes_as_single_token(): void
+    {
+        $tokens = $this->lex('##Inf');
+
+        self::assertSame(Token::T_SYMBOLIC_NUMBER, $tokens[0]->getType());
+        self::assertSame('##Inf', $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_double_hash_negative_inf_lexes_as_single_token(): void
+    {
+        $tokens = $this->lex('##-Inf');
+
+        self::assertSame(Token::T_SYMBOLIC_NUMBER, $tokens[0]->getType());
+        self::assertSame('##-Inf', $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_double_hash_nan_lexes_as_single_token(): void
+    {
+        $tokens = $this->lex('##NaN');
+
+        self::assertSame(Token::T_SYMBOLIC_NUMBER, $tokens[0]->getType());
+        self::assertSame('##NaN', $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_double_hash_with_space_does_not_lex_as_symbolic_number(): void
+    {
+        // `## Inf` with a space after `##` must NOT match the symbolic number rule.
+        // `##` on its own is not a valid lexer state.
+        $this->expectException(LexerValueException::class);
+        $this->lex('## Inf');
+    }
+
+    public function test_hash_tag_lexes_as_single_token(): void
+    {
+        $tokens = $this->lex('#cpp');
+
+        self::assertSame(Token::T_TAGGED_LITERAL, $tokens[0]->getType());
+        self::assertSame('#cpp', $tokens[0]->getCode());
+        self::assertSame(Token::T_EOF, $tokens[1]->getType());
+    }
+
+    public function test_hash_tag_does_not_consume_following_form(): void
+    {
+        // `#cpp (1 2 3)` → tag token, whitespace, ( , atoms..., )
+        $tokens = $this->lex('#cpp (1 2 3)');
+
+        self::assertSame(Token::T_TAGGED_LITERAL, $tokens[0]->getType());
+        self::assertSame('#cpp', $tokens[0]->getCode());
+        self::assertSame(Token::T_WHITESPACE, $tokens[1]->getType());
+        self::assertSame(Token::T_OPEN_PARENTHESIS, $tokens[2]->getType());
+        self::assertSame(Token::T_ATOM, $tokens[3]->getType());
+        self::assertSame('1', $tokens[3]->getCode());
+    }
+
+    public function test_hash_tag_with_dashes_and_digits(): void
+    {
+        $tokens = $this->lex('#my-tag1');
+
+        self::assertSame(Token::T_TAGGED_LITERAL, $tokens[0]->getType());
+        self::assertSame('#my-tag1', $tokens[0]->getCode());
+    }
+
+    public function test_hash_underscore_still_form_skip(): void
+    {
+        // regression: #_ must still match T_COMMENT_MACRO, not T_TAGGED_LITERAL
+        $tokens = $this->lex('#_a');
+
+        self::assertSame(Token::T_COMMENT_MACRO, $tokens[0]->getType());
+        self::assertSame('#_', $tokens[0]->getCode());
+        self::assertSame(Token::T_ATOM, $tokens[1]->getType());
+    }
+
+    public function test_hash_brace_still_set_literal(): void
+    {
+        $tokens = $this->lex('#{1 2}');
+        self::assertSame(Token::T_HASH_OPEN_BRACE, $tokens[0]->getType());
+    }
+
+    public function test_hash_paren_still_anon_fn(): void
+    {
+        $tokens = $this->lex('#(+ % 1)');
+        self::assertSame(Token::T_HASH_FN, $tokens[0]->getType());
+    }
+
+    public function test_hash_question_still_reader_conditional(): void
+    {
+        $tokens = $this->lex('#?(:phel 1)');
+        self::assertSame(Token::T_READER_COND, $tokens[0]->getType());
+    }
+
+    public function test_hash_quote_still_regex(): void
+    {
+        $tokens = $this->lex('#"foo"');
+        self::assertSame(Token::T_REGEX, $tokens[0]->getType());
+    }
+
+    public function test_hash_pipe_multiline_comment_still_deprecated_but_works(): void
+    {
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $tokens = $this->lex('#| multiline |#');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(Token::T_COMMENT, $tokens[0]->getType());
+        self::assertSame('#| multiline |#', $tokens[0]->getCode());
+        self::assertNotNull($warning);
+        self::assertStringContainsString('v0.33', $warning);
+    }
+
+    public function test_bare_hash_line_comment_still_deprecated_but_works(): void
+    {
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $tokens = $this->lex("# a bare comment\n");
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(Token::T_COMMENT, $tokens[0]->getType());
+        self::assertNotNull($warning);
+        self::assertStringContainsString('v0.33', $warning);
     }
 
     private function lex(string $string): array


### PR DESCRIPTION
## 🤔 Background

Two related gaps in the reader block `.cljc` interop today:

- **#1276** — Clojure uses symbolic number literals (`##Inf`, `##-Inf`, `##NaN`) for the three IEEE-754 special values. Phel has none of these; users have to reach for `php/INF`, `php/-INF`, `php/NAN` in a back-channel way that doesn't round-trip across dialects.
- **#1277** — Clojure's reader conditional lets `.cljc` files carry dialect-specific forms inside `#?(:phel ... :jank (#cpp ...))`. Today Phel crashes on the `#cpp` side because the lexer's `#` comment rule eats anything starting with `#` followed by a letter.

Both issues block running shared `.cljc` test suites that embed native forms for other hosts.

## 💡 Goal

One PR, one lexer pass, two features:

1. Add `##Inf` / `##-Inf` / `##NaN` as first-class number literals compiling to PHP `INF` / `-INF` / `NAN`.
2. Add generic `#<tag>` tagged-literal dispatch so `#cpp`, `#uuid`, `#inst`, ... parse cleanly. Unknown tags in **unselected** `#?` branches are discarded without error (the core `.cljc` interop use case); unknown tags in **selected** branches raise a clear reader error.

Explicitly **out of scope**: the `123M` (BigDecimal) and `123N` (BigInt) literals mentioned in the #1276 issue body are deferred to a future PR — Phel has no arbitrary-precision type today, and the investigation is worth its own discussion. Since this PR's commit auto-closes #1276 on merge, BigDecimal/BigInt tracking can live in a follow-up issue if you want to keep it on the board.

## 🔖 Changes

### Lexer (`src/php/Compiler/Application/Lexer.php`)
- Comment negative lookahead now also excludes `#` (for `##Inf`) and `[a-zA-Z]` (for `#cpp`), so those forms fall through to their own rules instead of being swallowed as `#` line comments.
- New regex rules (appended to keep existing indices stable):
  - `T_SYMBOLIC_NUMBER` (index 26) — `##(?:-?Inf|NaN)` with a word-boundary negative lookahead so `##Infinite` / `##Inf10` are correctly rejected rather than silently accepted.
  - `T_TAGGED_LITERAL` (index 27) — `#[A-Za-z][A-Za-z0-9_\-]*`, letting tag names use dashes, underscores, and digits after the leading letter.
- Deprecation notices for `#|...|#` multiline comments and bare `#` line comments now explicitly announce removal in **Phel v0.33** and point at `;;` / `#_` as migrations.

### Parser (`src/php/Compiler/Application/Parser.php`)
- `T_SYMBOLIC_NUMBER` becomes a `NumberNode` with `INF` / `-INF` / `NAN`. The emitter's existing float path (`LiteralEmitter::emitFloat`) already renders these correctly as PHP's built-in constants.
- `T_TAGGED_LITERAL` becomes a new `TaggedLiteralNode` wrapping the next non-trivia form. Because `parseReaderCondNode` reads both branches of `#?(...)` but only returns the selected one, a `TaggedLiteralNode` in a `:jank` branch is built but immediately dropped — parsing succeeds without ever hitting the Reader.

### Reader (`src/php/Compiler/Application/Reader.php`)
- When a `TaggedLiteralNode` reaches the Reader (meaning it was in a selected code path), it raises a `ReaderException` with a precise message: `Unknown tagged literal '#<tag>'. Phel has no built-in handler for this tag; it may only appear inside a non-selected reader-conditional branch (e.g. :clj, :jank).`

### New parse-tree node
- `src/php/Compiler/Domain/Parser/ParserNode/TaggedLiteralNode.php` — `readonly` class exposing `getTag()`, `getForm()`, plus the usual location accessors and `getCode()` for round-trippable source rendering.

Closes #1276
Closes #1277