### PR TITLE
fix(test): thrown? single-arg form catches any Throwable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix inside syntax-quote; use `name#` instead, matching Clojure's reader macro (#1203)
 
 ### Fixed
+- `(thrown? body)` single-arg form now defaults to catching any `\Throwable`, matching Clojure's convention used in portability shims (e.g. `jank-lang/clojure-test-suite`). The two-arg form `(thrown? ExceptionClass body)` still works unchanged. Unblocks ~52 test failures when running the clojure-test-suite against Phel (#1307)
 - `-0x8000000000000000` (and equivalent `-0b...`, `-0o...` at 64-bit minimum) now parses correctly to the int `PHP_INT_MIN` instead of crashing with `ParseError: syntax error, unexpected floating-point number ".0"`; previously `hexdec` silently overflowed to a float, which the emitter then wrote as `-9223372036854775808.0` and PHP's own parser rejected (#1278)
 - `are` macro no longer eagerly evaluates list literals in table cells (e.g. `()`), which previously caused `Value of type null is not callable`; cells are now substituted into the expression template via symbolic replacement, matching Clojure's `clojure.template/do-template` semantics (#1280)
 - `=` on lazy sequences now short-circuits on object identity, so `(let [r (range)] (= r (deref (atom r))))` returns `true` instantly instead of trying to realize the infinite sequence and crashing with a PHP integer-overflow allocation error (#1286)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -143,8 +143,14 @@
     (assert-binary `(= ~expected (with-output-buffer ~body)) message false)))
 
 (defn- assert-thrown [form message]
-  (let [exception-symbol (second form)
-        body (nnext form)
+  ;; `(thrown? ExceptionClass body...)` asserts that `body` throws an instance of
+  ;; `ExceptionClass` (or a subclass). The Clojure-style single-arg form
+  ;; `(thrown? body)` — used by portability shims like `jank-lang/clojure-test-suite` —
+  ;; asserts only that `body` throws *anything*, so we default the caught type to
+  ;; `\Throwable` (the root of all PHP throwables since PHP 7).
+  (let [single-arg? (= 2 (count form))
+        exception-symbol (if single-arg? '\Throwable (second form))
+        body (if single-arg? (next form) (nnext form))
         loc (location form)
         report-data (gensym)
         e (gensym)]

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -73,6 +73,38 @@
     (is (= 1 (:failed counts)) "thrown? without throw records a failure")))
 
 ;; ---------------------------------------------------------------------------
+;; 'thrown? — Clojure-style single-arg form: (thrown? body) catches any
+;; \Throwable, used by portability shims like jank-lang/clojure-test-suite
+;; ---------------------------------------------------------------------------
+
+(deftest test-is-thrown-single-arg-passes-for-any-exception
+  (is (thrown? (throw (php/new \Exception "boom")))
+      "single-arg thrown? catches a bare \\Exception")
+  (is (thrown? (throw (php/new \RuntimeException "runtime")))
+      "single-arg thrown? catches a \\RuntimeException")
+  (is (thrown? (throw (php/new \InvalidArgumentException "bad")))
+      "single-arg thrown? catches an \\InvalidArgumentException")
+  (is (thrown? (throw (php/new \DivisionByZeroError "divzero")))
+      "single-arg thrown? catches an \\Error subclass"))
+
+(deftest test-is-thrown-single-arg-fails-when-body-does-not-throw
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer
+            (is (thrown? (+ 1 2))))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 1 (:failed counts))
+        "single-arg thrown? without throw records a failure")
+    (is (= 0 (:pass counts)) "no pass recorded")))
+
+(deftest test-is-thrown-two-arg-still-works-alongside-single-arg
+  (is (thrown? \Exception (throw (php/new \Exception "still works")))
+      "two-arg thrown? keeps working when single-arg is supported")
+  (is (thrown? \RuntimeException (throw (php/new \RuntimeException "ok")))
+      "two-arg thrown? with explicit class still catches the right type"))
+
+;; ---------------------------------------------------------------------------
 ;; 'thrown-with-msg? — passes when body throws with the expected message
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 🤔 Background

When running portability-focused Clojure suites (e.g. [jank-lang/clojure-test-suite](https://github.com/jank-lang/clojure-test-suite)) against Phel, tests routinely use the Clojure-style single-arg `thrown?` form:

```clojure
(is (p/thrown? (/ 1 0)))
```

In Clojure, `(thrown? body)` (one argument) is shorthand for "this body must throw *anything*" — the class defaults to `java.lang.Throwable`. Phel's `assert-thrown` handler only recognised the two-arg form `(thrown? ExceptionClass body)` and, when handed a single argument, tried to parse the body itself as the exception-class symbol. The generated `catch` then received a list where a symbol was expected and the analyzer bailed out:

```
phel:1> (is (thrown? (/ 1 0)))
InvalidArgumentException: catch expects a symbol
```

A single missing arity was responsible for ~52 failures in the clojure-test-suite audit — easily the highest-leverage bug in that report. Fixing it unblocks all of them at once.

## 💡 Goal

Make `(thrown? body)` — the Clojure-style single-arg form — behave as "body must throw any `\\Throwable`", while leaving `(thrown? ExceptionClass body ...)` unchanged. Closes #1307.

## 🔖 Changes

- `src/phel/test.phel` — `assert-thrown` now branches on the count of the asserted form: arity-1 (`(thrown? body)`) defaults the caught type to `\\Throwable` (PHP's root throwable since PHP 7); arity-2+ (`(thrown? Class body...)`) keeps the previous behaviour untouched. `thrown-with-msg?` already requires a class + message and is out of scope.
- `tests/phel/test/test-framework.phel` — new `deftest` blocks covering:
  - single-arg `thrown?` catching `\\Exception`, `\\RuntimeException`, `\\InvalidArgumentException`, and `\\DivisionByZeroError` (an `\\Error` subclass, proving we really root at `\\Throwable`)
  - single-arg `thrown?` recording a failure when the body does not throw
  - two-arg `thrown?` continuing to work alongside the new single-arg form
- `CHANGELOG.md` — note under `## Unreleased → Fixed`, referencing #1307 and the ~52-failure unblock.

All three Phel suites remain green (`composer test-core`, `composer test-compiler`, `composer test-quality`).

Closes #1307