### PR TITLE
feat: add `*assert*` var controlling `assert` macro expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - `condp` macro for predicate-based conditional dispatch, matching Clojure semantics including `:>>` result threading (#1217)
 - `if-some`, `when-some`, `when-first` macros for nil-aware binding, matching Clojure semantics (#1218)
 - `assert` macro for precondition checking with optional custom message (#1222)
+- `*assert*` var in `phel\core` now resolves (default `true`). `assert` reads it at macroexpansion time — when set to logical false (e.g. `(\Phel::addDefinition("phel\\core", "*assert*", false))` before compilation), `assert` expands to `nil` and performs no runtime check, matching Clojure's compile-time `*assert*` semantics. Unblocks `.cljc` test suites that reference `*assert*` (#1315)
 - `dotimes` macro for evaluating body `n` times with a binding from `0` to `n-1` (#1252)
 - `run!` function for applying a function to each element of a collection for side effects (#1252)
 - `fnil` function for nil-safe function wrapping with default values (#1225)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -54,6 +54,14 @@
   {:doc "Returns the path of the current source file."}
   "")
 
+(def *assert*
+  {:doc "Controls whether `assert` expands to a runtime check. When logical
+  false at macroexpansion time, `assert` expands to nil and performs no
+  runtime check, matching Clojure's compile-time `*assert*` semantics.
+  Defaults to `true`. To disable globally, set the core binding before
+  compilation via PHP: `\\Phel::addDefinition(\"phel\\\\core\", \"*assert*\", false)`."}
+  true)
+
 ;; --------------------------------------------
 ;; Basic methods for quasiquote and destructure
 ;; --------------------------------------------
@@ -4250,14 +4258,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 
 (defmacro assert
   "Throws an exception if expr is falsy. Optional message string.
-  Used for precondition checking in application code."
-  {:see-also ["when" "throw"]}
+  Used for precondition checking in application code. When `*assert*`
+  is logical false at macroexpansion time, `assert` expands to nil and
+  performs no runtime check."
+  {:see-also ["when" "throw" "*assert*"]}
   [expr & [message]]
-  (let [msg (if message
-              `(str "Assert failed: " ~message)
-              `(str "Assert failed: " (quote ~expr)))]
-    `(when (not ~expr)
-       (throw (php/new \InvalidArgumentException ~msg)))))
+  (when *assert*
+    (let [msg (if message
+                `(str "Assert failed: " ~message)
+                `(str "Assert failed: " (quote ~expr)))]
+      `(when (not ~expr)
+         (throw (php/new \InvalidArgumentException ~msg))))))
 
 (defn name
   "Returns the name string of a string, keyword or symbol."

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -276,6 +276,28 @@
         (assert false "must be positive"))
       "assert includes custom message"))
 
+(deftest test-assert-var-default
+  (is (= true *assert*) "*assert* defaults to true"))
+
+;; Toggle phel\core/*assert* at file load time so the forms below are
+;; macroexpanded while the flag is false. The macro must read the current
+;; value of *assert* from the core namespace on each expansion.
+(php/:: \Phel (addDefinition "phel\\core" "*assert*" false))
+
+(defn- assert-while-disabled-returns-nil []
+  (list (assert false)
+        (assert nil "boom")
+        (assert (= 1 2) "not equal")))
+
+(php/:: \Phel (addDefinition "phel\\core" "*assert*" true))
+
+(deftest test-assert-disabled-at-expansion-time
+  (is (= '(nil nil nil) (assert-while-disabled-returns-nil))
+      "assert expands to nil while *assert* is false")
+  (is (= true *assert*) "*assert* restored to true for subsequent forms")
+  (is (thrown? \InvalidArgumentException (assert false))
+      "assert resumes throwing after re-enabling *assert*"))
+
 (deftest test-name
   (is (= "string" (name "string")) "name on string")
   (is (= "symbol" (name 'symbol)) "name on symbol")


### PR DESCRIPTION
## 🤔 Background

The Clojure test suite `var_qmark.cljc` fails against Phel with:

```
phel:1> *assert*
[PHEL001] Cannot resolve symbol '*assert*'. Did you mean 'assert'?
```

Clojure defines [`*assert*`](https://clojuredocs.org/clojure.core/*assert*) as a compile-time var that controls whether `assert` expands to a runtime check. Phel was missing the symbol entirely, blocking `.cljc` interop for test suites that reference it.

## 💡 Goal

Make `*assert*` resolve and honour its compile-time semantics so Clojure test suites that touch it are no longer blocked, and `assert` can be disabled globally at compile time.

## 🔖 Changes

- **`src/phel/core.phel`**
  - New `(def *assert* true)` near `*ns*` / `*file*` with docstring explaining the compile-time semantics.
  - `assert` macro now wraps its body in `(when *assert* ...)`. When `phel\core/*assert*` is logical false at macroexpansion time, `assert` expands to `nil` and performs no runtime check. When true (default), behaviour is unchanged.
- **`tests/phel/test/core.phel`**
  - `test-assert-var-default` — asserts the default value is `true`.
  - `test-assert-disabled-at-expansion-time` — toggles `phel\core/*assert*` via `\Phel::addDefinition` at file load time, then asserts that forms macroexpanded while the flag is false become `nil`, and that re-enabling the flag restores runtime throwing.
  - Existing `test-assert-passes` / `test-assert-fails` unchanged — default behaviour is preserved.
- **`CHANGELOG.md`** — Unreleased entry under Core Language, right below the existing `assert` entry.

### Why not `(def *assert* false)` from user code?

Phel `def` is namespace-local: `(def *assert* false)` in `user` namespace creates `user/*assert*`, not `phel\core/*assert*`, so it does not affect the macro. The documented way to toggle globally is to set the core binding before compilation via PHP — this matches how `phel\core/*file*` and `phel\core/*ns*` are already driven by the compiler. Wiring `PhelConfig::setEnableAsserts(false)` to set this binding automatically is a natural follow-up but intentionally left out of this PR to keep the scope tight.

Closes #1315

## ✅ Tests

- `composer test-core` — 2712 pass
- `composer test-compiler` — 1880 pass (0 errors)
- `composer test-quality` — clean (cs-fixer, psalm, phpstan, rector)