### PR TITLE
feat: allow def/defn nested inside another def/defn (#1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - `if-some`, `when-some`, `when-first` macros for nil-aware binding, matching Clojure semantics (#1218)
 - `assert` macro for precondition checking with optional custom message (#1222)
 - `*assert*` var in `phel\core` now resolves (default `true`). `assert` reads it at macroexpansion time — when set to logical false (e.g. `(\Phel::addDefinition("phel\\core", "*assert*", false))` before compilation), `assert` expands to `nil` and performs no runtime check, matching Clojure's compile-time `*assert*` semantics. Unblocks `.cljc` test suites that reference `*assert*` (#1315)
+- `def` and `defn` nested inside another `def`/`defn` body are now permitted, matching Clojure semantics. The previous "`'def inside of a 'def is forbidden`" analyzer error has been removed. The inner `def` runs as a side effect when the outer fn is invoked, adding the definition to the namespace, so `(defn a [] (def x 1) x)` returns `1` and `x` becomes visible in the enclosing namespace (#1316)
 - `dotimes` macro for evaluating body `n` times with a binding from `0` to `n-1` (#1252)
 - `run!` function for applying a function to each element of a collection for side effects (#1252)
 - `fnil` function for nil-safe function wrapping with default values (#1225)

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -18,9 +18,6 @@ final class NodeEnvironment implements NodeEnvironmentInterface
 
     public const string CONTEXT_RETURN = 'return';
 
-    /** Def inside of def should not work. This flag help us to keep track of this. */
-    private bool $defAllowed = true;
-
     /** Use Registry::getDefinitionReference() instead of Registry::getDefinition() */
     private bool $globalReference = false;
 
@@ -208,14 +205,6 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         return $result;
     }
 
-    public function withDefAllowed(bool $defAllowed): NodeEnvironmentInterface
-    {
-        $result = clone $this;
-        $result->defAllowed = $defAllowed;
-
-        return $result;
-    }
-
     public function getCurrentRecurFrame(): ?RecurFrame
     {
         if ($this->recurFrames === []) {
@@ -228,11 +217,6 @@ final class NodeEnvironment implements NodeEnvironmentInterface
     public function getBoundTo(): string
     {
         return $this->boundTo;
-    }
-
-    public function isDefAllowed(): bool
-    {
-        return $this->defAllowed;
     }
 
     public function useGlobalReference(): bool

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
@@ -50,13 +50,9 @@ interface NodeEnvironmentInterface extends ContextualEnvironmentInterface
 
     public function withBoundTo(string $boundTo): self;
 
-    public function withDefAllowed(bool $defAllowed): self;
-
     public function getCurrentRecurFrame(): ?RecurFrame;
 
     public function getBoundTo(): string;
-
-    public function isDefAllowed(): bool;
 
     public function useGlobalReference(): bool;
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -51,7 +51,6 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): DefNode
     {
-        $this->ensureDefIsAllowed($list, $env);
         $this->verifySizeOfTuple($list);
 
         $nameSymbol = $list->get(1);
@@ -99,13 +98,6 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $initNode,
             $list->getStartLocation(),
         );
-    }
-
-    private function ensureDefIsAllowed(PersistentListInterface $list, NodeEnvironmentInterface $env): void
-    {
-        if (!$env->isDefAllowed()) {
-            throw AnalyzerException::withLocation("'def inside of a 'def is forbidden", $list);
-        }
     }
 
     private function verifySizeOfTuple(PersistentListInterface $list): void
@@ -211,8 +203,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         $initEnv = $env
             ->withBoundTo($namespace . '\\' . $nameSymbol->__toString())
             ->withExpressionContext()
-            ->withDisallowRecurFrame()
-            ->withDefAllowed(false);
+            ->withDisallowRecurFrame();
 
         return $this->analyzer->analyze($init, $initEnv);
     }

--- a/tests/phel/test/core/def-in-def.phel
+++ b/tests/phel/test/core/def-in-def.phel
@@ -1,0 +1,30 @@
+(ns phel-test\test\core\def-in-def
+  (:require phel\test :refer [deftest is]))
+
+;; `def` inside `def` is permitted, matching Clojure's semantics:
+;;   (defn a [] (def x 1) x) => 1
+;;   (defn b [] (defn y [] (def z 2) z) (y)) => 2
+;; The inner `def` runs as a side effect when the outer fn body evaluates;
+;; the fn's return value is the last expression as usual.
+
+(defn def-in-defn-returns-following-expr []
+  (def nested-x 1)
+  nested-x)
+
+(defn defn-in-defn-returns-inner-call []
+  (defn nested-y [] (def nested-z 2) nested-z)
+  (nested-y))
+
+(deftest test-def-inside-defn
+  (is (= 1 (def-in-defn-returns-following-expr))
+      "def inside defn runs as a side effect and following form is returned")
+  (is (= 1 nested-x)
+      "the nested def is visible in the enclosing namespace after fn is called"))
+
+(deftest test-defn-inside-defn
+  (is (= 2 (defn-in-defn-returns-inner-call))
+      "defn and inner def inside defn both work")
+  (is (= 2 (nested-y))
+      "inner defn is callable from the enclosing namespace after outer runs")
+  (is (= 2 nested-z)
+      "inner def is visible in the enclosing namespace after fn is called"))

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -1,0 +1,47 @@
+--PHEL--
+(def f (fn [] (def x 1) x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "f",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\f";
+
+    public function __invoke() {
+      \Phel::addDefinition(
+        "user",
+        "x",
+        1,
+        \Phel::map(
+          \Phel::keyword("start-location"), \Phel::map(
+            \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
+            \Phel::keyword("line"), 1,
+            \Phel::keyword("column"), 14
+          ),
+          \Phel::keyword("end-location"), \Phel::map(
+            \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
+            \Phel::keyword("line"), 1,
+            \Phel::keyword("column"), 23
+          )
+        )
+      );
+
+      return \Phel::getDefinition("user", "x");
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 27
+    ),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -30,21 +30,22 @@ final class DefSymbolTest extends TestCase
         $this->analyzer = new Analyzer(new GlobalEnvironment());
     }
 
-    public function test_with_def_not_allowed(): void
+    public function test_nested_def_is_allowed(): void
     {
-        $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage("'def inside of a 'def is forbidden");
-
         $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
-            Symbol::create('name'),
+            Symbol::create('outer'),
             Phel::list([
                 Symbol::create(Symbol::NAME_DEF),
-                Symbol::create('name2'),
+                Symbol::create('inner'),
                 1,
             ]),
         ]);
-        (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+        $defNode = (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+
+        self::assertSame('outer', $defNode->getName()->getName());
+        self::assertInstanceOf(DefNode::class, $defNode->getInit());
+        self::assertSame('inner', $defNode->getInit()->getName()->getName());
     }
 
     public function test_with_wrong_number_of_arguments(): void
@@ -108,8 +109,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
-                        ->withBoundTo('user\name')
-                        ->withDefAllowed(false),
+                        ->withBoundTo('user\name'),
                     'any value',
                 ),
             ),
@@ -150,8 +150,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
-                        ->withBoundTo('user\name')
-                        ->withDefAllowed(false),
+                        ->withBoundTo('user\name'),
                     'any value',
                 ),
             ),
@@ -192,8 +191,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
-                        ->withBoundTo('user\name')
-                        ->withDefAllowed(false),
+                        ->withBoundTo('user\name'),
                     'any value',
                 ),
             ),
@@ -273,8 +271,7 @@ final class DefSymbolTest extends TestCase
                     $env
                         ->withExpressionContext()
                         ->withDisallowRecurFrame()
-                        ->withBoundTo('user\name')
-                        ->withDefAllowed(false),
+                        ->withBoundTo('user\name'),
                     'any value',
                 ),
             ),


### PR DESCRIPTION
## 🤔 Background

Phel's analyzer raised `'def inside of a 'def is forbidden` whenever a `def` (or `defn`, which expands to `def`) appeared inside another `def`/`defn`. This blocked patterns that are perfectly valid in Clojure, such as defining a helper fn inside another fn body, or setting a namespace-level var as a side effect from within a function.

Closes #1316

## 💡 Goal

Match Clojure's semantics: the inner `def` runs as a side effect when the outer fn body evaluates, adding the definition to the enclosing namespace. The fn's return value is the last expression as usual.

```phel
(defn a [] (def x 1) x)         ;; => 1, and user/x is now bound to 1
(defn b [] (defn y [] (def z 2) z) (y))  ;; => 2, and user/y + user/z exist
```

## 🔖 Changes

- Remove the `ensureDefIsAllowed` check in `DefSymbol::analyze`
- Delete the now-dead `defAllowed` flag from `NodeEnvironment` and `NodeEnvironmentInterface` (`withDefAllowed`, `isDefAllowed`)
- Replace the `test_with_def_not_allowed` unit test with a positive `test_nested_def_is_allowed` case
- Add `tests/phel/test/core/def-in-def.phel` covering def-in-defn and defn-in-defn patterns end-to-end
- Add `tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test` integration fixture capturing the exact PHP emission for `(def f (fn [] (def x 1) x))`
- CHANGELOG entry under Unreleased