### PR TITLE
feat: add object-array function (#1318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - `:strs` support in map destructuring for string key lookup (#1227)
 - `disj` function for removing keys from a set (hash-set or sorted-set), variadic over keys, matching Clojure's `disj` (#1285)
 - `float` and `double` coercion functions, returning a PHP float (PHP has no float/double distinction); matches Clojure's `(float x)` / `(double x)` for `.cljc` interop (#1282)
+- `object-array` function for creating a PHP array of a given size (initialized to `nil`) or from the elements of a sequence. PHP has no typed-array distinction, so `object-array` returns a plain PHP indexed array accessible via `php/aget`/`php/aset`, matching Clojure's `object-array` for `.cljc` interop (#1318)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -472,6 +472,23 @@ Otherwise, it tries to call `__toString`."
           (recur (php/+ i 2)))
         res))))
 
+(defn object-array
+  "Creates a PHP array of the given size initialized to `nil`, or a PHP
+  array containing the elements of the given sequence. Matches Clojure's
+  `object-array` for `.cljc` interop — in Phel the result is a plain PHP
+  array (accessible via `php/aget`/`php/aset`) since PHP has no typed
+  array distinction."
+  {:example "(object-array 3) ; => a PHP array [nil, nil, nil]\n(object-array [1 2 3]) ; => a PHP array [1, 2, 3]"
+   :see-also ["php-indexed-array" "to-php-array"]}
+  [size-or-seq]
+  (if (php/is_int size-or-seq)
+    (if (php/< size-or-seq 0)
+      (throw (php/new InvalidArgumentException "Size for 'object-array' must be non-negative"))
+      (if (php/=== 0 size-or-seq)
+        (php/array)
+        (php/array_fill 0 size-or-seq nil)))
+    (to-php-array size-or-seq)))
+
 ;; ------------------------
 ;; Basic sequence operation
 ;; ------------------------

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -54,3 +54,40 @@
   (let [arr (php-associative-array "a" 1 "b" 2)]
     (is (= 1 (php/aget arr "a")) "php-associative-array: first key")
     (is (= 2 (php/aget arr "b")) "php-associative-array: second key")))
+
+(deftest test-object-array-from-size
+  (let [arr (object-array 3)]
+    (is (php/is_array arr) "object-array with int returns a PHP array")
+    (is (= 3 (php/count arr)) "object-array size matches requested count")
+    (is (nil? (php/aget arr 0)) "object-array slot 0 is nil")
+    (is (nil? (php/aget arr 1)) "object-array slot 1 is nil")
+    (is (nil? (php/aget arr 2)) "object-array slot 2 is nil")))
+
+(deftest test-object-array-from-zero-size
+  (let [arr (object-array 0)]
+    (is (php/is_array arr) "object-array 0 returns a PHP array")
+    (is (= 0 (php/count arr)) "object-array 0 is empty")))
+
+(deftest test-object-array-from-vector
+  (let [arr (object-array [1 2 3])]
+    (is (php/is_array arr) "object-array from vector returns a PHP array")
+    (is (= 3 (php/count arr)) "object-array preserves vector length")
+    (is (= 1 (php/aget arr 0)) "object-array element 0")
+    (is (= 2 (php/aget arr 1)) "object-array element 1")
+    (is (= 3 (php/aget arr 2)) "object-array element 2")))
+
+(deftest test-object-array-from-list
+  (let [arr (object-array '(:a :b :c))]
+    (is (php/is_array arr) "object-array from list returns a PHP array")
+    (is (= 3 (php/count arr)) "object-array preserves list length")
+    (is (= :a (php/aget arr 0)) "object-array element 0")
+    (is (= :c (php/aget arr 2)) "object-array last element")))
+
+(deftest test-object-array-from-empty-vector
+  (let [arr (object-array [])]
+    (is (php/is_array arr) "object-array from empty vector is a PHP array")
+    (is (= 0 (php/count arr)) "object-array from empty vector is empty")))
+
+(deftest test-object-array-negative-size-throws
+  (is (thrown? \InvalidArgumentException (object-array -1))
+      "object-array raises InvalidArgumentException on negative size"))


### PR DESCRIPTION
## 🤔 Background

`clojure-test-suite` uses `object-array` in `vector_qmark.cljc` (currently commented out due to this gap). Phel rejects the bare symbol, preventing any `.cljc` file that references `object-array` from loading.

Closes #1318

## 💡 Goal

Expose a Phel-native `object-array` that matches Clojure's signature: a single-arg constructor accepting either a non-negative integer size (producing an array of `nil`s) or a sequence (producing an array of its elements). Because PHP has no typed-array distinction, the result is a plain PHP indexed array that can be read and updated via `php/aget`/`php/aset`.

## 🔖 Changes

- `src/phel/core.phel`: new `object-array` (placed next to `php-indexed-array`/`php-associative-array`) using `php/array_fill` for the int path and the existing `to-php-array` for the sequence path; negative sizes raise `InvalidArgumentException`
- `tests/phel/test/core/basic-constructors.phel`: 6 new tests covering int size, zero size, negative size, vector input, list input, and empty-vector input
- CHANGELOG entry under Unreleased → Core Language