### PR TITLE
feat: add to-array function (#1320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
 - `float` and `double` coercion functions, returning a PHP float (PHP has no float/double distinction); matches Clojure's `(float x)` / `(double x)` for `.cljc` interop (#1282)
 - `object-array` function for creating a PHP array of a given size (initialized to `nil`) or from the elements of a sequence. PHP has no typed-array distinction, so `object-array` returns a plain PHP indexed array accessible via `php/aget`/`php/aset`, matching Clojure's `object-array` for `.cljc` interop (#1318)
 - `array-map` function for constructing a map from key/value pairs, with later values replacing earlier ones on duplicate keys. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources (#1319)
+- `to-array` function for converting any collection (vector, list, set, map, PHP array, or `nil`) into a plain PHP array, matching Clojure's `to-array` for `.cljc` interop (#1320)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -500,6 +500,18 @@ Otherwise, it tries to call `__toString`."
         (php/array_fill 0 size-or-seq nil)))
     (to-php-array size-or-seq)))
 
+(defn to-array
+  "Returns a PHP array containing the elements of `coll`. Accepts any
+  collection (vector, list, set, map, PHP array) or `nil`, which yields
+  an empty PHP array. Matches Clojure's `to-array` for `.cljc` interop —
+  in Phel the result is a plain PHP array since PHP has no `Object[]`."
+  {:example "(to-array [1 2 3]) ; => a PHP array [1, 2, 3]\n(to-array nil) ; => a PHP array []"
+   :see-also ["to-php-array" "object-array"]}
+  [coll]
+  (if (php/=== coll nil)
+    (php/array)
+    (to-php-array coll)))
+
 ;; ------------------------
 ;; Basic sequence operation
 ;; ------------------------

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -102,3 +102,40 @@
 (deftest test-object-array-negative-size-throws
   (is (thrown? \InvalidArgumentException (object-array -1))
       "object-array raises InvalidArgumentException on negative size"))
+
+(deftest test-to-array-from-vector
+  (let [arr (to-array [1 2 3])]
+    (is (php/is_array arr) "to-array from vector returns a PHP array")
+    (is (= 3 (php/count arr)) "to-array preserves vector length")
+    (is (= 1 (php/aget arr 0)) "to-array element 0")
+    (is (= 3 (php/aget arr 2)) "to-array last element")))
+
+(deftest test-to-array-from-list
+  (let [arr (to-array '(:a :b :c))]
+    (is (php/is_array arr) "to-array from list returns a PHP array")
+    (is (= 3 (php/count arr)) "to-array preserves list length")
+    (is (= :a (php/aget arr 0)) "to-array element 0")
+    (is (= :c (php/aget arr 2)) "to-array last element")))
+
+(deftest test-to-array-from-empty
+  (let [arr (to-array [])]
+    (is (php/is_array arr) "to-array from empty vector is a PHP array")
+    (is (= 0 (php/count arr)) "to-array from empty vector is empty")))
+
+(deftest test-to-array-from-nil
+  (let [arr (to-array nil)]
+    (is (php/is_array arr) "to-array from nil returns a PHP array")
+    (is (= 0 (php/count arr)) "to-array from nil is empty")))
+
+(deftest test-to-array-from-set
+  (let [arr (to-array (set [1 2 3]))]
+    (is (php/is_array arr) "to-array from set returns a PHP array")
+    (is (= 3 (php/count arr)) "to-array preserves set size")
+    (is (= #{1 2 3} (set arr)) "to-array preserves set elements")))
+
+(deftest test-to-array-from-php-array
+  (let [src (php-indexed-array "a" "b" "c")
+        arr (to-array src)]
+    (is (php/is_array arr) "to-array passes through PHP array")
+    (is (= 3 (php/count arr)) "to-array preserves php array length")
+    (is (= "a" (php/aget arr 0)) "to-array php array element 0")))


### PR DESCRIPTION
## 🎯 What

Adds the `to-array` function to Phel's core library, matching Clojure's `to-array` for `.cljc` interop.

```phel
(to-array [1 2 3])        ; => PHP array [1, 2, 3]
(to-array '(:a :b :c))    ; => PHP array [:a, :b, :c]
(to-array nil)            ; => PHP array []
(to-array (set [1 2 3]))  ; => PHP array containing 1, 2, 3
```

## 🧩 Why

The clojure-test-suite uses `to-array` in shared `.cljc` files ([`vec.cljc`](https://github.com/jasalt/clojure-test-suite/tree/d3e7ab3b994c1a8bd597b8915e37b7e2a292784e/test/clojure/core_test), `associative_qmark.cljc`). Without `to-array`, those suites can't run against Phel.

Clojure's `to-array` returns `Object[]` — a Java-typed array — which PHP has no direct equivalent for. Phel returns a plain PHP indexed array (the same shape as `object-array` and `to-php-array`). Documented explicitly in the docstring and CHANGELOG.

Closes #1320

## 🛠️ How

- `src/phel/core.phel`: new `to-array` function placed right after `object-array`, delegating to `to-php-array` for non-nil inputs and returning an empty `php/array` for `nil`.
- `tests/phel/test/core/basic-constructors.phel`: six new `deftest` blocks covering vector / list / empty vector / nil / set / pre-existing PHP array inputs.
- `CHANGELOG.md`: `## Unreleased` entry under Core Language.

## ✅ Checklist

- [x] Tests added (Phel core — vector, list, empty, nil, set, php-array)
- [x] `composer test-core` — 2765 passed (+18 new)
- [x] `composer test-quality` — cs-fixer, psalm, phpstan, rector all clean
- [x] `composer test-compiler` — 1887 passed
- [x] CHANGELOG updated under `## Unreleased`