### PR TITLE
feat: add aclone function (#1321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 - `object-array` function for creating a PHP array of a given size (initialized to `nil`) or from the elements of a sequence. PHP has no typed-array distinction, so `object-array` returns a plain PHP indexed array accessible via `php/aget`/`php/aset`, matching Clojure's `object-array` for `.cljc` interop (#1318)
 - `array-map` function for constructing a map from key/value pairs, with later values replacing earlier ones on duplicate keys. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources (#1319)
 - `to-array` function for converting any collection (vector, list, set, map, PHP array, or `nil`) into a plain PHP array, matching Clojure's `to-array` for `.cljc` interop (#1320)
+- `aclone` function for producing a shallow copy of a PHP array — the returned array is independent so mutations via `php/aset` do not propagate; matches Clojure's `aclone` for `.cljc` interop (#1321)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -512,6 +512,20 @@ Otherwise, it tries to call `__toString`."
     (php/array)
     (to-php-array coll)))
 
+(defn aclone
+  "Returns a shallow copy of a PHP array. The returned array is a
+  distinct value — mutating the copy via `php/aset` does not affect the
+  original, and vice versa. Matches Clojure's `aclone` for `.cljc`
+  interop; raises `InvalidArgumentException` on non-array inputs since
+  Phel's persistent collections are already immutable and don't need
+  cloning."
+  {:example "(aclone (object-array 3)) ; => a fresh PHP array [nil, nil, nil]"
+   :see-also ["object-array" "to-array"]}
+  [arr]
+  (if (php/is_array arr)
+    (php/array_merge arr)
+    (throw (php/new InvalidArgumentException "aclone expects a PHP array"))))
+
 ;; ------------------------
 ;; Basic sequence operation
 ;; ------------------------

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -139,3 +139,46 @@
     (is (php/is_array arr) "to-array passes through PHP array")
     (is (= 3 (php/count arr)) "to-array preserves php array length")
     (is (= "a" (php/aget arr 0)) "to-array php array element 0")))
+
+(deftest test-aclone-preserves-elements
+  (let [arr (object-array 3)]
+    (php/aset arr 0 1)
+    (php/aset arr 1 2)
+    (php/aset arr 2 3)
+    (let [cloned (aclone arr)]
+      (is (php/is_array cloned) "aclone returns a PHP array")
+      (is (= 3 (php/count cloned)) "aclone preserves length")
+      (is (= 1 (php/aget cloned 0)) "aclone element 0")
+      (is (= 2 (php/aget cloned 1)) "aclone element 1")
+      (is (= 3 (php/aget cloned 2)) "aclone element 2"))))
+
+(deftest test-aclone-is-independent-copy
+  (let [original (object-array 3)]
+    (php/aset original 0 1)
+    (php/aset original 1 2)
+    (php/aset original 2 3)
+    (let [cloned (aclone original)]
+      (php/aset original 1 11)
+      (is (= 11 (php/aget original 1)) "original reflects its own mutation")
+      (is (= 2 (php/aget cloned 1)) "clone is unaffected by mutating original")
+      (php/aset cloned 2 12)
+      (is (= 3 (php/aget original 2)) "original is unaffected by mutating clone")
+      (is (= 12 (php/aget cloned 2)) "clone reflects its own mutation"))))
+
+(deftest test-aclone-empty-array
+  (let [cloned (aclone (object-array 0))]
+    (is (php/is_array cloned) "aclone of empty array returns a PHP array")
+    (is (= 0 (php/count cloned)) "aclone of empty array is empty")))
+
+(deftest test-aclone-from-php-indexed-array
+  (let [src (php-indexed-array "a" "b" "c")
+        cloned (aclone src)]
+    (is (php/is_array cloned) "aclone of php-indexed-array returns a PHP array")
+    (is (= 3 (php/count cloned)) "aclone preserves length")
+    (is (= "a" (php/aget cloned 0)) "aclone element 0")))
+
+(deftest test-aclone-rejects-non-array
+  (is (thrown? \InvalidArgumentException (aclone [1 2 3]))
+      "aclone of persistent vector raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (aclone nil))
+      "aclone of nil raises InvalidArgumentException"))


### PR DESCRIPTION
## 🎯 What

Adds the `aclone` function to Phel's core library, matching Clojure's `aclone` for `.cljc` interop.

```phel
(let [arr (object-array 3)]
  (php/aset arr 0 1)
  (php/aset arr 1 2)
  (php/aset arr 2 3)
  (let [cloned (aclone arr)]
    (php/aset arr 1 11)
    (php/aget cloned 1)))  ; => 2  (unchanged by original mutation)
```

## 🧩 Why

The clojure-test-suite references `aclone` in [`aclone.cljc`](https://github.com/jasalt/clojure-test-suite/blob/b737de93051950a615d541d70ad2e48683376b56/test/clojure/core_test/aclone.cljc). Without it, these shared `.cljc` suites can't run against Phel.

Clojure's `aclone` clones a Java array. Phel's analogue is the PHP array (which is what `object-array`, `to-array`, etc. produce). PHP arrays are value types with copy-on-write, so cloning is achieved via `php/array_merge` — this forces a fresh zval so subsequent mutations are fully independent (the guarantee that matters to callers).

Non-array inputs raise `InvalidArgumentException` because Phel's persistent collections (vector, map, set, list) are already immutable — cloning them would be meaningless, and matching Clojure's strict behavior (which throws on non-arrays) keeps the semantics explicit.

Closes #1321

## 🛠️ How

- `src/phel/core.phel`: new `aclone` function placed right after `to-array`. Uses `php/array_merge` with a single argument to produce a fresh PHP array.
- `tests/phel/test/core/basic-constructors.phel`: five new `deftest` blocks covering:
  - element preservation across clones
  - mutation independence in both directions (port of clojure-test-suite semantics)
  - empty arrays
  - cloning a pre-existing `php-indexed-array`
  - `InvalidArgumentException` for persistent vector and `nil`
- `CHANGELOG.md`: `## Unreleased` entry under Core Language.

## ✅ Checklist

- [x] Tests added (Phel core — preservation, independence, empty, php-array, rejection)
- [x] `composer test-core` — 2781 passed (+16 new)
- [x] `composer test-quality` — cs-fixer, psalm, phpstan, rector all clean
- [x] `composer test-compiler` — 1887 passed
- [x] CHANGELOG updated under `## Unreleased`