### PR TITLE
feat: add byte coercion function (#1327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - `array-map` function for constructing a map from key/value pairs, with later values replacing earlier ones on duplicate keys. Phel has no distinct array-map type, so the result is the same persistent map as `hash-map` — `array-map` exists for `.cljc` interop with Clojure sources (#1319)
 - `to-array` function for converting any collection (vector, list, set, map, PHP array, or `nil`) into a plain PHP array, matching Clojure's `to-array` for `.cljc` interop (#1320)
 - `aclone` function for producing a shallow copy of a PHP array — the returned array is independent so mutations via `php/aset` do not propagate; matches Clojure's `aclone` for `.cljc` interop (#1321)
+- `byte` coercion function truncating to a signed 8-bit integer in `-128..127`. Decimals are truncated toward zero; out-of-range and non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated byte type, so the result is a plain PHP int — `byte` exists for `.cljc` interop with Clojure sources (#1327)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3246,6 +3246,24 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [x]
   (php/floatval x))
 
+(defn byte
+  "Coerces `x` to a signed 8-bit integer in the range `-128..127`.
+   Decimal values are truncated toward zero (as in Clojure on the JVM).
+   Values outside the range or non-numeric inputs raise
+   `InvalidArgumentException`. Phel has no dedicated byte type, so the
+   result is a plain PHP int — `byte` exists for `.cljc` interop with
+   Clojure sources."
+  {:example "(byte 127) ; => 127\n(byte 1.9) ; => 1\n(byte -128) ; => -128"
+   :see-also ["int?" "float" "double"]}
+  [x]
+  (if (number? x)
+    (let [truncated (php/intval x)]
+      (if (or (php/< truncated -128) (php/> truncated 127))
+        (throw (php/new InvalidArgumentException
+                        (php/. "Value out of range for byte: " (php/strval x))))
+        truncated))
+    (throw (php/new InvalidArgumentException "byte expects a numeric value"))))
+
 (defn rand
   "Returns a random number between 0 and 1."
   []

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -181,6 +181,40 @@
   (is (= 3.14 (double "3.14")) "(double \"3.14\")")
   (is (= 0.0 (double nil)) "(double nil)"))
 
+(deftest test-byte-integer-values
+  (is (= 0 (byte 0)) "(byte 0)")
+  (is (= 1 (byte 1)) "(byte 1)")
+  (is (= -1 (byte -1)) "(byte -1)")
+  (is (= 127 (byte 127)) "(byte 127) is max")
+  (is (= -128 (byte -128)) "(byte -128) is min")
+  (is (int? (byte 0)) "(byte 0) returns an int"))
+
+(deftest test-byte-truncates-floats
+  (is (= 1 (byte 1.1)) "(byte 1.1) truncates toward zero")
+  (is (= 1 (byte 1.9)) "(byte 1.9) truncates toward zero")
+  (is (= -1 (byte -1.1)) "(byte -1.1) truncates toward zero")
+  (is (= -1 (byte -1.9)) "(byte -1.9) truncates toward zero")
+  (is (= 0 (byte 0.5)) "(byte 0.5) truncates to 0")
+  (is (= 0 (byte -0.5)) "(byte -0.5) truncates to 0"))
+
+(deftest test-byte-out-of-range
+  (is (thrown? \InvalidArgumentException (byte 128))
+      "(byte 128) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (byte -129))
+      "(byte -129) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (byte 1000))
+      "(byte 1000) raises InvalidArgumentException"))
+
+(deftest test-byte-non-numeric
+  (is (thrown? \InvalidArgumentException (byte "0"))
+      "(byte \"0\") raises InvalidArgumentException on string")
+  (is (thrown? \InvalidArgumentException (byte nil))
+      "(byte nil) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (byte :0))
+      "(byte :0) raises InvalidArgumentException on keyword")
+  (is (thrown? \InvalidArgumentException (byte [0]))
+      "(byte [0]) raises InvalidArgumentException on vector"))
+
 (deftest test-numbers-with-underscore
   (is (= 1337 0b10100111001) "binary number")
   (is (= 1337 0b101_0011_1001) "binary number with underscores")


### PR DESCRIPTION
## 🎯 What

Adds the `byte` coercion function to Phel's core library, matching Clojure's `byte` for `.cljc` interop.

```phel
(byte 127)    ; => 127
(byte -128)   ; => -128
(byte 1.9)    ; => 1   (truncates toward zero)
(byte -1.9)   ; => -1  (truncates toward zero)
(byte 128)    ; InvalidArgumentException — out of range
(byte "0")    ; InvalidArgumentException — non-numeric
```

## 🧩 Why

The clojure-test-suite uses `byte` in [`byte.cljc`](https://github.com/jasalt/clojure-test-suite/blob/1f060e8cf524825a5dac9d00bf2f7c3c6f1b0df9/test/clojure/core_test/byte.cljc). Without `byte`, those shared suites can't run against Phel.

On the JVM, Clojure's `byte` returns a `java.lang.Byte` — a signed 8-bit integer — and throws `IllegalArgumentException` for values outside `-128..127`. Decimals are truncated toward zero. This PR implements the same semantics on Phel: the result is a plain PHP int (Phel has no dedicated byte type), the range check throws `InvalidArgumentException`, and non-numeric inputs also throw (matching Clojure's `ClassCastException`-on-type-mismatch behavior with a more idiomatic Phel exception).

Closes #1327

## 🛠️ How

- `src/phel/core.phel`: new `byte` function placed right after `float` / `double` (the existing Clojure-compat numeric coercions from #1282). Uses `php/intval` for truncation and explicit range comparison.
- `tests/phel/test/core/math-operation.phel`: four new `deftest` blocks covering:
  - integer values across the full range, including `-128` / `127` boundaries
  - float truncation toward zero (positive and negative)
  - out-of-range values (`128`, `-129`, `1000`) all throwing
  - non-numeric inputs (string, `nil`, keyword, vector) all throwing
- `CHANGELOG.md`: `## Unreleased` entry under Core Language.

## ✅ Checklist

- [x] Tests added (integer, float truncation, out-of-range, non-numeric)
- [x] `composer test-core` — 2800 passed (+19 new)
- [x] `composer test-quality` — cs-fixer, psalm, phpstan, rector all clean
- [x] `composer test-compiler` — 1887 passed
- [x] CHANGELOG updated under `## Unreleased`