### PR TITLE
feat: add char coercion function (#1330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
 - `to-array` function for converting any collection (vector, list, set, map, PHP array, or `nil`) into a plain PHP array, matching Clojure's `to-array` for `.cljc` interop (#1320)
 - `aclone` function for producing a shallow copy of a PHP array — the returned array is independent so mutations via `php/aset` do not propagate; matches Clojure's `aclone` for `.cljc` interop (#1321)
 - `byte` coercion function truncating to a signed 8-bit integer in `-128..127`. Decimals are truncated toward zero; out-of-range and non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated byte type, so the result is a plain PHP int — `byte` exists for `.cljc` interop with Clojure sources (#1327)
+- `char` coercion function returning a single-character string from a non-negative Unicode code point (via `mb_chr`) or from an existing single-character string. Phel has no dedicated char type — character literals such as `\A` are already single-character strings — so the result is always a plain string. Invalid inputs raise `InvalidArgumentException` (#1330)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3264,6 +3264,39 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
         truncated))
     (throw (php/new InvalidArgumentException "byte expects a numeric value"))))
 
+(defn char
+  "Coerces `x` to a single-character string representing the given
+   Unicode code point. Accepts a non-negative integer (the code point,
+   converted via `mb_chr`) or a single-character string, which is
+   returned as-is. Phel has no dedicated char type — character literals
+   such as `\\A` are already single-character strings — so the result
+   is always a plain string. Matches Clojure's `char` for `.cljc`
+   interop; raises `InvalidArgumentException` on negative ints,
+   non-single-character strings, and all other inputs."
+  {:example "(char 65) ; => \"A\"\n(char 32) ; => \" \"\n(char \\A) ; => \"A\""
+   :see-also ["byte" "int?" "string?"]}
+  [x]
+  (cond
+    (integer? x)
+    (if (php/< x 0)
+      (throw (php/new InvalidArgumentException
+                      (php/. "Value out of range for char: " (php/strval x))))
+      (let [ch (php/mb_chr x "UTF-8")]
+        (if (php/=== ch false)
+          (throw (php/new InvalidArgumentException
+                          (php/. "Invalid code point for char: " (php/strval x))))
+          ch)))
+
+    (string? x)
+    (if (php/=== 1 (php/mb_strlen x "UTF-8"))
+      x
+      (throw (php/new InvalidArgumentException
+                      "char expects a single-character string")))
+
+    :else
+    (throw (php/new InvalidArgumentException
+                    "char expects a non-negative integer or a single-character string"))))
+
 (defn rand
   "Returns a random number between 0 and 1."
   []

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -215,6 +215,43 @@
   (is (thrown? \InvalidArgumentException (byte [0]))
       "(byte [0]) raises InvalidArgumentException on vector"))
 
+(deftest test-char-from-int
+  (is (= " " (char 32)) "(char 32) is space")
+  (is (= "@" (char 64)) "(char 64) is @")
+  (is (= "A" (char 65)) "(char 65) is A")
+  (is (= "a" (char 97)) "(char 97) is a")
+  (is (= "0" (char 48)) "(char 48) is 0")
+  (is (string? (char 65)) "(char 65) returns a string"))
+
+(deftest test-char-from-char-literal
+  (is (= "A" (char \A)) "(char \\A) returns A")
+  (is (= "z" (char \z)) "(char \\z) returns z")
+  (is (= "1" (char \1)) "(char \\1) returns 1"))
+
+(deftest test-char-unicode
+  (is (= "é" (char 233)) "(char 233) is é")
+  (is (= "€" (char 8364)) "(char 8364) is €"))
+
+(deftest test-char-negative
+  (is (thrown? \InvalidArgumentException (char -1))
+      "(char -1) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (char -100))
+      "(char -100) raises InvalidArgumentException"))
+
+(deftest test-char-invalid-inputs
+  (is (thrown? \InvalidArgumentException (char nil))
+      "(char nil) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (char "AB"))
+      "(char \"AB\") raises InvalidArgumentException on multi-char string")
+  (is (thrown? \InvalidArgumentException (char ""))
+      "(char \"\") raises InvalidArgumentException on empty string")
+  (is (thrown? \InvalidArgumentException (char :a))
+      "(char :a) raises InvalidArgumentException on keyword")
+  (is (thrown? \InvalidArgumentException (char [65]))
+      "(char [65]) raises InvalidArgumentException on vector")
+  (is (thrown? \InvalidArgumentException (char 1.5))
+      "(char 1.5) raises InvalidArgumentException on float"))
+
 (deftest test-numbers-with-underscore
   (is (= 1337 0b10100111001) "binary number")
   (is (= 1337 0b101_0011_1001) "binary number with underscores")


### PR DESCRIPTION
## 🎯 What

Adds the `char` coercion function to Phel's core library, matching Clojure's `char` for `.cljc` interop.

```phel
(char 65)     ; => "A"
(char 32)     ; => " "
(char 8364)   ; => "€"  (Unicode via mb_chr)
(char \A)     ; => "A"  (passthrough — Phel chars are already strings)
(char -1)     ; InvalidArgumentException
(char nil)    ; InvalidArgumentException
```

## 🧩 Why

The clojure-test-suite uses `char` in [`char.cljc`](https://github.com/jasalt/clojure-test-suite/blob/43f530ac7c98c1829d36341442ed6cd72c2d9c20/test/clojure/core_test/char.cljc). Without `char`, those shared suites can't run against Phel.

Clojure's `char` returns a `java.lang.Character` from an integer code point or passes through an existing char. Phel has no dedicated char type — character literals like `\A` already lex as single-character strings (see `parseCharNode` returning `StringNode`). So `char` in Phel is a coercion to a single-character string.

For Unicode support, this uses `mb_chr(x, "UTF-8")` rather than PHP's byte-oriented `chr()`. The test suite covers the ASCII range plus Latin-1 Supplement (`é`, code point 233) and the Currency Symbols block (`€`, code point 8364) to prove the Unicode path works.

Closes #1330

## 🛠️ How

- `src/phel/core.phel`: new `char` function placed right after `byte` (alongside the Clojure-compat numeric coercions). Uses `cond` to branch on input type:
  - Integer → `mb_chr` with range check (negative ints and invalid code points raise)
  - Single-character string → passthrough (via `mb_strlen` check)
  - Everything else → raise
- `tests/phel/test/core/math-operation.phel`: five new `deftest` blocks covering:
  - ASCII integer code points
  - Char literals (`\A`, `\z`, `\1`)
  - Unicode (`é`, `€`)
  - Negative ints throwing
  - All other invalid inputs throwing (`nil`, multi-char string, empty string, keyword, vector, float)
- `CHANGELOG.md`: `## Unreleased` entry under Core Language.

## ✅ Checklist

- [x] Tests added (ASCII, char literals, Unicode, negative, invalid inputs)
- [x] `composer test-core` — 2819 passed (+19 new)
- [x] `composer test-quality` — cs-fixer, psalm, phpstan, rector all clean
- [x] `composer test-compiler` — 1887 passed
- [x] CHANGELOG updated under `## Unreleased`