### PR TITLE
feat: add `char?` validation function (#1334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 - `aclone` function for producing a shallow copy of a PHP array — the returned array is independent so mutations via `php/aset` do not propagate; matches Clojure's `aclone` for `.cljc` interop (#1321)
 - `byte` coercion function truncating to a signed 8-bit integer in `-128..127`. Decimals are truncated toward zero; out-of-range and non-numeric inputs raise `InvalidArgumentException`. Phel has no dedicated byte type, so the result is a plain PHP int — `byte` exists for `.cljc` interop with Clojure sources (#1327)
 - `char` coercion function returning a single-character string from a non-negative Unicode code point (via `mb_chr`) or from an existing single-character string. Phel has no dedicated char type — character literals such as `\A` are already single-character strings — so the result is always a plain string. Invalid inputs raise `InvalidArgumentException` (#1330)
+- `char?` predicate returning `true` when the argument is a single-character string (UTF-8 counted), `false` otherwise. Since Phel has no distinct character type, this follows ClojureScript's `char?` semantics (any string of length 1 is a char) rather than Clojure/JVM's `Character`-type check; multi-byte UTF-8 characters like `\"ñ\"` or `\"漢\"` are recognized correctly via `mb_strlen`. Matches ClojureScript's `char?` for `.cljc` interop (#1334)
 - `NaN?` predicate as an alias for `nan?`, matching Clojure's `NaN?` spelling for `.cljc` interop (#1284)
 
 #### Clojure-Compatible Aliases

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1006,6 +1006,19 @@ Otherwise, it tries to call `__toString`."
   [x]
   (= (type x) :string))
 
+(defn char?
+  "Returns true if `x` is a single-character string, false otherwise.
+   Phel has no dedicated character type — character literals such as
+   `\\A` are already single-character strings — so `char?` is true for
+   any string of length 1 (UTF-8 counted). Matches ClojureScript's
+   `char?` for `.cljc` interop; Clojure/JVM's `char?` tests for the
+   distinct `Character` type, which does not exist here."
+  {:example "(char? \\A) ; => true\n(char? \"a\") ; => true\n(char? \"ab\") ; => false"
+   :see-also ["char" "string?"]}
+  [x]
+  (and (= (type x) :string)
+       (= 1 (php/mb_strlen x "UTF-8"))))
+
 (defn keyword?
   "Returns true if `x` is a keyword, false otherwise."
   [x]

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -56,6 +56,26 @@
   (is (true? (string? "")) "string? on empty string")
   (is (true? (string? ":test")) "string? on ':test'"))
 
+(deftest test-char?
+  (is (true? (char? "a")) "char? on single-character ASCII string")
+  (is (true? (char? "Z")) "char? on single-character uppercase ASCII")
+  (is (true? (char? " ")) "char? on single space")
+  (is (true? (char? "\n")) "char? on newline")
+  (is (true? (char? \A)) "char? on character literal")
+  (is (true? (char? \space)) "char? on named character literal")
+  (is (true? (char? "ñ")) "char? on single multi-byte UTF-8 character")
+  (is (true? (char? "漢")) "char? on CJK ideograph (single code point)")
+  (is (false? (char? "")) "char? on empty string")
+  (is (false? (char? "ab")) "char? on two-character string")
+  (is (false? (char? "hello")) "char? on multi-character string")
+  (is (false? (char? 65)) "char? on integer")
+  (is (false? (char? 1.0)) "char? on float")
+  (is (false? (char? nil)) "char? on nil")
+  (is (false? (char? true)) "char? on boolean")
+  (is (false? (char? :a)) "char? on keyword")
+  (is (false? (char? 'a)) "char? on symbol")
+  (is (false? (char? ["a"])) "char? on vector"))
+
 (deftest test-keyword?
   (is (true? (keyword? :test)) "keyword? on :test")
   (is (false? (keyword? ":test")) "keyword? on string"))


### PR DESCRIPTION
## 🤔 Background

Phel's predicate family already exposes `string?`, `integer?`, `number?`, `keyword?`, etc., and we recently added the `char` coercion function (#1330). Issue #1334 asks for the matching `char?` predicate.

Since Phel has no distinct `Character` type (PHP doesn't either), there are two reasonable definitions:

- **Clojure/JVM**: `char?` returns true only for `java.lang.Character` instances — impossible to match here, there's no such type.
- **ClojureScript**: `char?` returns true for any JS string of length 1 — the exact situation we have, so this is the right reference.

Choosing the ClojureScript definition keeps `.cljc` test suites (e.g. `clojure-test-suite/char_qmark.cljc`) portable without special-casing.

## 💡 Goal

Add a `char?` predicate that returns `true` iff the argument is a single-character string (UTF-8 counted), and `false` for every other value.

## 🔖 Changes

- New `char?` defn in `src/phel/core.phel`, placed next to `string?`, with a docstring that explains the ClojureScript alignment and a `:see-also` link to `char`/`string?`.
- UTF-8 length check via `php/mb_strlen … "UTF-8"` so multi-byte code points like `"ñ"` and `"漢"` correctly count as one character — matching how the existing `char` coercion validates its string input.
- 18 assertions in `tests/phel/test/core/type-operation.phel` covering:
  - ASCII single chars, whitespace, escapes, character literals (`\A`, `\space`)
  - Multi-byte UTF-8 code points (`"ñ"`, `"漢"`)
  - Rejection of empty, multi-character, and non-string values (int, float, nil, boolean, keyword, symbol, vector)
- `CHANGELOG.md` entry under `## Unreleased → Added → Core Language`.

Closes #1334