### PR TITLE
fix: `drop-last` errors on `nil` collection (#1344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix inside syntax-quote; use `name#` instead, matching Clojure's reader macro (#1203)
 
 ### Fixed
+- `drop-last` no longer errors on a `nil` collection: `(drop-last n nil)` and `(drop-last nil)` now return an empty vector `[]`, matching Clojure's `(drop-last 5 nil) => ()` and aligning with `drop`/`take`, which already return an empty result on `nil`. Previously it threw `InvalidArgumentException: Cannot slice` because the internal `slice` call was invoked on `nil` (#1344)
 - `reset!`, `swap!`, and `set!` now return the newly-stored value instead of `nil`, matching Clojure; `Variable::set()` likewise returns the stored value so direct PHP callers see the post-watch value. Callers that inspected the previous `nil` return (e.g. `(if (reset! a v) ...)`) will observe the new truthy result (#1304)
 - `associative?` now returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol. Previously only hash-maps, structs, and non-indexed PHP arrays returned true (#1303)
 - `(vec map)` now returns entries as 2-element vectors (e.g. `(vec {:a 1}) => [[:a 1]]`), matching Clojure. Previously it returned only the values (#1305)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2060,14 +2060,18 @@ Otherwise, it tries to call `__toString`."
 
 (defn drop-last
   "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted,
-   matching Clojure's `(drop-last coll)` single-arity form."
-  {:example "(drop-last [1 2 3 4 5]) ; => [1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => [1 2 3]"
+   matching Clojure's `(drop-last coll)` single-arity form. Returns an empty
+   vector when `coll` is `nil`, matching Clojure's `(drop-last n nil)` → `()`
+   and aligning with `drop`/`take`, which also return an empty result on `nil`."
+  {:example "(drop-last [1 2 3 4 5]) ; => [1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => [1 2 3]\n(drop-last 5 nil) ; => []"
    :see-also ["drop" "butlast"]}
   ([coll] (drop-last 1 coll))
   ([n coll]
-   (let [n (if (php/< n 0) 0 n)
-         end (php/- (count coll) n)]
-     (slice coll 0 (php/max 0 end)))))
+   (if (nil? coll)
+     []
+     (let [n (if (php/< n 0) 0 n)
+           end (php/- (count coll) n)]
+       (slice coll 0 (php/max 0 end))))))
 
 (defn last
   "Returns the last element of `coll` or nil if `coll` is empty or nil."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -102,6 +102,13 @@
   (is (= (php/array "a" "b") (drop-last (php/array "a" "b" "c"))) "drop-last single-arity on php array")
   (is (= (php/array) (drop-last (php/array "a"))) "drop-last single-arity on single-element php array"))
 
+(deftest test-drop-last-nil
+  (is (= [] (drop-last 5 nil)) "drop-last with n on nil returns empty vector")
+  (is (= [] (drop-last 1 nil)) "drop-last 1 on nil returns empty vector")
+  (is (= [] (drop-last 0 nil)) "drop-last 0 on nil returns empty vector")
+  (is (= [] (drop-last -1 nil)) "drop-last negative n on nil returns empty vector")
+  (is (= [] (drop-last nil)) "drop-last single-arity on nil returns empty vector"))
+
 (deftest test-last
   (is (= "c" (last ["a" "b" "c"])) "last element")
   (is (nil? (last [])) "last on empty vector")


### PR DESCRIPTION
## 🤔 Background

`(drop-last 5 nil)` currently throws `InvalidArgumentException: Cannot slice` because Phel's `drop-last` unconditionally passes its argument to the internal `slice` helper, which rejects `nil`. This diverges from Clojure, where `(drop-last 5 nil) => ()` is valid, and from Phel's own `drop` and `take`, which both happily return an empty result on `nil`. The divergence breaks `.cljc` interop (noted in clojure-test-suite).

Closes #1344

## 💡 Goal

Make `drop-last` safely return an empty result on `nil`, without changing behavior for any other input shape.

## 🔖 Changes

- `src/phel/core.phel`: add a `(nil? coll) → []` guard at the top of the two-arity body. The single-arity `[coll]` form delegates to the two-arity form and thus picks up the fix for free. Docstring and `:example` updated to document the `nil` case. No other branches are changed — negative-`n` clamping and the `slice` call stay identical for non-nil inputs.
- `tests/phel/test/core/sequence-functions.phel`: add `test-drop-last-nil` covering every combination that previously crashed — positive `n`, `n = 1`, `n = 0`, negative `n`, and the single-arity `(drop-last nil)` form — all expected to return `[]`.
- `CHANGELOG.md`: document the fix under `## Unreleased → Fixed`.

The returned empty value is the empty **vector** `[]`, not an empty list `()`. This is consistent with Phel's `drop`/`take`, which also return an empty vector on `nil` — callers that care about the concrete collection shape should wrap with `into` as they already do for `drop`/`take`.