### PR TITLE
feat: add `defrecord` and `deftype` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Clojure-compatible `&form` and `&env` implicit symbols inside every `defmacro` body: `&form` is the original macro call form, `&env` is a map of locals in scope at the call site, enabling dialect detection patterns like `(:ns &env)` for `.cljc` interop (#1185)
 
 #### Core Language
+- `defrecord` and `deftype` macros for Clojure-compatible record/type syntax. Both expand to a `defstruct` plus a `->Name` positional factory; `defrecord` additionally generates a `map->Name` factory. An optional protocol/method tail is spliced into an `extend-type` call, so inline protocol implementations in the macro body work exactly like Clojure's `defrecord`/`deftype`. Only Phel protocols are supported in the inline tail; PHP interface inline impls remain on `defstruct`. Phel's `deftype` shares the map-backed `defstruct` infrastructure, so instances remain map-like — a documented deviation from Clojure's non-map `deftype` (#1324)
 - `reify` for anonymous protocol/interface implementation, matching Clojure's `reify` (#1226)
 - `sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by` for Clojure-compatible sorted persistent collections (#1228)
 - `sorted?` predicate for checking whether a collection is a sorted-map or sorted-set, matching Clojure's `sorted?` (#1274)

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -179,21 +179,44 @@ Phel runs on PHP, which is single-threaded per request. This means several Cloju
 
 ## Structural differences
 
-### defstruct vs defrecord
+### defstruct, defrecord, and deftype
 
-Phel uses `defstruct` instead of Clojure's `defrecord`:
+Phel's native type form is `defstruct`. Clojure-compatible `defrecord` and
+`deftype` are thin macros over `defstruct` and produce the same `->Name` /
+`map->Name` factory functions Clojure programmers expect:
 
 ```phel
-;; Phel
+;; Phel — defstruct (native)
 (defstruct Point [x y])
 (let [p (Point 1 2)]
   (get p :x)) ;; => 1
 
-;; Clojure equivalent
+;; Phel — defrecord (Clojure-compatible)
 (defrecord Point [x y])
-(let [p (->Point 1 2)]
-  (:x p))
+(->Point 1 2)           ;; positional factory
+(map->Point {:x 1 :y 2}) ;; map factory
+
+;; Phel — deftype
+(deftype PointT [x y])
+(->PointT 1 2)          ;; positional factory (no map-> counterpart)
 ```
+
+Inline protocol method implementations work in both macro bodies and are
+spliced into an `extend-type` call:
+
+```phel
+(defprotocol Drawable
+  (draw [this canvas]))
+
+(defrecord Shape [label]
+  Drawable
+  (draw [this canvas] (str canvas ":" (get this :label))))
+```
+
+Note: Phel's `deftype` still shares the map-backed `defstruct` infrastructure,
+so instances remain map-like (keys are accessible via `get`). Clojure's
+`deftype` creates a non-map type; if you need that semantic, fall back to
+native PHP interop.
 
 ### No lazy-seq by default
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -4280,6 +4280,65 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        ~@dispatch-registrations
        ~instance-sym)))
 
+(defmacro defrecord
+  "Defines a record type with the given fields, matching Clojure's `defrecord`.
+
+  Expands to a `defstruct` plus Clojure-style factory functions:
+  - `Name` — positional constructor (from `defstruct`)
+  - `Name?` — type predicate (from `defstruct`)
+  - `->Name` — positional factory, identical to `Name`
+  - `map->Name` — map factory that takes `{:field value ...}`
+
+  An optional tail of protocol/method forms is spliced into an `extend-type`
+  call, so inline protocol implementations work exactly like Clojure's
+  `defrecord` body. Only Phel protocols are supported in the inline tail;
+  PHP interface implementations remain on `defstruct`."
+  {:example "(defrecord Point [x y] Drawable (draw [this canvas] ...))"
+   :see-also ["deftype" "defstruct" "defprotocol" "extend-type"]}
+  [name fields & impls]
+  (let [name-str (php/-> name (getName))
+        arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
+        map-ctor (php/:: Symbol (create (php/. "map->" name-str)))
+        m-sym (gensym "map__")
+        get-calls (for [f :in fields]
+                    `(get ~m-sym ~(keyword (php/-> f (getName)))))
+        forms [`(defstruct ~name ~fields)
+               `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))
+               `(defn ~map-ctor ~(php/. "Map factory function for " name-str ".") [~m-sym] (~name ~@get-calls))]
+        all-forms (if (seq impls)
+                    (conj forms `(extend-type ~name ~@impls))
+                    forms)]
+    `(do ~@all-forms)))
+
+(defmacro deftype
+  "Defines a type with the given fields, matching Clojure's `deftype` syntax.
+
+  Expands to a `defstruct` plus a Clojure-style positional factory:
+  - `Name` — positional constructor (from `defstruct`)
+  - `Name?` — type predicate (from `defstruct`)
+  - `->Name` — positional factory, identical to `Name`
+
+  Unlike `defrecord`, no `map->Name` factory is generated.
+
+  An optional tail of protocol/method forms is spliced into an `extend-type`
+  call. Only Phel protocols are supported in the inline tail.
+
+  Deviation from Clojure: Phel's `deftype` shares the map-backed
+  `defstruct` infrastructure, so instances remain map-like (keys are
+  accessible via `get`). Clojure's `deftype` produces a non-map type;
+  if you need that semantic, use native PHP interop."
+  {:example "(deftype PointT [x y] Drawable (draw [this canvas] ...))"
+   :see-also ["defrecord" "defstruct" "defprotocol" "extend-type"]}
+  [name fields & impls]
+  (let [name-str (php/-> name (getName))
+        arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
+        forms [`(defstruct ~name ~fields)
+               `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))]
+        all-forms (if (seq impls)
+                    (conj forms `(extend-type ~name ~@impls))
+                    forms)]
+    `(do ~@all-forms)))
+
 ;; ------------
 ;; Multimethods
 ;; ------------

--- a/tests/phel/test/core/records.phel
+++ b/tests/phel/test/core/records.phel
@@ -1,0 +1,107 @@
+(ns phel-test\test\core\records
+  (:require phel\test :refer [deftest is]))
+
+;; --- defrecord: basic shape and constructors ---
+
+(defrecord Point [x y])
+
+(deftest test-defrecord-positional-constructor
+  (let [p (Point 1 2)]
+    (is (= 1 (get p :x)) "defrecord: :x accessible via get")
+    (is (= 2 (get p :y)) "defrecord: :y accessible via get")
+    (is (true? (Point? p)) "defrecord: positional ctor makes a Point instance")))
+
+(deftest test-defrecord-arrow-constructor
+  (let [p (->Point 1 2)]
+    (is (= 1 (get p :x)) "->Point positional factory")
+    (is (true? (Point? p)) "->Point creates a Point instance")
+    (is (= (Point 1 2) (->Point 1 2)) "Point and ->Point are equivalent")))
+
+(deftest test-defrecord-map-constructor
+  (let [p (map->Point {:x 1 :y 2})]
+    (is (= 1 (get p :x)) "map->Point extracts :x")
+    (is (= 2 (get p :y)) "map->Point extracts :y")
+    (is (true? (Point? p)) "map->Point creates a Point instance")
+    (is (= (Point 1 2) (map->Point {:x 1 :y 2})) "map->Point equals positional ctor")))
+
+(deftest test-defrecord-equality
+  (is (= (Point 1 2) (Point 1 2)) "defrecord instances with same values are equal")
+  (is (not= (Point 1 2) (Point 1 3)) "defrecord instances with different values are not equal"))
+
+;; --- defrecord with inline protocol methods ---
+
+(defprotocol Drawable
+  (draw [this canvas]))
+
+(defrecord Shape [label]
+  Drawable
+  (draw [this canvas] (str canvas ":" (get this :label))))
+
+(deftest test-defrecord-with-protocol
+  (is (= "svg:hex" (draw (Shape "hex") "svg")) "inline protocol method dispatches"))
+
+(defprotocol Labellable
+  (label-of [this]))
+
+(defprotocol Sized
+  (size-of [this]))
+
+(defrecord Box [label w h]
+  Labellable
+  (label-of [this] (get this :label))
+  Sized
+  (size-of [this] (* (get this :w) (get this :h))))
+
+(deftest test-defrecord-multi-protocol
+  (let [b (Box "crate" 3 4)]
+    (is (= "crate" (label-of b)) "first protocol dispatches")
+    (is (= 12 (size-of b)) "second protocol dispatches")))
+
+;; --- defrecord with empty fields + marker protocol ---
+
+(defprotocol RecordMarker)
+
+(defrecord MarkerRecord [] RecordMarker)
+
+(deftest test-defrecord-empty-fields-marker-protocol
+  (let [r (MarkerRecord)]
+    (is (true? (MarkerRecord? r)) "empty-field defrecord is constructible")
+    (is (= r (->MarkerRecord)) "->MarkerRecord equal to MarkerRecord")
+    (is (= r (map->MarkerRecord {})) "map->MarkerRecord works with empty map")))
+
+;; --- deftype: basic shape ---
+
+(deftype TypePoint [x y])
+
+(deftest test-deftype-positional-constructor
+  (let [p (TypePoint 1 2)]
+    (is (= 1 (get p :x)) "deftype: :x accessible (map-backed in Phel)")
+    (is (true? (TypePoint? p)) "deftype predicate works")))
+
+(deftest test-deftype-arrow-constructor
+  (let [p (->TypePoint 1 2)]
+    (is (= (TypePoint 1 2) p) "->TypePoint equals positional TypePoint")
+    (is (true? (TypePoint? p)) "->TypePoint creates a TypePoint instance")))
+
+;; --- deftype with inline protocol methods ---
+
+(defprotocol TypeDescribable
+  (describe-type [this]))
+
+(deftype TypeThing [name]
+  TypeDescribable
+  (describe-type [this] (str "thing:" (get this :name))))
+
+(deftest test-deftype-with-protocol
+  (is (= "thing:foo" (describe-type (TypeThing "foo"))) "deftype inline protocol dispatches"))
+
+;; --- deftype with empty fields + marker protocol ---
+
+(defprotocol TypeMarker)
+
+(deftype MarkerType [] TypeMarker)
+
+(deftest test-deftype-empty-fields-marker-protocol
+  (let [t (MarkerType)]
+    (is (true? (MarkerType? t)) "empty-field deftype is constructible")
+    (is (= t (->MarkerType)) "->MarkerType equal to MarkerType")))


### PR DESCRIPTION
## 🤔 Background

Closes #1324.

Clojure's `defrecord` and `deftype` are widely used for creating tagged types. The immediate driver is the `clojure-test-suite` port (`ancestors.cljc`), which uses both forms to create marker types for hierarchy tests. Without them, that suite can't compile in Phel.

Phel already has all the building blocks — `defstruct` for map-like types, `defprotocol`/`extend-type` for protocol dispatch — so the forms can be added as pure macros in `src/phel/core.phel` with no compiler changes.

## 💡 Goal

Add Clojure-compatible `defrecord` and `deftype` macros so that the usual `(defrecord Name [fields] Protocol (method [this] ...))` shape works out of the box, and `->Name` / `map->Name` factory functions exist where Clojure programmers expect them.

## 🔖 Changes

- `src/phel/core.phel`
  - `defmacro defrecord` — expands to `defstruct` + `->Name` positional factory + `map->Name` map factory + optional `extend-type` for any inline protocol tail.
  - `defmacro deftype` — same, minus `map->Name`.
  - Both placed after `reify` (so `extend-type` is already defined at macro-expand time).
- `tests/phel/test/core/records.phel` — new Phel test file with 11 `deftest`s covering: positional/arrow/map constructors, equality, inline single-protocol, multi-protocol, empty-fields + marker protocol, and the `deftype` variants.
- `docs/clojure-migration.md` — rewrote the `defstruct vs defrecord` subsection to document all three forms, including the `deftype` map-backed caveat.
- `CHANGELOG.md` — bullet under `## Unreleased` → `#### Core Language`.

### Example

```phel
(defprotocol Drawable
  (draw [this canvas]))

(defrecord Shape [label]
  Drawable
  (draw [this canvas] (str canvas ":" (get this :label))))

(draw (Shape "hex") "svg")           ;; => "svg:hex"
(draw (->Shape "hex") "svg")         ;; => "svg:hex"
(draw (map->Shape {:label "hex"}) "svg") ;; => "svg:hex"
```

### Scope / deviations

- Inline protocol/method tail accepts **Phel protocols only**. For PHP interface inline implementations, use `defstruct` directly (unchanged).
- Phel's `deftype` shares the map-backed `defstruct` infrastructure, so instances remain map-like — documented in the macro docstring and `docs/clojure-migration.md` as a deviation from Clojure's non-map `deftype`.
- Zero-method marker protocols (`(defprotocol X)`) can be listed in the macro body but `satisfies?` will still return `false` for them — this is consistent with existing `extend-type` behavior and is out of scope for this PR. The motivating `ancestors.cljc` test only uses records as hierarchy tags, not as `satisfies?` targets.