### PR TITLE
fix(core): Clojure-test-suite compliance — meta, assoc, abs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - `(meta x)` on a local binding (let, fn parameter) returns the value's metadata instead of silently falling through to a top-level definition lookup. Definition metadata is now only consulted for the quoted form `(meta 'sym)`
 - `(assoc nil k v)` returns a fresh map instead of raising a PHP `TypeError`, matching Clojure's `(assoc nil :a 1) => {:a 1}`
+- `assoc` on any other non-associative value (string, list, set, number, …) throws a clean `InvalidArgumentException` with the received type in the message, instead of silently mutating strings via `php/aset` or leaking raw PHP "offsetSet not supported" errors
 - `drop-last` no longer errors on `nil`: `(drop-last n nil)` and `(drop-last nil)` return `[]`, aligning with `drop`/`take` (#1344)
 - `reset!`, `swap!`, `set!` now return the newly-stored value instead of `nil`, matching Clojure (#1304)
 - `associative?` returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol (#1303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,10 +111,10 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix; use `name#` instead (#1203)
 
 ### Fixed
-- `(meta x)` on a local binding (let, fn parameter) returns the value's metadata instead of silently falling through to a top-level definition lookup. Definition metadata is now only consulted for the quoted form `(meta 'sym)`
-- `(assoc nil k v)` returns a fresh map instead of raising a PHP `TypeError`, matching Clojure's `(assoc nil :a 1) => {:a 1}`
-- `assoc` on any other non-associative value (string, list, set, number, …) throws a clean `InvalidArgumentException` with the received type in the message, instead of silently mutating strings via `php/aset` or leaking raw PHP "offsetSet not supported" errors
-- `abs` rejects non-numeric arguments (`nil`, strings, keywords, …) with a clean `InvalidArgumentException` instead of silently returning `0` for nil or bubbling a PHP `TypeError` for strings
+- `(meta x)` on a local binding returns the value's metadata; only `(meta 'sym)` looks up definition metadata
+- `(assoc nil k v)` returns a fresh map, matching Clojure
+- `assoc` on a non-associative value throws `InvalidArgumentException` naming the received type
+- `abs` throws `InvalidArgumentException` on non-numeric input instead of silently returning `0`
 - `drop-last` no longer errors on `nil`: `(drop-last n nil)` and `(drop-last nil)` return `[]`, aligning with `drop`/`take` (#1344)
 - `reset!`, `swap!`, `set!` now return the newly-stored value instead of `nil`, matching Clojure (#1304)
 - `associative?` returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol (#1303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to this project will be documented in this file.
 - `name$` auto-gensym suffix; use `name#` instead (#1203)
 
 ### Fixed
+- `(meta x)` on a local binding (let, fn parameter) returns the value's metadata instead of silently falling through to a top-level definition lookup. Definition metadata is now only consulted for the quoted form `(meta 'sym)`
 - `drop-last` no longer errors on `nil`: `(drop-last n nil)` and `(drop-last nil)` return `[]`, aligning with `drop`/`take` (#1344)
 - `reset!`, `swap!`, `set!` now return the newly-stored value instead of `nil`, matching Clojure (#1304)
 - `associative?` returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol (#1303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ All notable changes to this project will be documented in this file.
 - `(meta x)` on a local binding (let, fn parameter) returns the value's metadata instead of silently falling through to a top-level definition lookup. Definition metadata is now only consulted for the quoted form `(meta 'sym)`
 - `(assoc nil k v)` returns a fresh map instead of raising a PHP `TypeError`, matching Clojure's `(assoc nil :a 1) => {:a 1}`
 - `assoc` on any other non-associative value (string, list, set, number, …) throws a clean `InvalidArgumentException` with the received type in the message, instead of silently mutating strings via `php/aset` or leaking raw PHP "offsetSet not supported" errors
+- `abs` rejects non-numeric arguments (`nil`, strings, keywords, …) with a clean `InvalidArgumentException` instead of silently returning `0` for nil or bubbling a PHP `TypeError` for strings
 - `drop-last` no longer errors on `nil`: `(drop-last n nil)` and `(drop-last nil)` return `[]`, aligning with `drop`/`take` (#1344)
 - `reset!`, `swap!`, `set!` now return the newly-stored value instead of `nil`, matching Clojure (#1304)
 - `associative?` returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol (#1303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - `(meta x)` on a local binding (let, fn parameter) returns the value's metadata instead of silently falling through to a top-level definition lookup. Definition metadata is now only consulted for the quoted form `(meta 'sym)`
+- `(assoc nil k v)` returns a fresh map instead of raising a PHP `TypeError`, matching Clojure's `(assoc nil :a 1) => {:a 1}`
 - `drop-last` no longer errors on `nil`: `(drop-last n nil)` and `(drop-last nil)` return `[]`, aligning with `drop`/`take` (#1344)
 - `reset!`, `swap!`, `set!` now return the newly-stored value instead of `nil`, matching Clojure (#1304)
 - `associative?` returns `true` for vectors and PHP indexed arrays, matching Clojure's `Associative` protocol (#1303)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1317,9 +1317,12 @@ Otherwise, it tries to call `__toString`."
     (or (vector? ds) (php/instanceof ds TransientVectorInterface))
     (php/-> ds (update key value))
 
-    (do
-      (php/aset ds key value)
-      ds)))
+    ;; Explicit rejection for any other shape (string, list, set, sorted set,
+    ;; number, …). Without this the old fall-through silently mutated strings
+    ;; via `php/aset` and leaked raw PHP "offsetSet not supported" errors for
+    ;; lists and sets.
+    (throw (php/new InvalidArgumentException
+                    (str "assoc expects a map, vector, struct, or nil; got " (type ds))))))
 
 (defn assoc
   "Associates one or more key-value pairs with a collection.

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1304,6 +1304,10 @@ Otherwise, it tries to call `__toString`."
   "Associates a single key-value pair with a collection."
   [ds key value]
   (cond
+    ;; Clojure-compat: (assoc nil k v) creates a fresh map instead of erroring.
+    (nil? ds)
+    (php/-> {} (put key value))
+
     (php-array? ds)
     (throw (php/new InvalidArgumentException "Cannot call assoc on pure PHP arrays. Use (php/aset ds key value)"))
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -188,22 +188,27 @@
 
 (def meta
   {:macro true
-   :doc "Gets the metadata of the given object or definition."}
+   :doc "Gets the metadata attached to a value.
+  For a quoted symbol (`(meta 'foo)`) the definition metadata registered via `def` is returned.
+  For any other expression the value is looked up at runtime and its `MetaInterface` metadata returned."}
   (fn [obj]
-    (let [sym (if (symbol? obj)
-                obj
-                (if (list? obj)
-                  (if (= (first obj) 'quote)
-                    (if (symbol? (second obj))
-                      (second obj)
-                      nil)
-                    nil)
-                  nil))]
-      (if sym
-        (let [ns (php/-> sym (getNamespace))]
+    ;; Only the quoted-symbol form routes to definition metadata. A bare symbol
+    ;; could refer to a local binding (let / fn parameter), so we must resolve it
+    ;; at runtime and call `getMeta` on its value; otherwise `(meta coll)` inside
+    ;; a function body would wrongly return nil for locals that were attached
+    ;; metadata via `with-meta`.
+    (let [quoted-sym (if (list? obj)
+                       (if (= (first obj) 'quote)
+                         (if (symbol? (second obj))
+                           (second obj)
+                           nil)
+                         nil)
+                       nil)]
+      (if quoted-sym
+        (let [ns (php/-> quoted-sym (getNamespace))]
           (if ns
-            `(php/:: \Phel (getDefinitionMetaData ~ns ~(php/-> sym (getName))))
-            `(php/:: \Phel (getDefinitionMetaData (php/str_replace "-" "_" *ns*) ~(php/-> sym (getName))))))
+            `(php/:: \Phel (getDefinitionMetaData ~ns ~(php/-> quoted-sym (getName))))
+            `(php/:: \Phel (getDefinitionMetaData (php/str_replace "-" "_" *ns*) ~(php/-> quoted-sym (getName))))))
         `(let [obj-meta ~obj]
            (if (php/instanceof obj-meta \Phel\Lang\MetaInterface)
              (php/-> obj-meta (getMeta))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3335,10 +3335,15 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (php/is_infinite x))
 
 (defn abs
-  "Returns the absolute value of `x`."
+  "Returns the absolute value of `x`.
+  Throws `InvalidArgumentException` if `x` is not a number, matching Clojure
+  rather than PHP's permissive `abs(null) => 0` / `abs(\"abc\")` coercions."
   {:example "(abs -5) ; => 5"}
   [x]
-  (php/abs x))
+  (if (number? x)
+    (php/abs x)
+    (throw (php/new InvalidArgumentException
+                    (str "abs expects a number, got " (type x))))))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and

--- a/tests/phel/test/core/meta.phel
+++ b/tests/phel/test/core/meta.phel
@@ -4,16 +4,28 @@
 (def secret {:private true} 1)
 
 (deftest meta-on-definition
-  ;; NOTE: (meta secret) expands to (getDefinitionMetaData *ns* "secret") at runtime.
-  ;; In the full test suite *ns* may differ from this file's namespace at execution time,
-  ;; so asserting non-nil here is unreliable. The consistency check below is what matters.
-  (is (= (meta secret) (meta 'secret)) "meta on quoted definition is consistent with unquoted"))
+  ;; `(meta 'sym)` looks up the metadata registered for the definition `sym`.
+  ;; Asserting non-nil here is unreliable because `*ns*` may differ from this
+  ;; file's namespace at execution time, but the definition must carry the
+  ;; `:private` flag when inspected from *this* namespace.
+  (let [m (meta 'secret)]
+    (is (or (nil? m) (= true (get m :private))) "meta on quoted definition reflects the :private flag")))
 
 (deftest meta-on-value
   (is (= nil (meta 1)) "meta on plain value returns nil"))
 
 (deftest meta-on-undefined-symbol
   (is (= nil (meta 'unknown)) "meta on undefined symbol returns nil"))
+
+(deftest meta-on-local-binding
+  ;; Regression for clojure-test-suite: `(meta local)` in a function/let body must
+  ;; return the metadata attached to the local's value, not a def lookup on its name.
+  (let [m {:tag :test}
+        data (with-meta {:a 1} m)]
+    (is (= m (meta data)) "meta on a let-bound value returns its metadata"))
+  (is (= {:tag :test}
+         ((fn [coll] (meta coll)) (with-meta [1 2 3] {:tag :test})))
+      "meta on a fn parameter returns its metadata"))
 
 (deftest meta-on-object-with-meta
   (is (= {:a 1} (meta (set-meta! [] {:a 1}))) "meta on object implementing MetaInterface"))

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -200,7 +200,10 @@
   (is (= {:a 9 :b 9 :c 9} (assoc {:a 1 :b 2 :c 3} :a 9 :b 9 :c 9)) "assoc: replace multiple entries")
   (is (= [10 2 3] (assoc [1 2 3] 0 10)) "assoc: single pair on vector unchanged")
   (is (= [10 20 3] (assoc [1 2 3] 0 10 1 20)) "assoc: multiple pairs on vector")
-  (is (thrown? \InvalidArgumentException (assoc {} :a 1 :b)) "assoc: odd extra args throws"))
+  (is (thrown? \InvalidArgumentException (assoc {} :a 1 :b)) "assoc: odd extra args throws")
+  ;; nil → empty map (Clojure-compat)
+  (is (= {:a 1} (assoc nil :a 1)) "assoc: nil becomes a new map")
+  (is (= {:a 1 :b 2} (assoc nil :a 1 :b 2)) "assoc: nil with multiple pairs"))
 
 (deftest test-unset
   (is (= {:b 2} (unset {:a 1 :b 2} :a)) "unset: remove key from map"))

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -203,7 +203,13 @@
   (is (thrown? \InvalidArgumentException (assoc {} :a 1 :b)) "assoc: odd extra args throws")
   ;; nil → empty map (Clojure-compat)
   (is (= {:a 1} (assoc nil :a 1)) "assoc: nil becomes a new map")
-  (is (= {:a 1 :b 2} (assoc nil :a 1 :b 2)) "assoc: nil with multiple pairs"))
+  (is (= {:a 1 :b 2} (assoc nil :a 1 :b 2)) "assoc: nil with multiple pairs")
+  ;; Unsupported targets raise a clean `InvalidArgumentException` instead of
+  ;; silently mutating strings or leaking raw PHP messages from lists/sets.
+  (is (thrown? \InvalidArgumentException (assoc "abc" 0 "z")) "assoc: rejects strings")
+  (is (thrown? \InvalidArgumentException (assoc '(1 2 3) 0 99)) "assoc: rejects lists")
+  (is (thrown? \InvalidArgumentException (assoc #{1 2 3} 1 9)) "assoc: rejects sets")
+  (is (thrown? \InvalidArgumentException (assoc 42 :a 1)) "assoc: rejects scalars"))
 
 (deftest test-unset
   (is (= {:b 2} (unset {:a 1 :b 2} :a)) "unset: remove key from map"))

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -14,7 +14,12 @@
   (is (= 5 (abs -5)) "(abs -5)")
   (is (= 5 (abs 5)) "(abs 5)")
   (is (= 0 (abs 0)) "(abs 0)")
-  (is (= 3.14 (abs -3.14)) "(abs -3.14)"))
+  (is (= 3.14 (abs -3.14)) "(abs -3.14)")
+  ;; Clojure-compat: reject non-numbers instead of PHP's permissive coercion
+  ;; (which would silently return 0 for nil and throw a raw TypeError for strings).
+  (is (thrown? \InvalidArgumentException (abs nil)) "(abs nil) throws")
+  (is (thrown? \InvalidArgumentException (abs "abc")) "(abs string) throws")
+  (is (thrown? \InvalidArgumentException (abs :k)) "(abs keyword) throws"))
 
 ;; --- Map utilities ---
 


### PR DESCRIPTION
## 🤔 Background

@jasalt is running the [jank-lang/clojure-test-suite](https://github.com/jank-lang/clojure-test-suite) against Phel in #1113 and reported a first compliance snapshot of **292 / 417 passing**. A handful of failures in the paste are not actually behavioural gaps, they are surface quality issues that make the suite misbehave or mask real wins.

This PR knocks down the four that showed up most often in his `assoc` / `abs` / meta-preservation categories, all driven from a single local reproduction against the relevant `.cljc` tests.

## 💡 Goal

Give the next clojure-test-suite run against Phel strictly better output — more passes, clearer error messages, no silent corruption — so @jasalt does not have to shim around Phel quirks in his fork.

## 🔖 Changes

Each commit is a single focused fix with a test and a changelog line.

- **`fix(core): meta returns local binding metadata instead of def lookup`** — `(meta x)` inside a `let` or fn body was expanding to `getDefinitionMetaData` on the bare symbol, so metadata attached via `with-meta` to a local came back as `nil`. This is the root cause of the `meta preservation` failures in the suite (`(defn with-test-meta? [coll] (meta coll))` always returned nil). Only `(meta 'sym)` now routes to definition metadata; everything else is resolved at runtime via `MetaInterface`. One existing test (`meta-on-definition`) was updated to use the quoted form.
- **`fix(core): assoc on nil returns a fresh map`** — `(assoc nil :a 1)` used to raise a PHP `TypeError`; now it returns `{:a 1}`, matching Clojure.
- **`fix(core): assoc rejects unsupported targets with a clean error`** — previously `(assoc "abc" 0 "z")` silently returned `"zbc"` (the old default branch fell through to `php/aset`), and `(assoc '(1 2) 0 9)` / `(assoc #{1 2} 1 9)` leaked raw PHP messages. Now all non-associative shapes throw `\InvalidArgumentException` with the received type in the message, so `(thrown? (assoc coll k v))` in the suite matches and users get a readable diagnostic.
- **`fix(core): abs rejects non-numeric input`** — `(abs nil)` used to silently return `0` and `(abs "abc")` bubbled a raw PHP `TypeError`. `abs` now `(number? x)`-checks up-front and throws `\InvalidArgumentException`, so `(thrown? (abs nil))` works.

### Developer experience focus

- Every new error message names the received type (`got :string`, `got :nil`), so failing suite output points at the real input rather than at PHP internals.
- Each fix keeps the existing happy path untouched — no signature changes, no new dependencies, no reshuffling of `assoc-pair`'s ordering.
- Tests live next to the existing assertions for each function (`test-assoc`, `test-abs`, `meta-on-local-binding`) so regressions surface in the same file future contributors will read.

### Test plan

- `composer test-core` → **2982 / 2982** passing
- `composer test-compiler` → **1910 / 1910** passing
- `composer test-quality` → php-cs-fixer, psalm, phpstan, rector all green

Refs #1113