### PR TITLE
feat(core): add persistent!, assoc!, dissoc!, disj!, pop!, double?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project will be documented in this file.
 - `char?` predicate (single-char string, UTF-8 counted), matching ClojureScript semantics (#1334)
 - `coll?` predicate for persistent collections (vectors, lists, hash-maps, structs, sets, lazy-seqs) (#1336)
 - `conj!` transient mutator with Clojure-compatible arities over transient vectors, sets, and maps (#1338)
+- `assoc!`, `dissoc!`, `disj!`, `pop!` transient mutators, throwing `InvalidArgumentException` on persistent or mismatched targets
 - `some-fn` higher-order predicate combinator, short-circuiting on first logical-true result (#1339)
 - `counted?` predicate for collections with constant-time length (lazy-seqs excluded) (#1340)
 - Single-arity `(drop-last coll)` equivalent to `(drop-last 1 coll)` (#1343)
@@ -70,6 +71,8 @@ All notable changes to this project will be documented in this file.
 
 #### Clojure-Compatible Aliases
 - `atom`, `atom?`, `reset!` as aliases for `var`, `var?`, `set!` (#1252)
+- `persistent!` as alias for `persistent`, matching Clojure's bang naming
+- `double?` as alias for `float?`, matching Clojure's `double?`
 - `identical?` as alias for `id` (#1252)
 - `fn?` as alias for `function?` (#1252)
 - `map?` as alias for `hash-map?` (#1252)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -417,6 +417,14 @@ Otherwise, it tries to call `__toString`."
   [coll]
   (php/-> coll (persistent)))
 
+(defn persistent!
+  "Converts a transient collection back to a persistent collection.
+   Alias for `persistent`, matching Clojure's `persistent!` naming."
+  {:example "(persistent! (conj! (transient []) 1 2 3)) ; => [1 2 3]"
+   :see-also ["persistent" "transient"]}
+  [coll]
+  (persistent coll))
+
 ;; ------------------
 ;; Basic constructors
 ;; ------------------
@@ -1005,6 +1013,15 @@ Otherwise, it tries to call `__toString`."
   "Returns true if `x` is a number, false otherwise."
   [x]
   (or (= (type x) :int) (= (type x) :float)))
+
+(defn double?
+  "Returns true if `x` is a floating-point number, false otherwise.
+   Alias for `float?`, matching Clojure's `double?` naming. Since Phel
+   uses PHP floats (IEEE 754 doubles) there is no separate single-precision
+   float type."
+  {:see-also ["float?" "number?"]}
+  [x]
+  (float? x))
 
 (defn string?
   "Returns true if `x` is a string, false otherwise."
@@ -1930,6 +1947,97 @@ Otherwise, it tries to call `__toString`."
   ([tcoll value] (conj-bang-single tcoll value))
   ([tcoll value & more]
    (reduce conj-bang-single (conj-bang-single tcoll value) more)))
+
+(defn- assoc-bang-pair
+  [tcoll key value]
+  (cond
+    (php/instanceof tcoll TransientMapInterface)
+    (php/-> tcoll (put key value))
+
+    (php/instanceof tcoll TransientVectorInterface)
+    (php/-> tcoll (update key value))
+
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "assoc! expects a transient map or transient vector, got " (type tcoll))))))
+
+(defn assoc!
+  "Associates one or more key-value pairs with a transient collection,
+   mutating it in place. Works on transient hash-maps and transient vectors.
+   Variadic forms apply each `key-value` pair in order. Raises
+   `InvalidArgumentException` when `tcoll` is not a supported transient
+   collection or when an odd number of extra arguments is provided.
+   Matches Clojure's `assoc!` semantics."
+  {:example "(persistent! (assoc! (transient {}) :a 1 :b 2)) ; => {:a 1 :b 2}"
+   :see-also ["assoc" "conj!" "transient" "persistent!"]}
+  [tcoll key value & more]
+  (when (php/!== 0 (php/& (count more) 1))
+    (throw (php/new InvalidArgumentException
+                    (str "assoc! expects an even number of extra arguments (key-value pairs), got "
+                         (count more)))))
+  (loop [acc (assoc-bang-pair tcoll key value)
+         remaining more]
+    (if (empty? remaining)
+      acc
+      (recur (assoc-bang-pair acc (first remaining) (second remaining))
+             (rest (rest remaining))))))
+
+(defn- dissoc-bang-single
+  [tcoll key]
+  (cond
+    (php/instanceof tcoll TransientMapInterface)
+    (php/-> tcoll (remove key))
+
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "dissoc! expects a transient map, got " (type tcoll))))))
+
+(defn dissoc!
+  "Dissociates one or more keys from a transient map, mutating it in place.
+   Raises `InvalidArgumentException` when `tcoll` is not a transient map.
+   Matches Clojure's `dissoc!` semantics."
+  {:example "(persistent! (dissoc! (transient {:a 1 :b 2}) :a)) ; => {:b 2}"
+   :see-also ["dissoc" "assoc!" "transient" "persistent!"]}
+  ([tcoll] tcoll)
+  ([tcoll key] (dissoc-bang-single tcoll key))
+  ([tcoll key & ks]
+   (reduce dissoc-bang-single (dissoc-bang-single tcoll key) ks)))
+
+(defn- disj-bang-single
+  [tcoll value]
+  (cond
+    (php/instanceof tcoll TransientHashSetInterface)
+    (php/-> tcoll (remove value))
+
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "disj! expects a transient set, got " (type tcoll))))))
+
+(defn disj!
+  "Removes one or more elements from a transient set, mutating it in place.
+   Raises `InvalidArgumentException` when `tcoll` is not a transient set.
+   Matches Clojure's `disj!` semantics."
+  {:example "(persistent! (disj! (transient #{1 2 3}) 2)) ; => #{1 3}"
+   :see-also ["disj" "conj!" "transient" "persistent!"]}
+  ([tcoll] tcoll)
+  ([tcoll value] (disj-bang-single tcoll value))
+  ([tcoll value & more]
+   (reduce disj-bang-single (disj-bang-single tcoll value) more)))
+
+(defn pop!
+  "Removes the last element from a transient vector, mutating it in place.
+   Raises `InvalidArgumentException` when `tcoll` is not a transient vector.
+   Matches Clojure's `pop!` semantics."
+  {:example "(persistent! (pop! (transient [1 2 3]))) ; => [1 2]"
+   :see-also ["pop" "conj!" "transient" "persistent!"]}
+  [tcoll]
+  (cond
+    (php/instanceof tcoll TransientVectorInterface)
+    (php/-> tcoll (pop))
+
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "pop! expects a transient vector, got " (type tcoll))))))
 
 (defn- disj-single
   [coll k]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -144,6 +144,63 @@
   (is (thrown? \InvalidArgumentException (conj! "string" 1)) "conj! on string throws")
   (is (thrown? \InvalidArgumentException (conj! nil 1)) "conj! on nil throws"))
 
+(deftest test-persistent-bang
+  (is (= [1 2 3] (persistent! (conj! (transient []) 1 2 3))) "persistent! round-trips a transient vector")
+  (is (= {:a 1} (persistent! (transient {:a 1}))) "persistent! round-trips a transient map")
+  (is (= #{1 2} (persistent! (transient #{1 2}))) "persistent! round-trips a transient set"))
+
+(deftest test-assoc-bang-map
+  (is (= {:a 1} (persistent! (assoc! (transient {}) :a 1))) "assoc! on empty transient map")
+  (is (= {:a 1 :b 2} (persistent! (assoc! (transient {:a 1}) :b 2))) "assoc! on transient map")
+  (is (= {:a 3 :b 2} (persistent! (assoc! (transient {:a 1 :b 2}) :a 3))) "assoc! overwrites existing key")
+  (is (= {:a 1 :b 2 :c 3} (persistent! (assoc! (transient {}) :a 1 :b 2 :c 3))) "assoc! variadic on transient map"))
+
+(deftest test-assoc-bang-vector
+  (is (= [9 2 3] (persistent! (assoc! (transient [1 2 3]) 0 9))) "assoc! on transient vector by index")
+  (is (= [1 2 9] (persistent! (assoc! (transient [1 2 3]) 2 9))) "assoc! at last index")
+  (is (= [9 2 8] (persistent! (assoc! (transient [1 2 3]) 0 9 2 8))) "assoc! variadic on transient vector"))
+
+(deftest test-assoc-bang-errors
+  (is (thrown? \InvalidArgumentException (assoc! (transient {:a 1}) :b 2 :c)) "assoc! with odd extra args throws")
+  (is (thrown? \InvalidArgumentException (assoc! {:a 1} :b 2)) "assoc! on persistent map throws")
+  (is (thrown? \InvalidArgumentException (assoc! [1 2] 0 9)) "assoc! on persistent vector throws")
+  (is (thrown? \InvalidArgumentException (assoc! (transient #{1 2}) 0 9)) "assoc! on transient set throws")
+  (is (thrown? \InvalidArgumentException (assoc! nil :a 1)) "assoc! on nil throws"))
+
+(deftest test-dissoc-bang
+  (is (= {} (persistent! (dissoc! (transient {:a 1}) :a))) "dissoc! single key")
+  (is (= {:b 2} (persistent! (dissoc! (transient {:a 1 :b 2}) :a))) "dissoc! leaves other keys intact")
+  (is (= {} (persistent! (dissoc! (transient {:a 1}) :a :a))) "dissoc! missing key is a no-op")
+  (is (= {:b 2} (persistent! (dissoc! (transient {:a 1 :b 2 :c 3}) :a :c))) "dissoc! variadic"))
+
+(deftest test-dissoc-bang-errors
+  (is (thrown? \InvalidArgumentException (dissoc! {:a 1} :a)) "dissoc! on persistent map throws")
+  (is (thrown? \InvalidArgumentException (dissoc! (transient [1 2]) 0)) "dissoc! on transient vector throws")
+  (is (thrown? \InvalidArgumentException (dissoc! (transient #{:a}) :a)) "dissoc! on transient set throws")
+  (is (thrown? \InvalidArgumentException (dissoc! nil :a)) "dissoc! on nil throws"))
+
+(deftest test-disj-bang
+  (is (= #{1 3} (persistent! (disj! (transient #{1 2 3}) 2))) "disj! single element")
+  (is (= #{1 2 3} (persistent! (disj! (transient #{1 2 3}) 4))) "disj! missing element is a no-op")
+  (is (= #{3} (persistent! (disj! (transient #{1 2 3}) 1 2))) "disj! variadic")
+  (is (= #{} (persistent! (disj! (transient #{1 2 3}) 1 2 3))) "disj! removes all"))
+
+(deftest test-disj-bang-errors
+  (is (thrown? \InvalidArgumentException (disj! #{1 2} 1)) "disj! on persistent set throws")
+  (is (thrown? \InvalidArgumentException (disj! (transient [1 2]) 0)) "disj! on transient vector throws")
+  (is (thrown? \InvalidArgumentException (disj! (transient {:a 1}) :a)) "disj! on transient map throws")
+  (is (thrown? \InvalidArgumentException (disj! nil 1)) "disj! on nil throws"))
+
+(deftest test-pop-bang
+  (is (= [1 2] (persistent! (pop! (transient [1 2 3])))) "pop! on transient vector")
+  (is (= [] (persistent! (pop! (transient [1])))) "pop! on single-element transient vector"))
+
+(deftest test-pop-bang-errors
+  (is (thrown? \InvalidArgumentException (pop! [1 2 3])) "pop! on persistent vector throws")
+  (is (thrown? \InvalidArgumentException (pop! (transient #{1 2}))) "pop! on transient set throws")
+  (is (thrown? \InvalidArgumentException (pop! (transient {:a 1}))) "pop! on transient map throws")
+  (is (thrown? \InvalidArgumentException (pop! nil)) "pop! on nil throws"))
+
 (deftest test-pop
   (let [x (php/array 1 2)
         y (pop x)]

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -31,6 +31,13 @@
   (is (false? (float? 10)) "float? on 10")
   (is (false? (float? 0)) "float? on 10"))
 
+(deftest test-double?
+  (is (true? (double? 10.0)) "double? on 10.0")
+  (is (true? (double? 0.0)) "double? on 0.0")
+  (is (false? (double? 10)) "double? on 10")
+  (is (false? (double? "1.5")) "double? on string")
+  (is (false? (double? nil)) "double? on nil"))
+
 (deftest test-int?
   (is (false? (int? 10.0)) "int? on 10.0")
   (is (false? (int? 0.0)) "int? on 0.0")


### PR DESCRIPTION
## 🤔 Background

Phel already ships `transient` / `persistent` and the `conj!` transient mutator (#1338), but the matching bang variants (`assoc!`, `dissoc!`, `disj!`, `pop!`, `persistent!`) that Clojure code reaches for when building collections in bulk were still missing. Phel users coming from Clojure also expected `double?` alongside the existing `float?`.

Surfaced while reviewing gaps between Phel and the `jank-lang/clojure-test-suite` progress reported in #1113, but every item in this PR is a real operation on a type Phel already owns. No interop-only shims (no constant-`false` `decimal?` / `ratio?`, no `numerator` / `denominator` against rationals Phel has no reader support for).

## 💡 Goal

Give Phel developers the full transient mutator surface they expect, under the Clojure-compatible bang naming, so bulk builders like

```phel
(persistent! (-> (transient {}) (assoc! :a 1) (assoc! :b 2) (dissoc! :a)))
```

work out of the box instead of erroring with `Cannot resolve symbol 'assoc!'`.

## 🔖 Changes

**New transient mutators in `src/phel/core.phel`:**

- `assoc!` — transient hash-map or transient vector, variadic, rejects odd extra-arg count
- `dissoc!` — transient hash-map, variadic
- `disj!` — transient hash-set, variadic
- `pop!` — transient vector
- Each validates its target via the corresponding `Transient*Interface` and throws `InvalidArgumentException` naming the received type when called on a persistent collection, a wrong-shape transient, or `nil`.

**New Clojure-named aliases:**

- `persistent!` → `persistent` (parallels the existing `atom` / `reset!` / `int?` / `NaN?` alias style in core)
- `double?` → `float?`

Refs #1113