### PR TITLE
fix(phar): stop PHAR root falling inside archive and dedupe core paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ All notable changes to this project will be documented in this file.
 - Lexer no longer swallows a reader conditional (`#?(...)`) following a gensym-suffixed symbol (#1195)
 - Lexer accepts `'` inside and at the end of symbol names (e.g. `a'`, `foo''`, `a'b`); leading `'` is still the quote reader macro (#1275)
 - `php/...` calls to namespaced PHP functions (e.g. `php/Amp\File\write`) emit fully qualified names so they resolve from compiled/cached files (#1180)
+- `phel.phar` no longer emits duplicate-namespace warnings or fails to write the compiled-code cache when run from a directory without `phel-config.php`
 
 ## [0.31.0](https://github.com/phel-lang/phel-lang/compare/v0.30.0...v0.31.0) - 2026-04-03
 

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -125,60 +125,18 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     private function warnAboutDuplicateNamespaces(array $allLocations): void
     {
         foreach ($allLocations as $namespace => $files) {
-            // Dedupe by canonical path so the same physical file discovered
-            // via nested source directories (e.g. `src/` and `src/phel/`, or a
-            // PHAR's internal dirs) is not reported as a duplicate of itself.
-            $uniqueFiles = array_values(array_unique(array_map(
-                $this->canonicalizeFilePath(...),
-                $files,
-            )));
-
-            if (count($uniqueFiles) > 1) {
-                $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $uniqueFiles));
-                fwrite(STDERR, sprintf(
-                    "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
-                    . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
-                    $namespace,
-                    $fileList,
-                ));
-            }
-        }
-    }
-
-    /**
-     * Canonicalize a file path for duplicate detection. Uses `realpath()` on
-     * the local filesystem and a manual '..' resolver for `phar://` paths,
-     * because `realpath()` does not resolve phar stream paths.
-     */
-    private function canonicalizeFilePath(string $path): string
-    {
-        if (str_starts_with($path, 'phar://')) {
-            $prefix = 'phar://';
-            $rest = substr($path, 7);
-            $isAbsolute = str_starts_with($rest, '/');
-            $segments = [];
-            foreach (explode('/', $rest) as $part) {
-                if ($part === '') {
-                    continue;
-                }
-
-                if ($part === '.') {
-                    continue;
-                }
-
-                if ($part === '..') {
-                    array_pop($segments);
-                    continue;
-                }
-
-                $segments[] = $part;
+            if (count($files) <= 1) {
+                continue;
             }
 
-            return $prefix . ($isAbsolute ? '/' : '') . implode('/', $segments);
+            $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $files));
+            fwrite(STDERR, sprintf(
+                "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
+                . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
+                $namespace,
+                $fileList,
+            ));
         }
-
-        $real = realpath($path);
-        return $real !== false ? $real : $path;
     }
 
     /**

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -125,8 +125,16 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
     private function warnAboutDuplicateNamespaces(array $allLocations): void
     {
         foreach ($allLocations as $namespace => $files) {
-            if (count($files) > 1) {
-                $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $files));
+            // Dedupe by canonical path so the same physical file discovered
+            // via nested source directories (e.g. `src/` and `src/phel/`, or a
+            // PHAR's internal dirs) is not reported as a duplicate of itself.
+            $uniqueFiles = array_values(array_unique(array_map(
+                $this->canonicalizeFilePath(...),
+                $files,
+            )));
+
+            if (count($uniqueFiles) > 1) {
+                $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $uniqueFiles));
                 fwrite(STDERR, sprintf(
                     "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
                     . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
@@ -135,6 +143,42 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
                 ));
             }
         }
+    }
+
+    /**
+     * Canonicalize a file path for duplicate detection. Uses `realpath()` on
+     * the local filesystem and a manual '..' resolver for `phar://` paths,
+     * because `realpath()` does not resolve phar stream paths.
+     */
+    private function canonicalizeFilePath(string $path): string
+    {
+        if (str_starts_with($path, 'phar://')) {
+            $prefix = 'phar://';
+            $rest = substr($path, 7);
+            $isAbsolute = str_starts_with($rest, '/');
+            $segments = [];
+            foreach (explode('/', $rest) as $part) {
+                if ($part === '') {
+                    continue;
+                }
+
+                if ($part === '.') {
+                    continue;
+                }
+
+                if ($part === '..') {
+                    array_pop($segments);
+                    continue;
+                }
+
+                $segments[] = $part;
+            }
+
+            return $prefix . ($isAbsolute ? '/' : '') . implode('/', $segments);
+        }
+
+        $real = realpath($path);
+        return $real !== false ? $real : $path;
     }
 
     /**

--- a/src/php/Command/Application/DirectoryFinder.php
+++ b/src/php/Command/Application/DirectoryFinder.php
@@ -50,7 +50,7 @@ final readonly class DirectoryFinder implements DirectoryFinderInterface
      */
     private function toAbsoluteDirectories(array $relativeDirectories): array
     {
-        return array_map(function (string $dir): string {
+        $absolute = array_map(function (string $dir): string {
             // PHAR path? return as-is
             if (str_starts_with($dir, 'phar://')) {
                 return $dir;
@@ -69,5 +69,10 @@ final readonly class DirectoryFinder implements DirectoryFinderInterface
             $resolved = realpath($joined);
             return $resolved !== false ? $resolved : $joined;
         }, $relativeDirectories);
+
+        // Dedupe identical entries so the same physical directory is not walked
+        // twice (e.g. when the prepended phel core dir resolves to the same path
+        // as a configured src dir, as happens inside a PHAR).
+        return array_values(array_unique($absolute));
     }
 }

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -9,6 +9,8 @@ use Phel\Command\Domain\CodeDirectories;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
+use function dirname;
+
 final class CommandConfig extends AbstractConfig
 {
     private const string DEFAULT_VENDOR_DIR = 'vendor';
@@ -25,8 +27,23 @@ final class CommandConfig extends AbstractConfig
     {
         $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
 
+        // Point at the parent `src` directory (which contains `phel/`) so
+        // phel's own core library is discoverable whether phel runs from its
+        // own source tree, from a composer vendor dir, or from a PHAR.
+        //
+        // Use `dirname(..., 2)` rather than `__DIR__ . '/../..'` so the path
+        // has no literal '..' segments: inside a PHAR the stream wrapper does
+        // not normalize '..', which otherwise produces duplicate namespace
+        // registrations when the same file is also reached via a clean path.
+        //
+        // The entry deliberately points one level above `src/phel` (so it
+        // contains rather than is `src/phel`) so that entry-point detection
+        // in `RunFacade::autoDetectEntryPoint` does not accidentally return
+        // phel's own `core.phel` when the user has no entry point of their own.
+        $phelInternalSrcDir = dirname(__DIR__, 2);
+
         return new CodeDirectories(
-            [__DIR__ . '/../../', ...(array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS)],
+            [$phelInternalSrcDir, ...(array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS)],
             (array) $this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS),
             (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
         );

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -174,7 +174,12 @@ class Phel
 
     /**
      * Resolve the project root directory when running from a PHAR.
-     * Priority: 1) CWD with config, 2) PHAR directory with config, 3) Inside PHAR
+     * Priority: 1) CWD with config, 2) PHAR directory with config, 3) CWD (auto-detected).
+     *
+     * The fallback must never point inside the PHAR: PHAR archives are read-only,
+     * and Gacela's config loader relies on `glob()` which does not match `phar://`
+     * paths on most platforms, so a phar:// root silently loads zero config values
+     * and every cache write targets the read-only archive.
      */
     private static function resolvePharProjectRoot(): string
     {
@@ -194,8 +199,9 @@ class Phel
             return $pharDir;
         }
 
-        // Fall back to inside the PHAR
-        return Phar::running(true);
+        // Fall back to CWD so auto-detected config kicks in (see configFn()).
+        // The phar's own phel core library is still loaded via NamespacesLoader.
+        return $cwd;
     }
 
     /**

--- a/src/php/Run/Application/NamespacesLoader.php
+++ b/src/php/Run/Application/NamespacesLoader.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application;
 
-use Phar;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Run\Domain\NamespacesLoaderInterface;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
-
-use function in_array;
 
 final readonly class NamespacesLoader implements NamespacesLoaderInterface
 {
@@ -24,19 +21,13 @@ final readonly class NamespacesLoader implements NamespacesLoaderInterface
      */
     public function getLoadedNamespaces(): array
     {
+        // The phel core library directory is already prepended to the source
+        // directories by `CommandConfig::getCodeDirs()` (works for phar, vendor,
+        // and source-tree installs), so no phar-specific fallback is needed here.
         $directories = [
             ...$this->commandFacade->getSourceDirectories(),
             ...$this->commandFacade->getVendorSourceDirectories(),
         ];
-
-        // Add core Phel files directory when running from PHAR,
-        // but only if not already present (avoids duplicate namespace registration)
-        if (str_starts_with(__FILE__, 'phar://')) {
-            $pharSrcDir = Phar::running(true) . '/src/phel';
-            if (!in_array($pharSrcDir, $directories, true)) {
-                $directories[] = $pharSrcDir;
-            }
-        }
 
         return $this->buildFacade->getNamespaceFromDirectories($directories);
     }

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Phar;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function sprintf;
+
+/**
+ * End-to-end test that runs the built `phel.phar` against a minimal user
+ * project. Guards against two regressions:
+ *
+ *   1. Duplicate namespace warnings caused by the same phel core file being
+ *      reached via both a `..`-prefixed and a clean path string inside the PHAR.
+ *   2. Cache write failures caused by the cache dir resolving to a `phar://`
+ *      location (which is read-only under `phar.readonly=1`).
+ *
+ * The test is skipped when the PHAR has not been built. Run `build/phar.sh`
+ * first to generate it.
+ */
+final class PharExecutionTest extends TestCase
+{
+    private const string PHAR_RELATIVE_PATH = '/build/out/phel.phar';
+
+    private string $pharPath;
+
+    private string $tempProjectDir;
+
+    protected function setUp(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $this->pharPath = $repoRoot . self::PHAR_RELATIVE_PATH;
+
+        if (!is_file($this->pharPath)) {
+            self::markTestSkipped(sprintf(
+                'phel.phar not found at %s; run build/phar.sh to generate it',
+                $this->pharPath,
+            ));
+        }
+
+        $this->tempProjectDir = sys_get_temp_dir() . '/phel-phar-test-' . bin2hex(random_bytes(6));
+        mkdir($this->tempProjectDir, 0755, true);
+        file_put_contents(
+            $this->tempProjectDir . '/main.phel',
+            "(ns local\\main)\n(println \"phar works\")\n",
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempProjectDir)) {
+            $this->removeDir($this->tempProjectDir);
+        }
+    }
+
+    public function test_phar_runs_from_external_directory_without_warnings(): void
+    {
+        $result = $this->runPhar(['run', 'main.phel']);
+
+        self::assertSame(
+            0,
+            $result['exit'],
+            sprintf("Non-zero exit.\nstdout:\n%s\nstderr:\n%s", $result['stdout'], $result['stderr']),
+        );
+        self::assertStringContainsString('phar works', $result['stdout']);
+
+        self::assertStringNotContainsString(
+            'defined in multiple locations',
+            $result['stderr'],
+            'PHAR should not emit duplicate-namespace warnings for phel core files',
+        );
+
+        self::assertStringNotContainsString(
+            'phar.readonly',
+            $result['stderr'],
+            'Compiled-code cache must not be written inside the (read-only) PHAR',
+        );
+        self::assertStringNotContainsString(
+            'Phel cache: failed to write',
+            $result['stderr'],
+            'atomicWrite must succeed (cache dir must resolve to a writable location)',
+        );
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{exit: int, stdout: string, stderr: string}
+     */
+    private function runPhar(array $args): array
+    {
+        $cmd = sprintf(
+            '%s %s',
+            escapeshellarg($this->pharPath),
+            implode(' ', array_map(escapeshellarg(...), $args)),
+        );
+
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $proc = proc_open($cmd, $descriptors, $pipes, $this->tempProjectDir);
+        self::assertIsResource($proc, 'proc_open failed');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+
+        return ['exit' => $exit, 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+
+    private function removeDir(string $dir): void
+    {
+        $entries = scandir($dir) ?: [];
+        foreach ($entries as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Running `phel.phar` from a directory without `phel-config.php` (e.g. any fresh user project) emitted 13 `WARNING: Namespace '...' is defined in multiple locations` lines for every phel core file, and then crashed trying to write the compiled-code cache because the cache dir resolved to a `phar://` path under `phar.readonly=1`.

## 💡 Goal

Make `phel.phar` usable out of the box from any directory: no spurious warnings, no read-only cache writes.

## 🔖 Changes

- `Phel::resolvePharProjectRoot()` falls back to CWD instead of the phar stream, so Gacela's config loader (which uses `glob()`, not phar-aware) still picks up defaults and the cache lands on a writable path.
- `CommandConfig` prepends phel core src via `dirname(__DIR__, 2)`, avoiding literal `..` segments that the phar wrapper does not normalize.
- `DirectoryFinder` dedupes absolute dirs; `NamespaceExtractor` dedupes duplicate-namespace warnings by canonical file path (with a manual `phar://` resolver, since `realpath()` skips phar streams).
- New end-to-end `PharExecutionTest` spawns the built phel.phar from an external temp dir and asserts a clean run.