### PR TITLE
feat: add phel/http-client module for outbound HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `phel\http-client` module for outbound HTTP requests (GET, POST, PUT, DELETE, PATCH, HEAD) using PHP streams, with JSON body encoding, query params, and configurable timeouts
+
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 
 ### Added

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -1,0 +1,144 @@
+(ns phel\http-client
+  (:require phel\http :as http)
+  (:require phel\json)
+  (:use RuntimeException))
+
+;; -----------
+;; Header helpers
+;; -----------
+
+(defn- format-header-name
+  "Converts a keyword or string header name to its string form."
+  [k]
+  (if (keyword? k) (name k) (str k)))
+
+(defn- build-headers-array
+  "Converts a Phel header map to a PHP associative array."
+  [headers]
+  (let [arr (php/array)]
+    (foreach [k v headers]
+      (php/aset arr (format-header-name k) (str v)))
+    arr))
+
+;; -----------
+;; Options helpers
+;; -----------
+
+(defn- build-options-array
+  "Converts Phel options to a PHP associative array for the transport."
+  [{:timeout timeout :follow-redirects follow-redirects :verify-ssl verify-ssl}]
+  (let [arr (php/array)]
+    (when timeout (php/aset arr "timeout" timeout))
+    (when-not (nil? follow-redirects) (php/aset arr "follow_redirects" follow-redirects))
+    (when-not (nil? verify-ssl) (php/aset arr "verify_ssl" verify-ssl))
+    arr))
+
+(defn- append-query-params
+  "Appends query parameters to a URL string."
+  [url params]
+  (if (or (nil? params) (empty? params))
+    url
+    (let [php-params (php/array)]
+      (foreach [k v params]
+        (php/aset php-params (format-header-name k) (str v)))
+      (let [query-string (php/http_build_query php-params)
+            separator (if (php/str_contains url "?") "&" "?")]
+        (str url separator query-string)))))
+
+;; -----------
+;; Response conversion
+;; -----------
+
+(defn- transport-result->response
+  "Converts a transport result PHP array to an http/response struct."
+  [result]
+  (let [raw-headers (php/aget result "headers")
+        headers (transient {})]
+    (foreach [k v raw-headers]
+      (assoc headers (keyword k) v))
+    (http/response
+     (php/aget result "status")
+     (persistent headers)
+     (php/aget result "body")
+     (php/aget result "version")
+     (php/aget result "reason"))))
+
+;; -----------
+;; Public API
+;; -----------
+
+(defn request
+  "Makes an HTTP request and returns an http/response struct.
+
+  `method` is a keyword or string (:get, :post, \"PUT\", etc.).
+  `url` is the target URL string.
+  `opts` is an optional map with:
+    :headers          - Map of header name to value
+    :body             - String request body
+    :json             - Value to JSON-encode as body (sets Content-Type)
+    :query-params     - Map of query parameters to append to URL
+    :timeout          - Timeout in seconds as float (default 30.0)
+    :follow-redirects - Follow HTTP redirects (default true)
+    :verify-ssl       - Verify SSL certificates (default true)"
+  {:doc "Makes an HTTP request. Returns an http/response struct."
+   :example "(request :get \"https://example.com\" {:headers {:accept \"application/json\"}})"}
+  [method url & [{:headers headers :body body :json json-body
+                  :query-params query-params :timeout timeout
+                  :follow-redirects follow-redirects :verify-ssl verify-ssl}]]
+  (let [headers (or headers {})
+        [headers body] (if json-body
+                         [(assoc headers :content-type "application/json")
+                          (json/encode json-body)]
+                         [headers body])
+        url (append-query-params url query-params)]
+    (transport-result->response
+     (php/:: \Phel\HttpClient\StreamTransport
+       (send (php/strtoupper (format-header-name method))
+             url
+             (build-headers-array headers)
+             body
+             (build-options-array {:timeout timeout
+                                  :follow-redirects follow-redirects
+                                  :verify-ssl verify-ssl}))))))
+
+(defn get
+  "Makes a GET request. See `request` for available options."
+  {:doc "Makes a GET request. Returns an http/response struct."
+   :example "(get \"https://example.com\")"}
+  [url & [opts]]
+  (request :GET url opts))
+
+(defn post
+  "Makes a POST request. See `request` for available options."
+  {:doc "Makes a POST request. Returns an http/response struct."
+   :example "(post \"https://api.example.com\" {:json {:name \"Alice\"}})"}
+  [url & [opts]]
+  (request :POST url opts))
+
+(defn put
+  "Makes a PUT request. See `request` for available options."
+  {:doc "Makes a PUT request. Returns an http/response struct."
+   :example "(put \"https://api.example.com/1\" {:json {:name \"Bob\"}})"}
+  [url & [opts]]
+  (request :PUT url opts))
+
+(defn delete
+  "Makes a DELETE request. See `request` for available options."
+  {:doc "Makes a DELETE request. Returns an http/response struct."
+   :example "(delete \"https://api.example.com/1\")"}
+  [url & [opts]]
+  (request :DELETE url opts))
+
+(defn patch
+  "Makes a PATCH request. See `request` for available options."
+  {:doc "Makes a PATCH request. Returns an http/response struct."
+   :example "(patch \"https://api.example.com/1\" {:json {:name \"Charlie\"}})"}
+  [url & [opts]]
+  (request :PATCH url opts))
+
+(defn head
+  "Makes a HEAD request. See `request` for available options."
+  {:doc "Makes a HEAD request. Returns an http/response struct."
+   :example "(head \"https://example.com\")"}
+  [url & [opts]]
+  (request :HEAD url opts))

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -4,11 +4,11 @@
   (:use RuntimeException))
 
 ;; -----------
-;; Header helpers
+;; Key helpers
 ;; -----------
 
-(defn- format-header-name
-  "Converts a keyword or string header name to its string form."
+(defn- key->string
+  "Converts a keyword or string key to its string form."
   [k]
   (if (keyword? k) (name k) (str k)))
 
@@ -17,7 +17,7 @@
   [headers]
   (let [arr (php/array)]
     (foreach [k v headers]
-      (php/aset arr (format-header-name k) (str v)))
+      (php/aset arr (key->string k) (str v)))
     arr))
 
 ;; -----------
@@ -40,7 +40,7 @@
     url
     (let [php-params (php/array)]
       (foreach [k v params]
-        (php/aset php-params (format-header-name k) (str v)))
+        (php/aset php-params (key->string k) (str v)))
       (let [query-string (php/http_build_query php-params)
             separator (if (php/str_contains url "?") "&" "?")]
         (str url separator query-string)))))
@@ -81,7 +81,8 @@
     :follow-redirects - Follow HTTP redirects (default true)
     :verify-ssl       - Verify SSL certificates (default true)"
   {:doc "Makes an HTTP request. Returns an http/response struct."
-   :example "(request :get \"https://example.com\" {:headers {:accept \"application/json\"}})"}
+   :example "(request :get \"https://example.com\" {:headers {:accept \"application/json\"}})"
+   :see-also ["get" "post" "put" "delete" "patch" "head"]}
   [method url & [{:headers headers :body body :json json-body
                   :query-params query-params :timeout timeout
                   :follow-redirects follow-redirects :verify-ssl verify-ssl}]]
@@ -93,7 +94,7 @@
         url (append-query-params url query-params)]
     (transport-result->response
      (php/:: \Phel\HttpClient\StreamTransport
-       (send (php/strtoupper (format-header-name method))
+       (send (php/strtoupper (key->string method))
              url
              (build-headers-array headers)
              body
@@ -104,41 +105,47 @@
 (defn get
   "Makes a GET request. See `request` for available options."
   {:doc "Makes a GET request. Returns an http/response struct."
-   :example "(get \"https://example.com\")"}
+   :example "(get \"https://example.com\")"
+   :see-also ["request" "post"]}
   [url & [opts]]
   (request :GET url opts))
 
 (defn post
   "Makes a POST request. See `request` for available options."
   {:doc "Makes a POST request. Returns an http/response struct."
-   :example "(post \"https://api.example.com\" {:json {:name \"Alice\"}})"}
+   :example "(post \"https://api.example.com\" {:json {:name \"Alice\"}})"
+   :see-also ["request" "get" "put"]}
   [url & [opts]]
   (request :POST url opts))
 
 (defn put
   "Makes a PUT request. See `request` for available options."
   {:doc "Makes a PUT request. Returns an http/response struct."
-   :example "(put \"https://api.example.com/1\" {:json {:name \"Bob\"}})"}
+   :example "(put \"https://api.example.com/1\" {:json {:name \"Bob\"}})"
+   :see-also ["request" "post" "patch"]}
   [url & [opts]]
   (request :PUT url opts))
 
 (defn delete
   "Makes a DELETE request. See `request` for available options."
   {:doc "Makes a DELETE request. Returns an http/response struct."
-   :example "(delete \"https://api.example.com/1\")"}
+   :example "(delete \"https://api.example.com/1\")"
+   :see-also ["request" "get"]}
   [url & [opts]]
   (request :DELETE url opts))
 
 (defn patch
   "Makes a PATCH request. See `request` for available options."
   {:doc "Makes a PATCH request. Returns an http/response struct."
-   :example "(patch \"https://api.example.com/1\" {:json {:name \"Charlie\"}})"}
+   :example "(patch \"https://api.example.com/1\" {:json {:name \"Charlie\"}})"
+   :see-also ["request" "put"]}
   [url & [opts]]
   (request :PATCH url opts))
 
 (defn head
   "Makes a HEAD request. See `request` for available options."
   {:doc "Makes a HEAD request. Returns an http/response struct."
-   :example "(head \"https://example.com\")"}
+   :example "(head \"https://example.com\")"
+   :see-also ["request" "get"]}
   [url & [opts]]
   (request :HEAD url opts))

--- a/src/php/HttpClient/ResponseParser.php
+++ b/src/php/HttpClient/ResponseParser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\HttpClient;
+
+/**
+ * Parses raw HTTP response headers from PHP's $http_response_header
+ * into a structured associative array.
+ */
+final class ResponseParser
+{
+    /**
+     * @param list<string> $rawHeaders Raw header lines from $http_response_header
+     *
+     * @return array{status: int, version: string, reason: string, headers: array<string, string>}
+     */
+    public static function parse(array $rawHeaders): array
+    {
+        $status = 200;
+        $version = '1.1';
+        $reason = 'OK';
+        $headers = [];
+
+        foreach ($rawHeaders as $line) {
+            if (preg_match('#^HTTP/(\d+\.\d+)\s+(\d+)\s*(.*)$#', $line, $matches) === 1) {
+                $version = $matches[1];
+                $status = (int) $matches[2];
+                $reason = trim($matches[3]);
+                continue;
+            }
+
+            $colonPos = strpos($line, ':');
+            if ($colonPos !== false) {
+                $name = strtolower(trim(substr($line, 0, $colonPos)));
+                $value = trim(substr($line, $colonPos + 1));
+                $headers[$name] = $value;
+            }
+        }
+
+        return [
+            'status' => $status,
+            'version' => $version,
+            'reason' => $reason,
+            'headers' => $headers,
+        ];
+    }
+}

--- a/src/php/HttpClient/ResponseParser.php
+++ b/src/php/HttpClient/ResponseParser.php
@@ -7,6 +7,10 @@ namespace Phel\HttpClient;
 /**
  * Parses raw HTTP response headers from PHP's $http_response_header
  * into a structured associative array.
+ *
+ * Header names are lowercased. For duplicate header names (e.g. Set-Cookie),
+ * only the last value is kept. Redirect chains are handled by resetting
+ * status/version/reason on each new HTTP status line encountered.
  */
 final class ResponseParser
 {

--- a/src/php/HttpClient/StreamTransport.php
+++ b/src/php/HttpClient/StreamTransport.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\HttpClient;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * HTTP transport using PHP's built-in stream context.
+ * No external dependencies required (no cURL, no Guzzle).
+ */
+final class StreamTransport
+{
+    /**
+     * @param array<string, string> $headers Header name => value pairs
+     * @param array<string, mixed>  $options Transport options (timeout, follow_redirects, verify_ssl)
+     *
+     * @return array{status: int, headers: array<string, string>, body: string, version: string, reason: string}
+     */
+    public static function send(
+        string $method,
+        string $url,
+        array $headers,
+        ?string $body,
+        array $options,
+    ): array {
+        $context = self::buildContext($method, $headers, $body, $options);
+
+        $http_response_header = [];
+        $responseBody = @file_get_contents($url, false, $context);
+
+        if ($responseBody === false) {
+            $error = error_get_last();
+            throw new RuntimeException(
+                sprintf('HTTP request to %s failed: %s', $url, $error['message'] ?? 'Unknown error'),
+            );
+        }
+
+        $parsed = ResponseParser::parse($http_response_header);
+
+        return [
+            'status' => $parsed['status'],
+            'headers' => $parsed['headers'],
+            'body' => $responseBody,
+            'version' => $parsed['version'],
+            'reason' => $parsed['reason'],
+        ];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>  $options
+     *
+     * @return resource
+     */
+    private static function buildContext(
+        string $method,
+        array $headers,
+        ?string $body,
+        array $options,
+    ) {
+        $headerLines = [];
+        foreach ($headers as $name => $value) {
+            $headerLines[] = sprintf('%s: %s', $name, $value);
+        }
+
+        $timeout = (float) ($options['timeout'] ?? 30.0);
+        $followRedirects = (bool) ($options['follow_redirects'] ?? true);
+        $verifySsl = (bool) ($options['verify_ssl'] ?? true);
+
+        return stream_context_create([
+            'http' => [
+                'method' => strtoupper($method),
+                'header' => implode("\r\n", $headerLines),
+                'content' => $body ?? '',
+                'timeout' => $timeout,
+                'follow_location' => $followRedirects ? 1 : 0,
+                'ignore_errors' => true,
+            ],
+            'ssl' => [
+                'verify_peer' => $verifySsl,
+                'verify_peer_name' => $verifySsl,
+            ],
+        ]);
+    }
+}

--- a/tests/phel/test/http-client.phel
+++ b/tests/phel/test/http-client.phel
@@ -28,19 +28,39 @@
     (is (= 404 (php/aget parsed "status")) "parses 404 status")
     (is (= "Not Found" (php/aget parsed "reason")) "parses reason phrase")))
 
+(deftest test-response-parser-redirect-chain
+  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
+                 (parse (php/array "HTTP/1.1 301 Moved"
+                                   "Location: /new"
+                                   "HTTP/1.1 200 OK"
+                                   "Content-Type: text/html")))]
+    (is (= 200 (php/aget parsed "status")) "uses final status after redirect")
+    (is (= "text/html" (php/aget (php/aget parsed "headers") "content-type"))
+        "parses headers from final response")))
+
+(deftest test-response-parser-colon-in-value
+  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
+                 (parse (php/array "HTTP/1.1 200 OK"
+                                   "Location: https://example.com:8080/path")))]
+    (is (= "https://example.com:8080/path"
+           (php/aget (php/aget parsed "headers") "location"))
+        "preserves colons in header values")))
+
 ;; --- Request error handling ---
 
 (deftest test-request-to-invalid-url-throws
-  (is (thrown? \RuntimeException (hc/request :get "http://invalid.test.localhost:1"))
+  (is (thrown? \RuntimeException
+              (hc/request :get "http://0.0.0.0:1" {:timeout 1}))
       "request to unreachable host throws RuntimeException"))
 
-;; --- Module API completeness ---
+;; --- Convenience function signatures ---
 
-(deftest test-public-functions-are-defined
-  (is (function? hc/request) "request is defined")
-  (is (function? hc/get) "get is defined")
-  (is (function? hc/post) "post is defined")
-  (is (function? hc/put) "put is defined")
-  (is (function? hc/delete) "delete is defined")
-  (is (function? hc/patch) "patch is defined")
-  (is (function? hc/head) "head is defined"))
+(deftest test-get-accepts-url-only
+  (is (thrown? \RuntimeException
+              (hc/get "http://0.0.0.0:1" {:timeout 1}))
+      "get delegates to request correctly"))
+
+(deftest test-post-accepts-url-and-opts
+  (is (thrown? \RuntimeException
+              (hc/post "http://0.0.0.0:1" {:json {:a 1} :timeout 1}))
+      "post delegates to request correctly"))

--- a/tests/phel/test/http-client.phel
+++ b/tests/phel/test/http-client.phel
@@ -1,0 +1,46 @@
+(ns phel-test\test\http-client
+  (:require phel\test :refer [deftest is])
+  (:require phel\http-client :as hc)
+  (:require phel\http :as http))
+
+;; --- Response parser integration (via PHP static call) ---
+
+(deftest test-response-parser-basic
+  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
+                 (parse (php/array "HTTP/1.1 200 OK"
+                                   "Content-Type: application/json"
+                                   "X-Request-Id: abc-123")))]
+    (is (= 200 (php/aget parsed "status")) "parses status code")
+    (is (= "1.1" (php/aget parsed "version")) "parses HTTP version")
+    (is (= "OK" (php/aget parsed "reason")) "parses reason phrase")
+    (let [headers (php/aget parsed "headers")]
+      (is (= "application/json" (php/aget headers "content-type")) "parses content-type header")
+      (is (= "abc-123" (php/aget headers "x-request-id")) "parses custom header"))))
+
+(deftest test-response-parser-empty-headers
+  (let [parsed (php/:: \Phel\HttpClient\ResponseParser (parse (php/array)))]
+    (is (= 200 (php/aget parsed "status")) "defaults to 200 when no status line")
+    (is (= "1.1" (php/aget parsed "version")) "defaults to HTTP/1.1")))
+
+(deftest test-response-parser-404
+  (let [parsed (php/:: \Phel\HttpClient\ResponseParser
+                 (parse (php/array "HTTP/1.1 404 Not Found")))]
+    (is (= 404 (php/aget parsed "status")) "parses 404 status")
+    (is (= "Not Found" (php/aget parsed "reason")) "parses reason phrase")))
+
+;; --- Request error handling ---
+
+(deftest test-request-to-invalid-url-throws
+  (is (thrown? \RuntimeException (hc/request :get "http://invalid.test.localhost:1"))
+      "request to unreachable host throws RuntimeException"))
+
+;; --- Module API completeness ---
+
+(deftest test-public-functions-are-defined
+  (is (function? hc/request) "request is defined")
+  (is (function? hc/get) "get is defined")
+  (is (function? hc/post) "post is defined")
+  (is (function? hc/put) "put is defined")
+  (is (function? hc/delete) "delete is defined")
+  (is (function? hc/patch) "patch is defined")
+  (is (function? hc/head) "head is defined"))

--- a/tests/php/Unit/HttpClient/ResponseParserTest.php
+++ b/tests/php/Unit/HttpClient/ResponseParserTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\HttpClient;
+
+use Phel\HttpClient\ResponseParser;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseParserTest extends TestCase
+{
+    public function test_parse_status_line(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+        ]);
+
+        self::assertSame(200, $result['status']);
+        self::assertSame('1.1', $result['version']);
+        self::assertSame('OK', $result['reason']);
+    }
+
+    public function test_parse_404_status(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 404 Not Found',
+        ]);
+
+        self::assertSame(404, $result['status']);
+        self::assertSame('Not Found', $result['reason']);
+    }
+
+    public function test_parse_headers(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'Content-Type: application/json',
+            'X-Request-Id: abc-123',
+        ]);
+
+        self::assertSame('application/json', $result['headers']['content-type']);
+        self::assertSame('abc-123', $result['headers']['x-request-id']);
+    }
+
+    public function test_parse_header_with_colon_in_value(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'Location: https://example.com:8080/path',
+        ]);
+
+        self::assertSame('https://example.com:8080/path', $result['headers']['location']);
+    }
+
+    public function test_parse_empty_headers_returns_defaults(): void
+    {
+        $result = ResponseParser::parse([]);
+
+        self::assertSame(200, $result['status']);
+        self::assertSame('1.1', $result['version']);
+        self::assertSame('OK', $result['reason']);
+        self::assertSame([], $result['headers']);
+    }
+
+    public function test_parse_redirect_chain_uses_last_status(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 301 Moved Permanently',
+            'Location: https://example.com/new',
+            'HTTP/1.1 200 OK',
+            'Content-Type: text/html',
+        ]);
+
+        self::assertSame(200, $result['status']);
+        self::assertSame('text/html', $result['headers']['content-type']);
+    }
+
+    public function test_parse_http2_version(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/2.0 204 No Content',
+        ]);
+
+        self::assertSame(204, $result['status']);
+        self::assertSame('2.0', $result['version']);
+        self::assertSame('No Content', $result['reason']);
+    }
+
+    public function test_parse_status_with_no_reason(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 204',
+        ]);
+
+        self::assertSame(204, $result['status']);
+        self::assertSame('', $result['reason']);
+    }
+
+    public function test_parse_header_names_are_lowercased(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'Content-Type: text/html',
+            'CACHE-CONTROL: no-cache',
+        ]);
+
+        self::assertArrayHasKey('content-type', $result['headers']);
+        self::assertArrayHasKey('cache-control', $result['headers']);
+    }
+
+    public function test_parse_last_header_wins_for_duplicate_names(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'X-Custom: first',
+            'X-Custom: second',
+        ]);
+
+        self::assertSame('second', $result['headers']['x-custom']);
+    }
+}

--- a/tests/php/Unit/HttpClient/ResponseParserTest.php
+++ b/tests/php/Unit/HttpClient/ResponseParserTest.php
@@ -118,4 +118,45 @@ final class ResponseParserTest extends TestCase
 
         self::assertSame('second', $result['headers']['x-custom']);
     }
+
+    public function test_parse_malformed_status_line_is_skipped(): void
+    {
+        $result = ResponseParser::parse([
+            '200 OK',
+            'Content-Type: text/plain',
+        ]);
+
+        self::assertSame(200, $result['status']);
+        self::assertSame('text/plain', $result['headers']['content-type']);
+    }
+
+    public function test_parse_line_without_colon_is_ignored(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'not-a-header-line',
+        ]);
+
+        self::assertSame([], $result['headers']);
+    }
+
+    public function test_parse_header_with_empty_value(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 200 OK',
+            'X-Empty:   ',
+        ]);
+
+        self::assertSame('', $result['headers']['x-empty']);
+    }
+
+    public function test_parse_500_server_error(): void
+    {
+        $result = ResponseParser::parse([
+            'HTTP/1.1 500 Internal Server Error',
+        ]);
+
+        self::assertSame(500, $result['status']);
+        self::assertSame('Internal Server Error', $result['reason']);
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Phel has server-side HTTP parsing (`phel\http`) for handling incoming requests but no way to make outbound HTTP calls. This is a prerequisite for any API integration, including the planned AI modules.

## 💡 Goal

Add a `phel\http-client` module that provides a functional API for making outbound HTTP requests from Phel, using PHP's built-in stream context (zero external dependencies).

## 🔖 Changes

- **`src/phel/http-client.phel`**: New core module with `request`, `get`, `post`, `put`, `delete`, `patch`, `head` functions. Supports `:headers`, `:body`, `:json` (auto-encode), `:query-params`, `:timeout`, `:follow-redirects`, `:verify-ssl` options. Returns `phel\http/response` structs for consistency.
- **`src/php/HttpClient/StreamTransport.php`**: PHP transport layer using `stream_context_create` + `file_get_contents`. No ext-curl or Guzzle dependency.
- **`src/php/HttpClient/ResponseParser.php`**: Parses raw `$http_response_header` lines into structured status/headers/version. Handles redirect chains (last status wins). Documents last-header-wins behavior for duplicates.
- **`tests/php/Unit/HttpClient/ResponseParserTest.php`**: 14 PHPUnit tests covering status parsing, header extraction, redirect chains, edge cases (malformed lines, empty values, colons in values).
- **`tests/phel/test/http-client.phel`**: 15 Phel tests covering response parser integration, error handling, and convenience function delegation.
- **`CHANGELOG.md`**: Updated Unreleased section.