### PR TITLE
feat: add phel/ai-structured module for structured output and tool use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `phel\http-client` module for outbound HTTP requests (GET, POST, PUT, DELETE, PATCH, HEAD) using PHP streams, with JSON body encoding, query params, and configurable timeouts
 - `phel\ai` module for LLM API access (Anthropic and OpenAI) with `complete`, `chat`, and `chat-with-history` functions
 - `phel\ai-repl` module with AI-assisted REPL commands: `explain`, `explain-sym`, `suggest`, `fix`, `review`
+- `phel\ai-structured` module for structured AI output: `extract`, `extract-many`, `tool`, `chat-with-tools`, `tool-calls`
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/src/phel/ai-structured.phel
+++ b/src/phel/ai-structured.phel
@@ -1,0 +1,198 @@
+(ns phel\ai-structured
+  (:require phel\ai :as ai)
+  (:require phel\http-client :as hc)
+  (:require phel\json)
+  (:use RuntimeException))
+
+;; -----------
+;; Schema helpers
+;; -----------
+
+(defn- schema->json-description
+  "Converts a field schema map to a human-readable JSON description
+  for the AI prompt."
+  [schema]
+  (let [lines (for [[k v] :pairs schema]
+                (str "  \"" (name k) "\": " (if (string? v) v (str v))))]
+    (str "{\n" (php/implode ",\n" (to-php-array lines)) "\n}")))
+
+(defn- schema->json-schema
+  "Converts a field schema map to a JSON Schema object for tool use."
+  [schema]
+  (let [properties (transient {})
+        required (transient [])]
+    (foreach [k v schema]
+      (let [prop-name (name k)]
+        (conj required prop-name)
+        (assoc properties (keyword prop-name)
+               (cond
+                 (map? v) v
+                 (= v "string") {:type "string"}
+                 (= v "integer") {:type "integer"}
+                 (= v "number") {:type "number"}
+                 (= v "boolean") {:type "boolean"}
+                 (string? v) {:type "string" :description v}
+                 {:type "string" :description (str v)}))))
+    {:type "object"
+     :properties (persistent properties)
+     :required (persistent required)}))
+
+;; -----------
+;; Structured extraction
+;; -----------
+
+(declare extract-json-from-response [response])
+
+(defn extract
+  "Extracts structured data from text using AI.
+
+  `schema` is a map of field names to type descriptions. Each key becomes
+  a field in the output, and each value tells the AI what to extract.
+
+  Returns a Phel map with the schema keys populated from the AI response.
+
+  Options:
+    :system     - Override the system prompt
+    :model      - Override the configured model
+    :max-tokens - Override the configured max tokens"
+  {:doc "Extracts structured data from text using AI. Returns a map matching the schema."
+   :example "(extract {:name \"string\" :age \"integer\"} \"John is 30 years old\")"
+   :see-also ["extract-many" "ai/complete" "ai/chat"]}
+  [schema text & [{:system system-prompt :model model :max-tokens max-tokens}]]
+  (let [schema-desc (schema->json-description schema)
+        prompt (str "Extract the following structured data from the given text.\n\n"
+                    "Schema (field name: expected type/format):\n"
+                    schema-desc "\n\n"
+                    "Text: " text "\n\n"
+                    "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
+        system (or system-prompt "You are a precise data extraction assistant. Return only valid JSON.")
+        response (ai/complete prompt {:system system :model model :max-tokens max-tokens})]
+    (json/decode (extract-json-from-response response))))
+
+(defn- extract-json-from-response
+  "Extracts JSON from an AI response, handling markdown code blocks."
+  [response]
+  (let [trimmed (php/trim response)]
+    (if (php/str_starts_with trimmed "{")
+      trimmed
+      (let [matches (php/array)
+            found (php/preg_match "/```(?:json)?\\s*\\n?(\\{[\\s\\S]*?\\})\\s*\\n?```/" trimmed matches)]
+        (if (one? found)
+          (php/aget matches 1)
+          (let [start (php/strpos trimmed "{")
+                end (php/strrpos trimmed "}")]
+            (if (and start end (php/>= end start))
+              (php/substr trimmed start (php/+ (php/- end start) 1))
+              (throw (php/new RuntimeException
+                       (str "Could not extract JSON from AI response: " trimmed))))))))))
+
+(defn extract-many
+  "Extracts a list of structured items from text.
+
+  Similar to `extract`, but returns a vector of maps when the text
+  contains multiple items matching the schema."
+  {:doc "Extracts a list of structured items from text. Returns a vector of maps."
+   :example "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")"
+   :see-also ["extract" "ai/complete"]}
+  [schema text & [{:system system-prompt :model model :max-tokens max-tokens}]]
+  (let [schema-desc (schema->json-description schema)
+        prompt (str "Extract ALL items matching the schema from the given text.\n\n"
+                    "Schema for each item (field name: expected type/format):\n"
+                    schema-desc "\n\n"
+                    "Text: " text "\n\n"
+                    "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
+        system (or system-prompt "You are a precise data extraction assistant. Return only valid JSON.")
+        response (ai/complete prompt {:system system :model model :max-tokens max-tokens})
+        trimmed (php/trim response)
+        json-str (if (php/str_starts_with trimmed "[")
+                   trimmed
+                   (let [start (php/strpos trimmed "[")
+                         end (php/strrpos trimmed "]")]
+                     (if (and start end (php/>= end start))
+                       (php/substr trimmed start (php/+ (php/- end start) 1))
+                       (throw (php/new RuntimeException
+                                (str "Could not extract JSON array from AI response: " trimmed))))))]
+    (json/decode json-str)))
+
+;; -----------
+;; Tool definition
+;; -----------
+
+(defn tool
+  "Creates a tool definition map for use with `chat-with-tools`.
+
+  `tool-name` is a string identifier for the tool.
+  `description` describes what the tool does.
+  `input-schema` is a map of parameter names to JSON Schema type maps."
+  {:doc "Creates a tool definition for AI tool use."
+   :example "(tool \"get-weather\" \"Gets weather for a city\" {:location {:type \"string\"}})"
+   :see-also ["chat-with-tools"]}
+  [tool-name description input-schema]
+  {:name tool-name
+   :description description
+   :input_schema (schema->json-schema input-schema)})
+
+;; -----------
+;; Tool use
+;; -----------
+
+(defn- build-tools-request
+  "Builds an Anthropic API request with tool definitions."
+  [messages tools opts]
+  (let [cfg @ai/config
+        cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
+        cfg (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
+        api-key (or (get cfg :api-key)
+                    (php/getenv "ANTHROPIC_API_KEY")
+                    (throw (php/new RuntimeException "No API key configured.")))
+        base-url (or (get cfg :base-url) "https://api.anthropic.com")
+        body {:model (get cfg :model)
+              :max_tokens (get cfg :max-tokens)
+              :messages messages
+              :tools tools}
+        body (if (get opts :system)
+               (assoc body :system (get opts :system))
+               body)]
+    {:url (str base-url "/v1/messages")
+     :headers {:x-api-key api-key
+               :anthropic-version "2023-06-01"
+               :content-type "application/json"}
+     :body body}))
+
+(defn chat-with-tools
+  "Sends a chat request with tool definitions.
+
+  Returns the full parsed API response map, which may include
+  tool_use content blocks that the caller can inspect and handle.
+
+  Tool call responses contain :type \"tool_use\", :name, :id, and :input."
+  {:doc "Chat with tool definitions. Returns full response with tool calls."
+   :example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
+                             [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
+   :see-also ["tool" "extract"]}
+  [messages tools & [opts]]
+  (let [req (build-tools-request messages tools opts)
+        response (hc/post (get req :url) {:headers (get req :headers)
+                                          :json (get req :body)
+                                          :timeout 120})
+        status (get response :status)]
+    (when (or (< status 200) (>= status 300))
+      (throw (php/new RuntimeException
+               (str "AI API error (HTTP " status "): " (get response :body)))))
+    (json/decode (get response :body))))
+
+(defn tool-calls
+  "Extracts tool_use blocks from an AI response.
+  Returns a vector of maps with :name, :id, and :input."
+  {:doc "Extracts tool call requests from a chat-with-tools response."
+   :example "(tool-calls response)"
+   :see-also ["chat-with-tools" "tool"]}
+  [response]
+  (let [content (get response :content)]
+    (if content
+      (for [block :in content
+            :when (= "tool_use" (get block :type))]
+        {:name (get block :name)
+         :id (get block :id)
+         :input (get block :input)})
+      [])))

--- a/tests/phel/test/ai-structured.phel
+++ b/tests/phel/test/ai-structured.phel
@@ -1,0 +1,89 @@
+(ns phel-test\test\ai-structured
+  (:require phel\test :refer [deftest is])
+  (:require phel\ai-structured :as ais)
+  (:require phel\ai :as ai)
+  (:require phel\json))
+
+;; --- Tool definition ---
+
+(deftest test-tool-creates-valid-definition
+  (let [t (ais/tool "get-weather" "Gets the weather" {:location {:type "string" :description "City name"}})]
+    (is (= "get-weather" (get t :name)) "tool has correct name")
+    (is (= "Gets the weather" (get t :description)) "tool has correct description")
+    (is (map? (get t :input_schema)) "tool has input schema")
+    (is (= "object" (get (get t :input_schema) :type)) "schema type is object")))
+
+(deftest test-tool-schema-with-string-shorthand
+  (let [t (ais/tool "search" "Searches" {:query "search query string"
+                                          :limit "integer"})]
+    (let [props (get (get t :input_schema) :properties)]
+      (is (= "string" (get (get props :query) :type)) "string shorthand creates string type")
+      (is (= "search query string" (get (get props :query) :description)) "description preserved")
+      (is (= "integer" (get (get props :limit) :type)) "integer shorthand creates integer type"))))
+
+(deftest test-tool-schema-required-fields
+  (let [t (ais/tool "test" "Test" {:a "string" :b "integer"})
+        required (get (get t :input_schema) :required)]
+    (is (= 2 (count required)) "all fields are required")))
+
+;; --- Tool calls extraction ---
+
+(deftest test-tool-calls-extracts-tool-use-blocks
+  (let [response {:content [{:type "text" :text "Let me check."}
+                            {:type "tool_use" :name "get-weather" :id "call-1"
+                             :input {:city "Paris"}}]}
+        calls (ais/tool-calls response)]
+    (is (= 1 (count calls)) "extracts one tool call")
+    (is (= "get-weather" (get (first calls) :name)) "extracts tool name")
+    (is (= "call-1" (get (first calls) :id)) "extracts tool id")
+    (is (= "Paris" (get (get (first calls) :input) :city)) "extracts tool input")))
+
+(deftest test-tool-calls-returns-empty-for-no-tools
+  (let [response {:content [{:type "text" :text "No tools needed."}]}]
+    (is (= [] (ais/tool-calls response)) "returns empty vector when no tool calls")))
+
+(deftest test-tool-calls-handles-multiple-calls
+  (let [response {:content [{:type "tool_use" :name "a" :id "1" :input {}}
+                            {:type "tool_use" :name "b" :id "2" :input {}}]}
+        calls (ais/tool-calls response)]
+    (is (= 2 (count calls)) "extracts multiple tool calls")))
+
+(deftest test-tool-calls-handles-nil-content
+  (is (= [] (ais/tool-calls {:content nil})) "handles nil content")
+  (is (= [] (ais/tool-calls {})) "handles missing content"))
+
+;; --- Extract requires API ---
+
+(deftest test-extract-requires-api-key
+  (let [original @ai/config]
+    (ai/configure {:api-key nil :base-url "http://0.0.0.0:1"})
+    (let [saved-key (php/getenv "ANTHROPIC_API_KEY")]
+      (php/putenv "ANTHROPIC_API_KEY=")
+      (is (thrown? \RuntimeException
+                  (ais/extract {:name "string"} "John Smith"))
+          "extract throws without API key")
+      (when saved-key
+        (php/putenv (str "ANTHROPIC_API_KEY=" saved-key))))
+    (reset! ai/config original)))
+
+(deftest test-chat-with-tools-requires-api-key
+  (let [original @ai/config]
+    (ai/configure {:api-key nil :base-url "http://0.0.0.0:1"})
+    (let [saved-key (php/getenv "ANTHROPIC_API_KEY")]
+      (php/putenv "ANTHROPIC_API_KEY=")
+      (is (thrown? \RuntimeException
+                  (ais/chat-with-tools [{:role "user" :content "test"}]
+                                       [(ais/tool "t" "test" {:a "string"})]))
+          "chat-with-tools throws without API key")
+      (when saved-key
+        (php/putenv (str "ANTHROPIC_API_KEY=" saved-key))))
+    (reset! ai/config original)))
+
+;; --- Public API completeness ---
+
+(deftest test-public-functions-exist
+  (is (function? ais/extract) "extract is defined")
+  (is (function? ais/extract-many) "extract-many is defined")
+  (is (function? ais/tool) "tool is defined")
+  (is (function? ais/chat-with-tools) "chat-with-tools is defined")
+  (is (function? ais/tool-calls) "tool-calls is defined"))


### PR DESCRIPTION
## 🤔 Background

With `phel\ai` providing basic chat/completion capabilities (#1386), the next step is structured interactions: extracting typed data from text and defining tools the AI can call.

## 💡 Goal

Add `phel\ai-structured` module for structured AI output (JSON extraction guided by field schemas) and tool use via the Anthropic Messages API.

## 🔖 Changes

- **`src/phel/ai-structured.phel`**: New module with:
  - `extract` takes a schema map (field name to type description) and text, returns a Phel map with extracted data
  - `extract-many` extracts a list of items matching a schema
  - `tool` creates tool definitions with name, description, and input schema
  - `chat-with-tools` sends messages with tool definitions, returns full response including tool calls
  - `tool-calls` extracts tool_use blocks from a response for easy processing
  - Schema helpers convert between Phel maps and JSON Schema objects
  - Robust JSON extraction from AI responses (handles markdown code blocks, bare JSON)
- **`tests/phel/test/ai-structured.phel`**: 23 tests covering tool definition, schema generation, tool call extraction, API error handling, and edge cases
- **`CHANGELOG.md`**: Updated Unreleased section