### PR TITLE
feat: add phel/ai-embed module for embeddings and semantic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `phel\ai` module for LLM API access (Anthropic and OpenAI) with `complete`, `chat`, and `chat-with-history` functions
 - `phel\ai-repl` module with AI-assisted REPL commands: `explain`, `explain-sym`, `suggest`, `fix`, `review`
 - `phel\ai-structured` module for structured AI output: `extract`, `extract-many`, `tool`, `chat-with-tools`, `tool-calls`
+- `phel\ai-embed` module for embeddings and semantic search: `embed`, `embed-one`, `cosine-similarity`, `nearest`, `build-index`, `search`, `embed-ns`, `search-ns`
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/src/phel/ai-embed.phel
+++ b/src/phel/ai-embed.phel
@@ -1,0 +1,214 @@
+(ns phel\ai-embed
+  (:require phel\ai :as ai)
+  (:require phel\http-client :as hc)
+  (:require phel\json)
+  (:require phel\repl :as repl)
+  (:use RuntimeException))
+
+;; -----------
+;; Vector math
+;; -----------
+
+(defn dot-product
+  "Computes the dot product of two numeric vectors."
+  {:doc "Computes the dot product of two vectors."
+   :example "(dot-product [1 2 3] [4 5 6]) ; => 32"
+   :see-also ["cosine-similarity" "magnitude"]}
+  [a b]
+  (when (not= (count a) (count b))
+    (throw (php/new RuntimeException "Vectors must have the same length for dot product.")))
+  (apply + (map * a b)))
+
+(defn magnitude
+  "Computes the magnitude (L2 norm) of a numeric vector."
+  {:doc "Computes the L2 norm of a vector."
+   :example "(magnitude [3 4]) ; => 5.0"
+   :see-also ["dot-product" "cosine-similarity"]}
+  [v]
+  (php/sqrt (apply + (map #(* % %) v))))
+
+(defn cosine-similarity
+  "Computes the cosine similarity between two numeric vectors.
+  Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
+  {:doc "Computes cosine similarity between two vectors. Returns -1.0 to 1.0."
+   :example "(cosine-similarity [1 0] [0 1]) ; => 0.0"
+   :see-also ["dot-product" "magnitude" "nearest"]}
+  [a b]
+  (let [mag-a (magnitude a)
+        mag-b (magnitude b)]
+    (if (or (zero? mag-a) (zero? mag-b))
+      0.0
+      (/ (dot-product a b) (* mag-a mag-b)))))
+
+;; -----------
+;; Embedding API
+;; -----------
+
+(defn- resolve-api-key
+  "Resolves the API key for embedding requests."
+  []
+  (let [cfg @ai/config]
+    (or (get cfg :api-key)
+        (case (get cfg :provider)
+          :openai (php/getenv "OPENAI_API_KEY")
+          (php/getenv "ANTHROPIC_API_KEY"))
+        (throw (php/new RuntimeException
+                 "No API key configured for embeddings.")))))
+
+(defn- openai-embed-request
+  "Makes an embedding request to the OpenAI Embeddings API."
+  [texts model]
+  (let [api-key (resolve-api-key)
+        cfg @ai/config
+        base-url (or (get cfg :base-url) "https://api.openai.com")
+        response (hc/post (str base-url "/v1/embeddings")
+                          {:headers {:authorization (str "Bearer " api-key)
+                                    :content-type "application/json"}
+                           :json {:model (or model "text-embedding-3-small")
+                                  :input texts}
+                           :timeout 60})
+        status (get response :status)]
+    (when (or (< status 200) (>= status 300))
+      (throw (php/new RuntimeException
+               (str "Embeddings API error (HTTP " status "): " (get response :body)))))
+    (let [body (json/decode (get response :body))
+          data (get body :data)]
+      (for [item :in data]
+        (get item :embedding)))))
+
+(defn- voyageai-embed-request
+  "Makes an embedding request to the Voyage AI API (used for Anthropic ecosystem)."
+  [texts model]
+  (let [api-key (resolve-api-key)
+        cfg @ai/config
+        base-url (or (get cfg :base-url) "https://api.voyageai.com")
+        response (hc/post (str base-url "/v1/embeddings")
+                          {:headers {:authorization (str "Bearer " api-key)
+                                    :content-type "application/json"}
+                           :json {:model (or model "voyage-3-lite")
+                                  :input texts}
+                           :timeout 60})
+        status (get response :status)]
+    (when (or (< status 200) (>= status 300))
+      (throw (php/new RuntimeException
+               (str "Embeddings API error (HTTP " status "): " (get response :body)))))
+    (let [body (json/decode (get response :body))
+          data (get body :data)]
+      (for [item :in data]
+        (get item :embedding)))))
+
+(defn embed
+  "Generates embeddings for one or more text strings.
+
+  Returns a vector of embedding vectors (one per input text).
+  Uses OpenAI's text-embedding-3-small by default.
+
+  Options:
+    :model - Override the embedding model name
+    :provider - :openai (default) or :voyageai"
+  {:doc "Generates text embeddings. Returns a vector of float vectors."
+   :example "(embed [\"hello world\"]) ; => [[0.123 -0.456 ...]]"
+   :see-also ["embed-one" "cosine-similarity" "nearest"]}
+  [texts & [{:model model :provider provider}]]
+  (let [provider (or provider :openai)]
+    (if (= provider :voyageai)
+      (voyageai-embed-request texts model)
+      (openai-embed-request texts model))))
+
+(defn embed-one
+  "Generates an embedding for a single text string.
+  Returns a single embedding vector."
+  {:doc "Generates an embedding for a single text. Returns a float vector."
+   :example "(embed-one \"hello world\") ; => [0.123 -0.456 ...]"
+   :see-also ["embed" "cosine-similarity"]}
+  [text & [opts]]
+  (first (embed [text] opts)))
+
+;; -----------
+;; Semantic search
+;; -----------
+
+(defn nearest
+  "Finds the k nearest items to a query embedding from an index.
+
+  `index` is a vector of {:text \"...\" :embedding [...]} maps.
+  Returns a vector of {:text, :embedding, :similarity} maps sorted
+  by descending similarity."
+  {:doc "Finds k nearest items to a query embedding by cosine similarity."
+   :example "(nearest query-embedding index 5)"
+   :see-also ["cosine-similarity" "build-index" "embed-one"]}
+  [query-embedding index & [k]]
+  (let [k (or k 5)
+        scored (for [item :in index]
+                 (assoc item :similarity
+                        (cosine-similarity query-embedding (get item :embedding))))
+        sorted (sort-by #(- (get % :similarity)) scored)]
+    (take k sorted)))
+
+(defn build-index
+  "Builds a searchable index from a collection of text strings.
+
+  Embeds all texts and returns a vector of {:text, :embedding} maps
+  suitable for use with `nearest`.
+
+  Options are passed through to `embed`."
+  {:doc "Builds a searchable index by embedding a collection of texts."
+   :example "(build-index [\"hello\" \"world\"])"
+   :see-also ["nearest" "embed" "search"]}
+  [texts & [opts]]
+  (let [embeddings (embed texts opts)]
+    (map (fn [text embedding]
+           {:text text :embedding embedding})
+         texts embeddings)))
+
+(defn search
+  "Semantic search: embeds a query and finds the k nearest matches
+  in a pre-built index.
+
+  Returns a vector of {:text, :embedding, :similarity} maps."
+  {:doc "Searches an index for texts most similar to the query."
+   :example "(search \"greeting\" my-index 3)"
+   :see-also ["nearest" "build-index" "embed-one"]}
+  [query index & [{:k k :model model :provider provider}]]
+  (let [query-embedding (embed-one query {:model model :provider provider})]
+    (nearest query-embedding index (or k 5))))
+
+;; -----------
+;; Namespace embedding (for code search)
+;; -----------
+
+(defn embed-ns
+  "Builds a searchable index of all public functions in a namespace.
+
+  Each entry contains the function name, docstring, and embedding
+  of the combined name+doc text. Useful for semantic code search.
+
+  Options are passed through to `embed`."
+  {:doc "Builds a searchable index of public functions in a namespace."
+   :example "(embed-ns \"phel\\core\")"
+   :see-also ["search" "build-index" "nearest"]}
+  [ns-str & [opts]]
+  (let [publics (repl/ns-publics ns-str)
+        entries (for [[fn-name _value] :pairs publics
+                      :let [info (repl/get-symbol-info ns-str fn-name)
+                            doc (or (when info (get info :doc)) "")]
+                      :when (not (when info (get info :private)))]
+                  {:name fn-name
+                   :doc doc
+                   :text (str fn-name ": " doc)})
+        texts (map #(get % :text) entries)
+        embeddings (embed (to-php-array texts) opts)]
+    (map (fn [entry embedding]
+           (assoc entry :embedding embedding))
+         entries embeddings)))
+
+(defn search-ns
+  "Semantic search over a namespace index built by `embed-ns`.
+
+  Returns the k most relevant functions for the query."
+  {:doc "Searches a namespace index for functions matching a query."
+   :example "(search-ns \"transform collections\" my-ns-index 5)"
+   :see-also ["embed-ns" "nearest" "search"]}
+  [query ns-index & [{:k k :model model :provider provider}]]
+  (let [query-embedding (embed-one query {:model model :provider provider})]
+    (nearest query-embedding ns-index (or k 5))))

--- a/tests/phel/test/ai-embed.phel
+++ b/tests/phel/test/ai-embed.phel
@@ -1,0 +1,115 @@
+(ns phel-test\test\ai-embed
+  (:require phel\test :refer [deftest is])
+  (:require phel\ai-embed :as embed)
+  (:require phel\ai :as ai))
+
+;; --- Vector math: dot-product ---
+
+(deftest test-dot-product-basic
+  (is (= 32 (embed/dot-product [1 2 3] [4 5 6])) "dot product of [1 2 3] and [4 5 6]"))
+
+(deftest test-dot-product-zero-vectors
+  (is (= 0 (embed/dot-product [0 0 0] [1 2 3])) "dot product with zero vector"))
+
+(deftest test-dot-product-single-element
+  (is (= 6 (embed/dot-product [2] [3])) "dot product of single-element vectors"))
+
+(deftest test-dot-product-negative-values
+  (is (= -4 (embed/dot-product [1 -2] [2 3])) "dot product with negative values"))
+
+(deftest test-dot-product-mismatched-lengths-throws
+  (is (thrown? \RuntimeException (embed/dot-product [1 2] [1 2 3]))
+      "mismatched vector lengths throw"))
+
+;; --- Vector math: magnitude ---
+
+(deftest test-magnitude-3-4-5-triangle
+  (is (= 5.0 (embed/magnitude [3 4])) "magnitude of [3 4] is 5"))
+
+(deftest test-magnitude-zero-vector
+  (is (= 0.0 (embed/magnitude [0 0 0])) "magnitude of zero vector is 0"))
+
+(deftest test-magnitude-unit-vector
+  (is (= 1.0 (embed/magnitude [1 0 0])) "magnitude of unit vector is 1"))
+
+;; --- Vector math: cosine-similarity ---
+
+(deftest test-cosine-similarity-identical
+  (let [v [1 2 3]]
+    (is (< (php/abs (- 1.0 (embed/cosine-similarity v v))) 0.0001)
+        "identical vectors have similarity ~1.0")))
+
+(deftest test-cosine-similarity-orthogonal
+  (is (< (php/abs (embed/cosine-similarity [1 0] [0 1])) 0.0001)
+      "orthogonal vectors have similarity ~0.0"))
+
+(deftest test-cosine-similarity-opposite
+  (is (< (php/abs (+ 1.0 (embed/cosine-similarity [1 0] [-1 0]))) 0.0001)
+      "opposite vectors have similarity ~-1.0"))
+
+(deftest test-cosine-similarity-zero-vector
+  (is (= 0.0 (embed/cosine-similarity [0 0] [1 2]))
+      "zero vector returns 0.0 similarity"))
+
+;; --- Nearest ---
+
+(deftest test-nearest-returns-sorted-results
+  (let [query [1 0]
+        index [{:text "a" :embedding [1 0]}
+               {:text "b" :embedding [0 1]}
+               {:text "c" :embedding [0.7 0.7]}]
+        results (embed/nearest query index 2)]
+    (is (= 2 (count results)) "returns k results")
+    (is (= "a" (get (first results) :text)) "most similar item first")
+    (is (> (get (first results) :similarity) (get (second results) :similarity))
+        "results sorted by descending similarity")))
+
+(deftest test-nearest-with-default-k
+  (let [query [1 0]
+        index [{:text "a" :embedding [1 0]}
+               {:text "b" :embedding [0 1]}]
+        results (embed/nearest query index)]
+    (is (= 2 (count results)) "returns all items when k > index size")))
+
+(deftest test-nearest-includes-similarity-score
+  (let [results (embed/nearest [1 0] [{:text "a" :embedding [1 0]}])]
+    (is (< (php/abs (- 1.0 (get (first results) :similarity))) 0.0001)
+        "perfect match has similarity ~1.0")))
+
+;; --- Embedding API requires configuration ---
+
+(deftest test-embed-requires-api-key
+  (let [original @ai/config]
+    (ai/configure {:api-key nil :base-url "http://0.0.0.0:1" :provider :openai})
+    (let [saved-key (php/getenv "OPENAI_API_KEY")]
+      (php/putenv "OPENAI_API_KEY=")
+      (let [saved-ant (php/getenv "ANTHROPIC_API_KEY")]
+        (php/putenv "ANTHROPIC_API_KEY=")
+        (is (thrown? \RuntimeException (embed/embed ["test"]))
+            "embed throws without API key")
+        (when saved-ant
+          (php/putenv (str "ANTHROPIC_API_KEY=" saved-ant))))
+      (when saved-key
+        (php/putenv (str "OPENAI_API_KEY=" saved-key))))
+    (reset! ai/config original)))
+
+(deftest test-embed-with-bad-endpoint-throws
+  (let [original @ai/config]
+    (ai/configure {:api-key "test-key" :base-url "http://0.0.0.0:1" :provider :openai})
+    (is (thrown? \RuntimeException (embed/embed ["test"]))
+        "embed throws with unreachable endpoint")
+    (reset! ai/config original)))
+
+;; --- Public API completeness ---
+
+(deftest test-public-functions-exist
+  (is (function? embed/dot-product) "dot-product is defined")
+  (is (function? embed/magnitude) "magnitude is defined")
+  (is (function? embed/cosine-similarity) "cosine-similarity is defined")
+  (is (function? embed/embed) "embed is defined")
+  (is (function? embed/embed-one) "embed-one is defined")
+  (is (function? embed/nearest) "nearest is defined")
+  (is (function? embed/build-index) "build-index is defined")
+  (is (function? embed/search) "search is defined")
+  (is (function? embed/embed-ns) "embed-ns is defined")
+  (is (function? embed/search-ns) "search-ns is defined"))


### PR DESCRIPTION
## 🤔 Background

The final piece of the AI capabilities roadmap. With `phel\http-client`, `phel\ai`, `phel\ai-repl`, and `phel\ai-structured` merged, this adds the embeddings layer for semantic search over text and Phel codebases.

## 💡 Goal

Add `phel\ai-embed` module providing vector math, embedding API integration, and semantic search capabilities, including the ability to build searchable indexes of Phel namespaces.

## 🔖 Changes

- **`src/phel/ai-embed.phel`**: New module with:
  - **Vector math**: `dot-product`, `magnitude`, `cosine-similarity` (pure functions, no API needed)
  - **Embedding API**: `embed` (batch), `embed-one` (single text), supporting OpenAI and Voyage AI providers
  - **Semantic search**: `nearest` (k-NN by cosine similarity), `build-index` (embed + index texts), `search` (embed query + find nearest)
  - **Namespace search**: `embed-ns` (index all public functions by name+docstring), `search-ns` (semantic search over namespace index)
- **`tests/phel/test/ai-embed.phel`**: 29 tests covering vector math (dot product, magnitude, cosine similarity edge cases), nearest neighbor search, API error handling, and completeness
- **`CHANGELOG.md`**: Updated Unreleased section with all 5 AI modules