### PR TITLE
fix: allow `def` with single argument, defaulting to nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `(def name)` without a value no longer throws; defines the var as `nil`, matching Clojure (#1361)
+
 ### Changed
 
 - Reorganized Phel test files: dissolved `core.phel` into topic files under `core/`, moved `comments.phel`, `special-forms.phel`, `multi-arity-fn.phel` into `core/`

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -41,7 +41,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 {
     use WithAnalyzerTrait;
 
-    private const array POSSIBLE_TUPLE_SIZES = [3, 4];
+    private const array POSSIBLE_TUPLE_SIZES = [2, 3, 4];
 
     /** Number of implicit parameters (`&form` and `&env`) injected into macro fns. */
     private const int MACRO_IMPLICIT_PARAMS = 2;
@@ -187,6 +187,10 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
     private function getInitialMetaAndInit(PersistentListInterface $list): array
     {
+        if (count($list) === 2) {
+            return [Phel::map(), null];
+        }
+
         if (count($list) === 3) {
             return [Phel::map(), $list->get(2)];
         }

--- a/tests/php/Integration/Fixtures/Def/def-no-value.test
+++ b/tests/php/Integration/Fixtures/Def/def-no-value.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def baz)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "baz",
+  null,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-no-value.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-no-value.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 9
+    )
+  )
+);

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DefSymbolTest.php
@@ -51,13 +51,25 @@ final class DefSymbolTest extends TestCase
     public function test_with_wrong_number_of_arguments(): void
     {
         $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
 
         $list = Phel::list([
             Symbol::create(Symbol::NAME_DEF),
-            Symbol::create('1'),
         ]);
         (new DefSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_def_without_value(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_DEF),
+            Symbol::create('baz'),
+        ]);
+        $env = NodeEnvironment::empty();
+        $defNode = (new DefSymbol($this->analyzer))->analyze($list, $env);
+
+        self::assertSame('baz', $defNode->getName()->getName());
+        self::assertInstanceOf(LiteralNode::class, $defNode->getInit());
+        self::assertNull($defNode->getInit()->getValue());
     }
 
     public function test_first_argument_must_be_symbol(): void


### PR DESCRIPTION
## 🤔 Background

In Clojure, `(def baz)` is valid and creates a var bound to `nil`. In Phel, this throws `Two or three arguments are required for 'def. Got 2`.

## 💡 Goal

Allow `(def name)` without a value, matching Clojure semantics.

## 🔖 Changes

- Added size `2` to `DefSymbol::POSSIBLE_TUPLE_SIZES`
- Handle the no-value case in `getInitialMetaAndInit()`, defaulting `init` to `null`
- Updated unit test: wrong-argument test now uses size 1 (just `def` with no name)
- Added `test_def_without_value` unit test
- Added `def-no-value.test` integration fixture
- Updated CHANGELOG

Closes #1361