### PR TITLE
fix: accept Clojure-style binding pairs in `doseq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `(def name)` without a value no longer throws; defines the var as `nil`, matching Clojure (#1361)
+- `doseq` now accepts Clojure-style binding pairs `(doseq [x coll] body)` without requiring `:in` verb (#1362)
 
 ### Changed
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1625,10 +1625,38 @@ Otherwise, it tries to call `__toString`."
   [head & body]
   (for-builder `(do ~@body) head 0))
 
+(def- for-verbs (hash-set :in :range :keys :pairs))
+
+(defn- doseq-normalize
+  "Transforms Clojure-style doseq bindings into Phel dofor format.
+  Pairs `[x coll]` become triples `[x :in coll]`. Already-present
+  verb triples `[x :in coll]` pass through unchanged. Modifier keywords
+  like :when, :while, :let pass through unchanged."
+  [head]
+  (loop [i 0
+         result []]
+    (if (>= i (count head))
+      result
+      (let [el (php/aget head i)]
+        (if (keyword? el)
+          ;; modifier keyword: keep pair as-is
+          (recur (php/+ i 2) (push (push result el) (php/aget head (php/+ i 1))))
+          ;; binding symbol: check if verb already present
+          (let [next-el (php/aget head (php/+ i 1))]
+            (if (and (keyword? next-el) (contains? for-verbs next-el))
+              ;; verb already present: keep triple as-is
+              (recur (php/+ i 3) (push (push (push result el) next-el) (php/aget head (php/+ i 2))))
+              ;; no verb: insert :in
+              (recur (php/+ i 2) (push (push (push result el) :in) next-el)))))))))
+
 (defmacro doseq
-  "Alias for `dofor`."
+  "Repeatedly executes body for side effects with bindings.
+  Uses Clojure-style binding pairs: `(doseq [x coll] body)`.
+  Supports :when, :while, :let modifiers."
+  {:example "(doseq [x [1 2 3]] (println x))"}
   [seq-exprs & body]
-  `(dofor ~seq-exprs ~@body))
+  (let [normalized (doseq-normalize seq-exprs)]
+    `(dofor ~normalized ~@body)))
 
 (defn identity
   "Returns its argument."

--- a/tests/phel/test/core/doseq.phel
+++ b/tests/phel/test/core/doseq.phel
@@ -15,3 +15,23 @@
             :let [y (* x 2)]]
            (swap! captured (fn [xs] (push xs y))))
     (is (= [4 8] (deref captured)) "doseq honors modifiers from for")))
+
+(deftest test-doseq-clojure-style-bindings
+  (let [captured (var [])]
+    (doseq [x [1 2 3]]
+           (swap! captured (fn [xs] (push xs x))))
+    (is (= [1 2 3] (deref captured)) "doseq accepts Clojure-style binding pairs")))
+
+(deftest test-doseq-clojure-style-nested
+  (let [captured (var [])]
+    (doseq [x [1 2]
+            y [3 4]]
+           (swap! captured (fn [xs] (push xs [x y]))))
+    (is (= [[1 3] [1 4] [2 3] [2 4]] (deref captured)) "doseq nested Clojure-style")))
+
+(deftest test-doseq-clojure-style-with-when
+  (let [captured (var [])]
+    (doseq [x [1 2 3 4 5]
+            :when (odd? x)]
+           (swap! captured (fn [xs] (push xs x))))
+    (is (= [1 3 5] (deref captured)) "doseq Clojure-style with :when modifier")))


### PR DESCRIPTION
## 🤔 Background

Clojure's `doseq` uses binding pairs `(doseq [x coll] body)`, but Phel's `doseq` delegated directly to `dofor` which requires verb triples `[x :in coll]`. This caused `(doseq [x [1 2 3]] x)` to fail with "This verb is not supported in for loop".

## 💡 Goal

Make `doseq` accept Clojure-style binding pairs while remaining backward-compatible with existing Phel `:in`/`:range`/`:keys`/`:pairs` verb syntax.

## 🔖 Changes

- Added `doseq-normalize` helper that transforms Clojure-style binding pairs `[x coll]` into Phel triples `[x :in coll]`, passing through existing verbs and modifier keywords unchanged
- Updated `doseq` macro to normalize bindings before delegating to `dofor`
- Added tests: Clojure-style, nested bindings, and `:when` modifier
- Updated CHANGELOG

Closes #1362