### PR TITLE
fix: make `drop-last` work with lazy sequences and ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `(def name)` without a value no longer throws; defines the var as `nil`, matching Clojure (#1361)
 - `doseq` now accepts Clojure-style binding pairs `(doseq [x coll] body)` without requiring `:in` verb (#1362)
+- `drop-last` now works with lazy sequences and ranges; returns a lazy sequence matching Clojure (#1360)
 
 ### Changed
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2209,17 +2209,13 @@ Otherwise, it tries to call `__toString`."
 (defn drop-last
   "Drops the last `n` elements of `coll`. `n` defaults to `1` when omitted,
    matching Clojure's `(drop-last coll)` single-arity form. Returns an empty
-   vector when `coll` is `nil`, matching Clojure's `(drop-last n nil)` → `()`
-   and aligning with `drop`/`take`, which also return an empty result on `nil`."
-  {:example "(drop-last [1 2 3 4 5]) ; => [1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; => [1 2 3]\n(drop-last 5 nil) ; => []"
+   sequence when `coll` is `nil`. Works with any seqable collection including
+   lazy sequences and ranges."
+  {:example "(drop-last [1 2 3 4 5]) ; => (1 2 3 4)\n(drop-last 2 [1 2 3 4 5]) ; => (1 2 3)\n(drop-last 5 nil) ; => ()"
    :see-also ["drop" "butlast"]}
   ([coll] (drop-last 1 coll))
   ([n coll]
-   (if (nil? coll)
-     []
-     (let [n (if (php/< n 0) 0 n)
-           end (php/- (count coll) n)]
-       (slice coll 0 (php/max 0 end))))))
+   (map (fn [x _] x) coll (drop n coll))))
 
 (defn last
   "Returns the last element of `coll` or nil if `coll` is empty or nil."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -84,30 +84,34 @@
   (is (= ["c"] (doall (drop 2 (php/array "a" "b" "c")))) "drop on php array (returns lazy seq)"))
 
 (deftest test-drop-last
-  (is (= ["a" "b"] (drop-last 1 ["a" "b" "c"])) "drop-last element")
-  (is (= ["a"] (drop-last 2 ["a" "b" "c"])) "drop-last two elements")
-  (is (= [] (drop-last 3 ["a" "b" "c"])) "drop-last three elements")
-  (is (= [] (drop-last 4 ["a" "b" "c"])) "drop-last four elements")
-  (is (= ["a" "b" "c"] (drop-last 0 ["a" "b" "c"])) "drop-last zero elements")
-  (is (= ["a" "b" "c"] (drop-last -1 ["a" "b" "c"])) "drop-last with negative number")
-  (is (= [] (drop-last 1 [])) "drop-last on empty vector")
-  (is (= (php/array "a" "b") (drop-last 1 (php/array "a" "b" "c"))) "drop-last on php array")
-  (is (= (php/array) (drop-last 1 (php/array))) "drop-last on empty php array"))
+  (is (= ["a" "b"] (doall (drop-last 1 ["a" "b" "c"]))) "drop-last element")
+  (is (= ["a"] (doall (drop-last 2 ["a" "b" "c"]))) "drop-last two elements")
+  (is (= [] (doall (drop-last 3 ["a" "b" "c"]))) "drop-last three elements")
+  (is (= [] (doall (drop-last 4 ["a" "b" "c"]))) "drop-last four elements")
+  (is (= ["a" "b" "c"] (doall (drop-last 0 ["a" "b" "c"]))) "drop-last zero elements")
+  (is (= ["a" "b" "c"] (doall (drop-last -1 ["a" "b" "c"]))) "drop-last with negative number")
+  (is (= [] (doall (drop-last 1 []))) "drop-last on empty vector")
+  (is (= ["a" "b"] (doall (drop-last 1 (php/array "a" "b" "c")))) "drop-last on php array")
+  (is (= [] (doall (drop-last 1 (php/array)))) "drop-last on empty php array"))
 
 (deftest test-drop-last-single-arity
-  (is (= ["a" "b"] (drop-last ["a" "b" "c"])) "drop-last single-arity defaults to 1 on vector")
-  (is (= [] (drop-last ["a"])) "drop-last single-arity on single-element vector")
-  (is (= [] (drop-last [])) "drop-last single-arity on empty vector")
-  (is (= [1 2 3] (drop-last [1 2 3 4])) "drop-last single-arity on longer vector")
-  (is (= (php/array "a" "b") (drop-last (php/array "a" "b" "c"))) "drop-last single-arity on php array")
-  (is (= (php/array) (drop-last (php/array "a"))) "drop-last single-arity on single-element php array"))
+  (is (= ["a" "b"] (doall (drop-last ["a" "b" "c"]))) "drop-last single-arity defaults to 1 on vector")
+  (is (= [] (doall (drop-last ["a"]))) "drop-last single-arity on single-element vector")
+  (is (= [] (doall (drop-last []))) "drop-last single-arity on empty vector")
+  (is (= [1 2 3] (doall (drop-last [1 2 3 4]))) "drop-last single-arity on longer vector")
+  (is (= ["a" "b"] (doall (drop-last (php/array "a" "b" "c")))) "drop-last single-arity on php array")
+  (is (= [] (doall (drop-last (php/array "a")))) "drop-last single-arity on single-element php array"))
 
 (deftest test-drop-last-nil
-  (is (= [] (drop-last 5 nil)) "drop-last with n on nil returns empty vector")
-  (is (= [] (drop-last 1 nil)) "drop-last 1 on nil returns empty vector")
-  (is (= [] (drop-last 0 nil)) "drop-last 0 on nil returns empty vector")
-  (is (= [] (drop-last -1 nil)) "drop-last negative n on nil returns empty vector")
-  (is (= [] (drop-last nil)) "drop-last single-arity on nil returns empty vector"))
+  (is (= [] (doall (drop-last 5 nil))) "drop-last with n on nil returns empty sequence")
+  (is (= [] (doall (drop-last 1 nil))) "drop-last 1 on nil returns empty sequence")
+  (is (= [] (doall (drop-last 0 nil))) "drop-last 0 on nil returns empty sequence")
+  (is (= [] (doall (drop-last -1 nil))) "drop-last negative n on nil returns empty sequence")
+  (is (= [] (doall (drop-last nil))) "drop-last single-arity on nil returns empty sequence"))
+
+(deftest test-drop-last-range
+  (is (= [0 1 2 3 4 5 6 7 8] (doall (drop-last (range 0 10)))) "drop-last on range")
+  (is (= [0 1 2] (doall (drop-last 3 (range 0 6)))) "drop-last 3 on range"))
 
 (deftest test-last
   (is (= "c" (last ["a" "b" "c"])) "last element")
@@ -116,10 +120,10 @@
   (is (nil? (last (php/array))) "last on empty php array"))
 
 (deftest test-butlast
-  (is (= ["a" "b"] (butlast ["a" "b" "c"])) "butlast element")
-  (is (= [] (butlast ["a"])) "butlast single element")
-  (is (= [] (butlast [])) "butlast empty vector")
-  (is (= (php/array "a" "b") (butlast (php/array "a" "b" "c"))) "butlast on php array"))
+  (is (= ["a" "b"] (doall (butlast ["a" "b" "c"]))) "butlast element")
+  (is (= [] (doall (butlast ["a"]))) "butlast single element")
+  (is (= [] (doall (butlast []))) "butlast empty vector")
+  (is (= ["a" "b"] (doall (butlast (php/array "a" "b" "c")))) "butlast on php array"))
 
 (deftest test-drop-while
   (is (= [1 2 3 4 -1 -2 -3] (doall (drop-while neg? [-1 -2 -3 1 2 3 4 -1 -2 -3]))) "drop-while: first three element")


### PR DESCRIPTION
## 🤔 Background

`drop-last` used `slice` internally which only works with collections implementing `SliceInterface`. Calling `(drop-last (range 0 10))` threw `InvalidArgumentException: Cannot slice` because lazy sequences from `range` don't implement `SliceInterface`.

## 💡 Goal

Make `drop-last` work with any seqable collection, including lazy sequences and ranges.

## 🔖 Changes

- Reimplemented `drop-last` using `(map (fn [x _] x) coll (drop n coll))`, the same approach Clojure uses. This zips the original collection with a version offset by `n`; when the shorter one is exhausted, the result stops, effectively dropping the last `n` elements.
- `drop-last` now returns a lazy sequence (matching Clojure behavior) instead of preserving the input collection type
- Updated tests to use `doall` where needed and added `test-drop-last-range`
- Updated CHANGELOG

Closes #1360