### PR TITLE
fix: prevent `empty?` from hanging on infinite lazy sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `(def name)` without a value no longer throws; defines the var as `nil`, matching Clojure (#1361)
 - `doseq` now accepts Clojure-style binding pairs `(doseq [x coll] body)` without requiring `:in` verb (#1362)
 - `drop-last` now works with lazy sequences and ranges; returns a lazy sequence matching Clojure (#1360)
+- `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences instead of `count` (#1366)
 
 ### Changed
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1124,13 +1124,14 @@ Otherwise, it tries to call `__toString`."
   (php/instanceof x LazySeqInterface))
 
 (defn empty?
-  "Returns true if x would be 0, \"\" or empty collection, false otherwise."
+  "Returns true if x would be 0, \"\" or empty collection, false otherwise.
+  Safe on infinite/lazy sequences: checks the first element instead of counting."
   [x]
-  (if (php/is_numeric x)
-    (= 0 x)
-    (if (php/is_string x)
-      (true? (php/empty x))
-      (= 0 (count x)))))
+  (cond
+    (php/is_numeric x) (= 0 x)
+    (php/is_string x) (true? (php/empty x))
+    (php/instanceof x LazySeqInterface) (nil? (first x))
+    :else (= 0 (count x))))
 
 (defn not-empty
   "Returns `coll` if it contains elements, otherwise nil."

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -131,7 +131,10 @@
   (is (false? (empty? 1)) "empty? on positive number")
   (is (true? (empty? 0)) "empty? on zero")
   (is (false? (empty? -1)) "empty? on negative number")
-  (is (false? (empty? "a")) "empty? on one string"))
+  (is (false? (empty? "a")) "empty? on one string")
+  (is (false? (empty? (range))) "empty? on infinite range returns false")
+  (is (true? (empty? (filter (fn [x] false) [1 2 3]))) "empty? on empty lazy seq")
+  (is (false? (empty? (filter odd? [1 2 3]))) "empty? on non-empty lazy seq"))
 
 (deftest test-indexed?
   (is (false? (indexed? {})) "indexed? on map")


### PR DESCRIPTION
## 🤔 Background

`(empty? (range))` hangs because `empty?` used `(= 0 (count x))` which tries to count all elements of an infinite range.

## 💡 Goal

Make `empty?` safe for infinite/lazy sequences by checking `first` instead of `count`.

## 🔖 Changes

- Added a `LazySeqInterface` check in `empty?`: for lazy sequences, checks `(nil? (first x))` instead of counting
- Added tests for infinite range, empty lazy seq, and non-empty lazy seq
- Updated CHANGELOG

Closes #1366