### PR TITLE
fix: prevent `is` macro from misinterpreting special forms as binary predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `doseq` now accepts Clojure-style binding pairs `(doseq [x coll] body)` without requiring `:in` verb (#1362)
 - `drop-last` now works with lazy sequences and ranges; returns a lazy sequence matching Clojure (#1360)
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences instead of `count` (#1366)
+- `is` macro no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
 
 ### Changed
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -233,12 +233,22 @@
   (assert-output form message))
 
 (defmethod assert-expr :default [form message]
-  (cond
-    (and (list? form) (= 3 (count form)))
-    (assert-binary form message false)
-    (and (list? form) (= 2 (count form)))
-    (assert-predicate form message false)
-    (assert-any form message)))
+  (let [head (when (list? form) (first form))
+        ;; Only treat as function call if head is a symbol that's NOT
+        ;; a special form or common macro with structured syntax
+        fn-call (and (symbol? head)
+                     (not (contains?
+                            (hash-set 'def 'fn 'if 'do 'let 'quote 'loop
+                                      'recur 'throw 'try 'ns 'set!
+                                      'defn 'defn- 'defmacro 'when 'when-not
+                                      'cond 'case 'binding 'for 'dofor 'doseq)
+                            head)))]
+    (cond
+      (and fn-call (= 3 (count form)))
+      (assert-binary form message false)
+      (and fn-call (= 2 (count form)))
+      (assert-predicate form message false)
+      (assert-any form message))))
 
 (defmacro is
   "Asserts that an expression is true."

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -149,6 +149,24 @@
     (is (= 1 (:failed counts)) "output? mismatch records a failure")))
 
 ;; ---------------------------------------------------------------------------
+;; :default — let/when/cond forms fall through to assert-any, not assert-binary
+;; ---------------------------------------------------------------------------
+
+(deftest test-is-let-binding-not-misread-as-binary
+  (is (let [f #(+ 2 %)
+            f' f]
+        (= f f'))
+      "let form inside is should evaluate normally"))
+
+(deftest test-is-when-form-not-misread-as-predicate
+  (is (when true 42)
+      "when form inside is should evaluate normally"))
+
+(deftest test-is-cond-form-not-misread-as-binary
+  (is (cond true 1 :else 2)
+      "cond form inside is should evaluate normally"))
+
+;; ---------------------------------------------------------------------------
 ;; :default — binary predicate (3-element list)
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 🤔 Background

The `is` macro's `:default` dispatch handler treated any 3-element list as a binary predicate assertion (like `(= a b)`). This meant `(is (let [f ...] (= f f')))` was incorrectly decomposed as pred=`let`, expected=`[f ...]`, actual=`(= f f')`, causing "Cannot resolve symbol" errors.

## 💡 Goal

Make `is` correctly handle special forms and macros like `let`, `when`, `cond`, etc. by routing them to `assert-any` instead of `assert-binary`.

## 🔖 Changes

- Updated `assert-expr :default` to check if the form head is a known special form/macro before routing to `assert-binary` or `assert-predicate`; special forms fall through to `assert-any`
- Added tests for `let`, `when`, and `cond` forms inside `is`
- Updated CHANGELOG

Closes #1367