### PR TITLE
fix: use eval-based class definition in statement mode to avoid namespace errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `drop-last` now works with lazy sequences and ranges; returns a lazy sequence matching Clojure (#1360)
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences instead of `count` (#1366)
 - `is` macro no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
+- `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -20,16 +20,55 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
         assert($node instanceof DefExceptionNode);
 
         if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            $this->outputEmitter->emitLine(
-                'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
-                $node->getStartSourceLocation(),
-            );
+            $this->emitViaEval($node);
+        } else {
+            $this->emitInline($node);
         }
+    }
 
+    /**
+     * In statement mode, the class definition may end up inside a function
+     * wrapper. PHP forbids namespace declarations inside functions, so we
+     * capture the class body at compile time and emit it as an eval() call.
+     */
+    private function emitViaEval(DefExceptionNode $node): void
+    {
+        $ns = $this->outputEmitter->mungeEncodeNs($node->getNamespace());
+        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+
+        ob_start();
+        $this->emitClassBody($node);
+        $classBody = (string) ob_get_clean();
+
+        $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $evalCode = 'namespace ' . $ns . ";\n" . $classBody;
+        $this->outputEmitter->emitLine(
+            'eval(' . var_export($evalCode, true) . ');',
+            $node->getStartSourceLocation(),
+        );
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * In file/cache mode the NsEmitter already declared the namespace.
+     */
+    private function emitInline(DefExceptionNode $node): void
+    {
         $fqcn = $this->outputEmitter->mungeEncodeNs($node->getNamespace())
             . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
         $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
 
+        $this->emitClassBody($node);
+
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitClassBody(DefExceptionNode $node): void
+    {
         $this->outputEmitter->emitStr(
             'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends ',
             $node->getStartSourceLocation(),
@@ -45,7 +84,6 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('}');
 
         $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
         $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -19,36 +19,68 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
     {
         assert($node instanceof DefInterfaceNode);
 
-        $this->emitClassBegin($node);
-        $this->emitMethods($node);
-        $this->emitClassEnd($node);
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            $this->emitViaEval($node);
+        } else {
+            $this->emitInline($node);
+        }
     }
 
-    private function emitClassBegin(DefInterfaceNode $node): void
+    /**
+     * In statement mode, the interface definition may end up inside a function
+     * wrapper. PHP forbids namespace declarations inside functions, so we
+     * capture the interface body at compile time and emit it as an eval() call.
+     */
+    private function emitViaEval(DefInterfaceNode $node): void
     {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            $this->outputEmitter->emitLine(
-                'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
-                $node->getStartSourceLocation(),
-            );
-        }
+        $ns = $this->outputEmitter->mungeEncodeNs($node->getNamespace());
+        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
 
+        ob_start();
+        $this->emitInterfaceBody($node);
+        $interfaceBody = (string) ob_get_clean();
+
+        $this->outputEmitter->emitLine("if (!interface_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $evalCode = 'namespace ' . $ns . ";\n" . $interfaceBody;
+        $this->outputEmitter->emitLine(
+            'eval(' . var_export($evalCode, true) . ');',
+            $node->getStartSourceLocation(),
+        );
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * In file/cache mode the NsEmitter already declared the namespace.
+     */
+    private function emitInline(DefInterfaceNode $node): void
+    {
         $fqcn = $this->outputEmitter->mungeEncodeNs($node->getNamespace())
             . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
         $this->outputEmitter->emitLine("if (!interface_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
 
+        $this->emitInterfaceBody($node);
+
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitInterfaceBody(DefInterfaceNode $node): void
+    {
         $this->outputEmitter->emitLine(
             'interface ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' {',
             $node->getStartSourceLocation(),
         );
         $this->outputEmitter->increaseIndentLevel();
-    }
 
-    private function emitMethods(DefInterfaceNode $node): void
-    {
         foreach ($node->getMethods() as $defInterfaceMethod) {
             $this->emitMethod($node, $defInterfaceMethod);
         }
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
     }
 
     private function emitMethod(DefInterfaceNode $node, DefInterfaceMethod $method): void
@@ -70,12 +102,5 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitLine(';');
-    }
-
-    private function emitClassEnd(DefInterfaceNode $node): void
-    {
-        $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -24,27 +24,75 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     {
         assert($node instanceof DefStructNode);
 
-        $this->emitClassBegin($node);
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            $this->emitViaEval($node);
+        } else {
+            $this->emitInline($node);
+        }
+    }
+
+    /**
+     * In statement mode, the class definition may end up inside a function
+     * wrapper (when a do-form is in expression context). PHP forbids namespace
+     * declarations inside functions, so we capture the class body at compile
+     * time and emit it as an eval() call. This guarantees the namespace is
+     * always the first statement within its own isolated eval context.
+     */
+    private function emitViaEval(DefStructNode $node): void
+    {
+        $ns = $this->outputEmitter->mungeEncodeNs($node->getNamespace());
+        $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+
+        // Capture the class body at compile time
+        ob_start();
+        $this->emitClassBody($node);
+        $classBody = (string) ob_get_clean();
+
+        // Emit: if (!class_exists(...)) { eval('namespace ...; <class body>'); }
+        $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+        $this->outputEmitter->increaseIndentLevel();
+
+        $evalCode = 'namespace ' . $ns . ";\n" . $classBody;
+        $this->outputEmitter->emitLine(
+            'eval(' . var_export($evalCode, true) . ');',
+            $node->getStartSourceLocation(),
+        );
+
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    /**
+     * In file/cache mode the NsEmitter already declared the namespace at the
+     * top of the file, so the class is emitted inline without its own
+     * namespace statement.
+     */
+    private function emitInline(DefStructNode $node): void
+    {
+        $this->emitClassExistsGuard($node);
+        $this->emitClassBody($node);
+        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+    }
+
+    private function emitClassExistsGuard(DefStructNode $node): void
+    {
+        $fqcn = $this->outputEmitter->mungeEncodeNs($node->getNamespace())
+            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
+        $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
+    }
+
+    private function emitClassBody(DefStructNode $node): void
+    {
+        $this->emitClassHeader($node);
         $this->emitAllowedKeys($node);
         $this->emitProperties($node);
         $this->emitConstructor($node);
         $this->emitInterfaces($node);
-        $this->emitClassEnd($node);
+        $this->emitClassFooter($node);
     }
 
-    private function emitClassBegin(DefStructNode $node): void
+    private function emitClassHeader(DefStructNode $node): void
     {
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
-            $this->outputEmitter->emitLine(
-                'namespace ' . $this->outputEmitter->mungeEncodeNs($node->getNamespace()) . ';',
-                $node->getStartSourceLocation(),
-            );
-        }
-
-        $fqcn = $this->outputEmitter->mungeEncodeNs($node->getNamespace())
-            . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
-        $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
-
         $this->outputEmitter->emitStr(
             'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
             $node->getStartSourceLocation(),
@@ -142,10 +190,9 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         }
     }
 
-    private function emitClassEnd(DefStructNode $node): void
+    private function emitClassFooter(DefStructNode $node): void
     {
         $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
         $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
     }
 }


### PR DESCRIPTION
## 🤔 Background

When `defrecord`/`defstruct`/`defexception`/`definterface` forms are compiled in statement mode (e.g. during test runner execution), the emitter would place a `namespace` declaration inside a function wrapper. PHP forbids namespace declarations inside functions, causing fatal errors.

This happens because `do`-forms in expression context get wrapped in `(function() { ... })()` by the `DoEmitter`, and the struct/exception/interface emitters were emitting `namespace Foo;` inline before the class definition.

## 💡 Goal

Ensure class and interface definitions always emit valid PHP regardless of the emit mode, by using `eval()` with an isolated namespace context in statement mode.

Closes #1358

## 🔖 Changes

- `DefStructEmitter`: split `emit()` into `emitViaEval()` (statement mode) and `emitInline()` (file/cache mode). In statement mode, the class body is captured at compile time via output buffering and emitted as `eval('namespace ...; <class body>')`, ensuring the namespace is always the first statement in its own isolated context.
- `DefExceptionEmitter`: same eval-based pattern for exception class definitions.
- `DefInterfaceEmitter`: same eval-based pattern for interface definitions.
- Updated `CHANGELOG.md` with the fix under `## Unreleased`.