### PR TITLE
feat: add `any?` predicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `any?` predicate function: returns true given any argument, matching Clojure (#1373)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search
 - `phel\repl` AI-powered helpers: `explain`, `suggest`, `fix`, `review`, `embed-ns`, `search-ns`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -917,6 +917,13 @@ Otherwise, it tries to call `__toString`."
   [x]
   (id x nil))
 
+(defn any?
+  "Returns true given any argument."
+  {:example "(any? 42) ; => true\n(any? nil) ; => true"
+   :see-also ["some?"]}
+  [x]
+  true)
+
 (defn str-contains?
   "Returns true if str contains s."
   {:deprecated "Use phel\\str\\contains?"}

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -26,6 +26,15 @@
   (is (false? (nil? false)) "nil? on false")
   (is (false? (nil? true)) "nil? on true"))
 
+(deftest test-any?
+  (is (true? (any? 42)) "any? on integer")
+  (is (true? (any? nil)) "any? on nil")
+  (is (true? (any? false)) "any? on false")
+  (is (true? (any? true)) "any? on true")
+  (is (true? (any? "hello")) "any? on string")
+  (is (true? (any? :kw)) "any? on keyword")
+  (is (true? (any? [])) "any? on vector"))
+
 (deftest test-float?
   (is (true? (float? 10.0)) "float? on 10.0")
   (is (true? (float? 0.0)) "float? on 0.0")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `any?` as a predicate that returns true for any argument. This is useful as a default predicate in higher-order functions and for completeness of the predicate function set.

## 💡 Goal

Add `any?` to `phel\core`, matching Clojure's semantics.

Closes #1373

## 🔖 Changes

- Added `any?` function to `src/phel/core.phel`: returns `true` given any argument
- Added tests in `tests/phel/test/core/type-operation.phel` covering integer, nil, false, true, string, keyword, and vector inputs
- Updated `CHANGELOG.md` under `## Unreleased`