### PR TITLE
feat: add `seqable?` predicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
+- `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search
 - `phel\repl` AI-powered helpers: `explain`, `suggest`, `fix`, `review`, `embed-ns`, `search-ns`

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1233,6 +1233,18 @@ Otherwise, it tries to call `__toString`."
         (= t :set)
         (php/instanceof x LazySeqInterface))))
 
+(defn seqable?
+  "Returns true if `(seq x)` is supported: collections (vectors, lists,
+   maps, sets, structs), lazy sequences, strings, PHP arrays, and nil.
+   Returns false for numbers, booleans, keywords, symbols, and other types."
+  {:example "(seqable? [1 2]) ; => true\n(seqable? 42) ; => false"
+   :see-also ["seq" "coll?" "seq?"]}
+  [x]
+  (or (nil? x)
+      (coll? x)
+      (php/is_string x)
+      (php/is_array x)))
+
 (defn counted?
   "Returns true if `coll` can report its length in constant time — persistent
    vectors, lists, hash-maps (including sorted-map), structs, and sets

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -231,6 +231,26 @@
   (is (false? (coll? (php/array))) "coll? on empty php array")
   (is (false? (coll? (php/array 1 2 3))) "coll? on non-empty php array"))
 
+(deftest test-seqable?
+  (is (true? (seqable? [])) "seqable? on empty vector")
+  (is (true? (seqable? [1 2 3])) "seqable? on non-empty vector")
+  (is (true? (seqable? '())) "seqable? on empty list")
+  (is (true? (seqable? '(1 2 3))) "seqable? on non-empty list")
+  (is (true? (seqable? {})) "seqable? on empty map")
+  (is (true? (seqable? {:a 1})) "seqable? on non-empty map")
+  (is (true? (seqable? #{})) "seqable? on empty set")
+  (is (true? (seqable? #{1 2})) "seqable? on non-empty set")
+  (is (true? (seqable? (range 3))) "seqable? on lazy sequence")
+  (is (true? (seqable? "hello")) "seqable? on string")
+  (is (true? (seqable? "")) "seqable? on empty string")
+  (is (true? (seqable? nil)) "seqable? on nil")
+  (is (true? (seqable? (php/array 1 2))) "seqable? on php array")
+  (is (false? (seqable? 42)) "seqable? on integer")
+  (is (false? (seqable? 1.5)) "seqable? on float")
+  (is (false? (seqable? true)) "seqable? on boolean")
+  (is (false? (seqable? :a)) "seqable? on keyword")
+  (is (false? (seqable? 'a)) "seqable? on symbol"))
+
 (deftest test-name
   (is (= "string" (name "string")) "name on string")
   (is (= "symbol" (name 'symbol)) "name on symbol")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `seqable?` to test whether `seq` can be called on a value. This is useful for writing generic functions that accept any sequence-compatible input.

## 💡 Goal

Add `seqable?` to `phel\core`, matching Clojure's semantics: true for collections, lazy sequences, strings, PHP arrays, and nil.

Closes #1379

## 🔖 Changes

- Added `seqable?` function to `src/phel/core.phel`
- Added 18 tests in `tests/phel/test/core/type-operation.phel` covering all seqable types and non-seqable types
- Updated `CHANGELOG.md` under `## Unreleased`