### PR TITLE
feat: add `special-symbol?` predicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 - `nth`, `nthrest`, `nthnext` sequence functions with Clojure-compatible semantics (#1375)
 - `simple-ident?`, `simple-keyword?`, `simple-symbol?` predicate functions for non-namespaced identifiers (#1381)
+- `special-symbol?` predicate function: returns true if a symbol names a special form (#1384)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1070,6 +1070,22 @@ Otherwise, it tries to call `__toString`."
   [x]
   (or (simple-symbol? x) (simple-keyword? x)))
 
+(def ^:private special-symbols
+  "The set of symbols that name Phel special forms."
+  (hash-set 'def 'ns 'in-ns 'load 'fn 'quote 'do 'if 'apply
+            'let 'recur 'try 'throw 'loop 'foreach 'set-var
+            'defstruct* 'definterface* 'defexception* 'reify*
+            'php/new 'php/-> 'php/:: 'php/aget 'php/aget-in
+            'php/aset 'php/aset-in 'php/apush 'php/apush-in
+            'php/aunset 'php/aunset-in 'php/oset))
+
+(defn special-symbol?
+  "Returns true if `s` names a special form."
+  {:example "(special-symbol? 'def) ; => true\n(special-symbol? 'map) ; => false"
+   :see-also ["symbol?"]}
+  [s]
+  (and (symbol? s) (contains? special-symbols s)))
+
 (defn fn?
   "Returns true if `x` is a function, false otherwise."
   [x]

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -110,6 +110,26 @@
   (is (false? (simple-ident? "test")) "simple-ident? on string")
   (is (false? (simple-ident? nil)) "simple-ident? on nil"))
 
+(deftest test-special-symbol?
+  (is (true? (special-symbol? 'def)) "special-symbol? on def")
+  (is (true? (special-symbol? 'fn)) "special-symbol? on fn")
+  (is (true? (special-symbol? 'if)) "special-symbol? on if")
+  (is (true? (special-symbol? 'do)) "special-symbol? on do")
+  (is (true? (special-symbol? 'let)) "special-symbol? on let")
+  (is (true? (special-symbol? 'quote)) "special-symbol? on quote")
+  (is (true? (special-symbol? 'try)) "special-symbol? on try")
+  (is (true? (special-symbol? 'throw)) "special-symbol? on throw")
+  (is (true? (special-symbol? 'recur)) "special-symbol? on recur")
+  (is (true? (special-symbol? 'loop)) "special-symbol? on loop")
+  (is (true? (special-symbol? 'ns)) "special-symbol? on ns")
+  (is (true? (special-symbol? 'php/new)) "special-symbol? on php/new")
+  (is (false? (special-symbol? 'map)) "special-symbol? on map")
+  (is (false? (special-symbol? 'filter)) "special-symbol? on filter")
+  (is (false? (special-symbol? :def)) "special-symbol? on keyword :def")
+  (is (false? (special-symbol? "def")) "special-symbol? on string")
+  (is (false? (special-symbol? 42)) "special-symbol? on integer")
+  (is (false? (special-symbol? nil)) "special-symbol? on nil"))
+
 (deftest test-function?
   (is (true? (function? concat)) "function? on concat"))
 


### PR DESCRIPTION
## 🤔 Background

Clojure provides `special-symbol?` to test whether a symbol names a special form. This is useful for macros and code analysis tools that need to distinguish special forms from regular function calls.

## 💡 Goal

Add `special-symbol?` to `phel\core`, using a hash-set of all registered Phel special forms for O(1) lookup.

Closes #1384

## 🔖 Changes

- Added `special-symbols` private def: hash-set of all 31 special form symbols
- Added `special-symbol?` function: checks if argument is a symbol naming a special form
- Added 18 tests covering special forms (`def`, `fn`, `if`, `do`, `let`, `quote`, `try`, `throw`, `recur`, `loop`, `ns`, `php/new`) and non-special forms (`map`, `filter`, keywords, strings, numbers, nil)
- Updated `CHANGELOG.md` under `## Unreleased`