### PR TITLE
feat: add `nth`, `nthrest`, `nthnext` sequence functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `nth`, `nthrest`, `nthnext` sequence functions with Clojure-compatible semantics (#1375)
 - `simple-ident?`, `simple-keyword?`, `simple-symbol?` predicate functions for non-namespaced identifiers (#1381)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2,6 +2,7 @@
   (:use Countable)
   (:use Traversable)
   (:use InvalidArgumentException)
+  (:use OutOfBoundsException)
   (:use Phel)
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Compiler\CompilerFacade)
@@ -1360,6 +1361,81 @@ Otherwise, it tries to call `__toString`."
       (if (nil? res)
         opt
         res))))
+
+(defn nth
+  "Returns the value at `index` in `coll`. Throws an
+   OutOfBoundsException if the index is out of range and no
+   `not-found` value is supplied. For indexed collections (vectors,
+   strings) this is O(1); for sequences it is O(n)."
+  {:example "(nth [1 2 3] 1) ; => 2\n(nth [1 2 3] 5 :default) ; => :default"
+   :see-also ["get" "first" "second"]}
+  ([coll index]
+   (cond
+     (nil? coll)
+     (throw (php/new OutOfBoundsException (str "Index " index " out of bounds on nil")))
+
+     (php/is_string coll)
+     (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))
+       (php/mb_substr coll index 1 "UTF-8")
+       (throw (php/new OutOfBoundsException (str "String index " index " out of bounds"))))
+
+     (vector? coll)
+     (if (and (php/>= index 0) (php/< index (count coll)))
+       (get coll index)
+       (throw (php/new OutOfBoundsException (str "Vector index " index " out of bounds"))))
+
+     :else
+     (loop [i index
+            s coll]
+       (cond
+         (nil? s) (throw (php/new OutOfBoundsException (str "Index " index " out of bounds")))
+         (php/=== i 0) (first s)
+         :else (recur (php/- i 1) (next s))))))
+
+  ([coll index not-found]
+   (cond
+     (nil? coll) not-found
+
+     (php/is_string coll)
+     (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))
+       (php/mb_substr coll index 1 "UTF-8")
+       not-found)
+
+     (vector? coll)
+     (if (and (php/>= index 0) (php/< index (count coll)))
+       (get coll index)
+       not-found)
+
+     :else
+     (loop [i index
+            s coll]
+       (cond
+         (nil? s) not-found
+         (php/=== i 0) (first s)
+         :else (recur (php/- i 1) (next s)))))))
+
+(defn nthrest
+  "Returns the nth rest of `coll`, `coll` when `n` is 0."
+  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)"
+   :see-also ["nth" "nthnext" "drop"]}
+  [coll n]
+  (loop [i n
+         s coll]
+    (if (and (php/> i 0) s)
+      (recur (php/- i 1) (next s))
+      s)))
+
+(defn nthnext
+  "Returns the nth next of `coll`, `(seq coll)` when `n` is 0.
+   Returns nil if there are fewer than `n` elements remaining."
+  {:example "(nthnext [1 2 3 4 5] 2) ; => (3 4 5)\n(nthnext [1 2] 5) ; => nil"
+   :see-also ["nth" "nthrest" "drop"]}
+  [coll n]
+  (loop [i n
+         s (seq coll)]
+    (if (and (php/> i 0) s)
+      (recur (php/- i 1) (next s))
+      s)))
 
 (defn- assoc-pair
   "Associates a single key-value pair with a collection."

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -1,4 +1,5 @@
 (ns phel-test\test\core\sequence-operation
+  (:use OutOfBoundsException)
   (:require phel\test :refer [deftest is]))
 
 (deftest test-peek
@@ -242,6 +243,33 @@
   (is (= "a" (get-in {:a ["a"]} [:a 0])) "get-in level 2")
   (is (= "a" (get-in {:a [["b" "a"]]} [:a 0 1])) "get-in level 3")
   (is (= "x" (get-in {:a [["b" "a"]]} [:b 0 1] "x")) "get-in level 3 with default"))
+
+(deftest test-nth
+  (is (= 2 (nth [1 2 3] 1)) "nth on vector")
+  (is (= 1 (nth [1 2 3] 0)) "nth on vector first")
+  (is (= 3 (nth [1 2 3] 2)) "nth on vector last")
+  (is (= :default (nth [1 2 3] 5 :default)) "nth on vector out of bounds with default")
+  (is (= "b" (nth "abc" 1)) "nth on string")
+  (is (= :default (nth "abc" 5 :default)) "nth on string out of bounds with default")
+  (is (= 3 (nth '(1 2 3) 2)) "nth on list")
+  (is (= :default (nth nil 0 :default)) "nth on nil with default"))
+
+(deftest test-nth-throws-on-out-of-bounds
+  (is (thrown? OutOfBoundsException (nth [1 2 3] 5)) "nth throws on vector out of bounds")
+  (is (thrown? OutOfBoundsException (nth "abc" 5)) "nth throws on string out of bounds")
+  (is (thrown? OutOfBoundsException (nth nil 0)) "nth throws on nil"))
+
+(deftest test-nthrest
+  (is (= [3 4 5] (nthrest [1 2 3 4 5] 2)) "nthrest drops first n")
+  (is (= [1 2 3] (nthrest [1 2 3] 0)) "nthrest 0 returns coll")
+  (is (nil? (nthrest [1 2] 5)) "nthrest past end returns nil")
+  (is (nil? (nthrest nil 3)) "nthrest on nil returns nil"))
+
+(deftest test-nthnext
+  (is (= [3 4 5] (nthnext [1 2 3 4 5] 2)) "nthnext drops first n")
+  (is (= [1 2 3] (nthnext [1 2 3] 0)) "nthnext 0 returns seq of coll")
+  (is (nil? (nthnext [1 2] 5)) "nthnext past end returns nil")
+  (is (nil? (nthnext nil 3)) "nthnext on nil returns nil"))
 
 (deftest test-put
   (is (= {:a nil :b 2} (put {:a 1 :b 2} :a nil)) "put: nil on map")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `nth` for indexed access with bounds checking, `nthrest` for dropping the first n elements, and `nthnext` for the nth next (returning nil when exhausted). These are commonly used sequence functions missing from Phel.

## 💡 Goal

Add `nth`, `nthrest`, and `nthnext` to `phel\core` with Clojure-compatible semantics.

Closes #1375

## 🔖 Changes

- `nth`: indexed access that throws `OutOfBoundsException` unless a not-found default is supplied. O(1) for vectors and strings, O(n) for sequences.
- `nthrest`: returns the nth rest of a collection, or the collection itself when n is 0.
- `nthnext`: returns the nth next of a collection, nil when fewer than n elements remain.
- Added `(:use OutOfBoundsException)` to core.phel namespace
- Added 20 tests covering vectors, strings, lists, nil, out-of-bounds throws, and defaults
- Updated `CHANGELOG.md` under `## Unreleased`