### PR TITLE
feat: add aget and aset for PHP array access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `nth`, `nthrest`, `nthnext` sequence functions with Clojure-compatible semantics (#1375)
+- `aget` and `aset` functions for PHP array access and mutation, with nested index support (#1356)
 - `simple-ident?`, `simple-keyword?`, `simple-symbol?` predicate functions for non-namespaced identifiers (#1381)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -540,6 +540,40 @@ Otherwise, it tries to call `__toString`."
     (php/array_merge arr)
     (throw (php/new InvalidArgumentException "aclone expects a PHP array"))))
 
+(defn aget
+  "Returns the value at `index` in a PHP array. With multiple indices,
+   accesses nested arrays: `(aget arr i j)` is `(aget (aget arr i) j)`.
+   Matches Clojure's `aget` for `.cljc` interop."
+  {:example "(aget (php/array 10 20 30) 1) ; => 20"
+   :see-also ["aset" "aclone" "object-array"]}
+  [arr & indices]
+  (loop [a arr
+         idxs indices]
+    (if (nil? idxs)
+      a
+      (recur (php/aget a (first idxs)) (next idxs)))))
+
+(defmacro aset
+  "Sets the value at `index` in a PHP array to `val`. Returns `val`.
+   With additional indices, navigates nested arrays before setting:
+   `(aset arr i j val)` sets index `j` in `(aget arr i)`.
+   Matches Clojure's `aset` for `.cljc` interop.
+   This is a macro because PHP arrays are value types; a function
+   wrapper would mutate a copy rather than the original."
+  {:example "(let [a (php/array 1 2 3)] (aset a 0 42) (aget a 0)) ; => 42"
+   :see-also ["aget" "aclone" "object-array"]}
+  [arr idx & more]
+  (let [n (php/-> more (count))
+        val (php/-> more (get (php/- n 1)))]
+    (if (php/=== 1 n)
+      `(do (php/aset ,arr ,idx ,val) ,val)
+      (let [extra-keys (loop [i 0
+                              ks [idx]]
+                         (if (php/< i (php/- n 1))
+                           (recur (php/+ i 1) (php/-> ks (push (php/-> more (get i)))))
+                           ks))]
+        `(do (php/aset-in ,arr ,extra-keys ,val) ,val)))))
+
 ;; ------------------------
 ;; Basic sequence operation
 ;; ------------------------

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -183,6 +183,32 @@
   (is (thrown? \InvalidArgumentException (aclone nil))
       "aclone of nil raises InvalidArgumentException"))
 
+(deftest test-aget
+  (let [a (php/array 10 20 30)]
+    (is (= 10 (aget a 0)) "aget first element")
+    (is (= 20 (aget a 1)) "aget second element")
+    (is (= 30 (aget a 2)) "aget third element")))
+
+(deftest test-aget-nested
+  (let [outer (php/array (php/array 1 2) (php/array 3 4))]
+    (is (= 2 (aget outer 0 1)) "aget nested with two indices")
+    (is (= 3 (aget outer 1 0)) "aget nested second array")))
+
+(deftest test-aset-returns-value
+  (let [a (php/array 1 2 3)]
+    (is (= 42 (aset a 0 42)) "aset returns the value")))
+
+(deftest test-aset-mutates-array
+  (let [a (php/array 1 2 3)]
+    (aset a 0 42)
+    (is (= 42 (php/aget a 0)) "aset mutated the array")))
+
+(deftest test-aset-nested
+  (let [inner (php/array 10 20)
+        outer (php/array inner)]
+    (aset outer 0 1 99)
+    (is (= 99 (php/aget (php/aget outer 0) 1)) "aset nested modified inner array")))
+
 (defstruct my-struct [a b c])
 
 (deftest test-struct


### PR DESCRIPTION
## 🤔 Background

Issue #1356 requests `aget` and `aset` functions for PHP array element access and mutation, matching Clojure's semantics.

## 💡 Goal

Add `aget` (function) and `aset` (macro) to the core library for PHP array access with nested index support.

## 🔖 Changes

- Add `aget` function: reads from PHP arrays with variadic index support for nested access
- Add `aset` macro: mutates PHP arrays in-place (emits `php/aset` or `php/aset-in` at the call site to avoid PHP copy-on-write issues)
- `aset` returns the value that was set, matching Clojure semantics
- Both support nested indices for multi-dimensional arrays
- Added tests in `tests/phel/test/core/basic-constructors.phel`
- Updated CHANGELOG.md

Closes #1356