### PR TITLE
feat: add `ident?` predicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `aget` and `aset` functions for PHP array access and mutation, with nested index support (#1356)
 - `simple-ident?`, `simple-keyword?`, `simple-symbol?` predicate functions for non-namespaced identifiers (#1381)
 - `special-symbol?` predicate function: returns true if a symbol names a special form (#1384)
+- `ident?` predicate function: returns true if the argument is a symbol or keyword (#1369)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1086,6 +1086,13 @@ Otherwise, it tries to call `__toString`."
   [x]
   (= (type x) :symbol))
 
+(defn ident?
+  "Returns true if `x` is a symbol or keyword."
+  {:example "(ident? 'x) ; => true\n(ident? :a) ; => true\n(ident? 42) ; => false"
+   :see-also ["symbol?" "keyword?" "simple-ident?"]}
+  [x]
+  (or (symbol? x) (keyword? x)))
+
 (defn simple-symbol?
   "Returns true if `x` is a symbol without a namespace."
   {:see-also ["symbol?" "simple-ident?"]}

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -91,6 +91,14 @@
 (deftest test-symbol?
   (is (true? (symbol? 'x)) "symbol? on 'x"))
 
+(deftest test-ident?
+  (is (true? (ident? 'x)) "ident? on symbol")
+  (is (true? (ident? :a)) "ident? on keyword")
+  (is (false? (ident? 42)) "ident? on integer")
+  (is (false? (ident? "test")) "ident? on string")
+  (is (false? (ident? nil)) "ident? on nil")
+  (is (false? (ident? [])) "ident? on vector"))
+
 (deftest test-simple-symbol?
   (is (true? (simple-symbol? 'x)) "simple-symbol? on simple symbol")
   (is (false? (simple-symbol? :kw)) "simple-symbol? on keyword")


### PR DESCRIPTION
## 🤔 Background

Issue #1369 requests the `ident?` predicate from Clojure, which returns true when a value is a symbol or keyword.

## 💡 Goal

Add `ident?` to the core library for Clojure-compatible identifier type checking.

## 🔖 Changes

- Add `ident?` function in `src/phel/core.phel`: returns true if the argument is a symbol or keyword
- Add tests in `tests/phel/test/core/type-operation.phel`
- Updated CHANGELOG.md

Closes #1369