### PR TITLE
feat: add `fnext` sequence function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - `simple-ident?`, `simple-keyword?`, `simple-symbol?` predicate functions for non-namespaced identifiers (#1381)
 - `special-symbol?` predicate function: returns true if a symbol names a special form (#1384)
 - `ident?` predicate function: returns true if the argument is a symbol or keyword (#1369)
+- `fnext` sequence function: same as `(first (next coll))` (#1368)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -626,6 +626,13 @@ Otherwise, it tries to call `__toString`."
   [coll]
   (next (first coll)))
 
+(defn fnext
+  "Same as `(first (next coll))`."
+  {:example "(fnext [1 2 3]) ; => 2"
+   :see-also ["second" "ffirst" "nfirst" "nnext"]}
+  [coll]
+  (first (next coll)))
+
 (defn nnext
   "Same as `(next (next coll))`."
   [coll]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -2,6 +2,14 @@
   (:use OutOfBoundsException)
   (:require phel\test :refer [deftest is]))
 
+(deftest test-fnext
+  (is (= 2 (fnext [1 2 3])) "fnext on vector")
+  (is (= 2 (fnext '(1 2 3))) "fnext on list")
+  (is (nil? (fnext [1])) "fnext on single-element vector")
+  (is (nil? (fnext [])) "fnext on empty vector")
+  (is (nil? (fnext nil)) "fnext on nil")
+  (is (= (second [1 2 3]) (fnext [1 2 3])) "fnext equals second"))
+
 (deftest test-peek
   (is (= 3 (peek [1 2 3])) "peek on vector")
   (is (nil? (peek [])) "peek on empty vector")


### PR DESCRIPTION
## 🤔 Background

Issue #1368 requests the `fnext` sequence function from Clojure, equivalent to `(first (next coll))`.

## 💡 Goal

Add `fnext` to complete the set of sequence navigation shortcuts (`ffirst`, `nfirst`, `nnext`, and now `fnext`).

## 🔖 Changes

- Add `fnext` function in `src/phel/core.phel`: same as `(first (next coll))`
- Add tests in `tests/phel/test/core/sequence-operation.phel`
- Updated CHANGELOG.md

Closes #1368