### PR TITLE
feat: add `neg-int?`, `pos-int?`, `nat-int?` predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - `special-symbol?` predicate function: returns true if a symbol names a special form (#1384)
 - `ident?` predicate function: returns true if the argument is a symbol or keyword (#1369)
 - `fnext` sequence function: same as `(first (next coll))` (#1368)
+- `neg-int?`, `pos-int?`, `nat-int?` integer predicate functions (#1374)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1051,6 +1051,27 @@ Otherwise, it tries to call `__toString`."
   [x]
   (integer? x))
 
+(defn neg-int?
+  "Returns true if `x` is a negative integer."
+  {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? 1) ; => false"
+   :see-also ["int?" "pos-int?" "nat-int?"]}
+  [x]
+  (and (integer? x) (php/< x 0)))
+
+(defn pos-int?
+  "Returns true if `x` is a positive integer (greater than zero)."
+  {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? -1) ; => false"
+   :see-also ["int?" "neg-int?" "nat-int?"]}
+  [x]
+  (and (integer? x) (php/> x 0)))
+
+(defn nat-int?
+  "Returns true if `x` is a non-negative integer (zero or positive)."
+  {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? -1) ; => false"
+   :see-also ["int?" "pos-int?" "neg-int?"]}
+  [x]
+  (and (integer? x) (php/>= x 0)))
+
 (defn number?
   "Returns true if `x` is a number, false otherwise."
   [x]

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -51,6 +51,31 @@
   (is (true? (integer? 10)) "integer? on 10")
   (is (true? (integer? 0)) "integer? on 10"))
 
+(deftest test-neg-int?
+  (is (true? (neg-int? -1)) "neg-int? on -1")
+  (is (true? (neg-int? -100)) "neg-int? on -100")
+  (is (false? (neg-int? 0)) "neg-int? on 0")
+  (is (false? (neg-int? 1)) "neg-int? on 1")
+  (is (false? (neg-int? -1.5)) "neg-int? on -1.5")
+  (is (false? (neg-int? nil)) "neg-int? on nil")
+  (is (false? (neg-int? "test")) "neg-int? on string"))
+
+(deftest test-pos-int?
+  (is (true? (pos-int? 1)) "pos-int? on 1")
+  (is (true? (pos-int? 100)) "pos-int? on 100")
+  (is (false? (pos-int? 0)) "pos-int? on 0")
+  (is (false? (pos-int? -1)) "pos-int? on -1")
+  (is (false? (pos-int? 1.5)) "pos-int? on 1.5")
+  (is (false? (pos-int? nil)) "pos-int? on nil"))
+
+(deftest test-nat-int?
+  (is (true? (nat-int? 0)) "nat-int? on 0")
+  (is (true? (nat-int? 1)) "nat-int? on 1")
+  (is (true? (nat-int? 100)) "nat-int? on 100")
+  (is (false? (nat-int? -1)) "nat-int? on -1")
+  (is (false? (nat-int? 0.0)) "nat-int? on 0.0")
+  (is (false? (nat-int? nil)) "nat-int? on nil"))
+
 (deftest test-number?
   (is (true? (number? 10.0)) "number? on 10.0")
   (is (true? (number? 0.0)) "number? on 0.0")


### PR DESCRIPTION
## 🤔 Background

Issue #1374 requests the `neg-int?` validation function from Clojure. The closely related `pos-int?` and `nat-int?` complete the standard integer predicate trio.

## 💡 Goal

Add the three Clojure integer predicates: `neg-int?`, `pos-int?`, and `nat-int?`.

## 🔖 Changes

- Add `neg-int?`: returns true if x is a negative integer
- Add `pos-int?`: returns true if x is a positive integer (> 0)
- Add `nat-int?`: returns true if x is a non-negative integer (>= 0)
- All three reject floats, strings, nil, etc.
- Added tests in `tests/phel/test/core/type-operation.phel`
- Updated CHANGELOG.md

Closes #1374