### PR TITLE
feat: add `ifn?` predicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - `special-symbol?` predicate function: returns true if a symbol names a special form (#1384)
 - `ident?` predicate function: returns true if the argument is a symbol or keyword (#1369)
 - `fnext` sequence function: same as `(first (next coll))` (#1368)
+- `ifn?` predicate function: returns true if the argument can be invoked as a function (#1370)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -24,6 +24,7 @@
   (:use Phel\Lang\ConcatInterface)
   (:use Phel\Lang\ConsInterface)
   (:use Phel\Lang\ContainsInterface)
+  (:use Phel\Lang\FnInterface)
   (:use Phel\Lang\FirstInterface)
   (:use Phel\Lang\IdenticalInterface)
   (:use Phel\Lang\Keyword)
@@ -1138,6 +1139,15 @@ Otherwise, it tries to call `__toString`."
   "Returns true if `x` is a function, false otherwise."
   [x]
   (= (type x) :function))
+
+(defn ifn?
+  "Returns true if `x` can be invoked as a function.
+   This includes functions, keywords, maps, vectors, sets, and lists."
+  {:example "(ifn? inc) ; => true\n(ifn? :a) ; => true\n(ifn? {}) ; => true\n(ifn? 42) ; => false"
+   :see-also ["fn?"]}
+  [x]
+  (or (php/instanceof x FnInterface)
+      (php/is_callable x)))
 
 (defn function?
   "Returns true if `x` is a function, false otherwise."

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -141,6 +141,17 @@
 (deftest test-function?
   (is (true? (function? concat)) "function? on concat"))
 
+(deftest test-ifn?
+  (is (true? (ifn? inc)) "ifn? on function")
+  (is (true? (ifn? :a)) "ifn? on keyword")
+  (is (true? (ifn? {})) "ifn? on map")
+  (is (true? (ifn? [])) "ifn? on vector")
+  (is (true? (ifn? #{})) "ifn? on set")
+  (is (true? (ifn? '())) "ifn? on list")
+  (is (false? (ifn? 42)) "ifn? on integer")
+  (is (false? (ifn? "str")) "ifn? on string")
+  (is (false? (ifn? nil)) "ifn? on nil"))
+
 (deftest test-hash-map?
   (is (true? (hash-map? {})) "hash-map?"))
 


### PR DESCRIPTION
## 🤔 Background

Issue #1370 requests the `ifn?` validation function from Clojure that checks if a value can be invoked as a function.

## 💡 Goal

Add `ifn?` to check whether a value implements `FnInterface` or is otherwise callable, matching Clojure's `ifn?` semantics.

## 🔖 Changes

- Add `(:use Phel\Lang\FnInterface)` to core ns form
- Add `ifn?` function: returns true for functions, keywords, maps, vectors, sets, and lists
- Add tests in `tests/phel/test/core/type-operation.phel`
- Updated CHANGELOG.md

Closes #1370