### PR TITLE
feat: add `key` and `val` map entry functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - `fnext` sequence function: same as `(first (next coll))` (#1368)
 - `ifn?` predicate function: returns true if the argument can be invoked as a function (#1370)
 - `neg-int?`, `pos-int?`, `nat-int?` integer predicate functions (#1374)
+- `key` and `val` functions for extracting key/value from a map entry (#1372)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2714,6 +2714,20 @@ Otherwise, it tries to call `__toString`."
   (let [result (for [x :in coll] x)]
     (copy-meta coll result)))
 
+(defn key
+  "Returns the key of a map entry (a two-element vector `[key value]`)."
+  {:example "(key (first (pairs {:a 1}))) ; => :a"
+   :see-also ["val" "keys" "pairs"]}
+  [entry]
+  (first entry))
+
+(defn val
+  "Returns the value of a map entry (a two-element vector `[key value]`)."
+  {:example "(val (first (pairs {:a 1}))) ; => 1"
+   :see-also ["key" "vals" "pairs"]}
+  [entry]
+  (second entry))
+
 (defn values
   "Returns a sequence of all values in a map."
   {:deprecated "0.32.0"

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -272,6 +272,14 @@
   (is (= [[:a 1] [:b 2] [:c 3]] (pairs {:a 1 :b 2 :c 3})) "pairs of maps")
   (is (= [[0 3] [1 2] [2 1]] (pairs [3 2 1])) "pairs of vector"))
 
+(deftest test-key
+  (is (= :a (key (first (pairs {:a 1 :b 2})))) "key of first map entry")
+  (is (= :a (key [:a 1])) "key of vector pair"))
+
+(deftest test-val
+  (is (= 1 (val (first (pairs {:a 1 :b 2})))) "val of first map entry")
+  (is (= 1 (val [:a 1])) "val of vector pair"))
+
 (deftest test-kvs
   (is (= [:a 1 :b 2 :c 3] (kvs {:a 1 :b 2 :c 3})) "kvs of maps")
   (is (= [0 3 1 2 2 1] (kvs [3 2 1])) "kvs of vector"))


### PR DESCRIPTION
## 🤔 Background

Clojure provides `key` and `val` functions to extract the key or value from a map entry. In Phel, map entries are represented as two-element vectors `[key value]` (e.g. from `pairs`).

## 💡 Goal

Add `key` and `val` functions that extract the key and value from a map entry, matching Clojure's `clojure.core/key` and `clojure.core/val`.

Closes #1372

## 🔖 Changes

- Added `key` function: returns the first element of a map entry (two-element vector)
- Added `val` function: returns the second element of a map entry (two-element vector)
- Added tests for both functions in `tests/phel/test/core/sequence-functions.phel`
- Updated CHANGELOG.md