### PR TITLE
feat: add `int` coercion function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - `ifn?` predicate function: returns true if the argument can be invoked as a function (#1370)
 - `neg-int?`, `pos-int?`, `nat-int?` integer predicate functions (#1374)
 - `key` and `val` functions for extracting key/value from a map entry (#1372)
+- `int` coercion function: coerces a value to an integer via PHP's `intval` (#1371)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3706,6 +3706,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (throw (php/new InvalidArgumentException
                     (str "abs expects a number, got " (type x))))))
 
+(defn int
+  "Coerces `x` to an integer. Delegates to PHP's `intval`, so floats are
+   truncated toward zero, numeric strings are parsed, and `nil` returns `0`."
+  {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42"
+   :see-also ["float" "double" "int?" "number?"]}
+  [x]
+  (php/intval x))
+
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and
    double; both map to the same native PHP float type. Delegates to PHP's

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -163,6 +163,15 @@
   (is (= 2.5 (median [4 1 3 2])) "(median [4 1 3 2])")
   (is (thrown? \InvalidArgumentException (median [])) "(median [])"))
 
+(deftest test-int
+  (is (= 1 (int 1.9)) "(int 1.9) truncates toward zero")
+  (is (= -1 (int -1.9)) "(int -1.9) truncates toward zero")
+  (is (true? (int? (int 1.5))) "(int 1.5) returns an int")
+  (is (= 42 (int "42")) "(int \"42\") parses string")
+  (is (= 0 (int nil)) "(int nil) returns 0")
+  (is (= 0 (int 0)) "(int 0)")
+  (is (= -3 (int -3)) "(int -3)"))
+
 (deftest test-float
   (is (= 1.0 (float 1)) "(float 1)")
   (is (true? (float? (float 1))) "(float 1) is float")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `(int x)` to coerce a value to an integer. Phel already has `float`, `double`, and `byte` coercion functions but was missing `int`.

## 💡 Goal

Add the `int` coercion function that converts a value to a PHP integer via `intval`.

Closes #1371

## 🔖 Changes

- Added `int` function in `src/phel/core.phel`: delegates to PHP's `intval`
- Added tests in `tests/phel/test/core/math-operation.phel` covering truncation, string parsing, nil, and identity cases
- Updated CHANGELOG.md