### PR TITLE
feat: add `empty` collection function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - `ifn?` predicate function: returns true if the argument can be invoked as a function (#1370)
 - `neg-int?`, `pos-int?`, `nat-int?` integer predicate functions (#1374)
 - `key` and `val` functions for extracting key/value from a map entry (#1372)
+- `empty` collection function: returns an empty collection of the same type, or nil (#1365)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1254,6 +1254,20 @@ Otherwise, it tries to call `__toString`."
     nil
     coll))
 
+(defn empty
+  "Returns an empty collection of the same category as `coll`, or nil."
+  {:example "(empty [1 2 3]) ; => []\n(empty {:a 1}) ; => {}"
+   :see-also ["empty?" "not-empty"]}
+  [coll]
+  (cond
+    (nil? coll) nil
+    (vector? coll) []
+    (map? coll) {}
+    (= (type coll) :set) (hash-set)
+    (list? coll) '()
+    (php-array? coll) (php/array)
+    :else nil))
+
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.
   Collections are unchanged. Returns nil if coll is empty or nil.

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -268,6 +268,13 @@
   (is (= [1] (not-empty [1])) "not-empty returns coll")
   (is (nil? (not-empty [])) "not-empty empty"))
 
+(deftest test-empty
+  (is (= [] (empty [1 2 3])) "empty of vector")
+  (is (= {} (empty {:a 1})) "empty of map")
+  (is (= (hash-set) (empty (set [1 2]))) "empty of set")
+  (is (= '() (empty '(1 2 3))) "empty of list")
+  (is (nil? (empty nil)) "empty of nil"))
+
 (deftest test-pairs
   (is (= [[:a 1] [:b 2] [:c 3]] (pairs {:a 1 :b 2 :c 3})) "pairs of maps")
   (is (= [[0 3] [1 2] [2 1]] (pairs [3 2 1])) "pairs of vector"))


### PR DESCRIPTION
## 🤔 Background

Clojure provides `(empty coll)` which returns an empty collection of the same category as `coll`, or nil.

## 💡 Goal

Add the `empty` function for creating empty collections matching the type of the input.

Closes #1365

## 🔖 Changes

- Added `empty` function in `src/phel/core.phel`: returns empty vector, map, set, list, or php-array matching the input type; nil for nil or unknown types
- Added tests in `tests/phel/test/core/sequence-functions.phel`
- Updated CHANGELOG.md