### PR TITLE
feat: add `long` and `short` coercion functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - `key` and `val` functions for extracting key/value from a map entry (#1372)
 - `empty` collection function: returns an empty collection of the same type, or nil (#1365)
 - `int` coercion function: coerces a value to an integer via PHP's `intval` (#1371)
+- `long` and `short` coercion functions for Clojure compatibility (#1383)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3745,6 +3745,31 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [x]
   (php/floatval x))
 
+(defn long
+  "Coerces `x` to a long integer. In PHP there is no distinction between int
+   and long; both map to the same native PHP int type. Alias for `int`."
+  {:example "(long 1.9) ; => 1"
+   :see-also ["int" "float" "double"]}
+  [x]
+  (php/intval x))
+
+(defn short
+  "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`.
+   Decimal values are truncated toward zero (as in Clojure on the JVM).
+   Values outside the range or non-numeric inputs raise
+   `InvalidArgumentException`. Phel has no dedicated short type, so the
+   result is a plain PHP int."
+  {:example "(short 32767) ; => 32767\n(short 1.9) ; => 1\n(short -32768) ; => -32768"
+   :see-also ["int" "byte" "long"]}
+  [x]
+  (if (number? x)
+    (let [truncated (php/intval x)]
+      (if (or (php/< truncated -32768) (php/> truncated 32767))
+        (throw (php/new InvalidArgumentException
+                        (php/. "Value out of range for short: " (php/strval x))))
+        truncated))
+    (throw (php/new InvalidArgumentException "short expects a numeric value"))))
+
 (defn byte
   "Coerces `x` to a signed 8-bit integer in the range `-128..127`.
    Decimal values are truncated toward zero (as in Clojure on the JVM).

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -190,6 +190,35 @@
   (is (= 3.14 (double "3.14")) "(double \"3.14\")")
   (is (= 0.0 (double nil)) "(double nil)"))
 
+(deftest test-long
+  (is (= 1 (long 1.9)) "(long 1.9) truncates toward zero")
+  (is (= -1 (long -1.9)) "(long -1.9) truncates toward zero")
+  (is (true? (int? (long 1.5))) "(long 1.5) returns an int")
+  (is (= 42 (long "42")) "(long \"42\") parses string")
+  (is (= 0 (long nil)) "(long nil) returns 0"))
+
+(deftest test-short
+  (is (= 0 (short 0)) "(short 0)")
+  (is (= 1 (short 1)) "(short 1)")
+  (is (= -1 (short -1)) "(short -1)")
+  (is (= 32767 (short 32767)) "(short 32767) is max")
+  (is (= -32768 (short -32768)) "(short -32768) is min")
+  (is (int? (short 0)) "(short 0) returns an int")
+  (is (= 1 (short 1.9)) "(short 1.9) truncates toward zero")
+  (is (= -1 (short -1.9)) "(short -1.9) truncates toward zero"))
+
+(deftest test-short-out-of-range
+  (is (thrown? \InvalidArgumentException (short 32768))
+      "(short 32768) raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (short -32769))
+      "(short -32769) raises InvalidArgumentException"))
+
+(deftest test-short-non-numeric
+  (is (thrown? \InvalidArgumentException (short "0"))
+      "(short \"0\") raises InvalidArgumentException on string")
+  (is (thrown? \InvalidArgumentException (short nil))
+      "(short nil) raises InvalidArgumentException"))
+
 (deftest test-byte-integer-values
   (is (= 0 (byte 0)) "(byte 0)")
   (is (= 1 (byte 1)) "(byte 1)")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `long`, `short`, `int`, `float`, `double`, and `byte` coercion functions. Phel already had `int`, `float`, `double`, and `byte`, but was missing `long` and `short`.

## 💡 Goal

Complete the set of numeric coercion functions for Clojure compatibility.

Closes #1383

## 🔖 Changes

- Added `long` function: alias for `int` (PHP has no distinction between int/long)
- Added `short` function: coerces to a 16-bit signed integer (-32768..32767), similar to `byte` but with wider range
- Added tests for both functions in `tests/phel/test/core/math-operation.phel`
- Updated CHANGELOG.md