### PR TITLE
feat: add typed array constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - `key` and `val` functions for extracting key/value from a map entry (#1372)
 - `empty` collection function: returns an empty collection of the same type, or nil (#1365)
 - `int` coercion function: coerces a value to an integer via PHP's `intval` (#1371)
+- `int-array`, `long-array`, `float-array`, `double-array`, `short-array` typed array constructors (#1382)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -541,6 +541,66 @@ Otherwise, it tries to call `__toString`."
     (php/array_merge arr)
     (throw (php/new InvalidArgumentException "aclone expects a PHP array"))))
 
+(defn- typed-array
+  [coerce-fn default size-or-seq]
+  (if (php/is_int size-or-seq)
+    (if (php/< size-or-seq 0)
+      (throw (php/new InvalidArgumentException "Array size must be non-negative"))
+      (if (php/=== 0 size-or-seq)
+        (php/array)
+        (php/array_fill 0 size-or-seq default)))
+    (let [arr (to-php-array size-or-seq)
+          len (php/count arr)
+          result (php/array)]
+      (loop [i 0]
+        (if (php/< i len)
+          (do
+            (php/aset result i (coerce-fn (php/aget arr i)))
+            (recur (php/+ i 1)))
+          nil))
+      result)))
+
+(defn int-array
+  "Creates a PHP array of integers. Given a size, fills with `0`.
+   Given a sequence, coerces each element to int via `intval`.
+   PHP has no typed arrays, so the result is a plain PHP array."
+  {:example "(int-array 3) ; => PHP array [0, 0, 0]\n(int-array [1.5 2.7]) ; => PHP array [1, 2]"
+   :see-also ["long-array" "float-array" "double-array" "short-array" "object-array"]}
+  [size-or-seq]
+  (typed-array php/intval 0 size-or-seq))
+
+(defn long-array
+  "Creates a PHP array of longs (same as int-array in PHP).
+   Given a size, fills with `0`. Given a sequence, coerces each element to int."
+  {:example "(long-array 3) ; => PHP array [0, 0, 0]\n(long-array [1.5 2.7]) ; => PHP array [1, 2]"
+   :see-also ["int-array" "float-array" "double-array" "short-array"]}
+  [size-or-seq]
+  (typed-array php/intval 0 size-or-seq))
+
+(defn float-array
+  "Creates a PHP array of floats. Given a size, fills with `0.0`.
+   Given a sequence, coerces each element to float via `floatval`."
+  {:example "(float-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(float-array [1 2]) ; => PHP array [1.0, 2.0]"
+   :see-also ["double-array" "int-array" "long-array" "short-array"]}
+  [size-or-seq]
+  (typed-array php/floatval 0.0 size-or-seq))
+
+(defn double-array
+  "Creates a PHP array of doubles (same as float-array in PHP).
+   Given a size, fills with `0.0`. Given a sequence, coerces each element to float."
+  {:example "(double-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(double-array [1 2]) ; => PHP array [1.0, 2.0]"
+   :see-also ["float-array" "int-array" "long-array" "short-array"]}
+  [size-or-seq]
+  (typed-array php/floatval 0.0 size-or-seq))
+
+(defn short-array
+  "Creates a PHP array of shorts (16-bit integers). Given a size, fills with `0`.
+   Given a sequence, coerces each element to int via `intval`."
+  {:example "(short-array 3) ; => PHP array [0, 0, 0]\n(short-array [1.5 2.7]) ; => PHP array [1, 2]"
+   :see-also ["int-array" "long-array" "float-array" "double-array"]}
+  [size-or-seq]
+  (typed-array php/intval 0 size-or-seq))
+
 (defn aget
   "Returns the value at `index` in a PHP array. With multiple indices,
    accesses nested arrays: `(aget arr i j)` is `(aget (aget arr i) j)`.

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -183,6 +183,49 @@
   (is (thrown? \InvalidArgumentException (aclone nil))
       "aclone of nil raises InvalidArgumentException"))
 
+(deftest test-int-array-from-size
+  (let [arr (int-array 3)]
+    (is (php/is_array arr) "int-array returns a PHP array")
+    (is (= 3 (php/count arr)) "int-array size matches")
+    (is (= 0 (php/aget arr 0)) "int-array default is 0")))
+
+(deftest test-int-array-from-seq
+  (let [arr (int-array [1.5 2.7 3.9])]
+    (is (= 3 (php/count arr)) "int-array from seq has correct length")
+    (is (= 1 (php/aget arr 0)) "int-array coerces to int")
+    (is (= 2 (php/aget arr 1)) "int-array truncates float")
+    (is (= 3 (php/aget arr 2)) "int-array truncates float")))
+
+(deftest test-long-array-from-size
+  (let [arr (long-array 2)]
+    (is (php/is_array arr) "long-array returns a PHP array")
+    (is (= 0 (php/aget arr 0)) "long-array default is 0")))
+
+(deftest test-float-array-from-seq
+  (let [arr (float-array [1 2 3])]
+    (is (= 3 (php/count arr)) "float-array from seq has correct length")
+    (is (= 1.0 (php/aget arr 0)) "float-array coerces to float")
+    (is (true? (float? (php/aget arr 0))) "float-array element is float")))
+
+(deftest test-double-array-from-size
+  (let [arr (double-array 2)]
+    (is (= 0.0 (php/aget arr 0)) "double-array default is 0.0")
+    (is (true? (float? (php/aget arr 0))) "double-array default is float")))
+
+(deftest test-short-array-from-seq
+  (let [arr (short-array [1.5 2.7])]
+    (is (= 2 (php/count arr)) "short-array from seq has correct length")
+    (is (= 1 (php/aget arr 0)) "short-array coerces to int")))
+
+(deftest test-typed-array-empty
+  (let [arr (int-array 0)]
+    (is (php/is_array arr) "int-array 0 returns a PHP array")
+    (is (= 0 (php/count arr)) "int-array 0 is empty")))
+
+(deftest test-typed-array-negative-size
+  (is (thrown? \InvalidArgumentException (int-array -1))
+      "int-array raises on negative size"))
+
 (deftest test-aget
   (let [a (php/array 10 20 30)]
     (is (= 10 (aget a 0)) "aget first element")


### PR DESCRIPTION
## 🤔 Background

Clojure provides `int-array`, `long-array`, `float-array`, `double-array`, and `short-array` for creating typed Java arrays. PHP has no typed arrays, but these functions are needed for `.cljc` interop compatibility.

## 💡 Goal

Add the five typed array constructor functions that create PHP arrays with coerced elements.

Closes #1382

## 🔖 Changes

- Added private `typed-array` helper that handles both size-based and sequence-based construction with element coercion
- Added `int-array`, `long-array`, `float-array`, `double-array`, `short-array` functions
- Added tests in `tests/phel/test/core/basic-constructors.phel`
- Updated CHANGELOG.md