### PR TITLE
feat: add `uuid?` and `parse-uuid` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - `long` and `short` coercion functions for Clojure compatibility (#1383)
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `rseq` and `reversible?` functions: reverse-iterate a vector or sorted-map in constant time (#1378)
+- `uuid?` and `parse-uuid` functions complementing the existing `random-uuid` (#1377)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -5258,9 +5258,23 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
         (= lower "true") true
         (= lower "false") false))))
 
+(def ^:private uuid-regex
+  "/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i")
+
+(defn uuid?
+  "Returns true if `x` is a canonical UUID string (36 characters,
+  `8-4-4-4-12` hexadecimal groups), false otherwise. PHP has no UUID
+  type, so UUIDs are represented as strings."
+  {:example "(uuid? \"550e8400-e29b-41d4-a716-446655440000\") ; => true"
+   :see-also ["random-uuid" "parse-uuid"]}
+  [x]
+  (and (string? x)
+       (php/=== 1 (php/preg_match uuid-regex x))))
+
 (defn random-uuid
   "Returns a random UUID v4 string."
-  {:example "(random-uuid) ; => \"550e8400-e29b-41d4-a716-446655440000\""}
+  {:example "(random-uuid) ; => \"550e8400-e29b-41d4-a716-446655440000\""
+   :see-also ["uuid?" "parse-uuid"]}
   []
   (let [bytes (php/random_bytes 16)]
     ;; Set version 4 (bits 12-15 of time_hi_and_version)
@@ -5274,6 +5288,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
        (php/substr hex 12 4) "-"
        (php/substr hex 16 4) "-"
        (php/substr hex 20 12)))))
+
+(defn parse-uuid
+  "Parses `s` as a canonical UUID string. Returns the lower-cased UUID
+  string if valid, or nil otherwise. Since PHP has no UUID type, UUIDs
+  are returned as strings."
+  {:example "(parse-uuid \"550E8400-E29B-41D4-A716-446655440000\")
+  ; => \"550e8400-e29b-41d4-a716-446655440000\""
+   :see-also ["uuid?" "random-uuid"]}
+  [s]
+  (when (uuid? s)
+    (php/strtolower s)))
 
 (defn run!
   "Calls `(f x)` for each element in `coll` for side effects. Returns nil."

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -75,6 +75,28 @@
         "random-uuid matches UUID v4 format")
     (is (not= uuid (random-uuid)) "random-uuid generates unique values")))
 
+(deftest test-uuid?
+  (is (true? (uuid? "00000000-0000-0000-0000-000000000000")) "uuid? accepts nil UUID")
+  (is (true? (uuid? "550e8400-e29b-41d4-a716-446655440000")) "uuid? accepts lowercase v4")
+  (is (true? (uuid? "550E8400-E29B-41D4-A716-446655440000")) "uuid? accepts uppercase")
+  (is (true? (uuid? (random-uuid))) "uuid? accepts random-uuid output")
+  (is (false? (uuid? "550e8400-e29b-41d4-a716-44665544000"))  "uuid? rejects short")
+  (is (false? (uuid? "550e8400e29b41d4a716446655440000"))     "uuid? rejects no-dashes")
+  (is (false? (uuid? "zzzzzzzz-e29b-41d4-a716-446655440000")) "uuid? rejects non-hex")
+  (is (false? (uuid? nil)) "uuid? rejects nil")
+  (is (false? (uuid? 42))  "uuid? rejects non-string"))
+
+(deftest test-parse-uuid
+  (is (= "550e8400-e29b-41d4-a716-446655440000"
+         (parse-uuid "550e8400-e29b-41d4-a716-446655440000"))
+      "parse-uuid returns lowercase")
+  (is (= "550e8400-e29b-41d4-a716-446655440000"
+         (parse-uuid "550E8400-E29B-41D4-A716-446655440000"))
+      "parse-uuid lowercases uppercase input")
+  (is (nil? (parse-uuid "not-a-uuid")) "parse-uuid returns nil on invalid")
+  (is (nil? (parse-uuid "")) "parse-uuid returns nil on empty")
+  (is (nil? (parse-uuid nil)) "parse-uuid returns nil on nil"))
+
 ;; --- resolve ---
 
 (deftest test-resolve-known-symbol


### PR DESCRIPTION
## 🤔 Background

Closes #1377

`random-uuid` already exists in Phel core. This PR completes the trio of Clojure-compatible UUID helpers by adding `uuid?` and `parse-uuid`. Since PHP has no UUID type, UUIDs are represented as canonical 36-character strings.

## 💡 Goal

Provide Clojure-parity UUID helpers so downstream code (notably `clojure-test-suite`'s `parse_uuid.cljc`) can rely on the same names.

## 🔖 Changes

- Add `uuid?` — true if `x` is a canonical UUID string (`8-4-4-4-12` hex, case-insensitive).
- Add `parse-uuid` — returns the lower-cased canonical string when valid, nil otherwise.
- Private helper `uuid-regex` centralises the format check so `uuid?` and `parse-uuid` stay in sync.
- Cross-link `random-uuid` via `:see-also`.
- Tests for all three functions in `tests/phel/test/core/utility-functions.phel`, covering valid, invalid, and nil inputs.
- Update `CHANGELOG.md` unreleased section.