### PR TITLE
feat: support `#uuid` tagged literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - `sequential?` predicate function: returns true for ordered collections (vectors, lists, lazy sequences) (#1380)
 - `rseq` and `reversible?` functions: reverse-iterate a vector or sorted-map in constant time (#1378)
 - `uuid?` and `parse-uuid` functions complementing the existing `random-uuid` (#1377)
+- `#uuid` tagged literal reads a canonical UUID string, e.g. `#uuid "550e8400-e29b-41d4-a716-446655440000"` (#1376)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search

--- a/src/php/Compiler/Application/Reader.php
+++ b/src/php/Compiler/Application/Reader.php
@@ -25,8 +25,6 @@ use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use RuntimeException;
 
-use function sprintf;
-
 final class Reader implements ReaderInterface
 {
     /** @var array<int,Symbol>|null */
@@ -87,20 +85,13 @@ final class Reader implements ReaderInterface
             return $this->readMetaNode($node, $root);
         }
 
-        // Phel does not (yet) register any tagged-literal handlers. Reaching
-        // this point means a `#<tag>` form survived parsing in a code path
-        // that is actually emitted — i.e. the selected `#?` branch or
-        // top-level code. Unselected branches of `#?` are discarded by the
-        // parser, so unknown tags inside `:jank`/`:clj`/... never reach here.
+        // Built-in tagged literals (e.g. `#uuid`) are dispatched to a dedicated
+        // reader. Unknown tags throw there; unselected `#?` branches are already
+        // discarded by the parser so their tags never reach this point.
         if ($node instanceof TaggedLiteralNode) {
-            throw ReaderException::forNode(
-                $node,
-                $root,
-                sprintf(
-                    "Unknown tagged literal '#%s'. Phel has no built-in handler for this tag; it may only appear inside a non-selected reader-conditional branch (e.g. :clj, :jank).",
-                    $node->getTag(),
-                ),
-            );
+            return $this->readerFactory
+                ->createTaggedLiteralReader()
+                ->read($node, $root);
         }
 
         throw ReaderException::forNode($node, $root, 'Unterminated list');

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Reader\ExpressionReader;
+
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+
+use function preg_match;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Reads Phel's built-in tagged literals (e.g. `#uuid`). Unknown tags are
+ * rejected here so they can still be silently discarded when they sit inside
+ * an unselected reader-conditional branch (that discard happens earlier, in
+ * the parser).
+ */
+final class TaggedLiteralReader
+{
+    private const string UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    /**
+     * @throws ReaderException
+     */
+    public function read(TaggedLiteralNode $node, NodeInterface $root): string
+    {
+        return match ($node->getTag()) {
+            'uuid' => $this->readUuid($node, $root),
+            default => throw ReaderException::forNode(
+                $node,
+                $root,
+                sprintf(
+                    "Unknown tagged literal '#%s'. Phel has no built-in handler for this tag; it may only appear inside a non-selected reader-conditional branch (e.g. :clj, :jank).",
+                    $node->getTag(),
+                ),
+            ),
+        };
+    }
+
+    /**
+     * @throws ReaderException
+     */
+    private function readUuid(TaggedLiteralNode $node, NodeInterface $root): string
+    {
+        $form = $node->getForm();
+
+        if (!$form instanceof StringNode) {
+            throw ReaderException::forNode(
+                $node,
+                $root,
+                '#uuid expects a string literal (e.g. #uuid "00000000-0000-0000-0000-000000000000").',
+            );
+        }
+
+        $value = $form->getValue();
+
+        if (preg_match(self::UUID_REGEX, $value) !== 1) {
+            throw ReaderException::forNode(
+                $node,
+                $root,
+                sprintf('#uuid value %s is not a canonical UUID string.', $form->getCode()),
+            );
+        }
+
+        return strtolower($value);
+    }
+}

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
@@ -13,6 +13,7 @@ use Phel\Compiler\Domain\Reader\ExpressionReader\MetaReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\QuoasiquoteReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\SetReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\SymbolReader;
+use Phel\Compiler\Domain\Reader\ExpressionReader\TaggedLiteralReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\VectorReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\WrapReader;
 
@@ -68,5 +69,10 @@ final class ExpressionReaderFactory implements ExpressionReaderFactoryInterface
     public function createMapReader(Reader $reader): MapReader
     {
         return new MapReader($reader);
+    }
+
+    public function createTaggedLiteralReader(): TaggedLiteralReader
+    {
+        return new TaggedLiteralReader();
     }
 }

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
@@ -13,6 +13,7 @@ use Phel\Compiler\Domain\Reader\ExpressionReader\MetaReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\QuoasiquoteReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\SetReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\SymbolReader;
+use Phel\Compiler\Domain\Reader\ExpressionReader\TaggedLiteralReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\VectorReader;
 use Phel\Compiler\Domain\Reader\ExpressionReader\WrapReader;
 
@@ -40,4 +41,6 @@ interface ExpressionReaderFactoryInterface
     ): QuoasiquoteReader;
 
     public function createMetaReader(Reader $reader): MetaReader;
+
+    public function createTaggedLiteralReader(): TaggedLiteralReader;
 }

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -97,6 +97,16 @@
   (is (nil? (parse-uuid "")) "parse-uuid returns nil on empty")
   (is (nil? (parse-uuid nil)) "parse-uuid returns nil on nil"))
 
+(deftest test-uuid-tagged-literal
+  (is (= "00000000-0000-0000-0000-000000000000"
+         #uuid "00000000-0000-0000-0000-000000000000")
+      "#uuid reads as the canonical string")
+  (is (= "550e8400-e29b-41d4-a716-446655440000"
+         #uuid "550E8400-E29B-41D4-A716-446655440000")
+      "#uuid lowercases uppercase hex")
+  (is (uuid? #uuid "00000012-0034-0056-0078-000000000009")
+      "#uuid result passes uuid?"))
+
 ;; --- resolve ---
 
 (deftest test-resolve-known-symbol

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -1295,6 +1295,43 @@ final class ReaderTest extends TestCase
         );
     }
 
+    public function test_uuid_tagged_literal_reads_as_string(): void
+    {
+        self::assertSame(
+            '00000000-0000-0000-0000-000000000000',
+            $this->read('#uuid "00000000-0000-0000-0000-000000000000"'),
+        );
+    }
+
+    public function test_uuid_tagged_literal_lowercases_input(): void
+    {
+        self::assertSame(
+            '550e8400-e29b-41d4-a716-446655440000',
+            $this->read('#uuid "550E8400-E29B-41D4-A716-446655440000"'),
+        );
+    }
+
+    public function test_uuid_tagged_literal_rejects_invalid_format(): void
+    {
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('is not a canonical UUID string');
+        $this->read('#uuid "not-a-uuid"');
+    }
+
+    public function test_uuid_tagged_literal_requires_string_form(): void
+    {
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('#uuid expects a string literal');
+        $this->read('#uuid 42');
+    }
+
+    public function test_unknown_tagged_literal_throws(): void
+    {
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage("Unknown tagged literal '#something'");
+        $this->read('#something "x"');
+    }
+
     private function read(string $string, bool $withLocation = true): float|bool|int|string|TypeInterface|null
     {
         Symbol::resetGen();


### PR DESCRIPTION
## 🤔 Background

Closes #1376

The reader already parses generic `#<tag>` literals (#1277) but threw `Unknown tagged literal '#uuid'` when such a form appears in a selected branch. Clojure and the `clojure-test-suite` rely on `#uuid "..."` for UUID constants, so Phel needs a built-in handler.

## 💡 Goal

Let `#uuid "..."` read as a canonical lowercase UUID string, matching the semantics of Clojure's reader macro. Since PHP has no native UUID type, the tag produces a plain string that round-trips through `uuid?` and `parse-uuid`.

## 🔖 Changes

- New `TaggedLiteralReader` that dispatches built-in tags. Unknown tags still throw the original helpful error message. Single entry point keeps future tags (`#inst`, …) easy to add.
- Wire the reader in via `ExpressionReaderFactory` (new `createTaggedLiteralReader`) and delegate from `Reader::readExpression`.
- Validate that `#uuid`'s form is a string literal and that the value matches the canonical `8-4-4-4-12` hex layout; emit descriptive errors otherwise.
- PHP tests in `ReaderTest` cover canonical, uppercase, invalid-format, non-string, and unknown-tag paths.
- Phel test in `utility-functions.phel` exercises the literal end-to-end alongside `uuid?`.
- Update `CHANGELOG.md` unreleased section.