### PR TITLE
feat: document `alter-var-root` as out of scope, throw on use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - `rseq` and `reversible?` functions: reverse-iterate a vector or sorted-map in constant time (#1378)
 - `uuid?` and `parse-uuid` functions complementing the existing `random-uuid` (#1377)
 - `#uuid` tagged literal reads a canonical UUID string, e.g. `#uuid "550e8400-e29b-41d4-a716-446655440000"` (#1376)
+- `alter-var-root` stub that throws `BadMethodCallException` with a migration hint, plus a note in `docs/clojure-migration.md`; Phel has no first-class vars (#1357)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -172,6 +172,7 @@ Phel runs on PHP. A handful of Clojure features don't translate directly:
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
 | **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |
+| **`alter-var-root`** | No first-class vars to re-root | Use an `atom` with `swap!` for mutable state, or redefine the top-level binding with `def`. Calling `alter-var-root` at runtime throws `BadMethodCallException` with this hint |
 
 Phel does provide `future`, `future-cancel`, and `pmap` via the `phel\async` module, which uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt.
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1769,6 +1769,18 @@ Otherwise, it tries to call `__toString`."
   (php/-> variable (addWatch (name key) f))
   variable)
 
+(defn alter-var-root
+  "Clojure's `alter-var-root` is out of scope in Phel: there are no first-class
+  vars whose root binding could be swapped. Reaching for this function in
+  `.cljc` code is nearly always a bug; prefer an `atom` and `swap!` for mutable
+  state, or redefine the top-level binding with `def` if the intent was to
+  replace it at load time. Calling `alter-var-root` at runtime throws to make
+  the mismatch obvious instead of silently no-oping."
+  {:see-also ["swap!" "atom" "def"]}
+  [& _]
+  (throw (php/new \BadMethodCallException
+           "alter-var-root is not supported in Phel: Phel has no first-class vars. Use an `atom` with `swap!` for mutable state, or redefine the top-level with `def`.")))
+
 (defn remove-watch
   "Removes a watch function from a variable by key."
   {:see-also ["add-watch"]}

--- a/tests/phel/test/core/watches-validators.phel
+++ b/tests/phel/test/core/watches-validators.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\core\watches-validators
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is thrown?]))
 
 ;; --- Return values ---
 
@@ -131,6 +131,14 @@
         _ (add-watch v :log (fn [k r o n] (set! fired true)))]
     (try (set! v -1) (catch \Throwable e nil))
     (is (false? (deref fired)) "watch does not fire when rejected")))
+
+;; --- alter-var-root (out of scope) ---
+
+(deftest test-alter-var-root-throws
+  (is (thrown? \BadMethodCallException (alter-var-root nil inc))
+      "alter-var-root throws BadMethodCallException")
+  (is (thrown? \BadMethodCallException (alter-var-root))
+      "alter-var-root throws even with no args"))
 
 
 


### PR DESCRIPTION
## 🤔 Background

Closes #1357

`.cljc` sources sometimes reach for `alter-var-root` (see `clojure-test-suite/add_watch.cljc`). Phel has no first-class vars, so the current behaviour is `[PHEL001] Cannot resolve symbol 'alter-var-root'`. The issue asked for an explicit doc note and, optionally, a clearer runtime error.

## 💡 Goal

Turn the silent mismatch into an obvious one: resolve the symbol, document the situation in the migration guide, and throw a `BadMethodCallException` whose message points users at `atom`/`swap!` or re-`def`.

## 🔖 Changes

- Add `alter-var-root` to `phel\core`: resolves as a variadic function that always throws, with a message explaining Phel's model and suggesting `atom`/`swap!` or re-`def`.
- Document the decision in `docs/clojure-migration.md`'s "What's not available" table.
- Test in `tests/phel/test/core/watches-validators.phel` asserts the exception class for both the single-arg and no-arg calls.
- Update `CHANGELOG.md` unreleased section.