### PR TITLE
feat: support `(ClassName. args)` constructor shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - `uuid?` and `parse-uuid` functions complementing the existing `random-uuid` (#1377)
 - `#uuid` tagged literal reads a canonical UUID string, e.g. `#uuid "550e8400-e29b-41d4-a716-446655440000"` (#1376)
 - `alter-var-root` stub that throws `BadMethodCallException` with a migration hint, plus a note in `docs/clojure-migration.md`; Phel has no first-class vars (#1357)
+- Clojure-style constructor shorthand `(ClassName. args)` expands to `(php/new ClassName args)` during analysis, including namespaced classes (`\Some\Class.`) (#1359)
 - `seqable?` predicate function: returns true if `seq` is supported for the argument (#1379)
 - `phel\http-client` module for outbound HTTP requests using PHP streams
 - `phel\ai` module: chat, completions, structured extraction, tool use, embeddings, and semantic search

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -9,7 +9,7 @@ Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know 
 | `(ns my.app (:require [clojure.string :as str]))` | `(ns my\app (:require phel\str :as str))` | `\` separator; `.` also works |
 | `(.method obj arg)` | `(php/-> obj (method arg))` | Instance method |
 | `(Class/staticMethod arg)` | `(php/:: Class (method arg))` | Static method |
-| `(ClassName. arg)` | `(php/new ClassName arg)` | Constructor |
+| `(ClassName. arg)` | `(ClassName. arg)` or `(php/new ClassName arg)` | `ClassName.` reads as `(php/new ClassName ...)` |
 | `(.-field obj)` | `(php/-> obj -field)` | Property access |
 | `(:import [java.util Date])` | `(:use DateTime)` in the `ns` form | Imports a PHP class by short name; also works with FQNs: `(:use Phel\Lang\Symbol)` |
 | `(instance? Type x)` | `(php/instanceof x Type)` | Type check (arg order differs) |

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -9,7 +9,7 @@ This guide shows how to seamlessly work between PHP and Phel code.
 | Call function | `strlen($str)` | `(php/strlen str)` |
 | Method call | `$obj->method($arg)` | `(php/-> obj (method arg))` |
 | Static call | `DateTime::createFromFormat(...)` | `(php/:: DateTime (createFromFormat ...))` |
-| New instance | `new DateTime()` | `(php/new DateTime)` |
+| New instance | `new DateTime()` | `(php/new DateTime)` or `(DateTime.)` |
 | Property access | `$obj->prop` | `(php/-> obj -prop)` |
 | Array access | `$arr[$key]` | `(php/aget arr key)` |
 
@@ -42,8 +42,9 @@ Prefix PHP functions with `php/`:
 (ns app\example
   (:use DateTime DateInterval))
 
-;; Create instance
+;; Create instance (both forms are equivalent)
 (def now (php/new DateTime))
+(def now (DateTime.))   ; Clojure-style shorthand for (php/new DateTime)
 
 ;; Call methods
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer;
 
+use Phel;
 use Phel\Compiler\Application\Munge;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
@@ -49,6 +50,11 @@ use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 
+use function count;
+use function str_ends_with;
+use function strlen;
+use function substr;
+
 final class AnalyzePersistentList
 {
     private const string EMPTY_SYMBOL_NAME = '';
@@ -66,6 +72,7 @@ final class AnalyzePersistentList
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {
+        $list = $this->expandConstructorShorthand($list);
         $symbolName = $this->getSymbolName($list);
 
         return $this
@@ -79,6 +86,58 @@ final class AnalyzePersistentList
         return $first instanceof Symbol
             ? $first->getFullName()
             : self::EMPTY_SYMBOL_NAME;
+    }
+
+    /**
+     * Expands Clojure's `(ClassName. args)` shorthand to `(php/new ClassName args)`.
+     *
+     * Only triggers when the head symbol looks like a class reference ending
+     * with `.`: the preceding character must be a PHP identifier character or
+     * a namespace separator. This excludes operator-style symbols such as
+     * `php/.` (string concatenation) and lone punctuation like `.` / `..`.
+     * Preserves source locations so downstream errors still point at the
+     * user's form.
+     */
+    private function expandConstructorShorthand(PersistentListInterface $list): PersistentListInterface
+    {
+        $first = $list->first();
+        if (!$first instanceof Symbol) {
+            return $list;
+        }
+
+        if (!$this->isConstructorShorthandName($first->getFullName())) {
+            return $list;
+        }
+
+        $name = $first->getFullName();
+        $className = substr($name, 0, -1);
+        $newSymbol = Symbol::create(Symbol::NAME_PHP_NEW)->copyLocationFrom($first);
+        $classSymbol = Symbol::create($className)->copyLocationFrom($first);
+
+        $elements = [$newSymbol, $classSymbol];
+        $count = count($list);
+        for ($i = 1; $i < $count; ++$i) {
+            $elements[] = $list->get($i);
+        }
+
+        return Phel::list($elements)->copyLocationFrom($list);
+    }
+
+    private function isConstructorShorthandName(string $name): bool
+    {
+        $len = strlen($name);
+        if ($len < 2 || !str_ends_with($name, '.')) {
+            return false;
+        }
+
+        $prev = $name[$len - 2];
+        // Accept a-z, A-Z, 0-9, `_`, or `\` — i.e. valid trailing chars of a
+        // PHP class reference. Rejects `php/.`, `..`, `:.`, etc.
+        return ($prev >= 'a' && $prev <= 'z')
+            || ($prev >= 'A' && $prev <= 'Z')
+            || ($prev >= '0' && $prev <= '9')
+            || $prev === '_'
+            || $prev === '\\';
     }
 
     private function createSymbolAnalyzerByName(string $symbolName): SpecialFormAnalyzerInterface

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -21,6 +21,14 @@
   (is (= :php/resource (type (php/tmpfile))) "type of php resource")
   (is (= :php/object (type (php/new DateTime))) "type of php object"))
 
+(deftest test-constructor-shorthand
+  (is (= :php/object (type (\DateTime.)))
+      "(ClassName.) behaves like (php/new ClassName)")
+  (is (= "msg" (php/-> (\RuntimeException. "msg") (getMessage)))
+      "(ClassName. args) forwards args to the constructor")
+  (is (= "ab" (php/. "a" "b"))
+      "php/. string concatenation is unaffected by the shorthand"))
+
 (deftest test-nil?
   (is (true? (nil? nil)) "nil? on nil")
   (is (false? (nil? false)) "nil? on false")

--- a/tests/php/Integration/Fixtures/New/constructor-shorthand-with-args.test
+++ b/tests/php/Integration/Fixtures/New/constructor-shorthand-with-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(\DateTimeImmutable. "2020-03-22" (\DateTimeZone. "Europe/Berlin"))
+--PHP--
+(new \DateTimeImmutable("2020-03-22", (new \DateTimeZone("Europe/Berlin"))));

--- a/tests/php/Integration/Fixtures/New/constructor-shorthand-zero-args.test
+++ b/tests/php/Integration/Fixtures/New/constructor-shorthand-zero-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(\DateTimeImmutable.)
+--PHP--
+(new \DateTimeImmutable());


### PR DESCRIPTION
## 🤔 Background

Closes #1359

Clojure sources lean on `(ClassName. args)` as sugar for `(new ClassName args)`. Phel's reader happily lexes `TestDissocRecord.` but the analyzer resolves it as an ordinary symbol, so code pulled in from `clojure-test-suite` (e.g. `dissoc.cljc`) trips on `Cannot resolve symbol 'TestDissocRecord.'`.

## 💡 Goal

Let `(SomeClass.)` and `(\Some\Class. a b)` desugar to `(php/new SomeClass ...)` at analysis time — no extra surface API, just a recognised shorthand. Only genuine class-like identifiers trigger the rewrite; operator-style symbols such as `php/.` (string concatenation) must keep working unchanged.

## 🔖 Changes

- `AnalyzePersistentList` expands constructor shorthand before dispatch: when the head symbol's name ends with `.` and the preceding char is a valid class-name character (`[A-Za-z0-9_\\]`), rebuild the list as `(php/new ClassName ...)` and re-enter the normal pipeline.
- Guard rails: `.`, `..`, `.foo`, `php/.`, and any symbol whose `.` sits against a non-identifier char are left untouched.
- Source locations propagate through the rewrite so analyzer errors still point at the user's form.
- Integration fixtures `constructor-shorthand-zero-args.test` / `constructor-shorthand-with-args.test` assert the expected PHP output.
- `tests/phel/test/core/type-operation.phel` adds `test-constructor-shorthand` covering object creation, arg forwarding, and the `php/.` regression guard.
- Docs: short row in `docs/clojure-migration.md`, updated `docs/php-interop.md` quick reference.
- `CHANGELOG.md` unreleased entry.