### PR TITLE
fix(core): align core fns with Clojure test suite gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Clojure-test-suite alignment: a batch of core functions now match Clojure's shape reported by `jasalt/clojure-test-suite`
+  - `keyword` is idempotent on keyword input, accepts symbols, handles `nil`, and gains the `(keyword ns name)` arity-2 namespaced form
+  - `dissoc` accepts zero keys and variadic key lists (`(apply dissoc m [:a :b])` removes both keys)
+  - `keys` / `vals` return `nil` for `nil` or empty collections
+  - `make-hierarchy` returns `{:parents {} :descendants {} :ancestors {}}`; `derive`/`underive` preserve all three keys
+  - `parse-double` accepts `Infinity`, `+Infinity`, `-Infinity`, and `NaN`
+  - `mapcat` accepts multiple collections, zipping corresponding elements into `f`
+  - `first` treats maps as a seq of entries, so `ffirst` / `nfirst` work on maps
+  - `str` preserves float representation: `(str 0.0)` → `"0.0"`; `NaN`, `Infinity`, `-Infinity` stringify readably
+  - `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` remains less than every non-nil value
+  - Transient vectors/maps/sets are callable like their persistent counterparts; `Keyword::__invoke` accepts any `ArrayAccess` so `(:a (transient m))` works
 - `deftest` rejects a missing/non-symbol name with a clear `InvalidArgumentException` instead of crashing inside macro expansion (#1364)
 - `(def name)` without a value no longer throws; binds `nil`, matching Clojure (#1361)
 - `doseq` accepts Clojure-style pairs `(doseq [x coll] body)` without requiring the `:in` verb (#1362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,16 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Clojure-test-suite alignment: a batch of core functions now match Clojure's shape reported by `jasalt/clojure-test-suite`
-  - `keyword` is idempotent on keyword input, accepts symbols, handles `nil`, and gains the `(keyword ns name)` arity-2 namespaced form
-  - `dissoc` accepts zero keys and variadic key lists (`(apply dissoc m [:a :b])` removes both keys)
-  - `keys` / `vals` return `nil` for `nil` or empty collections
-  - `make-hierarchy` returns `{:parents {} :descendants {} :ancestors {}}`; `derive`/`underive` preserve all three keys
-  - `parse-double` accepts `Infinity`, `+Infinity`, `-Infinity`, and `NaN`
-  - `mapcat` accepts multiple collections, zipping corresponding elements into `f`
-  - `first` treats maps as a seq of entries, so `ffirst` / `nfirst` work on maps
-  - `str` preserves float representation: `(str 0.0)` → `"0.0"`; `NaN`, `Infinity`, `-Infinity` stringify readably
-  - `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` remains less than every non-nil value
-  - Transient vectors/maps/sets are callable like their persistent counterparts; `Keyword::__invoke` accepts any `ArrayAccess` so `(:a (transient m))` works
+- `keyword` is idempotent on keywords, accepts symbols/nil, and gains the `(keyword ns name)` namespaced form
+- `dissoc` accepts zero keys and removes every key when given multiple (`(apply dissoc m ks)`)
+- `keys` / `vals` return `nil` for `nil` or empty collections
+- `make-hierarchy` returns `{:parents {} :descendants {} :ancestors {}}` and `derive`/`underive` preserve all three keys
+- `parse-double` accepts `Infinity`, `+Infinity`, `-Infinity`, and `NaN`
+- `mapcat` accepts multiple collections, zipping elements into `f`
+- `first` on a map returns its first entry, fixing `ffirst` / `nfirst` on maps
+- `str` preserves float shape: `(str 0.0)` → `"0.0"`, plus readable `NaN` / `Infinity` / `-Infinity`
+- `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` stays less than every non-nil value
+- Transient vectors/maps/sets are callable like their persistent counterparts; `:keyword` lookup works on transient maps
 - `deftest` rejects a missing/non-symbol name with a clear `InvalidArgumentException` instead of crashing inside macro expansion (#1364)
 - `(def name)` without a value no longer throws; binds `nil`, matching Clojure (#1361)
 - `doseq` accepts Clojure-style pairs `(doseq [x coll] body)` without requiring the `:in` verb (#1362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
 - `rseq` and `reversible?` — constant-time reverse view of a vector or sorted-map (#1378)
 - `empty` — returns an empty collection of the same type, or nil (#1365)
 - `key` and `val` for extracting from a map entry (#1372)
+- `(keyword ns name)` arity for namespaced keywords (#1428)
+- `mapcat` accepts multiple collections, zipping elements into `f` (#1428)
+- Transient vectors, maps, and sets are callable like their persistent counterparts (#1428)
 
 #### PHP Interop
 - `aget` and `aset` for PHP array access and mutation, with nested index support (#1356)
@@ -31,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - `int`, `long`, `short` coercion functions for Clojure compatibility (#1371, #1383)
 - `uuid?` and `parse-uuid` complementing the existing `random-uuid` (#1377)
 - `alter-var-root` stub that throws `BadMethodCallException` with a migration hint; documented as out of scope in `docs/clojure-migration.md` (#1357)
+- `parse-double` accepts `Infinity`, `-Infinity`, and `NaN` (#1428)
 
 #### Modules
 - `phel\http-client` — outbound HTTP requests over PHP streams
@@ -39,16 +43,14 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `keyword` is idempotent on keywords, accepts symbols/nil, and gains the `(keyword ns name)` namespaced form
-- `dissoc` accepts zero keys and removes every key when given multiple (`(apply dissoc m ks)`)
-- `keys` / `vals` return `nil` for `nil` or empty collections
-- `make-hierarchy` returns `{:parents {} :descendants {} :ancestors {}}` and `derive`/`underive` preserve all three keys
-- `parse-double` accepts `Infinity`, `+Infinity`, `-Infinity`, and `NaN`
-- `mapcat` accepts multiple collections, zipping elements into `f`
-- `first` on a map returns its first entry, fixing `ffirst` / `nfirst` on maps
-- `str` preserves float shape: `(str 0.0)` → `"0.0"`, plus readable `NaN` / `Infinity` / `-Infinity`
-- `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` stays less than every non-nil value
-- Transient vectors/maps/sets are callable like their persistent counterparts; `:keyword` lookup works on transient maps
+- `keyword` is idempotent on keywords and handles `nil` / symbol input (#1428)
+- `dissoc` accepts zero keys and reduces over variadic key lists (#1428)
+- `keys` / `vals` return `nil` for `nil` or empty collections (#1428)
+- `make-hierarchy` exposes `:parents`, `:descendants`, and `:ancestors` keys (#1428)
+- `first` on a map returns its first entry, so `ffirst` / `nfirst` work on maps (#1428)
+- `str` preserves float representation — `(str 0.0)` → `"0.0"`, readable `NaN` / `±Infinity` (#1428)
+- `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` stays less than every non-nil value (#1428)
+- `:keyword` lookup works on transient maps (#1428)
 - `deftest` rejects a missing/non-symbol name with a clear `InvalidArgumentException` instead of crashing inside macro expansion (#1364)
 - `(def name)` without a value no longer throws; binds `nil`, matching Clojure (#1361)
 - `doseq` accepts Clojure-style pairs `(doseq [x coll] body)` without requiring the `:in` verb (#1362)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3083,9 +3083,14 @@ Otherwise, it tries to call `__toString`."
     (xf-step rf (fn [result input] (reduce rrf result input)))))
 
 (defn mapcat
-  "Maps a function over a collection and concatenates the results. Returns a lazy sequence.
-  When called with f only, returns a transducer."
-  {:example "(mapcat reverse [[1 2] [3 4]]) ; => (2 1 4 3)"
+  "Maps a function over one or more collections and concatenates the results.
+  Returns a lazy sequence. When called with `f` alone, returns a transducer.
+
+  With a single collection behaves like `(apply concat (map f coll))`. With
+  multiple collections, `f` is called with corresponding elements from each
+  (stopping when the shortest is exhausted) and the resulting sequences are
+  concatenated."
+  {:example "(mapcat reverse [[1 2] [3 4]]) ; => (2 1 4 3)\n(mapcat list [:a :b :c] [1 2 3]) ; => (:a 1 :b 2 :c 3)"
    :see-also ["map" "cat" "transduce"]}
   [f & args]
   (case (count args)
@@ -3098,7 +3103,7 @@ Otherwise, it tries to call `__toString`."
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))
-    (throw (php/new InvalidArgumentException "mapcat expects 1 or 2 arguments"))))
+    (apply concat (apply map f args))))
 
 (defn interpose
   "Returns elements separated by a separator. Returns a lazy sequence.

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -469,10 +469,30 @@ Otherwise, it tries to call `__toString`."
   (php/:: Phel (sortedSetBy comp (apply php/array xs))))
 
 (defn keyword
-  "Creates a new Keyword from a given string."
-  {:example "(keyword \"name\") ; => :name"}
-  [x]
-  (php/:: Keyword (create x)))
+  "Creates a new Keyword.
+
+  Arity-1 accepts a string, keyword, or symbol. Returns `nil` when `x` is `nil`.
+  If `x` is already a keyword, it is returned unchanged.
+
+  Arity-2 builds a namespaced keyword from the namespace and name parts; returns
+  `nil` when `name` is `nil`."
+  {:example "(keyword \"name\") ; => :name\n(keyword :abc) ; => :abc\n(keyword \"ns\" \"name\") ; => :ns/name"}
+  ([x]
+    (if (php/=== nil x)
+      nil
+      (if (php/instanceof x Keyword)
+        x
+        (if (php/instanceof x Symbol)
+          (php/:: Keyword (create (php/-> x (getName)) (php/-> x (getNamespace))))
+          (if (php/is_string x)
+            (php/:: Keyword (create x))
+            nil)))))
+  ([ns nm]
+    (if (php/=== nil nm)
+      nil
+      (let [ns-str (if (php/=== nil ns) nil (php/strval ns))
+            nm-str (php/strval nm)]
+        (php/:: Keyword (create nm-str ns-str))))))
 
 (defn php-indexed-array
   "Creates a PHP indexed array from the given values."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2841,18 +2841,24 @@ Otherwise, it tries to call `__toString`."
     (copy-meta coll result)))
 
 (defn keys
-  "Returns a sequence of all keys in a map."
-  {:example "(keys {:a 1 :b 2}) ; => (:a :b)"}
+  "Returns a sequence of all keys in a map, or `nil` when the map is `nil`
+  or empty."
+  {:example "(keys {:a 1 :b 2}) ; => (:a :b)\n(keys nil) ; => nil"}
   [coll]
-  (let [result (for [k :keys coll] k)]
-    (copy-meta coll result)))
+  (if (or (nil? coll) (empty? coll))
+    nil
+    (let [result (for [k :keys coll] k)]
+      (copy-meta coll result))))
 
 (defn vals
-  "Returns a sequence of all values in a map."
-  {:example "(vals {:a 1 :b 2}) ; => (1 2)"}
+  "Returns a sequence of all values in a map, or `nil` when the map is `nil`
+  or empty."
+  {:example "(vals {:a 1 :b 2}) ; => (1 2)\n(vals nil) ; => nil"}
   [coll]
-  (let [result (for [x :in coll] x)]
-    (copy-meta coll result)))
+  (if (or (nil? coll) (empty? coll))
+    nil
+    (let [result (for [x :in coll] x)]
+      (copy-meta coll result))))
 
 (defn key
   "Returns the key of a map entry (a two-element vector `[key value]`)."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -118,6 +118,16 @@
             (throw (php/new InvalidArgumentException
                             (php/. "cannot call 'next on " (php/gettype xs))))))))))
 
+(def first-map-entry
+  {:private true
+   :doc "Returns the first `[k v]` entry of a persistent map, or nil if empty."}
+  (fn [m]
+    (let [it (php/-> m (getIterator))]
+      (php/-> it (rewind))
+      (if (php/-> it (valid))
+        [(php/-> it (key)) (php/-> it (current))]
+        nil))))
+
 (def first
   {:doc "Returns the first element of a sequence, or nil if empty.
 
@@ -128,16 +138,10 @@
   (fn [xs]
     (if (php/instanceof xs FirstInterface)
       (php/-> xs (first))
-      (if (php/instanceof xs \Phel\Lang\Collections\Map\PersistentMapInterface)
-        (let [it (php/-> xs (getIterator))]
-          (php/-> it (rewind))
-          (if (php/-> it (valid))
-            [(php/-> it (key)) (php/-> it (current))]
-            nil))
+      (if (php/instanceof xs PersistentMapInterface)
+        (first-map-entry xs)
         (if (php/is_string xs)
-          (if (php/=== "" xs)
-            nil
-            (php/mb_substr xs 0 1))
+          (if (php/=== "" xs) nil (php/mb_substr xs 0 1))
           (php/aget xs 0))))))
 
 (def concat1
@@ -385,31 +389,29 @@
   []
   (php/:: Symbol (gen)))
 
+(defn- float-to-str
+  "Renders a float so integer-valued floats keep the trailing `.0`, while `NaN`
+  and ±Infinity stringify readably."
+  [x]
+  (if (php/is_nan x)
+    "NaN"
+    (if (php/is_infinite x)
+      (if (php/> x 0) "Infinity" "-Infinity")
+      (let [s (php/. "" x)]
+        (if (php/=== 1 (php/preg_match "/[.eE]/" s))
+          s
+          (php/. s ".0"))))))
+
 (defn- val-to-str
   "Converts a value to its string representation. Booleans become \"true\" or
 \"false\". Nil becomes an empty string. Integer-valued floats keep their `.0`
 suffix (so `(str 0.0)` is `\"0.0\"`, not `\"0\"`). All other values use PHP
 string cast."
   [x]
-  (if (php/=== x true)
-    "true"
-    (if (php/=== x false)
-      "false"
-      (if (php/=== x nil)
-        ""
-        (if (php/is_float x)
-          (if (php/is_nan x)
-            "NaN"
-            (if (php/is_infinite x)
-              (if (php/> x 0) "Infinity" "-Infinity")
-              (let [s (php/. "" x)]
-                (if (php/str_contains s ".")
-                  s
-                  (if (php/str_contains s "e")
-                    s
-                    (if (php/str_contains s "E")
-                      s
-                      (php/. s ".0")))))))
+  (if (php/=== x true)      "true"
+    (if (php/=== x false)   "false"
+      (if (php/=== x nil)   ""
+        (if (php/is_float x) (float-to-str x)
           (php/. "" x))))))
 
 (defn str
@@ -503,21 +505,17 @@ Otherwise, it tries to call `__toString`."
   `nil` when `name` is `nil`."
   {:example "(keyword \"name\") ; => :name\n(keyword :abc) ; => :abc\n(keyword \"ns\" \"name\") ; => :ns/name"}
   ([x]
-    (if (php/=== nil x)
-      nil
-      (if (php/instanceof x Keyword)
-        x
+    (if (php/=== nil x)            nil
+      (if (php/instanceof x Keyword) x
         (if (php/instanceof x Symbol)
           (php/:: Keyword (create (php/-> x (getName)) (php/-> x (getNamespace))))
-          (if (php/is_string x)
-            (php/:: Keyword (create x))
+          (if (php/is_string x)    (php/:: Keyword (create x))
             nil)))))
   ([ns nm]
     (if (php/=== nil nm)
       nil
-      (let [ns-str (if (php/=== nil ns) nil (php/strval ns))
-            nm-str (php/strval nm)]
-        (php/:: Keyword (create nm-str ns-str))))))
+      (php/:: Keyword (create (php/strval nm)
+                              (if (php/=== nil ns) nil (php/strval ns)))))))
 
 (defn php-indexed-array
   "Creates a PHP indexed array from the given values."
@@ -1086,18 +1084,18 @@ Otherwise, it tries to call `__toString`."
   its own category so it can be treated as less than anything. Numbers share a
   category so `(compare 1 1.5)` works."
   [x]
-  (if (php/=== x nil) :nil
-    (if (php/is_bool x) :bool
-      (if (php/is_int x) :number
-        (if (php/is_float x) :number
-          (if (php/is_string x) :string
-            (if (php/instanceof x Keyword) :keyword
-              (if (php/instanceof x Symbol) :symbol
-                (if (php/instanceof x \Phel\Lang\Collections\Vector\PersistentVectorInterface) :sequential
-                  (if (php/instanceof x \Phel\Lang\Collections\LinkedList\PersistentListInterface) :sequential
-                    (if (php/instanceof x \Phel\Lang\Collections\Map\PersistentMapInterface) :map
-                      (if (php/instanceof x \Phel\Lang\Collections\HashSet\PersistentHashSetInterface) :set
-                        :other))))))))))))
+  (cond
+    (php/=== x nil)                      :nil
+    (php/is_bool x)                      :bool
+    (or (php/is_int x) (php/is_float x)) :number
+    (php/is_string x)                    :string
+    (php/instanceof x Keyword)           :keyword
+    (php/instanceof x Symbol)            :symbol
+    (or (php/instanceof x PersistentVectorInterface)
+        (php/instanceof x PersistentListInterface)) :sequential
+    (php/instanceof x PersistentMapInterface)       :map
+    (php/instanceof x PersistentHashSetInterface)   :set
+    :else                                :other))
 
 (defn compare
   "Compares `x` and `y` using PHP's spaceship operator, returning a negative
@@ -1108,16 +1106,16 @@ Otherwise, it tries to call `__toString`."
   `InvalidArgumentException` when `x` and `y` come from mutually incomparable
   categories (e.g. `(compare 1 [])`)."
   [x y]
-  (if (php/=== x nil)
-    (if (php/=== y nil) 0 -1)
-    (if (php/=== y nil)
-      1
-      (let [cx (compare-category x)
-            cy (compare-category y)]
-        (if (php/=== cx cy)
-          (php/<=> x y)
-          (throw (php/new InvalidArgumentException
-                          (str "Cannot compare " cx " with " cy))))))))
+  (cond
+    (php/=== x nil) (if (php/=== y nil) 0 -1)
+    (php/=== y nil) 1
+    :else
+    (let [cx (compare-category x)
+          cy (compare-category y)]
+      (if (= cx cy)
+        (php/<=> x y)
+        (throw (php/new InvalidArgumentException
+                        (str "Cannot compare " cx " with " cy)))))))
 
 ;; --------------
 ;; Type operation
@@ -1748,14 +1746,12 @@ Otherwise, it tries to call `__toString`."
 (defn dissoc
   "Returns `ds` without the given keys. With no keys returns `ds` unchanged."
   {:example "(dissoc {:a 1 :b 2} :b) ; => {:a 1}\n(dissoc {:a 1 :b 2 :c 3} :a :c) ; => {:b 2}"}
-  ([ds] ds)
-  ([ds key] (dissoc-one ds key))
-  ([ds key & ks]
-    (loop [acc (dissoc-one ds key)
-           remaining ks]
-      (if (empty? remaining)
-        acc
-        (recur (dissoc-one acc (first remaining)) (next remaining))))))
+  [ds & ks]
+  (loop [acc ds
+         remaining ks]
+    (if (empty? remaining)
+      acc
+      (recur (dissoc-one acc (first remaining)) (next remaining)))))
 
 (defn unset
   "Returns `ds` without `key`."
@@ -2900,20 +2896,16 @@ Otherwise, it tries to call `__toString`."
   or empty."
   {:example "(keys {:a 1 :b 2}) ; => (:a :b)\n(keys nil) ; => nil"}
   [coll]
-  (if (or (nil? coll) (empty? coll))
-    nil
-    (let [result (for [k :keys coll] k)]
-      (copy-meta coll result))))
+  (when-not (empty? coll)
+    (copy-meta coll (for [k :keys coll] k))))
 
 (defn vals
   "Returns a sequence of all values in a map, or `nil` when the map is `nil`
   or empty."
   {:example "(vals {:a 1 :b 2}) ; => (1 2)\n(vals nil) ; => nil"}
   [coll]
-  (if (or (nil? coll) (empty? coll))
-    nil
-    (let [result (for [x :in coll] x)]
-      (copy-meta coll result))))
+  (when-not (empty? coll)
+    (copy-meta coll (for [x :in coll] x))))
 
 (defn key
   "Returns the key of a map entry (a two-element vector `[key value]`)."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -5290,14 +5290,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
         (php/intval trimmed)))))
 
 (defn parse-double
-  "Parses a string as a float. Returns nil if parsing fails."
-  {:example "(parse-double \"3.14\") ; => 3.14"
+  "Parses a string as a float. Returns `nil` for non-numeric input or for
+  inputs that are not strings. Accepts `Infinity`, `-Infinity`, and `NaN`
+  alongside regular decimal and scientific notation."
+  {:example "(parse-double \"3.14\") ; => 3.14\n(parse-double \"Infinity\") ; => INF"
    :see-also ["parse-long"]}
   [s]
   (when (string? s)
     (let [trimmed (php/trim s)]
-      (when (php/is_numeric trimmed)
-        (php/floatval trimmed)))))
+      (cond
+        (or (= trimmed "Infinity") (= trimmed "+Infinity")) php/INF
+        (= trimmed "-Infinity") (php/- php/INF)
+        (= trimmed "NaN") NAN
+        (php/is_numeric trimmed) (php/floatval trimmed)
+        :else nil))))
 
 (defn parse-boolean
   "Parses a string as a boolean. Returns true for \"true\", false for \"false\", nil otherwise."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -4445,14 +4445,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 
 (def ^:private *hierarchy*
   "Global hierarchy for keyword/symbol taxonomies."
-  (var {:parents {}}))
+  (var {:parents {} :descendants {} :ancestors {}}))
 
 (defn make-hierarchy
-  "Creates a fresh, empty hierarchy."
-  {:doc "Returns a new hierarchy map with no parent relationships."
-   :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
+  "Creates a fresh, empty hierarchy.
+
+  Returns a map with `:parents`, `:descendants`, and `:ancestors` keys, each
+  holding an empty map. Matches Clojure's hierarchy shape so consumers can
+  destructure any of the three relationship views."
+  {:see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
   []
-  {:parents {}})
+  {:parents {} :descendants {} :ancestors {}})
 
 (defn- compute-ancestors
   "Computes all transitive ancestors of tag from a parents map."
@@ -4504,7 +4507,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
            (let [parents-map (get h :parents)
                  old-parents (get parents-map child (hash-set))
                  new-parents (union old-parents (hash-set parent))]
-             {:parents (assoc parents-map child new-parents)})))
+             (assoc h :parents (assoc parents-map child new-parents)))))
   nil)
 
 (defn underive
@@ -4520,7 +4523,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                  new-map (if (empty? new-parents)
                            (dissoc parents-map child)
                            (assoc parents-map child new-parents))]
-             {:parents new-map})))
+             (assoc h :parents new-map))))
   nil)
 
 (defn parents

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -119,16 +119,26 @@
                             (php/. "cannot call 'next on " (php/gettype xs))))))))))
 
 (def first
-  {:doc "Returns the first element of a sequence, or nil if empty."
+  {:doc "Returns the first element of a sequence, or nil if empty.
+
+  Maps are treated as a sequence of entries: `(first {:a 1})` returns the
+  first `[:a 1]` vector. Strings are treated as sequences of multibyte
+  characters."
    :example "(first [1 2 3]) ; => 1"}
   (fn [xs]
     (if (php/instanceof xs FirstInterface)
       (php/-> xs (first))
-      (if (php/is_string xs)
-        (if (php/=== "" xs)
-          nil
-          (php/mb_substr xs 0 1))
-        (php/aget xs 0)))))
+      (if (php/instanceof xs \Phel\Lang\Collections\Map\PersistentMapInterface)
+        (let [it (php/-> xs (getIterator))]
+          (php/-> it (rewind))
+          (if (php/-> it (valid))
+            [(php/-> it (key)) (php/-> it (current))]
+            nil))
+        (if (php/is_string xs)
+          (if (php/=== "" xs)
+            nil
+            (php/mb_substr xs 0 1))
+          (php/aget xs 0))))))
 
 (def concat1
   {:private true

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -387,7 +387,9 @@
 
 (defn- val-to-str
   "Converts a value to its string representation. Booleans become \"true\" or
-\"false\". Nil becomes an empty string. All other values use PHP string cast."
+\"false\". Nil becomes an empty string. Integer-valued floats keep their `.0`
+suffix (so `(str 0.0)` is `\"0.0\"`, not `\"0\"`). All other values use PHP
+string cast."
   [x]
   (if (php/=== x true)
     "true"
@@ -395,7 +397,20 @@
       "false"
       (if (php/=== x nil)
         ""
-        (php/. "" x)))))
+        (if (php/is_float x)
+          (if (php/is_nan x)
+            "NaN"
+            (if (php/is_infinite x)
+              (if (php/> x 0) "Infinity" "-Infinity")
+              (let [s (php/. "" x)]
+                (if (php/str_contains s ".")
+                  s
+                  (if (php/str_contains s "e")
+                    s
+                    (if (php/str_contains s "E")
+                      s
+                      (php/. s ".0")))))))
+          (php/. "" x))))))
 
 (defn str
   "Creates a string by concatenating values together. If no arguments are
@@ -5315,7 +5330,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (let [trimmed (php/trim s)]
       (cond
         (or (= trimmed "Infinity") (= trimmed "+Infinity")) php/INF
-        (= trimmed "-Infinity") (php/- php/INF)
+        (= trimmed "-Infinity") (php/- 0 php/INF)
         (= trimmed "NaN") NAN
         (php/is_numeric trimmed) (php/floatval trimmed)
         :else nil))))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -143,9 +143,9 @@
    :example "(first [1 2 3]) ; => 1"}
   (fn [xs]
     (if (php/instanceof xs FirstInterface)         (php/-> xs (first))
-      (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
-        (if (php/is_string xs)                      (first-of-string xs)
-          (php/aget xs 0))))))
+        (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
+            (if (php/is_string xs)                      (first-of-string xs)
+                (php/aget xs 0))))))
 
 (def concat1
   {:private true
@@ -412,10 +412,10 @@ suffix (so `(str 0.0)` is `\"0.0\"`, not `\"0\"`). All other values use PHP
 string cast."
   [x]
   (if (php/=== x true)      "true"
-    (if (php/=== x false)   "false"
-      (if (php/=== x nil)   ""
-        (if (php/is_float x) (float-to-str x)
-          (php/. "" x))))))
+      (if (php/=== x false)   "false"
+          (if (php/=== x nil)   ""
+              (if (php/is_float x) (float-to-str x)
+                  (php/. "" x))))))
 
 (defn str
   "Creates a string by concatenating values together. If no arguments are
@@ -863,17 +863,17 @@ Otherwise, it tries to call `__toString`."
   `nil` when `name` is `nil`."
   {:example "(keyword \"name\") ; => :name\n(keyword :abc) ; => :abc\n(keyword \"ns\" \"name\") ; => :ns/name"}
   ([x]
-    (cond
-      (php/=== nil x)            nil
-      (php/instanceof x Keyword) x
-      (php/instanceof x Symbol)  (php/:: Keyword (create (php/-> x (getName))
-                                                         (php/-> x (getNamespace))))
-      (php/is_string x)          (php/:: Keyword (create x))
-      :else                      nil))
+   (cond
+     (php/=== nil x)            nil
+     (php/instanceof x Keyword) x
+     (php/instanceof x Symbol)  (php/:: Keyword (create (php/-> x (getName))
+                                                        (php/-> x (getNamespace))))
+     (php/is_string x)          (php/:: Keyword (create x))
+     :else                      nil))
   ([ns nm]
-    (when-not (php/=== nil nm)
-      (php/:: Keyword (create (php/strval nm)
-                              (when-not (php/=== nil ns) (php/strval ns)))))))
+   (when-not (php/=== nil nm)
+     (php/:: Keyword (create (php/strval nm)
+                             (when-not (php/=== nil ns) (php/strval ns)))))))
 
 (defn- id2 [a b]
   (if (php/instanceof a IdenticalInterface)
@@ -1863,7 +1863,7 @@ Otherwise, it tries to call `__toString`."
   {:see-also ["swap!" "atom" "def"]}
   [& _]
   (throw (php/new \BadMethodCallException
-           "alter-var-root is not supported in Phel: Phel has no first-class vars. Use an `atom` with `swap!` for mutable state, or redefine the top-level with `def`.")))
+                  "alter-var-root is not supported in Phel: Phel has no first-class vars. Use an `atom` with `swap!` for mutable state, or redefine the top-level with `def`.")))
 
 (defn remove-watch
   "Removes a watch function from a variable by key."
@@ -2847,7 +2847,7 @@ Otherwise, it tries to call `__toString`."
   [rev]
   (when-not (reversible? rev)
     (throw (php/new InvalidArgumentException
-             "rseq requires a reversible collection (vector or sorted-map)")))
+                    "rseq requires a reversible collection (vector or sorted-map)")))
   (when (php/> (count rev) 0)
     (reverse (if (vector? rev) rev (vec rev)))))
 
@@ -3548,9 +3548,9 @@ Otherwise, it tries to call `__toString`."
                           :reduce [acc []]]
                       (let [arg (get args i)]
                         (conj acc
-                          (if (and (php/< i n) (nil? arg))
-                            (get defaults i)
-                            arg))))]
+                              (if (and (php/< i n) (nil? arg))
+                                (get defaults i)
+                                arg))))]
         (apply f patched)))))
 
 (defn memoize
@@ -4879,9 +4879,9 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                       margs (second method)
                       rest-args (next margs)
                       dispatch-var (php/:: Symbol
-                                          (create (php/. proto-str "--" mname-str "--dispatch")))
+                                           (create (php/. proto-str "--" mname-str "--dispatch")))
                       php-method-sym (php/:: Symbol
-                                            (create (php/-> munge (encode mname-str))))]
+                                             (create (php/-> munge (encode mname-str))))]
                   (conj inner
                         `(swap! ~dispatch-var assoc ~class-name-sym
                                 (fn ~margs
@@ -5000,8 +5000,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [multi-name dispatch-val & fn-tail]
   (let [multi-ns (php/-> multi-name (getNamespace))
         methods-name (php/:: Symbol (createForNamespace
-                                      multi-ns
-                                      (php/. (php/-> multi-name (getName)) "-methods")))]
+                                     multi-ns
+                                     (php/. (php/-> multi-name (getName)) "-methods")))]
     `(swap! ~methods-name assoc ~dispatch-val (fn ~@fn-tail))))
 
 (defmacro if-let
@@ -5110,11 +5110,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
         refs (for [n :in names :reduce [acc {}]]
                (put acc n (gensym)))
         var-decls (apply concat
-                    (for [n :in names]
-                      [(get refs n) '(var nil)]))
-        deref-bindings (apply concat
                          (for [n :in names]
-                           [n `(deref ~(get refs n))]))
+                           [(get refs n) '(var nil)]))
+        deref-bindings (apply concat
+                              (for [n :in names]
+                                [n `(deref ~(get refs n))]))
         assignments (for [spec :in bindings
                           :let [n (first spec)
                                 params (second spec)
@@ -5428,4 +5428,4 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (let [n-sym (gensym)]
     `(let [~n-sym ~n]
        (doseq [~binding :range [0 ~n-sym]]
-         ~@body))))
+              ~@body))))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -128,6 +128,12 @@
         [(php/-> it (key)) (php/-> it (current))]
         nil))))
 
+(def first-of-string
+  {:private true
+   :doc "Returns the first multibyte character of a string, or nil if empty."}
+  (fn [s]
+    (if (php/=== "" s) nil (php/mb_substr s 0 1))))
+
 (def first
   {:doc "Returns the first element of a sequence, or nil if empty.
 
@@ -136,12 +142,9 @@
   characters."
    :example "(first [1 2 3]) ; => 1"}
   (fn [xs]
-    (if (php/instanceof xs FirstInterface)
-      (php/-> xs (first))
-      (if (php/instanceof xs PersistentMapInterface)
-        (first-map-entry xs)
-        (if (php/is_string xs)
-          (if (php/=== "" xs) nil (php/mb_substr xs 0 1))
+    (if (php/instanceof xs FirstInterface)         (php/-> xs (first))
+      (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
+        (if (php/is_string xs)                      (first-of-string xs)
           (php/aget xs 0))))))
 
 (def concat1
@@ -494,28 +497,6 @@ Otherwise, it tries to call `__toString`."
    :see-also ["sorted-set" "compare"]}
   [comp & xs]
   (php/:: Phel (sortedSetBy comp (apply php/array xs))))
-
-(defn keyword
-  "Creates a new Keyword.
-
-  Arity-1 accepts a string, keyword, or symbol. Returns `nil` when `x` is `nil`.
-  If `x` is already a keyword, it is returned unchanged.
-
-  Arity-2 builds a namespaced keyword from the namespace and name parts; returns
-  `nil` when `name` is `nil`."
-  {:example "(keyword \"name\") ; => :name\n(keyword :abc) ; => :abc\n(keyword \"ns\" \"name\") ; => :ns/name"}
-  ([x]
-    (if (php/=== nil x)            nil
-      (if (php/instanceof x Keyword) x
-        (if (php/instanceof x Symbol)
-          (php/:: Keyword (create (php/-> x (getName)) (php/-> x (getNamespace))))
-          (if (php/is_string x)    (php/:: Keyword (create x))
-            nil)))))
-  ([ns nm]
-    (if (php/=== nil nm)
-      nil
-      (php/:: Keyword (create (php/strval nm)
-                              (if (php/=== nil ns) nil (php/strval ns)))))))
 
 (defn php-indexed-array
   "Creates a PHP indexed array from the given values."
@@ -871,6 +852,28 @@ Otherwise, it tries to call `__toString`."
     (let [v (gensym)]
       `(let [~v ~(first args)]
          (if ~v (and ~@(next args)) ~v)))))
+
+(defn keyword
+  "Creates a new Keyword.
+
+  Arity-1 accepts a string, keyword, or symbol. Returns `nil` when `x` is `nil`.
+  If `x` is already a keyword, it is returned unchanged.
+
+  Arity-2 builds a namespaced keyword from the namespace and name parts; returns
+  `nil` when `name` is `nil`."
+  {:example "(keyword \"name\") ; => :name\n(keyword :abc) ; => :abc\n(keyword \"ns\" \"name\") ; => :ns/name"}
+  ([x]
+    (cond
+      (php/=== nil x)            nil
+      (php/instanceof x Keyword) x
+      (php/instanceof x Symbol)  (php/:: Keyword (create (php/-> x (getName))
+                                                         (php/-> x (getNamespace))))
+      (php/is_string x)          (php/:: Keyword (create x))
+      :else                      nil))
+  ([ns nm]
+    (when-not (php/=== nil nm)
+      (php/:: Keyword (create (php/strval nm)
+                              (when-not (php/=== nil ns) (php/strval ns)))))))
 
 (defn- id2 [a b]
   (if (php/instanceof a IdenticalInterface)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1674,9 +1674,7 @@ Otherwise, it tries to call `__toString`."
   [ds key value]
   (assoc ds key value))
 
-(defn dissoc
-  "Dissociates `key` from the datastructure `ds`. Returns `ds` without `key`."
-  {:example "(dissoc {:a 1 :b 2} :b) ; => {:a 1}"}
+(defn- dissoc-one
   [ds key]
   (cond
     (php-array? ds)
@@ -1691,6 +1689,18 @@ Otherwise, it tries to call `__toString`."
     (let [x ds]
       (php/aunset x key)
       x)))
+
+(defn dissoc
+  "Returns `ds` without the given keys. With no keys returns `ds` unchanged."
+  {:example "(dissoc {:a 1 :b 2} :b) ; => {:a 1}\n(dissoc {:a 1 :b 2 :c 3} :a :c) ; => {:b 2}"}
+  ([ds] ds)
+  ([ds key] (dissoc-one ds key))
+  ([ds key & ks]
+    (loop [acc (dissoc-one ds key)
+           remaining ks]
+      (if (empty? remaining)
+        acc
+        (recur (dissoc-one acc (first remaining)) (next remaining))))))
 
 (defn unset
   "Returns `ds` without `key`."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1081,13 +1081,43 @@ Otherwise, it tries to call `__toString`."
     (php/is_string coll) (and (php/is_int key) (php/>= key 0) (php/< key (php/mb_strlen coll)))
     (throw (php/new InvalidArgumentException (php/. "cannot call 'contains?' on " (php/get_class coll))))))
 
+(defn- compare-category
+  "Returns a coarse category for `compare`'s type compatibility check. `nil` is
+  its own category so it can be treated as less than anything. Numbers share a
+  category so `(compare 1 1.5)` works."
+  [x]
+  (if (php/=== x nil) :nil
+    (if (php/is_bool x) :bool
+      (if (php/is_int x) :number
+        (if (php/is_float x) :number
+          (if (php/is_string x) :string
+            (if (php/instanceof x Keyword) :keyword
+              (if (php/instanceof x Symbol) :symbol
+                (if (php/instanceof x \Phel\Lang\Collections\Vector\PersistentVectorInterface) :sequential
+                  (if (php/instanceof x \Phel\Lang\Collections\LinkedList\PersistentListInterface) :sequential
+                    (if (php/instanceof x \Phel\Lang\Collections\Map\PersistentMapInterface) :map
+                      (if (php/instanceof x \Phel\Lang\Collections\HashSet\PersistentHashSetInterface) :set
+                        :other))))))))))))
+
 (defn compare
-  "Wrapper for PHP's spaceship operator (`php/<=>`).
-  Returns an integer less than, equal to, or greater than zero
-  when `x` is less than, equal to, or greater than `y`, respectively."
-  {:inline (fn [x y] `(php/<=> ~x ~y))}
+  "Compares `x` and `y` using PHP's spaceship operator, returning a negative
+  integer, zero, or a positive integer when `x` is less than, equal to, or
+  greater than `y`.
+
+  `nil` is less than every non-nil value and equal to itself. Throws
+  `InvalidArgumentException` when `x` and `y` come from mutually incomparable
+  categories (e.g. `(compare 1 [])`)."
   [x y]
-  (php/<=> x y))
+  (if (php/=== x nil)
+    (if (php/=== y nil) 0 -1)
+    (if (php/=== y nil)
+      1
+      (let [cx (compare-category x)
+            cy (compare-category y)]
+        (if (php/=== cx cy)
+          (php/<=> x y)
+          (throw (php/new InvalidArgumentException
+                          (str "Cannot compare " cx " with " cy))))))))
 
 ;; --------------
 ;; Type operation

--- a/src/php/Lang/Collections/HashSet/TransientHashSet.php
+++ b/src/php/Lang/Collections/HashSet/TransientHashSet.php
@@ -25,6 +25,19 @@ final readonly class TransientHashSet implements TransientHashSetInterface, Stri
         return '<TransientSet count=' . $this->transientMap->count() . '>';
     }
 
+    /**
+     * Membership lookup so transient sets remain callable like their persistent
+     * counterparts: `((transient #{:a}) :a) ; => :a`, else `nil`.
+     *
+     * @param V $key
+     *
+     * @return V|null
+     */
+    public function __invoke(mixed $key): mixed
+    {
+        return $this->transientMap->find($key);
+    }
+
     public function count(): int
     {
         return $this->transientMap->count();

--- a/src/php/Lang/Collections/Map/TransientMapWrapper.php
+++ b/src/php/Lang/Collections/Map/TransientMapWrapper.php
@@ -24,6 +24,20 @@ final class TransientMapWrapper implements TransientMapInterface, Stringable
         return '<TransientMap count=' . $this->count() . '>';
     }
 
+    /**
+     * Lookup by key so transient maps stay callable like their persistent
+     * counterparts: `((transient {:a 1}) :a) ; => 1`.
+     *
+     * @param K      $key
+     * @param V|null $default
+     *
+     * @return V|null
+     */
+    public function __invoke(mixed $key, mixed $default = null): mixed
+    {
+        return $this->offsetGet($key) ?? $default;
+    }
+
     public function contains($key): bool
     {
         return $this->internal->contains($key);

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -44,6 +44,17 @@ final class TransientVector implements TransientVectorInterface, Stringable
         return '<TransientVector count=' . $this->count . '>';
     }
 
+    /**
+     * Lookup by integer index so transient vectors remain callable like their
+     * persistent counterparts: `((transient [10 20]) 1) ; => 20`.
+     *
+     * @return T
+     */
+    public function __invoke(int $index)
+    {
+        return $this->get($index);
+    }
+
     public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
     {
         return new self(

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use ArrayAccess;
 use Override;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 
 final class Keyword extends AbstractType implements IdenticalInterface, FnInterface, NamedInterface
 {
@@ -25,8 +25,14 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
             : crc32(':' . $name);
     }
 
+    /**
+     * Callable behaviour for keyword-as-accessor. Accepts any `ArrayAccess`
+     * container so both persistent and transient maps work (previously the
+     * signature was narrowed to `PersistentMapInterface`, which raised a
+     * `TypeError` when called against a transient map).
+     */
     public function __invoke(
-        PersistentMapInterface $obj,
+        ArrayAccess $obj,
         float|bool|int|string|TypeInterface|null $default = null,
     ) {
         return $obj[$this] ?? $default;

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -8,7 +8,15 @@
   (is (= '[1 2 3] (vector '1 '2 '3)) "construct vector"))
 
 (deftest create-keyword
-  (is (= :a (keyword "a")) "construct keyword"))
+  (is (= :a (keyword "a")) "construct keyword from string")
+  (is (= :abc (keyword :abc)) "keyword is idempotent on keyword input")
+  (is (= :abc (keyword 'abc)) "keyword from symbol")
+  (is (nil? (keyword nil)) "keyword of nil is nil")
+  (is (nil? (keyword 42)) "keyword of non-string/ident is nil")
+  (is (= :ns/name (keyword "ns" "name")) "keyword with namespace and name")
+  (is (= :ns/name (keyword 'ns 'name)) "keyword accepts symbols as ns/name")
+  (is (= :name (keyword nil "name")) "keyword with nil namespace is unqualified")
+  (is (nil? (keyword "ns" nil)) "keyword with nil name is nil"))
 
 (deftest create-hash-map
   (is (= {:a 1 :b 2} (hash-map :a 1 :b 2)) "construct hash-map"))

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -35,7 +35,9 @@
 (deftest test-ffirst
   (is (= 1 (ffirst [[1]])) "ffirst of nested vector")
   (is (nil? (ffirst [1])) "ffirst of vector")
-  (is (nil? (ffirst nil)) "ffirst of nil"))
+  (is (nil? (ffirst nil)) "ffirst of nil")
+  (is (= :a (ffirst {:a 1})) "ffirst of single-entry map is its key")
+  (is (nil? (ffirst {})) "ffirst of empty map is nil"))
 
 (deftest test-second
   (is (= 2 (second [1 2])) "second of vector")
@@ -50,7 +52,12 @@
   (is (= [] (rest [])) "rest of empty vector"))
 
 (deftest test-nfirst
-  (is (= [2] (nfirst [[1 2]])) "(nfirst [[1 2]])"))
+  (is (= [2] (nfirst [[1 2]])) "(nfirst [[1 2]])")
+  (is (= [1] (nfirst {:a 1})) "nfirst of single-entry map is the rest of the entry"))
+
+(deftest test-first-map
+  (is (= [:a 1] (first {:a 1})) "first of map returns first entry as 2-vector")
+  (is (nil? (first {})) "first of empty map is nil"))
 
 (deftest test-nnext
   (is (= [3] (nnext [1 2 3])) "(nnext [1 2 3])"))

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -290,4 +290,16 @@
 (deftest test-compare
   (is (= -1 (compare 1 2)) "(compare 1 2)")
   (is (= 1 (compare 2 1)) "(compare 2 1)")
-  (is (= 0 (compare 1 1)) "(compare 1 1)"))
+  (is (= 0 (compare 1 1)) "(compare 1 1)")
+  (is (= 0 (compare 1 1.0)) "mixed int/float compare as same category")
+  (is (= -1 (compare "a" "b")) "strings compare")
+  (is (= 0 (compare nil nil)) "nil equals nil")
+  (is (= -1 (compare nil 1)) "nil is less than any non-nil")
+  (is (= 1 (compare 1 nil)) "non-nil is greater than nil"))
+
+(deftest test-compare-type-mismatch
+  (is (thrown? \InvalidArgumentException (compare 1 [])) "number vs vector throws")
+  (is (thrown? \InvalidArgumentException (compare 'x [])) "symbol vs vector throws")
+  (is (thrown? \InvalidArgumentException (compare 'x '(x))) "symbol vs list throws")
+  (is (thrown? \InvalidArgumentException (compare :a "a")) "keyword vs string throws")
+  (is (thrown? \InvalidArgumentException (compare {} [])) "map vs vector throws"))

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -85,7 +85,11 @@
 
 (deftest test-make-hierarchy
   (let [h (make-hierarchy)]
-    (is (= {:parents {}} h) "fresh hierarchy is empty map")))
+    (is (= {:parents {} :descendants {} :ancestors {}} h)
+        "fresh hierarchy exposes all three relationship views")
+    (is (= {} (get h :parents)) "fresh hierarchy has no parents")
+    (is (= {} (get h :descendants)) "fresh hierarchy has no descendants")
+    (is (= {} (get h :ancestors)) "fresh hierarchy has no ancestors")))
 
 ;; --- multimethod with hierarchy dispatch ---
 

--- a/tests/phel/test/core/print-operation.phel
+++ b/tests/phel/test/core/print-operation.phel
@@ -21,7 +21,14 @@
   (is (= "" (str nil nil)) "str on multiple nil")
   (is (= "truefalse" (str true false)) "str on true and false")
   (is (= "<function:name>" (str name)) "str on function")
-  (is (= "Hello, <function:name>!" (str "Hello, " name "!")) "str with function in middle"))
+  (is (= "Hello, <function:name>!" (str "Hello, " name "!")) "str with function in middle")
+  (is (= "0.0" (str 0.0)) "str on float zero preserves decimal")
+  (is (= "1.0" (str 1.0)) "str on integer-valued float preserves decimal")
+  (is (= "-1.0" (str -1.0)) "str on negative integer-valued float preserves decimal")
+  (is (= "1.5" (str 1.5)) "str on fractional float unchanged")
+  (is (= "NaN" (str NAN)) "str on NaN")
+  (is (= "Infinity" (str php/INF)) "str on positive infinity")
+  (is (= "-Infinity" (str (php/- 0 php/INF))) "str on negative infinity"))
 
 (deftest test-print-str
   (is (= "" (print-str)) "print-str with no arg")

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -276,11 +276,20 @@
 
 (deftest test-keys
   (is (= [:a :b :c] (keys {:a 1 :b 2 :c 3})) "keys of map")
-  (is (= [0 1 2] (keys [3 2 1])) "keys of vector"))
+  (is (= [0 1 2] (keys [3 2 1])) "keys of vector")
+  (is (nil? (keys nil)) "keys of nil is nil")
+  (is (nil? (keys {})) "keys of empty map is nil")
+  (is (nil? (keys [])) "keys of empty vector is nil"))
 
 (deftest test-values
   (is (= [1 2 3] (values {:a 1 :b 2 :c 3})) "values of map")
   (is (= [3 2 1] (values [3 2 1])) "values of vector"))
+
+(deftest test-vals
+  (is (= [1 2 3] (vals {:a 1 :b 2 :c 3})) "vals of map")
+  (is (nil? (vals nil)) "vals of nil is nil")
+  (is (nil? (vals {})) "vals of empty map is nil")
+  (is (nil? (vals [])) "vals of empty vector is nil"))
 
 (deftest test-not-empty
   (is (= [1] (not-empty [1])) "not-empty returns coll")

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -28,6 +28,15 @@
   (is (= [1 2 3 4 5 6] (mapcat reverse [[3 2 1] [6 5 4]])) "mapcat")
   (is (= [] (mapcat identity [])) "mapcat on empty vector"))
 
+(deftest test-mapcat-multi-collection
+  (is (= [:a 1 :b 2 :c 3] (mapcat list [:a :b :c] [1 2 3]))
+      "mapcat with list interleaves corresponding elements")
+  (is (= [2 2 4 4 6 6] (mapcat (fn [x y] [(* 2 x) (* 2 y)]) [1 2 3] [1 2 3]))
+      "mapcat with arity-2 fn zips collections")
+  (is (= [2 4] (mapcat (fn [x y] [(* x y)]) [1 2] [2 2 2]))
+      "mapcat stops at shortest collection")
+  (is (= [] (mapcat list [] [1 2 3])) "mapcat with empty first collection"))
+
 (deftest test-into
   (is (= [1 2 3 4] (into [] '(1 2 3 4))) "into vector from list")
   (is (= [1 2 3 4 5] (into [1 2] [3 4 5])) "into vector from vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -308,7 +308,13 @@
   (is (= {:b 2} (unset {:a 1 :b 2} :a)) "unset: remove key from map"))
 
 (deftest test-dissoc
-  (is (= {:b 2} (dissoc {:a 1 :b 2} :a)) "dissoc: remove key from map"))
+  (is (= {:b 2} (dissoc {:a 1 :b 2} :a)) "dissoc: remove key from map")
+  (is (= {:a 1} (dissoc {:a 1})) "dissoc with no keys returns map unchanged")
+  (is (= {} (dissoc {:a 1 :b 2 :c 3} :a :b :c)) "dissoc variadic removes all keys")
+  (is (= {:b 2} (dissoc {:a 1 :b 2 :c 3} :a :c)) "dissoc variadic removes multiple keys")
+  (is (= {:a 1} (dissoc {:a 1} :missing :also-missing)) "dissoc skips missing keys")
+  (is (= {} (apply dissoc {} [])) "apply dissoc with no keys does not raise")
+  (is (= {:b 2} (apply dissoc {:a 1 :b 2 :c 3} [:a :c])) "apply dissoc variadic through seq"))
 
 (deftest test-next
   (is (nil? (next [])) "next of empty vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -108,6 +108,16 @@
   (is (= #{1 2 3} (persistent (conj (transient #{1 2}) 3))) "conj on transient set adds element")
   (is (= {:a 1} (persistent (conj (transient {}) [:a 1]))) "conj on transient map with [key value] pair"))
 
+(deftest test-transient-invocation
+  (is (= 20 ((transient [10 20 30]) 1)) "transient vector is callable by index")
+  (is (= 1 ((transient {:a 1 :b 2}) :a)) "transient map is callable by key")
+  (is (nil? ((transient {:a 1}) :missing)) "transient map missing key returns nil")
+  (is (= "fallback" ((transient {:a 1}) :missing "fallback"))
+      "transient map missing key returns default")
+  (is (= :a ((transient #{:a :b}) :a)) "transient set returns member on lookup")
+  (is (nil? ((transient #{:a}) :missing)) "transient set missing element returns nil")
+  (is (= 1 (:a (transient {:a 1}))) "keyword-as-fn works on transient map"))
+
 (deftest test-conj-empty-collections
   (is (= {:a 1} (conj {} [:a 1])) "conj on empty map with [key value] pair")
   (is (= #{1} (conj #{} 1)) "conj on empty set adds element")

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -52,7 +52,12 @@
   (is (= 0.0 (parse-double "0")) "parse-double zero")
   (is (nil? (parse-double "abc")) "parse-double non-numeric")
   (is (nil? (parse-double "")) "parse-double empty string")
-  (is (nil? (parse-double nil)) "parse-double nil"))
+  (is (nil? (parse-double nil)) "parse-double nil")
+  (is (= php/INF (parse-double "Infinity")) "parse-double Infinity")
+  (is (= php/INF (parse-double "+Infinity")) "parse-double +Infinity")
+  (is (= php/INF (parse-double "  Infinity  ")) "parse-double Infinity with whitespace")
+  (is (= (php/- php/INF) (parse-double "-Infinity")) "parse-double -Infinity")
+  (is (nan? (parse-double "NaN")) "parse-double NaN"))
 
 (deftest test-parse-boolean
   (is (true? (parse-boolean "true")) "parse-boolean true")

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -56,7 +56,7 @@
   (is (= php/INF (parse-double "Infinity")) "parse-double Infinity")
   (is (= php/INF (parse-double "+Infinity")) "parse-double +Infinity")
   (is (= php/INF (parse-double "  Infinity  ")) "parse-double Infinity with whitespace")
-  (is (= (php/- php/INF) (parse-double "-Infinity")) "parse-double -Infinity")
+  (is (= (php/- 0 php/INF) (parse-double "-Infinity")) "parse-double -Infinity")
   (is (nan? (parse-double "NaN")) "parse-double NaN"))
 
 (deftest test-parse-boolean


### PR DESCRIPTION
## 🤔 Background

Running [`jasalt/clojure-test-suite`](https://github.com/jasalt/clojure-test-suite/commit/0f8218d11264036da7e78dfcd357e6f979aa614a) against Phel 0.32.0 surfaced ~800 failures/errors. Most cluster around a handful of small, correctable behavioural gaps in the core library and runtime.

## 💡 Goal

Close those fixable gaps without disturbing Phel's existing semantics. Skips two points explicitly: making seq-returning fns return lists instead of vectors (architectural), and fixing the shim's `thrown?` expansion (belongs in the external port).

## 🔖 Changes

- `keyword` idempotent on keywords, handles symbol / `nil` input, gains arity-2 namespaced form
- `dissoc` accepts zero keys and reduces over variadic key lists
- `keys` / `vals` return `nil` for `nil` / empty collections
- `make-hierarchy` returns `:parents` / `:descendants` / `:ancestors`; `derive` / `underive` preserve all three
- `parse-double` accepts `Infinity`, `-Infinity`, `NaN`
- `mapcat` accepts multiple collections
- `first` on a map returns its first entry, fixing `ffirst` / `nfirst` on maps
- `str` preserves float representation (`0.0`, `NaN`, `±Infinity`)
- `compare` throws on cross-category arguments; `nil` stays least
- Transient vectors / maps / sets are callable; `Keyword::__invoke` accepts any `ArrayAccess` so `:keyword` lookup works on transient maps