### PR TITLE
ref(phel): simplify branching in core.phel and test.phel

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1020,11 +1020,10 @@ Otherwise, it tries to call `__toString`."
   {:example "(some? 1) ; => true\n(some? even? [1 3 5 6 7]) ; => true"}
   ([x] (not (nil? x)))
   ([pred coll]
-   (if (empty? coll)
-     false
-     (if (truthy? (pred (first coll)))
-       true
-       (recur pred (next coll))))))
+   (cond
+     (empty? coll) false
+     (truthy? (pred (first coll))) true
+     :else (recur pred (next coll)))))
 
 (defn not-any?
   "Returns true if `(pred x)` is logical false for every `x` in `coll`
@@ -2649,7 +2648,7 @@ Otherwise, it tries to call `__toString`."
                         (let [n @nv
                               nn (vreset! nv (php/- n 1))
                               result (if (php/> n 0) (rf result input) result)]
-                          (if (not (php/> nn 0)) (ensure-reduced result) result))))))
+                          (if (php/<= nn 0) (ensure-reduced result) result))))))
     1 (let [coll (first args)
             n (if (php/< n 0) 0 n)]
         (if (php/=== n 0)
@@ -2777,11 +2776,10 @@ Otherwise, it tries to call `__toString`."
    :see-also ["find-index" "filter" "some?"]}
   [pred coll]
   (loop [s coll]
-    (if (empty? s)
-      nil
-      (if (pred (first s))
-        (first s)
-        (recur (next s))))))
+    (cond
+      (empty? s) nil
+      (pred (first s)) (first s)
+      :else (recur (next s)))))
 
 (defn find-index
   "Returns the index of the first item in `coll` where `(pred item)` evaluates to true."
@@ -2790,11 +2788,10 @@ Otherwise, it tries to call `__toString`."
   [pred coll]
   (loop [s coll
          i 0]
-    (if (empty? s)
-      nil
-      (if (pred (first s))
-        i
-        (recur (next s) (php/+ i 1))))))
+    (cond
+      (empty? s) nil
+      (pred (first s)) i
+      :else (recur (next s) (php/+ i 1)))))
 
 (defn distinct
   "Returns a lazy sequence with duplicated values removed in `coll`.

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -51,11 +51,10 @@
   {:example "(report {:state :pass})"}
   [data]
   (let [ctx (testing-contexts-str)
-        data (if (and ctx (:message data))
-               (put data :message (str ctx (:message data)))
-               (if ctx
-                 (put data :message (s/join " > " *testing-contexts*))
-                 data))
+        data (cond
+               (and ctx (:message data)) (put data :message (str ctx (:message data)))
+               ctx (put data :message (s/join " > " *testing-contexts*))
+               :else data)
         {:state state :type type} data
         ok (= state :pass)
         total-columns 80]
@@ -232,17 +231,18 @@
 (defmethod assert-expr 'output? [form message]
   (assert-output form message))
 
+(def- assert-expr-special-forms
+  ;; Special forms and structured-syntax macros that must not be treated as
+  ;; regular function calls when dispatching `is` assertions.
+  (hash-set 'def 'fn 'if 'do 'let 'quote 'loop
+            'recur 'throw 'try 'ns 'set!
+            'defn 'defn- 'defmacro 'when 'when-not
+            'cond 'case 'binding 'for 'dofor 'doseq))
+
 (defmethod assert-expr :default [form message]
   (let [head (when (list? form) (first form))
-        ;; Only treat as function call if head is a symbol that's NOT
-        ;; a special form or common macro with structured syntax
         fn-call (and (symbol? head)
-                     (not (contains?
-                            (hash-set 'def 'fn 'if 'do 'let 'quote 'loop
-                                      'recur 'throw 'try 'ns 'set!
-                                      'defn 'defn- 'defmacro 'when 'when-not
-                                      'cond 'case 'binding 'for 'dofor 'doseq)
-                            head)))]
+                     (not (contains? assert-expr-special-forms head)))]
     (cond
       (and fn-call (= 3 (count form)))
       (assert-binary form message false)


### PR DESCRIPTION
## 🤔 Background

While scanning `src/phel/*.phel` for cleanup opportunities, a handful of functions in `core.phel` and `test.phel` still used nested `if` chains and rebuilt a sizable `hash-set` on every call. All easy to flatten without touching behavior.

## 💡 Goal

Make core/test Phel sources easier to read and slightly cheaper to run, without changing any public API or semantics.

## 🔖 Changes

- `core.phel`: `find`, `find-index`, and the 2-arity `some?` use `cond` instead of nested `if`
- `core.phel`: `take` transducer replaces `(not (php/> nn 0))` with `(php/<= nn 0)`
- `test.phel`: `report` collapses two nested `if` branches into `cond`
- `test.phel`: extract the 20-symbol special-form set in `assert-expr :default` to a module-level `def-` constant so it is built once, not per call

No behavior change — full quality + compiler (1950) + core (3414) suites pass.