### PR TITLE
feat(router): DX and performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,21 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Reader & Compiler
-- `(ClassName. args)` constructor shorthand expands to `(php/new ClassName args)`, including namespaced classes like `\Some\Class.` (#1359)
-- `#uuid "…"` tagged literal reads as a canonical lowercase UUID string (#1376)
+- `(ClassName. args)` constructor shorthand, including namespaced classes like `\Some\Class.` (#1359)
+- `#uuid "…"` tagged literal, reads as a canonical lowercase UUID string (#1376)
 
 #### Predicates
-- `ident?`, `simple-ident?`, `simple-keyword?`, `simple-symbol?` for symbol/keyword introspection (#1369, #1381)
-- `special-symbol?` — true if a symbol names a special form (#1384)
-- `ifn?` — true if the argument is callable as a function (#1370)
-- `neg-int?`, `pos-int?`, `nat-int?` integer predicates (#1374)
-- `sequential?` — true for ordered collections (vectors, lists, lazy sequences) (#1380)
-- `seqable?` — true if `seq` is supported for the argument (#1379)
+- `ident?`, `simple-ident?`, `simple-keyword?`, `simple-symbol?` (#1369, #1381)
+- `special-symbol?` (#1384), `ifn?` (#1370)
+- `neg-int?`, `pos-int?`, `nat-int?` (#1374)
+- `sequential?` (#1380), `seqable?` (#1379)
 
 #### Sequences & Collections
 - `nth`, `nthrest`, `nthnext` with Clojure-compatible semantics (#1375)
-- `fnext` — equivalent to `(first (next coll))` (#1368)
-- `rseq` and `reversible?` — constant-time reverse view of a vector or sorted-map (#1378)
-- `empty` — returns an empty collection of the same type, or nil (#1365)
-- `key` and `val` for extracting from a map entry (#1372)
+- `fnext`, equivalent to `(first (next coll))` (#1368)
+- `rseq` and `reversible?`: constant-time reverse view of a vector or sorted-map (#1378)
+- `empty`: returns an empty collection of the same type, or nil (#1365)
+- `key` and `val` for map entries (#1372)
 - `(keyword ns name)` arity for namespaced keywords (#1428)
 - `mapcat` accepts multiple collections, zipping elements into `f` (#1428)
 - Transient vectors, maps, and sets are callable like their persistent counterparts (#1428)
@@ -31,41 +29,41 @@ All notable changes to this project will be documented in this file.
 #### PHP Interop
 - `aget` and `aset` for PHP array access and mutation, with nested index support (#1356)
 - `int-array`, `long-array`, `float-array`, `double-array`, `short-array` typed array constructors (#1382)
-- `int`, `long`, `short` coercion functions for Clojure compatibility (#1371, #1383)
-- `uuid?` and `parse-uuid` complementing the existing `random-uuid` (#1377)
-- `alter-var-root` stub that throws `BadMethodCallException` with a migration hint; documented as out of scope in `docs/clojure-migration.md` (#1357)
+- `int`, `long`, `short` coercion functions (#1371, #1383)
+- `uuid?` and `parse-uuid` (#1377)
+- `alter-var-root` stub that throws with a migration hint; out of scope per `docs/clojure-migration.md` (#1357)
 - `parse-double` accepts `Infinity`, `-Infinity`, and `NaN` (#1428)
 
 #### Modules
-- `phel\router`: data-driven router built on `symfony/routing`, previously shipped separately as `phel-lang/router`
-- `phel\router` `routes` introspection, `:route-name` on `match-by-path`, and per-case error handlers (`:not-found`, `:method-not-allowed`, `:not-acceptable`) on `handler`
-- `phel\http-client` — outbound HTTP requests over PHP streams
-- `phel\ai` — chat, completions, structured extraction, tool use, embeddings, semantic search
+- `phel\router`: data-driven router built on `symfony/routing`, previously shipped as `phel-lang/router`
+- `phel\router`: `routes` introspection, `:route-name` on `match-by-path`, and per-case error handlers (`:not-found`, `:method-not-allowed`, `:not-acceptable`) on `handler`
+- `phel\http-client`: outbound HTTP requests over PHP streams
+- `phel\ai`: chat, completions, structured extraction, tool use, embeddings, semantic search
 - `phel\repl` AI helpers: `explain`, `suggest`, `fix`, `review`, `embed-ns`, `search-ns`
 
 ### Fixed
 
-- `keyword` is idempotent on keywords and handles `nil` / symbol input (#1428)
+- `keyword` is idempotent and handles `nil` / symbol input (#1428)
 - `dissoc` accepts zero keys and reduces over variadic key lists (#1428)
 - `keys` / `vals` return `nil` for `nil` or empty collections (#1428)
-- `make-hierarchy` exposes `:parents`, `:descendants`, and `:ancestors` keys (#1428)
+- `make-hierarchy` exposes `:parents`, `:descendants`, `:ancestors` (#1428)
 - `first` on a map returns its first entry, so `ffirst` / `nfirst` work on maps (#1428)
-- `str` preserves float representation — `(str 0.0)` → `"0.0"`, readable `NaN` / `±Infinity` (#1428)
-- `compare` throws `InvalidArgumentException` on cross-category arguments; `nil` stays less than every non-nil value (#1428)
+- `str` preserves float representation: `(str 0.0)` → `"0.0"`, readable `NaN` / `±Infinity` (#1428)
+- `compare` throws on cross-category arguments; `nil` stays less than every non-nil value (#1428)
 - `:keyword` lookup works on transient maps (#1428)
-- `deftest` rejects a missing/non-symbol name with a clear `InvalidArgumentException` instead of crashing inside macro expansion (#1364)
-- `(def name)` without a value no longer throws; binds `nil`, matching Clojure (#1361)
-- `doseq` accepts Clojure-style pairs `(doseq [x coll] body)` without requiring the `:in` verb (#1362)
-- `drop-last` works with lazy sequences and ranges, returning a lazy sequence (#1360)
-- `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences instead of `count` (#1366)
+- `deftest` rejects a missing/non-symbol name with a clear error (#1364)
+- `(def name)` without a value binds `nil` instead of throwing (#1361)
+- `doseq` accepts Clojure-style pairs `[x coll]` without `:in` (#1362)
+- `drop-last` works with lazy sequences and ranges (#1360)
+- `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
 - `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
-- `phel\router` default error dispatch correctly returns 404/405/406 (previously always 404); `:not-acceptable` returns HTTP 406 (was 405)
+- `phel\router`: default error dispatch returns 404/405/406 correctly (was always 404); `:not-acceptable` returns 406 (was 405)
 
 ### Changed
 
 - Reorganized Phel test files: dissolved `core.phel` into topic files under `core/`; moved `comments.phel`, `special-forms.phel`, `multi-arity-fn.phel` into `core/`
-- `phel\router` caches the Symfony matcher/generator and precompiles middleware dispatch at `handler` construction; per-request work is two hash-map lookups
+- `phel\router`: caches Symfony matcher/generator, precompiles middleware dispatch at `handler` construction; per-request work is two hash-map lookups
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 
 #### Modules
 - `phel\router`: data-driven router built on `symfony/routing`, previously shipped separately as `phel-lang/router`
+- `phel\router` `routes` introspection, `:route-name` on `match-by-path`, and per-case error handlers (`:not-found`, `:method-not-allowed`, `:not-acceptable`) on `handler`
 - `phel\http-client` — outbound HTTP requests over PHP streams
 - `phel\ai` — chat, completions, structured extraction, tool use, embeddings, semantic search
 - `phel\repl` AI helpers: `explain`, `suggest`, `fix`, `review`, `embed-ns`, `search-ns`
@@ -59,10 +60,12 @@ All notable changes to this project will be documented in this file.
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences instead of `count` (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
 - `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
+- `phel\router` default error dispatch correctly returns 404/405/406 (previously always 404); `:not-acceptable` returns HTTP 406 (was 405)
 
 ### Changed
 
 - Reorganized Phel test files: dissolved `core.phel` into topic files under `core/`; moved `comments.phel`, `special-forms.phel`, `multi-arity-fn.phel` into `core/`
+- `phel\router` caches the Symfony matcher/generator and precompiles middleware dispatch at `handler` construction; per-request work is two hash-map lookups
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -69,31 +69,6 @@
 (defn- default-response [status body]
   (constantly (h/response-from-map {:status status :body body})))
 
-(defn- create-default-handler
-  "Create a default handler that handles the following cases, configured via options.
-
-   | key                   | description |
-   | ----------------------|-------------|
-   | `:not-found`          | 404, no route matches
-   | `:method-not-allowed` | 405, no method matches
-   | `:not-acceptable`     | 406, handler returned `nil`"
-  [{:not-found          not-found
-    :method-not-allowed method-not-allowed
-    :not-acceptable     not-acceptable
-    :or {not-found          (default-response 404 "Not found")
-         method-not-allowed (default-response 405 "Method not allowed")
-         not-acceptable     (default-response 405 "Not acceptable")}}]
-  (fn [request]
-    (if-let [route (get-in request [:attributes :route])]
-      (let [method (-> request :method name php/strtolower keyword)]
-        (if (find-handler route method nil)
-          (not-acceptable request)
-          (method-not-allowed request)))
-      (not-found request))))
-
-(defn- enrich-request [request match route-data]
-  (update request :attributes merge {:match match :route-data route-data}))
-
 (definterface Router
               (routes [this] "Returns all registered routes as a vector of [path data] tuples.")
               (match-by-path [this path] "Matches a route given a path. Returns nil if path doesn't match.")
@@ -217,16 +192,33 @@
         ,indexed-routes))))
 
 (defn handler
-  "Returns a function request -> response that can be used to handle a route request."
+  "Returns a function request -> response that can be used to handle a route request.
+
+  Options:
+
+  | key                   | description |
+  | ----------------------|-------------|
+  | `:middleware`         | global middleware applied to every matched route
+  | `:default-handler`    | fallback used for any 404/405/406 case not covered by a specific override
+  | `:not-found`          | handler invoked when no route matches (HTTP 404)
+  | `:method-not-allowed` | handler invoked when the path matches but no handler exists for the request method (HTTP 405)
+  | `:not-acceptable`     | handler invoked when a matched handler returns `nil` (HTTP 406)"
   [router & [options]]
-  (let [{:default-handler default-handler
-         :middleware      middleware
+  (let [{:middleware         middleware
+         :default-handler    default-handler
+         :not-found          not-found
+         :method-not-allowed method-not-allowed
+         :not-acceptable     not-acceptable
          :or {middleware []}} (or options {})
-        default-handler (or default-handler (create-default-handler {}))]
+        not-found          (or not-found          default-handler (default-response 404 "Not found"))
+        method-not-allowed (or method-not-allowed default-handler (default-response 405 "Method not allowed"))
+        not-acceptable     (or not-acceptable     default-handler (default-response 406 "Not acceptable"))]
     (fn [request]
       (if-let [match (match-by-path router (get-in request [:uri :path]))]
         (let [method (-> request :method name php/strtolower keyword)
-              [handler route-data] (or (find-handler match method middleware) [default-handler {}])
-              request (enrich-request request match route-data)]
-          (or (handler request) (default-handler request)))
-        (default-handler request)))))
+              request (assoc-in request [:attributes :match] match)]
+          (if-let [[handler route-data] (find-handler match method middleware)]
+            (or (handler (assoc-in request [:attributes :route-data] route-data))
+                (not-acceptable request))
+            (method-not-allowed request)))
+        (not-found request)))))

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -37,7 +37,14 @@
           (walk-many (keep identity childs) full-path next-data))))))
 
 (defn flatten-routes
-  "Flattens nested routes to a vector of tuples [path data]."
+  "Flattens nested routes to a vector of `[path data]` tuples.
+
+  Parent paths are concatenated with their children's paths and parent data
+  maps are deep-merged into their children's data. `path-prefix` and
+  `common-data` are merged into every route and let you mount a subtree under
+  a prefix or share data across all routes."
+  {:example "(flatten-routes [\"/api\" {:middleware [:auth]}\n                 [\"/ping\" {:handler :ping}]] \"\" {})\n; => [[\"/api/ping\" {:middleware [:auth] :handler :ping}]]"
+   :see-also ["router" "compiled-router"]}
   [raw-routes path-prefix common-data]
   (walk-one raw-routes path-prefix common-data))
 
@@ -185,7 +192,22 @@
                      (generate-with generator route-name parameters)))
 
 (defn router
-  "Builds a router"
+  "Builds a dynamic `Router` from a nested route tree.
+
+  Routes are described as `[path data children*]` where `data` is an optional
+  hash-map. Children inherit their parent's path prefix and have parent data
+  deep-merged into their own. `data` may contain:
+
+  - `:handler` — a 1-arg `request -> response` function (matches any method)
+  - `:middleware` — a vector of `(fn [handler request])` wrappers
+  - `:name` — a keyword used for URL generation via `match-by-name` / `generate`
+  - method keys (`:get`, `:post`, …) — nested maps with their own `:handler`
+    and `:middleware` that apply only for that HTTP method
+
+  `options` accepts `:path` (prefix prepended to every route) and `:data`
+  (merged into every route's data)."
+  {:example "(router [[\"/ping\" {:get {:handler pong}}]])"
+   :see-also ["compiled-router" "handler" "match-by-path"]}
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or options {})
         normalized (vec (flatten-routes raw-routes path data))
@@ -206,7 +228,16 @@
                      (generate-with generator route-name parameters)))
 
 (defmacro compiled-router
-  "Builds a compiled router"
+  "Like `router` but performs Symfony's route compilation at macro-expansion
+  time. The resulting router uses Symfony's `CompiledUrlMatcher`/`Generator`
+  which are ~3x faster than their dynamic counterparts for large route
+  tables.
+
+  Because compilation runs during macro expansion, `raw-routes` must be a
+  literal vector at the call site — it cannot be built from runtime values.
+  Use `router` if your routes are dynamic."
+  {:example "(compiled-router [[\"/ping\" {:get {:handler pong}}]])"
+   :see-also ["router" "handler"]}
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or (eval options) {})
         flattened-routes (vec (flatten-routes (eval raw-routes) path data))
@@ -225,7 +256,16 @@
         ,indexed-routes))))
 
 (defn handler
-  "Returns a function request -> response that can be used to handle a route request.
+  "Builds a `request -> response` function from a router.
+
+  Matching flow per request:
+
+  1. Resolve the request's path via `match-by-path`.
+  2. Look up the handler for the request method in the precompiled dispatch
+     table, falling back to the route's method-agnostic `:handler`.
+  3. Invoke the handler with the request enriched with `[:attributes :match]`
+     and `[:attributes :route-data]`. A `nil` response triggers the
+     `:not-acceptable` handler.
 
   Options:
 
@@ -235,7 +275,12 @@
   | `:default-handler`    | fallback used for any 404/405/406 case not covered by a specific override
   | `:not-found`          | handler invoked when no route matches (HTTP 404)
   | `:method-not-allowed` | handler invoked when the path matches but no handler exists for the request method (HTTP 405)
-  | `:not-acceptable`     | handler invoked when a matched handler returns `nil` (HTTP 406)"
+  | `:not-acceptable`     | handler invoked when a matched handler returns `nil` (HTTP 406)
+
+  Dispatch is precompiled at handler construction time, so per-request work
+  is reduced to two hash-map lookups."
+  {:example "(handler (router [[\"/ping\" {:get {:handler pong}}]])\n         {:middleware [logging-mw]\n          :not-found  (fn [_] {:status 404 :body \"nope\"})})"
+   :see-also ["router" "compiled-router"]}
   [router & [options]]
   (let [{:middleware         middleware
          :default-handler    default-handler

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -95,6 +95,7 @@
   (update request :attributes merge {:match match :route-data route-data}))
 
 (definterface Router
+              (routes [this] "Returns all registered routes as a vector of [path data] tuples.")
               (match-by-path [this path] "Matches a route given a path. Returns nil if path doesn't match.")
               (match-by-name [this route-name] "Matches a route given a route name. Returns nil if route can't be found.")
               (generate [this route-name parameter] "Generate a url for a route"))
@@ -159,8 +160,9 @@
   (when-let [[template data] route]
     {:template template :data data}))
 
-(defstruct SymfonyRouter [route-collection]
+(defstruct SymfonyRouter [normalized-routes route-collection]
            Router
+           (routes [this] normalized-routes)
            (match-by-path [this path]
                           (match-with
                            (php/new UrlMatcher route-collection (php/new RequestContext))
@@ -182,12 +184,13 @@
 (defn router
   "Builds a router"
   [raw-routes & [options]]
-  (let [{:path path :data data :or {path "" data {}}} (or options {})]
-    (SymfonyRouter
-     (-> raw-routes (flatten-routes path data) build-route-collection))))
+  (let [{:path path :data data :or {path "" data {}}} (or options {})
+        normalized (vec (flatten-routes raw-routes path data))]
+    (SymfonyRouter normalized (build-route-collection normalized))))
 
-(defstruct CompiledSymfonyRouter [compiled-matcher-routes compiled-generator-routes indexed-routes]
+(defstruct CompiledSymfonyRouter [normalized-routes compiled-matcher-routes compiled-generator-routes indexed-routes]
            Router
+           (routes [this] normalized-routes)
            (match-by-path [this path]
                           (match-with
                            (php/new CompiledUrlMatcher compiled-matcher-routes (php/new RequestContext))
@@ -205,14 +208,14 @@
   "Builds a compiled router"
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or (eval options) {})
-        flattened-routes (flatten-routes (eval raw-routes) path data)
+        flattened-routes (vec (flatten-routes (eval raw-routes) path data))
         indexed-routes (for [route :in flattened-routes
                              :reduce [acc {}]]
                          (put acc (route-name-of route) route))
         route-collection (build-route-collection flattened-routes)
         compiled-matcher-routes (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
         compiled-generator-routes (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))]
-    `(CompiledSymfonyRouter ,compiled-matcher-routes ,compiled-generator-routes ,indexed-routes)))
+    `(CompiledSymfonyRouter ,flattened-routes ,compiled-matcher-routes ,compiled-generator-routes ,indexed-routes)))
 
 (defn handler
   "Returns a function request -> response that can be used to handle a route request."

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -54,17 +54,56 @@
 (defn- compile-handler [middlewares handler]
   (partial (compose-middleware middlewares) handler))
 
-(defn- find-handler
-  "Finds the handler for given route match and request-method keyword (:get, :post, ...).
-   If no handler can be found nil is returned."
-  [match request-method middleware]
-  (let [route-data (:data match)
-        data (if-let [method-data (get route-data request-method)]
-               (deep-merge route-data method-data)
-               route-data)
-        middleware (concat middleware (get data :middleware []))]
-    (when-let [handler (:handler data)]
-      [(compile-handler middleware handler) data])))
+(defn- route-name-of
+  "Returns the Symfony route name for a `[path data]` tuple, falling back to
+   the path when `:name` isn't provided."
+  [route]
+  (let [[path data] route]
+    (if-let [name (get data :name)]
+      (full-name name)
+      path)))
+
+(def- http-method-keys
+  [:get :post :put :patch :delete :head :options])
+
+(defn- compile-route-dispatch
+  "For a single `[path data]` route and the global middleware, returns a map
+   `{method-kw → [compiled-handler merged-data]}` with an optional `:default`
+   entry for the method-agnostic top-level `:handler`."
+  [[_ data] global-mw]
+  (let [top-mw  (concat global-mw (get data :middleware []))
+        compile (fn [mw h merged]
+                  (when h [(compile-handler mw h) merged]))
+        by-method (reduce
+                   (fn [acc method]
+                     (if-let [md (get data method)]
+                       (let [merged (deep-merge data md)
+                             mw     (concat top-mw (get md :middleware []))]
+                         (if-let [entry (compile mw (:handler merged) merged)]
+                           (assoc acc method entry)
+                           acc))
+                       acc))
+                   {}
+                   http-method-keys)]
+    (if-let [default-entry (compile top-mw (:handler data) data)]
+      (assoc by-method :default default-entry)
+      by-method)))
+
+(defn- compile-dispatch
+  "Builds a `{route-name → method-dispatch-map}` lookup for all routes."
+  [all-routes global-mw]
+  (reduce
+   (fn [acc route]
+     (assoc acc (route-name-of route) (compile-route-dispatch route global-mw)))
+   {}
+   all-routes))
+
+(defn- dispatch-lookup
+  "Returns `[handler data]` for a given route-name and method, or nil."
+  [dispatch route-name method]
+  (let [methods (get dispatch route-name)]
+    (or (get methods method)
+        (get methods :default))))
 
 (defn- default-response [status body]
   (constantly (h/response-from-map {:status status :body body})))
@@ -74,13 +113,6 @@
               (match-by-path [this path] "Matches a route given a path. Returns nil if path doesn't match.")
               (match-by-name [this route-name] "Matches a route given a route name. Returns nil if route can't be found.")
               (generate [this route-name parameter] "Generate a url for a route"))
-
-(defn- route-name-of
-  "Returns the Symfony route name for a `[path data]` tuple, falling back to a
-   synthetic name when `:name` isn't provided."
-  [route]
-  (let [[_ data] route]
-    (full-name (get data :name (str "_unnamed_route_" route)))))
 
 (defn- build-route-collection [normalized-routes]
   (for [route :in normalized-routes
@@ -115,7 +147,8 @@
     (let [parameters (php/-> matcher (match path))
           route-name (php/aget parameters "_route")
           [template data] (lookup-fn route-name)]
-      {:template    template
+      {:route-name  route-name
+       :template    template
        :data        data
        :path        path
        :path-params (extract-path-params parameters)})
@@ -212,12 +245,13 @@
          :or {middleware []}} (or options {})
         not-found          (or not-found          default-handler (default-response 404 "Not found"))
         method-not-allowed (or method-not-allowed default-handler (default-response 405 "Method not allowed"))
-        not-acceptable     (or not-acceptable     default-handler (default-response 406 "Not acceptable"))]
+        not-acceptable     (or not-acceptable     default-handler (default-response 406 "Not acceptable"))
+        dispatch           (compile-dispatch (routes router) middleware)]
     (fn [request]
       (if-let [match (match-by-path router (get-in request [:uri :path]))]
         (let [method (-> request :method name php/strtolower keyword)
               request (assoc-in request [:attributes :match] match)]
-          (if-let [[handler route-data] (find-handler match method middleware)]
+          (if-let [[handler route-data] (dispatch-lookup dispatch (:route-name match) method)]
             (or (handler (assoc-in request [:attributes :route-data] route-data))
                 (not-acceptable request))
             (method-not-allowed request)))

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -160,13 +160,11 @@
   (when-let [[template data] route]
     {:template template :data data}))
 
-(defstruct SymfonyRouter [normalized-routes route-collection]
+(defstruct SymfonyRouter [normalized-routes route-collection matcher generator]
            Router
            (routes [this] normalized-routes)
            (match-by-path [this path]
-                          (match-with
-                           (php/new UrlMatcher route-collection (php/new RequestContext))
-                           path
+                          (match-with matcher path
                            (fn [route-name]
                              (let [route (php/-> route-collection (get route-name))]
                                [(php/-> route (getOption "template"))
@@ -176,33 +174,28 @@
                             {:template (php/-> route (getOption "template"))
                              :data     (php/-> route (getOption "data"))}))
            (generate [this route-name parameters]
-                     (generate-with
-                      (php/new UrlGenerator route-collection (php/new RequestContext))
-                      route-name
-                      parameters)))
+                     (generate-with generator route-name parameters)))
 
 (defn router
   "Builds a router"
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or options {})
-        normalized (vec (flatten-routes raw-routes path data))]
-    (SymfonyRouter normalized (build-route-collection normalized))))
+        normalized (vec (flatten-routes raw-routes path data))
+        coll (build-route-collection normalized)
+        ctx (php/new RequestContext)]
+    (SymfonyRouter normalized coll
+                   (php/new UrlMatcher coll ctx)
+                   (php/new UrlGenerator coll ctx))))
 
-(defstruct CompiledSymfonyRouter [normalized-routes compiled-matcher-routes compiled-generator-routes indexed-routes]
+(defstruct CompiledSymfonyRouter [normalized-routes matcher generator indexed-routes]
            Router
            (routes [this] normalized-routes)
            (match-by-path [this path]
-                          (match-with
-                           (php/new CompiledUrlMatcher compiled-matcher-routes (php/new RequestContext))
-                           path
-                           |(get indexed-routes $)))
+                          (match-with matcher path |(get indexed-routes $)))
            (match-by-name [this route-name]
                           (indexed-route->match (get indexed-routes (full-name route-name))))
            (generate [this route-name parameters]
-                     (generate-with
-                      (php/new CompiledUrlGenerator compiled-generator-routes (php/new RequestContext))
-                      route-name
-                      parameters)))
+                     (generate-with generator route-name parameters)))
 
 (defmacro compiled-router
   "Builds a compiled router"
@@ -214,8 +207,14 @@
                          (put acc (route-name-of route) route))
         route-collection (build-route-collection flattened-routes)
         compiled-matcher-routes (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
-        compiled-generator-routes (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))]
-    `(CompiledSymfonyRouter ,flattened-routes ,compiled-matcher-routes ,compiled-generator-routes ,indexed-routes)))
+        compiled-generator-routes (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))
+        ctx (gensym)]
+    `(let [,ctx (php/new \Symfony\Component\Routing\RequestContext)]
+       (CompiledSymfonyRouter
+        ,flattened-routes
+        (php/new \Symfony\Component\Routing\Matcher\CompiledUrlMatcher ,compiled-matcher-routes ,ctx)
+        (php/new \Symfony\Component\Routing\Generator\CompiledUrlGenerator ,compiled-generator-routes ,ctx)
+        ,indexed-routes))))
 
 (defn handler
   "Returns a function request -> response that can be used to handle a route request."

--- a/tests/phel/test/router.phel
+++ b/tests/phel/test/router.phel
@@ -127,3 +127,34 @@
         app (r/handler test-router {:middleware [(mv :top)] :default-handler (constantly nil)})]
     (is (= nil (app (req "/favicon.ico"))) "not found")
     (is (= {:status 200 :body [:top :api :ok]} (app (req "/api/get" "GET"))) "on match")))
+
+(defn- status [response]
+  (get response :status))
+
+(deftest default-error-dispatch
+  (let [test-router (r/router [["/ping" {:get {:handler (constantly {:status 200 :body "pong"})}}]
+                               ["/silent" {:get {:handler (constantly nil)}}]])
+        app (r/handler test-router)]
+    (is (= 404 (status (app (req "/nowhere")))) "no match returns 404")
+    (is (= 405 (status (app (req "/ping" "POST")))) "path matches but method has no handler returns 405")
+    (is (= 406 (status (app (req "/silent" "GET")))) "handler returned nil returns 406")
+    (is (= 200 (status (app (req "/ping" "GET")))) "happy path returns handler response")))
+
+(deftest per-case-error-handlers
+  (let [test-router (r/router [["/ping" {:get {:handler (constantly nil)}}]])
+        app (r/handler test-router
+                       {:not-found          (constantly {:status 404 :body "custom 404"})
+                        :method-not-allowed (constantly {:status 405 :body "custom 405"})
+                        :not-acceptable     (constantly {:status 406 :body "custom 406"})})]
+    (is (= "custom 404" (:body (app (req "/nowhere")))) "custom not-found handler is used")
+    (is (= "custom 405" (:body (app (req "/ping" "POST")))) "custom method-not-allowed handler is used")
+    (is (= "custom 406" (:body (app (req "/ping" "GET")))) "custom not-acceptable handler is used")))
+
+(deftest default-handler-is-catch-all
+  (let [test-router (r/router [["/ping" {:get {:handler (constantly nil)}}]])
+        app (r/handler test-router
+                       {:default-handler    (constantly {:status 500 :body "fallback"})
+                        :method-not-allowed (constantly {:status 405 :body "specific 405"})})]
+    (is (= "fallback" (:body (app (req "/nowhere")))) ":default-handler handles 404 when :not-found is omitted")
+    (is (= "specific 405" (:body (app (req "/ping" "POST")))) "specific per-case override wins over :default-handler")
+    (is (= "fallback" (:body (app (req "/ping" "GET")))) ":default-handler handles 406 when :not-acceptable is omitted")))

--- a/tests/phel/test/router.phel
+++ b/tests/phel/test/router.phel
@@ -1,7 +1,7 @@
 (ns phel-test\test\router
   (:require phel\http :as h)
   (:require phel\test :refer [deftest is])
-  (:require phel\router :as r :refer [match-by-path match-by-name generate])
+  (:require phel\router :as r :refer [routes match-by-path match-by-name generate])
   (:use Symfony\Component\Routing\Exception\RouteNotFoundException)
   (:use Symfony\Component\Routing\Exception\MissingMandatoryParametersException))
 
@@ -36,6 +36,16 @@
      (is (= nil (match-by-name (~mk-router [["/ping/{id}" {:name ::ping}]]) ::pong))
          "route with name not found")))
 
+(defmacro ^:private routes-asserts [mk-router]
+  `(do
+     (is (= [["/ping" {}]]
+            (routes (~mk-router ["/ping"])))
+         "single static route is returned as [path data]")
+     (is (= [["/api/users" {:name ::users}] ["/api/posts" {:name ::posts}]]
+            (routes (~mk-router ["/api" [["/users" {:name ::users}]
+                                         ["/posts" {:name ::posts}]]])))
+         "nested routes are flattened with merged path and data")))
+
 (defmacro ^:private generate-asserts [mk-router]
   `(do
      (is (= "/ping" (generate (~mk-router [["/ping" {:name ::ping}]]) ::ping {}))
@@ -69,6 +79,12 @@
 
 (deftest test-generate-compiled-router
   (generate-asserts r/compiled-router))
+
+(deftest test-routes
+  (routes-asserts r/router))
+
+(deftest test-routes-compiled-router
+  (routes-asserts r/compiled-router))
 
 (defn- fnil [f x]
   (fn [a & args]

--- a/tests/phel/test/router.phel
+++ b/tests/phel/test/router.phel
@@ -159,3 +159,52 @@
     (is (= "fallback" (:body (app (req "/nowhere")))) ":default-handler handles 404 when :not-found is omitted")
     (is (= "specific 405" (:body (app (req "/ping" "POST")))) "specific per-case override wins over :default-handler")
     (is (= "fallback" (:body (app (req "/ping" "GET")))) ":default-handler handles 406 when :not-acceptable is omitted")))
+
+(deftest default-error-bodies
+  (let [app (r/handler (r/router [["/ping" {:get  {:handler (constantly {:status 200 :body "pong"})}
+                                            :post {:handler (constantly nil)}}]]))]
+    (is (= "Not found"          (:body (app (req "/nowhere"))))      "404 body")
+    (is (= "Method not allowed" (:body (app (req "/ping" "PUT"))))   "405 body")
+    (is (= "Not acceptable"     (:body (app (req "/ping" "POST"))))  "406 body")))
+
+(deftest request-enrichment
+  (let [captured (atom nil)
+        capture  (fn [request] (reset! captured request) {:status 200 :body "ok"})
+        test-router (r/router [["/hello/{who}" {:name ::hello :get {:handler capture}}]])
+        app (r/handler test-router)]
+    (app (req "/hello/world" "GET"))
+    (let [attrs (get @captured :attributes)
+          match (:match attrs)
+          rd    (:route-data attrs)]
+      (is (= "phel-test\\test\\router/hello" (:route-name match))
+          "match exposes the route's :route-name")
+      (is (= "/hello/{who}" (:template match))
+          "match exposes the route template")
+      (is (= {:who "world"} (:path-params match))
+          "match exposes captured path params")
+      (is (= ::hello (:name rd))
+          ":route-data is the method-merged data map")
+      (is (contains? rd :handler)
+          ":route-data carries the resolved :handler entry"))))
+
+(deftest error-handlers-see-match
+  (let [captured-405 (atom nil)
+        captured-406 (atom nil)
+        test-router (r/router
+                     [["/ping" {:name ::ping
+                                :get  {:handler (constantly nil)}}]])
+        app (r/handler test-router
+                       {:method-not-allowed
+                        (fn [req] (reset! captured-405 req) {:status 405})
+                        :not-acceptable
+                        (fn [req] (reset! captured-406 req) {:status 406})})]
+    (app (req "/ping" "POST"))
+    (app (req "/ping" "GET"))
+    (is (= "phel-test\\test\\router/ping"
+           (get-in @captured-405 [:attributes :match :route-name]))
+        ":method-not-allowed handler sees the matched route")
+    (is (= "phel-test\\test\\router/ping"
+           (get-in @captured-406 [:attributes :match :route-name]))
+        ":not-acceptable handler sees the matched route")
+    (is (nil? (get-in @captured-405 [:attributes :route-data]))
+        "405 request is not enriched with :route-data (no handler matched)")))

--- a/tests/phel/test/router.phel
+++ b/tests/phel/test/router.phel
@@ -11,15 +11,16 @@
 
 (defmacro ^:private match-by-path-asserts [mk-router]
   `(do
-     (is (= {:template "/ping" :data {} :path "/ping" :path-params {}}
+     (is (= {:route-name "/ping" :template "/ping" :data {} :path "/ping" :path-params {}}
             (match-by-path (~mk-router ["/ping"]) "/ping"))
          "single static route")
      (is (= nil (match-by-path (~mk-router ["/ping"]) "/pong"))
          "no matching static route")
-     (is (= {:template "/pong" :data {} :path "/pong" :path-params {}}
+     (is (= {:route-name "/pong" :template "/pong" :data {} :path "/pong" :path-params {}}
             (match-by-path (~mk-router [["/ping"] ["/pong"]]) "/pong"))
          "two static route")
-     (is (= {:template "/ping/{id<\\d+>}" :data {:name ::ping} :path "/ping/123" :path-params {:id "123"}}
+     (is (= {:route-name "phel-test\\test\\router/ping"
+             :template "/ping/{id<\\d+>}" :data {:name ::ping} :path "/ping/123" :path-params {:id "123"}}
             (match-by-path (~mk-router [["/ping/{id<\\d+>}" {:name ::ping}]]) "/ping/123"))
          "route with path parameter")
      (is (= nil (match-by-path (~mk-router [["/ping/{id<\d+>}" {:name ::ping}]]) "/ping/abc"))


### PR DESCRIPTION
## 🤔 Background

`phel\router` worked for the happy path but left a few sharp edges: every request paid for a fresh `RequestContext`, matcher/generator, and middleware composition; the default error dispatch always returned 404 because `create-default-handler` read a key the router never wrote; and there was no way to introspect registered routes.

## 💡 Goal

Make `phel\router` both faster and nicer to use — correct error handling, per-case overrides, route introspection, precompiled dispatch, and real docstrings.

## 🔖 Changes

- `routes` method on the `Router` interface to enumerate registered routes.
- Cache Symfony matcher, generator, and `RequestContext` on the router struct.
- Correct 404/405/406 dispatch (previously collapsed to 404); `:not-acceptable` returns HTTP 406 (was 405); expose `:not-found` / `:method-not-allowed` / `:not-acceptable` as peer options alongside `:default-handler`.
- Precompile `{route-name → {method-or-:default → [handler data]}}` at `handler` construction so per-request work is two hash-map lookups.
- Docstrings with `:example` and `:see-also` on `router`, `compiled-router`, `handler`, `flatten-routes`; match results now expose `:route-name`.