### PR TITLE
fix: unblock clojure-test-suite (fail-soft runner, nested class, ratio literals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
 - `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
+- `defstruct`/`defrecord`/`defexception`/`definterface` inside another function body (e.g. a `defrecord` used inside a `deftest`) no longer triggers a PHP fatal "Class declarations may not be nested"; the class is lifted out via `eval()` when the surrounding code emits a PHP class body
 - `phel\router`: default error dispatch returns 404/405/406 correctly (was always 404); `:not-acceptable` returns 406 (was 405)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 #### Reader & Compiler
 - `(ClassName. args)` constructor shorthand, including namespaced classes like `\Some\Class.` (#1359)
 - `#uuid "…"` tagged literal, reads as a canonical lowercase UUID string (#1376)
-- Clojure ratio literals (`1/2`, `-3/4`, `0/2`) read as their float equivalent; Phel has no rational type, so `.cljc` sources using ratios now parse without error. A zero denominator yields `INF`/`-INF`/`NaN` instead of aborting the compile
+- Ratio literals `N/M` (e.g. `1/2`, `-3/4`), read as `num / den`; `1/0` → `INF`, `0/0` → `NaN`
 
 #### Predicates
 - `ident?`, `simple-ident?`, `simple-keyword?`, `simple-symbol?` (#1369, #1381)
@@ -59,14 +59,14 @@ All notable changes to this project will be documented in this file.
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)
 - `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
-- `defstruct`/`defrecord`/`defexception`/`definterface` inside another function body (e.g. a `defrecord` used inside a `deftest`) no longer triggers a PHP fatal "Class declarations may not be nested"; the class is lifted out via `eval()` when the surrounding code emits a PHP class body
+- `defstruct`/`defrecord`/`defexception`/`definterface` nested in a function body (e.g. a `defrecord` inside a `deftest`) no longer triggers "Class declarations may not be nested"
 - `phel\router`: default error dispatch returns 404/405/406 correctly (was always 404); `:not-acceptable` returns 406 (was 405)
 
 ### Changed
 
 - Reorganized Phel test files: dissolved `core.phel` into topic files under `core/`; moved `comments.phel`, `special-forms.phel`, `multi-arity-fn.phel` into `core/`
 - `phel\router`: caches Symfony matcher/generator, precompiles middleware dispatch at `handler` construction; per-request work is two hash-map lookups
-- `phel test` no longer aborts the whole run when one file fails to compile: it reports the failures, skips the affected files, and continues. Pass `--fail-fast` for the previous stop-on-first-error behavior
+- `phel test` skips files that fail to compile and continues the run; pass `--fail-fast` for the previous abort-on-first-error behavior
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 #### Reader & Compiler
 - `(ClassName. args)` constructor shorthand, including namespaced classes like `\Some\Class.` (#1359)
 - `#uuid "…"` tagged literal, reads as a canonical lowercase UUID string (#1376)
+- Clojure ratio literals (`1/2`, `-3/4`, `0/2`) read as their float equivalent; Phel has no rational type, so `.cljc` sources using ratios now parse without error. A zero denominator yields `INF`/`-INF`/`NaN` instead of aborting the compile
 
 #### Predicates
 - `ident?`, `simple-ident?`, `simple-keyword?`, `simple-symbol?` (#1369, #1381)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project will be documented in this file.
 
 - Reorganized Phel test files: dissolved `core.phel` into topic files under `core/`; moved `comments.phel`, `special-forms.phel`, `multi-arity-fn.phel` into `core/`
 - `phel\router`: caches Symfony matcher/generator, precompiles middleware dispatch at `handler` construction; per-request work is two hash-map lookups
+- `phel test` no longer aborts the whole run when one file fails to compile: it reports the failures, skips the affected files, and continues. Pass `--fail-fast` for the previous stop-on-first-error behavior
 
 ## [0.32.0](https://github.com/phel-lang/phel-lang/compare/v0.31.0...v0.32.0) - 2026-04-12
 

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -54,6 +54,7 @@ Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still w
 | `##Inf`, `##-Inf`, `##NaN` | Symbolic numeric literal | |
 | `2r1111`, `16rFF` | Radix literal (bases 2 to 36) | |
 | `1N`, `1.5M` | BigInt / BigDecimal suffix (accepted, truncated to PHP int/float) | |
+| `1/2`, `-3/4` | Ratio literal (accepted, evaluated as float division; `1/0` → `INF`, `0/0` → `NaN`) | |
 | `#"regex"` | Regex literal | |
 | `#?(...)`, `#?@(...)` | Reader conditionals (for `.cljc`) | |
 | `#<tag> form` | Tagged literal dispatch | |
@@ -168,7 +169,7 @@ Phel runs on PHP. A handful of Clojure features don't translate directly:
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
 | **core.async** | No goroutines/CSP | Use `phel\async` (fiber-based via AMPHP) |
-| **BigInt / BigDecimal / Ratio** | PHP number model | Suffix literals (`1N`, `1.5M`) are accepted but truncated to PHP int/float. Use `bcmath` / `gmp` via `php/` interop for real arbitrary precision |
+| **BigInt / BigDecimal / Ratio** | PHP number model | Suffix literals (`1N`, `1.5M`) and ratio literals (`1/2`) are accepted; ratios evaluate to `num / den` as a float. Use `bcmath` / `gmp` via `php/` interop for real arbitrary precision |
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
 | **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -25,6 +25,8 @@ final class OutputEmitter implements OutputEmitterInterface
 {
     private int $indentLevel = 0;
 
+    private int $classScopeDepth = 0;
+
     /** @var array<int, string> */
     private array $indentCache = [];
 
@@ -199,5 +201,20 @@ final class OutputEmitter implements OutputEmitterInterface
     public function decreaseIndentLevel(): void
     {
         --$this->indentLevel;
+    }
+
+    public function enterClassScope(): void
+    {
+        ++$this->classScopeDepth;
+    }
+
+    public function exitClassScope(): void
+    {
+        --$this->classScopeDepth;
+    }
+
+    public function isInsideClassScope(): bool
+    {
+        return $this->classScopeDepth > 0;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -19,17 +19,26 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
     {
         assert($node instanceof DefExceptionNode);
 
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+        if ($this->shouldEmitViaEval()) {
             $this->emitViaEval($node);
         } else {
             $this->emitInline($node);
         }
     }
 
+    private function shouldEmitViaEval(): bool
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            return true;
+        }
+
+        return $this->outputEmitter->isInsideClassScope();
+    }
+
     /**
-     * In statement mode, the class definition may end up inside a function
-     * wrapper. PHP forbids namespace declarations inside functions, so we
-     * capture the class body at compile time and emit it as an eval() call.
+     * Captures the class body at compile time and emits it as an `eval()`
+     * call guarded by `class_exists`. Needed both in statement mode and
+     * when we are inside another class's method body.
      */
     private function emitViaEval(DefExceptionNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefInterfaceEmitter.php
@@ -19,17 +19,27 @@ final class DefInterfaceEmitter implements NodeEmitterInterface
     {
         assert($node instanceof DefInterfaceNode);
 
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+        if ($this->shouldEmitViaEval()) {
             $this->emitViaEval($node);
         } else {
             $this->emitInline($node);
         }
     }
 
+    private function shouldEmitViaEval(): bool
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            return true;
+        }
+
+        return $this->outputEmitter->isInsideClassScope();
+    }
+
     /**
-     * In statement mode, the interface definition may end up inside a function
-     * wrapper. PHP forbids namespace declarations inside functions, so we
-     * capture the interface body at compile time and emit it as an eval() call.
+     * Captures the interface body at compile time and emits it as an
+     * `eval()` call guarded by `interface_exists`. Needed both in
+     * statement mode and when we are inside another class's method body
+     * (where PHP rejects nested declarations).
      */
     private function emitViaEval(DefInterfaceNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -24,7 +24,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     {
         assert($node instanceof DefStructNode);
 
-        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+        if ($this->shouldEmitViaEval()) {
             $this->emitViaEval($node);
         } else {
             $this->emitInline($node);
@@ -32,11 +32,24 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     }
 
     /**
-     * In statement mode, the class definition may end up inside a function
-     * wrapper (when a do-form is in expression context). PHP forbids namespace
-     * declarations inside functions, so we capture the class body at compile
-     * time and emit it as an eval() call. This guarantees the namespace is
-     * always the first statement within its own isolated eval context.
+     * The class declaration must be lifted into an `eval()` when it would
+     * otherwise land somewhere PHP forbids: inside a function wrapper in
+     * statement mode (namespace not allowed), or inside another class's
+     * method body, e.g. `defrecord` used inside a `deftest` body.
+     */
+    private function shouldEmitViaEval(): bool
+    {
+        if ($this->outputEmitter->getOptions()->isStatementEmitMode()) {
+            return true;
+        }
+
+        return $this->outputEmitter->isInsideClassScope();
+    }
+
+    /**
+     * Captures the class body at compile time and emits it as an `eval()`
+     * call guarded by `class_exists`. Works anywhere in the emitted PHP,
+     * because `eval` starts a fresh top-level scope.
      */
     private function emitViaEval(DefStructNode $node): void
     {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -171,6 +171,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
         $this->closureHelper->emitConstructorArguments($node->getUses(), $node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitLine(') extends \Phel\Lang\AbstractFn {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->enterClassScope();
     }
 
     private function emitProperties(FnNode $node): void
@@ -195,6 +196,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
 
     private function emitClassEnd(FnNode $node): void
     {
+        $this->outputEmitter->exitClassScope();
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -78,6 +78,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitLine(') extends \\Phel\\Lang\\AbstractFn {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->enterClassScope();
     }
 
     /**
@@ -198,6 +199,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
 
     private function emitClassEnd(MultiFnNode $node): void
     {
+        $this->outputEmitter->exitClassScope();
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ReifyEmitter.php
@@ -39,12 +39,14 @@ final readonly class ReifyEmitter implements NodeEmitterInterface
         $this->closureHelper->emitConstructorArguments($uses, $env, $loc);
         $this->outputEmitter->emitLine(') {', $loc);
         $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->enterClassScope();
 
         $this->closureHelper->emitProperties($uses, $env, $loc);
         $this->closureHelper->emitConstructor($uses, $env, $loc);
 
         $this->emitMethods($node);
 
+        $this->outputEmitter->exitClassScope();
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitStr('}', $loc);
         $this->outputEmitter->emitContextSuffix($env, $loc);

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -54,4 +54,17 @@ interface OutputEmitterInterface
     public function increaseIndentLevel(): void;
 
     public function decreaseIndentLevel(): void;
+
+    /**
+     * Record that the emitter is now writing into a class body (e.g. the
+     * `__invoke` method of a `new class() extends AbstractFn`). Nested
+     * `defstruct`/`definterface`/`defexception` forms must then emit via
+     * `eval()`, because PHP rejects class declarations nested inside
+     * another class's method body.
+     */
+    public function enterClassScope(): void;
+
+    public function exitClassScope(): void;
+
+    public function isInsideClassScope(): bool;
 }

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -50,6 +50,13 @@ final readonly class AtomParser
      */
     private const string REGEX_BIGDEC_LITERAL = '/^([+-]?\d+(?:_\d+)*(?:\.\d+(?:_\d+)*)?(?:[eE][+-]?\d+)?)M$/';
 
+    /**
+     * Ratio literal, e.g. `1/2`, `-3/4`, `0/5`. Phel has no first-class
+     * rational type, so the literal is parsed as `num / den` using PHP
+     * float division. Accepted mainly for `.cljc` source compatibility.
+     */
+    private const string REGEX_RATIO_LITERAL = '/^([+-]?\d+(?:_\d+)*)\/(\d+(?:_\d+)*)$/';
+
     private const string REGEX_DECIMAL_NUMBER = '/^(?:([+-])?\d+(_\d+)*[\.(_\d+]?|0)$/';
 
     public function __construct(private GlobalEnvironmentInterface $globalEnvironment) {}
@@ -98,6 +105,10 @@ final readonly class AtomParser
 
         if (preg_match(self::REGEX_BIGDEC_LITERAL, $word, $matches)) {
             return $this->parseBigdecLiteral($matches, $word, $token);
+        }
+
+        if (preg_match(self::REGEX_RATIO_LITERAL, $word, $matches)) {
+            return $this->parseRatioLiteral($matches, $word, $token);
         }
 
         if (is_numeric($word)) {
@@ -296,6 +307,22 @@ final readonly class AtomParser
     private function parseBigdecLiteral(array $matches, string $word, Token $token): NumberNode
     {
         $value = (float) str_replace('_', '', (string) $matches[1]);
+
+        return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
+    }
+
+    /**
+     * Parses a ratio literal `N/M` as the float `N / M`. A zero denominator
+     * yields a non-finite float (`NAN` for `0/0`, `INF`/`-INF` otherwise)
+     * rather than a runtime error.
+     */
+    private function parseRatioLiteral(array $matches, string $word, Token $token): NumberNode
+    {
+        $numerator = (float) str_replace('_', '', (string) $matches[1]);
+        $denominator = (float) str_replace('_', '', (string) $matches[2]);
+        $value = $denominator === 0.0
+            ? ($numerator === 0.0 ? NAN : ($numerator > 0 ? INF : -INF))
+            : $numerator / $denominator;
 
         return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
     }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function count;
 use function sprintf;
 
 /**
@@ -74,10 +75,13 @@ final class TestCommand extends Command
             /** @var list<string> $paths */
             $paths = (array) $input->getArgument(self::ARG_PATHS);
             $namespacesInformation = $this->getFacade()->getDependenciesFromPaths($paths);
+            $failFast = (bool) $input->getOption(self::OPT_FAIL_FAST);
 
             // Suppress output during file loading phase and filter out integration test fixtures
             ob_start();
             $filteredNamespaces = [];
+            /** @var list<array{0: NamespaceInformation, 1: Throwable}> $compileErrors */
+            $compileErrors = [];
             foreach ($namespacesInformation as $info) {
                 // Skip integration test fixture files - they are for PHPUnit tests only
                 if (str_contains($info->getFile(), 'tests/php/Integration/')) {
@@ -88,23 +92,36 @@ final class TestCommand extends Command
                     continue;
                 }
 
-                $filteredNamespaces[] = $info;
-
                 try {
                     $this->getFacade()->evalFile($info);
+                    $filteredNamespaces[] = $info;
                 } catch (Throwable $e) {
-                    ob_end_clean();
-                    throw $e;
+                    if ($failFast) {
+                        ob_end_clean();
+                        throw $e;
+                    }
+
+                    $compileErrors[] = [$info, $e];
                 }
             }
 
             ob_end_clean();
+
+            $this->reportCompileErrors($output, $compileErrors);
+
+            if ($filteredNamespaces === []) {
+                return ($compileErrors === []) ? self::SUCCESS : self::FAILURE;
+            }
 
             $phelCode = $this->generatePhelTestCode($input, $filteredNamespaces);
             $compileOptions = (new CompileOptions())->setIsEnabledSourceMaps(false);
             $result = $this->getFacade()->eval($phelCode, $compileOptions);
 
             $output->writeln((new ResourceUsageFormatter())->resourceUsageSinceStartOfRequest());
+
+            if ($compileErrors !== []) {
+                return self::FAILURE;
+            }
 
             return ($result) ? self::SUCCESS : self::FAILURE;
         } catch (CompilerException $e) {
@@ -114,6 +131,30 @@ final class TestCommand extends Command
         }
 
         return self::FAILURE;
+    }
+
+    /**
+     * @param list<array{0: NamespaceInformation, 1: Throwable}> $compileErrors
+     */
+    private function reportCompileErrors(OutputInterface $output, array $compileErrors): void
+    {
+        if ($compileErrors === []) {
+            return;
+        }
+
+        foreach ($compileErrors as [$info, $e]) {
+            $output->writeln(sprintf('<error>Failed to compile %s</error>', $info->getFile()));
+            if ($e instanceof CompilerException) {
+                $this->getFacade()->writeLocatedException($output, $e);
+            } else {
+                $output->writeln($e->getMessage());
+            }
+        }
+
+        $output->writeln(sprintf(
+            '<comment>Skipped %d file(s) due to compile errors; continuing with the rest.</comment>',
+            count($compileErrors),
+        ));
     }
 
     private function generatePhelTestCode(InputInterface $input, array $namespacesInformation): string

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -1,0 +1,47 @@
+--PHEL--
+(def make-foo
+  (fn []
+    (defstruct* foo-inside [a])))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "make-foo",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\make_foo";
+
+    public function __invoke() {
+      if (!class_exists('user\foo_inside')) {
+        eval('namespace user;
+      class foo_inside extends \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct {
+
+        protected const array ALLOWED_KEYS = [\'a\'];
+
+        protected $a;
+
+        public function __construct($a, $meta = null) {
+          parent::__construct();
+          $this->a = $a;
+          $this->meta = $meta;
+        }
+      }
+');
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defstruct-inside-fn-body.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defstruct-inside-fn-body.test",
+      \Phel::keyword("line"), 3,
+      \Phel::keyword("column"), 33
+    ),
+    "min-arity", 0,
+    "is-variadic", false,
+    "arglists", "[]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-nan.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-nan.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x 0/0)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  NAN,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-nan.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-nan.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 11
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative-inf.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative-inf.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x -1/0)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  -INF,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-negative-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-negative-inf.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 12
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x -3/4)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  -0.75,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-negative.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-negative.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 12
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-zero-denominator.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-zero-denominator.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x 1/0)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  INF,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-zero-denominator.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal-zero-denominator.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 11
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/ratio-literal.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x 1/2)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  0.5,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/ratio-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 11
+    )
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Running [jasalt's clojure-test-suite](https://github.com/jasalt/clojure-test-suite) against current `main` was impossible in practice: the first file with a compile error aborted the whole run, so we had zero visibility into the other ~200 test files. Two further PHP-level bugs blocked individual files outright.

## 💡 Goal

Make the `.cljc` compatibility suite runnable end-to-end on stock Phel, and eliminate the three most common blockers surfacing from that run.

## 🔖 Changes

- **`phel test` is fail-soft per file.** Compile errors are reported and skipped; the rest of the suite still runs. Use `--fail-fast` for the old abort-on-first-error behavior.
- **`defstruct`/`defrecord`/`defexception`/`definterface` no longer fatal when nested in a function body.** The emitter now tracks when it is writing into a PHP class body (`FnAsClass`/`MultiFnAsClass`/`Reify`) and lifts class declarations into `eval()` in that case — e.g. a `defrecord` inside a `deftest`.
- **Ratio literals `N/M` accepted.** They read as `num / den` (float), mirroring how `1N`/`1.5M` already strip their suffix; `1/0` → `INF`, `0/0` → `NaN`. Migration doc updated.

End-to-end against the full suite: 3 files skipped (vs 10 before), **Passed 2868 / Total 3679** (jasalt's pre-PR baseline on a hand-stubbed subset: Passed 2579 / Total 3314).