### PR TITLE
fix(core): doseq iterates maps as [k v] pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - `deftest` rejects a missing/non-symbol name with a clear error (#1364)
 - `(def name)` without a value binds `nil` instead of throwing (#1361)
 - `doseq` accepts Clojure-style pairs `[x coll]` without `:in` (#1362)
+- `doseq` iterates maps as `[k v]` entry pairs, so Clojure-style destructuring `(doseq [[k v] m] ...)` and single-binding `(doseq [e m] ...)` match Clojure semantics (#1433)
 - `drop-last` works with lazy sequences and ranges (#1360)
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2011,11 +2011,16 @@ Otherwise, it tries to call `__toString`."
 
 (def- for-verbs (hash-set :in :range :keys :pairs))
 
+(defn- for-verb?
+  "True when `x` is one of the keywords accepted by `for` / `dofor` as a verb."
+  [x]
+  (and (keyword? x) (contains? for-verbs x)))
+
 (defn doseq-iterable
-  "Internal helper used by the `doseq` macro expansion. Returns a collection
+  "Internal helper used by the `doseq` macro expansion. Returns a value
   suitable for Clojure-style iteration: maps are expanded to a sequence of
-  `[k v]` pair vectors so destructuring binds entries as in Clojure, and all
-  other values pass through unchanged."
+  `[k v]` pair vectors so destructuring binds entries as in Clojure. Every
+  other value is returned unchanged."
   [coll]
   (if (map? coll)
     (for [kv :pairs coll] kv)
@@ -2025,11 +2030,6 @@ Otherwise, it tries to call `__toString`."
   "Appends a `[binding verb coll-expr]` triple to the normalized doseq head."
   [head binding verb coll-expr]
   (push (push (push head binding) verb) coll-expr))
-
-(defn- push-modifier-pair
-  "Appends a `[modifier-keyword arg]` pair to the normalized doseq head."
-  [head modifier arg]
-  (push (push head modifier) arg))
 
 (defn- doseq-normalize
   "Transforms Clojure-style doseq bindings into Phel dofor format.
@@ -2047,10 +2047,10 @@ Otherwise, it tries to call `__toString`."
         (cond
           ;; modifier keyword: keep pair as-is
           (keyword? el)
-          (recur (php/+ i 2) (push-modifier-pair result el next-el))
+          (recur (php/+ i 2) (push (push result el) next-el))
 
           ;; explicit verb already present: keep triple as-is
-          (and (keyword? next-el) (contains? for-verbs next-el))
+          (for-verb? next-el)
           (recur (php/+ i 3) (push-binding-triple result el next-el (php/aget head (php/+ i 2))))
 
           ;; Clojure-style pair: insert `:in` with map-aware iteration helper
@@ -2058,10 +2058,12 @@ Otherwise, it tries to call `__toString`."
           (recur (php/+ i 2) (push-binding-triple result el :in `(doseq-iterable ~next-el))))))))
 
 (defmacro doseq
-  "Repeatedly executes body for side effects with bindings.
-  Uses Clojure-style binding pairs: `(doseq [x coll] body)`.
-  Supports :when, :while, :let modifiers."
-  {:example "(doseq [x [1 2 3]] (println x))"}
+  "Repeatedly executes body for side effects with Clojure-style bindings.
+  `(doseq [x coll] body)` runs `body` once per element of `coll`. When `coll`
+  is a map, each iteration sees a `[k v]` entry pair, so destructuring works
+  just like in Clojure: `(doseq [[k v] m] ...)`. Supports `:when`, `:while`,
+  and `:let` modifiers between bindings."
+  {:example "(doseq [x [1 2 3]] (println x))\n(doseq [[k v] {:a 1 :b 2}] (println k v))"}
   [seq-exprs & body]
   (let [normalized (doseq-normalize seq-exprs)]
     `(dofor ~normalized ~@body)))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2011,11 +2011,22 @@ Otherwise, it tries to call `__toString`."
 
 (def- for-verbs (hash-set :in :range :keys :pairs))
 
+(defn doseq-iterable
+  "Internal helper used by the `doseq` macro expansion. Returns a collection
+  suitable for Clojure-style iteration: maps are expanded to a sequence of
+  `[k v]` pair vectors so that destructuring binds entries as in Clojure, and
+  all other values pass through unchanged."
+  [coll]
+  (if (map? coll)
+    (for [[k v] :pairs coll] [k v])
+    coll))
+
 (defn- doseq-normalize
   "Transforms Clojure-style doseq bindings into Phel dofor format.
-  Pairs `[x coll]` become triples `[x :in coll]`. Already-present
-  verb triples `[x :in coll]` pass through unchanged. Modifier keywords
-  like :when, :while, :let pass through unchanged."
+  Pairs `[x coll]` become triples `[x :in (doseq-iterable coll)]` so maps
+  iterate as entry pairs. Already-present verb triples `[x :in coll]` pass
+  through unchanged. Modifier keywords like :when, :while, :let pass through
+  unchanged."
   [head]
   (loop [i 0
          result []]
@@ -2030,8 +2041,8 @@ Otherwise, it tries to call `__toString`."
             (if (and (keyword? next-el) (contains? for-verbs next-el))
               ;; verb already present: keep triple as-is
               (recur (php/+ i 3) (push (push (push result el) next-el) (php/aget head (php/+ i 2))))
-              ;; no verb: insert :in
-              (recur (php/+ i 2) (push (push (push result el) :in) next-el)))))))))
+              ;; no verb: insert :in with map-aware iteration helper
+              (recur (php/+ i 2) (push (push (push result el) :in) `(doseq-iterable ~next-el))))))))))
 
 (defmacro doseq
   "Repeatedly executes body for side effects with bindings.

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2014,35 +2014,48 @@ Otherwise, it tries to call `__toString`."
 (defn doseq-iterable
   "Internal helper used by the `doseq` macro expansion. Returns a collection
   suitable for Clojure-style iteration: maps are expanded to a sequence of
-  `[k v]` pair vectors so that destructuring binds entries as in Clojure, and
-  all other values pass through unchanged."
+  `[k v]` pair vectors so destructuring binds entries as in Clojure, and all
+  other values pass through unchanged."
   [coll]
   (if (map? coll)
-    (for [[k v] :pairs coll] [k v])
+    (for [kv :pairs coll] kv)
     coll))
+
+(defn- push-binding-triple
+  "Appends a `[binding verb coll-expr]` triple to the normalized doseq head."
+  [head binding verb coll-expr]
+  (push (push (push head binding) verb) coll-expr))
+
+(defn- push-modifier-pair
+  "Appends a `[modifier-keyword arg]` pair to the normalized doseq head."
+  [head modifier arg]
+  (push (push head modifier) arg))
 
 (defn- doseq-normalize
   "Transforms Clojure-style doseq bindings into Phel dofor format.
   Pairs `[x coll]` become triples `[x :in (doseq-iterable coll)]` so maps
   iterate as entry pairs. Already-present verb triples `[x :in coll]` pass
-  through unchanged. Modifier keywords like :when, :while, :let pass through
-  unchanged."
+  through unchanged. Modifier keywords like `:when`, `:while`, `:let` pass
+  through unchanged."
   [head]
   (loop [i 0
          result []]
     (if (>= i (count head))
       result
-      (let [el (php/aget head i)]
-        (if (keyword? el)
+      (let [el      (php/aget head i)
+            next-el (php/aget head (php/+ i 1))]
+        (cond
           ;; modifier keyword: keep pair as-is
-          (recur (php/+ i 2) (push (push result el) (php/aget head (php/+ i 1))))
-          ;; binding symbol: check if verb already present
-          (let [next-el (php/aget head (php/+ i 1))]
-            (if (and (keyword? next-el) (contains? for-verbs next-el))
-              ;; verb already present: keep triple as-is
-              (recur (php/+ i 3) (push (push (push result el) next-el) (php/aget head (php/+ i 2))))
-              ;; no verb: insert :in with map-aware iteration helper
-              (recur (php/+ i 2) (push (push (push result el) :in) `(doseq-iterable ~next-el))))))))))
+          (keyword? el)
+          (recur (php/+ i 2) (push-modifier-pair result el next-el))
+
+          ;; explicit verb already present: keep triple as-is
+          (and (keyword? next-el) (contains? for-verbs next-el))
+          (recur (php/+ i 3) (push-binding-triple result el next-el (php/aget head (php/+ i 2))))
+
+          ;; Clojure-style pair: insert `:in` with map-aware iteration helper
+          :else
+          (recur (php/+ i 2) (push-binding-triple result el :in `(doseq-iterable ~next-el))))))))
 
 (defmacro doseq
   "Repeatedly executes body for side effects with bindings.

--- a/tests/phel/test/core/doseq.phel
+++ b/tests/phel/test/core/doseq.phel
@@ -54,3 +54,48 @@
            (swap! captured (fn [xs] (push xs (+ a b)))))
     (is (= [3 7] (deref captured))
         "doseq destructuring over vector of vectors still iterates elements")))
+
+(deftest test-doseq-map-empty
+  (let [captured (var 0)]
+    (doseq [[_ _] {}]
+           (swap! captured inc))
+    (is (= 0 (deref captured)) "doseq over empty map does not execute body")))
+
+(deftest test-doseq-map-with-when
+  (let [captured (var {})]
+    (doseq [[k v] {:a 1 :b 2 :c 3}
+            :when (odd? v)]
+           (swap! captured put k v))
+    (is (= {:a 1 :c 3} (deref captured))
+        "doseq over map honors :when modifier after destructuring")))
+
+(deftest test-doseq-map-with-let
+  (let [captured (var {})]
+    (doseq [[k v] {:a 1 :b 2}
+            :let [v2 (* v 10)]]
+           (swap! captured put k v2))
+    (is (= {:a 10 :b 20} (deref captured))
+        "doseq over map supports :let over destructured bindings")))
+
+(deftest test-doseq-set-iterates-values
+  (let [captured (var #{})]
+    (doseq [x #{:a :b :c}]
+           (swap! captured (fn [s] (conj s x))))
+    (is (= #{:a :b :c} (deref captured))
+        "doseq over a set still iterates values (not treated as pairs)")))
+
+(deftest test-doseq-nested-map-and-vector
+  (let [captured (var [])]
+    (doseq [[k v] {:a 1 :b 2}
+            i [10 20]]
+           (swap! captured (fn [xs] (push xs [k (+ v i)]))))
+    (is (= [[:a 11] [:a 21] [:b 12] [:b 22]] (deref captured))
+        "doseq supports Clojure-style map destructuring nested with a vector iteration")))
+
+(deftest test-doseq-iterable-helper
+  (is (= [[:a 1] [:b 2]] (doseq-iterable {:a 1 :b 2}))
+      "doseq-iterable expands a map to a sequence of entry pairs")
+  (is (= [1 2 3] (doseq-iterable [1 2 3]))
+      "doseq-iterable returns vectors unchanged")
+  (is (nil? (doseq-iterable nil))
+      "doseq-iterable passes nil through unchanged"))

--- a/tests/phel/test/core/doseq.phel
+++ b/tests/phel/test/core/doseq.phel
@@ -35,3 +35,22 @@
             :when (odd? x)]
            (swap! captured (fn [xs] (push xs x))))
     (is (= [1 3 5] (deref captured)) "doseq Clojure-style with :when modifier")))
+
+(deftest test-doseq-map-destructuring
+  (let [captured (var {})]
+    (doseq [[k v] {:a 0 :b 1}]
+           (swap! captured put k v))
+    (is (= {:a 0 :b 1} (deref captured))
+        "doseq binds [k v] from map entries, Clojure-aligned"))
+  (let [captured (var [])]
+    (doseq [entry {:a 0 :b 1}]
+           (swap! captured (fn [xs] (push xs entry))))
+    (is (= [[:a 0] [:b 1]] (deref captured))
+        "doseq yields [k v] pair vectors when iterating a map")))
+
+(deftest test-doseq-vector-of-vectors-destructuring
+  (let [captured (var [])]
+    (doseq [[a b] [[1 2] [3 4]]]
+           (swap! captured (fn [xs] (push xs (+ a b)))))
+    (is (= [3 7] (deref captured))
+        "doseq destructuring over vector of vectors still iterates elements")))


### PR DESCRIPTION
## 🤔 Background

`(doseq [[k v] {:a 0 :b 1}] ...)` threw `cannot call 'next on integer` because Phel's single-binding iteration yielded map values instead of `[k v]` entry pairs, so destructuring collapsed on scalars. Clojure's `seq` on a map yields `MapEntry` pairs; the Clojure test suite integration surfaced the divergence.

## 💡 Goal

Align Clojure-style `doseq` bindings with Clojure semantics when the collection is a map, without changing explicit `:in` / `:pairs` verbs in `for` / `dofor`.

## 🔖 Changes

- `doseq-normalize` wraps auto-inserted `:in` collections with a new `doseq-iterable` helper that expands maps to `[k v]` vectors and passes other collections through.
- Tests in `tests/phel/test/core/doseq.phel` cover map destructuring, single-binding over a map, and vector-of-vectors destructuring.
- CHANGELOG entry under `Unreleased → Fixed`.

Closes #1433