### PR TITLE
feat(core): add any?, ratio?, instance?, alength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ All notable changes to this project will be documented in this file.
 - `special-symbol?` (#1384), `ifn?` (#1370)
 - `neg-int?`, `pos-int?`, `nat-int?` (#1374)
 - `sequential?` (#1380), `seqable?` (#1379)
+- `any?` always true, `ratio?` always false (no Ratio type), and `instance?` macro: `(instance? c x)` wraps `php/instanceof` with the class first (#1433)
 
 #### Sequences & Collections
-- `nth`, `nthrest`, `nthnext` with Clojure-compatible semantics (#1375)
+- `nth`, `nthrest`, `nthnext` for indexed access into vectors and seqs (#1375)
 - `fnext`, equivalent to `(first (next coll))` (#1368)
 - `rseq` and `reversible?`: constant-time reverse view of a vector or sorted-map (#1378)
 - `empty`: returns an empty collection of the same type, or nil (#1365)
@@ -34,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - `uuid?` and `parse-uuid` (#1377)
 - `alter-var-root` stub that throws with a migration hint; out of scope per `docs/clojure-migration.md` (#1357)
 - `parse-double` accepts `Infinity`, `-Infinity`, and `NaN` (#1428)
+- `alength` returns the length of a PHP array (#1433)
 
 #### Modules
 - `phel\router`: data-driven router built on `symfony/routing`, previously shipped as `phel-lang/router`
@@ -54,8 +56,8 @@ All notable changes to this project will be documented in this file.
 - `:keyword` lookup works on transient maps (#1428)
 - `deftest` rejects a missing/non-symbol name with a clear error (#1364)
 - `(def name)` without a value binds `nil` instead of throwing (#1361)
-- `doseq` accepts Clojure-style pairs `[x coll]` without `:in` (#1362)
-- `doseq` iterates maps as `[k v]` entry pairs, so Clojure-style destructuring `(doseq [[k v] m] ...)` and single-binding `(doseq [e m] ...)` match Clojure semantics (#1433)
+- `doseq` accepts pair bindings `[x coll]` without an `:in` verb (#1362)
+- `doseq` iterates maps as `[k v]` entry pairs, so `(doseq [[k v] m] ...)` destructures entries and `(doseq [e m] ...)` binds each entry (#1433)
 - `drop-last` works with lazy sequences and ranges (#1360)
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -12,7 +12,7 @@ Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know 
 | `(ClassName. arg)` | `(ClassName. arg)` or `(php/new ClassName arg)` | `ClassName.` reads as `(php/new ClassName ...)` |
 | `(.-field obj)` | `(php/-> obj -field)` | Property access |
 | `(:import [java.util Date])` | `(:use DateTime)` in the `ns` form | Imports a PHP class by short name; also works with FQNs: `(:use Phel\Lang\Symbol)` |
-| `(instance? Type x)` | `(php/instanceof x Type)` | Type check (arg order differs) |
+| `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | Phel ships an `instance?` macro that wraps `php/instanceof` with Clojure's argument order |
 | `(class x)` | `(type x)` | Returns a keyword like `:string`, `:int`, `:hash-map` |
 | `(subs s start end)` | `(phel\str\slice s start end)` | Substring |
 | `(clojure.string/upper-case s)` | `(phel\str\upper-case s)` | String utils in `phel\str` |
@@ -106,7 +106,7 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 | Property write | `(set! (.-x obj) 5)` | `(php/oset obj :x 5)` |
 | Array access | `(aget arr 0)` | `(php/aget arr 0)` |
 | Array write | `(aset arr 0 val)` | `(php/aset arr 0 val)` |
-| Type check | `(instance? String x)` | `(php/instanceof x String)` |
+| Type check | `(instance? String x)` | `(instance? \String x)` or `(php/instanceof x \String)` |
 | PHP function | N/A | `(php/strlen "hello")` |
 | String concat | `(str a b)` | `(str a b)` or `(php/. a b)` |
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1381,7 +1381,7 @@ Otherwise, it tries to call `__toString`."
   Clojure's `clojure.core/any?` — useful as a default predicate in spec
   / validation contexts where every value should be accepted."
   {:example "(any? nil) ; => true\n(any? 0) ; => true"
-   :see-also ["some?" "all?" "ifn?"]}
+   :see-also ["some?" "every?" "ifn?"]}
   [_]
   true)
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -551,6 +551,14 @@ Otherwise, it tries to call `__toString`."
     (php/array)
     (to-php-array coll)))
 
+(defn- ensure-php-array
+  "Returns `arr` when it is a PHP array, otherwise throws an
+  `InvalidArgumentException` naming the calling operation."
+  [op-name arr]
+  (if (php/is_array arr)
+    arr
+    (throw (php/new InvalidArgumentException (str op-name " expects a PHP array")))))
+
 (defn aclone
   "Returns a shallow copy of a PHP array. The returned array is a
   distinct value — mutating the copy via `php/aset` does not affect the
@@ -561,9 +569,7 @@ Otherwise, it tries to call `__toString`."
   {:example "(aclone (object-array 3)) ; => a fresh PHP array [nil, nil, nil]"
    :see-also ["object-array" "to-array"]}
   [arr]
-  (if (php/is_array arr)
-    (php/array_merge arr)
-    (throw (php/new InvalidArgumentException "aclone expects a PHP array"))))
+  (php/array_merge (ensure-php-array "aclone" arr)))
 
 (defn alength
   "Returns the number of elements in a PHP array. Matches Clojure's
@@ -572,9 +578,7 @@ Otherwise, it tries to call `__toString`."
   {:example "(alength (int-array 3)) ; => 3"
    :see-also ["aget" "aset" "count" "object-array"]}
   [arr]
-  (if (php/is_array arr)
-    (php/count arr)
-    (throw (php/new InvalidArgumentException "alength expects a PHP array"))))
+  (php/count (ensure-php-array "alength" arr)))
 
 (defn- typed-array
   [coerce-fn default size-or-seq]

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -565,6 +565,17 @@ Otherwise, it tries to call `__toString`."
     (php/array_merge arr)
     (throw (php/new InvalidArgumentException "aclone expects a PHP array"))))
 
+(defn alength
+  "Returns the number of elements in a PHP array. Matches Clojure's
+  `alength` for `.cljc` interop; raises `InvalidArgumentException` on
+  non-array inputs (use `count` for collections)."
+  {:example "(alength (int-array 3)) ; => 3"
+   :see-also ["aget" "aset" "count" "object-array"]}
+  [arr]
+  (if (php/is_array arr)
+    (php/count arr)
+    (throw (php/new InvalidArgumentException "alength expects a PHP array"))))
+
 (defn- typed-array
   [coerce-fn default size-or-seq]
   (if (php/is_int size-or-seq)
@@ -1213,6 +1224,16 @@ Otherwise, it tries to call `__toString`."
   [x]
   (or (= (type x) :int) (= (type x) :float)))
 
+(defn ratio?
+  "Always returns false. Phel has no Ratio type — Clojure-style ratio
+  literals like `1/2` are accepted by the reader but evaluate to floats
+  (`num / den`). Provided for `.cljc` interop so cross-host code can
+  call `ratio?` without compilation errors."
+  {:example "(ratio? 1/2) ; => false"
+   :see-also ["number?" "float?" "double?"]}
+  [_]
+  false)
+
 (defn double?
   "Returns true if `x` is a floating-point number, false otherwise.
    Alias for `float?`, matching Clojure's `double?` naming. Since Phel
@@ -1350,6 +1371,26 @@ Otherwise, it tries to call `__toString`."
   {:example "(boolean nil) ; => false"}
   [x]
   (if x true false))
+
+(defn any?
+  "Returns true given any argument, including `nil` and `false`. Mirrors
+  Clojure's `clojure.core/any?` — useful as a default predicate in spec
+  / validation contexts where every value should be accepted."
+  {:example "(any? nil) ; => true\n(any? 0) ; => true"
+   :see-also ["some?" "all?" "ifn?"]}
+  [_]
+  true)
+
+(defmacro instance?
+  "Returns true if `x` is an instance of class `c`, false otherwise.
+  Mirrors Clojure's `clojure.core/instance?` argument order (class first,
+  value second). `c` should be a literal class reference such as
+  `\\DateTime` or a `:use`d short name; for runtime class names use
+  `(php/is_a x class-name)`."
+  {:example "(instance? \\DateTime (php/new \\DateTime)) ; => true"
+   :see-also ["type"]}
+  [c x]
+  `(php/instanceof ~x ~c))
 
 (defn php-array?
   "Returns true if `x` is a PHP Array, false otherwise."

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\core\basic-constructors
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is are]))
 
 (deftest create-list
   (is (= '(1 2 3) (list '1 '2 '3)) "construct list"))
@@ -192,16 +192,18 @@
       "aclone of nil raises InvalidArgumentException"))
 
 (deftest test-alength
-  (is (= 0 (alength (object-array 0))) "alength of empty array is 0")
-  (is (= 3 (alength (object-array 3))) "alength of pre-sized array")
-  (is (= 3 (alength (int-array [1 2 3]))) "alength of int-array from seq")
-  (is (= 4 (alength (php-indexed-array :a :b :c :d))) "alength on php-indexed-array"))
+  (are [n arr] (= n (alength arr))
+    0 (object-array 0)
+    3 (object-array 3)
+    3 (int-array [1 2 3])
+    4 (php-indexed-array :a :b :c :d)))
 
 (deftest test-alength-rejects-non-array
-  (is (thrown? \InvalidArgumentException (alength [1 2 3]))
-      "alength of persistent vector raises InvalidArgumentException")
-  (is (thrown? \InvalidArgumentException (alength nil))
-      "alength of nil raises InvalidArgumentException"))
+  (are [arr] (thrown? \InvalidArgumentException (alength arr))
+    [1 2 3]
+    nil
+    "abc"
+    {:a 1}))
 
 (deftest test-int-array-from-size
   (let [arr (int-array 3)]

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -191,6 +191,18 @@
   (is (thrown? \InvalidArgumentException (aclone nil))
       "aclone of nil raises InvalidArgumentException"))
 
+(deftest test-alength
+  (is (= 0 (alength (object-array 0))) "alength of empty array is 0")
+  (is (= 3 (alength (object-array 3))) "alength of pre-sized array")
+  (is (= 3 (alength (int-array [1 2 3]))) "alength of int-array from seq")
+  (is (= 4 (alength (php-indexed-array :a :b :c :d))) "alength on php-indexed-array"))
+
+(deftest test-alength-rejects-non-array
+  (is (thrown? \InvalidArgumentException (alength [1 2 3]))
+      "alength of persistent vector raises InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (alength nil))
+      "alength of nil raises InvalidArgumentException"))
+
 (deftest test-int-array-from-size
   (let [arr (int-array 3)]
     (is (php/is_array arr) "int-array returns a PHP array")

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -201,6 +201,27 @@
   (is (true? (boolean? false)) "boolean? on false")
   (is (false? (boolean? nil)) "boolean? on nil"))
 
+(deftest test-any?
+  (is (true? (any? nil)) "any? on nil")
+  (is (true? (any? false)) "any? on false")
+  (is (true? (any? 0)) "any? on 0")
+  (is (true? (any? "")) "any? on empty string")
+  (is (true? (any? [])) "any? on empty vector"))
+
+(deftest test-ratio?
+  (is (false? (ratio? 1/2)) "ratio? on a ratio literal (reads as float)")
+  (is (false? (ratio? 0.5)) "ratio? on float")
+  (is (false? (ratio? 1)) "ratio? on int")
+  (is (false? (ratio? nil)) "ratio? on nil")
+  (is (false? (ratio? "1/2")) "ratio? on string"))
+
+(deftest test-instance?
+  (is (true? (instance? \DateTime (php/new DateTime))) "instance? matches concrete class")
+  (is (true? (instance? \Exception (php/new \RuntimeException "x")))
+      "instance? matches a parent class")
+  (is (false? (instance? \DateTime "not-a-date")) "instance? false on unrelated value")
+  (is (false? (instance? \DateTime nil)) "instance? false on nil"))
+
 (deftest test-php-array?
   (is (true? (php-array? (php/array))) "php-array? on php array")
   (is (false? (php-array? [])) "php-array? on vector"))

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -1,7 +1,8 @@
 (ns phel-test\test\core\type-operation
   (:use DateTime)
+  (:use RuntimeException)
   (:use Phel\Lang\Symbol)
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is are]))
 
 (deftest test-type
   (is (= :vector (type [])) "type of vector")
@@ -202,25 +203,31 @@
   (is (false? (boolean? nil)) "boolean? on nil"))
 
 (deftest test-any?
-  (is (true? (any? nil)) "any? on nil")
-  (is (true? (any? false)) "any? on false")
-  (is (true? (any? 0)) "any? on 0")
-  (is (true? (any? "")) "any? on empty string")
-  (is (true? (any? [])) "any? on empty vector"))
+  (are [x] (true? (any? x))
+    nil
+    false
+    0
+    ""
+    []))
 
 (deftest test-ratio?
-  (is (false? (ratio? 1/2)) "ratio? on a ratio literal (reads as float)")
-  (is (false? (ratio? 0.5)) "ratio? on float")
-  (is (false? (ratio? 1)) "ratio? on int")
-  (is (false? (ratio? nil)) "ratio? on nil")
-  (is (false? (ratio? "1/2")) "ratio? on string"))
+  (are [x] (false? (ratio? x))
+    1/2
+    0.5
+    1
+    nil
+    "1/2"))
 
 (deftest test-instance?
-  (is (true? (instance? \DateTime (php/new DateTime))) "instance? matches concrete class")
-  (is (true? (instance? \Exception (php/new \RuntimeException "x")))
-      "instance? matches a parent class")
-  (is (false? (instance? \DateTime "not-a-date")) "instance? false on unrelated value")
-  (is (false? (instance? \DateTime nil)) "instance? false on nil"))
+  (let [now (php/new DateTime)
+        err (php/new \RuntimeException "x")]
+    (are [c x] (true? (instance? c x))
+      \DateTime  now
+      DateTime   now            ;; :use'd short name resolves the same as the FQN
+      \Exception err)
+    (are [c x] (false? (instance? c x))
+      \DateTime "not-a-date"
+      \DateTime nil)))
 
 (deftest test-php-array?
   (is (true? (php-array? (php/array))) "php-array? on php array")


### PR DESCRIPTION
## 🤔 Background

The clojure-test-suite `phel-integration` branch (#1433) reports several `Cannot resolve symbol` failures for stdlib predicates that exist in Clojure but were missing from `phel\core`: `any?`, `ratio?`, `instance?`, `alength`. Cross-host `.cljc` test files cannot compile without these names.

## 💡 Goal

Provide thin Phel implementations of these names so `.cljc` code compiles unchanged, without forcing users away from `php/instanceof` or introducing a Ratio type Phel does not have.

## 🔖 Changes

- `any?` always returns true (default predicate for spec/validation contexts)
- `ratio?` always returns false (Phel reads `1/2` as `0.5`; no Ratio type exists)
- `instance?` macro: `(instance? c x)` wraps `php/instanceof` with the class first
- `alength` returns the length of a PHP array; rejects non-arrays with a clear message
- `docs/clojure-migration.md` updated so `instance?` is the recommended form
- 20 new tests in `tests/phel/test/core/`; CHANGELOG entries under `Unreleased > Added`

Refs #1433