### PR TITLE
fix(test): guard is macro against scalar literal arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - `(def name)` without a value binds `nil` instead of throwing (#1361)
 - `doseq` accepts pair bindings `[x coll]` without an `:in` verb (#1362)
 - `doseq` iterates maps as `[k v]` entry pairs, so `(doseq [[k v] m] ...)` destructures entries and `(doseq [e m] ...)` binds each entry (#1433)
+- `is` accepts scalar literal arguments (`true`, `false`, `nil`, numbers, strings) without crashing (#1433)
 - `drop-last` works with lazy sequences and ranges (#1360)
 - `(empty? (range))` no longer hangs; `empty?` checks `first` for lazy sequences (#1366)
 - `is` no longer misinterprets `let`/`when`/`cond` forms as binary predicates (#1367)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1,6 +1,7 @@
 (ns phel\test
   (:use Phel)
   (:use Phel\Lang\Symbol)
+  (:use Phel\Lang\SourceLocationInterface)
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Command\CommandFacade)
   (:require phel\str :as s))
@@ -85,11 +86,12 @@
 ;; ---------------------------
 
 (defn- location [form]
-  (let [loc (php/-> form (getStartLocation))]
-    (when loc
-      {:file (php/-> loc (getFile))
-       :line (php/-> loc (getLine))
-       :column (php/-> loc (getColumn))})))
+  (when (php/instanceof form SourceLocationInterface)
+    (let [loc (php/-> form (getStartLocation))]
+      (when loc
+        {:file (php/-> loc (getFile))
+         :line (php/-> loc (getLine))
+         :column (php/-> loc (getColumn))}))))
 
 (defn- assert-predicate [form message negated]
   (let [pred (first form)

--- a/tests/phel/test/core/doseq.phel
+++ b/tests/phel/test/core/doseq.phel
@@ -46,7 +46,12 @@
     (doseq [entry {:a 0 :b 1}]
            (swap! captured (fn [xs] (push xs entry))))
     (is (= [[:a 0] [:b 1]] (deref captured))
-        "doseq yields [k v] pair vectors when iterating a map")))
+        "doseq yields [k v] pair vectors when iterating a map"))
+  (let [acc (atom {})]
+    (doseq [[k v] {:a 0 :b 1}]
+      (swap! acc assoc k v))
+    (is (= {:a 0 :b 1} @acc)
+        "doseq [k v] destructuring over a map with (swap! acc assoc k v)")))
 
 (deftest test-doseq-vector-of-vectors-destructuring
   (let [captured (var [])]

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -217,6 +217,21 @@
     (restore-stats saved)
     (is (= 2 (:failed counts)) "falsy and/or expressions both record failures")))
 
+(deftest test-is-accepts-scalar-literal-arguments
+  (is true "true literal passes")
+  (is 1 "non-zero int literal passes")
+  (is "non-empty" "non-empty string literal passes"))
+
+(deftest test-is-scalar-literal-failures-record-failure
+  (let [saved (get-stats)
+        _ (reset-stats)
+        _ (with-output-buffer (is false "false literal"))
+        _ (with-output-buffer (is nil "nil literal"))
+        counts (get (get-stats) :counts)]
+    (restore-stats saved)
+    (is (= 2 (:failed counts)) "scalar false/nil record failures without error")
+    (is (= 0 (:error counts)) "scalar literals do not raise an internal error")))
+
 ;; ---------------------------------------------------------------------------
 ;; Error path — `is` catches exceptions raised by the assertion body and
 ;; reports them as :error (distinct from :failed).


### PR DESCRIPTION
## 🤔 Background

Reported in #1433 (comment: 4235165403). Running the Clojure test suite against Phel tripped the test macro with errors like `Call to a member function getStartLocation() on false`, `on true`, `on null`, `on int`. The crash blocked compilation of `inc.cljc`, `dec.cljc` and any fixture that invokes `(is <literal>)`.

## 💡 Goal

Let `is` accept scalar literal arguments (`true`, `false`, `nil`, numbers, strings) without blowing up, so Clojure-style tests compile. Also lock down `doseq` map destructuring with a regression test that mirrors the exact reproduction from the issue comment.

## 🔖 Changes

- `src/phel/test.phel` — `location` now checks `php/instanceof \Phel\Lang\SourceLocationInterface` before calling `getStartLocation`; scalars cleanly return `nil`.
- `tests/phel/test/test-framework.phel` — two new `deftest`s covering the pass path for truthy scalars and the failure path for `false` / `nil`.
- `tests/phel/test/core/doseq.phel` — regression test using `atom` + `swap! assoc` + `@deref` (the comment's exact repro).

<img width="587" height="274" alt="Screenshot 2026-04-13 at 12 21 10" src="https://github.com/user-attachments/assets/ef51712e-ef10-48bb-ad47-6e71511e63a0" />


Closes #1433