### PR TITLE
fix(build): skip build output dir in namespace scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 - `defrecord`/`defstruct`/`defexception`/`definterface` no longer emit invalid PHP namespace declarations in statement mode (#1358)
 - `defstruct`/`defrecord`/`defexception`/`definterface` nested in a function body (e.g. a `defrecord` inside a `deftest`) no longer triggers "Class declarations may not be nested"
 - `phel\router`: default error dispatch returns 404/405/406 correctly (was always 404); `:not-acceptable` returns 406 (was 405)
+- Namespace extractors skip the configured build output directory during recursive scans, so leftover compiled `.phel` source copies no longer shadow the real sources with duplicate-namespace warnings
 
 ### Changed
 

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -6,6 +6,7 @@ namespace Phel\Build\Application;
 
 use Phel\Build\Domain\Cache\NamespaceCacheEntry;
 use Phel\Build\Domain\Cache\NamespaceCacheInterface;
+use Phel\Build\Domain\Extractor\ExcludedScanPaths;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
@@ -19,24 +20,16 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
 {
     private NamespaceFileGrouper $grouper;
 
-    /** @var list<string> */
-    private array $excludedPrefixes;
+    private ExcludedScanPaths $excludedPaths;
 
-    /**
-     * @param list<string> $excludedDirectories absolute paths whose subtree must be
-     *                                          skipped during recursive namespace scanning
-     * @param string       $destDirBasename     when non-empty, any `<scan_root>/<basename>/`
-     *                                          subtree is skipped per walk
-     */
     public function __construct(
         private NamespaceExtractorInterface $innerExtractor,
         private NamespaceCacheInterface $cache,
         NamespaceSorterInterface $namespaceSorter,
-        array $excludedDirectories = [],
-        private string $destDirBasename = '',
+        ?ExcludedScanPaths $excludedPaths = null,
     ) {
         $this->grouper = new NamespaceFileGrouper($namespaceSorter);
-        $this->excludedPrefixes = $this->normalizeExcludedPrefixes($excludedDirectories);
+        $this->excludedPaths = $excludedPaths ?? ExcludedScanPaths::none();
     }
 
     public function getNamespaceFromFile(string $path): NamespaceInformation
@@ -111,15 +104,13 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
                 continue;
             }
 
-            $walkExcludedPrefixes = $this->excludedPrefixesForWalk($realpath);
-
             try {
                 $directoryIterator = new RecursiveDirectoryIterator($realpath);
                 $iterator = new RecursiveIteratorIterator($directoryIterator);
                 $phelIterator = new RegexIterator($iterator, '/^.+\.(phel|cljc)$/i', RegexIterator::GET_MATCH);
 
                 foreach ($phelIterator as $file) {
-                    if ($this->isExcluded($file[0], $walkExcludedPrefixes)) {
+                    if ($this->excludedPaths->contains($file[0], $realpath)) {
                         continue;
                     }
 
@@ -147,57 +138,5 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
         // Normal file system
         $real = realpath($path);
         return $real !== false ? $real : null;
-    }
-
-    /**
-     * @param list<string> $walkPrefixes
-     */
-    private function isExcluded(string $path, array $walkPrefixes): bool
-    {
-        foreach ($walkPrefixes as $prefix) {
-            if (str_starts_with($path, $prefix)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function excludedPrefixesForWalk(string $scanRoot): array
-    {
-        $prefixes = $this->excludedPrefixes;
-
-        if ($this->destDirBasename !== '') {
-            $prefixes[] = rtrim($scanRoot, DIRECTORY_SEPARATOR)
-                . DIRECTORY_SEPARATOR
-                . $this->destDirBasename
-                . DIRECTORY_SEPARATOR;
-        }
-
-        return $prefixes;
-    }
-
-    /**
-     * @param list<string> $directories
-     *
-     * @return list<string>
-     */
-    private function normalizeExcludedPrefixes(array $directories): array
-    {
-        $prefixes = [];
-        foreach ($directories as $dir) {
-            if ($dir === '') {
-                continue;
-            }
-
-            $real = realpath($dir);
-            $resolved = $real !== false ? $real : $dir;
-            $prefixes[] = rtrim($resolved, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        }
-
-        return $prefixes;
     }
 }

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -19,12 +19,24 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
 {
     private NamespaceFileGrouper $grouper;
 
+    /** @var list<string> */
+    private array $excludedPrefixes;
+
+    /**
+     * @param list<string> $excludedDirectories absolute paths whose subtree must be
+     *                                          skipped during recursive namespace scanning
+     * @param string       $destDirBasename     when non-empty, any `<scan_root>/<basename>/`
+     *                                          subtree is skipped per walk
+     */
     public function __construct(
         private NamespaceExtractorInterface $innerExtractor,
         private NamespaceCacheInterface $cache,
         NamespaceSorterInterface $namespaceSorter,
+        array $excludedDirectories = [],
+        private string $destDirBasename = '',
     ) {
         $this->grouper = new NamespaceFileGrouper($namespaceSorter);
+        $this->excludedPrefixes = $this->normalizeExcludedPrefixes($excludedDirectories);
     }
 
     public function getNamespaceFromFile(string $path): NamespaceInformation
@@ -99,12 +111,18 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
                 continue;
             }
 
+            $walkExcludedPrefixes = $this->excludedPrefixesForWalk($realpath);
+
             try {
                 $directoryIterator = new RecursiveDirectoryIterator($realpath);
                 $iterator = new RecursiveIteratorIterator($directoryIterator);
                 $phelIterator = new RegexIterator($iterator, '/^.+\.(phel|cljc)$/i', RegexIterator::GET_MATCH);
 
                 foreach ($phelIterator as $file) {
+                    if ($this->isExcluded($file[0], $walkExcludedPrefixes)) {
+                        continue;
+                    }
+
                     $resolvedFile = $this->resolvePath($file[0]);
                     if ($resolvedFile !== null) {
                         $files[] = $resolvedFile;
@@ -129,5 +147,57 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
         // Normal file system
         $real = realpath($path);
         return $real !== false ? $real : null;
+    }
+
+    /**
+     * @param list<string> $walkPrefixes
+     */
+    private function isExcluded(string $path, array $walkPrefixes): bool
+    {
+        foreach ($walkPrefixes as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function excludedPrefixesForWalk(string $scanRoot): array
+    {
+        $prefixes = $this->excludedPrefixes;
+
+        if ($this->destDirBasename !== '') {
+            $prefixes[] = rtrim($scanRoot, DIRECTORY_SEPARATOR)
+                . DIRECTORY_SEPARATOR
+                . $this->destDirBasename
+                . DIRECTORY_SEPARATOR;
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function normalizeExcludedPrefixes(array $directories): array
+    {
+        $prefixes = [];
+        foreach ($directories as $dir) {
+            if ($dir === '') {
+                continue;
+            }
+
+            $real = realpath($dir);
+            $resolved = $real !== false ? $real : $dir;
+            $prefixes[] = rtrim($resolved, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        return $prefixes;
     }
 }

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -29,12 +29,27 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 {
     private NamespaceFileGrouper $grouper;
 
+    /** @var list<string> */
+    private array $excludedPrefixes;
+
+    /**
+     * @param list<string> $excludedDirectories absolute paths whose subtree must be
+     *                                          skipped during recursive namespace scanning
+     * @param string       $destDirBasename     when non-empty, any `<scan_root>/<basename>/`
+     *                                          subtree is skipped per walk; lets us prune
+     *                                          the build output even when the scan root is
+     *                                          a different project root than where the
+     *                                          extractor was configured
+     */
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         NamespaceSorterInterface $namespaceSorter,
         private FileIoInterface $fileIo,
+        array $excludedDirectories = [],
+        private string $destDirBasename = '',
     ) {
         $this->grouper = new NamespaceFileGrouper($namespaceSorter);
+        $this->excludedPrefixes = $this->normalizeExcludedPrefixes($excludedDirectories);
     }
 
     /**
@@ -124,6 +139,8 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
             return [];
         }
 
+        $walkExcludedPrefixes = $this->excludedPrefixesForWalk($realpath);
+
         try {
             $directoryIterator = new RecursiveDirectoryIterator($realpath);
             $iterator = new RecursiveIteratorIterator($directoryIterator);
@@ -131,6 +148,10 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 
             $result = [];
             foreach ($phelIterator as $file) {
+                if ($this->isExcluded($file[0], $walkExcludedPrefixes)) {
+                    continue;
+                }
+
                 $result[] = $this->getNamespaceFromFile($file[0]);
             }
         } catch (UnexpectedValueException) {
@@ -152,5 +173,57 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
         // Normal file system
         $real = realpath($path);
         return $real !== false ? $real : null;
+    }
+
+    /**
+     * @param list<string> $walkPrefixes
+     */
+    private function isExcluded(string $path, array $walkPrefixes): bool
+    {
+        foreach ($walkPrefixes as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function excludedPrefixesForWalk(string $scanRoot): array
+    {
+        $prefixes = $this->excludedPrefixes;
+
+        if ($this->destDirBasename !== '') {
+            $prefixes[] = rtrim($scanRoot, DIRECTORY_SEPARATOR)
+                . DIRECTORY_SEPARATOR
+                . $this->destDirBasename
+                . DIRECTORY_SEPARATOR;
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function normalizeExcludedPrefixes(array $directories): array
+    {
+        $prefixes = [];
+        foreach ($directories as $dir) {
+            if ($dir === '') {
+                continue;
+            }
+
+            $real = realpath($dir);
+            $resolved = $real !== false ? $real : $dir;
+            $prefixes[] = rtrim($resolved, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        return $prefixes;
     }
 }

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Application;
 
+use Phel\Build\Domain\Extractor\ExcludedScanPaths;
 use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
@@ -29,27 +30,16 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 {
     private NamespaceFileGrouper $grouper;
 
-    /** @var list<string> */
-    private array $excludedPrefixes;
+    private ExcludedScanPaths $excludedPaths;
 
-    /**
-     * @param list<string> $excludedDirectories absolute paths whose subtree must be
-     *                                          skipped during recursive namespace scanning
-     * @param string       $destDirBasename     when non-empty, any `<scan_root>/<basename>/`
-     *                                          subtree is skipped per walk; lets us prune
-     *                                          the build output even when the scan root is
-     *                                          a different project root than where the
-     *                                          extractor was configured
-     */
     public function __construct(
         private CompilerFacadeInterface $compilerFacade,
         NamespaceSorterInterface $namespaceSorter,
         private FileIoInterface $fileIo,
-        array $excludedDirectories = [],
-        private string $destDirBasename = '',
+        ?ExcludedScanPaths $excludedPaths = null,
     ) {
         $this->grouper = new NamespaceFileGrouper($namespaceSorter);
-        $this->excludedPrefixes = $this->normalizeExcludedPrefixes($excludedDirectories);
+        $this->excludedPaths = $excludedPaths ?? ExcludedScanPaths::none();
     }
 
     /**
@@ -139,8 +129,6 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
             return [];
         }
 
-        $walkExcludedPrefixes = $this->excludedPrefixesForWalk($realpath);
-
         try {
             $directoryIterator = new RecursiveDirectoryIterator($realpath);
             $iterator = new RecursiveIteratorIterator($directoryIterator);
@@ -148,7 +136,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 
             $result = [];
             foreach ($phelIterator as $file) {
-                if ($this->isExcluded($file[0], $walkExcludedPrefixes)) {
+                if ($this->excludedPaths->contains($file[0], $realpath)) {
                     continue;
                 }
 
@@ -173,57 +161,5 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
         // Normal file system
         $real = realpath($path);
         return $real !== false ? $real : null;
-    }
-
-    /**
-     * @param list<string> $walkPrefixes
-     */
-    private function isExcluded(string $path, array $walkPrefixes): bool
-    {
-        foreach ($walkPrefixes as $prefix) {
-            if (str_starts_with($path, $prefix)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function excludedPrefixesForWalk(string $scanRoot): array
-    {
-        $prefixes = $this->excludedPrefixes;
-
-        if ($this->destDirBasename !== '') {
-            $prefixes[] = rtrim($scanRoot, DIRECTORY_SEPARATOR)
-                . DIRECTORY_SEPARATOR
-                . $this->destDirBasename
-                . DIRECTORY_SEPARATOR;
-        }
-
-        return $prefixes;
-    }
-
-    /**
-     * @param list<string> $directories
-     *
-     * @return list<string>
-     */
-    private function normalizeExcludedPrefixes(array $directories): array
-    {
-        $prefixes = [];
-        foreach ($directories as $dir) {
-            if ($dir === '') {
-                continue;
-            }
-
-            $real = realpath($dir);
-            $resolved = $real !== false ? $real : $dir;
-            $prefixes[] = rtrim($resolved, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        }
-
-        return $prefixes;
     }
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -19,6 +19,7 @@ use Phel\Build\Domain\Compile\Output\EntryPointPhpFile;
 use Phel\Build\Domain\Compile\Output\EntryPointPhpFileInterface;
 use Phel\Build\Domain\Compile\Output\NamespacePathTransformer;
 use Phel\Build\Domain\Compile\SecondaryFileHarvester;
+use Phel\Build\Domain\Extractor\ExcludedScanPaths;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
@@ -87,19 +88,13 @@ final class BuildFactory extends AbstractFactory
         return $this->singleton(
             NamespaceExtractorInterface::class,
             function (): NamespaceExtractorInterface {
-                // Compiled output contains a `.phel` source copy next to every generated
-                // `.php`; excluding that dir prevents duplicate-namespace shadowing when a
-                // scan root (e.g. cwd) sits above it.
-                $outputDirectory = $this->getCommandFacade()->getOutputDirectory();
-                $excludedDirectories = [$outputDirectory];
-                $destDirBasename = basename($outputDirectory);
+                $excludedPaths = $this->createExcludedScanPaths();
 
                 $innerExtractor = new NamespaceExtractor(
                     $this->getCompilerFacade(),
                     $this->createNamespaceSorter(),
                     $this->createFileIo(),
-                    $excludedDirectories,
-                    $destDirBasename,
+                    $excludedPaths,
                 );
 
                 if (!$this->getConfig()->isNamespaceCacheEnabled()) {
@@ -110,8 +105,7 @@ final class BuildFactory extends AbstractFactory
                     $innerExtractor,
                     $this->createNamespaceCache(),
                     $this->createNamespaceSorter(),
-                    $excludedDirectories,
-                    $destDirBasename,
+                    $excludedPaths,
                 );
             },
         );
@@ -186,6 +180,21 @@ final class BuildFactory extends AbstractFactory
     private function createNamespaceSorter(): NamespaceSorterInterface
     {
         return new TopologicalNamespaceSorter();
+    }
+
+    /**
+     * Compiled output contains a `.phel` source copy next to every generated
+     * `.php`; excluding that dir prevents duplicate-namespace shadowing when a
+     * scan root (e.g. cwd) sits above it.
+     */
+    private function createExcludedScanPaths(): ExcludedScanPaths
+    {
+        $outputDirectory = $this->getCommandFacade()->getOutputDirectory();
+
+        return new ExcludedScanPaths(
+            excludedDirectories: [$outputDirectory],
+            destDirBasename: basename($outputDirectory),
+        );
     }
 
     private function createFileIo(): FileIoInterface

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -87,10 +87,19 @@ final class BuildFactory extends AbstractFactory
         return $this->singleton(
             NamespaceExtractorInterface::class,
             function (): NamespaceExtractorInterface {
+                // Compiled output contains a `.phel` source copy next to every generated
+                // `.php`; excluding that dir prevents duplicate-namespace shadowing when a
+                // scan root (e.g. cwd) sits above it.
+                $outputDirectory = $this->getCommandFacade()->getOutputDirectory();
+                $excludedDirectories = [$outputDirectory];
+                $destDirBasename = basename($outputDirectory);
+
                 $innerExtractor = new NamespaceExtractor(
                     $this->getCompilerFacade(),
                     $this->createNamespaceSorter(),
                     $this->createFileIo(),
+                    $excludedDirectories,
+                    $destDirBasename,
                 );
 
                 if (!$this->getConfig()->isNamespaceCacheEnabled()) {
@@ -101,6 +110,8 @@ final class BuildFactory extends AbstractFactory
                     $innerExtractor,
                     $this->createNamespaceCache(),
                     $this->createNamespaceSorter(),
+                    $excludedDirectories,
+                    $destDirBasename,
                 );
             },
         );

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -44,3 +44,4 @@ Build/
 - `CachedNamespaceExtractor` decorates `NamespaceExtractor` with caching
 - `BuildOptions` controls source maps and cache behavior
 - Auto-detects main namespace from `core.phel` or `main.phel`
+- Namespace extractors prune the build output from recursive scans (absolute excluded dirs + per-scan-root `<dest_dir>/` subtree) to avoid duplicate-namespace shadowing when `FileCompiler::writeSourceReference` mirrors sources next to compiled files

--- a/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
+++ b/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Extractor;
+
+/**
+ * Prefixes that should be skipped during a recursive namespace scan. Combines
+ * pre-resolved absolute directories with a basename that prunes
+ * `<scan_root>/<basename>/` per walk, so a build output never shadows real
+ * sources regardless of which scan root the caller passes in.
+ */
+final readonly class ExcludedScanPaths
+{
+    /** @var list<string> */
+    private array $absolutePrefixes;
+
+    /**
+     * @param list<string> $excludedDirectories absolute paths whose subtree is skipped
+     * @param string       $destDirBasename     when non-empty, any `<scan_root>/<basename>/`
+     *                                          subtree is skipped per walk
+     */
+    public function __construct(
+        array $excludedDirectories = [],
+        private string $destDirBasename = '',
+    ) {
+        $this->absolutePrefixes = $this->normalizePrefixes($excludedDirectories);
+    }
+
+    public static function none(): self
+    {
+        return new self();
+    }
+
+    public function contains(string $path, string $scanRoot): bool
+    {
+        foreach ($this->absolutePrefixes as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        if ($this->destDirBasename !== '') {
+            $destPrefix = rtrim($scanRoot, DIRECTORY_SEPARATOR)
+                . DIRECTORY_SEPARATOR
+                . $this->destDirBasename
+                . DIRECTORY_SEPARATOR;
+
+            if (str_starts_with($path, $destPrefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function normalizePrefixes(array $directories): array
+    {
+        $prefixes = [];
+        foreach ($directories as $dir) {
+            if ($dir === '') {
+                continue;
+            }
+
+            $real = realpath($dir);
+            $resolved = $real !== false ? $real : $dir;
+            $prefixes[] = rtrim($resolved, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        return $prefixes;
+    }
+}

--- a/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Domain\Extractor;
+
+use Phel\Build\Domain\Extractor\ExcludedScanPaths;
+use PHPUnit\Framework\TestCase;
+
+final class ExcludedScanPathsTest extends TestCase
+{
+    public function test_none_excludes_nothing(): void
+    {
+        $paths = ExcludedScanPaths::none();
+
+        self::assertFalse($paths->contains('/repo/src/foo.phel', '/repo/src'));
+    }
+
+    public function test_dest_dir_basename_is_pruned_relative_to_scan_root(): void
+    {
+        $paths = new ExcludedScanPaths(destDirBasename: 'out');
+
+        self::assertTrue($paths->contains('/repo/out/phel/core.phel', '/repo'));
+        self::assertFalse($paths->contains('/repo/src/phel/core.phel', '/repo'));
+    }
+
+    public function test_dest_dir_basename_does_not_match_sibling_scan_root(): void
+    {
+        $paths = new ExcludedScanPaths(destDirBasename: 'out');
+
+        self::assertFalse($paths->contains('/other/out/phel/core.phel', '/repo'));
+    }
+
+    public function test_absolute_excluded_directory_is_matched_regardless_of_scan_root(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-excluded-' . uniqid();
+        mkdir($dir, 0777, true);
+        $real = realpath($dir);
+
+        try {
+            $paths = new ExcludedScanPaths(excludedDirectories: [$dir]);
+
+            self::assertTrue($paths->contains($real . '/nested.phel', '/any/scan/root'));
+            self::assertFalse($paths->contains('/elsewhere/file.phel', '/any/scan/root'));
+        } finally {
+            rmdir($dir);
+        }
+    }
+
+    public function test_empty_excluded_directory_strings_are_skipped(): void
+    {
+        $paths = new ExcludedScanPaths(excludedDirectories: ['']);
+
+        self::assertFalse($paths->contains('/anything.phel', '/scan'));
+    }
+
+    public function test_unresolvable_excluded_directory_still_prunes_by_literal_prefix(): void
+    {
+        // Configured output dirs may not exist yet (e.g. before first build);
+        // the literal path is still used as a prefix so the subtree is pruned
+        // once it materialises.
+        $paths = new ExcludedScanPaths(excludedDirectories: ['/not/yet/built']);
+
+        self::assertTrue($paths->contains('/not/yet/built/phel/core.phel', '/scan'));
+    }
+}

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Build\Domain\Extractor;
 
 use Phel\Build\Application\NamespaceExtractor;
+use Phel\Build\Domain\Extractor\ExcludedScanPaths;
 use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
@@ -124,8 +125,7 @@ final class NamespaceExtractorTest extends TestCase
             new CompilerFacade(),
             new TopologicalNamespaceSorter(),
             new SystemFileIo(),
-            excludedDirectories: [],
-            destDirBasename: 'out',
+            new ExcludedScanPaths(destDirBasename: 'out'),
         );
 
         $infos = $nsExtractor->getNamespacesFromDirectories([$dir]);
@@ -155,7 +155,7 @@ final class NamespaceExtractorTest extends TestCase
             new CompilerFacade(),
             new TopologicalNamespaceSorter(),
             new SystemFileIo(),
-            excludedDirectories: [$dir . '/vendor-build'],
+            new ExcludedScanPaths(excludedDirectories: [$dir . '/vendor-build']),
         );
 
         $infos = $nsExtractor->getNamespacesFromDirectories([$dir]);

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
@@ -109,6 +109,66 @@ final class NamespaceExtractorTest extends TestCase
         rmdir($dir);
     }
 
+    public function test_scan_skips_configured_output_subdirectory(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-extractor-test-' . uniqid();
+        mkdir($dir . '/out/phel', 0777, true);
+
+        $sourcePath = $dir . '/src.phel';
+        $outputCopyPath = $dir . '/out/phel/src.phel';
+
+        file_put_contents($sourcePath, '(ns app\\main)');
+        file_put_contents($outputCopyPath, '(ns app\\main)');
+
+        $nsExtractor = new NamespaceExtractor(
+            new CompilerFacade(),
+            new TopologicalNamespaceSorter(),
+            new SystemFileIo(),
+            excludedDirectories: [],
+            destDirBasename: 'out',
+        );
+
+        $infos = $nsExtractor->getNamespacesFromDirectories([$dir]);
+
+        self::assertCount(1, $infos, 'Output subtree must not be walked.');
+        self::assertStringEndsWith('/src.phel', $infos[0]->getFile());
+
+        unlink($sourcePath);
+        unlink($outputCopyPath);
+        rmdir($dir . '/out/phel');
+        rmdir($dir . '/out');
+        rmdir($dir);
+    }
+
+    public function test_scan_skips_absolute_excluded_directory(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-extractor-test-' . uniqid();
+        mkdir($dir . '/vendor-build', 0777, true);
+
+        $sourcePath = $dir . '/src.phel';
+        $excludedPath = $dir . '/vendor-build/copy.phel';
+
+        file_put_contents($sourcePath, '(ns app\\main)');
+        file_put_contents($excludedPath, '(ns app\\main)');
+
+        $nsExtractor = new NamespaceExtractor(
+            new CompilerFacade(),
+            new TopologicalNamespaceSorter(),
+            new SystemFileIo(),
+            excludedDirectories: [$dir . '/vendor-build'],
+        );
+
+        $infos = $nsExtractor->getNamespacesFromDirectories([$dir]);
+
+        self::assertCount(1, $infos, 'Excluded directory subtree must not be walked.');
+        self::assertStringEndsWith('/src.phel', $infos[0]->getFile());
+
+        unlink($sourcePath);
+        unlink($excludedPath);
+        rmdir($dir . '/vendor-build');
+        rmdir($dir);
+    }
+
     private function extractNamespace(string $code): NamespaceInformation
     {
         $filePath = tempnam(sys_get_temp_dir(), self::class);


### PR DESCRIPTION
## 🤔 Background

Running `composer test` printed dozens of `WARNING: Namespace '…' is defined in multiple locations` lines whenever a `./bin/phel build` had left an `out/` directory at the repo root. `FileCompiler::writeSourceReference` writes a `.phel` source copy next to every compiled `.php`, and the REPL's `NamespaceLoader` adds `getcwd()` as a scan root — so the recursive walker discovered every namespace twice.

## 💡 Goal

Prune the build output from recursive namespace scans so leftover compiled sources never shadow the real ones.

## 🔖 Changes

- `NamespaceExtractor` / `CachedNamespaceExtractor` accept absolute excluded directories plus a `destDirBasename` used to prune `<scan_root>/<basename>/` per walk.
- `BuildFactory` wires the configured output directory (absolute + basename) into both extractors.
- Unit tests cover absolute and basename-based exclusion.