### PR TITLE
Drop phpunit/php-timer runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Dropped `phpunit/php-timer` runtime dependency; `run --with-time`, `test`, and `build` now use an internal resource-usage formatter
 - **Breaking:** renamed `phel\str` namespace to `phel\string`. The automatic `clojure.*` → `phel.*` remap now targets `phel\string`; code requiring the old `phel\str` must update (#1440)
 - `(load path)` resolves relative paths from the caller file's compile-time location; `/path` is classpath-absolute and searches `phel\repl/src-dirs`. Leading `./`/`../` and explicit `.phel` extensions are rejected
 - `src/phel/core.phel` split into topic files under `src/phel/core/`, loaded via `(load ...)` from a bootstrap `core.phel`

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "php": ">=8.3",
         "amphp/amp": "^3.1",
         "gacela-project/gacela": "^1.13",
-        "phpunit/php-timer": "^6.0|^7.0|^8.0",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/routing": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7d2127b11479b799611b39f96b26cd0",
+    "content-hash": "afd03bea6e79b407f3634fa39d2eaf8f",
     "packages": [
         {
             "name": "amphp/amp",

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -10,7 +10,7 @@ use Phel\Build\BuildFacade;
 use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
-use SebastianBergmann\Timer\ResourceUsageFormatter;
+use Phel\Shared\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -10,7 +10,7 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Phel;
 use Phel\Run\Infrastructure\Service\DebugLineTap;
 use Phel\Run\RunFacade;
-use SebastianBergmann\Timer\ResourceUsageFormatter;
+use Phel\Shared\ResourceUsageFormatter;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -11,7 +11,7 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\RunFacade;
-use SebastianBergmann\Timer\ResourceUsageFormatter;
+use Phel\Shared\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/php/Shared/CLAUDE.md
+++ b/src/php/Shared/CLAUDE.md
@@ -31,6 +31,7 @@ Located in `Facade/` subdirectory. Each module implements its corresponding inte
 
 - **ColorStyle** (implements `ColorStyleInterface`) — ANSI terminal colors: `green()`, `yellow()`, `blue()`, `red()`
   - Factory: `ColorStyle::withStyles()` / `ColorStyle::noStyles()`
+- **ResourceUsageFormatter** — `resourceUsageSinceStartOfRequest()` returns `Time: HH:MM:SS.mmm, Memory: X.XX MB` (used by `run --with-time`, `test`, `build`)
 
 ## Dependencies
 

--- a/src/php/Shared/ResourceUsageFormatter.php
+++ b/src/php/Shared/ResourceUsageFormatter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared;
+
+use RuntimeException;
+
+use function floor;
+use function memory_get_peak_usage;
+use function microtime;
+use function sprintf;
+
+final class ResourceUsageFormatter
+{
+    private const array SIZES = [
+        'GB' => 1073741824,
+        'MB' => 1048576,
+        'KB' => 1024,
+    ];
+
+    public function resourceUsageSinceStartOfRequest(): string
+    {
+        if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+            throw new RuntimeException(
+                "Cannot determine time at which the request started because \$_SERVER['REQUEST_TIME_FLOAT'] is not available",
+            );
+        }
+
+        $seconds = microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'];
+
+        return sprintf(
+            'Time: %s, Memory: %s',
+            $this->formatDuration($seconds),
+            $this->formatBytes(memory_get_peak_usage(true)),
+        );
+    }
+
+    private function formatDuration(float $seconds): string
+    {
+        $totalMilliseconds = $seconds * 1000.0;
+        $hours = (int) floor($totalMilliseconds / 3600000.0);
+        $minutes = (int) floor($totalMilliseconds / 60000.0) % 60;
+        $remaining = $totalMilliseconds - ((float) $hours * 3600000.0) - ((float) $minutes * 60000.0);
+        $wholeSeconds = (int) floor($remaining / 1000.0);
+        $milliseconds = (int) ($remaining - ((float) $wholeSeconds * 1000.0));
+
+        $result = '';
+        if ($hours > 0) {
+            $result = sprintf('%02d:', $hours);
+        }
+
+        $result .= sprintf('%02d:%02d', $minutes, $wholeSeconds);
+
+        if ($milliseconds > 0) {
+            $result .= sprintf('.%03d', $milliseconds);
+        }
+
+        return $result;
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        foreach (self::SIZES as $unit => $value) {
+            if ($bytes >= $value) {
+                return sprintf('%.2f %s', $bytes / $value, $unit);
+            }
+        }
+
+        return $bytes . ' byte' . ($bytes !== 1 ? 's' : '');
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phpunit/php-timer` was a direct `require` (prod) dependency, pulled in solely to print `Time: X, Memory: Y` at the end of `run --with-time`, `test`, and `build`. It's really a PHPUnit internal utility — awkward to ship to Phel users.

## 💡 Goal

Drop the runtime dep and inline the tiny resource-usage formatting ourselves. Package still appears transitively via `phpunit/phpunit` (dev), so dev tooling is unaffected.

## 🔖 Changes

- Add `Phel\Shared\ResourceUsageFormatter` — matches the previous output format (`Time: HH:MM:SS.mmm, Memory: X.XX MB`)
- Switch `RunCommand`, `TestCommand`, `BuildCommand` to the internal formatter
- Remove `phpunit/php-timer` from `composer.json` require
- Update Shared `CLAUDE.md` to list the new utility
- Update `CHANGELOG.md` (Unreleased → Changed)