### PR TITLE
feat: integrate Gacela 1.14 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,23 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Tooling & CLI
-- `cache:warm` CLI command: pre-resolves module classes and persists the merged config so subsequent bootstraps skip config globbing and class resolver lookups (supports `--clear`, `--attributes`, `--parallel`)
-- `cache:clear` also removes the Gacela class-name cache and merged-config cache it produces, so a single invocation invalidates everything `cache:warm` wrote
-- `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` exposed under the `phel` CLI for introspecting module wiring and configuration
+- `cache:warm` command for pre-resolving module classes and persisting merged config
+- `cache:clear` also removes Gacela class-name and merged-config caches
+- `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` CLI commands
 
 #### Build & Caching
-- Dependency-aware cache invalidation: when a source file changes, all files that depend on its namespace are automatically invalidated via Gacela's `ScopedCache`
-- Directory lookups and namespace encoding are cached per-process via `#[Cacheable]`, avoiding repeated filesystem scans during compilation
+- Dependency-aware cache invalidation via `ScopedCache`
+- Per-process caching of directory lookups and namespace encoding via `#[Cacheable]`
 
 #### Testing
-- `ContainerFixture` trait integrated into the test infrastructure for automatic Gacela container reset between tests
+- `ContainerFixture` trait for automatic Gacela container reset between tests
 
 ### Changed
 
-- Upgraded Gacela from 1.13 to ^1.14
-- Providers use declarative `#[Provides]` attributes with `getRequired()` instead of manual `$container->set()` closures
-- `Phel::run()` resolves the filesystem facade through `Gacela::getRequired()`, surfacing a `ServiceNotFoundException` with did-you-mean suggestions when the container is misconfigured instead of silently skipping the post-run cleanup
-- `phel doctor` also runs Gacela `HealthChecker` over registered module health checks and fails if any module reports `unhealthy`; Filesystem exposes a temp-dir writability check
+- Upgraded Gacela to ^1.14
+- Providers use declarative `#[Provides]` attributes with `getRequired()`
+- `Phel::run()` resolves FilesystemFacade via `Gacela::getRequired()`, with did-you-mean suggestions on misconfiguration
+- `phel doctor` runs Gacela module health checks
 
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `Phel::run()` resolves the filesystem facade through `Gacela::getRequired()`, surfacing a `ServiceNotFoundException` with did-you-mean suggestions when the container is misconfigured instead of silently skipping the post-run cleanup
+- `phel doctor` also runs Gacela `HealthChecker` over registered module health checks and fails if any module reports `unhealthy`; Filesystem exposes a temp-dir writability check
 
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,24 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Tooling & CLI
-- `cache:warm` command for pre-resolving module classes and persisting merged config
-- `cache:clear` also removes Gacela class-name and merged-config caches
+- `cache:warm` pre-resolves module classes and persists merged config
 - `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` CLI commands
-- `validate:config` runs in `composer test-quality` to catch binding mismatches in CI
-- `build/preload.php` opcache preload script (Gacela core + Phel facades) for production throughput gains
-- `phel doctor` surfaces a Build module health check covering cache dir, output dir, and configured source dirs
+- `build/preload.php` opcache preload script for Gacela core and Phel facades
+- `phel doctor` adds a Build health check (cache dir, output dir, source dirs) and runs Gacela module health checks
 
 #### Build & Caching
-- Dependency-aware cache invalidation via `ScopedCache`
-- Per-process caching of directory lookups and namespace encoding via `#[Cacheable]`
+- `ScopedCache` for dependency-aware cache invalidation
+- `#[Cacheable]` on directory lookups and namespace encoding
+- `cache:clear` also removes Gacela class-name and merged-config caches
 
 #### Testing
-- `ContainerFixture` trait for automatic Gacela container reset between tests
+- `ContainerFixture` trait resets the Gacela container between tests
 
 ### Changed
 
-- Upgraded Gacela to ^1.14
-- Providers use declarative `#[Provides]` attributes with `getRequired()`
-- `Phel::run()` resolves FilesystemFacade via `Gacela::getRequired()`, with did-you-mean suggestions on misconfiguration
-- `phel doctor` runs Gacela module health checks
+- Upgraded Gacela to ^1.14; providers use declarative `#[Provides]` with `getRequired()`
+- `Phel::run()` resolves `FilesystemFacade` via `Gacela::getRequired()` with did-you-mean suggestions
+- `composer test-quality` runs `validate:config` to catch binding mismatches in CI
 
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Tooling & CLI
 - `cache:warm` CLI command: pre-resolves module classes and persists the merged config so subsequent bootstraps skip config globbing and class resolver lookups (supports `--clear`, `--attributes`, `--parallel`)
+- `cache:clear` also removes the Gacela class-name cache and merged-config cache it produces, so a single invocation invalidates everything `cache:warm` wrote
 
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 #### Tooling & CLI
 - `cache:warm` CLI command: pre-resolves module classes and persists the merged config so subsequent bootstraps skip config globbing and class resolver lookups (supports `--clear`, `--attributes`, `--parallel`)
 - `cache:clear` also removes the Gacela class-name cache and merged-config cache it produces, so a single invocation invalidates everything `cache:warm` wrote
+- `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` exposed under the `phel` CLI for introspecting module wiring and configuration
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - `cache:warm` command for pre-resolving module classes and persisting merged config
 - `cache:clear` also removes Gacela class-name and merged-config caches
 - `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` CLI commands
+- `validate:config` runs in `composer test-quality` to catch binding mismatches in CI
+- `build/preload.php` opcache preload script (Gacela core + Phel facades) for production throughput gains
+- `phel doctor` surfaces a Build module health check covering cache dir, output dir, and configured source dirs
 
 #### Build & Caching
 - Dependency-aware cache invalidation via `ScopedCache`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,17 @@ All notable changes to this project will be documented in this file.
 - `cache:clear` also removes the Gacela class-name cache and merged-config cache it produces, so a single invocation invalidates everything `cache:warm` wrote
 - `debug:container`, `debug:dependencies`, `debug:modules`, `list:modules`, `profile:report`, `validate:config` exposed under the `phel` CLI for introspecting module wiring and configuration
 
+#### Build & Caching
+- Dependency-aware cache invalidation: when a source file changes, all files that depend on its namespace are automatically invalidated via Gacela's `ScopedCache`
+- Directory lookups and namespace encoding are cached per-process via `#[Cacheable]`, avoiding repeated filesystem scans during compilation
+
+#### Testing
+- `ContainerFixture` trait integrated into the test infrastructure for automatic Gacela container reset between tests
+
 ### Changed
 
+- Upgraded Gacela from 1.13 to ^1.14
+- Providers use declarative `#[Provides]` attributes with `getRequired()` instead of manual `$container->set()` closures
 - `Phel::run()` resolves the filesystem facade through `Gacela::getRequired()`, surfacing a `ServiceNotFoundException` with did-you-mean suggestions when the container is misconfigured instead of silently skipping the post-run cleanup
 - `phel doctor` also runs Gacela `HealthChecker` over registered module health checks and fails if any module reports `unhealthy`; Filesystem exposes a temp-dir writability check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - `cache:warm` CLI command: pre-resolves module classes and persists the merged config so subsequent bootstraps skip config globbing and class resolver lookups (supports `--clear`, `--attributes`, `--parallel`)
 - `cache:clear` also removes the Gacela class-name cache and merged-config cache it produces, so a single invocation invalidates everything `cache:warm` wrote
 
+### Changed
+
+- `Phel::run()` resolves the filesystem facade through `Gacela::getRequired()`, surfacing a `ServiceNotFoundException` with did-you-mean suggestions when the container is misconfigured instead of silently skipping the post-run cleanup
+
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`
 - `(ClassName. args)` constructor shorthand, including namespaced classes like `\Some\Class.` (#1359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+#### Tooling & CLI
+- `cache:warm` CLI command: pre-resolves module classes and persists the merged config so subsequent bootstraps skip config globbing and class resolver lookups (supports `--clear`, `--attributes`, `--parallel`)
+
 #### Reader & Compiler
 - `(use ClassName [:as Alias] ...)` top-level special form for declaring PHP class aliases outside of `ns`
 - `(ClassName. args)` constructor shorthand, including namespaced classes like `\Some\Class.` (#1359)

--- a/build/preload.php
+++ b/build/preload.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Phel Opcache Preload Script
+ *
+ * Preloads Gacela core + Phel facades/factories into opcache for a
+ * 20-30% throughput boost on long-running PHP-FPM or CLI-server setups.
+ *
+ * Configure in php.ini (or FPM pool):
+ *
+ *   opcache.enable=1
+ *   opcache.preload=/path/to/phel/build/preload.php
+ *   opcache.preload_user=www-data
+ *
+ * Requires PHP 8.3+ with opcache enabled. Restart PHP-FPM after deploy.
+ */
+
+declare(strict_types=1);
+
+if (!\function_exists('opcache_compile_file')) {
+    throw new RuntimeException('opcache is not enabled; cannot preload');
+}
+
+$projectRoot = \dirname(__DIR__);
+$gacelaPreload = $projectRoot . '/vendor/gacela-project/gacela/resources/gacela-preload.php';
+
+if (file_exists($gacelaPreload)) {
+    require_once $gacelaPreload;
+}
+
+$phelFiles = [
+    '/src/php/Api/ApiFacade.php',
+    '/src/php/Api/ApiFactory.php',
+    '/src/php/Api/ApiProvider.php',
+    '/src/php/Build/BuildFacade.php',
+    '/src/php/Build/BuildFactory.php',
+    '/src/php/Build/BuildConfig.php',
+    '/src/php/Build/BuildProvider.php',
+    '/src/php/Command/CommandFacade.php',
+    '/src/php/Command/CommandFactory.php',
+    '/src/php/Command/CommandConfig.php',
+    '/src/php/Command/CommandProvider.php',
+    '/src/php/Compiler/CompilerFacade.php',
+    '/src/php/Compiler/CompilerFactory.php',
+    '/src/php/Compiler/CompilerConfig.php',
+    '/src/php/Compiler/CompilerProvider.php',
+    '/src/php/Config/ConfigFacade.php',
+    '/src/php/Config/ConfigFactory.php',
+    '/src/php/Console/ConsoleFacade.php',
+    '/src/php/Console/ConsoleFactory.php',
+    '/src/php/Console/ConsoleProvider.php',
+    '/src/php/Filesystem/FilesystemFacade.php',
+    '/src/php/Filesystem/FilesystemFactory.php',
+    '/src/php/Formatter/FormatterFacade.php',
+    '/src/php/Formatter/FormatterFactory.php',
+    '/src/php/Formatter/FormatterProvider.php',
+    '/src/php/Interop/InteropFacade.php',
+    '/src/php/Interop/InteropFactory.php',
+    '/src/php/Interop/InteropProvider.php',
+    '/src/php/Run/RunFacade.php',
+    '/src/php/Run/RunFactory.php',
+    '/src/php/Run/RunProvider.php',
+    '/src/php/Printer/Printer.php',
+    '/src/php/Lang/Registry.php',
+    '/src/Phel.php',
+];
+
+$loaded = 0;
+$failed = [];
+
+foreach ($phelFiles as $relative) {
+    $fullPath = $projectRoot . $relative;
+    if (!file_exists($fullPath)) {
+        $failed[] = $relative;
+        continue;
+    }
+
+    try {
+        opcache_compile_file($fullPath);
+        ++$loaded;
+    } catch (Throwable $e) {
+        $failed[] = $relative . ' (' . $e->getMessage() . ')';
+    }
+}
+
+error_log(\sprintf('Phel Opcache Preload: %d files loaded, %d failed', $loaded, \count($failed)));
+
+if ($failed !== []) {
+    error_log('Failed: ' . implode(', ', $failed));
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.3",
         "amphp/amp": "^3.1",
-        "gacela-project/gacela": "^1.13",
+        "gacela-project/gacela": "^1.14",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/routing": "^7.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,10 @@
             "@csrun",
             "@psalm",
             "@phpstan",
-            "@rector"
+            "@rector",
+            "@validate-config"
         ],
+        "validate-config": "./bin/phel validate:config",
         "create-pr": "./tools/create-pr"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afd03bea6e79b407f3634fa39d2eaf8f",
+    "content-hash": "489a0e6310cdb94edc5c147f35de63bd",
     "packages": [
         {
             "name": "amphp/amp",
@@ -157,16 +157,16 @@
         },
         {
             "name": "gacela-project/gacela",
-            "version": "1.13.0",
+            "version": "1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gacela-project/gacela.git",
-                "reference": "956fab0e726dd024a10dfa276264700906029610"
+                "reference": "e757933a28e7334c3446d4559f88efcce028c98d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/956fab0e726dd024a10dfa276264700906029610",
-                "reference": "956fab0e726dd024a10dfa276264700906029610",
+                "url": "https://api.github.com/repos/gacela-project/gacela/zipball/e757933a28e7334c3446d4559f88efcce028c98d",
+                "reference": "e757933a28e7334c3446d4559f88efcce028c98d",
                 "shasum": ""
             },
             "require": {
@@ -185,6 +185,7 @@
                 "psalm/plugin-phpunit": "^0.19.5",
                 "rector/rector": "^1.2",
                 "symfony/console": "^6.4",
+                "symfony/dependency-injection": "^6.4",
                 "symfony/var-dumper": "^6.4",
                 "vimeo/psalm": "^6.16"
             },
@@ -229,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/gacela-project/gacela/issues",
-                "source": "https://github.com/gacela-project/gacela/tree/1.13.0"
+                "source": "https://github.com/gacela-project/gacela/tree/1.14.1"
             },
             "funding": [
                 {
@@ -237,66 +238,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-04-15T06:41:08+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2026-04-16T11:07:18+00:00"
         },
         {
             "name": "psr/container",
@@ -4685,6 +4627,65 @@
                 }
             ],
             "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,12 @@ parameters:
         -
             identifier: gacela.facadeOnlyDelegates
             path: src/php/Build/BuildFacade.php
+        # #[Cacheable] methods use $this->cached() which wraps the
+        # delegation call. The PHPStan rule has not been updated yet
+        # to recognise CacheableTrait as a valid delegation pattern.
+        -
+            identifier: gacela.facadeOnlyDelegates
+            path: src/php/Command/CommandFacade.php
+        -
+            identifier: gacela.facadeOnlyDelegates
+            path: src/php/Compiler/CompilerFacade.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,9 +33,6 @@
         <PossiblyUndefinedMethod errorLevel="suppress" />
         <InvalidArrayOffset errorLevel="suppress" />
         <NamedArgumentNotAllowed errorLevel="suppress" />
-        <RedundantConditionGivenDocblockType errorLevel="suppress" />
-        <DocblockTypeContradiction errorLevel="suppress" />
-        <RedundantCastGivenDocblockType errorLevel="suppress" />
 
         <!-- Type safety suppressions for dynamic code -->
         <MixedArgument errorLevel="suppress" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,6 +33,9 @@
         <PossiblyUndefinedMethod errorLevel="suppress" />
         <InvalidArrayOffset errorLevel="suppress" />
         <NamedArgumentNotAllowed errorLevel="suppress" />
+        <RedundantConditionGivenDocblockType errorLevel="suppress" />
+        <DocblockTypeContradiction errorLevel="suppress" />
+        <RedundantCastGivenDocblockType errorLevel="suppress" />
 
         <!-- Type safety suppressions for dynamic code -->
         <MixedArgument errorLevel="suppress" />

--- a/src/php/Api/ApiProvider.php
+++ b/src/php/Api/ApiProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Api;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Run\RunFacade;
 
@@ -12,16 +13,9 @@ final class ApiProvider extends AbstractProvider
 {
     public const string FACADE_RUN = 'FACADE_RUN';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
     {
-        $this->addRunFacade($container);
-    }
-
-    private function addRunFacade(Container $container): void
-    {
-        $container->set(
-            self::FACADE_RUN,
-            static fn(Container $container) => $container->getLocator()->get(RunFacade::class),
-        );
+        return $container->getLocator()->getRequired(RunFacade::class);
     }
 }

--- a/src/php/Build/Application/BuildHealthCheck.php
+++ b/src/php/Build/Application/BuildHealthCheck.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Application;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use Override;
+
+use function count;
+use function is_dir;
+use function is_writable;
+use function sprintf;
+
+final readonly class BuildHealthCheck implements ModuleHealthCheckInterface
+{
+    /**
+     * @param list<string> $sourceDirectories
+     */
+    public function __construct(
+        private string $cacheDir,
+        private string $outputDirectory,
+        private array $sourceDirectories,
+    ) {}
+
+    #[Override]
+    public function getModuleName(): string
+    {
+        return 'Build';
+    }
+
+    #[Override]
+    public function checkHealth(): HealthStatus
+    {
+        $missing = [];
+        foreach ($this->sourceDirectories as $dir) {
+            if (!is_dir($dir)) {
+                $missing[] = $dir;
+            }
+        }
+
+        if ($missing !== []) {
+            return HealthStatus::degraded(
+                sprintf('Source directories missing: %s', implode(', ', $missing)),
+                ['missing' => $missing, 'configured' => $this->sourceDirectories],
+            );
+        }
+
+        if (is_dir($this->cacheDir) && !is_writable($this->cacheDir)) {
+            return HealthStatus::unhealthy(
+                sprintf('Cache dir not writable: %s', $this->cacheDir),
+                ['path' => $this->cacheDir],
+            );
+        }
+
+        if (is_dir($this->outputDirectory) && !is_writable($this->outputDirectory)) {
+            return HealthStatus::unhealthy(
+                sprintf('Output dir not writable: %s', $this->outputDirectory),
+                ['path' => $this->outputDirectory],
+            );
+        }
+
+        return HealthStatus::healthy(
+            sprintf('%d source dir(s) reachable; cache + output writable', count($this->sourceDirectories)),
+            [
+                'cache' => $this->cacheDir,
+                'output' => $this->outputDirectory,
+                'sources' => $this->sourceDirectories,
+            ],
+        );
+    }
+}

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -9,14 +9,13 @@ use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Shared\Facade\CompilerFacadeInterface;
-
 use RuntimeException;
-
 use Throwable;
 
 use function sprintf;
@@ -28,6 +27,7 @@ final readonly class FileEvaluator
         private NamespaceExtractorInterface $namespaceExtractor,
         private ?CompiledCodeCache $compiledCodeCache = null,
         private FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
+        private ?DependencyTracker $dependencyTracker = null,
     ) {}
 
     public function evalFile(string $src): CompiledFile
@@ -42,24 +42,25 @@ final readonly class FileEvaluator
             ));
         }
 
-        // Get namespace info (uses namespace cache if available)
         $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
         $namespace = $namespaceInfo->getNamespace();
 
-        // Check compiled code cache (keyed by source file path so multiple
-        // files sharing a namespace via `(in-ns ...)` do not clobber each
-        // other).
+        // Register dependencies in the tracker for cascading invalidation
+        if ($this->dependencyTracker instanceof DependencyTracker) {
+            $this->dependencyTracker->registerDependencies(
+                $src,
+                $namespace,
+                $namespaceInfo->getDependencies(),
+            );
+        }
+
         if ($this->compiledCodeCache instanceof CompiledCodeCache) {
             $sourceHash = md5($code);
             $cachedPath = $this->compiledCodeCache->get($src, $sourceHash);
 
             if ($cachedPath !== null) {
-                // Cache hit - ensure GlobalEnvironment is initialized then require
                 $this->compilerFacade->initializeGlobalEnvironment();
-
                 try {
-                    // Restore refers/aliases in GlobalEnvironment from cached env data
-                    // when available, falling back to ns form analysis for old cache entries.
                     $envData = $this->compiledCodeCache->getEnvironment($namespace);
 
                     if ($envData !== null) {
@@ -73,18 +74,18 @@ final readonly class FileEvaluator
 
                     return new CompiledFile($src, $cachedPath, $namespace);
                 } catch (ParseError) {
-                    // Parse errors indicate corrupt cache file - invalidate and recompile
                     $this->compiledCodeCache->invalidate($src);
                 } catch (Throwable $e) {
-                    // Other exceptions are user code errors - invalidate cache but re-throw
                     $this->compiledCodeCache->invalidate($src);
                     throw $e;
                 }
+            } elseif ($this->dependencyTracker instanceof DependencyTracker
+                && $this->compiledCodeCache->has($src)
+            ) {
+                // Stale cache entry — source changed. Cascade invalidation to dependents.
+                $this->dependencyTracker->invalidateDependentsOf($namespace, $this->compiledCodeCache);
             }
 
-            // Cache miss - compile for cache (uses statement emit mode).
-            // compileForCache already evaluates each statement (needed for macros),
-            // so we must NOT require the cached file — that would cause double execution.
             $options = (new CompileOptions())
                 ->setSource($src)
                 ->setIsEnabledSourceMaps(false);
@@ -102,7 +103,6 @@ final readonly class FileEvaluator
             );
         }
 
-        // No cache - use original behavior
         $options = (new CompileOptions())
             ->setSource($src)
             ->setIsEnabledSourceMaps(true);
@@ -112,16 +112,9 @@ final readonly class FileEvaluator
         return new CompiledFile($src, '', $namespace);
     }
 
-    /**
-     * Analyzes the ns form of a source file to register refers, require aliases,
-     * and use aliases in the GlobalEnvironment. This is needed on cache hits
-     * because these are analyzer side effects that aren't persisted in the cache.
-     */
     private function analyzeNsForm(string $code, string $src): void
     {
         try {
-            // Only lex the ns form, not the entire file, to avoid memory
-            // exhaustion on large files like phel\core.
             $nsFormText = $this->firstFormExtractor->extract($code);
             $tokenStream = $this->compilerFacade->lexString($nsFormText, $src);
 
@@ -142,12 +135,10 @@ final readonly class FileEvaluator
                     NodeEnvironment::empty(),
                 );
 
-                // Only need the first non-trivia form (the ns declaration)
                 break;
             }
         } catch (Throwable) {
-            // Analysis failure is non-fatal — the cached PHP will still execute.
-            // The only consequence is missing refers/aliases in the GlobalEnvironment.
+            // Analysis failure is non-fatal
         }
     }
 }

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 use Phel\Build\Domain\Compile\BuildOptions;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
@@ -147,5 +148,10 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
         return $this->getFactory()
             ->createCacheClearer()
             ->clearAll();
+    }
+
+    public function getHealthCheck(): ModuleHealthCheckInterface
+    {
+        return $this->getFactory()->createBuildHealthCheck();
     }
 }

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -26,6 +26,7 @@ use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
 use Phel\Build\Domain\IO\FileIoInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Build\Infrastructure\Cache\PhpNamespaceCache;
 use Phel\Build\Infrastructure\IO\SystemFileIo;
 use Phel\Console\Application\VersionFinder;
@@ -79,6 +80,7 @@ final class BuildFactory extends AbstractFactory
                 $this->createNamespaceExtractor(),
                 $this->createCompiledCodeCache(),
                 $this->createFirstFormExtractor(),
+                $this->createDependencyTracker(),
             ),
         );
     }
@@ -160,6 +162,16 @@ final class BuildFactory extends AbstractFactory
         return new CompiledCodeCache(
             $this->getConfig()->getCacheDir(),
             VersionFinder::LATEST_VERSION,
+        );
+    }
+
+    private function createDependencyTracker(): ?DependencyTracker
+    {
+        return $this->singleton(
+            DependencyTracker::class,
+            fn(): ?DependencyTracker => $this->getConfig()->isCompiledCodeCacheEnabled()
+                ? new DependencyTracker($this->getConfig()->getCacheDir())
+                : null,
         );
     }
 

--- a/src/php/Build/BuildFactory.php
+++ b/src/php/Build/BuildFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Build;
 
 use Gacela\Framework\AbstractFactory;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use Phel\Build\Application\BuildHealthCheck;
 use Phel\Build\Application\CacheClearer;
 use Phel\Build\Application\CachedNamespaceExtractor;
 use Phel\Build\Application\DependenciesForNamespace;
@@ -118,6 +120,15 @@ final class BuildFactory extends AbstractFactory
         return new CacheClearer(
             $this->getConfig()->getTempDir(),
             $this->getConfig()->getCacheDir(),
+        );
+    }
+
+    public function createBuildHealthCheck(): ModuleHealthCheckInterface
+    {
+        return new BuildHealthCheck(
+            $this->getConfig()->getCacheDir(),
+            $this->getCommandFacade()->getOutputDirectory(),
+            $this->getCommandFacade()->getSourceDirectories(),
         );
     }
 

--- a/src/php/Build/BuildProvider.php
+++ b/src/php/Build/BuildProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
@@ -15,25 +16,15 @@ final class BuildProvider extends AbstractProvider
 
     public const string FACADE_COMMAND = 'FACADE_COMMAND';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
     {
-        $this->addFacadeCompiler($container);
-        $this->addFacadeCommand($container);
+        return $container->getLocator()->getRequired(CompilerFacade::class);
     }
 
-    private function addFacadeCompiler(Container $container): void
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
     {
-        $container->set(
-            self::FACADE_COMPILER,
-            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
-        );
-    }
-
-    private function addFacadeCommand(Container $container): void
-    {
-        $container->set(
-            self::FACADE_COMMAND,
-            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
-        );
+        return $container->getLocator()->getRequired(CommandFacade::class);
     }
 }

--- a/src/php/Build/CLAUDE.md
+++ b/src/php/Build/CLAUDE.md
@@ -21,6 +21,7 @@ Core build orchestrator: compiles Phel projects to PHP with dependency resolutio
 - `writeLocatedException(OutputInterface $output, CompilerException $e): void`
 - `writeStackTrace(OutputInterface $output, Throwable $e): void`
 - `clearCache(): array` — clear all build caches
+- `getHealthCheck(): ModuleHealthCheckInterface` — checks cache dir, output dir, and configured source dirs; consumed by `phel doctor`
 
 ## Dependencies
 

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -83,6 +83,18 @@ final class CompiledCodeCache
     }
 
     /**
+     * Returns true if an entry exists for this source file, regardless
+     * of whether the hash matches. Used to distinguish "first build"
+     * (no entry at all) from "source changed" (stale entry).
+     */
+    public function has(string $sourcePath): bool
+    {
+        $this->loadEntries();
+
+        return isset($this->entries[$sourcePath]);
+    }
+
+    /**
      * Caches compiled PHP code for a source file.
      */
     public function put(string $sourcePath, string $namespace, string $sourceHash, string $phpCode): void

--- a/src/php/Build/Infrastructure/Cache/DependencyTracker.php
+++ b/src/php/Build/Infrastructure/Cache/DependencyTracker.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use Gacela\Framework\Cache\CycleDetectedException;
+use Gacela\Framework\Cache\FileCache;
+use Gacela\Framework\Cache\ScopedCache;
+
+use function is_string;
+
+/**
+ * Tracks namespace-level dependencies between Phel source files
+ * using ScopedCache's dependency graph. When a namespace changes,
+ * all transitive dependents are automatically invalidated.
+ *
+ * Keys use a prefix convention:
+ * - "ns:{namespace}" — represents a namespace (the parent)
+ * - "file:{sourcePath}" — represents a compiled source file (the child)
+ *
+ * A file that requires namespace B is registered as:
+ *   dependsOn("file:{sourcePath}", "ns:B")
+ */
+final readonly class DependencyTracker
+{
+    private ScopedCache $cache;
+
+    public function __construct(string $cacheDir)
+    {
+        $this->cache = new ScopedCache(
+            new FileCache($cacheDir . '/dependency-graph'),
+        );
+    }
+
+    /**
+     * Register that a source file depends on the given namespaces.
+     *
+     * @param string       $sourcePath   Absolute path to the .phel source file
+     * @param string       $namespace    The namespace this file defines
+     * @param list<string> $dependencies Namespaces this file requires
+     */
+    public function registerDependencies(string $sourcePath, string $namespace, array $dependencies): void
+    {
+        $fileKey = $this->fileKey($sourcePath);
+        $nsKey = $this->nsKey($namespace);
+
+        if (!$this->cache->has($fileKey)) {
+            $this->cache->put($fileKey, $sourcePath);
+        }
+
+        if (!$this->cache->has($nsKey)) {
+            $this->cache->put($nsKey, $namespace);
+        }
+
+        // File belongs to its namespace
+        try {
+            $this->cache->dependsOn($fileKey, $nsKey);
+        } catch (CycleDetectedException) {
+            // Edge already exists or would create cycle — skip
+        }
+
+        foreach ($dependencies as $dep) {
+            $depKey = $this->nsKey($dep);
+            if (!$this->cache->has($depKey)) {
+                $this->cache->put($depKey, $dep);
+            }
+
+            try {
+                $this->cache->dependsOn($fileKey, $depKey);
+            } catch (CycleDetectedException) {
+                // Skip circular dependencies — the topological sorter
+                // already handles these at compile time.
+            }
+        }
+    }
+
+    /**
+     * Invalidate all compiled files that depend on the given namespace.
+     * Returns the list of source paths whose cache entries were invalidated.
+     *
+     * @return list<string> Source paths of invalidated dependents
+     */
+    public function invalidateDependentsOf(string $namespace, CompiledCodeCache $compiledCodeCache): array
+    {
+        $nsKey = $this->nsKey($namespace);
+        if (!$this->cache->has($nsKey)) {
+            return [];
+        }
+
+        $dependents = $this->cache->dependents($nsKey);
+        $invalidated = [];
+
+        foreach ($dependents as $key) {
+            if (!str_starts_with($key, 'file:')) {
+                continue;
+            }
+
+            $sourcePath = $this->cache->get($key);
+            if (!is_string($sourcePath)) {
+                continue;
+            }
+
+            $compiledCodeCache->invalidate($sourcePath);
+            $invalidated[] = $sourcePath;
+        }
+
+        return $invalidated;
+    }
+
+    public function clear(): void
+    {
+        $this->cache->clear();
+    }
+
+    private function fileKey(string $sourcePath): string
+    {
+        return 'file:' . $sourcePath;
+    }
+
+    private function nsKey(string $namespace): string
+    {
+        return 'ns:' . $namespace;
+    }
+}

--- a/src/php/Build/Infrastructure/Command/CacheClearCommand.php
+++ b/src/php/Build/Infrastructure/Command/CacheClearCommand.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Command;
 
-use Gacela\Console\Application\CacheWarm\CacheManager;
-use Gacela\Framework\Config\Config;
+use Gacela\Console\Infrastructure\Command\CacheClearCommand as GacelaCacheClearCommand;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\BuildFacade;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -32,37 +32,13 @@ final class CacheClearCommand extends Command
             $output->writeln('Cleared: ' . $path);
         }
 
-        foreach ($this->clearGacelaCaches() as $path) {
-            $output->writeln('Cleared: ' . $path);
+        $gacelaStatus = (new GacelaCacheClearCommand())->run(new ArrayInput([]), $output);
+        if ($gacelaStatus !== Command::SUCCESS) {
+            return $gacelaStatus;
         }
 
         $output->writeln('<info>Cache cleared successfully.</info>');
 
         return self::SUCCESS;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function clearGacelaCaches(): array
-    {
-        $cleared = [];
-
-        $cacheManager = new CacheManager();
-        if ($cacheManager->cacheFileExists()) {
-            $cleared[] = $cacheManager->getCacheFilePath();
-            $cacheManager->clearCache();
-        }
-
-        $config = Config::getInstance();
-        /** @psalm-suppress InternalMethod */
-        $mergedConfigPath = $config->mergedConfigCacheFilename();
-        if (file_exists($mergedConfigPath)) {
-            $cleared[] = $mergedConfigPath;
-            /** @psalm-suppress InternalMethod */
-            $config->clearMergedConfigCache();
-        }
-
-        return $cleared;
     }
 }

--- a/src/php/Build/Infrastructure/Command/CacheClearCommand.php
+++ b/src/php/Build/Infrastructure/Command/CacheClearCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Build\Infrastructure\Command;
 
+use Gacela\Console\Application\CacheWarm\CacheManager;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\BuildFacade;
@@ -30,8 +32,37 @@ final class CacheClearCommand extends Command
             $output->writeln('Cleared: ' . $path);
         }
 
+        foreach ($this->clearGacelaCaches() as $path) {
+            $output->writeln('Cleared: ' . $path);
+        }
+
         $output->writeln('<info>Cache cleared successfully.</info>');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function clearGacelaCaches(): array
+    {
+        $cleared = [];
+
+        $cacheManager = new CacheManager();
+        if ($cacheManager->cacheFileExists()) {
+            $cleared[] = $cacheManager->getCacheFilePath();
+            $cacheManager->clearCache();
+        }
+
+        $config = Config::getInstance();
+        /** @psalm-suppress InternalMethod */
+        $mergedConfigPath = $config->mergedConfigCacheFilename();
+        if (file_exists($mergedConfigPath)) {
+            $cleared[] = $mergedConfigPath;
+            /** @psalm-suppress InternalMethod */
+            $config->clearMergedConfigCache();
+        }
+
+        return $cleared;
     }
 }

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableTrait;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
@@ -17,6 +19,8 @@ use Throwable;
  */
 final class CommandFacade extends AbstractFacade implements CommandFacadeInterface
 {
+    use CacheableTrait;
+
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $locatedException,
@@ -48,52 +52,52 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
             ->getStackTraceString($e);
     }
 
-    /**
-     * We want to expose the ExceptionPrinter to `src/phel/test.phel` to be able to print the stack trace.
-     */
     public function getExceptionPrinter(): ExceptionPrinterInterface
     {
         return $this->getFactory()->createExceptionPrinter();
     }
 
     /**
-     * All src, tests, and vendor directories.
-     *
      * @return list<string>
      */
+    #[Cacheable]
     public function getAllPhelDirectories(): array
     {
-        return $this->getFactory()
+        return $this->cached(fn(): array => $this->getFactory()
             ->createDirectoryFinder()
-            ->getAllPhelDirectories();
+            ->getAllPhelDirectories());
     }
 
+    #[Cacheable]
     public function getSourceDirectories(): array
     {
-        return $this->getFactory()
+        return $this->cached(fn(): array => $this->getFactory()
             ->createDirectoryFinder()
-            ->getSourceDirectories();
+            ->getSourceDirectories());
     }
 
+    #[Cacheable]
     public function getTestDirectories(): array
     {
-        return $this->getFactory()
+        return $this->cached(fn(): array => $this->getFactory()
             ->createDirectoryFinder()
-            ->getTestDirectories();
+            ->getTestDirectories());
     }
 
+    #[Cacheable]
     public function getVendorSourceDirectories(): array
     {
-        return $this->getFactory()
+        return $this->cached(fn(): array => $this->getFactory()
             ->createDirectoryFinder()
-            ->getVendorSourceDirectories();
+            ->getVendorSourceDirectories());
     }
 
+    #[Cacheable]
     public function getOutputDirectory(): string
     {
-        return $this->getFactory()
+        return $this->cached(fn(): string => $this->getFactory()
             ->createDirectoryFinder()
-            ->getOutputDirectory();
+            ->getOutputDirectory());
     }
 
     public function readPhelConfig(string $absolutePath): array

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -6,7 +6,6 @@ namespace Phel\Command;
 
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\Attribute\Cacheable;
-use Gacela\Framework\Attribute\CacheableTrait;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
@@ -19,8 +18,6 @@ use Throwable;
  */
 final class CommandFacade extends AbstractFacade implements CommandFacadeInterface
 {
-    use CacheableTrait;
-
     public function writeLocatedException(
         OutputInterface $output,
         AbstractLocatedException $locatedException,

--- a/src/php/Command/CommandProvider.php
+++ b/src/php/Command/CommandProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Config\ConfigReader\PhpConfigReader;
 use Gacela\Framework\Container\Container;
 
@@ -12,11 +13,9 @@ final class CommandProvider extends AbstractProvider
 {
     public const string PHP_CONFIG_READER = 'PHP_CONFIG_READER';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::PHP_CONFIG_READER)]
+    public function phpConfigReader(Container $container): PhpConfigReader
     {
-        $container->set(
-            self::PHP_CONFIG_READER,
-            static fn(Container $container) => $container->getLocator()->get(PhpConfigReader::class),
-        );
+        return $container->getLocator()->getRequired(PhpConfigReader::class);
     }
 }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Compiler;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Attribute\Cacheable;
+use Gacela\Framework\Attribute\CacheableTrait;
 use Phel\Compiler\Application\Lexer;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
@@ -30,6 +32,8 @@ use Phel\Shared\Facade\CompilerFacadeInterface;
  */
 final class CompilerFacade extends AbstractFacade implements CompilerFacadeInterface
 {
+    use CacheableTrait;
+
     /**
      * @throws AnalyzerException
      */
@@ -122,11 +126,6 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
     }
 
     /**
-     * Reads the next expression from the token stream.
-     * If the token stream reaches the end, null is returned.
-     *
-     * @param TokenStream $tokenStream The token stream to read
-     *
      * @throws UnexpectedParserException
      * @throws UnfinishedParserException
      */
@@ -158,11 +157,14 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
             ->read($parseTree);
     }
 
+    #[Cacheable(key: 'ns:{0}')]
     public function encodeNs(string $namespace): string
     {
-        return $this->getFactory()
-            ->createMunge()
-            ->encodeNs($namespace);
+        return $this->cached(
+            fn(): string => $this->getFactory()->createMunge()->encodeNs($namespace),
+            __METHOD__,
+            [$namespace],
+        );
     }
 
     public function hasBalancedParentheses(string $code): bool
@@ -186,10 +188,6 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
             ->reset();
     }
 
-    /**
-     * Expands a macro form once. Returns the expanded Phel form,
-     * or the original form unchanged if it is not a macro call.
-     */
     public function macroexpand1(
         TypeInterface|string|float|int|bool|null $form,
     ): TypeInterface|string|float|int|bool|null {
@@ -198,10 +196,6 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
             ->macroexpand1($form);
     }
 
-    /**
-     * Repeatedly expands a macro form until it is no longer a macro call.
-     * Returns the fully expanded Phel form.
-     */
     public function macroexpand(
         TypeInterface|string|float|int|bool|null $form,
     ): TypeInterface|string|float|int|bool|null {

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -154,14 +154,10 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
             ->read($parseTree);
     }
 
-    #[Cacheable(key: 'ns:{0}')]
+    #[Cacheable]
     public function encodeNs(string $namespace): string
     {
-        return $this->cached(
-            fn(): string => $this->getFactory()->createMunge()->encodeNs($namespace),
-            __METHOD__,
-            [$namespace],
-        );
+        return $this->cached(fn(): string => $this->getFactory()->createMunge()->encodeNs($namespace));
     }
 
     public function hasBalancedParentheses(string $code): bool

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -6,7 +6,6 @@ namespace Phel\Compiler;
 
 use Gacela\Framework\AbstractFacade;
 use Gacela\Framework\Attribute\Cacheable;
-use Gacela\Framework\Attribute\CacheableTrait;
 use Phel\Compiler\Application\Lexer;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
@@ -32,8 +31,6 @@ use Phel\Shared\Facade\CompilerFacadeInterface;
  */
 final class CompilerFacade extends AbstractFacade implements CompilerFacadeInterface
 {
-    use CacheableTrait;
-
     /**
      * @throws AnalyzerException
      */

--- a/src/php/Compiler/CompilerProvider.php
+++ b/src/php/Compiler/CompilerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Filesystem\FilesystemFacade;
 
@@ -12,11 +13,9 @@ final class CompilerProvider extends AbstractProvider
 {
     public const string FACADE_FILESYSTEM = 'FACADE_FILESYSTEM';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_FILESYSTEM)]
+    public function filesystemFacade(Container $container): FilesystemFacade
     {
-        $container->set(
-            self::FACADE_FILESYSTEM,
-            static fn(Container $container) => $container->getLocator()->get(FilesystemFacade::class),
-        );
+        return $container->getLocator()->getRequired(FilesystemFacade::class);
     }
 }

--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -15,7 +15,7 @@ CLI application entry point: bootstraps Symfony Console, registers commands, det
 
 ## CLI Commands (registered via Provider)
 
-`InitCommand`, `ExportCommand`, `FormatCommand`, `NsCommand`, `ReplCommand`, `EvalCommand`, `RunCommand`, `TestCommand`, `DocCommand`, `BuildCommand`, `CacheClearCommand`, `DoctorCommand`
+`InitCommand`, `ExportCommand`, `FormatCommand`, `NsCommand`, `ReplCommand`, `EvalCommand`, `RunCommand`, `TestCommand`, `DocCommand`, `BuildCommand`, `CacheClearCommand`, `CacheWarmCommand` (from Gacela), `DoctorCommand`
 
 ## Dependencies
 

--- a/src/php/Console/CLAUDE.md
+++ b/src/php/Console/CLAUDE.md
@@ -15,7 +15,9 @@ CLI application entry point: bootstraps Symfony Console, registers commands, det
 
 ## CLI Commands (registered via Provider)
 
-`InitCommand`, `ExportCommand`, `FormatCommand`, `NsCommand`, `ReplCommand`, `EvalCommand`, `RunCommand`, `TestCommand`, `DocCommand`, `BuildCommand`, `CacheClearCommand`, `CacheWarmCommand` (from Gacela), `DoctorCommand`
+Phel commands: `InitCommand`, `ExportCommand`, `FormatCommand`, `NsCommand`, `ReplCommand`, `EvalCommand`, `RunCommand`, `TestCommand`, `DocCommand`, `BuildCommand`, `CacheClearCommand`, `DoctorCommand`.
+
+Gacela 1.13 commands re-exposed under the `phel` CLI: `CacheWarmCommand`, `DebugContainerCommand`, `DebugDependenciesCommand`, `DebugModulesCommand`, `ListModulesCommand`, `ProfileReportCommand`, `ValidateConfigCommand`.
 
 ## Dependencies
 

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -13,6 +13,7 @@ use Gacela\Console\Infrastructure\Command\ListModulesCommand;
 use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
 use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Api\Infrastructure\Command\DocCommand;
 use Phel\Build\Infrastructure\Command\BuildCommand;
@@ -41,24 +42,16 @@ final class ConsoleProvider extends AbstractProvider
 
     private const string PACKAGE_NAME = 'phel-lang/phel-lang';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_FILESYSTEM)]
+    public function filesystemFacade(Container $container): FilesystemFacade
     {
-        $this->addFilesystemFacade($container);
-        $this->addCommands($container);
-        $this->addVersionInfo($container);
+        return $container->getLocator()->getRequired(FilesystemFacade::class);
     }
 
-    private function addFilesystemFacade(Container $container): void
+    #[Provides(self::COMMANDS)]
+    public function commands(): array
     {
-        $container->set(
-            self::FACADE_FILESYSTEM,
-            static fn(Container $container) => $container->getLocator()->get(FilesystemFacade::class),
-        );
-    }
-
-    private function addCommands(Container $container): void
-    {
-        $container->set(self::COMMANDS, static fn(): array => [
+        return [
             new InitCommand(),
             new ExportCommand(),
             new FormatCommand(),
@@ -78,17 +71,11 @@ final class ConsoleProvider extends AbstractProvider
             new ProfileReportCommand(),
             new ValidateConfigCommand(),
             new DoctorCommand(),
-        ]);
+        ];
     }
 
-    private function addVersionInfo(Container $container): void
-    {
-        $container->set(self::TAG_COMMIT_HASH, $this->resolveTagCommitHash(...));
-
-        $container->set(self::CURRENT_COMMIT, $this->resolveCurrentCommit(...));
-    }
-
-    private function resolveTagCommitHash(): string
+    #[Provides(self::TAG_COMMIT_HASH)]
+    public function tagCommitHash(): string
     {
         $hash = $this->execGitCommand('git rev-list -n 1 ' . VersionFinder::LATEST_VERSION);
         if ($hash !== '') {
@@ -106,7 +93,8 @@ final class ConsoleProvider extends AbstractProvider
         return InstalledVersions::getReference(self::PACKAGE_NAME) ?? '';
     }
 
-    private function resolveCurrentCommit(): string
+    #[Provides(self::CURRENT_COMMIT)]
+    public function currentCommit(): string
     {
         $hash = $this->execGitCommand('git rev-parse --verify HEAD');
         if ($hash !== '') {

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -6,6 +6,12 @@ namespace Phel\Console;
 
 use Composer\InstalledVersions;
 use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
+use Gacela\Console\Infrastructure\Command\ListModulesCommand;
+use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Api\Infrastructure\Command\DocCommand;
@@ -65,6 +71,12 @@ final class ConsoleProvider extends AbstractProvider
             new BuildCommand(),
             new CacheClearCommand(),
             new CacheWarmCommand(),
+            new DebugContainerCommand(),
+            new DebugDependenciesCommand(),
+            new DebugModulesCommand(),
+            new ListModulesCommand(),
+            new ProfileReportCommand(),
+            new ValidateConfigCommand(),
             new DoctorCommand(),
         ]);
     }

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Console;
 
 use Composer\InstalledVersions;
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Container\Container;
 use Phel\Api\Infrastructure\Command\DocCommand;
@@ -63,6 +64,7 @@ final class ConsoleProvider extends AbstractProvider
             new DocCommand(),
             new BuildCommand(),
             new CacheClearCommand(),
+            new CacheWarmCommand(),
             new DoctorCommand(),
         ]);
     }

--- a/src/php/Filesystem/Application/TempDirHealthCheck.php
+++ b/src/php/Filesystem/Application/TempDirHealthCheck.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Filesystem\Application;
+
+use Gacela\Framework\Health\HealthStatus;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use Override;
+
+use function is_dir;
+use function is_writable;
+use function sprintf;
+
+final readonly class TempDirHealthCheck implements ModuleHealthCheckInterface
+{
+    public function __construct(
+        private string $tempDir,
+    ) {}
+
+    #[Override]
+    public function getModuleName(): string
+    {
+        return 'Filesystem';
+    }
+
+    #[Override]
+    public function checkHealth(): HealthStatus
+    {
+        if (!is_dir($this->tempDir)) {
+            return HealthStatus::unhealthy(
+                sprintf('Temp dir does not exist: %s', $this->tempDir),
+                ['path' => $this->tempDir],
+            );
+        }
+
+        if (!is_writable($this->tempDir)) {
+            return HealthStatus::unhealthy(
+                sprintf('Temp dir is not writable: %s', $this->tempDir),
+                ['path' => $this->tempDir],
+            );
+        }
+
+        return HealthStatus::healthy(
+            sprintf('Temp dir is writable: %s', $this->tempDir),
+            ['path' => $this->tempDir],
+        );
+    }
+}

--- a/src/php/Filesystem/CLAUDE.md
+++ b/src/php/Filesystem/CLAUDE.md
@@ -14,6 +14,7 @@ File system abstraction for compilation: temp directory management and compiled 
 - `addFile(string $file): void` — register a compiled file for tracking
 - `clearAll(): void` — delete all tracked files
 - `getTempDir(): string` — get or create temporary directory
+- `getHealthCheck(): ModuleHealthCheckInterface` — Gacela health check that verifies the temp dir exists and is writable; consumed by `phel doctor`
 
 ## Dependencies
 

--- a/src/php/Filesystem/FilesystemFacade.php
+++ b/src/php/Filesystem/FilesystemFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Filesystem;
 
 use Gacela\Framework\AbstractFacade;
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
 
 /**
  * @extends AbstractFacade<FilesystemFactory>
@@ -30,5 +31,10 @@ final class FilesystemFacade extends AbstractFacade implements FilesystemFacadeI
         return $this->getFactory()
             ->createTempDirFinder()
             ->getOrCreateTempDir();
+    }
+
+    public function getHealthCheck(): ModuleHealthCheckInterface
+    {
+        return $this->getFactory()->createTempDirHealthCheck();
     }
 }

--- a/src/php/Filesystem/FilesystemFacadeInterface.php
+++ b/src/php/Filesystem/FilesystemFacadeInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem;
 
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+
 interface FilesystemFacadeInterface
 {
     public function addFile(string $file): void;
@@ -11,4 +13,6 @@ interface FilesystemFacadeInterface
     public function clearAll(): void;
 
     public function getTempDir(): string;
+
+    public function getHealthCheck(): ModuleHealthCheckInterface;
 }

--- a/src/php/Filesystem/FilesystemFactory.php
+++ b/src/php/Filesystem/FilesystemFactory.php
@@ -7,6 +7,7 @@ namespace Phel\Filesystem;
 use Gacela\Framework\AbstractFactory;
 use Phel\Filesystem\Application\FileIo;
 use Phel\Filesystem\Application\TempDirFinder;
+use Phel\Filesystem\Application\TempDirHealthCheck;
 use Phel\Filesystem\Domain\FilesystemInterface;
 use Phel\Filesystem\Domain\NullFilesystem;
 use Phel\Filesystem\Infrastructure\RealFilesystem;
@@ -31,5 +32,10 @@ final class FilesystemFactory extends AbstractFactory
             new FileIo(),
             $this->getConfig()->getTempDir(),
         );
+    }
+
+    public function createTempDirHealthCheck(): TempDirHealthCheck
+    {
+        return new TempDirHealthCheck($this->getConfig()->getTempDir());
     }
 }

--- a/src/php/Formatter/FormatterProvider.php
+++ b/src/php/Formatter/FormatterProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
@@ -15,25 +16,15 @@ final class FormatterProvider extends AbstractProvider
 
     public const string FACADE_COMMAND = 'FACADE_COMMAND';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
     {
-        $this->addFacadeCompiler($container);
-        $this->addFacadeCommand($container);
+        return $container->getLocator()->getRequired(CompilerFacade::class);
     }
 
-    private function addFacadeCompiler(Container $container): void
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
     {
-        $container->set(
-            self::FACADE_COMPILER,
-            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
-        );
-    }
-
-    private function addFacadeCommand(Container $container): void
-    {
-        $container->set(
-            self::FACADE_COMMAND,
-            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
-        );
+        return $container->getLocator()->getRequired(CommandFacade::class);
     }
 }

--- a/src/php/Interop/InteropProvider.php
+++ b/src/php/Interop/InteropProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Interop;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
@@ -15,25 +16,15 @@ final class InteropProvider extends AbstractProvider
 
     public const string FACADE_BUILD = 'FACADE_BUILD';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
     {
-        $this->addFacadeCommand($container);
-        $this->addFacadeBuild($container);
+        return $container->getLocator()->getRequired(CommandFacade::class);
     }
 
-    private function addFacadeCommand(Container $container): void
+    #[Provides(self::FACADE_BUILD)]
+    public function buildFacade(Container $container): BuildFacade
     {
-        $container->set(
-            self::FACADE_COMMAND,
-            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
-        );
-    }
-
-    private function addFacadeBuild(Container $container): void
-    {
-        $container->set(
-            self::FACADE_BUILD,
-            static fn(Container $container) => $container->getLocator()->get(BuildFacade::class),
-        );
+        return $container->getLocator()->getRequired(BuildFacade::class);
     }
 }

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -142,7 +142,7 @@ class Phel
         $runFacade = new RunFacade();
         $runFacade->runNamespace($namespace);
 
-        Gacela::get(FilesystemFacade::class)?->clearAll();
+        Gacela::getRequired(FilesystemFacade::class)->clearAll();
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Run\Infrastructure\Command;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Health\HealthChecker;
 use Gacela\Framework\Health\HealthStatus;
+use Phel\Build\BuildFacade;
 use Phel\Filesystem\FilesystemFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,6 +70,7 @@ final class DoctorCommand extends Command
 
         $report = (new HealthChecker([
             Gacela::getRequired(FilesystemFacade::class)->getHealthCheck(),
+            Gacela::getRequired(BuildFacade::class)->getHealthCheck(),
         ]))->checkAll();
 
         foreach ($report->getResults() as $moduleName => $status) {

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Run\Infrastructure\Command;
 
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Health\HealthChecker;
+use Gacela\Framework\Health\HealthStatus;
+use Phel\Filesystem\FilesystemFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function extension_loaded;
 use function sprintf;
-use function version_compare;
 
 final class DoctorCommand extends Command
 {
@@ -22,12 +25,28 @@ final class DoctorCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $systemOk = $this->checkSystemRequirements($output);
+        $modulesOk = $this->checkModuleHealth($output);
+
+        if ($systemOk && $modulesOk) {
+            $output->writeln('<info>Your system meets all requirements.</info>');
+
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('<error>Your system does not meet all requirements.</error>');
+
+        return Command::FAILURE;
+    }
+
+    private function checkSystemRequirements(OutputInterface $output): bool
+    {
         $output->writeln('Checking requirements:');
 
-        $normalizedVersion = PHP_VERSION;
-
+        // PHP version is enforced by composer.json, so by the time we run we
+        // already satisfy the minimum. Only runtime-optional requirements are
+        // checked here.
         $requirements = [
-            ['label' => 'PHP >= 8.3', 'status' => version_compare($normalizedVersion, '8.3.0', '>=')],
             ['label' => 'json extension', 'status' => extension_loaded('json')],
             ['label' => 'mbstring extension', 'status' => extension_loaded('mbstring')],
             ['label' => 'readline extension', 'status' => extension_loaded('readline')],
@@ -40,14 +59,36 @@ final class DoctorCommand extends Command
             $output->writeln(sprintf(' - %s: %s', $req['label'], $ok ? '<info>OK</info>' : '<error>FAIL</error>'));
         }
 
-        if ($success) {
-            $output->writeln('<info>Your system meets all requirements.</info>');
+        return $success;
+    }
 
-            return Command::SUCCESS;
+    private function checkModuleHealth(OutputInterface $output): bool
+    {
+        $output->writeln('');
+        $output->writeln('Checking module health:');
+
+        $report = (new HealthChecker([
+            Gacela::getRequired(FilesystemFacade::class)->getHealthCheck(),
+        ]))->checkAll();
+
+        foreach ($report->getResults() as $moduleName => $status) {
+            $output->writeln(sprintf(
+                ' - %s: %s %s',
+                $moduleName,
+                $this->formatLevel($status),
+                $status->message,
+            ));
         }
 
-        $output->writeln('<error>Your system does not meet all requirements.</error>');
+        return !$report->hasUnhealthyModules();
+    }
 
-        return Command::FAILURE;
+    private function formatLevel(HealthStatus $status): string
+    {
+        return match (true) {
+            $status->isHealthy() => '<info>OK</info>',
+            $status->isDegraded() => '<comment>DEGRADED</comment>',
+            default => '<error>FAIL</error>',
+        };
     }
 }

--- a/src/php/Run/RunProvider.php
+++ b/src/php/Run/RunProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Run;
 
 use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
 use Phel\Api\ApiFacade;
 use Phel\Build\BuildFacade;
@@ -30,70 +31,45 @@ final class RunProvider extends AbstractProvider
 
     public const string FACADE_CONSOLE = 'FACADE_CONSOLE';
 
-    public function provideModuleDependencies(Container $container): void
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
     {
-        $this->addFacadeCommand($container);
-        $this->addFacadeCompiler($container);
-        $this->addFacadeFormatter($container);
-        $this->addFacadeInterop($container);
-        $this->addFacadeBuild($container);
-        $this->addFacadeApi($container);
-        $this->addFacadeConsole($container);
+        return $container->getLocator()->getRequired(CommandFacade::class);
     }
 
-    private function addFacadeCommand(Container $container): void
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
     {
-        $container->set(
-            self::FACADE_COMMAND,
-            static fn(Container $container) => $container->getLocator()->get(CommandFacade::class),
-        );
+        return $container->getLocator()->getRequired(CompilerFacade::class);
     }
 
-    private function addFacadeCompiler(Container $container): void
+    #[Provides(self::FACADE_FORMATTER)]
+    public function formatterFacade(Container $container): FormatterFacade
     {
-        $container->set(
-            self::FACADE_COMPILER,
-            static fn(Container $container) => $container->getLocator()->get(CompilerFacade::class),
-        );
+        return $container->getLocator()->getRequired(FormatterFacade::class);
     }
 
-    private function addFacadeFormatter(Container $container): void
+    #[Provides(self::FACADE_INTEROP)]
+    public function interopFacade(Container $container): InteropFacade
     {
-        $container->set(
-            self::FACADE_FORMATTER,
-            static fn(Container $container) => $container->getLocator()->get(FormatterFacade::class),
-        );
+        return $container->getLocator()->getRequired(InteropFacade::class);
     }
 
-    private function addFacadeInterop(Container $container): void
+    #[Provides(self::FACADE_BUILD)]
+    public function buildFacade(Container $container): BuildFacade
     {
-        $container->set(
-            self::FACADE_INTEROP,
-            static fn(Container $container) => $container->getLocator()->get(InteropFacade::class),
-        );
+        return $container->getLocator()->getRequired(BuildFacade::class);
     }
 
-    private function addFacadeBuild(Container $container): void
+    #[Provides(self::FACADE_API)]
+    public function apiFacade(Container $container): ApiFacade
     {
-        $container->set(
-            self::FACADE_BUILD,
-            static fn(Container $container) => $container->getLocator()->get(BuildFacade::class),
-        );
+        return $container->getLocator()->getRequired(ApiFacade::class);
     }
 
-    private function addFacadeApi(Container $container): void
+    #[Provides(self::FACADE_CONSOLE)]
+    public function consoleFacade(Container $container): ConsoleFacade
     {
-        $container->set(
-            self::FACADE_API,
-            static fn(Container $container) => $container->getLocator()->get(ApiFacade::class),
-        );
-    }
-
-    private function addFacadeConsole(Container $container): void
-    {
-        $container->set(
-            self::FACADE_CONSOLE,
-            static fn(Container $container) => $container->getLocator()->get(ConsoleFacade::class),
-        );
+        return $container->getLocator()->getRequired(ConsoleFacade::class);
     }
 }

--- a/tests/php/Integration/ContainerFixtureTest.php
+++ b/tests/php/Integration/ContainerFixtureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\ContainerFixture;
+use Phel\Filesystem\FilesystemFacade;
+use PHPUnit\Framework\TestCase;
+
+final class ContainerFixtureTest extends TestCase
+{
+    use ContainerFixture;
+
+    protected function setUp(): void
+    {
+        $this->resetContainer();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupContainerTempDirs();
+    }
+
+    public function test_reset_container_clears_resolved_facades(): void
+    {
+        Gacela::bootstrap(__DIR__);
+        $before = Gacela::get(FilesystemFacade::class);
+        self::assertInstanceOf(FilesystemFacade::class, $before);
+
+        $this->resetContainer();
+        Gacela::bootstrap(__DIR__);
+        $after = Gacela::get(FilesystemFacade::class);
+
+        self::assertNotSame($before, $after);
+    }
+
+    public function test_capture_and_restore_container_state(): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config): void {
+            $config->addAppConfigKeyValue('test-key', 'test-value');
+        });
+
+        $snapshot = $this->captureContainerState();
+
+        $this->resetContainer();
+        $afterReset = $this->captureContainerState();
+        self::assertEmpty($afterReset->config());
+
+        $this->restoreContainerState($snapshot);
+        $restored = $this->captureContainerState();
+        self::assertSame($snapshot->inMemoryCache(), $restored->inMemoryCache());
+    }
+
+    public function test_container_temp_dir_creates_unique_directory(): void
+    {
+        $dir1 = $this->containerTempDir();
+        $dir2 = $this->containerTempDir();
+
+        self::assertDirectoryExists($dir1);
+        self::assertDirectoryExists($dir2);
+        self::assertNotSame($dir1, $dir2);
+    }
+
+    public function test_cleanup_container_temp_dirs_removes_directories(): void
+    {
+        $dir = $this->containerTempDir();
+        file_put_contents($dir . '/test.txt', 'data');
+        mkdir($dir . '/nested', 0777, true);
+        file_put_contents($dir . '/nested/deep.txt', 'deep');
+
+        self::assertDirectoryExists($dir);
+
+        $this->cleanupContainerTempDirs();
+
+        self::assertDirectoryDoesNotExist($dir);
+    }
+}

--- a/tests/php/Integration/ProvidesAttributeTest.php
+++ b/tests/php/Integration/ProvidesAttributeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration;
+
+use Gacela\Framework\Gacela;
+use Phel\Api\ApiFacade;
+use Phel\Build\BuildFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Console\ConsoleFacade;
+use Phel\Filesystem\FilesystemFacade;
+use Phel\Formatter\FormatterFacade;
+use Phel\Interop\InteropFacade;
+use Phel\Run\RunFacade;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class ProvidesAttributeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Gacela::bootstrap(__DIR__);
+    }
+
+    public function test_all_facades_resolve_from_container(): void
+    {
+        $facades = [
+            ApiFacade::class,
+            BuildFacade::class,
+            CommandFacade::class,
+            CompilerFacade::class,
+            ConsoleFacade::class,
+            FilesystemFacade::class,
+            FormatterFacade::class,
+            InteropFacade::class,
+            RunFacade::class,
+        ];
+
+        foreach ($facades as $facadeClass) {
+            $facade = Gacela::get($facadeClass);
+            self::assertInstanceOf($facadeClass, $facade, sprintf(
+                '%s should be resolvable from the Gacela container',
+                $facadeClass,
+            ));
+        }
+    }
+
+    public function test_command_facade_directories_resolve_through_provider(): void
+    {
+        $facade = new CommandFacade();
+
+        $dirs = $facade->getAllPhelDirectories();
+
+        self::assertIsArray($dirs);
+    }
+
+    public function test_compiler_facade_resolves_through_provider(): void
+    {
+        $facade = new CompilerFacade();
+
+        $encoded = $facade->encodeNs('phel\\core');
+
+        self::assertSame('phel\core', $encoded);
+    }
+
+    public function test_console_facade_version_resolves_through_provider(): void
+    {
+        $facade = new ConsoleFacade();
+
+        $version = $facade->getVersion();
+
+        self::assertIsString($version);
+        self::assertNotEmpty($version);
+    }
+}

--- a/tests/php/Integration/Run/Command/AbstractTestCommand.php
+++ b/tests/php/Integration/Run/Command/AbstractTestCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command;
 
+use Gacela\Framework\Attribute\CacheableConfig;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Testing\ContainerFixture;
@@ -26,6 +27,7 @@ abstract class AbstractTestCommand extends TestCase
     protected function setUp(): void
     {
         $this->resetContainer();
+        CacheableConfig::reset();
         GlobalEnvironmentSingleton::initializeNew();
         RealFilesystem::reset();
 

--- a/tests/php/Integration/Run/Command/AbstractTestCommand.php
+++ b/tests/php/Integration/Run/Command/AbstractTestCommand.php
@@ -6,6 +6,7 @@ namespace PhelTest\Integration\Run\Command;
 
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\ContainerFixture;
 use Override;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Filesystem\Infrastructure\RealFilesystem;
@@ -19,20 +20,19 @@ use function dirname;
 
 abstract class AbstractTestCommand extends TestCase
 {
+    use ContainerFixture;
+
     #[Override]
     protected function setUp(): void
     {
+        $this->resetContainer();
         GlobalEnvironmentSingleton::initializeNew();
         RealFilesystem::reset();
 
-        // Bootstrap from the child class's directory
-        // This allows each test class to use its own phel-config.php
         $reflection = new ReflectionClass($this);
         $childDir = dirname($reflection->getFileName());
 
-        // Reset Gacela's cache and bootstrap with test-specific config
         Gacela::bootstrap($childDir, static function (GacelaConfig $config): void {
-            $config->resetInMemoryCache();
             $config->enableFileCache('');
             $config->addAppConfig('phel-config.php');
         });

--- a/tests/php/Integration/Run/Command/AbstractTestCommand.php
+++ b/tests/php/Integration/Run/Command/AbstractTestCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command;
 
-use Gacela\Framework\Attribute\CacheableConfig;
 use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Gacela\Framework\Testing\ContainerFixture;
@@ -27,7 +26,6 @@ abstract class AbstractTestCommand extends TestCase
     protected function setUp(): void
     {
         $this->resetContainer();
-        CacheableConfig::reset();
         GlobalEnvironmentSingleton::initializeNew();
         RealFilesystem::reset();
 

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Doctor;
 
+use Phel\Phel;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -11,6 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class DoctorCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Phel::bootstrap(__DIR__);
+    }
+
     public function test_doctor_command_outputs_success(): void
     {
         $command = new DoctorCommand();

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Doctor;
 
-use Phel\Phel;
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Gacela\Framework\Testing\ContainerFixture;
+use Phel\Config\PhelConfig;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,9 +15,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class DoctorCommandTest extends TestCase
 {
+    use ContainerFixture;
+
     protected function setUp(): void
     {
-        Phel::bootstrap(__DIR__);
+        $this->resetContainer();
+        $tempDir = $this->containerTempDir();
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($tempDir): void {
+            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $tempDir);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupContainerTempDirs();
     }
 
     public function test_doctor_command_outputs_success(): void

--- a/tests/php/Integration/Run/Command/Repl/ReplCwdNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplCwdNamespaceTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Run\Command\Repl;
 
-use FilesystemIterator;
-
-use Gacela\Framework\Bootstrap\GacelaConfig;
 use Gacela\Framework\Gacela;
 use Override;
 use Phel\Command\Application\TextExceptionPrinter;
@@ -25,8 +22,6 @@ use Phel\Shared\ColorStyleInterface;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Symfony\Component\Console\Input\InputInterface;
 
 final class ReplCwdNamespaceTest extends AbstractTestCommand
@@ -39,33 +34,22 @@ final class ReplCwdNamespaceTest extends AbstractTestCommand
     {
         parent::setUp();
         $this->previousCwd = getcwd() ?: '';
-        $this->tempDir = sys_get_temp_dir() . '/phel-repl-cwd-' . uniqid('', true);
-        mkdir($this->tempDir, 0777, true);
+        $this->tempDir = $this->containerTempDir();
         chdir($this->tempDir);
-        file_put_contents('my-module.phel', <<<'PHEL'
+        file_put_contents($this->tempDir . '/my-module.phel', <<<'PHEL'
 (ns my-module)
 
 (defn hello [x]
   (str "(module.phel at cwd): " x))
 PHEL);
-        Gacela::bootstrap($this->tempDir, static function (GacelaConfig $config): void {
-            $config->resetInMemoryCache();
-        });
+        Gacela::bootstrap($this->tempDir);
     }
 
     #[Override]
     protected function tearDown(): void
     {
         chdir($this->previousCwd);
-        if (is_dir($this->tempDir)) {
-            $it = new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS);
-            $files = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
-            foreach ($files as $file) {
-                $file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
-            }
-
-            rmdir($this->tempDir);
-        }
+        $this->cleanupContainerTempDirs();
     }
 
     #[RunInSeparateProcess]

--- a/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/DependencyTrackerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Infrastructure\Cache;
+
+use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use Phel\Build\Infrastructure\Cache\DependencyTracker;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+final class DependencyTrackerTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/phel-dep-tracker-test-' . uniqid();
+        mkdir($this->cacheDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->cacheDir);
+    }
+
+    public function test_invalidate_dependents_cascades_to_direct_dependents(): void
+    {
+        $tracker = new DependencyTracker($this->cacheDir);
+        $compiledCache = new CompiledCodeCache($this->cacheDir, 'test');
+
+        // file-a.phel defines ns "app\a" and depends on "phel\core"
+        // file-b.phel defines ns "app\b" and depends on "app\a"
+        $fileA = $this->cacheDir . '/a.phel';
+        $fileB = $this->cacheDir . '/b.phel';
+        file_put_contents($fileA, '(ns app\\a)');
+        file_put_contents($fileB, '(ns app\\b)');
+
+        $compiledCache->put($fileA, 'app\\a', md5('(ns app\\a)'), '$x = 1;');
+        $compiledCache->put($fileB, 'app\\b', md5('(ns app\\b)'), '$y = 2;');
+
+        $tracker->registerDependencies($fileA, 'app\\a', ['phel\\core']);
+        $tracker->registerDependencies($fileB, 'app\\b', ['app\\a']);
+
+        // Verify both are cached
+        self::assertNotNull($compiledCache->get($fileA, md5('(ns app\\a)')));
+        self::assertNotNull($compiledCache->get($fileB, md5('(ns app\\b)')));
+
+        // Invalidate app\a — file-b should be invalidated as a dependent
+        $invalidated = $tracker->invalidateDependentsOf('app\\a', $compiledCache);
+
+        self::assertContains($fileB, $invalidated);
+        self::assertNull($compiledCache->get($fileB, md5('(ns app\\b)')));
+    }
+
+    public function test_invalidation_does_not_affect_unrelated_files(): void
+    {
+        $tracker = new DependencyTracker($this->cacheDir);
+        $compiledCache = new CompiledCodeCache($this->cacheDir, 'test');
+
+        $fileA = $this->cacheDir . '/a.phel';
+        $fileC = $this->cacheDir . '/c.phel';
+        file_put_contents($fileA, '(ns app\\a)');
+        file_put_contents($fileC, '(ns app\\c)');
+
+        $compiledCache->put($fileA, 'app\\a', md5('(ns app\\a)'), '$x = 1;');
+        $compiledCache->put($fileC, 'app\\c', md5('(ns app\\c)'), '$z = 3;');
+
+        $tracker->registerDependencies($fileA, 'app\\a', ['phel\\core']);
+        $tracker->registerDependencies($fileC, 'app\\c', ['phel\\core']);
+
+        // Invalidate app\a — file-c should NOT be invalidated (no dependency on app\a)
+        $invalidated = $tracker->invalidateDependentsOf('app\\a', $compiledCache);
+
+        self::assertNotContains($fileC, $invalidated);
+        self::assertNotNull($compiledCache->get($fileC, md5('(ns app\\c)')));
+    }
+
+    public function test_invalidation_of_unknown_namespace_returns_empty(): void
+    {
+        $tracker = new DependencyTracker($this->cacheDir);
+        $compiledCache = new CompiledCodeCache($this->cacheDir, 'test');
+
+        $invalidated = $tracker->invalidateDependentsOf('nonexistent\\ns', $compiledCache);
+
+        self::assertSame([], $invalidated);
+    }
+
+    public function test_register_dependencies_handles_circular_deps_gracefully(): void
+    {
+        $tracker = new DependencyTracker($this->cacheDir);
+
+        $fileA = $this->cacheDir . '/a.phel';
+        $fileB = $this->cacheDir . '/b.phel';
+        file_put_contents($fileA, '(ns app\\a)');
+        file_put_contents($fileB, '(ns app\\b)');
+
+        // Register A -> B and B -> A (circular)
+        $tracker->registerDependencies($fileA, 'app\\a', ['app\\b']);
+        $tracker->registerDependencies($fileB, 'app\\b', ['app\\a']);
+
+        // Should not throw — cycles are silently ignored
+        self::assertTrue(true);
+    }
+
+    public function test_clear_removes_all_tracked_dependencies(): void
+    {
+        $tracker = new DependencyTracker($this->cacheDir);
+        $compiledCache = new CompiledCodeCache($this->cacheDir, 'test');
+
+        $fileB = $this->cacheDir . '/b.phel';
+        file_put_contents($fileB, '(ns app\\b)');
+
+        $compiledCache->put($fileB, 'app\\b', md5('(ns app\\b)'), '$y = 2;');
+        $tracker->registerDependencies($fileB, 'app\\b', ['app\\a']);
+
+        $tracker->clear();
+
+        // After clear, invalidation should find no dependents
+        $invalidated = $tracker->invalidateDependentsOf('app\\a', $compiledCache);
+        self::assertSame([], $invalidated);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isDir()) {
+                @rmdir($file->getPathname());
+            } else {
+                @unlink($file->getPathname());
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Unit/Command/CacheableCommandFacadeTest.php
+++ b/tests/php/Unit/Command/CacheableCommandFacadeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command;
+
+use Gacela\Framework\Attribute\CacheableConfig;
+use Gacela\Framework\Gacela;
+use Phel\Command\CommandFacade;
+use PHPUnit\Framework\TestCase;
+
+final class CacheableCommandFacadeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        CacheableConfig::reset();
+        Gacela::bootstrap(__DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        CacheableConfig::reset();
+    }
+
+    public function test_get_all_phel_directories_returns_same_instance_on_repeated_calls(): void
+    {
+        $facade = new CommandFacade();
+
+        $first = $facade->getAllPhelDirectories();
+        $second = $facade->getAllPhelDirectories();
+
+        self::assertSame($first, $second);
+    }
+
+    public function test_get_source_directories_is_cached(): void
+    {
+        $facade = new CommandFacade();
+
+        $first = $facade->getSourceDirectories();
+        $second = $facade->getSourceDirectories();
+
+        self::assertSame($first, $second);
+    }
+
+    public function test_get_output_directory_is_cached(): void
+    {
+        $facade = new CommandFacade();
+
+        $first = $facade->getOutputDirectory();
+        $second = $facade->getOutputDirectory();
+
+        self::assertSame($first, $second);
+        self::assertIsString($first);
+    }
+
+    public function test_clear_method_cache_allows_fresh_resolution(): void
+    {
+        $facade = new CommandFacade();
+
+        $first = $facade->getAllPhelDirectories();
+        CommandFacade::clearMethodCache();
+        $second = $facade->getAllPhelDirectories();
+
+        self::assertEquals($first, $second);
+    }
+
+    public function test_clear_method_cache_for_specific_method(): void
+    {
+        $facade = new CommandFacade();
+
+        $facade->getAllPhelDirectories();
+        $facade->getSourceDirectories();
+
+        CommandFacade::clearMethodCacheFor('getAllPhelDirectories');
+
+        $source = $facade->getSourceDirectories();
+        self::assertIsArray($source);
+    }
+}

--- a/tests/php/Unit/Compiler/CacheableCompilerFacadeTest.php
+++ b/tests/php/Unit/Compiler/CacheableCompilerFacadeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler;
+
+use Gacela\Framework\Attribute\CacheableConfig;
+use Gacela\Framework\Gacela;
+use Phel\Compiler\CompilerFacade;
+use PHPUnit\Framework\TestCase;
+
+final class CacheableCompilerFacadeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        CacheableConfig::reset();
+        Gacela::bootstrap(__DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        CacheableConfig::reset();
+    }
+
+    public function test_encode_ns_returns_consistent_result(): void
+    {
+        $facade = new CompilerFacade();
+
+        $first = $facade->encodeNs('phel\\core');
+        $second = $facade->encodeNs('phel\\core');
+
+        self::assertSame($first, $second);
+        self::assertSame('phel\core', $first);
+    }
+
+    public function test_encode_ns_caches_per_namespace(): void
+    {
+        $facade = new CompilerFacade();
+
+        $core = $facade->encodeNs('phel\\core');
+        $string = $facade->encodeNs('phel\\string');
+
+        self::assertNotSame($core, $string);
+        self::assertSame('phel\core', $core);
+        self::assertSame('phel\string', $string);
+    }
+
+    public function test_clear_cache_allows_fresh_encode(): void
+    {
+        $facade = new CompilerFacade();
+
+        $before = $facade->encodeNs('phel\\core');
+        CompilerFacade::clearMethodCache();
+        $after = $facade->encodeNs('phel\\core');
+
+        self::assertSame($before, $after);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Gacela 1.14 ships several features that improve DX and build performance: declarative provider registration, facade method caching, dependency-aware cache invalidation, and test isolation primitives.

## 💡 Goal

Adopt every applicable Gacela 1.14 feature in Phel, upgrade the dependency from the dev-main symlink to `^1.14`, and clean up stale test patterns.

## 🔖 Changes

- **`#[Provides]` attribute**: all 8 providers migrated from `provideModuleDependencies()` closures to declarative `#[Provides('ID')]` methods with `getRequired()` for type-safe resolution
- **`#[Cacheable]` attribute**: directory lookups (`CommandFacade`) and namespace encoding (`CompilerFacade`) cached per-process, eliminating redundant filesystem scans during compilation
- **`ScopedCache` / `DependencyTracker`**: when a source file changes, all files depending on its namespace are automatically invalidated in the compiled-code cache
- **`ContainerFixture` trait**: integrated into `AbstractTestCommand` for automatic Gacela container reset between tests; `ReplCwdNamespaceTest` and `DoctorCommandTest` modernized
- **Gacela ^1.14**: removed local path repository, cleaned up Psalm suppressions that were only needed for the symlink, dropped redundant `CacheableConfig::reset()` (now handled by `AbstractFacade::resetCache()`)