### PR TITLE
feat(test): add phel\test\gen for property-based testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
+
 ## [0.33.0](https://github.com/phel-lang/phel-lang/compare/v0.32.0...v0.33.0) - 2026-04-17
 
 ### Added

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -1,0 +1,422 @@
+(ns phel\test\gen
+  (:require phel\core)
+  (:require phel\test :as t)
+  (:use InvalidArgumentException)
+  (:use RuntimeException))
+
+;; A generator is a function of one argument, a non-negative integer `size`
+;; controlling magnitude of the produced value:
+;;
+;;   gen :: (fn [size] -> value)
+;;
+;; Callers produce values with `sample`, `generate`, or by running a property
+;; with `quick-check` / `defspec`. Random numbers come from PHP's Mersenne
+;; Twister (`php/mt_rand`); seed the run with the `:seed` option to make a
+;; failure reproducible.
+;;
+;; Collection-producing generators are named `*-of` (`vector-of`, `list-of`,
+;; `map-of`, `set-of`) to avoid shadowing the core constructors used by
+;; syntax-quote during macroexpansion.
+
+(def default-size
+  "Default magnitude passed to generators when `sample`/`quick-check` is called
+  without an explicit `:size`."
+  100)
+
+(def default-num-tests
+  "Default number of trials `quick-check` runs per property."
+  100)
+
+(defn- rand-long [lo hi]
+  (php/mt_rand lo hi))
+
+(defn- seed-rng! [seed]
+  (when seed (php/mt_srand seed)))
+
+(defn- fresh-seed []
+  (php/mt_rand 0 php/PHP_INT_MAX))
+
+;; ---------------------------
+;; Primitive generator helpers
+;; ---------------------------
+
+(defn return
+  "Generator that always yields `x`."
+  {:example "((return 42) 100) ; => 42"}
+  [x]
+  (fn [_size] x))
+
+(defn fmap
+  "Returns a generator that applies `f` to values produced by `g`."
+  {:example "((fmap inc (return 1)) 100) ; => 2"}
+  [f g]
+  (fn [size] (f (g size))))
+
+(defn such-that
+  "Returns a generator yielding only values from `g` that satisfy `pred`. Retries
+  up to `max-tries` (default 100) before throwing."
+  {:example "((such-that even? (nat)) 100) ; => some even int"}
+  ([pred g] (such-that pred g 100))
+  ([pred g max-tries]
+   (fn [size]
+     (loop [i 0]
+       (if (>= i max-tries)
+         (throw (php/new RuntimeException
+                  (str "gen/such-that exceeded " max-tries " retries")))
+         (let [v (g size)]
+           (if (pred v) v (recur (inc i)))))))))
+
+(defn sized
+  "Builds a generator from a function `f` of `size`. The returned generator
+  forwards its `size` argument into `f`, which must yield another generator
+  that is then invoked with the same size."
+  {:example "(sized (fn [n] (return n)))"}
+  [f]
+  (fn [size] ((f size) size)))
+
+(defn resize
+  "Returns a generator equivalent to `g` but with `size` forced to `n`."
+  {:example "((resize 5 (nat)) 1000) ; => value in [0, 5]"}
+  [n g]
+  (fn [_size] (g n)))
+
+;; --------------------
+;; Scalar generators
+;; --------------------
+
+(defn boolean
+  "Generator of booleans."
+  {:example "((boolean) 100) ; => true or false"}
+  []
+  (fn [_size] (= 0 (rand-long 0 1))))
+
+(defn choose
+  "Generator of integers in the closed interval `[lo hi]`."
+  {:example "((choose 1 6) 100) ; => int in [1, 6]"}
+  [lo hi]
+  (when (> lo hi)
+    (throw (php/new InvalidArgumentException
+             (str "gen/choose requires lo <= hi, got " lo ", " hi))))
+  (fn [_size] (rand-long lo hi)))
+
+(defn nat
+  "Generator of non-negative integers in `[0, size]`."
+  {:example "((nat) 10) ; => int in [0, 10]"}
+  []
+  (fn [size] (rand-long 0 (max 0 size))))
+
+(defn int
+  "Generator of integers in `[-size, size]`."
+  {:example "((int) 10) ; => int in [-10, 10]"}
+  []
+  (fn [size]
+    (let [s (max 0 size)]
+      (rand-long (- s) s))))
+
+(defn large-int
+  "Generator of arbitrary PHP-range integers."
+  {:example "((large-int) 100) ; => any PHP int"}
+  []
+  (fn [_size] (rand-long php/PHP_INT_MIN php/PHP_INT_MAX)))
+
+(defn float
+  "Generator of floats in `[0, 1)`."
+  {:example "((float) 100) ; => 0.3721..."}
+  []
+  (fn [_size] (/ (rand-long 0 php/PHP_INT_MAX) php/PHP_INT_MAX)))
+
+;; --------------------
+;; Character generators
+;; --------------------
+
+(def- ascii-lower (for [c :range [97 123]] (php/chr c)))
+(def- ascii-upper (for [c :range [65 91]] (php/chr c)))
+(def- ascii-digit (for [c :range [48 58]] (php/chr c)))
+(def- printable-ascii-chars (for [c :range [32 127]] (php/chr c)))
+(def- alpha-chars (concat ascii-lower ascii-upper))
+(def- alphanumeric-chars (concat alpha-chars ascii-digit))
+
+(defn- pick-from [xs]
+  (let [v (into [] xs)
+        n (count v)]
+    (fn [_size] (get v (rand-long 0 (dec n))))))
+
+(defn char
+  "Generator of printable ASCII characters (space through `~`)."
+  {:example "((char) 100) ; => \"A\""}
+  []
+  (pick-from printable-ascii-chars))
+
+(defn char-alpha
+  "Generator of ASCII letters."
+  {:example "((char-alpha) 100) ; => \"q\""}
+  []
+  (pick-from alpha-chars))
+
+(defn char-alphanumeric
+  "Generator of ASCII letters and digits."
+  {:example "((char-alphanumeric) 100) ; => \"7\""}
+  []
+  (pick-from alphanumeric-chars))
+
+(defn- repeat-chars [cg size n]
+  (apply str (for [_ :range [0 n]] (cg size))))
+
+(defn string
+  "Generator of printable ASCII strings, length in `[0, size]`."
+  {:example "((string) 5) ; => \"aB?2q\""}
+  []
+  (let [cg (char)]
+    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
+
+(defn string-alpha
+  "Generator of ASCII alphabetic strings, length in `[0, size]`."
+  {:example "((string-alpha) 5) ; => \"heLlo\""}
+  []
+  (let [cg (char-alpha)]
+    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
+
+(defn string-alphanumeric
+  "Generator of ASCII alphanumeric strings, length in `[0, size]`."
+  {:example "((string-alphanumeric) 5) ; => \"a1B2c\""}
+  []
+  (let [cg (char-alphanumeric)]
+    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
+
+;; ----------------------
+;; Symbolic generators
+;; ----------------------
+
+;; `keyword`/`symbol` in core are plain functions (not used by syntax-quote),
+;; so shadowing them is safe. We still need a reference to the core
+;; constructors inside our generator bodies.
+(def- core-keyword keyword)
+(def- core-symbol symbol)
+
+(defn keyword
+  "Generator of keywords with alphabetic names of length `[1, size]`."
+  {:example "((keyword) 5) ; => :abcde"}
+  []
+  (let [cg (char-alpha)]
+    (fn [size]
+      (let [n (max 1 (rand-long 1 (max 1 size)))
+            name-str (repeat-chars cg size n)]
+        (core-keyword name-str)))))
+
+(defn symbol
+  "Generator of symbols with alphabetic names of length `[1, size]`."
+  {:example "((symbol) 5) ; => 'abcde"}
+  []
+  (let [cg (char-alpha)]
+    (fn [size]
+      (let [n (max 1 (rand-long 1 (max 1 size)))
+            name-str (repeat-chars cg size n)]
+        (core-symbol name-str)))))
+
+;; --------------------
+;; Combinators
+;; --------------------
+
+(defn elements
+  "Generator that picks a random element from `coll`. `coll` must be non-empty."
+  {:example "((elements [:a :b :c]) 100) ; => :a, :b, or :c"}
+  [coll]
+  (let [v (into [] coll)
+        n (count v)]
+    (when (zero? n)
+      (throw (php/new InvalidArgumentException
+               "gen/elements requires a non-empty collection")))
+    (fn [_size] (get v (rand-long 0 (dec n))))))
+
+(defn one-of
+  "Generator that selects uniformly from the given `gens` and runs it."
+  {:example "((one-of [(int) (boolean)]) 100) ; => int or bool"}
+  [gens]
+  (let [v (into [] gens)
+        n (count v)]
+    (when (zero? n)
+      (throw (php/new InvalidArgumentException
+               "gen/one-of requires at least one generator")))
+    (fn [size]
+      (let [g (get v (rand-long 0 (dec n)))]
+        (g size)))))
+
+(defn frequency
+  "Generator that picks one of the `[weight gen]` pairs with probability
+  proportional to weight."
+  {:example "((frequency [[9 (return :a)] [1 (return :b)]]) 100) ; => :a ~90% of the time"}
+  [pairs]
+  (let [v (into [] pairs)
+        total (reduce + 0 (map (fn [p] (get p 0)) v))]
+    (when (<= total 0)
+      (throw (php/new InvalidArgumentException
+               "gen/frequency requires at least one pair with positive weight")))
+    (fn [size]
+      (loop [i 0 remaining (rand-long 1 total)]
+        (let [pair (get v i)
+              w (get pair 0)
+              g (get pair 1)
+              next-remaining (- remaining w)]
+          (if (<= next-remaining 0)
+            (g size)
+            (recur (inc i) next-remaining)))))))
+
+(defn tuple
+  "Generator of a fixed-length vector produced by running each generator in
+  `gens` in order."
+  {:example "((tuple [(int) (boolean)]) 10) ; => [3 true]"}
+  [gens]
+  (let [v (into [] gens)]
+    (fn [size] (into [] (map (fn [g] (g size)) v)))))
+
+;; --------------------
+;; Collection generators
+;; --------------------
+;;
+;; Named `*-of` to avoid shadowing core constructors (`vector`, `list`,
+;; `hash-map`, `set`) that are invoked at macroexpansion time.
+
+(defn- gen-length [size]
+  (rand-long 0 (max 0 size)))
+
+(defn vector-of
+  "Generator of vectors whose elements come from `g`. With one arg, length is in
+  `[0, size]`. With `n`, length is exactly `n`. With `lo` and `hi`, length is in
+  `[lo, hi]`."
+  {:example "((vector-of (int)) 3) ; => [-1 2 0]"}
+  ([g]
+   (fn [size]
+     (into [] (for [_ :range [0 (gen-length size)]] (g size)))))
+  ([g n]
+   (fn [size]
+     (into [] (for [_ :range [0 n]] (g size)))))
+  ([g lo hi]
+   (fn [size]
+     (into [] (for [_ :range [0 (rand-long lo hi)]] (g size))))))
+
+(defn list-of
+  "Generator of lists whose elements come from `g`. Length in `[0, size]`."
+  {:example "((list-of (int)) 3) ; => (-1 2 0)"}
+  [g]
+  (fn [size]
+    (apply list (for [_ :range [0 (gen-length size)]] (g size)))))
+
+(defn map-of
+  "Generator of hash-maps with keys from `kg` and values from `vg`. Number of
+  entries is in `[0, size]`."
+  {:example "((map-of (keyword) (int)) 2) ; => {:a 1 :b -3}"}
+  [kg vg]
+  (fn [size]
+    (let [n (gen-length size)]
+      (loop [i 0 m {}]
+        (if (>= i n)
+          m
+          (recur (inc i) (put m (kg size) (vg size))))))))
+
+(defn set-of
+  "Generator of hash-sets with elements from `g`. Cardinality is in `[0, size]`."
+  {:example "((set-of (nat)) 3) ; => (set 1 2 3)"}
+  [g]
+  (fn [size]
+    (let [n (gen-length size)]
+      (loop [i 0 s (hash-set)]
+        (if (>= i n)
+          s
+          (recur (inc i) (conj s (g size))))))))
+
+;; --------------------
+;; Sampling
+;; --------------------
+
+(defn generate
+  "Runs `g` once and returns a single value. Options: `:size`, `:seed`."
+  {:example "(generate (int)) ; => 42"}
+  ([g] (generate g {}))
+  ([g {:size size :seed seed}]
+   (seed-rng! seed)
+   (g (or size default-size))))
+
+(defn sample
+  "Runs `g` `num-samples` times and returns a vector of values. Defaults to 10
+  samples at default size. Options: `:size`, `:seed`."
+  {:example "(sample (int) 5) ; => [3 -7 0 1 -2]"}
+  ([g] (sample g 10 {}))
+  ([g num-samples] (sample g num-samples {}))
+  ([g num-samples {:size size :seed seed}]
+   (seed-rng! seed)
+   (let [s (or size default-size)]
+     (into [] (for [_ :range [0 num-samples]] (g s))))))
+
+;; --------------------
+;; Property testing
+;; --------------------
+
+(defn- run-trials [property args-gen num-tests size]
+  (loop [i 0]
+    (if (>= i num-tests)
+      {:result :pass :num-tests i}
+      (let [args (args-gen size)
+            ok (try (apply property args)
+                    (catch \Throwable e e))]
+        (cond
+          (php/instanceof ok \Throwable)
+          {:result :error :num-tests (inc i) :args args :exception ok}
+          (not ok)
+          {:result :failed :num-tests (inc i) :args args}
+          :else (recur (inc i)))))))
+
+(defn quick-check
+  "Runs a property `num-tests` times, sampling arguments from `args-gen` (a
+  generator producing a vector of arguments). Returns a hash-map describing
+  the outcome; includes the `:seed` so a failure can be replayed.
+
+  Options:
+  - `:size` (default 100): magnitude passed to the generator.
+  - `:seed` (default: fresh per-run seed): PRNG seed.
+
+  The returned map has `:result` of `:pass`, `:failed`, or `:error`.
+  On `:failed`/`:error` it also carries `:args` (the failing input) and,
+  for `:error`, the original `:exception`."
+  {:example "(quick-check 50 (tuple [(int) (int)]) (fn [a b] (= (+ a b) (+ b a))))"}
+  ([num-tests args-gen property]
+   (quick-check num-tests args-gen property {}))
+  ([num-tests args-gen property {:size size :seed seed}]
+   (let [effective-seed (or seed (fresh-seed))
+         _ (seed-rng! effective-seed)
+         outcome (run-trials property args-gen num-tests (or size default-size))]
+     (put outcome :seed effective-seed))))
+
+(defn- spec-failure-message [name-str res]
+  (let [parts ["property " name-str " failed after " (get res :num-tests)
+               " tests (seed " (get res :seed)]
+        args (get res :args)
+        ex (get res :exception)
+        parts (if args (concat parts [", args " (print-str args)]) parts)
+        parts (if ex
+                (concat parts [", threw " (php/get_class ex) ": "
+                               (php/-> ex (getMessage))])
+                parts)
+        parts (concat parts [")"])]
+    (apply str parts)))
+
+(defmacro defspec
+  "Defines a property test that runs `quick-check` and asserts the result is a
+  pass. Integrates with `phel\\test`: the generated `deftest` is picked up by
+  `run-tests`. `options` is a hash-map accepting `:num-tests`, `:size`, and
+  `:seed`.
+
+  Shape: `(defspec name options args-gen property)`."
+  {:example "(defspec addition-commutes {:num-tests 200}
+              (tuple [(int) (int)])
+              (fn [a b] (= (+ a b) (+ b a))))"}
+  [name options args-gen property]
+  (let [opts-sym (gensym)
+        n-sym (gensym)
+        res-sym (gensym)
+        name-str (str name)]
+    `(t/deftest ~name
+       (let [~opts-sym ~options
+             ~n-sym (or (:num-tests ~opts-sym) default-num-tests)
+             ~res-sym (quick-check ~n-sym ~args-gen ~property ~opts-sym)]
+         (t/is (= :pass (:result ~res-sym))
+               (spec-failure-message ~name-str ~res-sym))))))

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -4,41 +4,172 @@
   (:use InvalidArgumentException)
   (:use RuntimeException))
 
-;; A generator is a function of one argument, a non-negative integer `size`
-;; controlling magnitude of the produced value:
+;; Property-based test-data generators.
+;;
+;; A generator is a function of a single argument `size` — a non-negative
+;; integer controlling the magnitude of produced values:
 ;;
 ;;   gen :: (fn [size] -> value)
 ;;
-;; Callers produce values with `sample`, `generate`, or by running a property
-;; with `quick-check` / `defspec`. Random numbers come from PHP's Mersenne
-;; Twister (`php/mt_rand`); seed the run with the `:seed` option to make a
-;; failure reproducible.
+;; Zero-arity generators are exposed as *values* (`g/int`, `g/boolean`, …) so
+;; callers can use them directly without extra parentheses. Generators that
+;; take arguments (e.g. `choose`, `vector-of`, `tuple`) are functions that
+;; return a generator.
 ;;
-;; Collection-producing generators are named `*-of` (`vector-of`, `list-of`,
-;; `map-of`, `set-of`) to avoid shadowing the core constructors used by
-;; syntax-quote during macroexpansion.
+;; Collection-producing generators use the `*-of` suffix (`vector-of`,
+;; `list-of`, `map-of`, `set-of`) to avoid shadowing the core constructors
+;; syntax-quote relies on at macroexpansion time.
+;;
+;; Randomness comes from PHP's Mersenne Twister (`php/mt_rand`). Pass `:seed`
+;; to `sample`/`generate`/`quick-check` for reproducible runs.
+
+;; -------------
+;; Configuration
+;; -------------
 
 (def default-size
-  "Default magnitude passed to generators when `sample`/`quick-check` is called
-  without an explicit `:size`."
+  "Magnitude used when no `:size` option is supplied."
   100)
 
 (def default-num-tests
-  "Default number of trials `quick-check` runs per property."
+  "Number of trials `quick-check` runs by default."
   100)
 
-(defn- rand-long [lo hi]
+;; -------------------
+;; Internal RNG helpers
+;; -------------------
+
+(defn- rand-int* [lo hi]
   (php/mt_rand lo hi))
 
 (defn- seed-rng! [seed]
-  (when seed (php/mt_srand seed)))
+  (when seed (php/mt_srand seed))
+  nil)
 
 (defn- fresh-seed []
   (php/mt_rand 0 php/PHP_INT_MAX))
 
-;; ---------------------------
-;; Primitive generator helpers
-;; ---------------------------
+(defn- non-negative [n]
+  (if (< n 0) 0 n))
+
+(defn- rand-index [n]
+  (rand-int* 0 (dec n)))
+
+;; ------------------
+;; Scalar generators
+;; ------------------
+
+(def boolean
+  "Generator of booleans."
+  (fn [_size] (= 0 (rand-int* 0 1))))
+
+(def nat
+  "Generator of non-negative integers in `[0, size]`."
+  (fn [size] (rand-int* 0 (non-negative size))))
+
+(def int
+  "Generator of integers in `[-size, size]`."
+  (fn [size]
+    (let [s (non-negative size)]
+      (rand-int* (- s) s))))
+
+(def large-int
+  "Generator of arbitrary PHP-range integers."
+  (fn [_size] (rand-int* php/PHP_INT_MIN php/PHP_INT_MAX)))
+
+(def float
+  "Generator of floats in `[0, 1)`."
+  (fn [_size] (/ (rand-int* 0 php/PHP_INT_MAX) php/PHP_INT_MAX)))
+
+(defn choose
+  "Generator of integers in the closed interval `[lo hi]`."
+  {:example "((choose 1 6) 100) ; => 1..6"}
+  [lo hi]
+  (when (> lo hi)
+    (throw (php/new InvalidArgumentException
+             (str "gen/choose requires lo <= hi, got " lo ", " hi))))
+  (fn [_size] (rand-int* lo hi)))
+
+;; -----------------
+;; Character tables
+;; -----------------
+
+(def- chars-alpha
+  (into [] (concat (for [c :range [97 123]] (php/chr c))
+                   (for [c :range [65 91]] (php/chr c)))))
+
+(def- chars-digit
+  (into [] (for [c :range [48 58]] (php/chr c))))
+
+(def- chars-alphanumeric (into [] (concat chars-alpha chars-digit)))
+
+(def- chars-printable
+  (into [] (for [c :range [32 127]] (php/chr c))))
+
+(defn- rand-elem [v] (get v (rand-index (count v))))
+
+(def char
+  "Generator of printable ASCII characters (space through `~`)."
+  (fn [_size] (rand-elem chars-printable)))
+
+(def char-alpha
+  "Generator of ASCII letters."
+  (fn [_size] (rand-elem chars-alpha)))
+
+(def char-alphanumeric
+  "Generator of ASCII letters and digits."
+  (fn [_size] (rand-elem chars-alphanumeric)))
+
+(defn- build-string [cg size n]
+  (loop [i 0 acc ""]
+    (if (>= i n)
+      acc
+      (recur (inc i) (str acc (cg size))))))
+
+(defn- string-gen-from [cg]
+  (fn [size]
+    (let [n (rand-int* 0 (non-negative size))]
+      (build-string cg size n))))
+
+(def string
+  "Generator of printable ASCII strings, length in `[0, size]`."
+  (string-gen-from char))
+
+(def string-alpha
+  "Generator of ASCII alphabetic strings, length in `[0, size]`."
+  (string-gen-from char-alpha))
+
+(def string-alphanumeric
+  "Generator of ASCII alphanumeric strings, length in `[0, size]`."
+  (string-gen-from char-alphanumeric))
+
+;; -------------------
+;; Symbolic generators
+;; -------------------
+
+;; `keyword` and `symbol` are plain core functions (not used by syntax-quote),
+;; so shadowing is safe. Keep a reference to the core constructors for
+;; internal use.
+(def- core-keyword keyword)
+(def- core-symbol symbol)
+
+(defn- named-gen [ctor]
+  (fn [size]
+    (let [upper (non-negative size)
+          n (if (zero? upper) 1 (rand-int* 1 upper))]
+      (ctor (build-string char-alpha size n)))))
+
+(def keyword
+  "Generator of keywords with alphabetic names, length in `[1, max(1, size)]`."
+  (named-gen core-keyword))
+
+(def symbol
+  "Generator of symbols with alphabetic names, length in `[1, max(1, size)]`."
+  (named-gen core-symbol))
+
+;; ------------
+;; Combinators
+;; ------------
 
 (defn return
   "Generator that always yields `x`."
@@ -53,198 +184,57 @@
   (fn [size] (f (g size))))
 
 (defn such-that
-  "Returns a generator yielding only values from `g` that satisfy `pred`. Retries
-  up to `max-tries` (default 100) before throwing."
-  {:example "((such-that even? (nat)) 100) ; => some even int"}
+  "Generator yielding only values from `g` that satisfy `pred`. Retries up to
+  `max-tries` (default 100) before throwing."
+  {:example "((such-that even? nat) 100)"}
   ([pred g] (such-that pred g 100))
   ([pred g max-tries]
    (fn [size]
      (loop [i 0]
-       (if (>= i max-tries)
+       (when (>= i max-tries)
          (throw (php/new RuntimeException
-                  (str "gen/such-that exceeded " max-tries " retries")))
-         (let [v (g size)]
-           (if (pred v) v (recur (inc i)))))))))
+                  (str "gen/such-that exceeded " max-tries " retries"))))
+       (let [v (g size)]
+         (if (pred v) v (recur (inc i))))))))
 
 (defn sized
   "Builds a generator from a function `f` of `size`. The returned generator
-  forwards its `size` argument into `f`, which must yield another generator
-  that is then invoked with the same size."
+  forwards its `size` into `f`, which must yield another generator that is
+  then invoked with the same size."
   {:example "(sized (fn [n] (return n)))"}
   [f]
   (fn [size] ((f size) size)))
 
 (defn resize
   "Returns a generator equivalent to `g` but with `size` forced to `n`."
-  {:example "((resize 5 (nat)) 1000) ; => value in [0, 5]"}
+  {:example "((resize 5 nat) 1000) ; => value in [0, 5]"}
   [n g]
   (fn [_size] (g n)))
 
-;; --------------------
-;; Scalar generators
-;; --------------------
-
-(defn boolean
-  "Generator of booleans."
-  {:example "((boolean) 100) ; => true or false"}
-  []
-  (fn [_size] (= 0 (rand-long 0 1))))
-
-(defn choose
-  "Generator of integers in the closed interval `[lo hi]`."
-  {:example "((choose 1 6) 100) ; => int in [1, 6]"}
-  [lo hi]
-  (when (> lo hi)
-    (throw (php/new InvalidArgumentException
-             (str "gen/choose requires lo <= hi, got " lo ", " hi))))
-  (fn [_size] (rand-long lo hi)))
-
-(defn nat
-  "Generator of non-negative integers in `[0, size]`."
-  {:example "((nat) 10) ; => int in [0, 10]"}
-  []
-  (fn [size] (rand-long 0 (max 0 size))))
-
-(defn int
-  "Generator of integers in `[-size, size]`."
-  {:example "((int) 10) ; => int in [-10, 10]"}
-  []
-  (fn [size]
-    (let [s (max 0 size)]
-      (rand-long (- s) s))))
-
-(defn large-int
-  "Generator of arbitrary PHP-range integers."
-  {:example "((large-int) 100) ; => any PHP int"}
-  []
-  (fn [_size] (rand-long php/PHP_INT_MIN php/PHP_INT_MAX)))
-
-(defn float
-  "Generator of floats in `[0, 1)`."
-  {:example "((float) 100) ; => 0.3721..."}
-  []
-  (fn [_size] (/ (rand-long 0 php/PHP_INT_MAX) php/PHP_INT_MAX)))
-
-;; --------------------
-;; Character generators
-;; --------------------
-
-(def- ascii-lower (for [c :range [97 123]] (php/chr c)))
-(def- ascii-upper (for [c :range [65 91]] (php/chr c)))
-(def- ascii-digit (for [c :range [48 58]] (php/chr c)))
-(def- printable-ascii-chars (for [c :range [32 127]] (php/chr c)))
-(def- alpha-chars (concat ascii-lower ascii-upper))
-(def- alphanumeric-chars (concat alpha-chars ascii-digit))
-
-(defn- pick-from [xs]
-  (let [v (into [] xs)
-        n (count v)]
-    (fn [_size] (get v (rand-long 0 (dec n))))))
-
-(defn char
-  "Generator of printable ASCII characters (space through `~`)."
-  {:example "((char) 100) ; => \"A\""}
-  []
-  (pick-from printable-ascii-chars))
-
-(defn char-alpha
-  "Generator of ASCII letters."
-  {:example "((char-alpha) 100) ; => \"q\""}
-  []
-  (pick-from alpha-chars))
-
-(defn char-alphanumeric
-  "Generator of ASCII letters and digits."
-  {:example "((char-alphanumeric) 100) ; => \"7\""}
-  []
-  (pick-from alphanumeric-chars))
-
-(defn- repeat-chars [cg size n]
-  (apply str (for [_ :range [0 n]] (cg size))))
-
-(defn string
-  "Generator of printable ASCII strings, length in `[0, size]`."
-  {:example "((string) 5) ; => \"aB?2q\""}
-  []
-  (let [cg (char)]
-    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
-
-(defn string-alpha
-  "Generator of ASCII alphabetic strings, length in `[0, size]`."
-  {:example "((string-alpha) 5) ; => \"heLlo\""}
-  []
-  (let [cg (char-alpha)]
-    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
-
-(defn string-alphanumeric
-  "Generator of ASCII alphanumeric strings, length in `[0, size]`."
-  {:example "((string-alphanumeric) 5) ; => \"a1B2c\""}
-  []
-  (let [cg (char-alphanumeric)]
-    (fn [size] (repeat-chars cg size (rand-long 0 (max 0 size))))))
-
-;; ----------------------
-;; Symbolic generators
-;; ----------------------
-
-;; `keyword`/`symbol` in core are plain functions (not used by syntax-quote),
-;; so shadowing them is safe. We still need a reference to the core
-;; constructors inside our generator bodies.
-(def- core-keyword keyword)
-(def- core-symbol symbol)
-
-(defn keyword
-  "Generator of keywords with alphabetic names of length `[1, size]`."
-  {:example "((keyword) 5) ; => :abcde"}
-  []
-  (let [cg (char-alpha)]
-    (fn [size]
-      (let [n (max 1 (rand-long 1 (max 1 size)))
-            name-str (repeat-chars cg size n)]
-        (core-keyword name-str)))))
-
-(defn symbol
-  "Generator of symbols with alphabetic names of length `[1, size]`."
-  {:example "((symbol) 5) ; => 'abcde"}
-  []
-  (let [cg (char-alpha)]
-    (fn [size]
-      (let [n (max 1 (rand-long 1 (max 1 size)))
-            name-str (repeat-chars cg size n)]
-        (core-symbol name-str)))))
-
-;; --------------------
-;; Combinators
-;; --------------------
-
 (defn elements
-  "Generator that picks a random element from `coll`. `coll` must be non-empty."
-  {:example "((elements [:a :b :c]) 100) ; => :a, :b, or :c"}
+  "Generator that picks a random element from `coll`."
+  {:example "((elements [:a :b :c]) 100) ; => :a, :b or :c"}
   [coll]
-  (let [v (into [] coll)
-        n (count v)]
-    (when (zero? n)
+  (let [v (into [] coll)]
+    (when (zero? (count v))
       (throw (php/new InvalidArgumentException
                "gen/elements requires a non-empty collection")))
-    (fn [_size] (get v (rand-long 0 (dec n))))))
+    (fn [_size] (rand-elem v))))
 
 (defn one-of
-  "Generator that selects uniformly from the given `gens` and runs it."
-  {:example "((one-of [(int) (boolean)]) 100) ; => int or bool"}
+  "Generator that selects uniformly from `gens` and runs the chosen one."
+  {:example "((one-of [int boolean]) 100)"}
   [gens]
-  (let [v (into [] gens)
-        n (count v)]
-    (when (zero? n)
+  (let [v (into [] gens)]
+    (when (zero? (count v))
       (throw (php/new InvalidArgumentException
                "gen/one-of requires at least one generator")))
-    (fn [size]
-      (let [g (get v (rand-long 0 (dec n)))]
-        (g size)))))
+    (fn [size] ((rand-elem v) size))))
 
 (defn frequency
   "Generator that picks one of the `[weight gen]` pairs with probability
   proportional to weight."
-  {:example "((frequency [[9 (return :a)] [1 (return :b)]]) 100) ; => :a ~90% of the time"}
+  {:example "((frequency [[9 (return :a)] [1 (return :b)]]) 100)"}
   [pairs]
   (let [v (into [] pairs)
         total (reduce + 0 (map (fn [p] (get p 0)) v))]
@@ -252,7 +242,7 @@
       (throw (php/new InvalidArgumentException
                "gen/frequency requires at least one pair with positive weight")))
     (fn [size]
-      (loop [i 0 remaining (rand-long 1 total)]
+      (loop [i 0 remaining (rand-int* 1 total)]
         (let [pair (get v i)
               w (get pair 0)
               g (get pair 1)
@@ -262,84 +252,78 @@
             (recur (inc i) next-remaining)))))))
 
 (defn tuple
-  "Generator of a fixed-length vector produced by running each generator in
-  `gens` in order."
-  {:example "((tuple [(int) (boolean)]) 10) ; => [3 true]"}
-  [gens]
-  (let [v (into [] gens)]
+  "Generator of a fixed-length vector produced by running each of the given
+  generators in order. Accepts either a vector of generators or variadic
+  generator arguments."
+  {:example "((tuple int boolean) 10) ; => [3 true]"}
+  [& gens]
+  (let [v (if (and (= 1 (count gens)) (vector? (first gens)))
+            (first gens)
+            (into [] gens))]
     (fn [size] (into [] (map (fn [g] (g size)) v)))))
 
-;; --------------------
+;; -------------------
 ;; Collection generators
-;; --------------------
-;;
-;; Named `*-of` to avoid shadowing core constructors (`vector`, `list`,
-;; `hash-map`, `set`) that are invoked at macroexpansion time.
-
-(defn- gen-length [size]
-  (rand-long 0 (max 0 size)))
+;; -------------------
 
 (defn vector-of
-  "Generator of vectors whose elements come from `g`. With one arg, length is in
-  `[0, size]`. With `n`, length is exactly `n`. With `lo` and `hi`, length is in
-  `[lo, hi]`."
-  {:example "((vector-of (int)) 3) ; => [-1 2 0]"}
+  "Generator of vectors. Length is `[0, size]` with one arg, exactly `n` with
+  `(vector-of g n)`, or `[lo, hi]` with `(vector-of g lo hi)`."
+  {:example "((vector-of int) 3) ; => [-1 2 0]"}
   ([g]
    (fn [size]
-     (into [] (for [_ :range [0 (gen-length size)]] (g size)))))
+     (into [] (for [_ :range [0 (rand-int* 0 (non-negative size))]] (g size)))))
   ([g n]
    (fn [size]
      (into [] (for [_ :range [0 n]] (g size)))))
   ([g lo hi]
    (fn [size]
-     (into [] (for [_ :range [0 (rand-long lo hi)]] (g size))))))
+     (into [] (for [_ :range [0 (rand-int* lo hi)]] (g size))))))
 
 (defn list-of
   "Generator of lists whose elements come from `g`. Length in `[0, size]`."
-  {:example "((list-of (int)) 3) ; => (-1 2 0)"}
+  {:example "((list-of int) 3) ; => (-1 2 0)"}
   [g]
   (fn [size]
-    (apply list (for [_ :range [0 (gen-length size)]] (g size)))))
+    (apply list (for [_ :range [0 (rand-int* 0 (non-negative size))]] (g size)))))
 
 (defn map-of
   "Generator of hash-maps with keys from `kg` and values from `vg`. Number of
   entries is in `[0, size]`."
-  {:example "((map-of (keyword) (int)) 2) ; => {:a 1 :b -3}"}
+  {:example "((map-of keyword int) 2) ; => {:a 1 :b -3}"}
   [kg vg]
   (fn [size]
-    (let [n (gen-length size)]
-      (loop [i 0 m {}]
-        (if (>= i n)
-          m
-          (recur (inc i) (put m (kg size) (vg size))))))))
+    (loop [i 0 n (rand-int* 0 (non-negative size)) m {}]
+      (if (>= i n)
+        m
+        (recur (inc i) n (put m (kg size) (vg size)))))))
 
 (defn set-of
-  "Generator of hash-sets with elements from `g`. Cardinality is in `[0, size]`."
-  {:example "((set-of (nat)) 3) ; => (set 1 2 3)"}
+  "Generator of hash-sets with elements from `g`. Cardinality in `[0, size]`."
+  {:example "((set-of nat) 3) ; => (set 1 2 3)"}
   [g]
   (fn [size]
-    (let [n (gen-length size)]
-      (loop [i 0 s (hash-set)]
-        (if (>= i n)
-          s
-          (recur (inc i) (conj s (g size))))))))
+    (loop [i 0 n (rand-int* 0 (non-negative size)) s (hash-set)]
+      (if (>= i n)
+        s
+        (recur (inc i) n (conj s (g size)))))))
 
-;; --------------------
+;; ---------
 ;; Sampling
-;; --------------------
+;; ---------
 
 (defn generate
-  "Runs `g` once and returns a single value. Options: `:size`, `:seed`."
-  {:example "(generate (int)) ; => 42"}
+  "Runs `g` once and returns a single value. Accepts `:size` and `:seed`."
+  {:example "(generate int) ; => 42"}
   ([g] (generate g {}))
   ([g {:size size :seed seed}]
    (seed-rng! seed)
    (g (or size default-size))))
 
 (defn sample
-  "Runs `g` `num-samples` times and returns a vector of values. Defaults to 10
-  samples at default size. Options: `:size`, `:seed`."
-  {:example "(sample (int) 5) ; => [3 -7 0 1 -2]"}
+  "Runs `g` `num-samples` times (default 10) and returns a vector of values.
+  Accepts `:size` and `:seed`."
+  {:example "(sample int 5) ; => [3 -7 0 1 -2]"}
   ([g] (sample g 10 {}))
   ([g num-samples] (sample g num-samples {}))
   ([g num-samples {:size size :seed seed}]
@@ -347,37 +331,40 @@
    (let [s (or size default-size)]
      (into [] (for [_ :range [0 num-samples]] (g s))))))
 
-;; --------------------
-;; Property testing
-;; --------------------
+;; ----------------
+;; Property runner
+;; ----------------
+
+(defn- trial-result [property args]
+  (try
+    (if (apply property args) :pass :fail)
+    (catch \Throwable e e)))
 
 (defn- run-trials [property args-gen num-tests size]
   (loop [i 0]
     (if (>= i num-tests)
       {:result :pass :num-tests i}
       (let [args (args-gen size)
-            ok (try (apply property args)
-                    (catch \Throwable e e))]
+            outcome (trial-result property args)]
         (cond
-          (php/instanceof ok \Throwable)
-          {:result :error :num-tests (inc i) :args args :exception ok}
-          (not ok)
-          {:result :failed :num-tests (inc i) :args args}
-          :else (recur (inc i)))))))
+          (= :pass outcome)
+          (recur (inc i))
+          (php/instanceof outcome \Throwable)
+          {:result :error :num-tests (inc i) :args args :exception outcome}
+          :else
+          {:result :failed :num-tests (inc i) :args args})))))
 
 (defn quick-check
-  "Runs a property `num-tests` times, sampling arguments from `args-gen` (a
-  generator producing a vector of arguments). Returns a hash-map describing
-  the outcome; includes the `:seed` so a failure can be replayed.
+  "Runs `property` for `num-tests` trials, drawing each trial's arguments from
+  `args-gen` (a generator returning a vector of arguments). Returns a hash-map
+  with `:result` (`:pass`, `:failed`, or `:error`), `:num-tests`, and the
+  effective `:seed` for replay. On failure/error the failing `:args` (and
+  `:exception`) are also included.
 
   Options:
   - `:size` (default 100): magnitude passed to the generator.
-  - `:seed` (default: fresh per-run seed): PRNG seed.
-
-  The returned map has `:result` of `:pass`, `:failed`, or `:error`.
-  On `:failed`/`:error` it also carries `:args` (the failing input) and,
-  for `:error`, the original `:exception`."
-  {:example "(quick-check 50 (tuple [(int) (int)]) (fn [a b] (= (+ a b) (+ b a))))"}
+  - `:seed` (default: fresh per-run): PRNG seed."
+  {:example "(quick-check 50 (tuple int int) (fn [a b] (= (+ a b) (+ b a))))"}
   ([num-tests args-gen property]
    (quick-check num-tests args-gen property {}))
   ([num-tests args-gen property {:size size :seed seed}]
@@ -387,27 +374,25 @@
      (put outcome :seed effective-seed))))
 
 (defn- spec-failure-message [name-str res]
-  (let [parts ["property " name-str " failed after " (get res :num-tests)
-               " tests (seed " (get res :seed)]
+  (let [parts [(str "property " name-str " failed after " (get res :num-tests)
+                    " tests (seed " (get res :seed))]
         args (get res :args)
         ex (get res :exception)
-        parts (if args (concat parts [", args " (print-str args)]) parts)
+        parts (if args (push parts (str ", args " (print-str args))) parts)
         parts (if ex
-                (concat parts [", threw " (php/get_class ex) ": "
-                               (php/-> ex (getMessage))])
-                parts)
-        parts (concat parts [")"])]
-    (apply str parts)))
+                (push parts (str ", threw " (php/get_class ex) ": "
+                                 (php/-> ex (getMessage))))
+                parts)]
+    (apply str (push parts ")"))))
 
 (defmacro defspec
-  "Defines a property test that runs `quick-check` and asserts the result is a
-  pass. Integrates with `phel\\test`: the generated `deftest` is picked up by
-  `run-tests`. `options` is a hash-map accepting `:num-tests`, `:size`, and
-  `:seed`.
+  "Defines a property test. The generated `deftest` runs `quick-check` and
+  asserts the result is `:pass`. `options` is a hash-map accepting
+  `:num-tests`, `:size`, and `:seed`.
 
   Shape: `(defspec name options args-gen property)`."
   {:example "(defspec addition-commutes {:num-tests 200}
-              (tuple [(int) (int)])
+              (tuple int int)
               (fn [a b] (= (+ a b) (+ b a))))"}
   [name options args-gen property]
   (let [opts-sym (gensym)

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -79,7 +79,7 @@
 
 (def float
   "Generator of floats in `[0, 1)`."
-  (fn [_size] (/ (rand-int* 0 php/PHP_INT_MAX) php/PHP_INT_MAX)))
+  (fn [_size] (/ (rand-int* 0 (dec php/PHP_INT_MAX)) php/PHP_INT_MAX)))
 
 (defn choose
   "Generator of integers in the closed interval `[lo hi]`."

--- a/tests/phel/test/gen.phel
+++ b/tests/phel/test/gen.phel
@@ -1,0 +1,168 @@
+(ns phel-test\test\gen
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\test\gen :as g))
+
+(def- fixed-seed 1729)
+
+;; --------------------
+;; Primitives
+;; --------------------
+
+(deftest test-return
+  (is (= :x ((g/return :x) 100)))
+  (is (= 42 (g/generate (g/return 42)))))
+
+(deftest test-boolean
+  (testing "produces only booleans"
+    (let [vs (g/sample (g/boolean) 50 {:seed fixed-seed})]
+      (is (every? boolean? vs)))))
+
+(deftest test-nat
+  (testing "stays within [0, size]"
+    (let [vs (g/sample (g/nat) 100 {:size 20 :seed fixed-seed})]
+      (is (every? (fn [n] (and (int? n) (<= 0 n) (<= n 20))) vs)))))
+
+(deftest test-int
+  (testing "stays within [-size, size]"
+    (let [vs (g/sample (g/int) 100 {:size 10 :seed fixed-seed})]
+      (is (every? (fn [n] (and (int? n) (<= -10 n) (<= n 10))) vs)))))
+
+(deftest test-choose
+  (testing "stays within [lo, hi]"
+    (let [vs (g/sample (g/choose 5 9) 100 {:seed fixed-seed})]
+      (is (every? (fn [n] (and (<= 5 n) (<= n 9))) vs))))
+  (testing "rejects lo > hi"
+    (is (thrown? \InvalidArgumentException (g/choose 10 1)))))
+
+(deftest test-float
+  (let [vs (g/sample (g/float) 100 {:seed fixed-seed})]
+    (is (every? (fn [f] (and (<= 0 f) (< f 1.0001))) vs))))
+
+;; --------------------
+;; Chars & strings
+;; --------------------
+
+(deftest test-char-alpha
+  (let [vs (g/sample (g/char-alpha) 50 {:seed fixed-seed})]
+    (is (every? (fn [c] (php/preg_match "/^[A-Za-z]$/" c)) vs))))
+
+(deftest test-string-alpha
+  (let [vs (g/sample (g/string-alpha) 50 {:size 8 :seed fixed-seed})]
+    (is (every? string? vs))
+    (is (every? (fn [s] (<= (php/strlen s) 8)) vs))))
+
+(deftest test-keyword
+  (let [vs (g/sample (g/keyword) 30 {:size 5 :seed fixed-seed})]
+    (is (every? keyword? vs))))
+
+(deftest test-symbol
+  (let [vs (g/sample (g/symbol) 30 {:size 5 :seed fixed-seed})]
+    (is (every? symbol? vs))))
+
+;; --------------------
+;; Combinators
+;; --------------------
+
+(deftest test-elements
+  (let [vs (g/sample (g/elements [:a :b :c]) 50 {:seed fixed-seed})]
+    (is (every? (fn [v] (contains? (hash-set :a :b :c) v)) vs)))
+  (is (thrown? \InvalidArgumentException (g/elements []))))
+
+(deftest test-one-of
+  (let [vs (g/sample (g/one-of [(g/return :a) (g/return :b)]) 50 {:seed fixed-seed})]
+    (is (every? (fn [v] (contains? (hash-set :a :b) v)) vs))))
+
+(deftest test-frequency
+  (let [vs (g/sample (g/frequency [[99 (g/return :hit)] [1 (g/return :miss)]])
+                     200 {:seed fixed-seed})
+        hits (count (filter (fn [v] (= :hit v)) vs))]
+    (is (> hits 150) "weighted pick favours heavy bucket")))
+
+(deftest test-fmap
+  (let [vs (g/sample (g/fmap inc (g/return 1)) 10)]
+    (is (every? (fn [n] (= 2 n)) vs))))
+
+(deftest test-such-that
+  (let [vs (g/sample (g/such-that even? (g/nat)) 20 {:size 50 :seed fixed-seed})]
+    (is (every? even? vs)))
+  (testing "fails when predicate is unsatisfiable"
+    (is (thrown? \RuntimeException
+          (g/generate (g/such-that (fn [_] false) (g/nat) 5))))))
+
+(deftest test-tuple
+  (let [v (g/generate (g/tuple [(g/return 1) (g/return :a) (g/return "z")]))]
+    (is (= [1 :a "z"] v))))
+
+;; --------------------
+;; Collections
+;; --------------------
+
+(deftest test-vector-of
+  (testing "default length in [0, size]"
+    (let [vs (g/sample (g/vector-of (g/nat)) 30 {:size 5 :seed fixed-seed})]
+      (is (every? vector? vs))
+      (is (every? (fn [v] (<= (count v) 5)) vs))))
+  (testing "fixed length"
+    (let [v (g/generate (g/vector-of (g/return :x) 4))]
+      (is (= [:x :x :x :x] v))))
+  (testing "ranged length"
+    (let [vs (g/sample (g/vector-of (g/return 0) 2 4) 20 {:seed fixed-seed})]
+      (is (every? (fn [v] (and (<= 2 (count v)) (<= (count v) 4))) vs)))))
+
+(deftest test-list-of
+  (let [vs (g/sample (g/list-of (g/nat)) 10 {:size 4 :seed fixed-seed})]
+    (is (every? list? vs))))
+
+(deftest test-map-of
+  (let [vs (g/sample (g/map-of (g/keyword) (g/nat)) 10
+                     {:size 3 :seed fixed-seed})]
+    (is (every? hash-map? vs))))
+
+(deftest test-set-of
+  (let [vs (g/sample (g/set-of (g/nat)) 10 {:size 4 :seed fixed-seed})]
+    (is (every? set? vs))))
+
+;; --------------------
+;; quick-check + defspec
+;; --------------------
+
+(deftest test-quick-check-pass
+  (let [res (g/quick-check 50
+              (g/tuple [(g/int) (g/int)])
+              (fn [a b] (= (+ a b) (+ b a)))
+              {:seed fixed-seed})]
+    (is (= :pass (:result res)))
+    (is (= 50 (:num-tests res)))
+    (is (int? (:seed res)))))
+
+(deftest test-quick-check-fail
+  (let [res (g/quick-check 100
+              (g/tuple [(g/nat)])
+              (fn [n] (< n 0))
+              {:seed fixed-seed})]
+    (is (= :failed (:result res)))
+    (is (some? (:args res)))
+    (is (int? (:seed res)))))
+
+(deftest test-quick-check-error
+  (let [res (g/quick-check 10
+              (g/tuple [(g/return 0)])
+              (fn [_] (throw (php/new \RuntimeException "boom")))
+              {:seed fixed-seed})]
+    (is (= :error (:result res)))
+    (is (some? (:exception res)))))
+
+(deftest test-seed-repeatability
+  (let [s1 (g/sample (g/int) 20 {:seed 42})
+        s2 (g/sample (g/int) 20 {:seed 42})]
+    (is (= s1 s2))))
+
+(g/defspec spec-reverse-involution
+  {:num-tests 50 :size 10 :seed fixed-seed}
+  (g/tuple [(g/vector-of (g/int))])
+  (fn [v] (= v (reverse (reverse v)))))
+
+(g/defspec spec-int-identity
+  {:num-tests 30 :seed fixed-seed}
+  (g/tuple [(g/int)])
+  (fn [n] (= n (+ n 0))))

--- a/tests/phel/test/gen.phel
+++ b/tests/phel/test/gen.phel
@@ -31,7 +31,7 @@
 
 (deftest test-float
   (let [vs (g/sample g/float 100 {:seed fixed-seed})]
-    (is (every? (fn [f] (and (<= 0 f) (< f 1.0001))) vs))))
+    (is (every? (fn [f] (and (<= 0 f) (< f 1.0))) vs))))
 
 ;; ----------------
 ;; Chars & strings

--- a/tests/phel/test/gen.phel
+++ b/tests/phel/test/gen.phel
@@ -4,64 +4,59 @@
 
 (def- fixed-seed 1729)
 
-;; --------------------
+;; -----------
 ;; Primitives
-;; --------------------
+;; -----------
 
 (deftest test-return
   (is (= :x ((g/return :x) 100)))
   (is (= 42 (g/generate (g/return 42)))))
 
 (deftest test-boolean
-  (testing "produces only booleans"
-    (let [vs (g/sample (g/boolean) 50 {:seed fixed-seed})]
-      (is (every? boolean? vs)))))
+  (let [vs (g/sample g/boolean 50 {:seed fixed-seed})]
+    (is (every? boolean? vs))))
 
 (deftest test-nat
-  (testing "stays within [0, size]"
-    (let [vs (g/sample (g/nat) 100 {:size 20 :seed fixed-seed})]
-      (is (every? (fn [n] (and (int? n) (<= 0 n) (<= n 20))) vs)))))
+  (let [vs (g/sample g/nat 100 {:size 20 :seed fixed-seed})]
+    (is (every? (fn [n] (and (int? n) (<= 0 n) (<= n 20))) vs))))
 
 (deftest test-int
-  (testing "stays within [-size, size]"
-    (let [vs (g/sample (g/int) 100 {:size 10 :seed fixed-seed})]
-      (is (every? (fn [n] (and (int? n) (<= -10 n) (<= n 10))) vs)))))
+  (let [vs (g/sample g/int 100 {:size 10 :seed fixed-seed})]
+    (is (every? (fn [n] (and (int? n) (<= -10 n) (<= n 10))) vs))))
 
 (deftest test-choose
-  (testing "stays within [lo, hi]"
-    (let [vs (g/sample (g/choose 5 9) 100 {:seed fixed-seed})]
-      (is (every? (fn [n] (and (<= 5 n) (<= n 9))) vs))))
-  (testing "rejects lo > hi"
-    (is (thrown? \InvalidArgumentException (g/choose 10 1)))))
+  (let [vs (g/sample (g/choose 5 9) 100 {:seed fixed-seed})]
+    (is (every? (fn [n] (and (<= 5 n) (<= n 9))) vs)))
+  (is (thrown? \InvalidArgumentException (g/choose 10 1))))
 
 (deftest test-float
-  (let [vs (g/sample (g/float) 100 {:seed fixed-seed})]
+  (let [vs (g/sample g/float 100 {:seed fixed-seed})]
     (is (every? (fn [f] (and (<= 0 f) (< f 1.0001))) vs))))
 
-;; --------------------
+;; ----------------
 ;; Chars & strings
-;; --------------------
+;; ----------------
 
 (deftest test-char-alpha
-  (let [vs (g/sample (g/char-alpha) 50 {:seed fixed-seed})]
+  (let [vs (g/sample g/char-alpha 50 {:seed fixed-seed})]
     (is (every? (fn [c] (php/preg_match "/^[A-Za-z]$/" c)) vs))))
 
 (deftest test-string-alpha
-  (let [vs (g/sample (g/string-alpha) 50 {:size 8 :seed fixed-seed})]
+  (let [vs (g/sample g/string-alpha 50 {:size 8 :seed fixed-seed})]
     (is (every? string? vs))
     (is (every? (fn [s] (<= (php/strlen s) 8)) vs))))
 
 (deftest test-keyword
-  (let [vs (g/sample (g/keyword) 30 {:size 5 :seed fixed-seed})]
+  (let [vs (g/sample g/keyword 30 {:size 5 :seed fixed-seed})]
     (is (every? keyword? vs))))
 
 (deftest test-symbol
-  (let [vs (g/sample (g/symbol) 30 {:size 5 :seed fixed-seed})]
+  (let [vs (g/sample g/symbol 30 {:size 5 :seed fixed-seed})]
     (is (every? symbol? vs))))
 
-;; --------------------
+;; ------------
 ;; Combinators
-;; --------------------
+;; ------------
 
 (deftest test-elements
   (let [vs (g/sample (g/elements [:a :b :c]) 50 {:seed fixed-seed})]
@@ -83,23 +78,27 @@
     (is (every? (fn [n] (= 2 n)) vs))))
 
 (deftest test-such-that
-  (let [vs (g/sample (g/such-that even? (g/nat)) 20 {:size 50 :seed fixed-seed})]
+  (let [vs (g/sample (g/such-that even? g/nat) 20 {:size 50 :seed fixed-seed})]
     (is (every? even? vs)))
-  (testing "fails when predicate is unsatisfiable"
-    (is (thrown? \RuntimeException
-          (g/generate (g/such-that (fn [_] false) (g/nat) 5))))))
+  (is (thrown? \RuntimeException
+        (g/generate (g/such-that (fn [_] false) g/nat 5)))))
 
-(deftest test-tuple
-  (let [v (g/generate (g/tuple [(g/return 1) (g/return :a) (g/return "z")]))]
+(deftest test-tuple-variadic
+  (let [v (g/generate (g/tuple (g/return 1) (g/return :a) (g/return "z")))]
     (is (= [1 :a "z"] v))))
 
-;; --------------------
+(deftest test-tuple-vector-arg
+  (testing "vector of generators is accepted for backward compatibility"
+    (let [v (g/generate (g/tuple [(g/return 1) (g/return :a)]))]
+      (is (= [1 :a] v)))))
+
+;; ------------
 ;; Collections
-;; --------------------
+;; ------------
 
 (deftest test-vector-of
   (testing "default length in [0, size]"
-    (let [vs (g/sample (g/vector-of (g/nat)) 30 {:size 5 :seed fixed-seed})]
+    (let [vs (g/sample (g/vector-of g/nat) 30 {:size 5 :seed fixed-seed})]
       (is (every? vector? vs))
       (is (every? (fn [v] (<= (count v) 5)) vs))))
   (testing "fixed length"
@@ -110,25 +109,24 @@
       (is (every? (fn [v] (and (<= 2 (count v)) (<= (count v) 4))) vs)))))
 
 (deftest test-list-of
-  (let [vs (g/sample (g/list-of (g/nat)) 10 {:size 4 :seed fixed-seed})]
+  (let [vs (g/sample (g/list-of g/nat) 10 {:size 4 :seed fixed-seed})]
     (is (every? list? vs))))
 
 (deftest test-map-of
-  (let [vs (g/sample (g/map-of (g/keyword) (g/nat)) 10
+  (let [vs (g/sample (g/map-of g/keyword g/nat) 10
                      {:size 3 :seed fixed-seed})]
     (is (every? hash-map? vs))))
 
 (deftest test-set-of
-  (let [vs (g/sample (g/set-of (g/nat)) 10 {:size 4 :seed fixed-seed})]
+  (let [vs (g/sample (g/set-of g/nat) 10 {:size 4 :seed fixed-seed})]
     (is (every? set? vs))))
 
-;; --------------------
+;; ----------------------
 ;; quick-check + defspec
-;; --------------------
+;; ----------------------
 
 (deftest test-quick-check-pass
-  (let [res (g/quick-check 50
-              (g/tuple [(g/int) (g/int)])
+  (let [res (g/quick-check 50 (g/tuple g/int g/int)
               (fn [a b] (= (+ a b) (+ b a)))
               {:seed fixed-seed})]
     (is (= :pass (:result res)))
@@ -136,8 +134,7 @@
     (is (int? (:seed res)))))
 
 (deftest test-quick-check-fail
-  (let [res (g/quick-check 100
-              (g/tuple [(g/nat)])
+  (let [res (g/quick-check 100 (g/tuple g/nat)
               (fn [n] (< n 0))
               {:seed fixed-seed})]
     (is (= :failed (:result res)))
@@ -145,24 +142,23 @@
     (is (int? (:seed res)))))
 
 (deftest test-quick-check-error
-  (let [res (g/quick-check 10
-              (g/tuple [(g/return 0)])
+  (let [res (g/quick-check 10 (g/tuple (g/return 0))
               (fn [_] (throw (php/new \RuntimeException "boom")))
               {:seed fixed-seed})]
     (is (= :error (:result res)))
     (is (some? (:exception res)))))
 
 (deftest test-seed-repeatability
-  (let [s1 (g/sample (g/int) 20 {:seed 42})
-        s2 (g/sample (g/int) 20 {:seed 42})]
+  (let [s1 (g/sample g/int 20 {:seed 42})
+        s2 (g/sample g/int 20 {:seed 42})]
     (is (= s1 s2))))
 
 (g/defspec spec-reverse-involution
   {:num-tests 50 :size 10 :seed fixed-seed}
-  (g/tuple [(g/vector-of (g/int))])
+  (g/tuple (g/vector-of g/int))
   (fn [v] (= v (reverse (reverse v)))))
 
 (g/defspec spec-int-identity
   {:num-tests 30 :seed fixed-seed}
-  (g/tuple [(g/int)])
+  (g/tuple g/int)
   (fn [n] (= n (+ n 0))))


### PR DESCRIPTION
## 🤔 Background

Phel has rand/rand-int/rand-nth primitives but no generator-based random data for tests — no equivalent of Clojure's `test.check`.

## 💡 Goal

Introduce a new `phel\test\gen` module that provides composable random generators, a sampling API, and a property-based runner (`quick-check` + `defspec`) that integrates with the existing `phel\test` framework.

## 🔖 Changes

- New `src/phel/test/gen.phel` module with:
  - Scalars: `boolean`, `int`, `nat`, `large-int`, `choose`, `float`, `char*`, `string*`, `keyword`, `symbol`
  - Combinators: `return`, `fmap`, `such-that`, `sized`, `resize`, `elements`, `one-of`, `frequency`, `tuple`
  - Collections: `vector-of`, `list-of`, `map-of`, `set-of`
  - Runners: `generate`, `sample`, `quick-check`, `defspec` macro
  - Seedable PRNG via `:seed` option; `quick-check` returns the effective seed for replay
- Self-tests in `tests/phel/test/gen.phel` (39 cases)
- `CHANGELOG.md` entry under `## Unreleased`

No shrinking yet — deferred to a follow-up; API is forward-compatible.