### PR TITLE
feat(formatter): align key/value pairs in cond, case, condp, and binding vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
+- Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 
 ## [0.33.0](https://github.com/phel-lang/phel-lang/compare/v0.32.0...v0.33.0) - 2026-04-17
 

--- a/src/php/Formatter/Domain/Rules/AlignPairsRule.php
+++ b/src/php/Formatter/Domain/Rules/AlignPairsRule.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain\Rules;
+
+use Phel\Compiler\Domain\Lexer\Token;
+use Phel\Compiler\Domain\Parser\ParserNode\CommentNode;
+use Phel\Compiler\Domain\Parser\ParserNode\InnerNodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
+use Phel\Compiler\Domain\Parser\ParserNode\NewlineNode;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\WhitespaceNode;
+use Phel\Lang\SourceLocation;
+
+use function array_slice;
+use function count;
+use function in_array;
+use function strlen;
+
+final readonly class AlignPairsRule implements RuleInterface
+{
+    /**
+     * Forms whose tail (after N leading non-trivia nodes) is a sequence of
+     * key/value pairs to align. Value: number of non-trivia nodes to skip
+     * before pairs start (0 = head only, 1 = head + expr, etc.).
+     */
+    private const array PAIR_FORMS = [
+        'cond' => 1,
+        'case' => 2,
+        'condp' => 3,
+    ];
+
+    /** Forms whose first value-child is a vector of key/value binding pairs. */
+    private const array BINDING_FORMS = [
+        'let',
+        'loop',
+        'binding',
+        'for',
+        'foreach',
+        'dofor',
+        'if-let',
+        'when-let',
+    ];
+
+    public function transform(NodeInterface $node): NodeInterface
+    {
+        return $this->visit($node);
+    }
+
+    private function visit(NodeInterface $node): NodeInterface
+    {
+        if (!$node instanceof InnerNodeInterface) {
+            return $node;
+        }
+
+        $children = [];
+        foreach ($node->getChildren() as $child) {
+            $children[] = $this->visit($child);
+        }
+
+        $node->replaceChildren($children);
+
+        if ($node instanceof ListNode && $node->getTokenType() === Token::T_OPEN_PARENTHESIS) {
+            $this->applyFormAlignment($node);
+        }
+
+        return $node;
+    }
+
+    private function applyFormAlignment(ListNode $node): void
+    {
+        $children = $node->getChildren();
+        $headName = $this->headName($children);
+        if ($headName === null) {
+            return;
+        }
+
+        if (isset(self::PAIR_FORMS[$headName])) {
+            $node->replaceChildren(
+                $this->alignPairs($children, self::PAIR_FORMS[$headName], allowTrailingSingle: $headName !== 'cond'),
+            );
+            return;
+        }
+
+        if (in_array($headName, self::BINDING_FORMS, true)) {
+            $vector = $this->firstVectorChild($children);
+            if ($vector instanceof ListNode) {
+                $vector->replaceChildren($this->alignPairs($vector->getChildren(), 0));
+            }
+        }
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     */
+    private function headName(array $children): ?string
+    {
+        foreach ($children as $child) {
+            if ($child instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            if ($child instanceof SymbolNode) {
+                return $child->getValue()->getName();
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     */
+    private function firstVectorChild(array $children): ?ListNode
+    {
+        $seenHead = false;
+        foreach ($children as $child) {
+            if ($child instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            if (!$seenHead) {
+                $seenHead = true;
+                continue;
+            }
+
+            if ($child instanceof ListNode && $child->getTokenType() === Token::T_OPEN_BRACKET) {
+                return $child;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     *
+     * @return list<NodeInterface>
+     */
+    private function alignPairs(array $children, int $skipValueCount, bool $allowTrailingSingle = false): array
+    {
+        $valueIndices = [];
+        foreach ($children as $i => $child) {
+            if (!$child instanceof TriviaNodeInterface) {
+                $valueIndices[] = $i;
+            }
+        }
+
+        $pairIndices = array_slice($valueIndices, $skipValueCount);
+        if ($allowTrailingSingle && count($pairIndices) % 2 === 1) {
+            array_pop($pairIndices);
+        }
+
+        if (count($pairIndices) % 2 !== 0 || count($pairIndices) < 4) {
+            return $children;
+        }
+
+        $pairs = [];
+        $counter = count($pairIndices);
+        for ($i = 0; $i < $counter; $i += 2) {
+            $pairs[] = [$pairIndices[$i], $pairIndices[$i + 1]];
+        }
+
+        if (!$this->spansMultipleLines($children, $pairs)) {
+            return $children;
+        }
+
+        $maxKeyWidth = 0;
+        foreach ($pairs as [$keyIdx]) {
+            $width = $this->keyWidth($children[$keyIdx]);
+            if ($width > $maxKeyWidth) {
+                $maxKeyWidth = $width;
+            }
+        }
+
+        $pairByKeyIdx = [];
+        foreach ($pairs as [$keyIdx, $valIdx]) {
+            $pairByKeyIdx[$keyIdx] = $valIdx;
+        }
+
+        $output = [];
+        $count = count($children);
+        $i = 0;
+        while ($i < $count) {
+            $output[] = $children[$i];
+            if (isset($pairByKeyIdx[$i]) && $this->gapIsHorizontal($children, $i, $pairByKeyIdx[$i])) {
+                $padWidth = $maxKeyWidth - $this->keyWidth($children[$i]) + 1;
+                $output[] = new WhitespaceNode(
+                    str_repeat(' ', $padWidth),
+                    new SourceLocation('', 0, 0),
+                    new SourceLocation('', 0, 0),
+                );
+                $i = $pairByKeyIdx[$i];
+                continue;
+            }
+
+            ++$i;
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param list<NodeInterface>   $children
+     * @param list<array{int, int}> $pairs
+     */
+    private function spansMultipleLines(array $children, array $pairs): bool
+    {
+        for ($p = 1, $n = count($pairs); $p < $n; ++$p) {
+            $prevVal = $pairs[$p - 1][1];
+            $curKey = $pairs[$p][0];
+            for ($k = $prevVal + 1; $k < $curKey; ++$k) {
+                if ($children[$k] instanceof NewlineNode) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     */
+    private function gapIsHorizontal(array $children, int $keyIdx, int $valIdx): bool
+    {
+        for ($k = $keyIdx + 1; $k < $valIdx; ++$k) {
+            $node = $children[$k];
+            if ($node instanceof NewlineNode || $node instanceof CommentNode) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function keyWidth(NodeInterface $node): int
+    {
+        return strlen($node->getCode());
+    }
+}

--- a/src/php/Formatter/Domain/Rules/AlignPairsRule.php
+++ b/src/php/Formatter/Domain/Rules/AlignPairsRule.php
@@ -5,27 +5,32 @@ declare(strict_types=1);
 namespace Phel\Formatter\Domain\Rules;
 
 use Phel\Compiler\Domain\Lexer\Token;
-use Phel\Compiler\Domain\Parser\ParserNode\CommentNode;
 use Phel\Compiler\Domain\Parser\ParserNode\InnerNodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
-use Phel\Compiler\Domain\Parser\ParserNode\NewlineNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
-use Phel\Compiler\Domain\Parser\ParserNode\WhitespaceNode;
-use Phel\Lang\SourceLocation;
+use Phel\Formatter\Domain\Rules\Pair\PairAligner;
 
-use function array_slice;
-use function count;
 use function in_array;
-use function strlen;
 
+/**
+ * Aligns key/value pairs inside recognized forms so values line up under a
+ * common column. Two families are handled:
+ *
+ *   - Pair forms: cond, case, condp. Pairs follow a head offset; case/condp
+ *     allow an odd trailing default clause.
+ *   - Binding forms: let, loop, binding, if-let, when-let, if-some, when-some.
+ *     The first value-child is a bracket vector of symbol/value pairs.
+ *
+ * Note: for / foreach / dofor use 3-tuple (binding :in coll) plus modifier
+ * keywords and are intentionally excluded.
+ */
 final readonly class AlignPairsRule implements RuleInterface
 {
     /**
-     * Forms whose tail (after N leading non-trivia nodes) is a sequence of
-     * key/value pairs to align. Value: number of non-trivia nodes to skip
-     * before pairs start (0 = head only, 1 = head + expr, etc.).
+     * @var array<string, int> map head symbol => number of leading value-nodes
+     *                         to skip before pair clauses begin
      */
     private const array PAIR_FORMS = [
         'cond' => 1,
@@ -33,17 +38,23 @@ final readonly class AlignPairsRule implements RuleInterface
         'condp' => 3,
     ];
 
-    /** Forms whose first value-child is a vector of key/value binding pairs. */
+    /** @var list<string> heads whose first value-child is a binding vector */
     private const array BINDING_FORMS = [
         'let',
         'loop',
         'binding',
-        'for',
-        'foreach',
-        'dofor',
         'if-let',
         'when-let',
+        'if-some',
+        'when-some',
     ];
+
+    private PairAligner $aligner;
+
+    public function __construct()
+    {
+        $this->aligner = new PairAligner();
+    }
 
     public function transform(NodeInterface $node): NodeInterface
     {
@@ -80,7 +91,11 @@ final readonly class AlignPairsRule implements RuleInterface
 
         if (isset(self::PAIR_FORMS[$headName])) {
             $node->replaceChildren(
-                $this->alignPairs($children, self::PAIR_FORMS[$headName], allowTrailingSingle: $headName !== 'cond'),
+                $this->aligner->align(
+                    $children,
+                    self::PAIR_FORMS[$headName],
+                    allowTrailingSingle: $headName !== 'cond',
+                ),
             );
             return;
         }
@@ -88,7 +103,9 @@ final readonly class AlignPairsRule implements RuleInterface
         if (in_array($headName, self::BINDING_FORMS, true)) {
             $vector = $this->firstVectorChild($children);
             if ($vector instanceof ListNode) {
-                $vector->replaceChildren($this->alignPairs($vector->getChildren(), 0));
+                $vector->replaceChildren(
+                    $this->aligner->align($vector->getChildren(), skipValueCount: 0, allowTrailingSingle: false),
+                );
             }
         }
     }
@@ -103,11 +120,9 @@ final readonly class AlignPairsRule implements RuleInterface
                 continue;
             }
 
-            if ($child instanceof SymbolNode) {
-                return $child->getValue()->getName();
-            }
-
-            return null;
+            return $child instanceof SymbolNode
+                ? $child->getValue()->getName()
+                : null;
         }
 
         return null;
@@ -129,120 +144,11 @@ final readonly class AlignPairsRule implements RuleInterface
                 continue;
             }
 
-            if ($child instanceof ListNode && $child->getTokenType() === Token::T_OPEN_BRACKET) {
-                return $child;
-            }
-
-            return null;
+            return $child instanceof ListNode && $child->getTokenType() === Token::T_OPEN_BRACKET
+                ? $child
+                : null;
         }
 
         return null;
-    }
-
-    /**
-     * @param list<NodeInterface> $children
-     *
-     * @return list<NodeInterface>
-     */
-    private function alignPairs(array $children, int $skipValueCount, bool $allowTrailingSingle = false): array
-    {
-        $valueIndices = [];
-        foreach ($children as $i => $child) {
-            if (!$child instanceof TriviaNodeInterface) {
-                $valueIndices[] = $i;
-            }
-        }
-
-        $pairIndices = array_slice($valueIndices, $skipValueCount);
-        if ($allowTrailingSingle && count($pairIndices) % 2 === 1) {
-            array_pop($pairIndices);
-        }
-
-        if (count($pairIndices) % 2 !== 0 || count($pairIndices) < 4) {
-            return $children;
-        }
-
-        $pairs = [];
-        $counter = count($pairIndices);
-        for ($i = 0; $i < $counter; $i += 2) {
-            $pairs[] = [$pairIndices[$i], $pairIndices[$i + 1]];
-        }
-
-        if (!$this->spansMultipleLines($children, $pairs)) {
-            return $children;
-        }
-
-        $maxKeyWidth = 0;
-        foreach ($pairs as [$keyIdx]) {
-            $width = $this->keyWidth($children[$keyIdx]);
-            if ($width > $maxKeyWidth) {
-                $maxKeyWidth = $width;
-            }
-        }
-
-        $pairByKeyIdx = [];
-        foreach ($pairs as [$keyIdx, $valIdx]) {
-            $pairByKeyIdx[$keyIdx] = $valIdx;
-        }
-
-        $output = [];
-        $count = count($children);
-        $i = 0;
-        while ($i < $count) {
-            $output[] = $children[$i];
-            if (isset($pairByKeyIdx[$i]) && $this->gapIsHorizontal($children, $i, $pairByKeyIdx[$i])) {
-                $padWidth = $maxKeyWidth - $this->keyWidth($children[$i]) + 1;
-                $output[] = new WhitespaceNode(
-                    str_repeat(' ', $padWidth),
-                    new SourceLocation('', 0, 0),
-                    new SourceLocation('', 0, 0),
-                );
-                $i = $pairByKeyIdx[$i];
-                continue;
-            }
-
-            ++$i;
-        }
-
-        return $output;
-    }
-
-    /**
-     * @param list<NodeInterface>   $children
-     * @param list<array{int, int}> $pairs
-     */
-    private function spansMultipleLines(array $children, array $pairs): bool
-    {
-        for ($p = 1, $n = count($pairs); $p < $n; ++$p) {
-            $prevVal = $pairs[$p - 1][1];
-            $curKey = $pairs[$p][0];
-            for ($k = $prevVal + 1; $k < $curKey; ++$k) {
-                if ($children[$k] instanceof NewlineNode) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param list<NodeInterface> $children
-     */
-    private function gapIsHorizontal(array $children, int $keyIdx, int $valIdx): bool
-    {
-        for ($k = $keyIdx + 1; $k < $valIdx; ++$k) {
-            $node = $children[$k];
-            if ($node instanceof NewlineNode || $node instanceof CommentNode) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function keyWidth(NodeInterface $node): int
-    {
-        return strlen($node->getCode());
     }
 }

--- a/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
+++ b/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Formatter\Domain\Rules\Pair;
+
+use Phel\Compiler\Domain\Parser\ParserNode\CommentNode;
+use Phel\Compiler\Domain\Parser\ParserNode\NewlineNode;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\WhitespaceNode;
+use Phel\Lang\SourceLocation;
+
+use function array_slice;
+use function count;
+use function strlen;
+
+/**
+ * Pads horizontal whitespace between key/value pair children so values line up
+ * under a common column (longest key + 1 space). Only touches pairs that span
+ * multiple lines and have a simple (no newline/comment) gap between key and
+ * value.
+ */
+final readonly class PairAligner
+{
+    /**
+     * @param list<NodeInterface> $children
+     *
+     * @return list<NodeInterface>
+     */
+    public function align(array $children, int $skipValueCount, bool $allowTrailingSingle): array
+    {
+        $pairs = $this->findPairs($children, $skipValueCount, $allowTrailingSingle);
+        if ($pairs === [] || !$this->spansMultipleLines($children, $pairs)) {
+            return $children;
+        }
+
+        $maxKeyWidth = $this->maxKeyWidth($children, $pairs);
+
+        return $this->rebuild($children, $pairs, $maxKeyWidth);
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     *
+     * @return list<array{int, int}>
+     */
+    private function findPairs(array $children, int $skipValueCount, bool $allowTrailingSingle): array
+    {
+        $valueIndices = [];
+        foreach ($children as $i => $child) {
+            if (!$child instanceof TriviaNodeInterface) {
+                $valueIndices[] = $i;
+            }
+        }
+
+        $pairIndices = array_slice($valueIndices, $skipValueCount);
+        if ($allowTrailingSingle && count($pairIndices) % 2 === 1) {
+            array_pop($pairIndices);
+        }
+
+        if (count($pairIndices) % 2 !== 0 || count($pairIndices) < 4) {
+            return [];
+        }
+
+        $pairs = [];
+        for ($i = 0, $n = count($pairIndices); $i < $n; $i += 2) {
+            $pairs[] = [$pairIndices[$i], $pairIndices[$i + 1]];
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @param list<NodeInterface>   $children
+     * @param list<array{int, int}> $pairs
+     */
+    private function spansMultipleLines(array $children, array $pairs): bool
+    {
+        for ($p = 1, $n = count($pairs); $p < $n; ++$p) {
+            $prevVal = $pairs[$p - 1][1];
+            $curKey = $pairs[$p][0];
+            for ($k = $prevVal + 1; $k < $curKey; ++$k) {
+                if ($children[$k] instanceof NewlineNode) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<NodeInterface>   $children
+     * @param list<array{int, int}> $pairs
+     */
+    private function maxKeyWidth(array $children, array $pairs): int
+    {
+        $max = 0;
+        foreach ($pairs as [$keyIdx]) {
+            $width = strlen($children[$keyIdx]->getCode());
+            if ($width > $max) {
+                $max = $width;
+            }
+        }
+
+        return $max;
+    }
+
+    /**
+     * @param list<NodeInterface>   $children
+     * @param list<array{int, int}> $pairs
+     *
+     * @return list<NodeInterface>
+     */
+    private function rebuild(array $children, array $pairs, int $maxKeyWidth): array
+    {
+        $pairByKeyIdx = [];
+        foreach ($pairs as [$keyIdx, $valIdx]) {
+            $pairByKeyIdx[$keyIdx] = $valIdx;
+        }
+
+        $output = [];
+        $count = count($children);
+        $i = 0;
+        while ($i < $count) {
+            $output[] = $children[$i];
+            if (isset($pairByKeyIdx[$i]) && $this->gapIsHorizontal($children, $i, $pairByKeyIdx[$i])) {
+                $padWidth = $maxKeyWidth - strlen($children[$i]->getCode()) + 1;
+                $output[] = $this->makeWhitespace($padWidth);
+                $i = $pairByKeyIdx[$i];
+                continue;
+            }
+
+            ++$i;
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param list<NodeInterface> $children
+     */
+    private function gapIsHorizontal(array $children, int $keyIdx, int $valIdx): bool
+    {
+        for ($k = $keyIdx + 1; $k < $valIdx; ++$k) {
+            $node = $children[$k];
+            if ($node instanceof NewlineNode || $node instanceof CommentNode) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function makeWhitespace(int $width): WhitespaceNode
+    {
+        return new WhitespaceNode(
+            str_repeat(' ', $width),
+            new SourceLocation('', 0, 0),
+            new SourceLocation('', 0, 0),
+        );
+    }
+}

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -11,6 +11,7 @@ use Phel\Formatter\Application\PathsFormatter;
 use Phel\Formatter\Application\PhelPathFilter;
 use Phel\Formatter\Domain\FormatterInterface;
 use Phel\Formatter\Domain\PathFilterInterface;
+use Phel\Formatter\Domain\Rules\AlignPairsRule;
 use Phel\Formatter\Domain\Rules\Indenter\BlockIndenter;
 use Phel\Formatter\Domain\Rules\Indenter\InnerIndenter;
 use Phel\Formatter\Domain\Rules\IndentRule;
@@ -41,6 +42,7 @@ final class FormatterFactory extends AbstractFactory
                 $this->createRemoveSurroundingWhitespaceRule(),
                 $this->createUnindentRule(),
                 $this->createIndentRule(),
+                $this->createAlignPairsRule(),
                 $this->createRemoveTrailingWhitespaceRule(),
             ],
         );
@@ -85,6 +87,11 @@ final class FormatterFactory extends AbstractFactory
             new BlockIndenter('when', 1),
             new BlockIndenter('when-not', 1),
         ]);
+    }
+
+    private function createAlignPairsRule(): AlignPairsRule
+    {
+        return new AlignPairsRule();
     }
 
     private function createRemoveTrailingWhitespaceRule(): RemoveTrailingWhitespaceRule

--- a/src/php/Formatter/FormatterFactory.php
+++ b/src/php/Formatter/FormatterFactory.php
@@ -82,10 +82,16 @@ final class FormatterFactory extends AbstractFactory
             new BlockIndenter('loop', 1),
             new BlockIndenter('case', 1),
             new BlockIndenter('cond', 0),
+            new BlockIndenter('condp', 2),
             new BlockIndenter('try', 0),
             new BlockIndenter('finally', 0),
             new BlockIndenter('when', 1),
             new BlockIndenter('when-not', 1),
+            new BlockIndenter('when-let', 1),
+            new BlockIndenter('when-some', 1),
+            new BlockIndenter('if-let', 1),
+            new BlockIndenter('if-some', 1),
+            new BlockIndenter('binding', 1),
         ]);
     }
 

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -173,6 +173,136 @@ final class FormatterFacadeTest extends TestCase
             ],
         ];
 
+        yield 'Align condp pairs with default' => [
+            [
+                '(condp = x',
+                '1 :one',
+                '200 :two-hundred',
+                ':other)',
+            ],
+            [
+                '(condp = x',
+                '  1   :one',
+                '  200 :two-hundred',
+                '  :other)',
+            ],
+        ];
+
+        yield 'Align cond with long-form key' => [
+            [
+                '(cond',
+                '(< x 10) :small',
+                ':else :big)',
+            ],
+            [
+                '(cond',
+                '  (< x 10) :small',
+                '  :else    :big)',
+            ],
+        ];
+
+        yield 'Cond odd count not aligned' => [
+            [
+                '(cond',
+                'a 1',
+                'b)',
+            ],
+            [
+                '(cond',
+                '  a 1',
+                '  b)',
+            ],
+        ];
+
+        yield 'Align when-let bindings' => [
+            [
+                '(when-let [x 1',
+                'longer 2]',
+                '(+ x longer))',
+            ],
+            [
+                '(when-let [x      1',
+                '           longer 2]',
+                '  (+ x longer))',
+            ],
+        ];
+
+        yield 'Align if-let bindings' => [
+            [
+                '(if-let [x 1',
+                'longer 2]',
+                'true',
+                'false)',
+            ],
+            [
+                '(if-let [x      1',
+                '         longer 2]',
+                '  true',
+                '  false)',
+            ],
+        ];
+
+        yield 'Align loop bindings' => [
+            [
+                '(loop [i 0',
+                'total 0]',
+                '(recur (inc i) total))',
+            ],
+            [
+                '(loop [i     0',
+                '       total 0]',
+                '  (recur (inc i) total))',
+            ],
+        ];
+
+        yield 'For bindings not aligned as pairs' => [
+            [
+                '(for [x :in xs',
+                'y :in ys]',
+                'body)',
+            ],
+            [
+                '(for [x :in xs',
+                '      y :in ys]',
+                '  body)',
+            ],
+        ];
+
+        yield 'Map literal not aligned' => [
+            [
+                '{:a 1',
+                ':bbbb 2}',
+            ],
+            [
+                '{:a 1',
+                ' :bbbb 2}',
+            ],
+        ];
+
+        yield 'Plain vector not aligned' => [
+            [
+                '[a 1',
+                'bb 22]',
+            ],
+            [
+                '[a 1',
+                ' bb 22]',
+            ],
+        ];
+
+        yield 'Nested cond aligns independently' => [
+            [
+                '(cond',
+                'a :outer-a',
+                'bigger :outer-big)',
+            ],
+            [
+                '(cond',
+                '  a      :outer-a',
+                '  bigger :outer-big)',
+            ],
+        ];
+
         yield 'Indent def block' => [
             [
                 '(def foo',

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -107,8 +107,69 @@ final class FormatterFacadeTest extends TestCase
             ],
             [
                 '(case (+ 7 5)',
-                '  3 :small',
+                '  3  :small',
                 '  12 :big)',
+            ],
+        ];
+
+        yield 'Align cond pairs' => [
+            [
+                '(cond',
+                'won? :won',
+                '(board-full? b) :draw',
+                ':else :playing)',
+            ],
+            [
+                '(cond',
+                '  won?            :won',
+                '  (board-full? b) :draw',
+                '  :else           :playing)',
+            ],
+        ];
+
+        yield 'Align case pairs with default' => [
+            [
+                '(case x',
+                '1 :one',
+                '200 :two-hundred',
+                ':other)',
+            ],
+            [
+                '(case x',
+                '  1   :one',
+                '  200 :two-hundred',
+                '  :other)',
+            ],
+        ];
+
+        yield 'Align let bindings' => [
+            [
+                '(let [x 1',
+                'longer 2',
+                'a 3]',
+                '(+ x longer a))',
+            ],
+            [
+                '(let [x      1',
+                '      longer 2',
+                '      a      3]',
+                '  (+ x longer a))',
+            ],
+        ];
+
+        yield 'Single line cond not aligned' => [
+            ['(cond a 1 b 2)'],
+            ['(cond a 1 b 2)'],
+        ];
+
+        yield 'Cond with single pair not aligned' => [
+            [
+                '(cond',
+                'a 1)',
+            ],
+            [
+                '(cond',
+                '  a 1)',
             ],
         ];
 


### PR DESCRIPTION
## 🤔 Background

The `fmt` command did not align key/value pairs in forms like `cond`, `case`, `condp`, or in binding vectors (`let`, `loop`, etc.). Values appeared with a single space after the key, even when the surrounding pairs had keys of very different widths, producing visually noisy output:

```phel
(cond
  won?            :won
  (board-full? b) :draw
  :else           :playing)
```

Before this PR, the formatter would only normalize leading indentation, leaving values unaligned after the key token.

## 💡 Goal

Pad whitespace between pair keys and pair values so values align under a common column (longest key width + 1), matching the idiomatic Clojure/Phel style commonly written by hand.

## 🔖 Changes

- New `AlignPairsRule` (`src/php/Formatter/Domain/Rules/AlignPairsRule.php`) runs after `IndentRule` in the formatter pipeline.
- Pair forms supported: `cond`, `case`, `condp`. Trailing single default permitted for `case`/`condp`.
- Binding vectors supported: `let`, `loop`, `binding`, `for`, `foreach`, `dofor`, `if-let`, `when-let`.
- Activates only when pairs span multiple lines; single-line forms left untouched.
- Skips a pair whose key→value gap contains a newline or comment.
- Registered in `FormatterFactory::createFormatter()`.
- Tests: 5 new `FormatterFacadeTest` cases (`cond`, `case` with default, `let` bindings, single-line, single-pair); one existing `case` test updated to reflect alignment.
- `CHANGELOG.md` entry under `## Unreleased`.

Closes #