### PR TITLE
ref(init)!: default to flat layout; rename Conventional to Nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed (breaking)
 
-- `phel init` now defaults to the Flat layout (`src/`, `tests/`). Use `--nested` for the previous `src/phel/`, `tests/phel/` structure.
-- `ProjectLayout::Conventional` renamed to `ProjectLayout::Nested`. `useConventionalLayout()` renamed to `useNestedLayout()`.
-- Generated `phel-config.php` now uses `use` imports and named arguments (`mainNamespace:`, `layout:`) and always sets `mainNamespace` explicitly.
-- Default `PhelConfig` source/test/format directories changed from `src/phel`/`tests/phel` to `src`/`tests` to match the new Flat default.
+- `phel init` defaults to Flat layout (`src/`, `tests/`); use `--nested` for the previous `src/phel/` structure. `ProjectLayout::Conventional` renamed to `ProjectLayout::Nested` (`useConventionalLayout()` → `useNestedLayout()`).
 
 ## [0.33.0](https://github.com/phel-lang/phel-lang/compare/v0.32.0...v0.33.0) - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 
+### Changed (breaking)
+
+- `phel init` now defaults to the Flat layout (`src/`, `tests/`). Use `--nested` for the previous `src/phel/`, `tests/phel/` structure.
+- `ProjectLayout::Conventional` renamed to `ProjectLayout::Nested`. `useConventionalLayout()` renamed to `useNestedLayout()`.
+- Generated `phel-config.php` now uses `use` imports and named arguments (`mainNamespace:`, `layout:`) and always sets `mainNamespace` explicitly.
+- Default `PhelConfig` source/test/format directories changed from `src/phel`/`tests/phel` to `src`/`tests` to match the new Flat default.
+
 ## [0.33.0](https://github.com/phel-lang/phel-lang/compare/v0.32.0...v0.33.0) - 2026-04-17
 
 ### Added

--- a/phel-config.php
+++ b/phel-config.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Phel\Config\PhelConfig;
+use Phel\Config\ProjectLayout;
 
-// Minimal configuration - all other settings use sensible defaults.
-// The conventional layout (src/phel, tests/phel) is used by default.
 return PhelConfig::forProject('phel\core')
+    ->useNestedLayout()
     ->setIgnoreWhenBuilding(['src/phel/local.phel']);

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -6,7 +6,7 @@ Foundational infrastructure: error reporting, exception formatting, and project 
 
 - **Facade**: `CommandFacade` implements `CommandFacadeInterface`
 - **Factory**: `CommandFactory` extends `AbstractFactory<CommandConfig>`
-- **Config**: `CommandConfig` — source dirs (`src/phel`), test dirs (`tests/phel`), vendor, output, error log
+- **Config**: `CommandConfig` — source dirs (`src`), test dirs (`tests`), vendor, output, error log
 - **Provider**: `CommandProvider` — injects `PHP_CONFIG_READER` from container
 
 ## Public API (Facade)

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -15,9 +15,9 @@ final class CommandConfig extends AbstractConfig
 {
     private const string DEFAULT_VENDOR_DIR = 'vendor';
 
-    private const array DEFAULT_SRC_DIRS = ['src/phel'];
+    private const array DEFAULT_SRC_DIRS = ['src'];
 
-    private const array DEFAULT_TEST_DIRS = ['tests/phel'];
+    private const array DEFAULT_TEST_DIRS = ['tests'];
 
     private const string DEFAULT_OUTPUT_DIR = 'out';
 

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -26,8 +26,9 @@ Build-specific: `setMainPhelNamespace()`, `setMainPhpPath()`, `setDestDir()`, `s
 Export/interop: `setFromDirectories()`, `setNamespacePrefix()`, `setTargetDirectory()`
 
 ### `ProjectLayout` (enum)
-- `Conventional` — `src/phel`, `tests/phel`
-- `Flat` — `src`, `tests`
+- `Flat` — `src`, `tests` (default)
+- `Nested` — `src/phel`, `tests/phel` (useful when PHP lives under `src/php/`)
+- `Root` — `.`, `.` (single-file / scratch)
 
 ## Consumed By
 
@@ -40,5 +41,5 @@ None. This is a leaf module with zero internal dependencies.
 ## Key Constraints
 
 - Config constants (e.g. `PhelConfig::SRC_DIRS`) are used as keys throughout Gacela's config system
-- Default source dirs: `['src/phel']`, test dirs: `['tests/phel']`
-- Auto-detection in `Phel.php` checks for conventional vs flat layout when no `phel-config.php` exists
+- Default source dirs: `['src/phel']`, test dirs: `['tests/phel']` (changed by `useLayout`)
+- Auto-detection in `Phel.php` checks for nested (`src/phel`) vs flat (`src`) layout when no `phel-config.php` exists

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -41,7 +41,7 @@ final class PhelConfig implements JsonSerializable
     public const string CACHE_DIR = 'cache-dir';
 
     /** @var list<string> */
-    public const array DEFAULT_SRC_DIRS = ['src/phel'];
+    public const array DEFAULT_SRC_DIRS = ['src'];
 
     private const string PHEL_TEMP_SUBDIR = '/phel';
 
@@ -49,7 +49,7 @@ final class PhelConfig implements JsonSerializable
     private array $srcDirs = self::DEFAULT_SRC_DIRS;
 
     /** @var list<string> */
-    private array $testDirs = ['tests/phel'];
+    private array $testDirs = ['tests'];
 
     private string $vendorDir = 'vendor';
 
@@ -72,7 +72,7 @@ final class PhelConfig implements JsonSerializable
     private string $cacheDir;
 
     /** @var list<string> */
-    private array $formatDirs = ['src/phel', 'tests/phel'];
+    private array $formatDirs = ['src', 'tests'];
 
     private bool $enableAsserts = true;
 
@@ -96,7 +96,7 @@ final class PhelConfig implements JsonSerializable
      *
      * - Pass `$layout` to force a specific layout. When omitted, the layout is
      *   auto-detected from the current working directory: `src/phel/` →
-     *   Conventional, `src/` → Flat, otherwise → Root.
+     *   Nested, `src/` → Flat, otherwise → Root.
      * - `$mainNamespace` is optional; when left blank, the build step infers it
      *   from `core.phel` / `main.phel` at the configured source roots.
      *
@@ -104,7 +104,7 @@ final class PhelConfig implements JsonSerializable
      *   return PhelConfig::forProject();                                 // zero-config, auto-detects layout + namespace
      *   return PhelConfig::forProject('my-app\core');                    // explicit namespace
      *   return PhelConfig::forProject(layout: ProjectLayout::Root);      // single-file / scratch project
-     *   return PhelConfig::forProject('my-app\main', ProjectLayout::Flat);
+     *   return PhelConfig::forProject('my-app\main', ProjectLayout::Nested);
      */
     public static function forProject(
         string $mainNamespace = '',
@@ -219,7 +219,7 @@ final class PhelConfig implements JsonSerializable
     // ========================================
 
     /**
-     * Apply a project layout (conventional or flat).
+     * Apply a project layout (nested or flat).
      */
     public function useLayout(ProjectLayout $layout): self
     {
@@ -232,16 +232,16 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Use conventional directory layout: src/phel and tests/phel.
-     * This is the recommended structure for Phel projects.
+     * Use nested directory layout: src/phel and tests/phel.
+     * Useful when the project also hosts PHP sources alongside Phel.
      */
-    public function useConventionalLayout(): self
+    public function useNestedLayout(): self
     {
-        return $this->useLayout(ProjectLayout::Conventional);
+        return $this->useLayout(ProjectLayout::Nested);
     }
 
     /**
-     * Use flat directory layout: src and tests (for simpler projects).
+     * Use flat directory layout: src and tests (default, simpler projects).
      */
     public function useFlatLayout(): self
     {
@@ -507,17 +507,17 @@ final class PhelConfig implements JsonSerializable
 
     /**
      * Auto-detect the most likely layout from the current working directory.
-     * Falls back to Conventional when the cwd is not available or probing fails.
+     * Falls back to Flat when the cwd is not available or probing fails.
      */
     private static function detectLayout(): ProjectLayout
     {
         $cwd = getcwd();
         if ($cwd === false) {
-            return ProjectLayout::Conventional;
+            return ProjectLayout::Flat;
         }
 
         if (is_dir($cwd . '/src/phel')) {
-            return ProjectLayout::Conventional;
+            return ProjectLayout::Nested;
         }
 
         if (is_dir($cwd . '/src')) {

--- a/src/php/Config/PhelExportConfig.php
+++ b/src/php/Config/PhelExportConfig.php
@@ -15,7 +15,7 @@ final class PhelExportConfig implements JsonSerializable
     public const string TARGET_DIRECTORY = 'target-directory';
 
     /** @var list<string> */
-    private array $fromDirectories = ['src/phel'];
+    private array $fromDirectories = ['src'];
 
     private string $namespacePrefix = 'PhelGenerated';
 

--- a/src/php/Config/ProjectLayout.php
+++ b/src/php/Config/ProjectLayout.php
@@ -6,14 +6,14 @@ namespace Phel\Config;
 
 enum ProjectLayout: string
 {
-    case Conventional = 'conventional';
+    case Nested = 'nested';
     case Flat = 'flat';
     case Root = 'root';
 
     public function getSrcDir(): string
     {
         return match ($this) {
-            self::Conventional => 'src/phel',
+            self::Nested => 'src/phel',
             self::Flat => 'src',
             self::Root => '.',
         };
@@ -22,7 +22,7 @@ enum ProjectLayout: string
     public function getTestDir(): string
     {
         return match ($this) {
-            self::Conventional => 'tests/phel',
+            self::Nested => 'tests/phel',
             self::Flat => 'tests',
             self::Root => '.',
         };

--- a/src/php/Formatter/CLAUDE.md
+++ b/src/php/Formatter/CLAUDE.md
@@ -6,7 +6,7 @@ Code formatting for Phel source files: parses code into AST, applies formatting 
 
 - **Facade**: `FormatterFacade` implements `FormatterFacadeInterface`
 - **Factory**: `FormatterFactory` — creates `PathsFormatter`, `Formatter`, individual rules
-- **Config**: `FormatterConfig` — `getFormatDirs()` (default: `['src/phel', 'tests/phel']`)
+- **Config**: `FormatterConfig` — `getFormatDirs()` (default: `['src', 'tests']`)
 - **Provider**: `FormatterProvider` — injects `CompilerFacade` (`FACADE_COMPILER`) and `CommandFacade` (`FACADE_COMMAND`)
 
 ## Public API (Facade)

--- a/src/php/Formatter/FormatterConfig.php
+++ b/src/php/Formatter/FormatterConfig.php
@@ -9,7 +9,7 @@ use Phel\Config\PhelConfig;
 
 final class FormatterConfig extends AbstractConfig
 {
-    private const array DEFAULT_FORMAT_DIRS = ['src/phel', 'tests/phel'];
+    private const array DEFAULT_FORMAT_DIRS = ['src', 'tests'];
 
     public function getFormatDirs(): array
     {

--- a/src/php/Interop/CLAUDE.md
+++ b/src/php/Interop/CLAUDE.md
@@ -6,7 +6,7 @@ PHP-Phel interoperability: generates PHP wrapper classes for Phel functions mark
 
 - **Facade**: `InteropFacade` implements `InteropFacadeInterface`
 - **Factory**: `InteropFactory` extends `AbstractFactory<InteropConfig>`
-- **Config**: `InteropConfig` — export dirs (`src/phel`), namespace prefix (`PhelGenerated`), target dir (`src/PhelGenerated`)
+- **Config**: `InteropConfig` — export dirs (`src`), namespace prefix (`PhelGenerated`), target dir (`src/PhelGenerated`)
 - **Provider**: `InteropProvider` — injects `CommandFacade` (`FACADE_COMMAND`) and `BuildFacade` (`FACADE_BUILD`)
 
 ## Public API (Facade)

--- a/src/php/Interop/InteropConfig.php
+++ b/src/php/Interop/InteropConfig.php
@@ -10,7 +10,7 @@ use Phel\Config\PhelExportConfig;
 
 final class InteropConfig extends AbstractConfig
 {
-    private const array DEFAULT_EXPORT_DIRECTORIES = ['src/phel'];
+    private const array DEFAULT_EXPORT_DIRECTORIES = ['src'];
 
     private const string DEFAULT_EXPORT_NAMESPACE_PREFIX = 'PhelGenerated';
 

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -101,13 +101,13 @@ class Phel
         $hasTests = in_array('tests', $topLevel, true);
         $hasVendor = in_array('vendor', $topLevel, true);
 
-        // Check for conventional layout (src/phel, tests/phel) only if parent exists
+        // Check for nested layout (src/phel, tests/phel) only if parent exists
         $hasSrcPhel = $hasSrc && is_dir($projectRootDir . '/src/phel');
         $hasTestsPhel = $hasTests && is_dir($projectRootDir . '/tests/phel');
 
         // Determine layout based on detected structure
         if ($hasSrcPhel || $hasTestsPhel) {
-            $config->useLayout(ProjectLayout::Conventional);
+            $config->useLayout(ProjectLayout::Nested);
         } elseif ($hasSrc || $hasTests) {
             $config->useLayout(ProjectLayout::Flat);
         }

--- a/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
+++ b/src/php/Run/Domain/Init/ProjectTemplateGenerator.php
@@ -11,16 +11,30 @@ final class ProjectTemplateGenerator
     public function generateConfig(string $namespace, ProjectLayout $layout): string
     {
         return match ($layout) {
-            ProjectLayout::Conventional => <<<'PHP'
-<?php return \Phel\Config\PhelConfig::forProject();
+            ProjectLayout::Flat => <<<PHP
+<?php
+
+use Phel\\Config\\PhelConfig;
+
+return PhelConfig::forProject(mainNamespace: '{$namespace}');
 
 PHP,
-            ProjectLayout::Flat => <<<'PHP'
-<?php return \Phel\Config\PhelConfig::forProject(layout: \Phel\Config\ProjectLayout::Flat);
+            ProjectLayout::Nested => <<<PHP
+<?php
+
+use Phel\\Config\\PhelConfig;
+use Phel\\Config\\ProjectLayout;
+
+return PhelConfig::forProject(mainNamespace: '{$namespace}', layout: ProjectLayout::Nested);
 
 PHP,
-            ProjectLayout::Root => <<<'PHP'
-<?php return \Phel\Config\PhelConfig::forProject(layout: \Phel\Config\ProjectLayout::Root);
+            ProjectLayout::Root => <<<PHP
+<?php
+
+use Phel\\Config\\PhelConfig;
+use Phel\\Config\\ProjectLayout;
+
+return PhelConfig::forProject(mainNamespace: '{$namespace}', layout: ProjectLayout::Root);
 
 PHP,
         };
@@ -58,7 +72,7 @@ PHEL;
 PHEL;
     }
 
-    public function generateGitignore(ProjectLayout $layout = ProjectLayout::Conventional): string
+    public function generateGitignore(ProjectLayout $layout = ProjectLayout::Flat): string
     {
         if ($layout === ProjectLayout::Root) {
             return <<<'GITIGNORE'

--- a/src/php/Run/Infrastructure/Command/InitCommand.php
+++ b/src/php/Run/Infrastructure/Command/InitCommand.php
@@ -19,7 +19,7 @@ final class InitCommand extends Command
 {
     private const string ARG_PROJECT_NAME = 'project-name';
 
-    private const string OPT_FLAT = 'flat';
+    private const string OPT_NESTED = 'nested';
 
     private const string OPT_MINIMAL = 'minimal';
 
@@ -51,10 +51,10 @@ final class InitCommand extends Command
                 'app',
             )
             ->addOption(
-                self::OPT_FLAT,
-                'f',
+                self::OPT_NESTED,
+                null,
                 InputOption::VALUE_NONE,
-                'Use flat directory layout (src/ instead of src/phel/)',
+                'Use nested directory layout (src/phel/ instead of src/)',
             )
             ->addOption(
                 self::OPT_MINIMAL,
@@ -175,11 +175,11 @@ final class InitCommand extends Command
             return ProjectLayout::Root;
         }
 
-        if ((bool) $input->getOption(self::OPT_FLAT)) {
-            return ProjectLayout::Flat;
+        if ((bool) $input->getOption(self::OPT_NESTED)) {
+            return ProjectLayout::Nested;
         }
 
-        return ProjectLayout::Conventional;
+        return ProjectLayout::Flat;
     }
 
     private function mainFilename(ProjectLayout $layout): string

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -91,7 +91,7 @@ final class RunCommand extends Command
             if ($path === null || $path === '') {
                 $path = $this->getFacade()->autoDetectEntryPoint();
                 if ($path === null) {
-                    $output->writeln('<error>No entry point found. Create src/phel/main.phel or specify a path.</error>');
+                    $output->writeln('<error>No entry point found. Create src/main.phel or specify a path.</error>');
                     return self::FAILURE;
                 }
 

--- a/tests/php/Integration/Run/Command/Init/InitCommandTest.php
+++ b/tests/php/Integration/Run/Command/Init/InitCommandTest.php
@@ -25,7 +25,7 @@ final class InitCommandTest extends TestCase
         $this->removeDirectory($this->testDir);
     }
 
-    public function test_creates_conventional_layout_structure(): void
+    public function test_creates_flat_layout_structure_by_default(): void
     {
         $command = new InitCommand();
         $output = new BufferedOutput();
@@ -34,16 +34,17 @@ final class InitCommandTest extends TestCase
         $result = $command->run(new ArrayInput(['project-name' => 'my-app']), $output);
 
         self::assertSame(Command::SUCCESS, $result);
-        self::assertDirectoryExists($this->testDir . '/src/phel');
-        self::assertDirectoryExists($this->testDir . '/tests/phel');
+        self::assertDirectoryExists($this->testDir . '/src');
+        self::assertDirectoryExists($this->testDir . '/tests');
         self::assertDirectoryExists($this->testDir . '/out');
+        self::assertDirectoryDoesNotExist($this->testDir . '/src/phel');
         self::assertFileExists($this->testDir . '/phel-config.php');
-        self::assertFileExists($this->testDir . '/src/phel/main.phel');
-        self::assertFileExists($this->testDir . '/tests/phel/main_test.phel');
+        self::assertFileExists($this->testDir . '/src/main.phel');
+        self::assertFileExists($this->testDir . '/tests/main_test.phel');
         self::assertFileExists($this->testDir . '/.gitignore');
     }
 
-    public function test_creates_flat_layout_structure(): void
+    public function test_creates_nested_layout_structure(): void
     {
         $command = new InitCommand();
         $output = new BufferedOutput();
@@ -51,15 +52,14 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $result = $command->run(new ArrayInput([
             'project-name' => 'my-app',
-            '--flat' => true,
+            '--nested' => true,
         ]), $output);
 
         self::assertSame(Command::SUCCESS, $result);
-        self::assertDirectoryExists($this->testDir . '/src');
-        self::assertDirectoryExists($this->testDir . '/tests');
-        self::assertDirectoryDoesNotExist($this->testDir . '/src/phel');
-        self::assertFileExists($this->testDir . '/src/main.phel');
-        self::assertFileExists($this->testDir . '/tests/main_test.phel');
+        self::assertDirectoryExists($this->testDir . '/src/phel');
+        self::assertDirectoryExists($this->testDir . '/tests/phel');
+        self::assertFileExists($this->testDir . '/src/phel/main.phel');
+        self::assertFileExists($this->testDir . '/tests/phel/main_test.phel');
     }
 
     public function test_creates_minimal_root_layout_structure(): void
@@ -96,8 +96,8 @@ final class InitCommandTest extends TestCase
 
         $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
 
-        self::assertStringContainsString('PhelConfig::forProject(layout:', $configContent);
-        self::assertStringContainsString('ProjectLayout::Root', $configContent);
+        self::assertStringContainsString("mainNamespace: 'sandbox\\main'", $configContent);
+        self::assertStringContainsString('layout: ProjectLayout::Root', $configContent);
     }
 
     public function test_minimal_main_file_uses_main_namespace(): void
@@ -163,8 +163,8 @@ final class InitCommandTest extends TestCase
             '--no-tests' => true,
         ]), $output);
 
-        self::assertFileDoesNotExist($this->testDir . '/tests/phel/main_test.phel');
-        self::assertFileExists($this->testDir . '/src/phel/main.phel');
+        self::assertFileDoesNotExist($this->testDir . '/tests/main_test.phel');
+        self::assertFileExists($this->testDir . '/src/main.phel');
     }
 
     public function test_no_tests_output_omits_test_step(): void
@@ -192,14 +192,14 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput(['project-name' => 'my-app']), $output);
 
-        $configContent = file_get_contents($this->testDir . '/phel-config.php');
+        $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
 
-        self::assertStringContainsString('PhelConfig::forProject()', (string) $configContent);
-        self::assertStringNotContainsString('useFlatLayout', (string) $configContent);
-        self::assertStringNotContainsString('ProjectLayout::', (string) $configContent);
+        self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $configContent);
+        self::assertStringContainsString("PhelConfig::forProject(mainNamespace: 'myapp\\main')", $configContent);
+        self::assertStringNotContainsString('ProjectLayout::', $configContent);
     }
 
-    public function test_generated_config_uses_flat_layout(): void
+    public function test_generated_config_uses_nested_layout(): void
     {
         $command = new InitCommand();
         $output = new BufferedOutput();
@@ -207,13 +207,13 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput([
             'project-name' => 'test-project',
-            '--flat' => true,
+            '--nested' => true,
         ]), $output);
 
         $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
 
-        self::assertStringContainsString('PhelConfig::forProject(layout:', $configContent);
-        self::assertStringContainsString('ProjectLayout::Flat', $configContent);
+        self::assertStringContainsString("mainNamespace: 'testproject\\main'", $configContent);
+        self::assertStringContainsString('layout: ProjectLayout::Nested', $configContent);
     }
 
     public function test_generated_main_file_contains_namespace(): void
@@ -224,7 +224,7 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput(['project-name' => 'my-app']), $output);
 
-        $mainContent = file_get_contents($this->testDir . '/src/phel/main.phel');
+        $mainContent = file_get_contents($this->testDir . '/src/main.phel');
 
         self::assertStringContainsString('(ns myapp\\main)', (string) $mainContent);
         self::assertStringContainsString('(defn main []', (string) $mainContent);
@@ -250,9 +250,9 @@ final class InitCommandTest extends TestCase
 
     public function test_skips_existing_main_file(): void
     {
-        mkdir($this->testDir . '/src/phel', 0755, true);
+        mkdir($this->testDir . '/src', 0755, true);
         $existingMain = '(ns existing)';
-        file_put_contents($this->testDir . '/src/phel/main.phel', $existingMain);
+        file_put_contents($this->testDir . '/src/main.phel', $existingMain);
 
         $command = new InitCommand();
         $output = new BufferedOutput();
@@ -260,7 +260,7 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput(['project-name' => 'my-app']), $output);
 
-        $mainContent = file_get_contents($this->testDir . '/src/phel/main.phel');
+        $mainContent = file_get_contents($this->testDir . '/src/main.phel');
 
         self::assertSame($existingMain, $mainContent);
     }
@@ -273,12 +273,10 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput([]), $output);
 
-        // Config is now minimal (namespace auto-detected from main.phel)
-        $configContent = file_get_contents($this->testDir . '/phel-config.php');
-        self::assertStringContainsString('PhelConfig::forProject()', (string) $configContent);
+        $configContent = (string) file_get_contents($this->testDir . '/phel-config.php');
+        self::assertStringContainsString("PhelConfig::forProject(mainNamespace: 'app\\main')", $configContent);
 
-        // Default namespace is in the main.phel file
-        $mainContent = file_get_contents($this->testDir . '/src/phel/main.phel');
+        $mainContent = file_get_contents($this->testDir . '/src/main.phel');
         self::assertStringContainsString('(ns app\\main)', (string) $mainContent);
     }
 
@@ -290,7 +288,7 @@ final class InitCommandTest extends TestCase
         chdir($this->testDir);
         $command->run(new ArrayInput(['project-name' => 'my-cool-app']), $output);
 
-        $mainContent = file_get_contents($this->testDir . '/src/phel/main.phel');
+        $mainContent = file_get_contents($this->testDir . '/src/main.phel');
 
         self::assertStringContainsString('(ns mycoolapp\\main)', (string) $mainContent);
     }
@@ -357,7 +355,7 @@ final class InitCommandTest extends TestCase
 
         self::assertSame(Command::SUCCESS, $result);
         self::assertFileDoesNotExist($this->testDir . '/phel-config.php');
-        self::assertDirectoryDoesNotExist($this->testDir . '/src/phel');
+        self::assertDirectoryDoesNotExist($this->testDir . '/src');
 
         $outputContent = $output->fetch();
 
@@ -368,7 +366,7 @@ final class InitCommandTest extends TestCase
     public function test_force_overwrites_existing_files(): void
     {
         $existingConfig = '<?php return [];';
-        mkdir($this->testDir . '/src/phel', 0755, true);
+        mkdir($this->testDir . '/src', 0755, true);
         file_put_contents($this->testDir . '/phel-config.php', $existingConfig);
 
         $command = new InitCommand();

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -17,8 +17,8 @@ final class PhelConfigTest extends TestCase
         $config = new PhelConfig();
 
         $expected = [
-            PhelConfig::SRC_DIRS => ['src/phel'],
-            PhelConfig::TEST_DIRS => ['tests/phel'],
+            PhelConfig::SRC_DIRS => ['src'],
+            PhelConfig::TEST_DIRS => ['tests'],
             PhelConfig::VENDOR_DIR => 'vendor',
             PhelConfig::ERROR_LOG_FILE => '/tmp/phel-error.log',
             PhelConfig::BUILD_CONFIG => [
@@ -29,14 +29,14 @@ final class PhelConfigTest extends TestCase
             ],
             PhelConfig::EXPORT_CONFIG => [
                 PhelExportConfig::TARGET_DIRECTORY => 'src/PhelGenerated',
-                PhelExportConfig::FROM_DIRECTORIES => ['src/phel'],
+                PhelExportConfig::FROM_DIRECTORIES => ['src'],
                 PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
             ],
             PhelConfig::IGNORE_WHEN_BUILDING => [],
             PhelConfig::NO_CACHE_WHEN_BUILDING => [],
             PhelConfig::KEEP_GENERATED_TEMP_FILES => false,
             PhelConfig::TEMP_DIR => sys_get_temp_dir() . '/phel/tmp',
-            PhelConfig::FORMAT_DIRS => ['src/phel', 'tests/phel'],
+            PhelConfig::FORMAT_DIRS => ['src', 'tests'],
             PhelConfig::ASSERTS_ENABLED => true,
             PhelConfig::ENABLE_NAMESPACE_CACHE => true,
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
@@ -48,7 +48,7 @@ final class PhelConfigTest extends TestCase
 
     public function test_for_project_factory(): void
     {
-        $config = PhelConfig::forProject('my-app\\core', ProjectLayout::Conventional);
+        $config = PhelConfig::forProject('my-app\\core', ProjectLayout::Nested);
 
         $serialized = $config->jsonSerialize();
 
@@ -87,7 +87,7 @@ final class PhelConfigTest extends TestCase
     public function test_for_project_factory_without_namespace(): void
     {
         // Without a layout arg, auto-detect runs against the current cwd.
-        // PHPUnit runs from the phel-lang repo root, which has src/phel → Conventional.
+        // PHPUnit runs from the phel-lang repo root, which has src/phel → Nested.
         $config = PhelConfig::forProject();
 
         $serialized = $config->jsonSerialize();
@@ -157,9 +157,9 @@ final class PhelConfigTest extends TestCase
         self::assertSame(['src'], $serialized[PhelConfig::EXPORT_CONFIG][PhelExportConfig::FROM_DIRECTORIES]);
     }
 
-    public function test_use_conventional_layout(): void
+    public function test_use_nested_layout(): void
     {
-        $config = (new PhelConfig())->useFlatLayout()->useConventionalLayout();
+        $config = (new PhelConfig())->useFlatLayout()->useNestedLayout();
 
         $serialized = $config->jsonSerialize();
 
@@ -253,8 +253,8 @@ final class PhelConfigTest extends TestCase
     {
         $config = new PhelConfig();
 
-        self::assertSame(['src/phel'], $config->getSrcDirs());
-        self::assertSame(['tests/phel'], $config->getTestDirs());
+        self::assertSame(['src'], $config->getSrcDirs());
+        self::assertSame(['tests'], $config->getTestDirs());
         self::assertSame('vendor', $config->getVendorDir());
         self::assertSame('/tmp/phel-error.log', $config->getErrorLogFile());
         self::assertInstanceOf(PhelBuildConfig::class, $config->getBuildConfig());
@@ -262,7 +262,7 @@ final class PhelConfigTest extends TestCase
         self::assertSame([], $config->getIgnoreWhenBuilding());
         self::assertSame([], $config->getNoCacheWhenBuilding());
         self::assertFalse($config->getKeepGeneratedTempFiles());
-        self::assertSame(['src/phel', 'tests/phel'], $config->getFormatDirs());
+        self::assertSame(['src', 'tests'], $config->getFormatDirs());
         self::assertTrue($config->isAssertsEnabled());
         self::assertTrue($config->isNamespaceCacheEnabled());
         self::assertTrue($config->isCompiledCodeCacheEnabled());

--- a/tests/php/Unit/Config/ProjectLayoutTest.php
+++ b/tests/php/Unit/Config/ProjectLayoutTest.php
@@ -9,9 +9,9 @@ use PHPUnit\Framework\TestCase;
 
 final class ProjectLayoutTest extends TestCase
 {
-    public function test_conventional_layout_directories(): void
+    public function test_nested_layout_directories(): void
     {
-        $layout = ProjectLayout::Conventional;
+        $layout = ProjectLayout::Nested;
 
         self::assertSame('src/phel', $layout->getSrcDir());
         self::assertSame('tests/phel', $layout->getTestDir());
@@ -41,7 +41,7 @@ final class ProjectLayoutTest extends TestCase
 
     public function test_enum_values(): void
     {
-        self::assertSame('conventional', ProjectLayout::Conventional->value);
+        self::assertSame('nested', ProjectLayout::Nested->value);
         self::assertSame('flat', ProjectLayout::Flat->value);
         self::assertSame('root', ProjectLayout::Root->value);
     }

--- a/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
+++ b/tests/php/Unit/Run/Domain/Init/ProjectTemplateGeneratorTest.php
@@ -17,29 +17,33 @@ final class ProjectTemplateGeneratorTest extends TestCase
         $this->generator = new ProjectTemplateGenerator();
     }
 
-    public function test_generate_config_conventional_layout(): void
-    {
-        $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Conventional);
-
-        self::assertStringContainsString('PhelConfig::forProject()', $config);
-        self::assertStringNotContainsString('useFlatLayout', $config);
-        self::assertStringNotContainsString('ProjectLayout::', $config);
-    }
-
     public function test_generate_config_flat_layout(): void
     {
         $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Flat);
 
-        self::assertStringContainsString('PhelConfig::forProject(layout:', $config);
-        self::assertStringContainsString('ProjectLayout::Flat', $config);
+        self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
+        self::assertStringContainsString("PhelConfig::forProject(mainNamespace: 'myapp\\main')", $config);
+        self::assertStringNotContainsString('ProjectLayout::', $config);
+    }
+
+    public function test_generate_config_nested_layout(): void
+    {
+        $config = $this->generator->generateConfig('myapp\\main', ProjectLayout::Nested);
+
+        self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
+        self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
+        self::assertStringContainsString("mainNamespace: 'myapp\\main'", $config);
+        self::assertStringContainsString('layout: ProjectLayout::Nested', $config);
     }
 
     public function test_generate_config_root_layout(): void
     {
         $config = $this->generator->generateConfig('sandbox\\main', ProjectLayout::Root);
 
-        self::assertStringContainsString('PhelConfig::forProject(layout:', $config);
-        self::assertStringContainsString('ProjectLayout::Root', $config);
+        self::assertStringContainsString('use Phel\\Config\\PhelConfig;', $config);
+        self::assertStringContainsString('use Phel\\Config\\ProjectLayout;', $config);
+        self::assertStringContainsString("mainNamespace: 'sandbox\\main'", $config);
+        self::assertStringContainsString('layout: ProjectLayout::Root', $config);
     }
 
     public function test_generate_main_file(): void


### PR DESCRIPTION
## 🤔 Background

The `phel init` scaffolder defaulted to the Nested layout (`src/phel/`, `tests/phel/`), and the `ProjectLayout` enum used `Conventional` as the label for that structure. For new Phel-only projects this adds an extra directory level without a clear benefit. The Flat layout (`src/`, `tests/`) is a better default, and it leaves `src/php/` free for PHP sources alongside Phel when needed.

## 💡 Goal

Best DX for new projects out of the box. Make Flat the default everywhere, and give the other layout a name that actually describes its structure.

## 🔖 Changes

- `phel init` defaults to Flat. New flag: `--nested` (replaces `--flat`).
- `ProjectLayout::Conventional` → `ProjectLayout::Nested`. `useConventionalLayout()` → `useNestedLayout()`.
- Generated `phel-config.php` uses `use` imports + named args and always sets `mainNamespace` explicitly.
- Default src/test/format/export dirs across `PhelConfig`, `CommandConfig`, `FormatterConfig`, `InteropConfig`, `PhelExportConfig` changed from `src/phel`/`tests/phel` to `src`/`tests`. Auto-detect in `Phel.php` + `PhelConfig::detectLayout` still selects Nested when `src/phel/` exists.
- Updated unit/integration tests + module CLAUDE.md docs. CHANGELOG `Unreleased` lists breaking changes.