### PR TITLE
docs: framework integration recipes (Laravel, Symfony, framework-less)

### DIFF
--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -238,7 +238,7 @@ echo $greet('World') . "\n";
 
 ## Notes
 
-- **Boot namespace**: one `.phel` file with `(:require ...)` for every feature ns. Load it once, every exported wrapper is ready. Adding a new feature = one new `:require` line.
+- **Boot namespace**: `phel/app/boot.phel` lists one `(:require other\ns)` per feature namespace. The build step walks those requires transitively, so the compiled `build/app/boot.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function in one shot — controllers then call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` line in `app/boot.phel`, rerun `phel export` + `phel build`.
 - Namespace path matches directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
 - Prod path (`require build/app/boot.php`): self-contained — no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls.

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -13,12 +13,13 @@ Two ways to call Phel from PHP:
 | Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
 | Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
-Both require this bootstrap step at startup (service provider, kernel event, entry script):
+Both require loading the Phel namespace once at startup (service provider, kernel event, entry script):
 
 ```php
-\Phel::bootstrap(__DIR__);
-(new \Phel\Run\RunFacade())->runNamespace('shop\\pricing');
+\Phel::run(__DIR__, 'shop\\pricing');
 ```
+
+`\Phel::run($projectRootDir, $namespace)` bootstraps the runtime and evaluates the namespace so `Registry` has its defs. Without it, wrapper methods and `\Phel::getDefinition()` return null.
 
 Namespaces must have at least two segments (`shop\pricing`, not `pricing`) so the generated PHP namespace is well-formed.
 
@@ -68,14 +69,12 @@ vendor/bin/phel export
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Phel\Run\RunFacade;
 
 final class PhelServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        \Phel::bootstrap(base_path());
-        (new RunFacade())->runNamespace('shop\\pricing');
+        \Phel::run(base_path(), 'shop\\pricing');
     }
 }
 ```
@@ -137,8 +136,7 @@ public function boot(): void
 {
     parent::boot();
 
-    \Phel::bootstrap($this->getProjectDir());
-    (new \Phel\Run\RunFacade())->runNamespace('reports\\domain');
+    \Phel::run($this->getProjectDir(), 'reports\\domain');
 }
 ```
 
@@ -190,8 +188,7 @@ Call dynamically:
 
 require __DIR__ . '/vendor/autoload.php';
 
-\Phel::bootstrap(__DIR__);
-(new \Phel\Run\RunFacade())->runNamespace('app\\main');
+\Phel::run(__DIR__, 'app\\main');
 
 $greet = \Phel::getDefinition('app\\main', 'greet');
 echo $greet('World') . "\n";
@@ -203,7 +200,7 @@ echo $greet('World') . "\n";
 
 - Namespace path must match directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns (`pricing`) produces invalid PHP on export; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
-- `\Phel::bootstrap()` registers the config; `RunFacade::runNamespace()` compiles and evaluates the ns so `Registry` has its defs. Skip the second call and wrapper methods return null.
+- `\Phel::run()` is the only public entry point for loading a Phel namespace from PHP. Skip it and wrapper methods or `\Phel::getDefinition()` return null.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -1,10 +1,10 @@
 # Framework Integration Recipes
 
-Drop Phel into an existing PHP project without touching `app/` or `src/`.
+Add Phel to an existing PHP project without touching `app/` or `src/`.
 
 ## Core idea
 
-Put Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions to PHP wrappers under your framework's existing `App\` PSR-4 root, then load the Phel namespace once at app boot so Registry has the definitions.
+Keep Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions as PHP wrappers under your framework's `App\` PSR-4 root. Load the namespace once at boot.
 
 Two ways to call Phel from PHP:
 
@@ -13,15 +13,22 @@ Two ways to call Phel from PHP:
 | Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
 | Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
-Both require loading the Phel namespace once at startup (service provider, kernel event, entry script):
+Two ways to load definitions at runtime:
+
+| Mode | How | Cost per request |
+|------|-----|------------------|
+| JIT (dev) | `\Phel::run($root, $ns)` at boot — compiles on first call | Bootstrap + compile (cached after first) |
+| AOT (prod) | `vendor/bin/phel build` once, `require 'build/ns/name.php'` at boot | Zero compile — just `require` |
+
+Load the namespace once at startup:
 
 ```php
 \Phel::run(__DIR__, 'shop\\pricing');
 ```
 
-`\Phel::run($projectRootDir, $namespace)` bootstraps the runtime and evaluates the namespace so `Registry` has its defs. Without it, wrapper methods and `\Phel::getDefinition()` return null.
+`\Phel::run($projectRootDir, $namespace)` bootstraps the runtime and registers the defs. Without it, wrappers and `\Phel::getDefinition()` return null.
 
-Namespaces must have at least two segments (`shop\pricing`, not `pricing`) so the generated PHP namespace is well-formed.
+Namespaces need at least two segments (`shop\pricing`, not `pricing`).
 
 Install: `composer require phel-lang/phel-lang`
 
@@ -63,7 +70,7 @@ Generate the wrapper:
 vendor/bin/phel export
 ```
 
-`app/Providers/PhelServiceProvider.php` (load Phel namespaces once per process):
+`app/Providers/PhelServiceProvider.php`:
 
 ```php
 namespace App\Providers;
@@ -72,14 +79,21 @@ use Illuminate\Support\ServiceProvider;
 
 final class PhelServiceProvider extends ServiceProvider
 {
-    public function register(): void
+    private static bool $loaded = false;
+
+    public function boot(): void
     {
+        if (self::$loaded) {
+            return;
+        }
+
         \Phel::run(base_path(), 'shop\\pricing');
+        self::$loaded = true;
     }
 }
 ```
 
-Register it in `config/app.php` or via package discovery, then call the wrapper:
+Register it, then call the wrapper:
 
 ```php
 use App\PhelGenerated\Shop\Pricing;
@@ -98,7 +112,7 @@ final class CheckoutController
 }
 ```
 
-Keep wrappers in sync via a composer script:
+Keep wrappers in sync:
 
 ```json
 "scripts": {
@@ -129,14 +143,21 @@ return PhelConfig::forProject()
 
 Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
 
-Load Phel on kernel boot (`src/Kernel.php` or a `KernelEvents::REQUEST` listener):
+Load on kernel boot (`src/Kernel.php`):
 
 ```php
+private static bool $phelLoaded = false;
+
 public function boot(): void
 {
     parent::boot();
 
+    if (self::$phelLoaded) {
+        return;
+    }
+
     \Phel::run($this->getProjectDir(), 'reports\\domain');
+    self::$phelLoaded = true;
 }
 ```
 
@@ -196,11 +217,70 @@ echo $greet('World') . "\n";
 
 ---
 
+## Production: ahead-of-time build
+
+`\Phel::run()` boots Gacela and compiles on first call. Fine for dev. In production, compile once at deploy and skip bootstrap entirely.
+
+Add a build config:
+
+```php
+use Phel\Config\PhelBuildConfig;
+use Phel\Config\PhelConfig;
+
+return PhelConfig::forProject()
+    ->setSrcDirs(['phel'])
+    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
+    // ...export config as before
+    ;
+```
+
+Build at deploy time:
+
+```bash
+vendor/bin/phel build
+```
+
+Output: `build/<ns-path>.php` — self-contained, registers defs via `\Phel::addDefinition()`, only depends on the `\Phel` class from Composer autoload.
+
+**Laravel** — replace `\Phel::run(...)` in the provider:
+
+```php
+public function boot(): void
+{
+    if (self::$loaded) {
+        return;
+    }
+
+    require base_path('build/shop/pricing.php');
+    self::$loaded = true;
+}
+```
+
+**Symfony** — same swap in `Kernel::boot()`:
+
+```php
+require $this->getProjectDir() . '/build/reports/domain.php';
+```
+
+Wire into Composer so the build runs on deploy:
+
+```json
+"scripts": {
+    "post-install-cmd": ["phel build", "phel export"],
+    "post-update-cmd": ["phel build", "phel export"]
+}
+```
+
+Commit `build/` in the deploy artifact (or generate during CI). No runtime Phel compiler, no Gacela bootstrap — just `require`.
+
+---
+
 ## Notes
 
-- Namespace path must match directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns (`pricing`) produces invalid PHP on export; use at least two segments.
+- Namespace path matches directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
-- `\Phel::run()` is the only public entry point for loading a Phel namespace from PHP. Skip it and wrapper methods or `\Phel::getDefinition()` return null.
+- `\Phel::run()` is the only public entry to load a namespace. Skip it and wrappers return null.
+- `\Phel::run()` bootstraps Gacela and compiles temp files. Call it once per process (guard with a static flag, or load once on Octane/long-running workers). Avoid calling it from `register()` or per-request hot paths.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -4,7 +4,14 @@ Add Phel to an existing PHP project without touching `app/` or `src/`.
 
 ## Core idea
 
-Keep Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions as PHP wrappers under your framework's `App\` PSR-4 root. Load the namespace once at boot.
+Keep Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions as typed PHP wrappers under your framework's `App\` PSR-4 root. Load the namespace once at boot.
+
+Two load modes, both via the same provider/kernel hook:
+
+| Mode | What | When |
+|------|------|------|
+| Prod (AOT) | `require 'build/<ns>.php'` — precompiled, zero runtime compile | Production, CI, every deploy |
+| Dev (JIT) | `\Phel::run($root, $ns)` — compiles on first call | Local development |
 
 Two ways to call Phel from PHP:
 
@@ -13,24 +20,18 @@ Two ways to call Phel from PHP:
 | Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
 | Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
-Two ways to load definitions at runtime:
-
-| Mode | How | Cost per request |
-|------|-----|------------------|
-| JIT (dev) | `\Phel::run($root, $ns)` at boot — compiles on first call | Bootstrap + compile (cached after first) |
-| AOT (prod) | `vendor/bin/phel build` once, `require 'build/ns/name.php'` at boot | Zero compile — just `require` |
-
-Load the namespace once at startup:
-
-```php
-\Phel::run(__DIR__, 'shop\\pricing');
-```
-
-`\Phel::run($projectRootDir, $namespace)` bootstraps the runtime and registers the defs. Without it, wrappers and `\Phel::getDefinition()` return null.
-
 Namespaces need at least two segments (`shop\pricing`, not `pricing`).
 
 Install: `composer require phel-lang/phel-lang`
+
+Build artifacts on every deploy (Composer does it for you):
+
+```json
+"scripts": {
+    "post-install-cmd": ["phel export", "phel build"],
+    "post-update-cmd": ["phel export", "phel build"]
+}
+```
 
 ---
 
@@ -41,12 +42,14 @@ Install: `composer require phel-lang/phel-lang`
 ```php
 <?php
 
+use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Config\PhelExportConfig;
 
 return PhelConfig::forProject()
     ->setSrcDirs(['phel'])
     ->setTestDirs(['tests-phel'])
+    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
     ->setExportConfig((new PhelExportConfig())
         ->setFromDirectories(['phel'])
         ->setNamespacePrefix('App\\PhelGenerated')
@@ -62,12 +65,6 @@ return PhelConfig::forProject()
   {:export true}
   [price percent]
   (- price (* price (/ percent 100))))
-```
-
-Generate the wrapper:
-
-```bash
-vendor/bin/phel export
 ```
 
 `app/Providers/PhelServiceProvider.php`:
@@ -87,13 +84,23 @@ final class PhelServiceProvider extends ServiceProvider
             return;
         }
 
-        \Phel::run(base_path(), 'shop\\pricing');
+        $built = base_path('build/shop/pricing.php');
+
+        if (is_file($built)) {
+            require $built;
+        } else {
+            \Phel::run(base_path(), 'shop\\pricing');
+        }
+
         self::$loaded = true;
     }
 }
 ```
 
-Register it, then call the wrapper:
+Prod: `phel build` runs on deploy, `build/shop/pricing.php` is present → `require` wins, no runtime compile.
+Dev: `build/` absent → `\Phel::run()` compiles on first request.
+
+Controller:
 
 ```php
 use App\PhelGenerated\Shop\Pricing;
@@ -112,14 +119,6 @@ final class CheckoutController
 }
 ```
 
-Keep wrappers in sync:
-
-```json
-"scripts": {
-    "post-autoload-dump": ["phel export"]
-}
-```
-
 ---
 
 ## Symfony
@@ -129,12 +128,14 @@ Keep wrappers in sync:
 ```php
 <?php
 
+use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Config\PhelExportConfig;
 
 return PhelConfig::forProject()
     ->setSrcDirs(['phel'])
     ->setTestDirs(['tests/phel'])
+    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
     ->setExportConfig((new PhelExportConfig())
         ->setFromDirectories(['phel'])
         ->setNamespacePrefix('App\\PhelGenerated')
@@ -143,7 +144,7 @@ return PhelConfig::forProject()
 
 Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
 
-Load on kernel boot (`src/Kernel.php`):
+`src/Kernel.php`:
 
 ```php
 private static bool $phelLoaded = false;
@@ -156,7 +157,14 @@ public function boot(): void
         return;
     }
 
-    \Phel::run($this->getProjectDir(), 'reports\\domain');
+    $built = $this->getProjectDir() . '/build/reports/domain.php';
+
+    if (is_file($built)) {
+        require $built;
+    } else {
+        \Phel::run($this->getProjectDir(), 'reports\\domain');
+    }
+
     self::$phelLoaded = true;
 }
 ```
@@ -186,11 +194,13 @@ final class ReportController
 ```php
 <?php
 
+use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
 return PhelConfig::forProject(mainNamespace: 'app\\main')
     ->setSrcDirs(['phel'])
-    ->setTestDirs(['tests/phel']);
+    ->setTestDirs(['tests/phel'])
+    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'));
 ```
 
 `phel/app/main.phel`:
@@ -202,14 +212,20 @@ return PhelConfig::forProject(mainNamespace: 'app\\main')
   (str "Hello, " name "!"))
 ```
 
-Call dynamically:
+Entry script (same prod/dev switch):
 
 ```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
 
-\Phel::run(__DIR__, 'app\\main');
+$built = __DIR__ . '/build/app/main.php';
+
+if (is_file($built)) {
+    require $built;
+} else {
+    \Phel::run(__DIR__, 'app\\main');
+}
 
 $greet = \Phel::getDefinition('app\\main', 'greet');
 echo $greet('World') . "\n";
@@ -217,70 +233,14 @@ echo $greet('World') . "\n";
 
 ---
 
-## Production: ahead-of-time build
-
-`\Phel::run()` boots Gacela and compiles on first call. Fine for dev. In production, compile once at deploy and skip bootstrap entirely.
-
-Add a build config:
-
-```php
-use Phel\Config\PhelBuildConfig;
-use Phel\Config\PhelConfig;
-
-return PhelConfig::forProject()
-    ->setSrcDirs(['phel'])
-    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
-    // ...export config as before
-    ;
-```
-
-Build at deploy time:
-
-```bash
-vendor/bin/phel build
-```
-
-Output: `build/<ns-path>.php` — self-contained, registers defs via `\Phel::addDefinition()`, only depends on the `\Phel` class from Composer autoload.
-
-**Laravel** — replace `\Phel::run(...)` in the provider:
-
-```php
-public function boot(): void
-{
-    if (self::$loaded) {
-        return;
-    }
-
-    require base_path('build/shop/pricing.php');
-    self::$loaded = true;
-}
-```
-
-**Symfony** — same swap in `Kernel::boot()`:
-
-```php
-require $this->getProjectDir() . '/build/reports/domain.php';
-```
-
-Wire into Composer so the build runs on deploy:
-
-```json
-"scripts": {
-    "post-install-cmd": ["phel build", "phel export"],
-    "post-update-cmd": ["phel build", "phel export"]
-}
-```
-
-Commit `build/` in the deploy artifact (or generate during CI). No runtime Phel compiler, no Gacela bootstrap — just `require`.
-
----
-
 ## Notes
 
 - Namespace path matches directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
-- `\Phel::run()` is the only public entry to load a namespace. Skip it and wrappers return null.
-- `\Phel::run()` bootstraps Gacela and compiles temp files. Call it once per process (guard with a static flag, or load once on Octane/long-running workers). Avoid calling it from `register()` or per-request hot paths.
+- Prod path (`require build/...`) is self-contained: no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls. One `require`, zero overhead per request.
+- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag — never call from Laravel `register()` or per-request hot paths.
+- `setBuildConfig()` dest dir is relative to the project root.
+- Commit `build/` in the deploy artifact or run `phel build` in CI. Skip committing in dev so `is_file()` stays false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -1,47 +1,25 @@
 # Framework Integration Recipes
 
-How to drop Phel into an existing PHP project without fighting the framework's conventions.
+Drop Phel into an existing PHP project without touching `app/` or `src/`.
 
-## The core idea
+## Core idea
 
-Phel reads one file at your project root: `phel-config.php`. Point `setSrcDirs()` at a directory that does **not** collide with your framework's PHP tree (`app/`, `src/`, whatever), and you are done. Phel only scans `.phel` files, so in principle it can share a dir with PHP, but a dedicated `phel/` folder keeps things tidy and discoverable.
+Put Phel sources in a dedicated dir (e.g. `phel/`). Generate PHP wrappers under the framework's existing `App\` PSR-4 root so no composer changes are needed.
 
-Calling Phel from PHP has two flavors:
+Two ways to call Phel from PHP:
 
 | Flavor | How | When |
 |--------|-----|------|
-| **Exported wrappers** | Mark fns `{:export true}`, run `vendor/bin/phel export`, call the generated PHP class | Typed, IDE-friendly, stable surface |
-| **Dynamic lookup** | `\Phel::bootstrap($root)` then `\Phel::getDefinition($ns, $name)(...)` | Prototyping, scripting, one-offs |
+| Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
+| Dynamic lookup | `\Phel::bootstrap($root)` + `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
-All recipes below assume:
-
-```bash
-composer require phel-lang/phel-lang
-```
+Install: `composer require phel-lang/phel-lang`
 
 ---
 
 ## Laravel
 
-Laravel owns `app/`. Keep Phel out of it.
-
-### Directory layout
-
-```
-my-laravel-app/
-├── app/
-│   ├── ...                # Laravel (untouched)
-│   └── PhelGenerated/     # Generated PHP wrappers (auto-created by phel export)
-├── phel/                  # Phel sources
-│   └── pricing.phel
-├── tests-phel/            # Phel tests
-├── phel-config.php
-└── composer.json
-```
-
-Putting the generated wrappers inside `app/` means Laravel's default `App\` PSR-4 entry autoloads them without extra config.
-
-### `phel-config.php`
+`phel-config.php`:
 
 ```php
 <?php
@@ -52,16 +30,11 @@ use Phel\Config\PhelExportConfig;
 return PhelConfig::forProject()
     ->setSrcDirs(['phel'])
     ->setTestDirs(['tests-phel'])
-    ->setFormatDirs(['phel', 'tests-phel'])
     ->setExportConfig((new PhelExportConfig())
         ->setFromDirectories(['phel'])
         ->setNamespacePrefix('App\\PhelGenerated')
         ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
 ```
-
-Add `app/PhelGenerated/` to `.gitignore` if you prefer regenerating on deploy instead of committing the wrappers.
-
-### Write and export a fn
 
 `phel/pricing.phel`:
 
@@ -78,7 +51,7 @@ Add `app/PhelGenerated/` to `.gitignore` if you prefer regenerating on deploy in
 vendor/bin/phel export
 ```
 
-### Call from a controller
+Controller:
 
 ```php
 use App\PhelGenerated\Pricing;
@@ -87,22 +60,21 @@ final class CheckoutController
 {
     public function __invoke(Request $request): JsonResponse
     {
-        $final = Pricing::applyDiscount(
+        $total = Pricing::applyDiscount(
             (float) $request->input('price'),
             (float) $request->input('percent'),
         );
 
-        return response()->json(['total' => $final]);
+        return response()->json(['total' => $total]);
     }
 }
 ```
 
-Add a `composer scripts` hook so exports stay in sync:
+Auto-regenerate wrappers on `composer install`:
 
 ```json
 "scripts": {
-    "phel:export": "phel export",
-    "post-autoload-dump": ["@phel:export"]
+    "post-autoload-dump": ["phel export"]
 }
 ```
 
@@ -110,22 +82,7 @@ Add a `composer scripts` hook so exports stay in sync:
 
 ## Symfony
 
-Symfony owns `src/`. Same pattern: new `phel/` folder.
-
-### Directory layout
-
-```
-my-symfony-app/
-├── src/
-│   ├── ...                # Symfony (untouched)
-│   └── PhelGenerated/     # Generated PHP wrappers (under existing App\ PSR-4)
-├── phel/
-│   └── domain.phel
-├── phel-config.php
-└── composer.json
-```
-
-### `phel-config.php`
+`phel-config.php`:
 
 ```php
 <?php
@@ -142,34 +99,29 @@ return PhelConfig::forProject()
         ->setTargetDirectory(__DIR__ . '/src/PhelGenerated'));
 ```
 
-No `composer.json` changes needed; Symfony's default `App\ → src/` PSR-4 entry already covers `App\PhelGenerated\`.
+Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
 
-### Call from a controller
-
-Wrappers expose static methods, so call them directly; no DI wiring required.
+Controller:
 
 ```php
-namespace App\Controller;
-
 use App\PhelGenerated\Domain;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 final class ReportController
 {
-    public function __invoke(): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
-        return new JsonResponse(Domain::summarize($input));
+        return new JsonResponse(Domain::summarize($request->toArray()));
     }
 }
 ```
 
 ---
 
-## Framework-less (or when `src/` is already PHP)
+## Framework-less / existing `src/`
 
-Same mechanics, no framework glue.
-
-### `phel-config.php`
+`phel-config.php`:
 
 ```php
 <?php
@@ -181,7 +133,7 @@ return PhelConfig::forProject(mainNamespace: 'app\\main')
     ->setTestDirs(['tests/phel']);
 ```
 
-### Call dynamically (no export step)
+Call without export:
 
 ```php
 <?php
@@ -194,19 +146,15 @@ $greet = \Phel::getDefinition('app\\main', 'greet');
 echo $greet('World');
 ```
 
-Use this shape for scripts, cron jobs, or when you want to avoid a build step. For long-lived apps, prefer the exported-wrapper flavor: it caches definition lookups and gives IDEs something to autocomplete.
-
 ---
 
-## Tips
+## Notes
 
-- **Namespaces mirror directories.** `phel/pricing.phel` declares `(ns pricing)`; `phel/domain/cart.phel` declares `(ns domain\cart)`.
-- **Hyphens become underscores in PHP.** `(ns my-lib)` exports as `PhelGenerated\MyLib` with camelCased method names (`apply-discount` → `applyDiscount`).
-- **Cache and temp paths.** Phel writes to `sys_get_temp_dir()/phel/` by default. Override via `setCacheDir()` / `setTempDir()` if your host restricts that.
-- **CI.** Run `vendor/bin/phel test` alongside `phpunit`. Add `vendor/bin/phel export` to the build step so generated wrappers match your Phel sources.
-- **REPL against your project.** `vendor/bin/phel repl` boots with your `phel-config.php`, so `(require 'pricing)` works immediately.
+- `phel/pricing.phel` → `(ns pricing)`; `phel/domain/cart.phel` → `(ns domain\cart)`. Namespace must match path.
+- Hyphens become camelCase: `(ns my-lib)` → `PhelGenerated\MyLib`; `apply-discount` → `applyDiscount`.
+- Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also
 
-- [PHP/Phel Interop](php-interop.md) — lower-level `php/` forms, type conversions, exceptions.
-- [Quickstart](quickstart.md) — zero-to-running tutorial for greenfield projects.
+- [PHP/Phel Interop](php-interop.md)
+- [Quickstart](quickstart.md)

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -4,14 +4,11 @@ Add Phel to an existing PHP project without touching `app/` or `src/`.
 
 ## Core idea
 
-Keep Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions as typed PHP wrappers under your framework's `App\` PSR-4 root. Load the namespace once at boot.
-
-Two load modes, both via the same provider/kernel hook:
-
-| Mode | What | When |
-|------|------|------|
-| Prod (AOT) | `require 'build/<ns>.php'` — precompiled, zero runtime compile | Production, CI, every deploy |
-| Dev (JIT) | `\Phel::run($root, $ns)` — compiles on first call | Local development |
+1. Keep Phel sources under `phel/`.
+2. Mark public functions with `{:export true}`.
+3. Create **one boot namespace** (`app\boot`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
+4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
+5. In prod, build once at deploy (`phel build`) and `require 'build/app/boot.php'` at boot. In dev, `\Phel::run($root, 'app\\boot')` compiles on first call.
 
 Two ways to call Phel from PHP:
 
@@ -20,11 +17,18 @@ Two ways to call Phel from PHP:
 | Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
 | Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
+Two load modes, same provider/kernel hook:
+
+| Mode | What | Per-request cost |
+|------|------|------------------|
+| Prod (AOT) | `require 'build/app/boot.php'` — precompiled | Zero compile, one `require` |
+| Dev (JIT) | `\Phel::run($root, 'app\\boot')` | Gacela bootstrap + compile on first call |
+
 Namespaces need at least two segments (`shop\pricing`, not `pricing`).
 
 Install: `composer require phel-lang/phel-lang`
 
-Build artifacts on every deploy (Composer does it for you):
+Build artifacts on deploy (Composer runs both):
 
 ```json
 "scripts": {
@@ -32,6 +36,37 @@ Build artifacts on every deploy (Composer does it for you):
     "post-update-cmd": ["phel export", "phel build"]
 }
 ```
+
+---
+
+## Boot namespace pattern
+
+```
+phel/
+├── app/boot.phel          ; lists every feature ns
+├── shop/pricing.phel
+├── reports/daily.phel
+└── auth/tokens.phel
+```
+
+`phel/app/boot.phel`:
+
+```phel
+(ns app\boot
+  (:require shop\pricing)
+  (:require reports\daily)
+  (:require auth\tokens))
+```
+
+Loading `app\boot` (via `require` or `\Phel::run()`) registers **every** exported function across all three namespaces. Any controller in your app can then call any wrapper:
+
+```php
+App\PhelGenerated\Shop\Pricing::applyDiscount(...)
+App\PhelGenerated\Reports\Daily::summary(...)
+App\PhelGenerated\Auth\Tokens::makeToken(...)
+```
+
+Add a new Phel feature = add the file + add one `:require` line to `app/boot.phel`. Run `phel export` + `phel build`. Done.
 
 ---
 
@@ -56,18 +91,7 @@ return PhelConfig::forProject()
         ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
 ```
 
-`phel/shop/pricing.phel`:
-
-```phel
-(ns shop\pricing)
-
-(defn apply-discount
-  {:export true}
-  [price percent]
-  (- price (* price (/ percent 100))))
-```
-
-`app/Providers/PhelServiceProvider.php`:
+`app/Providers/PhelServiceProvider.php` (loads the boot ns once — all wrappers ready):
 
 ```php
 namespace App\Providers;
@@ -84,12 +108,12 @@ final class PhelServiceProvider extends ServiceProvider
             return;
         }
 
-        $built = base_path('build/shop/pricing.php');
+        $built = base_path('build/app/boot.php');
 
         if (is_file($built)) {
             require $built;
         } else {
-            \Phel::run(base_path(), 'shop\\pricing');
+            \Phel::run(base_path(), 'app\\boot');
         }
 
         self::$loaded = true;
@@ -97,13 +121,11 @@ final class PhelServiceProvider extends ServiceProvider
 }
 ```
 
-Prod: `phel build` runs on deploy, `build/shop/pricing.php` is present → `require` wins, no runtime compile.
-Dev: `build/` absent → `\Phel::run()` compiles on first request.
-
-Controller:
+Controller (any wrapper works without further setup):
 
 ```php
 use App\PhelGenerated\Shop\Pricing;
+use App\PhelGenerated\Reports\Daily;
 
 final class CheckoutController
 {
@@ -114,7 +136,10 @@ final class CheckoutController
             (float) $request->input('percent'),
         );
 
-        return response()->json(['total' => $total]);
+        return response()->json([
+            'total' => $total,
+            'report' => Daily::summary((int) $request->input('day')),
+        ]);
     }
 }
 ```
@@ -157,33 +182,19 @@ public function boot(): void
         return;
     }
 
-    $built = $this->getProjectDir() . '/build/reports/domain.php';
+    $built = $this->getProjectDir() . '/build/app/boot.php';
 
     if (is_file($built)) {
         require $built;
     } else {
-        \Phel::run($this->getProjectDir(), 'reports\\domain');
+        \Phel::run($this->getProjectDir(), 'app\\boot');
     }
 
     self::$phelLoaded = true;
 }
 ```
 
-Controller:
-
-```php
-use App\PhelGenerated\Reports\Domain;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-
-final class ReportController
-{
-    public function __invoke(Request $request): JsonResponse
-    {
-        return new JsonResponse(Domain::summarize($request->toArray()));
-    }
-}
-```
+Controllers use any wrapper — `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the single boot load.
 
 ---
 
@@ -197,36 +208,28 @@ final class ReportController
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
-return PhelConfig::forProject(mainNamespace: 'app\\main')
+return PhelConfig::forProject(mainNamespace: 'app\\boot')
     ->setSrcDirs(['phel'])
     ->setTestDirs(['tests/phel'])
     ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'));
 ```
 
-`phel/app/main.phel`:
-
-```phel
-(ns app\main)
-
-(defn greet [name]
-  (str "Hello, " name "!"))
-```
-
-Entry script (same prod/dev switch):
+Entry script:
 
 ```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
 
-$built = __DIR__ . '/build/app/main.php';
+$built = __DIR__ . '/build/app/boot.php';
 
 if (is_file($built)) {
     require $built;
 } else {
-    \Phel::run(__DIR__, 'app\\main');
+    \Phel::run(__DIR__, 'app\\boot');
 }
 
+// Call anything
 $greet = \Phel::getDefinition('app\\main', 'greet');
 echo $greet('World') . "\n";
 ```
@@ -235,12 +238,13 @@ echo $greet('World') . "\n";
 
 ## Notes
 
+- **Boot namespace**: one `.phel` file with `(:require ...)` for every feature ns. Load it once, every exported wrapper is ready. Adding a new feature = one new `:require` line.
 - Namespace path matches directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
-- Prod path (`require build/...`) is self-contained: no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls. One `require`, zero overhead per request.
+- Prod path (`require build/app/boot.php`): self-contained — no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls.
 - Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag — never call from Laravel `register()` or per-request hot paths.
 - `setBuildConfig()` dest dir is relative to the project root.
-- Commit `build/` in the deploy artifact or run `phel build` in CI. Skip committing in dev so `is_file()` stays false and `\Phel::run()` kicks in.
+- Commit `build/` in the deploy artifact or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -4,14 +4,23 @@ Drop Phel into an existing PHP project without touching `app/` or `src/`.
 
 ## Core idea
 
-Put Phel sources in a dedicated dir (e.g. `phel/`). Generate PHP wrappers under the framework's existing `App\` PSR-4 root so no composer changes are needed.
+Put Phel sources in a dedicated dir (e.g. `phel/`). Export `{:export true}` functions to PHP wrappers under your framework's existing `App\` PSR-4 root, then load the Phel namespace once at app boot so Registry has the definitions.
 
 Two ways to call Phel from PHP:
 
 | Flavor | How | When |
 |--------|-----|------|
 | Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
-| Dynamic lookup | `\Phel::bootstrap($root)` + `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
+| Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
+
+Both require this bootstrap step at startup (service provider, kernel event, entry script):
+
+```php
+\Phel::bootstrap(__DIR__);
+(new \Phel\Run\RunFacade())->runNamespace('shop\\pricing');
+```
+
+Namespaces must have at least two segments (`shop\pricing`, not `pricing`) so the generated PHP namespace is well-formed.
 
 Install: `composer require phel-lang/phel-lang`
 
@@ -36,10 +45,10 @@ return PhelConfig::forProject()
         ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
 ```
 
-`phel/pricing.phel`:
+`phel/shop/pricing.phel`:
 
 ```phel
-(ns pricing)
+(ns shop\pricing)
 
 (defn apply-discount
   {:export true}
@@ -47,14 +56,34 @@ return PhelConfig::forProject()
   (- price (* price (/ percent 100))))
 ```
 
+Generate the wrapper:
+
 ```bash
 vendor/bin/phel export
 ```
 
-Controller:
+`app/Providers/PhelServiceProvider.php` (load Phel namespaces once per process):
 
 ```php
-use App\PhelGenerated\Pricing;
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Phel\Run\RunFacade;
+
+final class PhelServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        \Phel::bootstrap(base_path());
+        (new RunFacade())->runNamespace('shop\\pricing');
+    }
+}
+```
+
+Register it in `config/app.php` or via package discovery, then call the wrapper:
+
+```php
+use App\PhelGenerated\Shop\Pricing;
 
 final class CheckoutController
 {
@@ -70,7 +99,7 @@ final class CheckoutController
 }
 ```
 
-Auto-regenerate wrappers on `composer install`:
+Keep wrappers in sync via a composer script:
 
 ```json
 "scripts": {
@@ -101,10 +130,22 @@ return PhelConfig::forProject()
 
 Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
 
+Load Phel on kernel boot (`src/Kernel.php` or a `KernelEvents::REQUEST` listener):
+
+```php
+public function boot(): void
+{
+    parent::boot();
+
+    \Phel::bootstrap($this->getProjectDir());
+    (new \Phel\Run\RunFacade())->runNamespace('reports\\domain');
+}
+```
+
 Controller:
 
 ```php
-use App\PhelGenerated\Domain;
+use App\PhelGenerated\Reports\Domain;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -133,7 +174,16 @@ return PhelConfig::forProject(mainNamespace: 'app\\main')
     ->setTestDirs(['tests/phel']);
 ```
 
-Call without export:
+`phel/app/main.phel`:
+
+```phel
+(ns app\main)
+
+(defn greet [name]
+  (str "Hello, " name "!"))
+```
+
+Call dynamically:
 
 ```php
 <?php
@@ -141,17 +191,19 @@ Call without export:
 require __DIR__ . '/vendor/autoload.php';
 
 \Phel::bootstrap(__DIR__);
+(new \Phel\Run\RunFacade())->runNamespace('app\\main');
 
 $greet = \Phel::getDefinition('app\\main', 'greet');
-echo $greet('World');
+echo $greet('World') . "\n";
 ```
 
 ---
 
 ## Notes
 
-- `phel/pricing.phel` → `(ns pricing)`; `phel/domain/cart.phel` → `(ns domain\cart)`. Namespace must match path.
-- Hyphens become camelCase: `(ns my-lib)` → `PhelGenerated\MyLib`; `apply-discount` → `applyDiscount`.
+- Namespace path must match directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns (`pricing`) produces invalid PHP on export; use at least two segments.
+- Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
+- `\Phel::bootstrap()` registers the config; `RunFacade::runNamespace()` compiles and evaluates the ns so `Registry` has its defs. Skip the second call and wrapper methods return null.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -1,0 +1,212 @@
+# Framework Integration Recipes
+
+How to drop Phel into an existing PHP project without fighting the framework's conventions.
+
+## The core idea
+
+Phel reads one file at your project root: `phel-config.php`. Point `setSrcDirs()` at a directory that does **not** collide with your framework's PHP tree (`app/`, `src/`, whatever), and you are done. Phel only scans `.phel` files, so in principle it can share a dir with PHP, but a dedicated `phel/` folder keeps things tidy and discoverable.
+
+Calling Phel from PHP has two flavors:
+
+| Flavor | How | When |
+|--------|-----|------|
+| **Exported wrappers** | Mark fns `{:export true}`, run `vendor/bin/phel export`, call the generated PHP class | Typed, IDE-friendly, stable surface |
+| **Dynamic lookup** | `\Phel::bootstrap($root)` then `\Phel::getDefinition($ns, $name)(...)` | Prototyping, scripting, one-offs |
+
+All recipes below assume:
+
+```bash
+composer require phel-lang/phel-lang
+```
+
+---
+
+## Laravel
+
+Laravel owns `app/`. Keep Phel out of it.
+
+### Directory layout
+
+```
+my-laravel-app/
+├── app/
+│   ├── ...                # Laravel (untouched)
+│   └── PhelGenerated/     # Generated PHP wrappers (auto-created by phel export)
+├── phel/                  # Phel sources
+│   └── pricing.phel
+├── tests-phel/            # Phel tests
+├── phel-config.php
+└── composer.json
+```
+
+Putting the generated wrappers inside `app/` means Laravel's default `App\` PSR-4 entry autoloads them without extra config.
+
+### `phel-config.php`
+
+```php
+<?php
+
+use Phel\Config\PhelConfig;
+use Phel\Config\PhelExportConfig;
+
+return PhelConfig::forProject()
+    ->setSrcDirs(['phel'])
+    ->setTestDirs(['tests-phel'])
+    ->setFormatDirs(['phel', 'tests-phel'])
+    ->setExportConfig((new PhelExportConfig())
+        ->setFromDirectories(['phel'])
+        ->setNamespacePrefix('App\\PhelGenerated')
+        ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
+```
+
+Add `app/PhelGenerated/` to `.gitignore` if you prefer regenerating on deploy instead of committing the wrappers.
+
+### Write and export a fn
+
+`phel/pricing.phel`:
+
+```phel
+(ns pricing)
+
+(defn apply-discount
+  {:export true}
+  [price percent]
+  (- price (* price (/ percent 100))))
+```
+
+```bash
+vendor/bin/phel export
+```
+
+### Call from a controller
+
+```php
+use App\PhelGenerated\Pricing;
+
+final class CheckoutController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $final = Pricing::applyDiscount(
+            (float) $request->input('price'),
+            (float) $request->input('percent'),
+        );
+
+        return response()->json(['total' => $final]);
+    }
+}
+```
+
+Add a `composer scripts` hook so exports stay in sync:
+
+```json
+"scripts": {
+    "phel:export": "phel export",
+    "post-autoload-dump": ["@phel:export"]
+}
+```
+
+---
+
+## Symfony
+
+Symfony owns `src/`. Same pattern: new `phel/` folder.
+
+### Directory layout
+
+```
+my-symfony-app/
+├── src/
+│   ├── ...                # Symfony (untouched)
+│   └── PhelGenerated/     # Generated PHP wrappers (under existing App\ PSR-4)
+├── phel/
+│   └── domain.phel
+├── phel-config.php
+└── composer.json
+```
+
+### `phel-config.php`
+
+```php
+<?php
+
+use Phel\Config\PhelConfig;
+use Phel\Config\PhelExportConfig;
+
+return PhelConfig::forProject()
+    ->setSrcDirs(['phel'])
+    ->setTestDirs(['tests/phel'])
+    ->setExportConfig((new PhelExportConfig())
+        ->setFromDirectories(['phel'])
+        ->setNamespacePrefix('App\\PhelGenerated')
+        ->setTargetDirectory(__DIR__ . '/src/PhelGenerated'));
+```
+
+No `composer.json` changes needed; Symfony's default `App\ → src/` PSR-4 entry already covers `App\PhelGenerated\`.
+
+### Call from a controller
+
+Wrappers expose static methods, so call them directly; no DI wiring required.
+
+```php
+namespace App\Controller;
+
+use App\PhelGenerated\Domain;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class ReportController
+{
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse(Domain::summarize($input));
+    }
+}
+```
+
+---
+
+## Framework-less (or when `src/` is already PHP)
+
+Same mechanics, no framework glue.
+
+### `phel-config.php`
+
+```php
+<?php
+
+use Phel\Config\PhelConfig;
+
+return PhelConfig::forProject(mainNamespace: 'app\\main')
+    ->setSrcDirs(['phel'])
+    ->setTestDirs(['tests/phel']);
+```
+
+### Call dynamically (no export step)
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+\Phel::bootstrap(__DIR__);
+
+$greet = \Phel::getDefinition('app\\main', 'greet');
+echo $greet('World');
+```
+
+Use this shape for scripts, cron jobs, or when you want to avoid a build step. For long-lived apps, prefer the exported-wrapper flavor: it caches definition lookups and gives IDEs something to autocomplete.
+
+---
+
+## Tips
+
+- **Namespaces mirror directories.** `phel/pricing.phel` declares `(ns pricing)`; `phel/domain/cart.phel` declares `(ns domain\cart)`.
+- **Hyphens become underscores in PHP.** `(ns my-lib)` exports as `PhelGenerated\MyLib` with camelCased method names (`apply-discount` → `applyDiscount`).
+- **Cache and temp paths.** Phel writes to `sys_get_temp_dir()/phel/` by default. Override via `setCacheDir()` / `setTempDir()` if your host restricts that.
+- **CI.** Run `vendor/bin/phel test` alongside `phpunit`. Add `vendor/bin/phel export` to the build step so generated wrappers match your Phel sources.
+- **REPL against your project.** `vendor/bin/phel repl` boots with your `phel-config.php`, so `(require 'pricing)` works immediately.
+
+## See also
+
+- [PHP/Phel Interop](php-interop.md) — lower-level `php/` forms, type conversions, exceptions.
+- [Quickstart](quickstart.md) — zero-to-running tutorial for greenfield projects.


### PR DESCRIPTION
## 🤔 Background

Existing PHP projects (Laravel uses `app/`, Symfony uses `src/`, custom setups vary) have no drop-in guide for integrating Phel. Users have to reverse-engineer `PhelConfig`, `phel export`, and PSR-4 placement themselves.

## 💡 Goal

Give users a single scannable page with copy-pasteable recipes so adopting Phel in an existing project is friction-free.

## 🔖 Changes

- New `docs/framework-integration.md` covering three recipes: Laravel, Symfony, framework-less/custom.
- Each recipe shows directory layout, `phel-config.php` (built via `PhelConfig::forProject()`), PSR-4-friendly placement of generated wrappers under the framework's existing `App\` root, and a call-site example.
- Documents the two call flavors: exported wrappers (`phel export` → static typed PHP classes) vs dynamic lookup (`\Phel::bootstrap` + `\Phel::getDefinition`).
- Note: official docs live in the `phel-lang.org` repo; this file is the in-tree sneak peek.