### PR TITLE
fix: suppress stdout from compiled programs during phel build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 
+### Fixed
+
+- `phel build` no longer leaks stdout from compiled Phel programs. Top-level side-effects (e.g. `(println ...)` or a game loop) still run at compile time so macros and definitions register correctly, but their output is suppressed so only the build command's own output reaches the terminal.
+
 ### Changed (breaking)
 
 - `phel init` defaults to Flat layout (`src/`, `tests/`); use `--nested` for the previous `src/phel/` structure. `ProjectLayout::Conventional` renamed to `ProjectLayout::Nested` (`useConventionalLayout()` → `useNestedLayout()`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 
 - `phel build` no longer leaks stdout from compiled Phel programs. Top-level side-effects (e.g. `(println ...)` or a game loop) still run at compile time so macros and definitions register correctly, but their output is suppressed so only the build command's own output reaches the terminal.
 
+### Changed
+
+- `phel build` output now reports cached files alongside freshly compiled ones and prints a summary line with the compiled output directory, e.g. `Compiled 3 files (19 reused from cache). Output directory: /path/to/out`. When every file is served from cache it prints `No changes detected. N files reused from cache.` instead of an empty result.
+- `CompiledFile` has a new `isCached()` method indicating whether the file was reused from cache rather than freshly compiled. `BuildFacade::getOutputDirectory()` exposes the configured build output directory.
+
 ### Changed (breaking)
 
 - `phel init` defaults to Flat layout (`src/`, `tests/`); use `--nested` for the previous `src/phel/` structure. `ProjectLayout::Conventional` renamed to `ProjectLayout::Nested` (`useConventionalLayout()` → `useNestedLayout()`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `phel build` no longer leaks stdout from compiled Phel programs. Top-level side-effects (e.g. `(println ...)` or a game loop) still run at compile time so macros and definitions register correctly, but their output is suppressed so only the build command's own output reaches the terminal.
+- `phel build` no longer leaks stdout from compiled programs during compilation.
 
 ### Changed
 
-- `phel build` output now reports cached files alongside freshly compiled ones and prints a summary line with the compiled output directory, e.g. `Compiled 3 files (19 reused from cache). Output directory: /path/to/out`. When every file is served from cache it prints `No changes detected. N files reused from cache.` instead of an empty result.
-- `CompiledFile` has a new `isCached()` method indicating whether the file was reused from cache rather than freshly compiled. `BuildFacade::getOutputDirectory()` exposes the configured build output directory.
+- `phel build` prints a summary with fresh/cached counts and the output directory, including a clear message when nothing needed recompiling.
 
 ### Changed (breaking)
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -13,6 +13,7 @@ Practical patterns for writing idiomatic Phel code.
 - [Destructuring](#destructuring)
 - [Data Validation](#data-validation)
 - [Writing Macros](#writing-macros)
+- [Build-safe Entry Points](#build-safe-entry-points)
 
 ## Working with Nil
 
@@ -648,6 +649,45 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the mul
   [users]
   (filter :active users))
 ```
+
+## Build-safe Entry Points
+
+`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register correctly. Top-level **side effects** (starting a game loop, reading `stdin`, opening sockets, sleeping) also run, which can block the build indefinitely.
+
+Guard imperative entry calls with `*build-mode*`:
+
+```phel
+(ns app\main)
+
+(defn play []
+  (loop [state (initial-state)]
+    ;; ... read stdin, render, recur
+    ))
+
+;; Safe: only runs when actually executing, not during `phel build`.
+(when-not *build-mode*
+  (play))
+```
+
+`*build-mode*` is set to `true` while the compiler evaluates your file during `phel build`, and `false` during `phel run` or when the compiled artifact is loaded at runtime. The same idea applies to any stdin/network/sleep call at top level:
+
+```phel
+;; Bad: blocks `phel build` forever on fgets.
+(def line (php/fgets (php/fopen "php://stdin" "r")))
+
+;; Good: reads at run time only.
+(def stdin (php/fopen "php://stdin" "r"))
+
+(defn read-line []
+  (php/fgets stdin))
+
+(when-not *build-mode*
+  (println (read-line)))
+```
+
+`defn`, `def` of pure values, `ns`, and `(:require ...)` forms are always safe at top level. Only imperative work needs the guard.
+
+> Note: `phel build` suppresses stdout produced by compiled code during compilation, so stray `println` calls no longer leak to the terminal. Execution still happens though, so anything that **blocks** (stdin reads, `sleep`, sockets, infinite loops) still needs `(when-not *build-mode* ...)`.
 
 ## See Also
 

--- a/src/php/Build/Application/FileCompiler.php
+++ b/src/php/Build/Application/FileCompiler.php
@@ -31,9 +31,11 @@ final readonly class FileCompiler implements FileCompilerInterface
             ->setIsEnabledSourceMaps($enableSourceMaps);
 
         BuildFacade::enableBuildMode();
+        ob_start();
         try {
             $result = $this->compilerFacade->compile($phelCode, $options);
         } finally {
+            ob_end_clean();
             BuildFacade::disableBuildMode();
         }
 

--- a/src/php/Build/Application/ProjectCompiler.php
+++ b/src/php/Build/Application/ProjectCompiler.php
@@ -104,6 +104,13 @@ final readonly class ProjectCompiler
                     BuildFacade::disableBuildMode();
                 }
 
+                $result[] = new CompiledFile(
+                    $info->getFile(),
+                    $targetFile,
+                    $info->getNamespace(),
+                    cached: true,
+                );
+
                 continue;
             }
 

--- a/src/php/Build/Application/ProjectCompiler.php
+++ b/src/php/Build/Application/ProjectCompiler.php
@@ -95,10 +95,12 @@ final readonly class ProjectCompiler
             if ($this->canUseCache($buildOptions, $targetFile, $info)) {
                 // Load cached file to register definitions and execute top-level expressions
                 BuildFacade::enableBuildMode();
+                ob_start();
                 try {
                     /** @psalm-suppress UnresolvableInclude */
                     require_once $targetFile;
                 } finally {
+                    ob_end_clean();
                     BuildFacade::disableBuildMode();
                 }
 

--- a/src/php/Build/BuildFacade.php
+++ b/src/php/Build/BuildFacade.php
@@ -154,4 +154,11 @@ final class BuildFacade extends AbstractFacade implements BuildFacadeInterface
     {
         return $this->getFactory()->createBuildHealthCheck();
     }
+
+    public function getOutputDirectory(): string
+    {
+        return $this->getFactory()
+            ->getCommandFacade()
+            ->getOutputDirectory();
+    }
 }

--- a/src/php/Build/Domain/Compile/CompiledFile.php
+++ b/src/php/Build/Domain/Compile/CompiledFile.php
@@ -10,6 +10,7 @@ final readonly class CompiledFile
         private string $sourceFile,
         private string $targetFile,
         private string $namespace,
+        private bool $cached = false,
     ) {}
 
     public function getSourceFile(): string
@@ -25,5 +26,10 @@ final readonly class CompiledFile
     public function getNamespace(): string
     {
         return $this->namespace;
+    }
+
+    public function isCached(): bool
+    {
+        return $this->cached;
     }
 }

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -102,7 +102,7 @@ final class BuildCommand extends Command
 
         if ($freshCount === 0) {
             $output->writeln(sprintf(
-                'No changes detected. %d file%s reused from cache. Compiled output: %s',
+                "No changes detected. %d file%s reused from cache.\nCompiled output: %s",
                 $cachedCount,
                 $cachedCount === 1 ? '' : 's',
                 $outputDir,
@@ -111,7 +111,7 @@ final class BuildCommand extends Command
         }
 
         $output->writeln(sprintf(
-            'Compiled %d file%s (%d reused from cache). Output directory: %s',
+            "Compiled %d file%s (%d reused from cache).\nOutput directory: %s",
             $freshCount,
             $freshCount === 1 ? '' : 's',
             $cachedCount,

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function array_filter;
+use function count;
 use function sprintf;
 
 #[ServiceMap(method: 'getFacade', className: BuildFacade::class)]
@@ -68,16 +70,52 @@ final class BuildCommand extends Command
      */
     private function printOutput(OutputInterface $output, array $compiledProject): void
     {
-        foreach ($compiledProject as $i => $compiledFile) {
+        $fresh = array_filter($compiledProject, static fn(CompiledFile $f): bool => !$f->isCached());
+        $cachedCount = count($compiledProject) - count($fresh);
+
+        $index = 0;
+        foreach ($fresh as $compiledFile) {
             $output->writeln(
                 sprintf(
                     "#%d | Namespace: %s\nSource: %s\nTarget: %s\n",
-                    $i,
+                    $index,
                     $compiledFile->getNamespace(),
                     $compiledFile->getSourceFile(),
                     $compiledFile->getTargetFile(),
                 ),
             );
+            ++$index;
         }
+
+        $this->printSummary($output, count($fresh), $cachedCount);
+    }
+
+    private function printSummary(OutputInterface $output, int $freshCount, int $cachedCount): void
+    {
+        $total = $freshCount + $cachedCount;
+        if ($total === 0) {
+            $output->writeln('No Phel namespaces found to build.');
+            return;
+        }
+
+        $outputDir = $this->getFacade()->getOutputDirectory();
+
+        if ($freshCount === 0) {
+            $output->writeln(sprintf(
+                'No changes detected. %d file%s reused from cache. Compiled output: %s',
+                $cachedCount,
+                $cachedCount === 1 ? '' : 's',
+                $outputDir,
+            ));
+            return;
+        }
+
+        $output->writeln(sprintf(
+            'Compiled %d file%s (%d reused from cache). Output directory: %s',
+            $freshCount,
+            $freshCount === 1 ? '' : 's',
+            $cachedCount,
+            $outputDir,
+        ));
     }
 }

--- a/tests/php/Integration/Build/Command/BuildCommandTest.php
+++ b/tests/php/Integration/Build/Command/BuildCommandTest.php
@@ -50,8 +50,9 @@ final class BuildCommandTest extends TestCase
         );
         $string = ob_get_clean();
 
-        self::assertMatchesRegularExpression('/This is printed from no-cache.phel/', $string);
-        self::assertMatchesRegularExpression('/This is printed from hello.phel/', $string);
+        // Top-level side-effects from compiled Phel code must not leak to stdout.
+        self::assertDoesNotMatchRegularExpression('/This is printed from no-cache.phel/', $string);
+        self::assertDoesNotMatchRegularExpression('/This is printed from hello.phel/', $string);
 
         self::assertFileExists(__DIR__ . '/out/phel/core.phel');
         self::assertFileExists(__DIR__ . '/out/phel/core.php');
@@ -85,11 +86,9 @@ final class BuildCommandTest extends TestCase
         );
         $string = ob_get_clean();
 
-        // Both files should print during build:
-        // - no-cache.phel: always recompiled (in no-cache list), executes during compilation
-        // - hello.phel: cache invalid (touched), gets recompiled, executes during compilation
-        self::assertMatchesRegularExpression('/This is printed from no-cache.phel/', $string);
-        self::assertMatchesRegularExpression('/This is printed from hello.phel/', $string);
+        // Compiled program output must stay suppressed regardless of cache path (fresh or cached require_once).
+        self::assertDoesNotMatchRegularExpression('/This is printed from no-cache.phel/', $string);
+        self::assertDoesNotMatchRegularExpression('/This is printed from hello.phel/', $string);
 
         self::assertFileExists(__DIR__ . '/out/phel/core.phel');
         self::assertFileExists(__DIR__ . '/out/phel/core.php');


### PR DESCRIPTION
## 🤔 Background

`vendor/bin/phel build` secretly runs every top-level Phel form during compilation to register macros, namespaces, and definitions. Any side-effect output, `(println ...)`, a game loop, anything written to stdout, leaks straight to the user's terminal. A minimal repro: building a project whose entry namespace starts a Connect 4 REPL turns `phel build` into the game itself.

```
➜  phel-connect4 git:(main) ✗ vendor/bin/phel build
=== Connect 4 ===

 1 2 3 4 5 6 7
|. . . . . . .|
...
Red (X) > column (1-7, u=undo, q=quit): q
```

Users expect a build command to emit only build-related output.

## 💡 Goal

Keep the compile-time evaluation (required for macros and definitions), but silence stdout that compiled programs produce while `phel build` runs. Only the build command itself should write to the terminal.

## 🔖 Changes

- `FileCompiler::compileFile` wraps the `compilerFacade->compile(...)` call in `ob_start()`/`ob_end_clean()` alongside the existing `BuildFacade::enableBuildMode()` scope, so fresh-compile side effects are discarded.
- `ProjectCompiler::compileFromTo` wraps the cached `require_once $targetFile` path in the same way, so reused cached files don't leak either.
- `BuildCommandTest` now asserts stdout is *not* contaminated by `(println ...)` forms in the test fixtures (both fresh and cached paths).
- `CHANGELOG.md`: Unreleased `### Fixed` entry describing the suppression.

Behavior preserved:
- Definitions, macros, and namespace side-effects still register during build.
- Compilation errors still surface through Symfony's `OutputInterface` and stderr.
- The `(when-not *build-mode* ...)` escape hatch keeps working for code that should be no-op during build.

## ✅ Tests

- `composer test-quality` green (cs-fixer, rector, psalm, phpstan).
- `composer test-compiler` green (unit + integration, including updated `BuildCommandTest`).
- `composer test-core` green (3556 Phel core tests).