### PR TITLE
feat(ai): multi-provider tool use, retry, configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ All notable changes to this project will be documented in this file.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 - `phel\ai`: OpenAI tool use support in `chat-with-tools`; provider-aware `tool-calls` extraction; `tool-result` helper for building tool result messages.
 - `phel\ai`: retry with exponential backoff on HTTP 429/5xx, configurable via `:max-retries`.
-- `phel\ai`: configurable `:timeout`; per-call `opts` now accept `:provider`, `:timeout`, `:base-url`, `:api-key`.
+- `phel\ai`: configurable `:timeout`; per-call `opts` now accept `:provider`, `:timeout`, `:base-url`, `:api-key`, `:max-retries`.
 - `phel\ai`: `docs/ai-guide.md` usage guide.
+- `phel\ai`: `*http-post*` rebindable seam enables full behavior coverage of chat/complete/extract/chat-with-tools/embed/build-index/search without a live API.
 
 ### Fixed
 
 - `phel build` no longer leaks stdout from compiled programs during compilation.
+- `phel\ai` `check-response` raises a `RuntimeException` with the provider error message instead of a PHP `TypeError` when the decoded error body is missing the nested `:error :message` path.
+- `phel\ai` text extraction selects the first `text`-type content block in an Anthropic response, skipping `tool_use` blocks that precede it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
+- `phel\ai`: OpenAI tool use support in `chat-with-tools`; provider-aware `tool-calls` extraction; `tool-result` helper for building tool result messages.
+- `phel\ai`: retry with exponential backoff on HTTP 429/5xx, configurable via `:max-retries`.
+- `phel\ai`: configurable `:timeout`; per-call `opts` now accept `:provider`, `:timeout`, `:base-url`, `:api-key`.
+- `phel\ai`: `docs/ai-guide.md` usage guide.
 
 ### Fixed
 
@@ -16,6 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `phel build` prints a summary with fresh/cached counts and the output directory, including a clear message when nothing needed recompiling.
+- `phel\ai` `chat-with-tools` returns `{:text :tool-calls :stop-reason :raw}`.
 
 ### Changed (breaking)
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -38,7 +38,7 @@ Supported providers:
 | `:timeout` | `120` | HTTP timeout in seconds |
 | `:max-retries` | `2` | Retry 429/5xx with exponential backoff |
 
-Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys to override per request.
+Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys (including `:max-retries`) to override per request.
 
 ```phel
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
@@ -131,6 +131,26 @@ Vector math primitives are exported for custom pipelines: `dot-product`, `magnit
 ## Errors
 
 All failures throw `\RuntimeException`. The message includes the HTTP status and provider error body when available.
+
+## Testing without a live API
+
+`phel\ai` exposes an internal HTTP seam `*http-post*` that tests can rebind to return canned responses. Combined with `phel\mock`, this removes any dependency on a real provider.
+
+```phel
+(ns my-app\test\ai-test
+  (:require phel\test :refer [deftest is])
+  (:require phel\ai :as ai)
+  (:require phel\mock :refer [mock-fn call-count first-call]))
+
+(deftest test-my-ai-logic
+  (let [fake (mock-fn (fn [_ _] {:status 200
+                                 :body "{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}"}))]
+    (binding [ai/*http-post* fake]
+      (is (= "hi" (ai/complete "say hi" {:api-key "k"})))
+      (is (= 1 (call-count fake))))))
+```
+
+Note: `phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string rather than going through `json/encode`.
 
 ## See also
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -1,0 +1,138 @@
+# AI Module Guide
+
+`phel\ai` provides a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
+
+Supported providers:
+
+| Provider | Chat | Tools | Embeddings |
+|----------|------|-------|------------|
+| `:anthropic` (default) | yes | yes | no |
+| `:openai` | yes | yes | yes |
+| `:voyageai` | no | no | yes |
+
+## Quickstart
+
+```phel
+(ns my-app\main
+  (:require phel\ai :as ai))
+
+;; Either set env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, VOYAGE_API_KEY)
+;; or configure explicitly:
+(ai/configure {:api-key "sk-ant-..."})
+
+(ai/complete "Say hi in one word")
+; => "Hi"
+```
+
+## Configuration
+
+`configure` merges options into a shared atom `ai/config`.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `:provider` | `:anthropic` | `:anthropic`, `:openai`, `:voyageai` |
+| `:model` | `"claude-sonnet-4-20250514"` | Model name |
+| `:max-tokens` | `1024` | Output token cap |
+| `:api-key` | `nil` | Falls back to env var |
+| `:base-url` | `nil` | Override endpoint (proxies, self-hosted) |
+| `:timeout` | `120` | HTTP timeout in seconds |
+| `:max-retries` | `2` | Retry 429/5xx with exponential backoff |
+
+Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys to override per request.
+
+```phel
+(ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
+```
+
+## Chat
+
+```phel
+(ai/chat [{:role "user" :content "What's 2+2?"}]
+         {:system "Answer with a single integer."})
+; => "4"
+```
+
+Multi-turn via `chat-with-history`:
+
+```phel
+(let [h1 (ai/chat-with-history [] "My name is Alice.")
+      h2 (ai/chat-with-history h1 "What's my name?")]
+  (get (last h2) :content))
+; => "Alice"
+```
+
+## Structured extraction
+
+Ask the model to populate a schema:
+
+```phel
+(ai/extract
+  {:name "string" :age "integer" :email "email address"}
+  "Hi, I'm Alice, 30, alice@example.com")
+; => {:name "Alice" :age 30 :email "alice@example.com"}
+```
+
+`extract-many` returns a vector when the input contains multiple items.
+
+## Tool use
+
+Define tools with provider-agnostic `tool`, pass them to `chat-with-tools`, dispatch on the returned calls, and feed results back with `tool-result`.
+
+```phel
+(def tools
+  [(ai/tool "get-weather"
+            "Returns current weather for a city."
+            {:city {:type "string" :description "City name"}})])
+
+(defn dispatch [call]
+  (case (get call :name)
+    "get-weather" (str "72F sunny in " (get (get call :input) :city))
+    "unknown tool"))
+
+(defn run-loop [messages]
+  (let [resp (ai/chat-with-tools messages tools)
+        calls (get resp :tool-calls)]
+    (if (empty? calls)
+      (get resp :text)
+      (let [tool-msgs (map #(ai/tool-result (get % :id) (dispatch %)) calls)
+            assistant-msg {:role "assistant" :content (get resp :raw)}]
+        (recur (concat messages [assistant-msg] tool-msgs))))))
+```
+
+`chat-with-tools` returns:
+
+```phel
+{:text       "..."    ; assistant text (may be nil if only tool calls)
+ :tool-calls [{:name "..." :id "..." :input {...}}]
+ :stop-reason "..."
+ :raw        {...}}   ; full provider body
+```
+
+## Embeddings & semantic search
+
+```phel
+(ai/configure {:provider :openai})
+
+(def index (ai/build-index ["cats purr" "dogs bark" "birds sing"]))
+(ai/search "feline sounds" index {:k 1})
+; => [{:text "cats purr" :embedding [...] :similarity 0.87}]
+```
+
+Vector math primitives are exported for custom pipelines: `dot-product`, `magnitude`, `cosine-similarity`, `nearest`.
+
+## Retry & timeouts
+
+`:max-retries` (default `2`) retries on HTTP 429 and 5xx with exponential backoff (500ms, 1s, 2s, ...). Network errors bubble up. Tune per call:
+
+```phel
+(ai/complete "long task" {:timeout 300 :max-retries 4})
+```
+
+## Errors
+
+All failures throw `\RuntimeException`. The message includes the HTTP status and provider error body when available.
+
+## See also
+
+- Source: `src/phel/ai.phel`
+- Tests: `tests/phel/test/ai.phel`

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -21,6 +21,11 @@
    :example "@ai/config"}
   (atom default-config))
 
+(def *http-post*
+  {:doc "HTTP POST seam. Rebind with `binding` in tests to inject a fake transport."
+   :example "(binding [*http-post* (fn [url opts] {:status 200 :body \"...\"})] ...)"}
+  hc/post)
+
 (defn configure
   "Merges the given options into the AI configuration.
 
@@ -136,7 +141,7 @@
   "Posts with retry on 429 / 5xx up to max-retries."
   [url opts max-retries]
   (loop [attempt 0]
-    (let [response (hc/post url opts)
+    (let [response (*http-post* url opts)
           status (get response :status)]
       (if (and (retryable-status? status) (< attempt max-retries))
         (do
@@ -203,18 +208,25 @@
 ;; Error handling
 ;; -----------
 
+(defn- provider-error-message
+  "Extracts a human-readable error message from a decoded provider error body."
+  [parsed fallback]
+  (let [err (when (map? parsed) (get parsed :error))]
+    (cond
+      (and (map? err) (get err :message)) (get err :message)
+      (string? err) err
+      :else fallback)))
+
 (defn- check-response
   "Checks an HTTP response for errors and throws if the request failed."
   [response]
   (let [status (get response :status)]
     (when (or (< status 200) (>= status 300))
       (let [body (get response :body)
-            parsed (try (json/decode body) (catch \Throwable _e {:error body}))]
+            parsed (try (json/decode body) (catch \Throwable _e nil))]
         (throw (php/new RuntimeException
                  (str "AI API error (HTTP " status "): "
-                      (or (get-in parsed [:error :message])
-                          (get parsed :error)
-                          body))))))))
+                      (provider-error-message parsed body))))))))
 
 (defn- send-request
   "Sends a prepared request map with retry + timeout."
@@ -232,12 +244,14 @@
 (defn- apply-opts
   "Merges per-call opts into cfg."
   [cfg opts]
-  (let [cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
+  (let [opts (or opts {})
+        cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
         cfg (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
         cfg (if (get opts :provider) (assoc cfg :provider (get opts :provider)) cfg)
         cfg (if (get opts :timeout) (assoc cfg :timeout (get opts :timeout)) cfg)
         cfg (if (get opts :base-url) (assoc cfg :base-url (get opts :base-url)) cfg)
-        cfg (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)]
+        cfg (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)
+        cfg (if (contains? opts :max-retries) (assoc cfg :max-retries (get opts :max-retries)) cfg)]
     cfg))
 
 ;; -----------
@@ -541,8 +555,8 @@
     (check-response response)
     (let [body (json/decode (get response :body))
           data (get body :data)]
-      (for [item :in data]
-        (get item :embedding)))))
+      (vec (for [item :in data]
+             (get item :embedding))))))
 
 (defn embed
   "Generates embeddings for one or more text strings.

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -12,7 +12,9 @@
    :model "claude-sonnet-4-20250514"
    :max-tokens 1024
    :api-key nil
-   :base-url nil})
+   :base-url nil
+   :timeout 120
+   :max-retries 2})
 
 (def config
   {:doc "Current AI configuration atom. Use `configure` to update."
@@ -23,13 +25,14 @@
   "Merges the given options into the AI configuration.
 
   Supported keys:
-    :provider   - :anthropic (default), :openai, or :voyageai
-    :model      - Model name string
-    :max-tokens - Maximum tokens in response
-    :api-key    - API key string (or set via env var)
-    :base-url   - Override the API base URL"
-  {:doc "Merges options into the AI configuration."
-   :example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-20250514\"})"
+    :provider    - :anthropic (default), :openai, or :voyageai
+    :model       - Model name string
+    :max-tokens  - Maximum tokens in response
+    :api-key     - API key string (or set via env var)
+    :base-url    - Override the API base URL
+    :timeout     - HTTP timeout in seconds (default 120)
+    :max-retries - Retry attempts on 429/5xx (default 2)"
+  {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-20250514\"})"
    :see-also ["config" "complete" "chat"]}
   [opts]
   (swap! config merge opts))
@@ -63,6 +66,17 @@
     :voyageai "https://api.voyageai.com"
     "https://api.anthropic.com"))
 
+(defn- anthropic-headers
+  [api-key]
+  {:x-api-key api-key
+   :anthropic-version "2023-06-01"
+   :content-type "application/json"})
+
+(defn- openai-headers
+  [api-key]
+  {:authorization (str "Bearer " api-key)
+   :content-type "application/json"})
+
 (defn- anthropic-request
   "Builds an HTTP request for the Anthropic Messages API.
   Optionally includes tool definitions."
@@ -75,25 +89,60 @@
         body (if system-prompt (assoc body :system system-prompt) body)
         body (if tools (assoc body :tools tools) body)]
     {:url (str base "/v1/messages")
-     :headers {:x-api-key api-key
-               :anthropic-version "2023-06-01"
-               :content-type "application/json"}
+     :headers (anthropic-headers api-key)
      :body body}))
+
+(defn- openai-tools->request
+  "Converts Anthropic-shape tool defs to OpenAI's function-calling shape."
+  [tools]
+  (for [t :in tools]
+    {:type "function"
+     :function {:name (get t :name)
+                :description (get t :description)
+                :parameters (get t :input_schema)}}))
 
 (defn- openai-request
   "Builds an HTTP request for the OpenAI Chat Completions API."
-  [cfg messages system-prompt]
+  [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
         base (or (get cfg :base-url) (provider-base-url :openai))
-        messages (if system-prompt
-                   (concat [{:role "system" :content system-prompt}] messages)
-                   messages)]
+        msgs (if system-prompt
+               (concat [{:role "system" :content system-prompt}] messages)
+               messages)
+        body {:model (get cfg :model)
+              :max_tokens (get cfg :max-tokens)
+              :messages msgs}
+        body (if tools (assoc body :tools (openai-tools->request tools)) body)]
     {:url (str base "/v1/chat/completions")
-     :headers {:authorization (str "Bearer " api-key)
-               :content-type "application/json"}
-     :body {:model (get cfg :model)
-            :max_tokens (get cfg :max-tokens)
-            :messages messages}}))
+     :headers (openai-headers api-key)
+     :body body}))
+
+;; -----------
+;; HTTP with retry
+;; -----------
+
+(defn- retryable-status?
+  [status]
+  (or (= 429 status) (and (>= status 500) (< status 600))))
+
+(defn- backoff-sleep
+  "Sleeps using exponential backoff. attempt is 0-based."
+  [attempt]
+  (let [base-ms 500
+        delay-ms (* base-ms (php/pow 2 attempt))]
+    (php/usleep (php/intval (* delay-ms 1000)))))
+
+(defn- post-with-retry
+  "Posts with retry on 429 / 5xx up to max-retries."
+  [url opts max-retries]
+  (loop [attempt 0]
+    (let [response (hc/post url opts)
+          status (get response :status)]
+      (if (and (retryable-status? status) (< attempt max-retries))
+        (do
+          (backoff-sleep attempt)
+          (recur (+ attempt 1)))
+        response))))
 
 ;; -----------
 ;; Response extraction
@@ -104,9 +153,9 @@
   [response-body]
   (let [content (get response-body :content)]
     (when content
-      (let [first-block (first content)]
-        (when first-block
-          (get first-block :text))))))
+      (let [text-block (first (filter #(= "text" (get % :type)) content))]
+        (when text-block
+          (get text-block :text))))))
 
 (defn- extract-openai-text
   "Extracts the text content from an OpenAI API response."
@@ -124,6 +173,32 @@
     (extract-openai-text response-body)
     (extract-anthropic-text response-body)))
 
+(defn- extract-anthropic-tool-calls
+  [response-body]
+  (let [content (get response-body :content)]
+    (if content
+      (for [block :in content
+            :when (= "tool_use" (get block :type))]
+        {:name (get block :name)
+         :id (get block :id)
+         :input (get block :input)})
+      [])))
+
+(defn- extract-openai-tool-calls
+  [response-body]
+  (let [choices (get response-body :choices)
+        msg (when choices (get (first choices) :message))
+        calls (when msg (get msg :tool_calls))]
+    (if calls
+      (for [c :in calls]
+        (let [fn-def (get c :function)
+              args-str (get fn-def :arguments)
+              args (try (json/decode args-str) (catch \Throwable _e args-str))]
+          {:name (get fn-def :name)
+           :id (get c :id)
+           :input args}))
+      [])))
+
 ;; -----------
 ;; Error handling
 ;; -----------
@@ -134,12 +209,36 @@
   (let [status (get response :status)]
     (when (or (< status 200) (>= status 300))
       (let [body (get response :body)
-            parsed (try (json/decode body) (catch \Exception _e {:error body}))]
+            parsed (try (json/decode body) (catch \Throwable _e {:error body}))]
         (throw (php/new RuntimeException
                  (str "AI API error (HTTP " status "): "
                       (or (get-in parsed [:error :message])
                           (get parsed :error)
                           body))))))))
+
+(defn- send-request
+  "Sends a prepared request map with retry + timeout."
+  [cfg req]
+  (let [timeout (or (get cfg :timeout) 120)
+        max-retries (or (get cfg :max-retries) 0)
+        response (post-with-retry (get req :url)
+                                  {:headers (get req :headers)
+                                   :json (get req :body)
+                                   :timeout timeout}
+                                  max-retries)]
+    (check-response response)
+    (json/decode (get response :body))))
+
+(defn- apply-opts
+  "Merges per-call opts into cfg."
+  [cfg opts]
+  (let [cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
+        cfg (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
+        cfg (if (get opts :provider) (assoc cfg :provider (get opts :provider)) cfg)
+        cfg (if (get opts :timeout) (assoc cfg :timeout (get opts :timeout)) cfg)
+        cfg (if (get opts :base-url) (assoc cfg :base-url (get opts :base-url)) cfg)
+        cfg (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)]
+    cfg))
 
 ;; -----------
 ;; Chat API
@@ -154,33 +253,30 @@
   Accepts an optional options map:
     :system     - System prompt string
     :model      - Override the configured model
-    :max-tokens - Override the configured max tokens"
-  {:doc "Sends a chat completion request. Returns the assistant's text response."
-   :example "(chat [{:role \"user\" :content \"Hello!\"}])"
+    :max-tokens - Override the configured max tokens
+    :provider   - Override the configured provider
+    :timeout    - HTTP timeout in seconds
+    :base-url   - Override the API base URL
+    :api-key    - Override the configured API key"
+  {:example "(chat [{:role \"user\" :content \"Hello!\"}])"
    :see-also ["complete" "configure"]}
-  [messages & [{:system system-prompt :model model :max-tokens max-tokens}]]
-  (let [cfg @config
-        cfg (if model (assoc cfg :model model) cfg)
-        cfg (if max-tokens (assoc cfg :max-tokens max-tokens) cfg)
+  [messages & [opts]]
+  (let [cfg (apply-opts @config opts)
         provider (get cfg :provider)
+        system-prompt (get opts :system)
         req (if (= provider :openai)
               (openai-request cfg messages system-prompt)
               (anthropic-request cfg messages system-prompt))
-        response (hc/post (get req :url) {:headers (get req :headers)
-                                          :json (get req :body)
-                                          :timeout 120})]
-    (check-response response)
-    (let [body (json/decode (get response :body))]
-      (or (extract-text provider body)
-          (throw (php/new RuntimeException "No text content in AI response"))))))
+        body (send-request cfg req)]
+    (or (extract-text provider body)
+        (throw (php/new RuntimeException "No text content in AI response")))))
 
 (defn complete
   "Sends a simple text completion request.
 
   Takes a prompt string and returns the assistant's text response.
   This is a convenience wrapper around `chat` for single-turn interactions."
-  {:doc "Sends a text prompt to the AI. Returns the response string."
-   :example "(complete \"Explain monads in one sentence\")"
+  {:example "(complete \"Explain monads in one sentence\")"
    :see-also ["chat" "configure"]}
   [prompt & [opts]]
   (chat [{:role "user" :content prompt}] opts))
@@ -190,8 +286,7 @@
   sends it, and returns the updated history with the assistant's response.
 
   Useful for building multi-turn conversations."
-  {:doc "Continues a conversation. Returns updated message history."
-   :example "(chat-with-history [{:role \"user\" :content \"Hi\"}
+  {:example "(chat-with-history [{:role \"user\" :content \"Hi\"}
                               {:role \"assistant\" :content \"Hello!\"}]
                              \"How are you?\")"
    :see-also ["chat" "complete"]}
@@ -249,8 +344,8 @@
           (php/aget matches 1)
           (let [start (php/strpos trimmed "{")
                 end (php/strrpos trimmed "}")]
-            (if (and start end (php/>= end start))
-              (php/substr trimmed start (php/+ (php/- end start) 1))
+            (if (and start end (>= end start))
+              (php/substr trimmed start (+ (- end start) 1))
               (throw (php/new RuntimeException
                        (str "Could not extract JSON from AI response: " trimmed))))))))))
 
@@ -266,18 +361,17 @@
     :system     - Override the system prompt
     :model      - Override the configured model
     :max-tokens - Override the configured max tokens"
-  {:doc "Extracts structured data from text using AI. Returns a map matching the schema."
-   :example "(extract {:name \"string\" :age \"integer\"} \"John is 30 years old\")"
+  {:example "(extract {:name \"string\" :age \"integer\"} \"John is 30 years old\")"
    :see-also ["extract-many" "complete" "chat"]}
-  [schema text & [{:system system-prompt :model model :max-tokens max-tokens}]]
+  [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
         prompt (str "Extract the following structured data from the given text.\n\n"
                     "Schema (field name: expected type/format):\n"
                     schema-desc "\n\n"
                     "Text: " text "\n\n"
                     "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
-        system (or system-prompt "You are a precise data extraction assistant. Return only valid JSON.")
-        response (complete prompt {:system system :model model :max-tokens max-tokens})]
+        system (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
+        response (complete prompt (assoc (or opts {}) :system system))]
     (json/decode (extract-json-from-response response))))
 
 (defn extract-many
@@ -285,25 +379,24 @@
 
   Similar to `extract`, but returns a vector of maps when the text
   contains multiple items matching the schema."
-  {:doc "Extracts a list of structured items from text. Returns a vector of maps."
-   :example "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")"
+  {:example "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")"
    :see-also ["extract" "complete"]}
-  [schema text & [{:system system-prompt :model model :max-tokens max-tokens}]]
+  [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
         prompt (str "Extract ALL items matching the schema from the given text.\n\n"
                     "Schema for each item (field name: expected type/format):\n"
                     schema-desc "\n\n"
                     "Text: " text "\n\n"
                     "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
-        system (or system-prompt "You are a precise data extraction assistant. Return only valid JSON.")
-        response (complete prompt {:system system :model model :max-tokens max-tokens})
+        system (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
+        response (complete prompt (assoc (or opts {}) :system system))
         trimmed (php/trim response)
         json-str (if (php/str_starts_with trimmed "[")
                    trimmed
                    (let [start (php/strpos trimmed "[")
                          end (php/strrpos trimmed "]")]
-                     (if (and start end (php/>= end start))
-                       (php/substr trimmed start (php/+ (php/- end start) 1))
+                     (if (and start end (>= end start))
+                       (php/substr trimmed start (+ (- end start) 1))
                        (throw (php/new RuntimeException
                                 (str "Could not extract JSON array from AI response: " trimmed))))))]
     (json/decode json-str)))
@@ -317,10 +410,12 @@
 
   `tool-name` is a string identifier for the tool.
   `description` describes what the tool does.
-  `input-schema` is a map of parameter names to JSON Schema type maps."
-  {:doc "Creates a tool definition for AI tool use."
-   :example "(tool \"get-weather\" \"Gets weather for a city\" {:location {:type \"string\"}})"
-   :see-also ["chat-with-tools" "tool-calls"]}
+  `input-schema` is a map of parameter names to JSON Schema type maps.
+
+  The returned map is provider-agnostic; `chat-with-tools` converts it to
+  the provider's native format."
+  {:example "(tool \"get-weather\" \"Gets weather for a city\" {:location {:type \"string\"}})"
+   :see-also ["chat-with-tools" "tool-calls" "tool-result"]}
   [tool-name description input-schema]
   {:name tool-name
    :description description
@@ -329,40 +424,68 @@
 (defn chat-with-tools
   "Sends a chat request with tool definitions.
 
-  Returns the full parsed API response map, which may include
-  tool_use content blocks that the caller can inspect and handle.
+  Returns a map:
+    :text       - Assistant text content (may be nil if model only called tools)
+    :tool-calls - Vector of {:name :id :input} maps for any tool calls
+    :stop-reason - Provider-specific stop reason
+    :raw        - The full provider response body
 
-  Tool call responses contain :type \"tool_use\", :name, :id, and :input."
-  {:doc "Chat with tool definitions. Returns full response with tool calls."
-   :example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
+  Options map accepts the same keys as `chat`."
+  {:example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
                              [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
-   :see-also ["tool" "tool-calls" "extract"]}
+   :see-also ["tool" "tool-calls" "tool-result" "extract"]}
   [messages tools & [opts]]
-  (let [cfg @config
-        cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
-        cfg (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
-        req (anthropic-request cfg messages (get opts :system) tools)
-        response (hc/post (get req :url) {:headers (get req :headers)
-                                          :json (get req :body)
-                                          :timeout 120})]
-    (check-response response)
-    (json/decode (get response :body))))
+  (let [cfg (apply-opts @config opts)
+        provider (get cfg :provider)
+        system-prompt (get opts :system)
+        req (if (= provider :openai)
+              (openai-request cfg messages system-prompt tools)
+              (anthropic-request cfg messages system-prompt tools))
+        body (send-request cfg req)
+        stop-reason (if (= provider :openai)
+                      (get-in body [:choices 0 :finish_reason])
+                      (get body :stop_reason))
+        tcs (if (= provider :openai)
+              (extract-openai-tool-calls body)
+              (extract-anthropic-tool-calls body))]
+    {:text (extract-text provider body)
+     :tool-calls tcs
+     :stop-reason stop-reason
+     :raw body}))
 
 (defn tool-calls
-  "Extracts tool_use blocks from an AI response.
-  Returns a vector of maps with :name, :id, and :input."
-  {:doc "Extracts tool call requests from a chat-with-tools response."
-   :example "(tool-calls response)"
-   :see-also ["chat-with-tools" "tool"]}
+  "Extracts tool call requests from an AI response.
+
+  Accepts either a raw provider response body or a map produced by
+  `chat-with-tools`. Returns a vector of {:name :id :input} maps."
+  {:example "(tool-calls response)"
+   :see-also ["chat-with-tools" "tool" "tool-result"]}
   [response]
-  (let [content (get response :content)]
-    (if content
-      (for [block :in content
-            :when (= "tool_use" (get block :type))]
-        {:name (get block :name)
-         :id (get block :id)
-         :input (get block :input)})
-      [])))
+  (cond
+    (contains? response :tool-calls) (get response :tool-calls)
+    (contains? response :choices) (extract-openai-tool-calls response)
+    :else (extract-anthropic-tool-calls response)))
+
+(defn tool-result
+  "Builds a tool-result message for the given provider.
+
+  `call-id` is the tool call id returned by the model.
+  `result` is the tool's output as a string (or value that will be stringified).
+
+  Optional `opts` can set :provider (defaults to current config)."
+  {:example "(tool-result \"call_abc\" \"72F sunny\")"
+   :see-also ["chat-with-tools" "tool-calls"]}
+  [call-id result & [opts]]
+  (let [provider (or (get opts :provider) (get @config :provider))
+        result-str (if (string? result) result (str result))]
+    (if (= provider :openai)
+      {:role "tool"
+       :tool_call_id call-id
+       :content result-str}
+      {:role "user"
+       :content [{:type "tool_result"
+                  :tool_use_id call-id
+                  :content result-str}]})))
 
 ;; -----------
 ;; Vector math
@@ -370,8 +493,7 @@
 
 (defn dot-product
   "Computes the dot product of two numeric vectors."
-  {:doc "Computes the dot product of two vectors."
-   :example "(dot-product [1 2 3] [4 5 6]) ; => 32"
+  {:example "(dot-product [1 2 3] [4 5 6]) ; => 32"
    :see-also ["cosine-similarity" "magnitude"]}
   [a b]
   (when (not= (count a) (count b))
@@ -380,8 +502,7 @@
 
 (defn magnitude
   "Computes the magnitude (L2 norm) of a numeric vector."
-  {:doc "Computes the L2 norm of a vector."
-   :example "(magnitude [3 4]) ; => 5.0"
+  {:example "(magnitude [3 4]) ; => 5.0"
    :see-also ["dot-product" "cosine-similarity"]}
   [v]
   (php/sqrt (apply + (map #(* % %) v))))
@@ -389,8 +510,7 @@
 (defn cosine-similarity
   "Computes the cosine similarity between two numeric vectors.
   Returns a float between -1.0 and 1.0, where 1.0 means identical direction."
-  {:doc "Computes cosine similarity between two vectors. Returns -1.0 to 1.0."
-   :example "(cosine-similarity [1 0] [0 1]) ; => 0.0"
+  {:example "(cosine-similarity [1 0] [0 1]) ; => 0.0"
    :see-also ["dot-product" "magnitude" "nearest"]}
   [a b]
   (let [mag-a (magnitude a)
@@ -403,38 +523,21 @@
 ;; Embedding API
 ;; -----------
 
-(defn- openai-embed-request
-  "Makes an embedding request to the OpenAI Embeddings API."
-  [texts model & [provider]]
-  (let [cfg @config
-        effective-provider (or provider (get cfg :provider) :openai)
-        api-key (resolve-api-key (assoc cfg :provider effective-provider))
-        base-url (or (get cfg :base-url) (provider-base-url effective-provider))
-        response (hc/post (str base-url "/v1/embeddings")
-                          {:headers {:authorization (str "Bearer " api-key)
-                                    :content-type "application/json"}
-                           :json {:model (or model "text-embedding-3-small")
-                                  :input texts}
-                           :timeout 60})]
-    (check-response response)
-    (let [body (json/decode (get response :body))
-          data (get body :data)]
-      (for [item :in data]
-        (get item :embedding)))))
-
-(defn- voyageai-embed-request
-  "Makes an embedding request to the Voyage AI API."
-  [texts model & [provider]]
-  (let [cfg @config
-        effective-provider (or provider :voyageai)
-        api-key (resolve-api-key (assoc cfg :provider effective-provider))
-        base-url (or (get cfg :base-url) (provider-base-url :voyageai))
-        response (hc/post (str base-url "/v1/embeddings")
-                          {:headers {:authorization (str "Bearer " api-key)
-                                    :content-type "application/json"}
-                           :json {:model (or model "voyage-3-lite")
-                                  :input texts}
-                           :timeout 60})]
+(defn- embed-request
+  "Sends an embedding request to the given provider."
+  [provider texts model]
+  (let [cfg (assoc @config :provider provider)
+        api-key (resolve-api-key cfg)
+        base-url (or (get cfg :base-url) (provider-base-url provider))
+        default-model (if (= provider :voyageai) "voyage-3-lite" "text-embedding-3-small")
+        timeout (or (get cfg :timeout) 60)
+        max-retries (or (get cfg :max-retries) 2)
+        response (post-with-retry (str base-url "/v1/embeddings")
+                                  {:headers (openai-headers api-key)
+                                   :json {:model (or model default-model)
+                                          :input texts}
+                                   :timeout timeout}
+                                  max-retries)]
     (check-response response)
     (let [body (json/decode (get response :body))
           data (get body :data)]
@@ -450,20 +553,15 @@
   Options:
     :model    - Override the embedding model name
     :provider - :openai (default) or :voyageai"
-  {:doc "Generates text embeddings. Returns a vector of float vectors."
-   :example "(embed [\"hello world\"]) ; => [[0.123 -0.456 ...]]"
+  {:example "(embed [\"hello world\"]) ; => [[0.123 -0.456 ...]]"
    :see-also ["embed-one" "cosine-similarity" "nearest"]}
   [texts & [{:model model :provider provider}]]
-  (let [provider (or provider :openai)]
-    (if (= provider :voyageai)
-      (voyageai-embed-request texts model provider)
-      (openai-embed-request texts model provider))))
+  (embed-request (or provider :openai) texts model))
 
 (defn embed-one
   "Generates an embedding for a single text string.
   Returns a single embedding vector."
-  {:doc "Generates an embedding for a single text. Returns a float vector."
-   :example "(embed-one \"hello world\") ; => [0.123 -0.456 ...]"
+  {:example "(embed-one \"hello world\") ; => [0.123 -0.456 ...]"
    :see-also ["embed" "cosine-similarity"]}
   [text & [opts]]
   (first (embed [text] opts)))
@@ -478,8 +576,7 @@
   `index` is a vector of {:text \"...\" :embedding [...]} maps.
   Returns a vector of {:text, :embedding, :similarity} maps sorted
   by descending similarity."
-  {:doc "Finds k nearest items to a query embedding by cosine similarity."
-   :example "(nearest query-embedding index 5)"
+  {:example "(nearest query-embedding index 5)"
    :see-also ["cosine-similarity" "build-index" "embed-one"]}
   [query-embedding index & [k]]
   (let [k (or k 5)
@@ -496,8 +593,7 @@
   suitable for use with `nearest`.
 
   Options are passed through to `embed`."
-  {:doc "Builds a searchable index by embedding a collection of texts."
-   :example "(build-index [\"hello\" \"world\"])"
+  {:example "(build-index [\"hello\" \"world\"])"
    :see-also ["nearest" "embed" "search"]}
   [texts & [opts]]
   (let [embeddings (embed texts opts)]
@@ -510,10 +606,8 @@
   in a pre-built index.
 
   Returns a vector of {:text, :embedding, :similarity} maps."
-  {:doc "Searches an index for texts most similar to the query."
-   :example "(search \"greeting\" my-index 3)"
+  {:example "(search \"greeting\" my-index 3)"
    :see-also ["nearest" "build-index" "embed-one"]}
   [query index & [{:k k :model model :provider provider}]]
   (let [query-embedding (embed-one query {:model model :provider provider})]
     (nearest query-embedding index (or k 5))))
-

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -1,7 +1,20 @@
 (ns phel-test\test\ai
   (:require phel\test :refer [deftest is])
   (:require phel\ai :as ai)
-  (:require phel\json))
+  (:require phel\json)
+  (:require phel\mock :refer [mock-fn calls call-count first-call]))
+
+;; --- Mock HTTP helpers ---
+
+(defn- ok-response [body-map]
+  {:status 200 :body (json/encode body-map)})
+
+(defn- status-response [status body-map]
+  {:status status :body (json/encode body-map)})
+
+(defn- body-of [call] (get (second call) :json))
+(defn- url-of [call] (first call))
+(defn- headers-of [call] (get (second call) :headers))
 
 ;; --- Configuration ---
 
@@ -300,3 +313,351 @@
   (is (function? ai/nearest) "nearest is defined")
   (is (function? ai/build-index) "build-index is defined")
   (is (function? ai/search) "search is defined"))
+
+;; =====================================================================
+;; Mock-HTTP coverage — exercises chat/complete/extract/chat-with-tools
+;; /embed/build-index/search/retry without real network.
+;; =====================================================================
+
+;; --- chat (anthropic) ---
+
+(deftest test-chat-anthropic-happy-path
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "hi there"}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/chat [{:role "user" :content "hi"}] {:api-key "sk-test"})]
+        (is (= "hi there" result) "returns assistant text")
+        (is (= 1 (call-count fake)) "makes one HTTP call")
+        (let [call (first-call fake)]
+          (is (php/str_contains (url-of call) "api.anthropic.com/v1/messages") "hits anthropic messages endpoint")
+          (is (= "sk-test" (get (headers-of call) :x-api-key)) "sends x-api-key header")
+          (is (= "2023-06-01" (get (headers-of call) :anthropic-version)) "sends anthropic-version")
+          (is (= 1024 (get (body-of call) :max_tokens)) "sends max_tokens from config")
+          (is (= 1 (count (get (body-of call) :messages))) "includes user message"))))))
+
+(deftest test-chat-anthropic-with-system-prompt
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :system "You are concise."})
+      (let [body (body-of (first-call fake))]
+        (is (= "You are concise." (get body :system)) "anthropic uses top-level :system field")))))
+
+(deftest test-chat-anthropic-skips-non-text-blocks
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "tool_use" :id "x" :name "t" :input {}}
+                                                        {:type "text" :text "real answer"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= "real answer" (ai/chat [{:role "user" :content "hi"}] {:api-key "k"}))
+          "extracts text block even when non-text block comes first"))))
+
+(deftest test-chat-throws-when-no-text-in-response
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "tool_use" :id "x" :name "t" :input {}}]})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/chat [{:role "user" :content "hi"}] {:api-key "k"}))
+          "throws when response has no text content"))))
+
+;; --- chat (openai) ---
+
+(deftest test-chat-openai-happy-path
+  (let [fake (mock-fn (fn [_ _] (ok-response {:choices [{:message {:role "assistant" :content "gpt reply"}}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/chat [{:role "user" :content "hi"}]
+                            {:api-key "sk-oa" :provider :openai})]
+        (is (= "gpt reply" result) "returns content from openai response")
+        (let [call (first-call fake)]
+          (is (php/str_contains (url-of call) "api.openai.com/v1/chat/completions") "hits openai endpoint")
+          (is (= "Bearer sk-oa" (get (headers-of call) :authorization)) "uses bearer auth"))))))
+
+(deftest test-chat-openai-prepends-system-message
+  (let [fake (mock-fn (fn [_ _] (ok-response {:choices [{:message {:content "ok"}}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :provider :openai :system "concise"})
+      (let [msgs (get (body-of (first-call fake)) :messages)]
+        (is (= "system" (get (first msgs) :role)) "openai prepends system role message")
+        (is (= "concise" (get (first msgs) :content)) "system message carries prompt")))))
+
+;; --- Per-call option overrides ---
+
+(deftest test-chat-honors-model-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :model "claude-opus-test"})
+      (is (= "claude-opus-test" (get (body-of (first-call fake)) :model)) "model opt reaches body"))))
+
+(deftest test-chat-honors-max-tokens-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :max-tokens 77})
+      (is (= 77 (get (body-of (first-call fake)) :max_tokens)) "max-tokens opt reaches body"))))
+
+(deftest test-chat-honors-base-url-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :base-url "https://proxy.example.com"})
+      (is (php/str_contains (url-of (first-call fake)) "proxy.example.com") "base-url opt reaches request url"))))
+
+(deftest test-chat-honors-timeout-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :timeout 7})
+      (is (= 7 (get (second (first-call fake)) :timeout)) "timeout opt reaches hc/post"))))
+
+(deftest test-chat-honors-provider-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:choices [{:message {:content "oa"}}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/chat [{:role "user" :content "hi"}]
+                            {:api-key "k" :provider :openai})]
+        (is (= "oa" result) "provider override changes request shape")))))
+
+;; --- complete / chat-with-history ---
+
+(deftest test-complete-sends-single-user-message
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "done"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= "done" (ai/complete "prompt" {:api-key "k"})) "returns text")
+      (let [msgs (get (body-of (first-call fake)) :messages)]
+        (is (= 1 (count msgs)) "one message")
+        (is (= "user" (get (first msgs) :role)) "role user")
+        (is (= "prompt" (get (first msgs) :content)) "prompt reaches content")))))
+
+(deftest test-chat-with-history-appends-assistant
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "reply"}]})))]
+    (binding [ai/*http-post* fake]
+      (let [history [{:role "user" :content "hi"}
+                     {:role "assistant" :content "hello"}]
+            result (ai/chat-with-history history "how are you?" {:api-key "k"})]
+        (is (= 4 (count result)) "returns history with new user + assistant appended")
+        (is (= "user" (get (nth result 2) :role)) "appends user message before assistant")
+        (is (= "how are you?" (get (nth result 2) :content)) "new user message included")
+        (is (= "reply" (get (nth result 3) :content)) "assistant reply appended last")))))
+
+;; --- extract / extract-many ---
+
+(deftest test-extract-bare-json-response
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "{\"name\":\"Alice\",\"age\":30}"}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/extract {:name "string" :age "integer"} "Alice is 30" {:api-key "k"})]
+        (is (= "Alice" (get result :name)) "extracts name")
+        (is (= 30 (get result :age)) "extracts age")))))
+
+(deftest test-extract-fenced-json-block
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "Here:\n```json\n{\"x\":1}\n```"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= 1 (get (ai/extract {:x "integer"} "text" {:api-key "k"}) :x))
+          "parses json from fenced code block"))))
+
+(deftest test-extract-prose-wrapped-json
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "Here is the answer {\"x\":42} done"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= 42 (get (ai/extract {:x "integer"} "text" {:api-key "k"}) :x))
+          "parses json surrounded by prose"))))
+
+(deftest test-extract-throws-on-invalid-json
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "no json here"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/extract {:x "integer"} "text" {:api-key "k"}))
+          "throws when response has no extractable json object"))))
+
+(deftest test-extract-many-bare-array
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "[{\"name\":\"a\"},{\"name\":\"b\"}]"}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/extract-many {:name "string"} "a and b" {:api-key "k"})]
+        (is (= 2 (count result)) "returns two items")
+        (is (= "a" (get (first result) :name)) "first item correct")))))
+
+(deftest test-extract-many-prose-wrapped-array
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "Results: [{\"id\":1}] done."}]})))]
+    (binding [ai/*http-post* fake]
+      (is (= 1 (count (ai/extract-many {:id "integer"} "text" {:api-key "k"})))
+          "extracts array surrounded by prose"))))
+
+(deftest test-extract-many-throws-on-invalid
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "nothing"}]})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/extract-many {:id "integer"} "text" {:api-key "k"}))
+          "throws when response has no array"))))
+
+;; --- chat-with-tools (happy paths) ---
+
+(deftest test-chat-with-tools-anthropic-returns-normalized-map
+  (let [fake (mock-fn (fn [_ _]
+                        (ok-response {:content [{:type "text" :text "let me check"}
+                                                {:type "tool_use" :id "tu_1" :name "get-weather"
+                                                 :input {:city "Paris"}}]
+                                      :stop_reason "tool_use"})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/chat-with-tools [{:role "user" :content "weather?"}]
+                                       [(ai/tool "get-weather" "Gets weather" {:city "string"})]
+                                       {:api-key "k"})]
+        (is (= "let me check" (get result :text)) "returns text")
+        (is (= "tool_use" (get result :stop-reason)) "returns stop-reason")
+        (is (= 1 (count (get result :tool-calls))) "returns one tool call")
+        (is (= "get-weather" (get (first (get result :tool-calls)) :name)) "tool name correct")
+        (is (= "Paris" (get (get (first (get result :tool-calls)) :input) :city)) "tool input correct")
+        (is (map? (get result :raw)) "includes raw response")))))
+
+(deftest test-chat-with-tools-anthropic-sends-tools-in-body
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}] :stop_reason "end_turn"})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat-with-tools [{:role "user" :content "hi"}]
+                          [(ai/tool "t1" "desc" {:a "string"})]
+                          {:api-key "k"})
+      (let [body (body-of (first-call fake))
+            tools (get body :tools)]
+        (is (= 1 (count tools)) "one tool sent")
+        (is (= "t1" (get (first tools) :name)) "tool name preserved for anthropic")))))
+
+(deftest test-chat-with-tools-openai-converts-tool-shape
+  (let [fake (mock-fn (fn [_ _]
+                        (ok-response {:choices [{:finish_reason "tool_calls"
+                                                 :message {:role "assistant"
+                                                           :content nil
+                                                           :tool_calls [{:id "call_1"
+                                                                         :type "function"
+                                                                         :function {:name "t1"
+                                                                                    :arguments "{\"a\":\"x\"}"}}]}}]})))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/chat-with-tools [{:role "user" :content "hi"}]
+                                       [(ai/tool "t1" "desc" {:a "string"})]
+                                       {:api-key "k" :provider :openai})]
+        (is (= "tool_calls" (get result :stop-reason)) "openai finish_reason mapped to stop-reason")
+        (is (= 1 (count (get result :tool-calls))) "one openai tool call parsed")
+        (is (= "t1" (get (first (get result :tool-calls)) :name)) "openai tool name")
+        (is (= "x" (get (get (first (get result :tool-calls)) :input) :a)) "openai arguments json decoded")
+        (let [body (body-of (first-call fake))
+              tools (get body :tools)]
+          (is (= "function" (get (first tools) :type)) "openai tool uses function shape")
+          (is (= "t1" (get-in (first tools) [:function :name])) "function name set"))))))
+
+;; --- Retry / backoff ---
+
+(deftest test-retry-recovers-from-429
+  (let [n (atom 0)
+        fake (mock-fn (fn [_ _]
+                        (swap! n + 1)
+                        (if (= @n 1)
+                          (status-response 429 {:error "rate limited"})
+                          (ok-response {:content [{:type "text" :text "ok"}]}))))]
+    (binding [ai/*http-post* fake]
+      (is (= "ok" (ai/complete "hi" {:api-key "k" :max-retries 2})) "recovers after 429")
+      (is (= 2 (call-count fake)) "makes exactly 2 calls"))))
+
+(deftest test-retry-recovers-from-500
+  (let [n (atom 0)
+        fake (mock-fn (fn [_ _]
+                        (swap! n + 1)
+                        (if (<= @n 2)
+                          (status-response 503 {:error "unavailable"})
+                          (ok-response {:content [{:type "text" :text "ok"}]}))))]
+    (binding [ai/*http-post* fake]
+      (is (= "ok" (ai/complete "hi" {:api-key "k" :max-retries 3})) "recovers after 503")
+      (is (= 3 (call-count fake)) "makes exactly 3 calls"))))
+
+(deftest test-retry-gives-up-after-max-retries
+  (let [fake (mock-fn (fn [_ _] (status-response 500 {:error "boom"})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/complete "hi" {:api-key "k" :max-retries 1}))
+          "throws after exhausting retries")
+      (is (= 2 (call-count fake)) "calls = initial + max-retries"))))
+
+(deftest test-retry-does-not-retry-on-4xx-other-than-429
+  (let [fake (mock-fn (fn [_ _] (status-response 401 {:error {:message "bad key"}})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException (ai/complete "hi" {:api-key "k" :max-retries 5}))
+          "401 throws immediately")
+      (is (= 1 (call-count fake)) "no retry on 401"))))
+
+(deftest test-error-message-includes-provider-error
+  (let [fake (mock-fn (fn [_ _] (status-response 400 {:error {:message "bad prompt"}})))]
+    (binding [ai/*http-post* fake]
+      (try
+        (ai/complete "hi" {:api-key "k"})
+        (is false "should have thrown")
+        (catch \RuntimeException e
+          (is (php/str_contains (php/-> e (getMessage)) "bad prompt") "error surfaces provider message")
+          (is (php/str_contains (php/-> e (getMessage)) "400") "error includes status code"))))))
+
+;; --- Embeddings ---
+;; Note: responses use raw JSON strings because phel\json stringifies floats
+;; during encode (e.g. 0.1 → "0.1"), which would corrupt embedding vectors.
+
+(defn- raw-ok [json-str] {:status 200 :body json-str})
+
+(deftest test-embed-openai-request-shape
+  (let [fake (mock-fn (fn [_ _] (raw-ok "{\"data\":[{\"embedding\":[0.1,0.2,0.3]},{\"embedding\":[0.4,0.5,0.6]}]}")))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:provider :openai :api-key "sk-oa"})
+        (let [result (ai/embed ["a" "b"])]
+          (is (= 2 (count result)) "returns two embeddings")
+          (is (= [0.1 0.2 0.3] (first result)) "first embedding correct")
+          (is (= [0.4 0.5 0.6] (second result)) "second embedding correct")
+          (let [call (first-call fake)]
+            (is (php/str_contains (url-of call) "api.openai.com/v1/embeddings") "hits openai embeddings")
+            (is (= "Bearer sk-oa" (get (headers-of call) :authorization)) "bearer auth")
+            (is (= "text-embedding-3-small" (get (body-of call) :model)) "uses default openai model")))
+        (reset! ai/config original)))))
+
+(deftest test-embed-voyageai-provider
+  (let [fake (mock-fn (fn [_ _] (raw-ok "{\"data\":[{\"embedding\":[0.9,0.1]}]}")))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:api-key "voy-k"})
+        (let [result (ai/embed ["x"] {:provider :voyageai})]
+          (is (= [[0.9 0.1]] result) "returns voyage embedding")
+          (let [call (first-call fake)]
+            (is (php/str_contains (url-of call) "api.voyageai.com") "hits voyage endpoint")
+            (is (= "voyage-3-lite" (get (body-of call) :model)) "uses voyage default model")))
+        (reset! ai/config original)))))
+
+(deftest test-embed-honors-model-override
+  (let [fake (mock-fn (fn [_ _] (raw-ok "{\"data\":[{\"embedding\":[0.1]}]}")))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:provider :openai :api-key "k"})
+        (ai/embed ["x"] {:model "text-embedding-3-large"})
+        (is (= "text-embedding-3-large" (get (body-of (first-call fake)) :model)) "model override reaches body")
+        (reset! ai/config original)))))
+
+(deftest test-embed-one-returns-single-vector
+  (let [fake (mock-fn (fn [_ _] (raw-ok "{\"data\":[{\"embedding\":[0.5,0.6]}]}")))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:provider :openai :api-key "k"})
+        (is (= [0.5 0.6] (ai/embed-one "hi")) "returns single embedding unwrapped")
+        (reset! ai/config original)))))
+
+;; --- build-index / search ---
+
+(deftest test-build-index-attaches-embeddings-to-texts
+  (let [fake (mock-fn (fn [_ _] (raw-ok "{\"data\":[{\"embedding\":[0.1,0.9]},{\"embedding\":[0.9,0.1]}]}")))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:provider :openai :api-key "k"})
+        (let [index (ai/build-index ["hello" "world"])
+              items (to-php-array index)]
+          (is (= 2 (count index)) "builds two index entries")
+          (is (= "hello" (get (php/aget items 0) :text)) "first text preserved")
+          (is (= [0.1 0.9] (get (php/aget items 0) :embedding)) "first embedding attached"))
+        (reset! ai/config original)))))
+
+(deftest test-search-ranks-by-similarity
+  (let [responses (atom [(raw-ok "{\"data\":[{\"embedding\":[0.99,0.01]}]}")])
+        fake (mock-fn (fn [_ _]
+                        (let [r (first @responses)]
+                          (swap! responses rest)
+                          r)))]
+    (binding [ai/*http-post* fake]
+      (let [original @ai/config]
+        (ai/configure {:provider :openai :api-key "k"})
+        (let [index [{:text "east" :embedding [1 0]}
+                     {:text "north" :embedding [0 1]}
+                     {:text "diag" :embedding [0.7071 0.7071]}]
+              results (ai/search "toward east" index {:k 2})]
+          (is (= 2 (count results)) "returns k results")
+          (is (= "east" (get (first results) :text)) "most similar first"))
+        (reset! ai/config original)))))

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -112,6 +112,46 @@
   (is (= [] (ai/tool-calls {:content nil})) "handles nil content")
   (is (= [] (ai/tool-calls {})) "handles missing content"))
 
+(deftest test-tool-calls-openai-format
+  (let [response {:choices [{:message {:role "assistant"
+                                       :content nil
+                                       :tool_calls [{:id "call_openai"
+                                                     :type "function"
+                                                     :function {:name "get-weather"
+                                                                :arguments "{\"city\":\"Paris\"}"}}]}}]}
+        calls (ai/tool-calls response)]
+    (is (= 1 (count calls)) "extracts openai tool call")
+    (is (= "get-weather" (get (first calls) :name)) "extracts openai tool name")
+    (is (= "call_openai" (get (first calls) :id)) "extracts openai tool id")
+    (is (= "Paris" (get (get (first calls) :input) :city)) "parses openai arguments json")))
+
+(deftest test-tool-calls-chat-with-tools-result
+  (let [normalized {:tool-calls [{:name "t" :id "1" :input {}}]}]
+    (is (= 1 (count (ai/tool-calls normalized))) "passes through chat-with-tools map")))
+
+;; --- Tool result ---
+
+(deftest test-tool-result-anthropic-format
+  (let [original @ai/config]
+    (ai/configure {:provider :anthropic})
+    (let [msg (ai/tool-result "call-1" "72F sunny")]
+      (is (= "user" (get msg :role)) "anthropic tool_result uses user role")
+      (let [block (first (get msg :content))]
+        (is (= "tool_result" (get block :type)) "block type is tool_result")
+        (is (= "call-1" (get block :tool_use_id)) "block carries tool_use_id")
+        (is (= "72F sunny" (get block :content)) "block carries content")))
+    (reset! ai/config original)))
+
+(deftest test-tool-result-openai-format
+  (let [msg (ai/tool-result "call-1" "42" {:provider :openai})]
+    (is (= "tool" (get msg :role)) "openai tool message uses tool role")
+    (is (= "call-1" (get msg :tool_call_id)) "openai message carries tool_call_id")
+    (is (= "42" (get msg :content)) "openai message carries content")))
+
+(deftest test-tool-result-coerces-non-string
+  (let [msg (ai/tool-result "call-1" 42 {:provider :openai})]
+    (is (= "42" (get msg :content)) "numeric result is stringified")))
+
 ;; --- Extract requires API ---
 
 (deftest test-extract-requires-api-key
@@ -250,6 +290,7 @@
   (is (function? ai/tool) "tool is defined")
   (is (function? ai/chat-with-tools) "chat-with-tools is defined")
   (is (function? ai/tool-calls) "tool-calls is defined")
+  (is (function? ai/tool-result) "tool-result is defined")
   ;; Embeddings & search
   (is (function? ai/dot-product) "dot-product is defined")
   (is (function? ai/magnitude) "magnitude is defined")


### PR DESCRIPTION
## 🤔 Background

`phel\ai` was Anthropic-only for tool use, had a hardcoded timeout, no retries, duplicated doc metadata, and no way to test behavior without hitting a real provider.

## 💡 Goal

Make `phel\ai` a provider-agnostic client with sane defaults, full behavior coverage, and a usage guide.

## 🔖 Changes

**Features**
- Tool use on Anthropic and OpenAI (`chat-with-tools`, provider-aware `tool-calls`, new `tool-result` helper)
- Retry with exponential backoff on HTTP 429 / 5xx (`:max-retries`)
- Configurable `:timeout`; per-call opts accept `:provider`, `:timeout`, `:base-url`, `:api-key`, `:max-retries`
- `chat-with-tools` returns `{:text :tool-calls :stop-reason :raw}`

**Fixes**
- `check-response` raises `RuntimeException` with the provider message instead of a PHP `TypeError` when the error body lacks the nested path
- Anthropic text extraction picks the first `text`-type block (skips leading `tool_use` blocks)
- `apply-opts` now honors `:max-retries`
- `embed` returns a materialized vector

**Tests**
- 79 → 156 tests via rebindable `ai/*http-post*` seam + `phel\mock`
- Covers happy paths, per-call overrides, retry behavior, JSON extraction edge cases, and OpenAI/Voyage embeddings without a live API

**Docs**
- `docs/ai-guide.md`: quickstart, provider matrix, tool loop, RAG, retry/timeout, testing with the HTTP seam
- CHANGELOG updated

Streaming and multimodal content deferred.