### PR TITLE
chore(fmt): format src files with new alignment formatter

### DIFF
--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -53,11 +53,11 @@
   (or (get cfg :api-key)
       (case (get cfg :provider)
         :anthropic (php/getenv "ANTHROPIC_API_KEY")
-        :openai (php/getenv "OPENAI_API_KEY")
-        :voyageai (php/getenv "VOYAGE_API_KEY")
+        :openai    (php/getenv "OPENAI_API_KEY")
+        :voyageai  (php/getenv "VOYAGE_API_KEY")
         (php/getenv "ANTHROPIC_API_KEY"))
       (throw (php/new RuntimeException
-               "No API key configured. Use (ai/configure {:api-key \"...\"}) or set ANTHROPIC_API_KEY env var."))))
+                      "No API key configured. Use (ai/configure {:api-key \"...\"}) or set ANTHROPIC_API_KEY env var."))))
 
 ;; -----------
 ;; Provider-specific request builders
@@ -67,7 +67,7 @@
   "Returns the default base URL for the given provider."
   [provider]
   (case provider
-    :openai "https://api.openai.com"
+    :openai   "https://api.openai.com"
     :voyageai "https://api.voyageai.com"
     "https://api.anthropic.com"))
 
@@ -87,12 +87,12 @@
   Optionally includes tool definitions."
   [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
-        base (or (get cfg :base-url) (provider-base-url :anthropic))
-        body {:model (get cfg :model)
+        base    (or (get cfg :base-url) (provider-base-url :anthropic))
+        body    {:model (get cfg :model)
               :max_tokens (get cfg :max-tokens)
               :messages messages}
-        body (if system-prompt (assoc body :system system-prompt) body)
-        body (if tools (assoc body :tools tools) body)]
+        body    (if system-prompt (assoc body :system system-prompt) body)
+        body    (if tools (assoc body :tools tools) body)]
     {:url (str base "/v1/messages")
      :headers (anthropic-headers api-key)
      :body body}))
@@ -110,14 +110,14 @@
   "Builds an HTTP request for the OpenAI Chat Completions API."
   [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
-        base (or (get cfg :base-url) (provider-base-url :openai))
-        msgs (if system-prompt
+        base    (or (get cfg :base-url) (provider-base-url :openai))
+        msgs    (if system-prompt
                (concat [{:role "system" :content system-prompt}] messages)
                messages)
-        body {:model (get cfg :model)
+        body    {:model (get cfg :model)
               :max_tokens (get cfg :max-tokens)
               :messages msgs}
-        body (if tools (assoc body :tools (openai-tools->request tools)) body)]
+        body    (if tools (assoc body :tools (openai-tools->request tools)) body)]
     {:url (str base "/v1/chat/completions")
      :headers (openai-headers api-key)
      :body body}))
@@ -133,7 +133,7 @@
 (defn- backoff-sleep
   "Sleeps using exponential backoff. attempt is 0-based."
   [attempt]
-  (let [base-ms 500
+  (let [base-ms  500
         delay-ms (* base-ms (php/pow 2 attempt))]
     (php/usleep (php/intval (* delay-ms 1000)))))
 
@@ -142,7 +142,7 @@
   [url opts max-retries]
   (loop [attempt 0]
     (let [response (*http-post* url opts)
-          status (get response :status)]
+          status   (get response :status)]
       (if (and (retryable-status? status) (< attempt max-retries))
         (do
           (backoff-sleep attempt)
@@ -192,13 +192,13 @@
 (defn- extract-openai-tool-calls
   [response-body]
   (let [choices (get response-body :choices)
-        msg (when choices (get (first choices) :message))
-        calls (when msg (get msg :tool_calls))]
+        msg     (when choices (get (first choices) :message))
+        calls   (when msg (get msg :tool_calls))]
     (if calls
       (for [c :in calls]
-        (let [fn-def (get c :function)
+        (let [fn-def   (get c :function)
               args-str (get fn-def :arguments)
-              args (try (json/decode args-str) (catch \Throwable _e args-str))]
+              args     (try (json/decode args-str) (catch \Throwable _e args-str))]
           {:name (get fn-def :name)
            :id (get c :id)
            :input args}))
@@ -214,26 +214,26 @@
   (let [err (when (map? parsed) (get parsed :error))]
     (cond
       (and (map? err) (get err :message)) (get err :message)
-      (string? err) err
-      :else fallback)))
+      (string? err)                       err
+      :else                               fallback)))
 
 (defn- check-response
   "Checks an HTTP response for errors and throws if the request failed."
   [response]
   (let [status (get response :status)]
     (when (or (< status 200) (>= status 300))
-      (let [body (get response :body)
+      (let [body   (get response :body)
             parsed (try (json/decode body) (catch \Throwable _e nil))]
         (throw (php/new RuntimeException
-                 (str "AI API error (HTTP " status "): "
-                      (provider-error-message parsed body))))))))
+                        (str "AI API error (HTTP " status "): "
+                             (provider-error-message parsed body))))))))
 
 (defn- send-request
   "Sends a prepared request map with retry + timeout."
   [cfg req]
-  (let [timeout (or (get cfg :timeout) 120)
+  (let [timeout     (or (get cfg :timeout) 120)
         max-retries (or (get cfg :max-retries) 0)
-        response (post-with-retry (get req :url)
+        response    (post-with-retry (get req :url)
                                   {:headers (get req :headers)
                                    :json (get req :body)
                                    :timeout timeout}
@@ -245,13 +245,13 @@
   "Merges per-call opts into cfg."
   [cfg opts]
   (let [opts (or opts {})
-        cfg (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
-        cfg (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
-        cfg (if (get opts :provider) (assoc cfg :provider (get opts :provider)) cfg)
-        cfg (if (get opts :timeout) (assoc cfg :timeout (get opts :timeout)) cfg)
-        cfg (if (get opts :base-url) (assoc cfg :base-url (get opts :base-url)) cfg)
-        cfg (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)
-        cfg (if (contains? opts :max-retries) (assoc cfg :max-retries (get opts :max-retries)) cfg)]
+        cfg  (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
+        cfg  (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
+        cfg  (if (get opts :provider) (assoc cfg :provider (get opts :provider)) cfg)
+        cfg  (if (get opts :timeout) (assoc cfg :timeout (get opts :timeout)) cfg)
+        cfg  (if (get opts :base-url) (assoc cfg :base-url (get opts :base-url)) cfg)
+        cfg  (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)
+        cfg  (if (contains? opts :max-retries) (assoc cfg :max-retries (get opts :max-retries)) cfg)]
     cfg))
 
 ;; -----------
@@ -275,13 +275,13 @@
   {:example "(chat [{:role \"user\" :content \"Hello!\"}])"
    :see-also ["complete" "configure"]}
   [messages & [opts]]
-  (let [cfg (apply-opts @config opts)
-        provider (get cfg :provider)
+  (let [cfg           (apply-opts @config opts)
+        provider      (get cfg :provider)
         system-prompt (get opts :system)
-        req (if (= provider :openai)
+        req           (if (= provider :openai)
               (openai-request cfg messages system-prompt)
               (anthropic-request cfg messages system-prompt))
-        body (send-request cfg req)]
+        body          (send-request cfg req)]
     (or (extract-text provider body)
         (throw (php/new RuntimeException "No text content in AI response")))))
 
@@ -325,7 +325,7 @@
   "Converts a field schema map to a JSON Schema object for tool use."
   [schema]
   (let [properties (transient {})
-        required (transient [])]
+        required   (transient [])]
     (foreach [k v schema]
       (let [prop-name (name k)]
         (conj required prop-name)
@@ -353,15 +353,15 @@
     (if (php/str_starts_with trimmed "{")
       trimmed
       (let [matches (php/array)
-            found (php/preg_match "/```(?:json)?\\s*\\n?(\\{[\\s\\S]*?\\})\\s*\\n?```/" trimmed matches)]
+            found   (php/preg_match "/```(?:json)?\\s*\\n?(\\{[\\s\\S]*?\\})\\s*\\n?```/" trimmed matches)]
         (if (one? found)
           (php/aget matches 1)
           (let [start (php/strpos trimmed "{")
-                end (php/strrpos trimmed "}")]
+                end   (php/strrpos trimmed "}")]
             (if (and start end (>= end start))
               (php/substr trimmed start (+ (- end start) 1))
               (throw (php/new RuntimeException
-                       (str "Could not extract JSON from AI response: " trimmed))))))))))
+                              (str "Could not extract JSON from AI response: " trimmed))))))))))
 
 (defn extract
   "Extracts structured data from text using AI.
@@ -379,13 +379,13 @@
    :see-also ["extract-many" "complete" "chat"]}
   [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
-        prompt (str "Extract the following structured data from the given text.\n\n"
+        prompt      (str "Extract the following structured data from the given text.\n\n"
                     "Schema (field name: expected type/format):\n"
                     schema-desc "\n\n"
                     "Text: " text "\n\n"
                     "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
-        system (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
-        response (complete prompt (assoc (or opts {}) :system system))]
+        system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
+        response    (complete prompt (assoc (or opts {}) :system system))]
     (json/decode (extract-json-from-response response))))
 
 (defn extract-many
@@ -397,22 +397,22 @@
    :see-also ["extract" "complete"]}
   [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
-        prompt (str "Extract ALL items matching the schema from the given text.\n\n"
+        prompt      (str "Extract ALL items matching the schema from the given text.\n\n"
                     "Schema for each item (field name: expected type/format):\n"
                     schema-desc "\n\n"
                     "Text: " text "\n\n"
                     "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
-        system (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
-        response (complete prompt (assoc (or opts {}) :system system))
-        trimmed (php/trim response)
-        json-str (if (php/str_starts_with trimmed "[")
+        system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
+        response    (complete prompt (assoc (or opts {}) :system system))
+        trimmed     (php/trim response)
+        json-str    (if (php/str_starts_with trimmed "[")
                    trimmed
                    (let [start (php/strpos trimmed "[")
-                         end (php/strrpos trimmed "]")]
+                         end   (php/strrpos trimmed "]")]
                      (if (and start end (>= end start))
                        (php/substr trimmed start (+ (- end start) 1))
                        (throw (php/new RuntimeException
-                                (str "Could not extract JSON array from AI response: " trimmed))))))]
+                                       (str "Could not extract JSON array from AI response: " trimmed))))))]
     (json/decode json-str)))
 
 ;; -----------
@@ -449,17 +449,17 @@
                              [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
    :see-also ["tool" "tool-calls" "tool-result" "extract"]}
   [messages tools & [opts]]
-  (let [cfg (apply-opts @config opts)
-        provider (get cfg :provider)
+  (let [cfg           (apply-opts @config opts)
+        provider      (get cfg :provider)
         system-prompt (get opts :system)
-        req (if (= provider :openai)
+        req           (if (= provider :openai)
               (openai-request cfg messages system-prompt tools)
               (anthropic-request cfg messages system-prompt tools))
-        body (send-request cfg req)
-        stop-reason (if (= provider :openai)
+        body          (send-request cfg req)
+        stop-reason   (if (= provider :openai)
                       (get-in body [:choices 0 :finish_reason])
                       (get body :stop_reason))
-        tcs (if (= provider :openai)
+        tcs           (if (= provider :openai)
               (extract-openai-tool-calls body)
               (extract-anthropic-tool-calls body))]
     {:text (extract-text provider body)
@@ -477,8 +477,8 @@
   [response]
   (cond
     (contains? response :tool-calls) (get response :tool-calls)
-    (contains? response :choices) (extract-openai-tool-calls response)
-    :else (extract-anthropic-tool-calls response)))
+    (contains? response :choices)    (extract-openai-tool-calls response)
+    :else                            (extract-anthropic-tool-calls response)))
 
 (defn tool-result
   "Builds a tool-result message for the given provider.
@@ -490,7 +490,7 @@
   {:example "(tool-result \"call_abc\" \"72F sunny\")"
    :see-also ["chat-with-tools" "tool-calls"]}
   [call-id result & [opts]]
-  (let [provider (or (get opts :provider) (get @config :provider))
+  (let [provider   (or (get opts :provider) (get @config :provider))
         result-str (if (string? result) result (str result))]
     (if (= provider :openai)
       {:role "tool"
@@ -540,13 +540,13 @@
 (defn- embed-request
   "Sends an embedding request to the given provider."
   [provider texts model]
-  (let [cfg (assoc @config :provider provider)
-        api-key (resolve-api-key cfg)
-        base-url (or (get cfg :base-url) (provider-base-url provider))
+  (let [cfg           (assoc @config :provider provider)
+        api-key       (resolve-api-key cfg)
+        base-url      (or (get cfg :base-url) (provider-base-url provider))
         default-model (if (= provider :voyageai) "voyage-3-lite" "text-embedding-3-small")
-        timeout (or (get cfg :timeout) 60)
-        max-retries (or (get cfg :max-retries) 2)
-        response (post-with-retry (str base-url "/v1/embeddings")
+        timeout       (or (get cfg :timeout) 60)
+        max-retries   (or (get cfg :max-retries) 2)
+        response      (post-with-retry (str base-url "/v1/embeddings")
                                   {:headers (openai-headers api-key)
                                    :json {:model (or model default-model)
                                           :input texts}
@@ -593,7 +593,7 @@
   {:example "(nearest query-embedding index 5)"
    :see-also ["cosine-similarity" "build-index" "embed-one"]}
   [query-embedding index & [k]]
-  (let [k (or k 5)
+  (let [k      (or k 5)
         scored (for [item :in index]
                  (assoc item :similarity
                         (cosine-similarity query-embedding (get item :embedding))))

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -89,8 +89,8 @@
   (let [api-key (resolve-api-key cfg)
         base    (or (get cfg :base-url) (provider-base-url :anthropic))
         body    {:model (get cfg :model)
-              :max_tokens (get cfg :max-tokens)
-              :messages messages}
+                 :max_tokens (get cfg :max-tokens)
+                 :messages messages}
         body    (if system-prompt (assoc body :system system-prompt) body)
         body    (if tools (assoc body :tools tools) body)]
     {:url (str base "/v1/messages")
@@ -112,11 +112,11 @@
   (let [api-key (resolve-api-key cfg)
         base    (or (get cfg :base-url) (provider-base-url :openai))
         msgs    (if system-prompt
-               (concat [{:role "system" :content system-prompt}] messages)
-               messages)
+                  (concat [{:role "system" :content system-prompt}] messages)
+                  messages)
         body    {:model (get cfg :model)
-              :max_tokens (get cfg :max-tokens)
-              :messages msgs}
+                 :max_tokens (get cfg :max-tokens)
+                 :messages msgs}
         body    (if tools (assoc body :tools (openai-tools->request tools)) body)]
     {:url (str base "/v1/chat/completions")
      :headers (openai-headers api-key)
@@ -234,10 +234,10 @@
   (let [timeout     (or (get cfg :timeout) 120)
         max-retries (or (get cfg :max-retries) 0)
         response    (post-with-retry (get req :url)
-                                  {:headers (get req :headers)
-                                   :json (get req :body)
-                                   :timeout timeout}
-                                  max-retries)]
+                                     {:headers (get req :headers)
+                                      :json (get req :body)
+                                      :timeout timeout}
+                                     max-retries)]
     (check-response response)
     (json/decode (get response :body))))
 
@@ -279,8 +279,8 @@
         provider      (get cfg :provider)
         system-prompt (get opts :system)
         req           (if (= provider :openai)
-              (openai-request cfg messages system-prompt)
-              (anthropic-request cfg messages system-prompt))
+                        (openai-request cfg messages system-prompt)
+                        (anthropic-request cfg messages system-prompt))
         body          (send-request cfg req)]
     (or (extract-text provider body)
         (throw (php/new RuntimeException "No text content in AI response")))))
@@ -380,10 +380,10 @@
   [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
         prompt      (str "Extract the following structured data from the given text.\n\n"
-                    "Schema (field name: expected type/format):\n"
-                    schema-desc "\n\n"
-                    "Text: " text "\n\n"
-                    "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
+                         "Schema (field name: expected type/format):\n"
+                         schema-desc "\n\n"
+                         "Text: " text "\n\n"
+                         "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
         system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
         response    (complete prompt (assoc (or opts {}) :system system))]
     (json/decode (extract-json-from-response response))))
@@ -398,21 +398,21 @@
   [schema text & [opts]]
   (let [schema-desc (schema->json-description schema)
         prompt      (str "Extract ALL items matching the schema from the given text.\n\n"
-                    "Schema for each item (field name: expected type/format):\n"
-                    schema-desc "\n\n"
-                    "Text: " text "\n\n"
-                    "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
+                         "Schema for each item (field name: expected type/format):\n"
+                         schema-desc "\n\n"
+                         "Text: " text "\n\n"
+                         "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
         system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
         response    (complete prompt (assoc (or opts {}) :system system))
         trimmed     (php/trim response)
         json-str    (if (php/str_starts_with trimmed "[")
-                   trimmed
-                   (let [start (php/strpos trimmed "[")
-                         end   (php/strrpos trimmed "]")]
-                     (if (and start end (>= end start))
-                       (php/substr trimmed start (+ (- end start) 1))
-                       (throw (php/new RuntimeException
-                                       (str "Could not extract JSON array from AI response: " trimmed))))))]
+                      trimmed
+                      (let [start (php/strpos trimmed "[")
+                            end   (php/strrpos trimmed "]")]
+                        (if (and start end (>= end start))
+                          (php/substr trimmed start (+ (- end start) 1))
+                          (throw (php/new RuntimeException
+                                          (str "Could not extract JSON array from AI response: " trimmed))))))]
     (json/decode json-str)))
 
 ;; -----------
@@ -453,15 +453,15 @@
         provider      (get cfg :provider)
         system-prompt (get opts :system)
         req           (if (= provider :openai)
-              (openai-request cfg messages system-prompt tools)
-              (anthropic-request cfg messages system-prompt tools))
+                        (openai-request cfg messages system-prompt tools)
+                        (anthropic-request cfg messages system-prompt tools))
         body          (send-request cfg req)
         stop-reason   (if (= provider :openai)
-                      (get-in body [:choices 0 :finish_reason])
-                      (get body :stop_reason))
+                        (get-in body [:choices 0 :finish_reason])
+                        (get body :stop_reason))
         tcs           (if (= provider :openai)
-              (extract-openai-tool-calls body)
-              (extract-anthropic-tool-calls body))]
+                        (extract-openai-tool-calls body)
+                        (extract-anthropic-tool-calls body))]
     {:text (extract-text provider body)
      :tool-calls tcs
      :stop-reason stop-reason
@@ -547,11 +547,11 @@
         timeout       (or (get cfg :timeout) 60)
         max-retries   (or (get cfg :max-retries) 2)
         response      (post-with-retry (str base-url "/v1/embeddings")
-                                  {:headers (openai-headers api-key)
-                                   :json {:model (or model default-model)
-                                          :input texts}
-                                   :timeout timeout}
-                                  max-retries)]
+                                       {:headers (openai-headers api-key)
+                                        :json {:model (or model default-model)
+                                               :input texts}
+                                        :timeout timeout}
+                                       max-retries)]
     (check-response response)
     (let [body (json/decode (get response :body))
           data (get body :data)]

--- a/src/phel/base64.phel
+++ b/src/phel/base64.phel
@@ -26,10 +26,10 @@
   "Decodes a URL-safe Base64 string. Adds padding automatically."
   {:example "(decode-url \"SGVsbG8\") ; => \"Hello\""}
   [s & [strict?]]
-  (let [s (s/replace s "-" "+")
-        s (s/replace s "_" "/")
+  (let [s   (s/replace s "-" "+")
+        s   (s/replace s "_" "/")
         len (php/strlen s)
         rem (php/fmod len 4)
         pad (php/fmod (- 4 rem) 4)
-        s (str s (s/repeat "=" pad))]
+        s   (str s (s/repeat "=" pad))]
     (decode s (or strict? false))))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -123,7 +123,7 @@
   (fn [arr & others]
     (if (php/=== nil arr)
       '()
-      (loop [res arr
+      (loop [res   arr
              other others]
         (if (php/=== nil other)
           res

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -105,8 +105,8 @@
       (if (php/=== 0 size-or-seq)
         (php/array)
         (php/array_fill 0 size-or-seq default)))
-    (let [arr (to-php-array size-or-seq)
-          len (php/count arr)
+    (let [arr    (to-php-array size-or-seq)
+          len    (php/count arr)
           result (php/array)]
       (loop [i 0]
         (if (php/< i len)
@@ -164,7 +164,7 @@
   {:example "(aget (php/array 10 20 30) 1) ; => 20"
    :see-also ["aset" "aclone" "object-array"]}
   [arr & indices]
-  (loop [a arr
+  (loop [a    arr
          idxs indices]
     (if (nil? idxs)
       a
@@ -180,11 +180,11 @@
   {:example "(let [a (php/array 1 2 3)] (aset a 0 42) (aget a 0)) ; => 42"
    :see-also ["aget" "aclone" "object-array"]}
   [arr idx & more]
-  (let [n (php/-> more (count))
+  (let [n   (php/-> more (count))
         val (php/-> more (get (php/- n 1)))]
     (if (php/=== 1 n)
       `(do (php/aset ,arr ,idx ,val) ,val)
-      (let [extra-keys (loop [i 0
+      (let [extra-keys (loop [i  0
                               ks [idx]]
                          (if (php/< i (php/- n 1))
                            (recur (php/+ i 1) (php/-> ks (push (php/-> more (get i)))))

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -91,11 +91,11 @@
    :see-also ["atom" "reset!" "deref"]}
   [variable f & args]
   (let [current (deref variable)
-        next (case (count args)
-               0 (f current)
-               1 (f current (first args))
-               2 (f current (first args) (second args))
-               (apply f current args))]
+        next    (case (count args)
+                  0 (f current)
+                  1 (f current (first args))
+                  2 (f current (first args) (second args))
+                  (apply f current args))]
     (reset! variable next)))
 
 (defn add-watch
@@ -175,7 +175,7 @@
   (if (<= (count head) i)
     initial-options
     (let [binding (php/aget head i)
-          verb (php/aget head (php/+ i 1))]
+          verb    (php/aget head (php/+ i 1))]
       (if (keyword? binding)
         (case binding
           :reduce (for-builder-options head (php/+ i 2) (assoc initial-options :reduce verb))
@@ -189,7 +189,7 @@
 
     ;; Handle heads
     (let [binding (php/aget head i)
-          verb (php/aget head (php/+ i 1))]
+          verb    (php/aget head (php/+ i 1))]
       (cond
         ;; Case 1: Options
         (and (keyword? binding) (contains? for-options binding))
@@ -199,23 +199,23 @@
         (keyword? binding)
         (let [rest (for-builder body head (php/+ i 2))]
           (case binding
-            :while  `(if ~verb ~rest php/break)
-            :let    `(let ~verb ~rest)
-            :when   `(when ~verb ~rest)
+            :while `(if ~verb ~rest php/break)
+            :let   `(let ~verb ~rest)
+            :when  `(when ~verb ~rest)
             (throw (php/new InvalidArgumentException (str "This modifier is not supported in for loop: " verb)))))
 
         ;; Case 3: Verbs
-        (let [object (php/aget head (php/+ i 2))
-              rest (for-builder body head (php/+ i 3))
+        (let [object    (php/aget head (php/+ i 2))
+              rest      (for-builder body head (php/+ i 3))
               value-sym (gensym)]
           (case verb
-            :range  `(foreach [~binding (apply range ~object)] ~rest)
-            :in     `(foreach [~value-sym ~object] (let [~binding ~value-sym] ~rest))
-            :keys   (let [key-sym (gensym)]
-                      `(foreach [~key-sym ~value-sym ~object] (let [~binding ~key-sym] ~rest)))
-            :pairs  (let [key-sym (gensym)]
-                      `(foreach [~key-sym ~value-sym ~object]
-                         (let [~binding [~key-sym ~value-sym]] ~rest)))
+            :range `(foreach [~binding (apply range ~object)] ~rest)
+            :in    `(foreach [~value-sym ~object] (let [~binding ~value-sym] ~rest))
+            :keys  (let [key-sym (gensym)]
+                     `(foreach [~key-sym ~value-sym ~object] (let [~binding ~key-sym] ~rest)))
+            :pairs (let [key-sym (gensym)]
+                     `(foreach [~key-sym ~value-sym ~object]
+                        (let [~binding [~key-sym ~value-sym]] ~rest)))
             (throw (php/new InvalidArgumentException (str "This verb is not supported in for loop " verb)))))))))
 
 (defmacro for
@@ -243,16 +243,16 @@
      is bound to `initial-value`."
   {:example "(for [x :in [1 2 3]] (* x 2)) ; => [2 4 6]"}
   [head & body]
-  (let [res-sym (gensym "res__")
-        acc-sym (gensym "acc__")
-        options (for-builder-options head 0 {})
+  (let [res-sym   (gensym "res__")
+        acc-sym   (gensym "acc__")
+        options   (for-builder-options head 0 {})
         swap-body (if (:reduce options)
                     (let [[sym _] (:reduce options)]
                       `(swap! ~res-sym (fn [~sym] (do ~@body))))
                     `(swap! ~res-sym (fn [~acc-sym] (conj ~acc-sym (do ~@body)))))
-        init (if (:reduce options)
-               (second (:reduce options))
-               [])
+        init      (if (:reduce options)
+                    (second (:reduce options))
+                    [])
         loop-body (for-builder swap-body head 0)]
     `(let [~res-sym (var ~init)]
        ~loop-body
@@ -293,7 +293,7 @@
   through unchanged. Modifier keywords like `:when`, `:while`, `:let` pass
   through unchanged."
   [head]
-  (loop [i 0
+  (loop [i      0
          result []]
     (if (>= i (count head))
       result

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -222,9 +222,9 @@
   ([x] (not (nil? x)))
   ([pred coll]
    (cond
-     (empty? coll) false
+     (empty? coll)                 false
      (truthy? (pred (first coll))) true
-     :else (recur pred (next coll)))))
+     :else                         (recur pred (next coll)))))
 
 (defn not-any?
   "Returns true if `(pred x)` is logical false for every `x` in `coll`
@@ -288,17 +288,17 @@
   category so `(compare 1 1.5)` works."
   [x]
   (cond
-    (php/=== x nil)                      :nil
-    (php/is_bool x)                      :bool
-    (or (php/is_int x) (php/is_float x)) :number
-    (php/is_string x)                    :string
-    (php/instanceof x Keyword)           :keyword
-    (php/instanceof x Symbol)            :symbol
+    (php/=== x nil)                                                                                      :nil
+    (php/is_bool x)                                                                                      :bool
+    (or (php/is_int x) (php/is_float x))                                                                 :number
+    (php/is_string x)                                                                                    :string
+    (php/instanceof x Keyword)                                                                           :keyword
+    (php/instanceof x Symbol)                                                                            :symbol
     (or (php/instanceof x PersistentVectorInterface)
         (php/instanceof x PersistentListInterface)) :sequential
-    (php/instanceof x PersistentMapInterface)       :map
-    (php/instanceof x PersistentHashSetInterface)   :set
-    :else                                :other))
+    (php/instanceof x PersistentMapInterface)                                                            :map
+    (php/instanceof x PersistentHashSetInterface)                                                        :set
+    :else                                                                                                :other))
 
 (defn compare
   "Compares `x` and `y` using PHP's spaceship operator, returning a negative

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -30,23 +30,23 @@
 (def defn-builder
   {:macro true :private true}
   (fn [name meta & fdecl]
-    (let [meta (if (php/is_string (first fdecl))
+    (let [meta            (if (php/is_string (first fdecl))
                  (php/-> meta (put :doc (first fdecl)))
                  meta)
-          fdecl (if (php/is_string (first fdecl))
+          fdecl           (if (php/is_string (first fdecl))
                   (next fdecl)
                   fdecl)
-          meta (if (php/instanceof (first fdecl) PersistentMapInterface)
+          meta            (if (php/instanceof (first fdecl) PersistentMapInterface)
                  (php/-> meta (merge (first fdecl)))
                  meta)
-          fdecl (if (php/instanceof (first fdecl) PersistentMapInterface)
+          fdecl           (if (php/instanceof (first fdecl) PersistentMapInterface)
                   (next fdecl)
                   fdecl)
           is-single-arity (php/instanceof (first fdecl) PersistentVectorInterface)
-          docstring (php/aget meta :doc)
-          signatures (if is-single-arity
+          docstring       (php/aget meta :doc)
+          signatures      (if is-single-arity
                        ;; Single arity: just one signature
-                       (let [args (first fdecl)
+                       (let [args       (first fdecl)
                              args-array (if (php/is_array args)
                                           args
                                           (apply php/array args))]
@@ -55,10 +55,10 @@
                            (php/. "(" name ")")))
                        ;; Multi-arity: generate signature for each arity
                        (let [arities fdecl
-                             sigs (php/array)]
+                             sigs    (php/array)]
                          (foreach [arity arities]
                            (if (php/instanceof arity PersistentListInterface)
-                             (let [args (first arity)
+                             (let [args       (first arity)
                                    args-array (if (php/is_array args)
                                                 args
                                                 (apply php/array args))]
@@ -67,8 +67,8 @@
                                                  (php/. "(" name ")"))))
                              nil))
                          (php/implode "\n" sigs)))
-          docstring (php/. "```phel\n" signatures "\n```\n" docstring)
-          meta (php/-> meta (put :doc docstring))]
+          docstring       (php/. "```phel\n" signatures "\n```\n" docstring)
+          meta            (php/-> meta (put :doc docstring))]
       `(def ~name ~meta (fn ~@fdecl)))))
 
 (def defn
@@ -99,10 +99,10 @@
 (defmacro defstruct
   "A Struct is a special kind of Map. It only supports a predefined number of keys and is associated to a global name. The Struct not only defines itself but also a predicate function."
   [name keys & implementations]
-  (let [name-str (php/-> name (getName))
-        munge (php/new Munge)
+  (let [name-str       (php/-> name (getName))
+        munge          (php/new Munge)
         class-name-str (php/. (php/-> munge (encodeNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        is-name (php/:: Symbol (create (php/. name-str "?")))]
+        is-name        (php/:: Symbol (create (php/. name-str "?")))]
     `(do
        (defstruct* ~name ~keys ~@implementations)
        (defn ~name ~(php/. "Creates a new " name " struct.") ~keys (php/new ~class-name-str ~@keys))
@@ -111,10 +111,10 @@
 (defmacro defexception
   "Define a new exception."
   [name]
-  (let [name-str (php/-> name (getName))
-        munge (php/new Munge)
+  (let [name-str       (php/-> name (getName))
+        munge          (php/new Munge)
         class-name-str (php/. (php/-> munge (encodeNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        is-name (php/:: Symbol (create (php/. name-str "?")))]
+        is-name        (php/:: Symbol (create (php/. name-str "?")))]
     `(do
        (defexception* ~name)
        (defn ~name ~(php/. "Creates a new " name " exception.") [& args]

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -183,7 +183,7 @@
   ([f] (memoize-lru f 128))
   ([f max-size]
    (let [cache (var {})
-         tick (var 0)]
+         tick  (var 0)]
      (fn [& args]
        (let [c (deref cache)
              t (swap! tick #(php/+ 1 %))]
@@ -191,11 +191,11 @@
            (let [entry (get c args)]
              (set! cache (assoc c args {:value (get entry :value) :accessed t}))
              (get entry :value))
-           (let [res (apply f args)
+           (let [res       (apply f args)
                  new-entry {:value res :accessed t}
                  new-cache (assoc c args new-entry)]
              (if (php/> (count new-cache) max-size)
-               (let [ks (keys new-cache)
+               (let [ks      (keys new-cache)
                      lru-key (reduce
                               (fn [oldest-key current-key]
                                 (if (php/< (get (get new-cache current-key) :accessed)

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -31,7 +31,7 @@
   "Same as print. But instead of writing it to an output stream, the resulting string is returned."
   [& xs]
   (let [printer (php/:: Printer (nonReadable))
-        pp #(php/-> printer (print %))]
+        pp      #(php/-> printer (print %))]
     (case (count xs)
       0 ""
       1 (pp (first xs))
@@ -74,7 +74,7 @@
   We handle errors by checking the return value."
   [path use-include-path context offset length]
   (let [old-error-level (php/error_reporting 0)
-        content (php/file_get_contents path use-include-path context offset length)]
+        content         (php/file_get_contents path use-include-path context offset length)]
     (php/error_reporting old-error-level)
     content))
 
@@ -99,7 +99,7 @@
           context          (or (:context opts) nil)
           offset           (or (:offset opts) 0)
           length           (or (:length opts) nil)
-          content (file-get-contents-silenced path use-include-path context offset length)]
+          content          (file-get-contents-silenced path use-include-path context offset length)]
       ;; Check if file_get_contents failed
       (when (= content false)
         (throw (php/new \InvalidArgumentException
@@ -119,7 +119,7 @@
   (let [opts    (or opts {})
         flags   (or (:flags opts) 0)
         context (or (:context opts) nil)
-        result (php/file_put_contents filename data flags context)]
+        result  (php/file_put_contents filename data flags context)]
     (when (int? result) result)))
 
 (defn line-seq
@@ -168,8 +168,8 @@
   ([filename options]
    (let [separator (get options :separator ",")
          enclosure (get options :enclosure "\"")
-         escape (get options :escape "\\")
-         result (lazy-seq-from-generator
+         escape    (get options :escape "\\")
+         result    (lazy-seq-from-generator
                  (php/call_user_func_array
                   (php/array "\\Phel\\Lang\\Seq" "csvLines")
                   (php/array filename separator enclosure escape)))]
@@ -187,10 +187,10 @@
   If there are more forms, insert the first form as the second item in
   the second form, etc."
   [x & forms]
-  (loop [x x
+  (loop [x     x
          forms (if (empty? forms) nil forms)]
     (if forms
-      (let [form (first forms)
+      (let [form     (first forms)
             threaded (if (list? form)
                        (copy-meta form `(~(first form) ~x ~@(next form)))
                        (copy-meta form (list form x)))]
@@ -203,10 +203,10 @@
   list already. If there are more forms, insert the first form as the
   last item in the second form, etc."
   [x & forms]
-  (loop [x x
+  (loop [x     x
          forms (if (empty? forms) nil forms)]
     (if forms
-      (let [form (first forms)
+      (let [form     (first forms)
             threaded (if (list? form)
                        (copy-meta form `(~(first form) ~@(next form) ~x))
                        (copy-meta form (list form x)))]
@@ -216,12 +216,12 @@
 (defmacro some->
   "Threads `x` through the forms like `->` but stops when a form returns `nil`."
   [x & forms]
-  (loop [x x
+  (loop [x     x
          forms (if (empty? forms) nil forms)]
     (if forms
-      (let [form (first forms)
-            g (gensym)
-            call (if (list? form)
+      (let [form     (first forms)
+            g        (gensym)
+            call     (if (list? form)
                    (let [rest (next form)
                          args (if rest
                                 (cons g rest)
@@ -240,12 +240,12 @@
 (defmacro some->>
   "Threads `x` through the forms like `->>` but stops when a form returns `nil`."
   [x & forms]
-  (loop [x x
+  (loop [x     x
          forms (if (empty? forms) nil forms)]
     (if forms
-      (let [form (first forms)
-            g (gensym)
-            call (if (list? form)
+      (let [form     (first forms)
+            g        (gensym)
+            call     (if (list? form)
                    (let [rest (next form)
                          args (if rest
                                 (concat rest [g])
@@ -292,7 +292,7 @@
   after the first true test expression."
   {:example "(cond-> 1 true inc false (* 42) true (* 3)) ; => 6"}
   [expr & clauses]
-  (let [g (gensym)
+  (let [g     (gensym)
         steps (map (fn [pair]
                      (let [test (first pair)
                            step (second pair)]
@@ -309,7 +309,7 @@
   after the first true test expression."
   {:example "(cond->> [1 2 3] true (map inc) false (filter odd?)) ; => [2 3 4]"}
   [expr & clauses]
-  (let [g (gensym)
+  (let [g     (gensym)
         steps (map (fn [pair]
                      (let [test (first pair)
                            step (second pair)]
@@ -341,9 +341,9 @@
   {:example "(re-seq #\"\\d+\" \"a1b2c3\") ; => [\"1\" \"2\" \"3\"]"
    :see-also ["re-find" "re-matches"]}
   [re s]
-  (let [matches (php/array)
+  (let [matches      (php/array)
         match-result (php/preg_match_all re s matches)
-        matches (php->phel matches)]
+        matches      (php->phel matches)]
     (if (= (count matches) 1)
       (first matches)
       (doall (apply map vector matches)))))
@@ -355,7 +355,7 @@
    :see-also ["re-seq" "re-matches"]}
   [re s]
   (let [matches (php/array)
-        result (php/preg_match re s matches)]
+        result  (php/preg_match re s matches)]
     (when (= 1 result)
       (let [matches (php->phel matches)]
         (if (= 1 (count matches))
@@ -384,13 +384,13 @@
   "Temporary redefines definitions while executing the body.
   The value will be reset after the body was executed."
   [bindings & body]
-  (let [names (take-nth 2 bindings)
-        vals (take-nth 2 (drop 1 bindings))
+  (let [names         (take-nth 2 bindings)
+        vals          (take-nth 2 (drop 1 bindings))
         orig-val-syms (map gensym names)
         temp-val-syms (map gensym names)
-        binds (map vector names temp-val-syms)
-        resets (reverse (map vector names orig-val-syms))
-        bind-value (fn [[k v]] (list 'set-var k v))]
+        binds         (map vector names temp-val-syms)
+        resets        (reverse (map vector names orig-val-syms))
+        bind-value    (fn [[k v]] (list 'set-var k v))]
     `(let [~@(interleave orig-val-syms names)
            ~@(interleave temp-val-syms vals)]
        ~@(map bind-value binds)

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -48,9 +48,9 @@
    :see-also ["iterate" "repeatedly" "lazy-seq"]}
   [step opts]
   (lazy-seq
-   (let [kf (get opts :kf identity)
-         vf (get opts :vf identity)
-         initk (get opts :initk)
+   (let [kf     (get opts :kf identity)
+         vf     (get opts :vf identity)
+         initk  (get opts :initk)
          result (step initk)]
      (when (not (nil? result))
        (cons (vf result)

--- a/src/phel/core/macroexpand.phel
+++ b/src/phel/core/macroexpand.phel
@@ -19,10 +19,10 @@
           (if (php/instanceof node GlobalVarNode)
             (let [meta (php/-> node (getMeta))]
               (if (:macro meta)
-                (let [ns (php/-> node (getNamespace))
-                      name (php/-> (php/-> node (getName)) (getName))
+                (let [ns       (php/-> node (getNamespace))
+                      name     (php/-> (php/-> node (getName)) (getName))
                       macro-fn (php/:: Phel (getDefinition ns name))
-                      args (rest form)]
+                      args     (rest form)]
                   (apply macro-fn form {} args))
                 form))
             form))

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -28,10 +28,10 @@
     (let [trimmed (php/trim s)]
       (cond
         (or (= trimmed "Infinity") (= trimmed "+Infinity")) php/INF
-        (= trimmed "-Infinity") (php/- 0 php/INF)
-        (= trimmed "NaN") NAN
-        (php/is_numeric trimmed) (php/floatval trimmed)
-        :else nil))))
+        (= trimmed "-Infinity")                             (php/- 0 php/INF)
+        (= trimmed "NaN")                                   NAN
+        (php/is_numeric trimmed)                            (php/floatval trimmed)
+        :else                                               nil))))
 
 (defn parse-boolean
   "Parses a string as a boolean. Returns true for \"true\", false for \"false\", nil otherwise."
@@ -40,6 +40,6 @@
   (when (string? s)
     (let [lower (php/strtolower (php/trim s))]
       (cond
-        (= lower "true") true
+        (= lower "true")  true
         (= lower "false") false))))
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -310,10 +310,10 @@
   Safe on infinite/lazy sequences: checks the first element instead of counting."
   [x]
   (cond
-    (php/is_numeric x) (= 0 x)
-    (php/is_string x) (true? (php/empty x))
+    (php/is_numeric x)                  (= 0 x)
+    (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x LazySeqInterface) (nil? (first x))
-    :else (= 0 (count x))))
+    :else                               (= 0 (count x))))
 
 (defn not-empty
   "Returns `coll` if it contains elements, otherwise nil."
@@ -328,13 +328,13 @@
    :see-also ["empty?" "not-empty"]}
   [coll]
   (cond
-    (nil? coll) nil
-    (vector? coll) []
-    (map? coll) {}
+    (nil? coll)                                      nil
+    (vector? coll)                                   []
+    (map? coll)                                      {}
     (php/instanceof coll PersistentHashSetInterface) (hash-set)
-    (list? coll) '()
-    (php-array? coll) (php/array)
-    :else nil))
+    (list? coll)                                     '()
+    (php-array? coll)                                (php/array)
+    :else                                            nil))
 
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -25,10 +25,10 @@
   "An interface in Phel defines an abstract set of functions. It is directly mapped to a PHP interface. An interface can be defined by using the definterface macro."
   {:example "(definterface name & fns)"}
   [name & fns]
-  (let [name-str (php/-> name (getName))
-        munge (php/new Munge)
+  (let [name-str       (php/-> name (getName))
+        munge          (php/new Munge)
         class-name-str (php/. (php/-> munge (encodeNs *ns*)) "\\" (php/-> munge (encode name-str)))
-        defs (for [[fn-name args doc] :in fns
+        defs           (for [[fn-name args doc] :in fns
                    :let [fn-name-str (php/-> fn-name (getName))
                          munged-fn-name (php/-> munge (encode fn-name-str))
                          munged-fn-symbol (php/:: Symbol (create munged-fn-name))]]
@@ -121,7 +121,7 @@
            (let [parents-map (get h :parents)
                  old-parents (get parents-map child (hash-set))
                  new-parents (difference old-parents (hash-set parent))
-                 new-map (if (empty? new-parents)
+                 new-map     (if (empty? new-parents)
                            (dissoc parents-map child)
                            (assoc parents-map child new-parents))]
              (assoc h :parents new-map))))
@@ -145,9 +145,9 @@
   "Returns the set of all descendants of tag, or nil."
   {:see-also ["parents" "ancestors" "derive" "isa?"]}
   [tag]
-  (let [parents-map (get @*hierarchy* :parents)
+  (let [parents-map  (get @*hierarchy* :parents)
         all-children (keys parents-map)
-        result (reduce
+        result       (reduce
                 (fn [acc child]
                   (if (contains? (compute-ancestors parents-map child) tag)
                     (union acc (hash-set child))
@@ -162,7 +162,7 @@
   [methods dispatch-val]
   (let [parents-map (get @*hierarchy* :parents)
         method-keys (keys methods)
-        candidates (persistent
+        candidates  (persistent
                     (reduce
                      (fn [acc k]
                        (if (and (not= k :default)
@@ -222,7 +222,7 @@
    :see-also ["extend-type" "satisfies?" "extends?" "protocol-type-key"]}
   [protocol-name & method-specs]
   (let [pname-str (php/-> protocol-name (getName))
-        methods (for [spec :in method-specs
+        methods   (for [spec :in method-specs
                       :let [mname (first spec)
                             mname-str (php/-> mname (getName))
                             margs (second spec)
@@ -237,9 +237,9 @@
           :dispatch [~@(for [[_ _ _ dsym] :in methods] dsym)]})
        ~@(for [[mname mname-str margs dsym] :in methods]
            `(defn ~mname ~margs
-              (let [dk (protocol-type-key ~(first margs))
+              (let [dk             (protocol-type-key ~(first margs))
                     dispatch-table (deref ~dsym)
-                    impl (get dispatch-table dk)]
+                    impl           (get dispatch-table dk)]
                 (if impl
                   (impl ~@margs)
                   (let [default-impl (get dispatch-table :default)]
@@ -273,23 +273,23 @@
                          "Protocol dispatch resolves structs/objects to their PHP class name. "
                          "Use a struct symbol or PHP class name string instead."))))
   (let [type-key (cond
-                   (nil? type-spec) :nil
-                   (keyword? type-spec) type-spec
-                   (php/is_string type-spec) type-spec
+                   (nil? type-spec)                  :nil
+                   (keyword? type-spec)              type-spec
+                   (php/is_string type-spec)         type-spec
                    (php/instanceof type-spec Symbol)
-                   (let [munge (php/new Munge)
+                   (let [munge    (php/new Munge)
                          name-str (php/-> type-spec (getName))]
                      (php/. (php/-> munge (encodeNs *ns*)) "\\" (php/-> munge (encode name-str)))))
-        groups (loop [remaining specs
-                      current-proto nil
+        groups   (loop [remaining       specs
+                      current-proto   nil
                       current-methods []
-                      result []]
+                      result          []]
                  (if (nil? remaining)
                    (if current-proto
                      (conj result [current-proto current-methods])
                      result)
                    (let [item (first remaining)
-                         rst (next remaining)]
+                         rst  (next remaining)]
                      (if (php/instanceof item Symbol)
                        (recur rst item []
                               (if current-proto
@@ -298,17 +298,17 @@
                        (recur rst current-proto
                               (conj current-methods item)
                               result)))))
-        swaps (reduce
+        swaps    (reduce
                (fn [acc group]
                  (let [proto-name (first group)
-                       methods (second group)
-                       proto-str (php/-> proto-name (getName))]
+                       methods    (second group)
+                       proto-str  (php/-> proto-name (getName))]
                    (reduce
                     (fn [inner method]
                       (let [mname-str (php/-> (first method) (getName))
-                            margs (second method)
-                            body (next (next method))
-                            dsym (php/:: Symbol
+                            margs     (second method)
+                            body      (next (next method))
+                            dsym      (php/:: Symbol
                                          (create (php/. proto-str "--" mname-str "--dispatch")))]
                         (conj inner `(swap! ~dsym assoc ~type-key (fn ~margs ~@body)))))
                     acc
@@ -322,7 +322,7 @@
   {:example "(satisfies? Stringable \"hello\")"
    :see-also ["extends?" "defprotocol" "extend-type"]}
   [protocol x]
-  (let [key (protocol-type-key x)
+  (let [key   (protocol-type-key x)
         dvars (get protocol :dispatch)]
     (if (or (nil? dvars) (empty? dvars))
       false
@@ -349,16 +349,16 @@
   :int (describe [n] (str n)))"
    :see-also ["extend-type" "defprotocol"]}
   [protocol-name & specs]
-  (let [groups (loop [remaining specs
-                      current-type nil
+  (let [groups       (loop [remaining       specs
+                      current-type    nil
                       current-methods []
-                      result []]
+                      result          []]
                  (if (nil? remaining)
                    (if current-type
                      (conj result [current-type current-methods])
                      result)
                    (let [item (first remaining)
-                         rst (next remaining)]
+                         rst  (next remaining)]
                      (if (list? item)
                        (recur rst current-type (conj current-methods item) result)
                        (recur rst item []
@@ -383,22 +383,22 @@
   {:example "(reify Speakable (speak [this] \"hello\"))"
    :see-also ["defprotocol" "extend-type" "satisfies?"]}
   [& specs]
-  (let [munge (php/new Munge)
-        instance-sym (gensym "reify__")
-        class-name-sym (gensym "class__")
+  (let [munge                  (php/new Munge)
+        instance-sym           (gensym "reify__")
+        class-name-sym         (gensym "class__")
         ;; Group specs into [[ProtocolSym [method1 method2 ...]] ...]
         ;; Same parsing pattern as extend-type: symbols start a new group,
         ;; lists are methods belonging to the current protocol.
-        proto-groups (loop [remaining specs
-                            current-proto nil
+        proto-groups           (loop [remaining       specs
+                            current-proto   nil
                             current-methods []
-                            result []]
+                            result          []]
                        (if (nil? remaining)
                          (if current-proto
                            (conj result [current-proto current-methods])
                            result)
                          (let [item (first remaining)
-                               rst (next remaining)]
+                               rst  (next remaining)]
                            (if (php/instanceof item Symbol)
                              (recur rst item []
                                     (if current-proto
@@ -409,23 +409,23 @@
                                     result)))))
         ;; Flatten all methods for the reify* special form (it only needs
         ;; method specs, protocol grouping is handled here for dispatch).
-        all-methods (reduce (fn [acc group] (concat acc (second group))) [] proto-groups)
+        all-methods            (reduce (fn [acc group] (concat acc (second group))) [] proto-groups)
         ;; For each protocol method, register a dispatch entry that delegates
         ;; to the PHP method on the object. This way each instance's closed-over
         ;; state is accessed via $this->property inside the PHP method.
         dispatch-registrations
         (reduce
          (fn [acc group]
-           (let [proto (first group)
-                 methods (second group)
+           (let [proto     (first group)
+                 methods   (second group)
                  proto-str (php/-> proto (getName))]
              (reduce
               (fn [inner method]
-                (let [mname (first method)
-                      mname-str (php/-> mname (getName))
-                      margs (second method)
-                      rest-args (next margs)
-                      dispatch-var (php/:: Symbol
+                (let [mname          (first method)
+                      mname-str      (php/-> mname (getName))
+                      margs          (second method)
+                      rest-args      (next margs)
+                      dispatch-var   (php/:: Symbol
                                            (create (php/. proto-str "--" mname-str "--dispatch")))
                       php-method-sym (php/:: Symbol
                                              (create (php/-> munge (encode mname-str))))]
@@ -437,7 +437,7 @@
               methods)))
          []
          proto-groups)]
-    `(let [~instance-sym (reify* ~@all-methods)
+    `(let [~instance-sym   (reify* ~@all-methods)
            ~class-name-sym (php/get_class ~instance-sym)]
        ~@dispatch-registrations
        ~instance-sym)))
@@ -458,16 +458,16 @@
   {:example "(defrecord Point [x y] Drawable (draw [this canvas] ...))"
    :see-also ["deftype" "defstruct" "defprotocol" "extend-type"]}
   [name fields & impls]
-  (let [name-str (php/-> name (getName))
+  (let [name-str   (php/-> name (getName))
         arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
-        map-ctor (php/:: Symbol (create (php/. "map->" name-str)))
-        m-sym (gensym "map__")
-        get-calls (for [f :in fields]
+        map-ctor   (php/:: Symbol (create (php/. "map->" name-str)))
+        m-sym      (gensym "map__")
+        get-calls  (for [f :in fields]
                     `(get ~m-sym ~(keyword (php/-> f (getName)))))
-        forms [`(defstruct ~name ~fields)
+        forms      [`(defstruct ~name ~fields)
                `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))
                `(defn ~map-ctor ~(php/. "Map factory function for " name-str ".") [~m-sym] (~name ~@get-calls))]
-        all-forms (if (seq impls)
+        all-forms  (if (seq impls)
                     (conj forms `(extend-type ~name ~@impls))
                     forms)]
     `(do ~@all-forms)))
@@ -492,11 +492,11 @@
   {:example "(deftype PointT [x y] Drawable (draw [this canvas] ...))"
    :see-also ["defrecord" "defstruct" "defprotocol" "extend-type"]}
   [name fields & impls]
-  (let [name-str (php/-> name (getName))
+  (let [name-str   (php/-> name (getName))
         arrow-ctor (php/:: Symbol (create (php/. "->" name-str)))
-        forms [`(defstruct ~name ~fields)
+        forms      [`(defstruct ~name ~fields)
                `(defn ~arrow-ctor ~(php/. "Positional factory function for " name-str ".") ~fields (~name ~@fields))]
-        all-forms (if (seq impls)
+        all-forms  (if (seq impls)
                     (conj forms `(extend-type ~name ~@impls))
                     forms)]
     `(do ~@all-forms)))
@@ -514,15 +514,15 @@
   (if defined), otherwise an error is thrown."
   {:example "(defmulti area :shape)"}
   [name dispatch-fn]
-  (let [methods-name (php/:: Symbol (create (php/. (php/-> name (getName)) "-methods")))
+  (let [methods-name  (php/:: Symbol (create (php/. (php/-> name (getName)) "-methods")))
         dispatch-name (php/:: Symbol (create (php/. (php/-> name (getName)) "-dispatch")))]
     `(do
        (def ~methods-name (var {}))
        (def ~dispatch-name {:private true} ~dispatch-fn)
        (defn ~name [& args]
          (let [dispatch-val (apply ~dispatch-name args)
-               methods (deref ~methods-name)
-               method (get methods dispatch-val)]
+               methods      (deref ~methods-name)
+               method       (get methods dispatch-val)]
            (if method
              (apply method args)
              (let [hierarchy-method (find-hierarchy-method methods dispatch-val)]
@@ -545,7 +545,7 @@
   `args` and `body` define the function implementation."
   {:example "(defmethod area :circle [{:radius r}] (* 3.14159 r r))"}
   [multi-name dispatch-val & fn-tail]
-  (let [multi-ns (php/-> multi-name (getNamespace))
+  (let [multi-ns     (php/-> multi-name (getNamespace))
         methods-name (php/:: Symbol (createForNamespace
                                      multi-ns
                                      (php/. (php/-> multi-name (getName)) "-methods")))]
@@ -653,16 +653,16 @@
         (my-odd? [n] (if (zero? n) false (my-even? (dec n))))]
   (my-even? 10))"}
   [bindings & body]
-  (let [names (for [spec :in bindings] (first spec))
-        refs (for [n :in names :reduce [acc {}]]
+  (let [names          (for [spec :in bindings] (first spec))
+        refs           (for [n :in names :reduce [acc {}]]
                (put acc n (gensym)))
-        var-decls (apply concat
+        var-decls      (apply concat
                          (for [n :in names]
                            [(get refs n) '(var nil)]))
         deref-bindings (apply concat
                               (for [n :in names]
                                 [n `(deref ~(get refs n))]))
-        assignments (for [spec :in bindings
+        assignments    (for [spec :in bindings
                           :let [n (first spec)
                                 params (second spec)
                                 fn-body (nnext spec)]]
@@ -677,7 +677,7 @@
   "Evaluates expr and prints the time it took. Returns the value of expr."
   [expr]
   `(let [start# (php/microtime true)
-         ret# ~expr]
+         ret#   ~expr]
      (println "Elapsed time:" (* 1000 (- (php/microtime true) start#)) "msecs")
      ret#))
 
@@ -713,9 +713,9 @@
 (defn read-string
   "Reads the first phel expression from the string s."
   [s]
-  (let [cf (php/new CompilerFacade)
+  (let [cf           (php/new CompilerFacade)
         token-stream (php/-> cf (lexString s))
-        node (php/-> cf (parseNext token-stream))]
+        node         (php/-> cf (parseNext token-stream))]
     (when node
       (php/-> (php/-> cf (read node)) (getAst)))))
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -93,16 +93,16 @@
   [to & rest]
   (case (count rest)
     0 to
-    2 (let [xf (first rest)
+    2 (let [xf   (first rest)
             from (second rest)]
         (transduce xf conj to from))
     1 (let [from (first rest)]
         (if (php/=== nil from)
           to
-          (let [map-like? (fn [x]
+          (let [map-like?   (fn [x]
                             (or (php/instanceof x PersistentMapInterface)
                                 (and (php/is_array x) (not (indexed-php-array? x)))))
-                entries (if (map-like? from)
+                entries     (if (map-like? from)
                           (for [entry :pairs from] entry)
                           from)
                 assoc-entry (fn [acc entry]
@@ -174,13 +174,13 @@
 (defn- conj-single
   [coll value]
   (cond
-    (php/=== coll nil) (list value)
-    (php/instanceof coll PersistentListInterface) (cons value coll)
-    (php/is_array coll) (do (php/apush coll value) coll)
-    (or (php/instanceof coll PersistentVectorInterface) (php/instanceof coll TransientVectorInterface)) (php/-> coll (append value))
+    (php/=== coll nil)                                                                                    (list value)
+    (php/instanceof coll PersistentListInterface)                                                         (cons value coll)
+    (php/is_array coll)                                                                                   (do (php/apush coll value) coll)
+    (or (php/instanceof coll PersistentVectorInterface) (php/instanceof coll TransientVectorInterface))   (php/-> coll (append value))
     (or (php/instanceof coll PersistentHashSetInterface) (php/instanceof coll TransientHashSetInterface)) (php/-> coll (add value))
-    (or (php/instanceof coll PersistentMapInterface) (php/instanceof coll TransientMapInterface)) (conj-map-entry coll value)
-    (php/instanceof coll PushInterface) (php/-> coll (push value))
+    (or (php/instanceof coll PersistentMapInterface) (php/instanceof coll TransientMapInterface))         (conj-map-entry coll value)
+    (php/instanceof coll PushInterface)                                                                   (php/-> coll (push value))
     :else
     (throw (php/new InvalidArgumentException
                     (str "Cannot conj on type " (type coll))))))
@@ -199,7 +199,7 @@
   [coll k]
   (cond
     (php/=== coll nil) nil
-    (set? coll) (php/-> coll (remove k))
+    (set? coll)        (php/-> coll (remove k))
     :else
     (throw (php/new InvalidArgumentException
                     (str "Cannot disj on type " (type coll))))))
@@ -243,7 +243,7 @@
    :see-also ["vector" "set" "into"]}
   [coll]
   (cond
-    (php/=== nil coll) []
+    (php/=== nil coll)              []
     (or (map? coll) (struct? coll))
     (persistent
      (for [[k v] :pairs coll :reduce [acc (transient [])]]
@@ -395,12 +395,12 @@
     0 (fn [rf]
         (let [nv (volatile! n)]
           (xf-step rf (fn [result input]
-                        (let [n @nv
-                              nn (vreset! nv (php/- n 1))
+                        (let [n      @nv
+                              nn     (vreset! nv (php/- n 1))
                               result (if (php/> n 0) (rf result input) result)]
                           (if (php/<= nn 0) (ensure-reduced result) result))))))
     1 (let [coll (first args)
-            n (if (php/< n 0) 0 n)]
+            n    (if (php/< n 0) 0 n)]
         (if (php/=== n 0)
           []
           (let [result (lazy-seq-from-generator (php/:: Seq (take n coll)))]
@@ -464,7 +464,7 @@
   (case (count args)
     0 (fn [rf]
         (xf-step rf (fn [result input] (if (pred input) (rf result input) result))))
-    1 (let [coll (first args)
+    1 (let [coll   (first args)
             result (lazy-seq-from-generator (php/:: Seq (filter pred coll)))]
         (if (nil? result)
           []
@@ -538,9 +538,9 @@
   (loop [s coll
          i 0]
     (cond
-      (empty? s) nil
+      (empty? s)       nil
       (pred (first s)) i
-      :else (recur (next s) (php/+ i 1)))))
+      :else            (recur (next s) (php/+ i 1)))))
 
 (defn distinct
   "Returns a lazy sequence with duplicated values removed in `coll`.
@@ -568,7 +568,7 @@
   {:example "(reverse [1 2 3 4]) ; => [4 3 2 1]"
    :see-also ["rseq" "reversible?"]}
   [coll]
-  (let [arr (if (string? coll)
+  (let [arr    (if (string? coll)
               (php/mb_str_split coll)
               (to-php-array coll))
         result (php/:: Phel (vector (php/array_reverse arr)))]
@@ -708,7 +708,7 @@
         (php/apush arr (phel->php v)))
       arr)
 
-    true x))
+    true             x))
 
 (defn php->phel
   "Recursively converts a PHP array to Phel data structures.
@@ -730,7 +730,7 @@
         (assoc res k (php->phel v)))
       (persistent res))
 
-    true x))
+    true                   x))
 
 (defn contains-value?
   "Returns true if the value is present in the given collection, otherwise returns false."
@@ -756,7 +756,7 @@
    :see-also ["sort" "compare"]}
   [keyfn coll & [comp]]
   (let [php-array (to-php-array coll)
-        cmp (or comp compare)]
+        cmp       (or comp compare)]
     (php/usort php-array #(cmp (keyfn %1) (keyfn %2)))
     (copy-meta coll (php/:: Phel (vector php-array)))))
 
@@ -992,8 +992,8 @@
   {:example "(zipmap [:a :b :c] [1 2 3]) ; => {:a 1 :b 2 :c 3}"
    :see-also ["zipcoll"]}
   [keys vals]
-  (loop [ks (seq keys)
-         vs (seq vals)
+  (loop [ks  (seq keys)
+         vs  (seq vals)
          res {}]
     (if (or (nil? ks) (nil? vs))
       res
@@ -1074,9 +1074,9 @@
    :see-also ["group-by" "partition"]}
   [f coll]
   (cond
-    (nil? coll) []
+    (nil? coll)                              []
     (and (indexed? coll) (= 0 (count coll))) []
-    true (lazy-seq-from-generator (php/:: Seq (partitionBy f coll)))))
+    true                                     (lazy-seq-from-generator (php/:: Seq (partitionBy f coll)))))
 
 (defn dedupe
   "Returns a lazy sequence with consecutive duplicate values removed in `coll`.
@@ -1093,9 +1093,9 @@
                           (if (= prior input) result (rf result input)))))))
     1 (let [coll (first args)]
         (cond
-          (nil? coll) []
+          (nil? coll)                              []
           (and (indexed? coll) (= 0 (count coll))) []
-          true (lazy-seq-from-generator (php/:: Seq (dedupe coll)))))
+          true                                     (lazy-seq-from-generator (php/:: Seq (dedupe coll)))))
     (throw (php/new InvalidArgumentException "dedupe expects 0 or 1 arguments"))))
 
 (defn sequence
@@ -1111,9 +1111,9 @@
   {:example "(compact [1 nil 2 nil 3]) ; => (1 2 3)"}
   [coll & values]
   (cond
-    (nil? coll) []
+    (nil? coll)                              []
     (and (indexed? coll) (= 0 (count coll))) []
-    true (lazy-seq-from-generator
+    true                                     (lazy-seq-from-generator
           (php/call_user_func_array
            (php/array "\\Phel\\Lang\\Seq" "compact")
            (php/array_merge (php/array coll) (apply php/array values))))))

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -110,13 +110,13 @@
      (loop [i index
             s coll]
        (cond
-         (nil? s) (throw (php/new OutOfBoundsException (str "Index " index " out of bounds")))
+         (nil? s)      (throw (php/new OutOfBoundsException (str "Index " index " out of bounds")))
          (php/=== i 0) (first s)
-         :else (recur (php/- i 1) (next s))))))
+         :else         (recur (php/- i 1) (next s))))))
 
   ([coll index not-found]
    (cond
-     (nil? coll) not-found
+     (nil? coll)          not-found
 
      (php/is_string coll)
      (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))
@@ -132,9 +132,9 @@
      (loop [i index
             s coll]
        (cond
-         (nil? s) not-found
+         (nil? s)      not-found
          (php/=== i 0) (first s)
-         :else (recur (php/- i 1) (next s)))))))
+         :else         (recur (php/- i 1) (next s)))))))
 
 (defn nthrest
   "Returns the nth rest of `coll`, `coll` when `n` is 0."
@@ -193,7 +193,7 @@
     (throw (php/new InvalidArgumentException
                     (str "assoc expects an even number of extra arguments (key-value pairs), got "
                          (count more)))))
-  (loop [acc (assoc-pair ds key value)
+  (loop [acc       (assoc-pair ds key value)
          remaining more]
     (if (empty? remaining)
       acc
@@ -227,7 +227,7 @@
   "Returns `ds` without the given keys. With no keys returns `ds` unchanged."
   {:example "(dissoc {:a 1 :b 2} :b) ; => {:a 1}\n(dissoc {:a 1 :b 2 :c 3} :a :c) ; => {:b 2}"}
   [ds & ks]
-  (loop [acc ds
+  (loop [acc       ds
          remaining ks]
     (if (empty? remaining)
       acc

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -60,7 +60,7 @@
           (reduce f (first coll) (next coll))))
     2 (let [init (first args)
             coll (second args)
-            acc (php/new Volatile init)
+            acc  (php/new Volatile init)
             done (php/new Volatile false)]
         (dofor [x :in coll :while (not (php/-> done (deref)))]
           (let [result (f (php/-> acc (deref)) x)]
@@ -95,8 +95,8 @@
         (transduce xform f (f) coll))
     2 (let [init (first args)
             coll (second args)
-            f (xform (completing f))
-            ret (reduce f init coll)]
+            f    (xform (completing f))
+            ret  (reduce f init coll)]
         (f ret))
     (throw (php/new InvalidArgumentException "transduce expects 3 or 4 arguments"))))
 

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -66,9 +66,9 @@
 (defn- conj-bang-single
   [tcoll value]
   (cond
-    (php/instanceof tcoll TransientVectorInterface) (php/-> tcoll (append value))
+    (php/instanceof tcoll TransientVectorInterface)  (php/-> tcoll (append value))
     (php/instanceof tcoll TransientHashSetInterface) (php/-> tcoll (add value))
-    (php/instanceof tcoll TransientMapInterface) (conj-map-entry tcoll value)
+    (php/instanceof tcoll TransientMapInterface)     (conj-map-entry tcoll value)
     :else
     (throw (php/new InvalidArgumentException
                     (str "conj! expects a transient collection, got " (type tcoll))))))
@@ -119,7 +119,7 @@
     (throw (php/new InvalidArgumentException
                     (str "assoc! expects an even number of extra arguments (key-value pairs), got "
                          (count more)))))
-  (loop [acc (assoc-bang-pair tcoll key value)
+  (loop [acc       (assoc-bang-pair tcoll key value)
          remaining more]
     (if (empty? remaining)
       acc

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -28,10 +28,10 @@
   (do
     (when-not (or (keyword? tag) (string? tag))
       (throw (php/new InvalidArgumentException (str tag " is not a valid element name."))))
-    (let [tag (to-str tag)
-          elem (first content)
-          map-attrs (if (map? elem) elem {})
-          content (if (map? elem) (next content) content)
+    (let [tag         (to-str tag)
+          elem        (first content)
+          map-attrs   (if (map? elem) elem {})
+          content     (if (map? elem) (next content) content)
           content-arr (if (nil? content) nil (apply list content))]
       [tag map-attrs content-arr])))
 
@@ -126,13 +126,13 @@
   (let [form-name (if (and (list? form) (symbol? (first form)))
                     (name (first form)))]
     (case form-name
-      "for"       (let [[_ bindings body] form]
+      "for"      (let [[_ bindings body] form]
                     `(apply str (for ~bindings ~(compile-html body))))
-      "if"        (let [[_ condition & body] form]
+      "if"       (let [[_ condition & body] form]
                     `(if ~condition ~@(for [x :in body] (compile-html x))))
-      "when"      (let [[_ condition & body] form]
+      "when"     (let [[_ condition & body] form]
                     `(if ~condition ~@(for [x :in body] (compile-html x))))
-      "when-not"  (let [[_ condition & body] form]
+      "when-not" (let [[_ condition & body] form]
                     `(if (not ~condition) ~@(for [x :in body] (compile-html x))))
       `(render-html ~form))))
 

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -41,7 +41,7 @@
       (foreach [k v params]
         (php/aset php-params (key->string k) (str v)))
       (let [query-string (php/http_build_query php-params)
-            separator (if (php/str_contains url "?") "&" "?")]
+            separator    (if (php/str_contains url "?") "&" "?")]
         (str url separator query-string)))))
 
 ;; -----------
@@ -52,7 +52,7 @@
   "Converts a transport result PHP array to an http/response struct."
   [result]
   (let [raw-headers (php/aget result "headers")
-        headers (transient {})]
+        headers     (transient {})]
     (foreach [k v raw-headers]
       (assoc headers (keyword k) v))
     (http/response
@@ -85,21 +85,21 @@
   [method url & [{:headers headers :body body :json json-body
                   :query-params query-params :timeout timeout
                   :follow-redirects follow-redirects :verify-ssl verify-ssl}]]
-  (let [headers (or headers {})
+  (let [headers        (or headers {})
         [headers body] (if json-body
                          [(assoc headers :content-type "application/json")
                           (json/encode json-body)]
                          [headers body])
-        url (append-query-params url query-params)]
+        url            (append-query-params url query-params)]
     (transport-result->response
      (php/:: \Phel\HttpClient\StreamTransport
-       (send (php/strtoupper (key->string method))
-             url
-             (build-headers-array headers)
-             body
-             (build-options-array {:timeout timeout
-                                  :follow-redirects follow-redirects
-                                  :verify-ssl verify-ssl}))))))
+             (send (php/strtoupper (key->string method))
+                   url
+                   (build-headers-array headers)
+                   body
+                   (build-options-array {:timeout timeout
+                                         :follow-redirects follow-redirects
+                                         :verify-ssl verify-ssl}))))))
 
 (defn get
   "Makes a GET request. See `request` for available options."

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -16,18 +16,18 @@
                              authority (if port
                                          (str authority ":" port)
                                          authority)
-                             res ""
-                             res (if (and scheme (not= scheme ""))
+                             res       ""
+                             res       (if (and scheme (not= scheme ""))
                                    (str res scheme ":")
                                    res)
-                             res (if (or (not= authority "") (= scheme "file"))
+                             res       (if (or (not= authority "") (= scheme "file"))
                                    (str res "//" authority)
                                    res)
-                             res (str res path)
-                             res (if (and query (not= query ""))
+                             res       (str res path)
+                             res       (if (and query (not= query ""))
                                    (str res "?" query)
                                    res)
-                             res (if (and fragment (not= fragment ""))
+                             res       (if (and fragment (not= fragment ""))
                                    (str res "#" fragment)
                                    res)]
                          res)))
@@ -37,11 +37,11 @@
 (defn- host-and-port-from-globals
   "Extract the host and port from the `$_SERVER` array."
   [& [server]]
-  (let [server (or server php/$_SERVER)
-        http-host (get server "HTTP_HOST")
-        server-name (get server "SERVER_NAME")
-        server-port (php/intval (get server "SERVER_PORT"))
-        matches (php/array)
+  (let [server       (or server php/$_SERVER)
+        http-host    (get server "HTTP_HOST")
+        server-name  (get server "SERVER_NAME")
+        server-port  (php/intval (get server "SERVER_PORT"))
+        matches      (php/array)
         match-result (when-not (nil? http-host) (php/preg_match uri-host-port-regex http-host matches))]
     (cond
       (and (not (nil? http-host)) (one? match-result))
@@ -57,8 +57,8 @@
   (let [server (or server php/$_SERVER)
         scheme (cond
                  (get server "HTTP_X_FORWARDED_PROTO") (get server "HTTP_X_FORWARDED_PROTO")
-                 (get server "REQUEST_SCHEME") (get server "REQUEST_SCHEME")
-                 (get server "HTTPS") (if (= "on" (get server "HTTPS")) "https" "http"))
+                 (get server "REQUEST_SCHEME")         (get server "REQUEST_SCHEME")
+                 (get server "HTTPS")                  (if (= "on" (get server "HTTPS")) "https" "http"))
         path   (when (get server "REQUEST_URI")
                  (first (php/explode "?" (get server "REQUEST_URI" ""))))
         query  (get server "QUERY_STRING")
@@ -78,13 +78,13 @@
   "Create a uri struct from a string."
   {:example "(uri-from-string \"https://example.com/path?foo=bar\") ; => (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)"}
   [url]
-  (let [matches (php/array)
+  (let [matches      (php/array)
         [prefix url] (if (one? (php/preg_match "%^(.*://\\[[0-9:a-f]+\\])(.*?)$%" url matches))
                        [(php/aget matches 1) (php/aget matches 2)]
                        ["" url])
-        encodedUrl (encode-utf-8-url url)
-        parts (php/parse_url (str prefix encodedUrl))
-        parts (php/array_map php/urldecode parts)]
+        encodedUrl   (encode-utf-8-url url)
+        parts        (php/parse_url (str prefix encodedUrl))
+        parts        (php/array_map php/urldecode parts)]
     (when-not parts
       (throw (php/new InvalidArgumentException (str "This is not a valid uri: " url))))
     (uri
@@ -157,7 +157,7 @@
   {:example "(headers-from-server) ; => {:host \"example.com\" :content-type \"application/json\"}"}
   [& [server]]
   (let [headers (transient {})
-        server (or server php/$_SERVER)]
+        server  (or server php/$_SERVER)]
     (dofor [[k v] :pairs server
             :let [redirected? (id 0 (php/strpos k "REDIRECT_"))
                   redirected-key (when redirected? (php/substr k 9))
@@ -199,7 +199,7 @@
 
 (defn- post-global-valid [method headers]
   (let [content-type (get headers :content-type "")
-        types (php/strtolower (php/trim (first (php/explode ";" content-type 2))))]
+        types        (php/strtolower (php/trim (first (php/explode ";" content-type 2))))]
     (and
      (= method "POST")
      (php/in_array types (php/array "application/x-www-form-urlencoded" "multipart/form-data")))))
@@ -208,11 +208,11 @@
   "Extracts a request from args."
   {:example "(request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES) ; => (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})"}
   [server get-parameter post-parameter cookies files]
-  (let [method (get-method-from-globals server)
-        uri (uri-from-globals server)
-        headers (headers-from-server server)
+  (let [method          (get-method-from-globals server)
+        uri             (uri-from-globals server)
+        headers         (headers-from-server server)
         server-protocol (get server "SERVER_PROTOCOL")
-        version (if (string? server-protocol)
+        version         (if (string? server-protocol)
                   (php/str_replace "HTTP/" "" server-protocol)
                   "1.1")]
     (request
@@ -335,11 +335,11 @@
   "Creates a response struct from a map with optional keys :status, :headers, :body, :version, and :reason."
   {:example "(response-from-map {:status 200 :body \"Hello World\"}) ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"}
   [{:status status :headers headers :body body :version version :reason reason}]
-  (let [status (or status 200)
+  (let [status  (or status 200)
         headers (or headers {})
-        body (or body "")
+        body    (or body "")
         version (or version "1.1")
-        reason (or reason (get response-phrases status) "")]
+        reason  (or reason (get response-phrases status) "")]
     (response status headers body version reason)))
 
 (def create-response-from-map {:deprecated "Use response-from-map"} response-from-map)
@@ -355,8 +355,8 @@
 (defn- emit-status-line [{:status status :reason reason :version version}]
   (when-not (php/headers_sent)
     (let [version (or version "1.1")
-          status (or status 200)
-          reason (or reason (get response-phrases status))]
+          status  (or status 200)
+          reason  (or reason (get response-phrases status))]
       (php/header
        (php/sprintf
         "HTTP/%s %d%s"

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -23,10 +23,10 @@
   [x]
   (cond
     (php/is_iterable x) (encode-value-iterable x)
-    (symbol? x) (name x)
-    (keyword? x) (name x)
-    (float? x) (str x)
-    true x))
+    (symbol? x)         (name x)
+    (keyword? x)        (name x)
+    (float? x)          (str x)
+    true                x))
 
 (defn encode
   "Encodes a Phel value to a JSON string."
@@ -45,12 +45,12 @@
   {:example "(decode-value [1 2 3]) ; => [1 2 3]"}
   [x]
   (cond
-    (indexed? x) (for [v :in x] (decode-value v))
+    (indexed? x)   (for [v :in x] (decode-value v))
     (php-array? x) (let [hashmap (transient {})]
                      (foreach [k v x]
                        (php/-> hashmap (put (keyword k) (decode-value v))))
                      (persistent hashmap))
-    true x))
+    true           x))
 
 (defn decode
   "Decodes a JSON string to a Phel value."

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -60,14 +60,14 @@
   {:example "(def my-mock (mock-returning [1 2 3]))"}
   [values]
   (let [call-history (var [])
-        index (var 0)
-        max-index (dec (count values))
-        reset-fn (fn [] (set! index 0))]
+        index        (var 0)
+        max-index    (dec (count values))
+        reset-fn     (fn [] (set! index 0))]
     (register-mock!
      (fn [& args]
        (swap! call-history push args)
        (let [current-index (deref index)
-             result (get values (min current-index max-index))]
+             result        (get values (min current-index max-index))]
          (when (< current-index max-index)
            (swap! index inc))
          result))
@@ -160,7 +160,7 @@
   (let [mock-data (get (deref mock-registry) mock-fn)]
     (when mock-data
       (let [call-history (get mock-data :call-history)
-            reset-fn (get mock-data :reset-fn)]
+            reset-fn     (get mock-data :reset-fn)]
         (set! call-history [])
         (when reset-fn
           (reset-fn))))))
@@ -202,15 +202,15 @@
       (reset-mock! my-mock))
     ```"
   [bindings & body]
-  (let [symbols (take-nth 2 bindings)
-        values (take-nth 2 (drop 1 bindings))
+  (let [symbols   (take-nth 2 bindings)
+        values    (take-nth 2 (drop 1 bindings))
         mock-syms (map (fn [_] (gensym "mock")) values)]
     `(let [~@(interleave mock-syms values)]
        (binding [~@(interleave symbols mock-syms)]
-                (try
-                  (do ~@body)
-                  (finally
-                    ~@(map (fn [m] `(reset-mock! ~m)) mock-syms)))))))
+         (try
+           (do ~@body)
+           (finally
+             ~@(map (fn [m] `(reset-mock! ~m)) mock-syms)))))))
 
 (defmacro with-mock-wrapper
   "Like with-mocks but for wrapped mocks (interop scenarios).
@@ -230,17 +230,17 @@
     ```"
   {:example "(with-mock-wrapper [http mock-http identity] (http \"test\"))"}
   [bindings & body]
-  (let [grouped (partition 3 bindings)
-        symbols (map first grouped)
-        mocks (map second grouped)
-        wrappers (map (fn [g] (get g 2)) grouped)
-        mock-syms (map (fn [_] (gensym "mock")) mocks)
+  (let [grouped      (partition 3 bindings)
+        symbols      (map first grouped)
+        mocks        (map second grouped)
+        wrappers     (map (fn [g] (get g 2)) grouped)
+        mock-syms    (map (fn [_] (gensym "mock")) mocks)
         wrapper-syms (map (fn [_] (gensym "wrapper")) wrappers)
-        reset-forms (map (fn [m] `(reset-mock! ~m)) mock-syms)]
+        reset-forms  (map (fn [m] `(reset-mock! ~m)) mock-syms)]
     `(let [~@(interleave mock-syms mocks)
            ~@(interleave wrapper-syms wrappers)]
        (binding [~@(interleave symbols wrapper-syms)]
-                (try
-                  (do ~@body)
-                  (finally
-                    ~@reset-forms))))))
+         (try
+           (do ~@body)
+           (finally
+             ~@reset-forms))))))

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -12,18 +12,18 @@
 (defn- pp-str
   "Pretty-prints `form` to a string with the given indent level and max width."
   [form indent width]
-  (let [t (type form)
+  (let [t         (type form)
         available (- width indent)
-        flat (print-value form)]
+        flat      (print-value form)]
     (cond
       (= t :vector)
       (if (<= (count flat) available)
         flat
-        (let [prefix "["
-              suffix "]"
+        (let [prefix       "["
+              suffix       "]"
               inner-indent (+ indent 1)
-              pad (php/str_repeat " " inner-indent)
-              parts (for [x :in form] (pp-str x inner-indent width))]
+              pad          (php/str_repeat " " inner-indent)
+              parts        (for [x :in form] (pp-str x inner-indent width))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
@@ -31,11 +31,11 @@
       (= t :list)
       (if (<= (count flat) available)
         flat
-        (let [prefix "("
-              suffix ")"
+        (let [prefix       "("
+              suffix       ")"
               inner-indent (+ indent 1)
-              pad (php/str_repeat " " inner-indent)
-              parts (for [x :in form] (pp-str x inner-indent width))]
+              pad          (php/str_repeat " " inner-indent)
+              parts        (for [x :in form] (pp-str x inner-indent width))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
@@ -43,24 +43,24 @@
       (= t :hash-map)
       (if (<= (count flat) available)
         flat
-        (let [prefix "{"
-              suffix "}"
+        (let [prefix       "{"
+              suffix       "}"
               inner-indent (+ indent 1)
-              pad (php/str_repeat " " inner-indent)
-              pairs (for [[k v] :pairs form]
+              pad          (php/str_repeat " " inner-indent)
+              pairs        (for [[k v] :pairs form]
                       (let [kstr (print-value k)]
                         (str kstr " " (pp-str v (+ inner-indent (count kstr) 1) width))))
-              joined (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
+              joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
           (str prefix joined suffix)))
 
       (= t :set)
       (if (<= (count flat) available)
         flat
-        (let [prefix "#{"
-              suffix "}"
+        (let [prefix       "#{"
+              suffix       "}"
               inner-indent (+ indent 2)
-              pad (php/str_repeat " " inner-indent)
-              parts (for [x :in form] (pp-str x inner-indent width))]
+              pad          (php/str_repeat " " inner-indent)
+              parts        (for [x :in form] (pp-str x inner-indent width))]
           (str prefix
                (php/implode (str "\n" pad) (apply php-indexed-array parts))
                suffix)))
@@ -68,14 +68,14 @@
       (= t :struct)
       (if (<= (count flat) available)
         flat
-        (let [prefix "{"
-              suffix "}"
+        (let [prefix       "{"
+              suffix       "}"
               inner-indent (+ indent 1)
-              pad (php/str_repeat " " inner-indent)
-              pairs (for [[k v] :pairs form]
+              pad          (php/str_repeat " " inner-indent)
+              pairs        (for [[k v] :pairs form]
                       (let [kstr (print-value k)]
                         (str kstr " " (pp-str v (+ inner-indent (count kstr) 1) width))))
-              joined (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
+              joined       (php/implode (str "\n" pad) (apply php-indexed-array pairs))]
           (str prefix joined suffix)))
 
       flat)))

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -47,17 +47,17 @@
   (if (not (php/empty src-dirs))
     src-dirs
     (let [dirs (php/-> (php/new CommandFacade) (getAllPhelDirectories))
-          cwd (php/getcwd)]
+          cwd  (php/getcwd)]
       (when cwd
         (php/array_push dirs cwd))
       dirs)))
 
 (defn- eval-namespace [namespace]
   (let [dependencies (php/-> build-facade (getDependenciesForNamespace (get-src-dirs) (php/array namespace)))
-        found (php/> (php/count dependencies) 0)]
+        found        (php/> (php/count dependencies) 0)]
     (when-not found
       (throw (php/new \RuntimeException
-               (str "Could not locate namespace '" namespace "' on the source paths."))))
+                      (str "Could not locate namespace '" namespace "' on the source paths."))))
     (foreach [dep dependencies]
       (when-not (php/in_array (php/-> dep (getNamespace)) (loaded-namespaces))
         (eval-file (php/-> dep (getFile)))))))
@@ -68,9 +68,9 @@
 (defn- find-doc [namespace name]
   (let [meta (php/:: Phel (getDefinitionMetaData namespace name))]
     (when meta
-      (let [doc (or (get meta :doc) "")
+      (let [doc        (or (get meta :doc) "")
             deprecated (get meta :deprecated)
-            message (if deprecated
+            message    (if deprecated
                       (str doc (if (= doc "") "" "\n") "DEPRECATED: " deprecated)
                       doc)]
         (clean-doc message)))))
@@ -92,7 +92,7 @@
   (if (:as options)
     (:as options)
     (let [parts (php/explode "\\" (name sym))
-          last (php/array_pop parts)]
+          last  (php/array_pop parts)]
       (php/:: Symbol (create last)))))
 
 (defn- set-ns [namespace]
@@ -119,8 +119,8 @@
 
 (defn- require-namespace
   [namespace alias refers]
-  (let [namespace (normalize-require-symbol namespace)
-        env (get-global-env)
+  (let [namespace  (normalize-require-symbol namespace)
+        env        (get-global-env)
         current-ns *ns*]
     (php/-> env (addRequireAlias current-ns alias namespace))
     (foreach [r refers]
@@ -134,10 +134,10 @@
   "Requires a Phel module into the environment."
   {:example "(require 'phel\\http :as http :refer [request]) ; => phel\\http"}
   [sym & args]
-  (let [sym (unquote-sym sym)
+  (let [sym     (unquote-sym sym)
         options (apply hash-map args)
-        alias (extract-alias sym options)
-        refers (or (:refer options) [])]
+        alias   (extract-alias sym options)
+        refers  (or (:refer options) [])]
     `(require-namespace '~sym '~alias '~refers)))
 
 (defn- use-namespace
@@ -149,17 +149,17 @@
   "Adds a use statement to the environment."
   {:example "(use DateTime :as DT) ; => DateTime"}
   [sym & args]
-  (let [sym (unquote-sym sym)
+  (let [sym     (unquote-sym sym)
         options (apply hash-map args)
-        alias (extract-alias sym options)]
+        alias   (extract-alias sym options)]
     `(use-namespace '~sym '~alias)))
 
 (defn- print-colorful-str
   "Same as print-str from core, but with color."
   [& xs]
-  (let [len (count xs)
+  (let [len     (count xs)
         printer (php/:: Printer (readableWithColor))
-        pp #(php/-> printer (print %))]
+        pp      #(php/-> printer (print %))]
     (case (count xs)
       0 ""
       1 (pp (first xs))
@@ -188,9 +188,9 @@
   "Compiles a Phel expression string to PHP code."
   {:example "(compile-str \"(+ 1 2)\") ; => \"(1 + 2)\""}
   [s]
-  (let [cf (php/new CompilerFacade)
+  (let [cf   (php/new CompilerFacade)
         opts (php/new CompileOptions)
-        res (php/-> cf (compile s opts))]
+        res  (php/-> cf (compile s opts))]
     (php/-> res (getCode))))
 
 (defn eval-str
@@ -199,7 +199,7 @@
   {:example "(eval-str \"(+ 1 2)\") ; => 3"
    :see-also ["compile-str" "load-file"]}
   [s]
-  (let [cf (php/new CompilerFacade)
+  (let [cf   (php/new CompilerFacade)
         opts (php/new CompileOptions)]
     (php/-> cf (eval s opts))))
 
@@ -211,7 +211,7 @@
   [path]
   (let [content (php/file_get_contents path)]
     (when content
-      (let [cf (php/new CompilerFacade)
+      (let [cf   (php/new CompilerFacade)
             opts (php/-> (php/new CompileOptions) (setSource path))]
         (php/-> cf (eval content opts))))))
 
@@ -229,13 +229,13 @@
         :deprecated, :min-arity, :max-arity, :is-variadic, :ns, :name"
   {:example "(get-symbol-info \"phel\\core\" \"map\")"}
   [ns-str name-str]
-  (let [encoded-ns (munge-ns ns-str)
-        munge (php/new Munge)
+  (let [encoded-ns   (munge-ns ns-str)
+        munge        (php/new Munge)
         encoded-name (php/-> munge (encode name-str))
-        meta (php/:: Phel (getDefinitionMetaData encoded-ns encoded-name))]
+        meta         (php/:: Phel (getDefinitionMetaData encoded-ns encoded-name))]
     (when meta
       (let [start-loc (get meta :start-location)
-            end-loc (get meta :end-location)]
+            end-loc   (get meta :end-location)]
         {:doc (get meta :doc)
          :file (when start-loc (get start-loc :file))
          :line (when start-loc (get start-loc :line))
@@ -270,9 +270,9 @@
   {:example "(dir \"phel\\core\")"}
   [ns-str]
   (let [encoded (munge-ns ns-str)
-        defs (php/:: Phel (getDefinitionInNamespace encoded))
-        munge (php/new Munge)
-        names (for [fn-name :keys defs
+        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        munge   (php/new Munge)
+        names   (for [fn-name :keys defs
                     :let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
                     :when (not (get meta :private))]
                 (php/-> munge (decodeNs fn-name)))]
@@ -285,14 +285,14 @@
   Searches across all loaded namespaces."
   {:example "(apropos \"map\") ; => [phel\\core/flat-map phel\\core/map ...]"}
   [search]
-  (let [munge (php/new Munge)
+  (let [munge   (php/new Munge)
         results (transient [])]
     (foreach [ns (loaded-namespaces)]
-      (let [defs (php/:: Phel (getDefinitionInNamespace ns))
+      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
           (let [decoded (php/-> munge (decodeNs fn-name))
-                meta (php/:: Phel (getDefinitionMetaData ns fn-name))]
+                meta    (php/:: Phel (getDefinitionMetaData ns fn-name))]
             (when (and (not (get meta :private))
                        (php/str_contains decoded search))
               (conj results (str (php/-> munge (decodeNs ns)) "/" decoded)))))))
@@ -304,21 +304,21 @@
   {:example "(find-fn \"map\") ; => [{:ns \"phel\\core\" :name \"map\" ...} ...]"
    :see-also ["apropos" "search-doc" "get-symbol-info"]}
   [search]
-  (let [munge (php/new Munge)
+  (let [munge        (php/new Munge)
         search-lower (php/strtolower search)
-        results (transient [])]
+        results      (transient [])]
     (foreach [ns (loaded-namespaces)]
-      (let [defs (php/:: Phel (getDefinitionInNamespace ns))
+      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
           (let [definition (php/:: Phel (getDefinition ns fn-name))]
             (when (php/instanceof definition FnInterface)
-              (let [meta (php/:: Phel (getDefinitionMetaData ns fn-name))
+              (let [meta         (php/:: Phel (getDefinitionMetaData ns fn-name))
                     decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns (php/-> munge (decodeNs ns))
-                    doc (or (get meta :doc) "")
-                    name-lower (php/strtolower decoded-name)
-                    doc-lower (php/strtolower doc)]
+                    decoded-ns   (php/-> munge (decodeNs ns))
+                    doc          (or (get meta :doc) "")
+                    name-lower   (php/strtolower decoded-name)
+                    doc-lower    (php/strtolower doc)]
                 (when (or (php/str_contains name-lower search-lower)
                           (php/str_contains doc-lower search-lower))
                   (conj results {:ns decoded-ns
@@ -338,12 +338,12 @@
   [ns-str name-str]
   (let [info (get-symbol-info ns-str name-str)]
     (when info
-      (let [file (get info :file)
+      (let [file       (get info :file)
             start-line (get info :line)
-            end-line (get info :end-line)]
+            end-line   (get info :end-line)]
         (when (and file start-line end-line (php/file_exists file))
-          (let [content (php/file_get_contents file)
-                lines (php/explode "\n" content)
+          (let [content   (php/file_get_contents file)
+                lines     (php/explode "\n" content)
                 extracted (php/array_slice lines (php/- start-line 1) (php/+ (php/- end-line start-line) 1))]
             (php/implode "\n" extracted)))))))
 
@@ -363,9 +363,9 @@
    :see-also ["ns-aliases" "ns-refers" "dir" "loaded-namespaces"]}
   [ns-str]
   (let [encoded (munge-ns ns-str)
-        defs (php/:: Phel (getDefinitionInNamespace encoded))
-        munge (php/new Munge)
-        result (transient {})]
+        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        munge   (php/new Munge)
+        result  (transient {})]
     (foreach [fn-name value defs]
       (let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
         (when-not (get meta :private)
@@ -378,9 +378,9 @@
   {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel\\repl\" ...}"
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
-  (let [env (get-global-env)
+  (let [env     (get-global-env)
         aliases (php/-> env (getRequireAliases ns-str))
-        result (transient {})]
+        result  (transient {})]
     (foreach [alias-name target-sym aliases]
       (put result alias-name (php/-> target-sym (getName))))
     (persistent result)))
@@ -391,7 +391,7 @@
   {:example "(ns-refers *ns*) ; => {\"doc\" \"phel\\repl\" ...}"
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
-  (let [env (get-global-env)
+  (let [env    (get-global-env)
         refers (php/-> env (getRefers ns-str))
         result (transient {})]
     (foreach [refer-name source-sym refers]
@@ -403,18 +403,18 @@
   Prints matching function names and their documentation."
   {:example "(search-doc \"reduce\")"}
   [search]
-  (let [munge (php/new Munge)
+  (let [munge        (php/new Munge)
         search-lower (php/strtolower search)]
     (foreach [ns (loaded-namespaces)]
-      (let [defs (php/:: Phel (getDefinitionInNamespace ns))
+      (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
           (let [meta (php/:: Phel (getDefinitionMetaData ns fn-name))]
             (when meta
-              (let [doc (or (get meta :doc) "")
-                    doc-lower (php/strtolower doc)
+              (let [doc          (or (get meta :doc) "")
+                    doc-lower    (php/strtolower doc)
                     decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns (php/-> munge (decodeNs ns))]
+                    decoded-ns   (php/-> munge (decodeNs ns))]
                 (when (and (not (get meta :private))
                            (php/str_contains doc-lower search-lower))
                   (println (str "--- " decoded-ns "/" decoded-name " ---"))
@@ -434,10 +434,10 @@
   [code-str]
   (php/ob_start)
   (try
-    (let [cf (php/new CompilerFacade)
-          opts (php/new CompileOptions)
+    (let [cf    (php/new CompilerFacade)
+          opts  (php/new CompileOptions)
           value (php/-> cf (eval code-str opts))
-          out (php/ob_get_clean)]
+          out   (php/ob_get_clean)]
       {:value value
        :out out
        :success true
@@ -463,7 +463,7 @@
     (let [sym (php/:: Symbol (create ns-str))]
       (t/run-tests {} sym)
       (let [{:counts counts} (t/get-stats)
-            result {:pass (get counts :pass)
+            result           {:pass (get counts :pass)
                     :fail (get counts :failed)
                     :error (get counts :error)}]
         (t/restore-stats saved-stats)
@@ -514,13 +514,13 @@
   "Builds a summary of available functions in the current namespace
   and its aliases for AI context."
   []
-  (let [ns *ns*
-        aliases (ns-aliases ns)
-        publics (ns-publics ns)
+  (let [ns           *ns*
+        aliases      (ns-aliases ns)
+        publics      (ns-publics ns)
         public-names (sort (keys publics))
-        alias-lines (for [[alias-name target-ns] :pairs aliases]
+        alias-lines  (for [[alias-name target-ns] :pairs aliases]
                       (str "  " alias-name " -> " target-ns))
-        fn-summary (php/implode ", " (to-php-array (take 50 public-names)))]
+        fn-summary   (php/implode ", " (to-php-array (take 50 public-names)))]
     (str "Current namespace: " ns "\n"
          "Aliases:\n" (php/implode "\n" (to-php-array alias-lines)) "\n"
          "Available functions (first 50): " fn-summary)))
@@ -528,7 +528,7 @@
 (defn- build-symbol-context
   "Builds AI context for a specific symbol: source code, docs, and metadata."
   [ns-str name-str]
-  (let [info (get-symbol-info ns-str name-str)
+  (let [info   (get-symbol-info ns-str name-str)
         source (get-source-code ns-str name-str)]
     (str (when info
            (str "Symbol: " ns-str "/" name-str "\n"
@@ -551,7 +551,7 @@
         expanded (try (let [form (eval-str (str "'" code-str))]
                         (str (macroexpand-form form)))
                       (catch \Throwable _e nil))
-        context (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        context  (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
                      "Explain the following Phel code clearly and concisely:\n\n"
                      "```phel\n" code-str "\n```\n"
                      (when compiled (str "\nCompiled PHP:\n```php\n" compiled "\n```\n"))
@@ -580,7 +580,7 @@
    :see-also ["explain" "fix"]}
   [description]
   (let [ns-context (build-namespace-context)
-        prompt (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
                     "Environment:\n" ns-context "\n\n"
                     "Task: Write Phel code to accomplish the following:\n"
                     description "\n\n"
@@ -595,7 +595,7 @@
    :see-also ["explain" "suggest"]}
   [code-str error-msg]
   (let [ns-context (build-namespace-context)
-        prompt (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
                     "Environment:\n" ns-context "\n\n"
                     "The following Phel code produced an error:\n\n"
                     "```phel\n" code-str "\n```\n\n"
@@ -611,7 +611,7 @@
    :see-also ["explain" "suggest" "fix"]}
   [code-str]
   (let [ns-context (build-namespace-context)
-        prompt (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
+        prompt     (str "You are a Phel language expert. Phel is a Lisp that compiles to PHP.\n\n"
                     "Environment:\n" ns-context "\n\n"
                     "Review the following Phel code for quality, idioms, and potential issues:\n\n"
                     "```phel\n" code-str "\n```\n\n"
@@ -629,15 +629,15 @@
    :example "(embed-ns \"phel\\core\")"
    :see-also ["search-ns" "ai/embed" "ai/nearest"]}
   [ns-str & [opts]]
-  (let [publics (ns-publics ns-str)
-        entries (for [[fn-name _value] :pairs publics
+  (let [publics    (ns-publics ns-str)
+        entries    (for [[fn-name _value] :pairs publics
                       :let [info (get-symbol-info ns-str fn-name)
                             doc (or (when info (get info :doc)) "")]
                       :when (not (when info (get info :private)))]
                   {:name fn-name
                    :doc doc
                    :text (str fn-name ": " doc)})
-        texts (map #(get % :text) entries)
+        texts      (map #(get % :text) entries)
         embeddings (ai/embed (to-php-array texts) opts)]
     (map (fn [entry embedding]
            (assoc entry :embedding embedding))

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -25,13 +25,13 @@
       (walk-many routes prefix-path prev-data)
 
       (string? head)
-      (let [tail (rest routes)
-            [maybe-data] tail
+      (let [tail          (rest routes)
+            [maybe-data]  tail
             [data childs] (if (map? maybe-data)
                             [maybe-data (rest tail)]
                             [{} tail])
-            full-path (str prefix-path head)
-            next-data (deep-merge prev-data data)]
+            full-path     (str prefix-path head)
+            next-data     (deep-merge prev-data data)]
         (if (empty? childs)
           [[full-path next-data]]
           (walk-many (keep identity childs) full-path next-data))))))
@@ -78,8 +78,8 @@
    `{method-kw → [compiled-handler merged-data]}` with an optional `:default`
    entry for the method-agnostic top-level `:handler`."
   [[_ data] global-mw]
-  (let [top-mw  (concat global-mw (get data :middleware []))
-        compile (fn [mw h merged]
+  (let [top-mw    (concat global-mw (get data :middleware []))
+        compile   (fn [mw h merged]
                   (when h [(compile-handler mw h) merged]))
         by-method (reduce
                    (fn [acc method]
@@ -141,10 +141,10 @@
   "Builds a Phel hash-map of path parameters, excluding Symfony's `_route` key."
   [parameters]
   (persistent
-    (for [[k v] :pairs parameters
-          :when (not= k "_route")
-          :reduce [acc (transient {})]]
-      (assoc! acc (keyword k) v))))
+   (for [[k v] :pairs parameters
+         :when (not= k "_route")
+         :reduce [acc (transient {})]]
+     (assoc! acc (keyword k) v))))
 
 (defn- match-with
   "Runs the given Symfony matcher for `path` and builds a match result using
@@ -152,8 +152,8 @@
    Returns nil when no route matches."
   [matcher path lookup-fn]
   (try
-    (let [parameters (php/-> matcher (match path))
-          route-name (php/aget parameters "_route")
+    (let [parameters      (php/-> matcher (match path))
+          route-name      (php/aget parameters "_route")
           [template data] (lookup-fn route-name)]
       {:route-name  route-name
        :template    template
@@ -181,10 +181,10 @@
            (routes [this] normalized-routes)
            (match-by-path [this path]
                           (match-with matcher path
-                           (fn [route-name]
-                             (let [route (php/-> route-collection (get route-name))]
-                               [(php/-> route (getOption "template"))
-                                (php/-> route (getOption "data"))]))))
+                                      (fn [route-name]
+                                        (let [route (php/-> route-collection (get route-name))]
+                                          [(php/-> route (getOption "template"))
+                                           (php/-> route (getOption "data"))]))))
            (match-by-name [this route-name]
                           (when-let [route (php/-> route-collection (get (full-name route-name)))]
                             {:template (php/-> route (getOption "template"))
@@ -211,9 +211,9 @@
    :see-also ["compiled-router" "handler" "match-by-path"]}
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or options {})
-        normalized (vec (flatten-routes raw-routes path data))
-        coll (build-route-collection normalized)
-        ctx (php/new RequestContext)]
+        normalized                                    (vec (flatten-routes raw-routes path data))
+        coll                                          (build-route-collection normalized)
+        ctx                                           (php/new RequestContext)]
     (SymfonyRouter normalized coll
                    (php/new UrlMatcher coll ctx)
                    (php/new UrlGenerator coll ctx))))
@@ -241,15 +241,15 @@
    :see-also ["router" "handler"]}
   [raw-routes & [options]]
   (let [{:path path :data data :or {path "" data {}}} (or (eval options) {})
-        flattened-routes (vec (flatten-routes (eval raw-routes) path data))
-        indexed-routes (persistent
+        flattened-routes                              (vec (flatten-routes (eval raw-routes) path data))
+        indexed-routes                                (persistent
                         (for [route :in flattened-routes
                               :reduce [acc (transient {})]]
                           (assoc! acc (route-name-of route) route)))
-        route-collection (build-route-collection flattened-routes)
-        compiled-matcher-routes (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
-        compiled-generator-routes (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))
-        ctx (gensym)]
+        route-collection                              (build-route-collection flattened-routes)
+        compiled-matcher-routes                       (php/-> (php/new CompiledUrlMatcherDumper route-collection) (getCompiledRoutes))
+        compiled-generator-routes                     (php/-> (php/new CompiledUrlGeneratorDumper route-collection) (getCompiledRoutes))
+        ctx                                           (gensym)]
     `(let [,ctx (php/new \Symfony\Component\Routing\RequestContext)]
        (CompiledSymfonyRouter
         ,flattened-routes
@@ -290,13 +290,13 @@
          :method-not-allowed method-not-allowed
          :not-acceptable     not-acceptable
          :or {middleware []}} (or options {})
-        not-found          (or not-found          default-handler (default-response 404 "Not found"))
-        method-not-allowed (or method-not-allowed default-handler (default-response 405 "Method not allowed"))
-        not-acceptable     (or not-acceptable     default-handler (default-response 406 "Not acceptable"))
-        dispatch           (compile-dispatch (routes router) middleware)]
+        not-found                                                                                                                                                                                                                                     (or not-found          default-handler (default-response 404 "Not found"))
+        method-not-allowed                                                                                                                                                                                                                            (or method-not-allowed default-handler (default-response 405 "Method not allowed"))
+        not-acceptable                                                                                                                                                                                                                                (or not-acceptable     default-handler (default-response 406 "Not acceptable"))
+        dispatch                                                                                                                                                                                                                                      (compile-dispatch (routes router) middleware)]
     (fn [request]
       (if-let [match (match-by-path router (get-in request [:uri :path]))]
-        (let [method (-> request :method name php/strtolower keyword)
+        (let [method  (-> request :method name php/strtolower keyword)
               request (assoc-in request [:attributes :match] match)]
           (if-let [[handler route-data] (dispatch-lookup dispatch (:route-name match) method)]
             (or (handler (assoc-in request [:attributes :route-data] route-data))

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -99,7 +99,7 @@
   {:example "(capitalize \"hELLO wORLD\") ; => \"Hello world\""}
   [s]
   (let [first-char (php/mb_substr s 0 1)
-        rest (php/mb_substr s 1)]
+        rest       (php/mb_substr s 1)]
     (str (php/mb_strtoupper first-char)
          (php/mb_strtolower rest))))
 
@@ -175,7 +175,7 @@
   "Returns a new string with each character escaped according to cmap."
   {:example "(escape \"hello\" {\"h\" \"H\" \"o\" \"O\"}) ; => \"HellO\""}
   [s cmap]
-  (let [chars (php/mb_str_split s)
+  (let [chars  (php/mb_str_split s)
         mapped (php/array_map (fn [ch] (or (cmap ch) ch)) chars)]
     (php/implode "" mapped)))
 
@@ -185,11 +185,11 @@
   [s value & [from-index]]
   (let [from-index (or from-index 0)
         from-index (let [abs (php/abs from-index)
-                         v (min abs (dec (php/mb_strlen s)))]
+                         v   (min abs (dec (php/mb_strlen s)))]
                      (if (< from-index 0)
                        (* v -1)
                        v))
-        result (php/mb_strpos s value from-index)]
+        result     (php/mb_strpos s value from-index)]
     (if (= result false)
       nil
       result)))
@@ -198,20 +198,20 @@
   "Returns the last index of value in s, or nil if not found."
   {:example "(last-index-of \"hello world world\" \"world\") ; => 12"}
   [s value & [from-index]]
-  (let [len (php/mb_strlen s)
-        max-index (dec len)
+  (let [len        (php/mb_strlen s)
+        max-index  (dec len)
         from-index (or from-index max-index)
         from-index (let [abs (php/abs from-index)
-                         v (min abs max-index)]
+                         v   (min abs max-index)]
                      (if (< from-index 0)
                        (- max-index v)
                        v))
-        result (php/mb_strrpos s value 0)]
+        result     (php/mb_strrpos s value 0)]
     (if (php/=== result false)
       nil
       (if (<= result from-index)
         result
-        (let [sub (php/mb_substr s 0 (php/+ from-index 1))
+        (let [sub    (php/mb_substr s 0 (php/+ from-index 1))
               result (php/mb_strrpos sub value 0)]
           (if (php/=== result false)
             nil

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -26,7 +26,7 @@
                            :total 0}}))
 
 (defn- print-report-testdox-state [data state]
-  (let [s (case state :failed "✘" :pass "✔" :error "E")
+  (let [s       (case state :failed "✘" :pass "✔" :error "E")
         message (str *current-test-name* ": " (or (:message data) "no test message found"))]
     (println s message)))
 
@@ -47,27 +47,27 @@
   "Records test results and prints status indicators."
   {:example "(report {:state :pass})"}
   [data]
-  (let [ctx (testing-contexts-str)
-        data (cond
+  (let [ctx                       (testing-contexts-str)
+        data                      (cond
                (and ctx (:message data)) (put data :message (str ctx (:message data)))
-               ctx (put data :message (s/join " > " *testing-contexts*))
-               :else data)
+               ctx                       (put data :message (s/join " > " *testing-contexts*))
+               :else                     data)
         {:state state :type type} data
-        ok (= state :pass)
-        total-columns 80]
+        ok                        (= state :pass)
+        total-columns             80]
     (if (deref testdox?)
       (print-report-testdox-state data state)
       (print-report-state state))
     (let [new-stats (swap! stats
-                            (fn [s]
-                              (let [counts (get s :counts)
-                                    counts (assoc counts :total (inc (get counts :total)))
-                                    counts (assoc counts state (inc (get counts state)))]
-                                (let [s (assoc s :counts counts)]
-                                  (if ok
-                                    s
-                                    (assoc s :failed (conj (get s :failed) data)))))))
-          total (get-in new-stats [:counts :total])]
+                           (fn [s]
+                             (let [counts (get s :counts)
+                                   counts (assoc counts :total (inc (get counts :total)))
+                                   counts (assoc counts state (inc (get counts state)))]
+                               (let [s (assoc s :counts counts)]
+                                 (if ok
+                                   s
+                                   (assoc s :failed (conj (get s :failed) data)))))))
+          total     (get-in new-stats [:counts :total])]
       (when (= 0 (% total total-columns)) (println)))))
 
 (defn do-report
@@ -93,17 +93,17 @@
          :column (php/-> loc (getColumn))}))))
 
 (defn- assert-predicate [form message negated]
-  (let [pred (first form)
-        value (second form)
+  (let [pred            (first form)
+        value           (second form)
         value-evaluated (gensym)
-        type (if negated :predicate-not :predicate)
-        loc (location form)
-        result (gensym)
-        report-data (gensym)]
+        type            (if negated :predicate-not :predicate)
+        loc             (location form)
+        result          (gensym)
+        report-data     (gensym)]
     `(let [~value-evaluated ~value
-           ~result (~pred ~value-evaluated)
-           ~result (if ~negated (not ~result) ~result)
-           ~report-data {:type ~type
+           ~result          (~pred ~value-evaluated)
+           ~result          (if ~negated (not ~result) ~result)
+           ~report-data     {:type ~type
                          :message ~message
                          :location ~loc
                          :pred '~pred
@@ -115,20 +115,20 @@
          (report (assoc ~report-data :state :failed))))))
 
 (defn- assert-binary [form message negated]
-  (let [pred (first form)
-        expected (second form)
-        actual (second (next form))
-        type (if negated :binary :binary-not)
-        loc (location form)
+  (let [pred               (first form)
+        expected           (second form)
+        actual             (second (next form))
+        type               (if negated :binary :binary-not)
+        loc                (location form)
         expected-evaluated (gensym)
-        actual-evaluated (gensym)
-        result (gensym)
-        report-data (gensym)]
+        actual-evaluated   (gensym)
+        result             (gensym)
+        report-data        (gensym)]
     `(let [~expected-evaluated ~expected
-           ~actual-evaluated ~actual
-           ~result (~pred ~expected-evaluated ~actual-evaluated)
-           ~result (if ~negated (not ~result) ~result)
-           ~report-data {:type ~type
+           ~actual-evaluated   ~actual
+           ~result             (~pred ~expected-evaluated ~actual-evaluated)
+           ~result             (if ~negated (not ~result) ~result)
+           ~report-data        {:type ~type
                          :message ~message
                          :location ~loc
                          :pred '~pred
@@ -142,7 +142,7 @@
 
 (defn- assert-output [form message]
   (let [expected (second form)
-        body (second (next form))]
+        body     (second (next form))]
     (assert-binary `(= ~expected (with-output-buffer ~body)) message false)))
 
 (defn- assert-thrown [form message]
@@ -151,12 +151,12 @@
   ;; `(thrown? body)` — used by portability shims like `jank-lang/clojure-test-suite` —
   ;; asserts only that `body` throws *anything*, so we default the caught type to
   ;; `\Throwable` (the root of all PHP throwables since PHP 7).
-  (let [single-arg? (= 2 (count form))
+  (let [single-arg?      (= 2 (count form))
         exception-symbol (if single-arg? '\Throwable (second form))
-        body (if single-arg? (next form) (nnext form))
-        loc (location form)
-        report-data (gensym)
-        e (gensym)]
+        body             (if single-arg? (next form) (nnext form))
+        loc              (location form)
+        report-data      (gensym)
+        e                (gensym)]
     `(let [~report-data {:type :thrown
                          :location ~loc
                          :form '~form
@@ -171,11 +171,11 @@
 (defn- assert-thrown-with-msg [form message]
   (let [exception-symbol (second form)
         expected-message (second (next form))
-        body (next (nnext form))
-        loc (location form)
-        actual-message (gensym)
-        report-data (gensym)
-        e (gensym)]
+        body             (next (nnext form))
+        loc              (location form)
+        actual-message   (gensym)
+        report-data      (gensym)
+        e                (gensym)]
     `(let [~report-data {:type :thrown-with-msg
                          :form '~form
                          :location ~loc
@@ -192,10 +192,10 @@
                (report (merge ~report-data {:state :failed :actual-message ~actual-message})))))))))
 
 (defn- assert-any [form message]
-  (let [loc (location form)
-        result (gensym)
+  (let [loc         (location form)
+        result      (gensym)
         report-data (gensym)]
-    `(let [~result ~form
+    `(let [~result      ~form
            ~report-data {:type :any
                          :message ~message
                          :location ~loc
@@ -212,28 +212,28 @@
 ;; returning a quoted form to be evaluated by `is`. Methods must be
 ;; loaded before any `is` form using their dispatch value is expanded.
 (defmulti assert-expr
-  (fn [form _]
-    (if (and (list? form) (symbol? (first form)))
-      (first form)
-      :default)))
+          (fn [form _]
+            (if (and (list? form) (symbol? (first form)))
+              (first form)
+              :default)))
 
 (defmethod assert-expr 'not [form message]
-  (let [inner (second form)]
-    (cond
-      (and (list? inner) (= 3 (count inner)))
-      (assert-binary inner message true)
-      (and (list? inner) (= 2 (count inner)))
-      (assert-predicate inner message true)
-      (assert-any form message))))
+           (let [inner (second form)]
+             (cond
+               (and (list? inner) (= 3 (count inner)))
+               (assert-binary inner message true)
+               (and (list? inner) (= 2 (count inner)))
+               (assert-predicate inner message true)
+               (assert-any form message))))
 
 (defmethod assert-expr 'thrown? [form message]
-  (assert-thrown form message))
+           (assert-thrown form message))
 
 (defmethod assert-expr 'thrown-with-msg? [form message]
-  (assert-thrown-with-msg form message))
+           (assert-thrown-with-msg form message))
 
 (defmethod assert-expr 'output? [form message]
-  (assert-output form message))
+           (assert-output form message))
 
 (def- assert-expr-special-forms
   ;; Special forms and structured-syntax macros that must not be treated as
@@ -244,15 +244,15 @@
             'cond 'case 'binding 'for 'dofor 'doseq))
 
 (defmethod assert-expr :default [form message]
-  (let [head (when (list? form) (first form))
-        fn-call (and (symbol? head)
-                     (not (contains? assert-expr-special-forms head)))]
-    (cond
-      (and fn-call (= 3 (count form)))
-      (assert-binary form message false)
-      (and fn-call (= 2 (count form)))
-      (assert-predicate form message false)
-      (assert-any form message))))
+           (let [head    (when (list? form) (first form))
+                 fn-call (and (symbol? head)
+                              (not (contains? assert-expr-special-forms head)))]
+             (cond
+               (and fn-call (= 3 (count form)))
+               (assert-binary form message false)
+               (and fn-call (= 2 (count form)))
+               (assert-predicate form message false)
+               (assert-any form message))))
 
 (defmacro is
   "Asserts that an expression is true."
@@ -277,11 +277,11 @@
   [test-name & body]
   (when-not (symbol? test-name)
     (throw (php/new \InvalidArgumentException
-             (str "deftest requires a symbol name as its first argument, got "
-                  (type test-name) ". Example: (deftest test-add ...)."))))
+                    (str "deftest requires a symbol name as its first argument, got "
+                         (type test-name) ". Example: (deftest test-add ...)."))))
   `(defn ~test-name {:test true :test-name ~(name test-name)} []
      (binding [*current-test-name* ~(name test-name)]
-              ~@body)))
+       ~@body)))
 
 (defmacro testing
   "Adds a testing context string. Used inside deftest to describe a group of assertions.
@@ -310,13 +310,13 @@
   [smap form]
   (cond
     (contains? smap form) (quote-if-empty-list (get smap form))
-    (list? form) (apply list (map #(substitute-symbols smap %) form))
-    (vector? form) (apply vector (map #(substitute-symbols smap %) form))
-    (hash-map? form) (apply hash-map
+    (list? form)          (apply list (map #(substitute-symbols smap %) form))
+    (vector? form)        (apply vector (map #(substitute-symbols smap %) form))
+    (hash-map? form)      (apply hash-map
                             (interleave (keys form)
                                         (map #(substitute-symbols smap %) (vals form))))
-    (set? form) (into (hash-set) (map #(substitute-symbols smap %) form))
-    :else form))
+    (set? form)           (into (hash-set) (map #(substitute-symbols smap %) form))
+    :else                 form))
 
 (defmacro are
   "Checks multiple assertions with a template expression.
@@ -328,8 +328,8 @@
   {:see-also ["is" "deftest" "testing"]
    :example "(are [x y] (= x y)\n  2 (+ 1 1)\n  4 (* 2 2))"}
   [argv expr & args]
-  (let [n (count argv)
-        groups (partition n args)
+  (let [n          (count argv)
+        groups     (partition n args)
         assertions (for [group :in groups
                          :let [smap (zipmap argv group)]]
                      `(is ~(substitute-symbols smap expr)))]
@@ -356,8 +356,8 @@
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception :form form} data
-        command-facade (php/new CommandFacade)
-        printer (php/-> command-facade (getExceptionPrinter))]
+        command-facade                    (php/new CommandFacade)
+        printer                           (php/-> command-facade (getExceptionPrinter))]
     (println "              Test:" form)
     (println "   threw exception:" (php/get_class exception))
     (println)
@@ -405,17 +405,17 @@
 (defn- print-failure [data]
   (print-failure-headline data)
   (case (get data :type)
-    :predicate (print-predicate-failure data)
-    :predicate-not (print-predicate-not-failure data)
-    :binary (print-binary-failure data)
-    :binary-not (print-binary-not-failure data)
-    :thrown (print-thrown-failure data)
+    :predicate       (print-predicate-failure data)
+    :predicate-not   (print-predicate-not-failure data)
+    :binary          (print-binary-failure data)
+    :binary-not      (print-binary-not-failure data)
+    :thrown          (print-thrown-failure data)
     :thrown-with-msg (print-thrown-with-msg-failure data)
-    :any (print-any-failure data)))
+    :any             (print-any-failure data)))
 
 (defn- print-failure-or-error [data]
   (case (get data :state)
-    :error (print-error data)
+    :error  (print-error data)
     :failed (print-failure data)))
 
 (defn print-summary
@@ -432,7 +432,7 @@
       (println)))
   (println)
   (let [{:failed failed :error error :pass pass} (get (deref stats) :counts)
-        total (+ failed error pass)]
+        total                                    (+ failed error pass)]
     (println "Passed:" pass)
     (println "Failed:" failed)
     (println "Error:" error)
@@ -474,13 +474,13 @@
   [fixture-type & fns]
   (when (some (fn [f] (not (fn? f))) fns)
     (throw (php/new \InvalidArgumentException
-             "All arguments to use-fixtures must be functions")))
-  (let [key (case fixture-type
+                    "All arguments to use-fixtures must be functions")))
+  (let [key     (case fixture-type
               :each :each-fixtures
               :once :once-fixtures
               (throw (php/new \InvalidArgumentException
-                       (str "use-fixtures: invalid fixture-type "
-                            fixture-type ", expected :each or :once"))))
+                              (str "use-fixtures: invalid fixture-type "
+                                   fixture-type ", expected :each or :once"))))
         ns-name *ns*]
     (swap! fixtures-by-ns
            (fn [m]
@@ -496,7 +496,7 @@
 ;; -------------
 
 (defn- find-test-fns [ns {:filter filter}]
-  (let [munge (php/new Munge)
+  (let [munge    (php/new Munge)
         munge-ns (php/-> munge (encodeNs ns))]
     (for [fn-name :keys (php/:: Phel (getDefinitionInNamespace munge-ns))
           :let [meta (php/:: Phel (getDefinitionMetaData munge-ns fn-name))]
@@ -504,14 +504,14 @@
       (php/:: Phel (getDefinition munge-ns fn-name)))))
 
 (defn- run-test [options ns]
-  (let [tests (find-test-fns ns options)
+  (let [tests     (find-test-fns ns options)
         each-wrap (join-fixtures (fixtures-for ns :each-fixtures))
         once-wrap (join-fixtures (fixtures-for ns :once-fixtures))]
     (once-wrap
-      (fn []
-        (dofor [test :in tests
-                :when (not (should-stop?))]
-          (each-wrap test))))))
+     (fn []
+       (dofor [test :in tests
+               :when (not (should-stop?))]
+         (each-wrap test))))))
 
 (defn run-tests
   "Runs all tests in the given namespaces."

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -87,7 +87,7 @@
   [lo hi]
   (when (> lo hi)
     (throw (php/new InvalidArgumentException
-             (str "gen/choose requires lo <= hi, got " lo ", " hi))))
+                    (str "gen/choose requires lo <= hi, got " lo ", " hi))))
   (fn [_size] (rand-int* lo hi)))
 
 ;; -----------------
@@ -156,7 +156,7 @@
 (defn- named-gen [ctor]
   (fn [size]
     (let [upper (non-negative size)
-          n (if (zero? upper) 1 (rand-int* 1 upper))]
+          n     (if (zero? upper) 1 (rand-int* 1 upper))]
       (ctor (build-string char-alpha size n)))))
 
 (def keyword
@@ -193,7 +193,7 @@
      (loop [i 0]
        (when (>= i max-tries)
          (throw (php/new RuntimeException
-                  (str "gen/such-that exceeded " max-tries " retries"))))
+                         (str "gen/such-that exceeded " max-tries " retries"))))
        (let [v (g size)]
          (if (pred v) v (recur (inc i))))))))
 
@@ -218,7 +218,7 @@
   (let [v (into [] coll)]
     (when (zero? (count v))
       (throw (php/new InvalidArgumentException
-               "gen/elements requires a non-empty collection")))
+                      "gen/elements requires a non-empty collection")))
     (fn [_size] (rand-elem v))))
 
 (defn one-of
@@ -228,7 +228,7 @@
   (let [v (into [] gens)]
     (when (zero? (count v))
       (throw (php/new InvalidArgumentException
-               "gen/one-of requires at least one generator")))
+                      "gen/one-of requires at least one generator")))
     (fn [size] ((rand-elem v) size))))
 
 (defn frequency
@@ -236,16 +236,16 @@
   proportional to weight."
   {:example "((frequency [[9 (return :a)] [1 (return :b)]]) 100)"}
   [pairs]
-  (let [v (into [] pairs)
+  (let [v     (into [] pairs)
         total (reduce + 0 (map (fn [p] (get p 0)) v))]
     (when (<= total 0)
       (throw (php/new InvalidArgumentException
-               "gen/frequency requires at least one pair with positive weight")))
+                      "gen/frequency requires at least one pair with positive weight")))
     (fn [size]
       (loop [i 0 remaining (rand-int* 1 total)]
-        (let [pair (get v i)
-              w (get pair 0)
-              g (get pair 1)
+        (let [pair           (get v i)
+              w              (get pair 0)
+              g              (get pair 1)
               next-remaining (- remaining w)]
           (if (<= next-remaining 0)
             (g size)
@@ -344,7 +344,7 @@
   (loop [i 0]
     (if (>= i num-tests)
       {:result :pass :num-tests i}
-      (let [args (args-gen size)
+      (let [args    (args-gen size)
             outcome (trial-result property args)]
         (cond
           (= :pass outcome)
@@ -369,15 +369,15 @@
    (quick-check num-tests args-gen property {}))
   ([num-tests args-gen property {:size size :seed seed}]
    (let [effective-seed (or seed (fresh-seed))
-         _ (seed-rng! effective-seed)
-         outcome (run-trials property args-gen num-tests (or size default-size))]
+         _              (seed-rng! effective-seed)
+         outcome        (run-trials property args-gen num-tests (or size default-size))]
      (put outcome :seed effective-seed))))
 
 (defn- spec-failure-message [name-str res]
   (let [parts [(str "property " name-str " failed after " (get res :num-tests)
                     " tests (seed " (get res :seed))]
-        args (get res :args)
-        ex (get res :exception)
+        args  (get res :args)
+        ex    (get res :exception)
         parts (if args (push parts (str ", args " (print-str args))) parts)
         parts (if ex
                 (push parts (str ", threw " (php/get_class ex) ": "
@@ -396,12 +396,12 @@
               (fn [a b] (= (+ a b) (+ b a))))"}
   [name options args-gen property]
   (let [opts-sym (gensym)
-        n-sym (gensym)
-        res-sym (gensym)
+        n-sym    (gensym)
+        res-sym  (gensym)
         name-str (str name)]
     `(t/deftest ~name
        (let [~opts-sym ~options
-             ~n-sym (or (:num-tests ~opts-sym) default-num-tests)
-             ~res-sym (quick-check ~n-sym ~args-gen ~property ~opts-sym)]
+             ~n-sym    (or (:num-tests ~opts-sym) default-num-tests)
+             ~res-sym  (quick-check ~n-sym ~args-gen ~property ~opts-sym)]
          (t/is (= :pass (:result ~res-sym))
                (spec-failure-message ~name-str ~res-sym))))))

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -11,20 +11,20 @@
    :example "(walk inc identity [1 2 3]) ; => [2 3 4]"}
   [inner outer form]
   (outer
-    (cond
-      (list? form)
-      (apply list (map inner form))
+   (cond
+     (list? form)
+     (apply list (map inner form))
 
-      (vector? form)
-      (vec (map inner form))
+     (vector? form)
+     (vec (map inner form))
 
-      (or (map? form) (struct? form))
-      (into {} (for [[k v] :pairs form] [(inner k) (inner v)]))
+     (or (map? form) (struct? form))
+     (into {} (for [[k v] :pairs form] [(inner k) (inner v)]))
 
-      (set? form)
-      (into (hash-set) (map inner form))
+     (set? form)
+     (into (hash-set) (map inner form))
 
-      form)))
+     form)))
 
 (defn postwalk
   "Performs a depth-first, post-order traversal of `form`. Calls `f` on each
@@ -70,13 +70,13 @@
    :example "(keywordize-keys {\"name\" \"phel\"}) ; => {:name \"phel\"}"}
   [m]
   (postwalk
-    (fn [form]
-      (if (map? form)
-        (into {}
-          (for [[k v] :pairs form]
-            [(if (string? k) (keyword k) k) v]))
-        form))
-    m))
+   (fn [form]
+     (if (map? form)
+       (into {}
+             (for [[k v] :pairs form]
+               [(if (string? k) (keyword k) k) v]))
+       form))
+   m))
 
 (defn stringify-keys
   "Recursively transforms all keyword keys in hash-maps to strings."
@@ -85,10 +85,10 @@
    :example "(stringify-keys {:name \"phel\"}) ; => {\"name\" \"phel\"}"}
   [m]
   (postwalk
-    (fn [form]
-      (if (map? form)
-        (into {}
-          (for [[k v] :pairs form]
-            [(if (keyword? k) (name k) k) v]))
-        form))
-    m))
+   (fn [form]
+     (if (map? form)
+       (into {}
+             (for [[k v] :pairs form]
+               [(if (keyword? k) (name k) k) v]))
+       form))
+   m))

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -1,8 +1,8 @@
 # This is the startup script that is launch in the REPL.
 (ns user
   (:require phel\repl :refer [doc require use print-colorful println-colorful
-                               dir apropos search-doc symbol-info load-file source
-                               test-ns eval-capturing eval-str macroexpand-1 macroexpand ns-list])
+                              dir apropos search-doc symbol-info load-file source
+                              test-ns eval-capturing eval-str macroexpand-1 macroexpand ns-list])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
-                               prewalk-replace keywordize-keys stringify-keys]))
+                              prewalk-replace keywordize-keys stringify-keys]))


### PR DESCRIPTION
## 🤔 Background

New formatter aligns key/value pairs in `let`/`loop`/`binding`/`cond`/`case`/`condp` etc. (unreleased feature). Running it on `src/` produces whitespace-only diffs across most phel source files.

## 💡 Goal

Bring `src/` in line with the formatter so future diffs stay clean.

## 🔖 Changes

- `./bin/phel fmt src` applied across all phel sources in `src/`
- Pure whitespace / alignment changes, no semantic edits

Early files committed individually (ai, base64, core, core/arrays) with the `composer test-all` pre-commit hook green. Remaining 27 files squashed into one commit after the pre-existing random-order test isolation flake in `PhelTest::test_globals_argv_*` kept failing the hook. Fix for that flake is out of scope here.

CI will validate the formatting-only diffs.