### PR TITLE
fix(test): reset GlobalEnvironmentSingleton in PhelTest setUp

### DIFF
--- a/tests/php/Integration/Phel/PhelTest.php
+++ b/tests/php/Integration/Phel/PhelTest.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Phel;
 
 use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use PHPUnit\Framework\TestCase;
 
 final class PhelTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        GlobalEnvironmentSingleton::reset();
+    }
+
     public function test_globals_argv_as_array_with_multiple_args_via_run(): void
     {
         Phel::run(__DIR__ . '/../../../../', 'phel\\testing-argv', ['k1=v1', 'additional']);


### PR DESCRIPTION
## 🤔 Background

`tests/php/Integration/Phel/PhelTest.php` cases that call `Phel::run()` intermittently fail with `Error: Value of type null is not callable` under `composer test-all`. PHPUnit runs tests in random order; PhelTest has no setUp, and `GlobalEnvironmentSingleton` retains definitions from whichever earlier tests ran first. When a later test evaluates against that polluted environment, a previously-registered macro reference resolves to `null`.

## 💡 Goal

Guarantee each PhelTest case starts from a clean global environment so results no longer depend on test order.

## 🔖 Changes

- Add `setUp` to `PhelTest` that calls `GlobalEnvironmentSingleton::reset()` before every case.

Verified locally: `rm -rf cache && composer test` passes three consecutive runs (previously flaked roughly every other run).