### PR TITLE
fix(build): detect Windows absolute cache paths (#1459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `phel build` no longer leaks stdout from compiled programs during compilation.
+- Windows compiled-code cache crash: absolute cache paths with drive letters or UNC prefixes are no longer prefixed with the app root.
 - `phel\ai` `check-response` raises a `RuntimeException` with the provider error message instead of a PHP `TypeError` when the decoded error body is missing the nested `:error :message` path.
 - `phel\ai` text extraction selects the first `text`-type content block in an Anthropic response, skipping `tool_use` blocks that precede it.
 

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -66,7 +66,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
         $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, 'cache');
 
         // If absolute path, use as-is; otherwise relative to app root
-        if (str_starts_with($cacheDir, '/') || str_starts_with($cacheDir, 'phar://')) {
+        if ($this->isAbsolutePath($cacheDir)) {
             return $cacheDir;
         }
 
@@ -76,6 +76,28 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
     public function getNamespaceCacheFile(): string
     {
         return $this->getCacheDir() . '/namespace-cache.php';
+    }
+
+    /**
+     * Cross-platform absolute-path detection so Windows cache dirs
+     * (drive letters, UNC shares) aren't mistaken for relative paths
+     * and prefixed with the app root.
+     */
+    private function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if ($path[0] === '/' || $path[0] === '\\') {
+            return true;
+        }
+
+        if (str_starts_with($path, 'phar://')) {
+            return true;
+        }
+
+        return (bool) preg_match('~^[A-Za-z]:[\\\\/]~', $path);
     }
 
     /**

--- a/tests/php/Unit/Build/BuildConfigTest.php
+++ b/tests/php/Unit/Build/BuildConfigTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build;
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Gacela;
+use Phel\Build\BuildConfig;
+use Phel\Config\PhelConfig;
+use PHPUnit\Framework\TestCase;
+
+final class BuildConfigTest extends TestCase
+{
+    public function test_posix_absolute_cache_dir_returned_as_is(): void
+    {
+        $this->bootstrapWithCacheDir('/var/cache/phel');
+
+        $config = new BuildConfig();
+
+        self::assertSame('/var/cache/phel', $config->getCacheDir());
+    }
+
+    public function test_phar_absolute_cache_dir_returned_as_is(): void
+    {
+        $this->bootstrapWithCacheDir('phar:///app.phar/cache');
+
+        $config = new BuildConfig();
+
+        self::assertSame('phar:///app.phar/cache', $config->getCacheDir());
+    }
+
+    public function test_windows_drive_letter_cache_dir_returned_as_is(): void
+    {
+        $this->bootstrapWithCacheDir('C:\\Users\\user\\AppData\\Local\\Temp\\phel\\cache');
+
+        $config = new BuildConfig();
+
+        self::assertSame(
+            'C:\\Users\\user\\AppData\\Local\\Temp\\phel\\cache',
+            $config->getCacheDir(),
+        );
+    }
+
+    public function test_windows_drive_letter_with_forward_slashes_cache_dir_returned_as_is(): void
+    {
+        $this->bootstrapWithCacheDir('C:/Users/user/AppData/Local/Temp/phel/cache');
+
+        $config = new BuildConfig();
+
+        self::assertSame(
+            'C:/Users/user/AppData/Local/Temp/phel/cache',
+            $config->getCacheDir(),
+        );
+    }
+
+    public function test_windows_unc_cache_dir_returned_as_is(): void
+    {
+        $this->bootstrapWithCacheDir('\\\\server\\share\\phel\\cache');
+
+        $config = new BuildConfig();
+
+        self::assertSame('\\\\server\\share\\phel\\cache', $config->getCacheDir());
+    }
+
+    public function test_relative_cache_dir_prefixed_with_app_root(): void
+    {
+        $this->bootstrapWithCacheDir('cache');
+
+        $config = new BuildConfig();
+
+        self::assertStringEndsWith('/cache', $config->getCacheDir());
+        self::assertNotSame('cache', $config->getCacheDir());
+    }
+
+    private function bootstrapWithCacheDir(string $cacheDir): void
+    {
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {
+            $config->addAppConfigKeyValue(PhelConfig::CACHE_DIR, $cacheDir);
+        });
+    }
+}


### PR DESCRIPTION
## 🤔 Background

On Windows, `phel` crashes when `CompiledCodeCache` is enabled. Reported in #1459:

```
RuntimeException: Directory " C:\demo\example-app/C:\Users\username\AppData\Local\Temp/phel/cache/dependency-graph" was not created
```

The app root is mistakenly prepended to the absolute Windows temp path, producing a mangled mixed-separator directory that cannot be created.

Root cause: `BuildConfig::getCacheDir()` detects absolute paths with `str_starts_with($cacheDir, '/')`. Windows absolute paths (`C:\…`, `C:/…`, `\\server\share`) don't start with `/`, so the default `sys_get_temp_dir() . '/phel/cache'` value is treated as relative and gets prefixed with `appRootDir`.

## 💡 Goal

Make compiled-code cache work on native Windows (non-WSL) without requiring the `->isCompiledCodeCacheEnabled(false)` workaround.

## 🔖 Changes

- `src/php/Build/BuildConfig.php`: add private `isAbsolutePath()` helper covering POSIX (`/…`), `phar://…`, Windows drive letters (`C:\…` / `C:/…`), and UNC (`\\server\share`) paths. Use it in `getCacheDir()`.
- `tests/php/Unit/Build/BuildConfigTest.php`: new unit test covering POSIX, phar, Windows drive letter (both separators), UNC, and relative cases.
- `CHANGELOG.md`: entry under `## Unreleased` → `### Fixed`.

Closes #1459