### PR TITLE
feat: support `new` as alias for `php/new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 - `phel\ai`: OpenAI tool use support in `chat-with-tools`; provider-aware `tool-calls` extraction; `tool-result` helper for building tool result messages.

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -9,7 +9,7 @@ Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know 
 | `(ns my.app (:require [clojure.string :as str]))` | `(ns my\app (:require phel\string :as str))` | `\` separator; `.` also works |
 | `(.method obj arg)` | `(php/-> obj (method arg))` | Instance method |
 | `(Class/staticMethod arg)` | `(php/:: Class (method arg))` | Static method |
-| `(ClassName. arg)` | `(ClassName. arg)` or `(php/new ClassName arg)` | `ClassName.` reads as `(php/new ClassName ...)` |
+| `(ClassName. arg)` | `(ClassName. arg)`, `(new ClassName arg)`, or `(php/new ClassName arg)` | `ClassName.` and `new` both read as `(php/new ClassName ...)` |
 | `(.-field obj)` | `(php/-> obj -field)` | Property access |
 | `(:import [java.util Date])` | `(:use DateTime)` in the `ns` form | Imports a PHP class by short name; also works with FQNs: `(:use Phel\Lang\Symbol)` |
 | `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | Phel ships an `instance?` macro that wraps `php/instanceof` with Clojure's argument order |

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -9,7 +9,7 @@ This guide shows how to seamlessly work between PHP and Phel code.
 | Call function | `strlen($str)` | `(php/strlen str)` |
 | Method call | `$obj->method($arg)` | `(php/-> obj (method arg))` |
 | Static call | `DateTime::createFromFormat(...)` | `(php/:: DateTime (createFromFormat ...))` |
-| New instance | `new DateTime()` | `(php/new DateTime)` or `(DateTime.)` |
+| New instance | `new DateTime()` | `(php/new DateTime)`, `(new DateTime)`, or `(DateTime.)` |
 | Property access | `$obj->prop` | `(php/-> obj -prop)` |
 | Array access | `$arr[$key]` | `(php/aget arr key)` |
 
@@ -42,9 +42,10 @@ Prefix PHP functions with `php/`:
 (ns app\example
   (:use DateTime DateInterval))
 
-;; Create instance (both forms are equivalent)
+;; Create instance (all forms are equivalent)
 (def now (php/new DateTime))
-(def now (DateTime.))   ; Clojure-style shorthand for (php/new DateTime)
+(def now (new DateTime))
+(def now (DateTime.))
 
 ;; Call methods
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -159,7 +159,7 @@ final class AnalyzePersistentList
             Symbol::NAME_IF => new IfSymbol($this->analyzer),
             Symbol::NAME_APPLY => new ApplySymbol($this->analyzer),
             Symbol::NAME_LET => new LetSymbol($this->analyzer, new Deconstructor(new BindingValidator())),
-            Symbol::NAME_PHP_NEW => new PhpNewSymbol($this->analyzer),
+            Symbol::NAME_PHP_NEW, Symbol::NAME_NEW => new PhpNewSymbol($this->analyzer),
             Symbol::NAME_PHP_OBJECT_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: false),
             Symbol::NAME_PHP_OBJECT_STATIC_CALL => new PhpObjectCallSymbol($this->analyzer, isStatic: true),
             Symbol::NAME_PHP_ARRAY_GET => new PhpAGetSymbol($this->analyzer),

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -50,6 +50,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
 
     public const string NAME_PHP_NEW = 'php/new';
 
+    public const string NAME_NEW = 'new';
+
     public const string NAME_PHP_OBJECT_CALL = 'php/->';
 
     public const string NAME_PHP_OBJECT_STATIC_CALL = 'php/::';

--- a/tests/php/Integration/Fixtures/New/new-keyword-with-args.test
+++ b/tests/php/Integration/Fixtures/New/new-keyword-with-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(new \DateTimeImmutable "2020-03-22" (new \DateTimeZone "Europe/Berlin"))
+--PHP--
+(new \DateTimeImmutable("2020-03-22", (new \DateTimeZone("Europe/Berlin"))));

--- a/tests/php/Integration/Fixtures/New/new-keyword-zero-args.test
+++ b/tests/php/Integration/Fixtures/New/new-keyword-zero-args.test
@@ -1,0 +1,4 @@
+--PHEL--
+(new \DateTimeImmutable)
+--PHP--
+(new \DateTimeImmutable());

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -126,6 +126,14 @@ final class AnalyzePersistentListTest extends TestCase
         self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
     }
 
+    public function test_symbol_with_name_new(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NEW), '',
+        ]);
+        self::assertInstanceOf(PhpNewNode::class, $this->listAnalyzer->analyze($list, NodeEnvironment::empty()));
+    }
+
     public function test_symbol_with_name_php_object_call(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

Closes #1464.

Phel already supports `(ClassName. args)` as shorthand for `(php/new ClassName args)` (PR #1425). Clojure also exposes a plain `new` special form, which the dot shorthand macroexpands to. Adding `new` as an alias makes the interop easier to discover for Clojure users and lets shared `.cljc`-style code work with fewer Phel-specific branches.

## 💡 Goal

Accept `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.

## 🔖 Changes

- Added `Symbol::NAME_NEW` constant.
- `AnalyzePersistentList` dispatches both `php/new` and `new` to `PhpNewSymbol`.
- Integration fixtures `new-keyword-zero-args.test` and `new-keyword-with-args.test`.
- Unit test covers the new dispatch in `AnalyzePersistentListTest`.
- Updated `docs/php-interop.md` and `docs/clojure-migration.md` with the new form.
- CHANGELOG entry under `Unreleased`.