### PR TITLE
feat: def evaluates to a printable var reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.
+- `def` evaluates to a printable var reference (e.g. `#'user/my-var`) instead of `nil`, making REPL feedback explicit.
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.
 - Formatter aligns key/value pairs in `cond`, `case`, `condp`, and binding vectors of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let` when pairs span multiple lines.
 - `phel\ai`: OpenAI tool use support in `chat-with-tools`; provider-aware `tool-calls` extraction; `tool-result` helper for building tool result messages.

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -39,6 +39,7 @@ final class DefEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitLine('}');
         }
 
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitLine('\\Phel::addDefinition(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -41,10 +41,12 @@ final class Registry
         $this->definitionsMetaData = [];
     }
 
-    public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): void
+    public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): VarReference
     {
         $this->definitions[$ns][$name] = $value;
         $this->definitionsMetaData[$ns][$name] = $metaData;
+
+        return new VarReference($ns, $name);
     }
 
     public function hasDefinition(string $ns, string $name): bool

--- a/src/php/Lang/VarReference.php
+++ b/src/php/Lang/VarReference.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+/**
+ * A reference to a global definition created by `def`.
+ *
+ * Evaluating `(def my-var 123)` returns a `VarReference` which prints as
+ * `#'ns/my-var`, giving REPL users a non-nil confirmation that mirrors
+ * the Var reference used in other Lisp dialects.
+ */
+final readonly class VarReference
+{
+    public function __construct(
+        private string $namespace,
+        private string $name,
+    ) {}
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getFullName(): string
+    {
+        return $this->namespace . '/' . $this->name;
+    }
+}

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -14,6 +14,7 @@ use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\Variable;
+use Phel\Lang\VarReference;
 use Phel\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Printer\TypePrinter\ArrayPrinter;
 use Phel\Printer\TypePrinter\BooleanPrinter;
@@ -35,6 +36,7 @@ use Phel\Printer\TypePrinter\SymbolPrinter;
 use Phel\Printer\TypePrinter\ToStringPrinter;
 use Phel\Printer\TypePrinter\TypePrinterInterface;
 use Phel\Printer\TypePrinter\VariablePrinter;
+use Phel\Printer\TypePrinter\VarReferencePrinter;
 use ReflectionClass;
 use RuntimeException;
 
@@ -116,6 +118,10 @@ final readonly class Printer implements PrinterInterface
 
         if ($form instanceof Variable) {
             return new VariablePrinter($this);
+        }
+
+        if ($form instanceof VarReference) {
+            return new VarReferencePrinter($this->withColor);
         }
 
         if ($form instanceof FnInterface) {

--- a/src/php/Printer/TypePrinter/VarReferencePrinter.php
+++ b/src/php/Printer/TypePrinter/VarReferencePrinter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Printer\TypePrinter;
+
+use Phel\Lang\VarReference;
+
+use function sprintf;
+
+/**
+ * @implements TypePrinterInterface<VarReference>
+ */
+final class VarReferencePrinter implements TypePrinterInterface
+{
+    use WithColorTrait;
+
+    /**
+     * @param VarReference $form
+     */
+    public function print(mixed $form): string
+    {
+        return $this->color("#'" . $form->getFullName());
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;91m%s\033[0m", $str);
+        }
+
+        return $str;
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/Fixtures/redef.test
+++ b/tests/php/Integration/Run/Command/Repl/Fixtures/redef.test
@@ -1,6 +1,6 @@
 phel:1> (def x 1)
-1
+#'user/x
 phel:2> (def x 2)
-2
+#'user/x
 phel:3> x
 2

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang;
 
 use Phel\Lang\Registry;
+use Phel\Lang\VarReference;
 use PHPUnit\Framework\TestCase;
 
 final class RegistryTest extends TestCase
@@ -52,5 +53,15 @@ final class RegistryTest extends TestCase
         $actual = $this->registry->getDefinition('ns', 'array');
 
         self::assertSame([1, 2, 3, 4], $actual);
+    }
+
+    public function test_add_definition_returns_var_reference(): void
+    {
+        $actual = $this->registry->addDefinition('my-ns', 'my-var', 42);
+
+        self::assertInstanceOf(VarReference::class, $actual);
+        self::assertSame('my-ns', $actual->getNamespace());
+        self::assertSame('my-var', $actual->getName());
+        self::assertSame('my-ns/my-var', $actual->getFullName());
     }
 }

--- a/tests/php/Unit/Printer/TypePrinter/VarReferencePrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/VarReferencePrinterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Phel\Lang\VarReference;
+use Phel\Printer\TypePrinter\VarReferencePrinter;
+use PHPUnit\Framework\TestCase;
+
+final class VarReferencePrinterTest extends TestCase
+{
+    public function test_prints_with_clojure_like_var_syntax(): void
+    {
+        $ref = new VarReference('user', 'my-var');
+
+        self::assertSame("#'user/my-var", (new VarReferencePrinter())->print($ref));
+    }
+
+    public function test_prints_namespace_with_backslashes(): void
+    {
+        $ref = new VarReference('phel\\core', 'map');
+
+        self::assertSame("#'phel\\core/map", (new VarReferencePrinter())->print($ref));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Closes #1458.

Previously `(def a 123)` evaluated to `nil`, offering no feedback that the definition was installed. Other Lisp dialects evaluate a definition to a reference that prints as `#'ns/name`, which is clearer in the REPL and easier to explain to newcomers.

## 💡 Goal

`(def a 123)` in the REPL prints `#'user/a` rather than `nil`.

## 🔖 Changes

- New `Phel\Lang\VarReference` value: holds the defining namespace and name of a definition.
- `Registry::addDefinition` now returns a `VarReference`.
- `DefEmitter` prefixes the compiled `\Phel::addDefinition(...)` call with `return` only in return context (REPL eval), leaving file compilation untouched.
- `VarReferencePrinter` renders `#'ns/name`; `Printer` dispatches to it.
- Unit tests cover `Registry::addDefinition` return type and the printer.
- REPL redef fixture updated to the new output.
- CHANGELOG entry under `Unreleased`.