### PR TITLE
docs(php-interop): document calling namespaced PHP functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `docs/php-interop.md`: documents calling namespaced PHP functions (`php/Amp\trapSignal`) and capturing them with `(def alias php/\Ns\fn)` for shorter use sites.
 - `phel build` prints a summary with fresh/cached counts and the output directory, including a clear message when nothing needed recompiling.
 - `phel\ai` `chat-with-tools` returns `{:text :tool-calls :stop-reason :raw}`.
 

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -34,6 +34,25 @@ Prefix PHP functions with `php/`:
 ;; Math functions
 (php/abs -5)                      ; => 5
 (php/max 1 5 3)                   ; => 5
+
+;; Namespaced functions — keep the original casing
+(php/Amp\trapSignal [php/SIGINT php/SIGTERM])
+(php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
+```
+
+The `php/` prefix resolves any global or namespaced PHP function. For
+namespaced functions the name after `php/` is the full PHP path (use `\\`
+to disambiguate from the root namespace when needed). Case is preserved,
+so `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
+
+To keep calls short, capture the function reference with `def`:
+
+```phel
+(def trap-signal php/\Amp\trapSignal)
+(def detect-utf8 php/\Monolog\Logger\Utils\detectAndCleanUtf8)
+
+(trap-signal [php/SIGINT php/SIGTERM])
+(detect-utf8 "input")
 ```
 
 ### Classes and Objects

--- a/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def uc php/\strtoupper)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "uc",
+  (function(...$args) { return \strtoupper(...$args);}),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-php-function-reference.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-php-function-reference.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 24
+    )
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Closes #1460.

Phel can already call PHP namespaced functions via the `php/` prefix — `(php/Amp\trapSignal ...)` compiles to `\Amp\trapSignal(...)`, casing preserved. The feature is usable today but undocumented, so users who discover it via `get_defined_functions` end up typing the lower-cased form PHP returns there and assume the casing is a limitation. The issue also asked for a shorter local name; Phel's existing `def` + function reference pattern already covers that.

## 💡 Goal

Document both patterns so they're discoverable from the interop guide.

## 🔖 Changes

- `docs/php-interop.md`: new "Namespaced functions" examples calling `\Amp\trapSignal` with original casing, plus a `def` alias pattern (`(def trap-signal php/\Amp\trapSignal)`).
- Integration fixture `Def/def-php-function-reference.test` locks in the alias compilation output.
- CHANGELOG entry under `Unreleased` / `Changed`.