### PR TITLE
feat: add Clojure-style member access shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Member-access shorthand: `(.method obj args)` / `(.-field obj)` expand to `(php/-> obj (method args))` / `(php/-> obj field)`; `(ClassName/method args)` (or `(\Class/method ...)` for FQN) expands to `(php/:: ClassName (method args))`.
 - `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.
 - `def` evaluates to a printable var reference (e.g. `#'user/my-var`) instead of `nil`, making REPL feedback explicit.
 - `phel\test\gen` module: random-value generators, `sample`, `quick-check`, and `defspec` macro with seedable PRNG for property-based testing.

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -7,10 +7,10 @@ This guide shows how to seamlessly work between PHP and Phel code.
 | Task | PHP | Phel |
 |------|-----|------|
 | Call function | `strlen($str)` | `(php/strlen str)` |
-| Method call | `$obj->method($arg)` | `(php/-> obj (method arg))` |
-| Static call | `DateTime::createFromFormat(...)` | `(php/:: DateTime (createFromFormat ...))` |
+| Method call | `$obj->method($arg)` | `(php/-> obj (method arg))` or `(.method obj arg)` |
+| Static call | `DateTime::createFromFormat(...)` | `(php/:: DateTime (createFromFormat ...))` or `(DateTime/createFromFormat ...)` |
 | New instance | `new DateTime()` | `(php/new DateTime)`, `(new DateTime)`, or `(DateTime.)` |
-| Property access | `$obj->prop` | `(php/-> obj -prop)` |
+| Property access | `$obj->prop` | `(php/-> obj prop)` or `(.-prop obj)` |
 | Array access | `$arr[$key]` | `(php/aget arr key)` |
 
 ## Calling PHP from Phel
@@ -70,6 +70,13 @@ To keep calls short, capture the function reference with `def`:
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"
 (php/-> now (getTimestamp))       ; => 1705334400
 
+;; Method call shorthand — `.method` expands to `(php/-> ...)`
+(.format now "Y-m-d")             ; => "2024-01-15"
+(.getTimestamp now)               ; => 1705334400
+
+;; Property access shorthand — `.-field` expands to `(php/-> ...)`
+(.-y (new DateInterval "P1D"))    ; => 0
+
 ;; Chain method calls
 (php/-> now
   (add (php/new DateInterval "P1D"))
@@ -77,9 +84,10 @@ To keep calls short, capture the function reference with `def`:
 
 ;; Static methods
 (php/:: DateTime (createFromFormat "Y-m-d" "2024-01-15"))
+(DateTime/createFromFormat "Y-m-d" "2024-01-15")   ; shorthand
 
 ;; Access properties
-(php/-> obj -propertyName)
+(php/-> obj propertyName)
 ```
 
 ### Working with PHP Arrays

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -52,6 +52,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 
 use function count;
+use function in_array;
 use function str_ends_with;
 use function strlen;
 use function substr;
@@ -74,6 +75,8 @@ final class AnalyzePersistentList
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {
         $list = $this->expandConstructorShorthand($list);
+        $list = $this->expandMemberAccessShorthand($list);
+
         $symbolName = $this->getSymbolName($list);
 
         return $this
@@ -139,6 +142,116 @@ final class AnalyzePersistentList
             || ($prev >= '0' && $prev <= '9')
             || $prev === '_'
             || $prev === '\\';
+    }
+
+    /**
+     * Expands Clojure-style member access shorthand:
+     *   `(.method obj args...)`       -> `(php/-> obj (method args...))`
+     *   `(.-field obj)`               -> `(php/-> obj field)`
+     *   `(Classname/method args...)`  -> `(php/:: Classname (method args...))`
+     *
+     * Only triggers when the head symbol starts with `.` followed by a valid
+     * PHP identifier start character, or when the head symbol's namespace
+     * looks like a PHP class reference (uppercase first letter or `\` prefix).
+     * Operator-style symbols like `php/.`, `.` and `..` are left alone, and
+     * Phel-style namespaces (lowercase first letter) resolve as before.
+     */
+    private function expandMemberAccessShorthand(PersistentListInterface $list): PersistentListInterface
+    {
+        $first = $list->first();
+        if (!$first instanceof Symbol) {
+            return $list;
+        }
+
+        $name = $first->getFullName();
+        $count = count($list);
+
+        if ($this->isPropertyAccessShorthandName($name) && $count === 2) {
+            $callSymbol = Symbol::create(Symbol::NAME_PHP_OBJECT_CALL)->copyLocationFrom($first);
+            $instance = $list->get(1);
+            $propertySymbol = Symbol::create(substr($name, 2))->copyLocationFrom($first);
+
+            return Phel::list([$callSymbol, $instance, $propertySymbol])->copyLocationFrom($list);
+        }
+
+        if ($this->isMethodCallShorthandName($name) && $count >= 2) {
+            $callSymbol = Symbol::create(Symbol::NAME_PHP_OBJECT_CALL)->copyLocationFrom($first);
+            $instance = $list->get(1);
+            $methodSymbol = Symbol::create(substr($name, 1))->copyLocationFrom($first);
+
+            $methodSegment = [$methodSymbol];
+            for ($i = 2; $i < $count; ++$i) {
+                $methodSegment[] = $list->get($i);
+            }
+
+            return Phel::list([
+                $callSymbol,
+                $instance,
+                Phel::list($methodSegment)->copyLocationFrom($first),
+            ])->copyLocationFrom($list);
+        }
+
+        if ($this->isStaticCallShorthand($first)) {
+            $staticSymbol = Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL)->copyLocationFrom($first);
+            $classSymbol = Symbol::create((string) $first->getNamespace())->copyLocationFrom($first);
+            $methodSymbol = Symbol::create($first->getName())->copyLocationFrom($first);
+
+            $methodSegment = [$methodSymbol];
+            for ($i = 1; $i < $count; ++$i) {
+                $methodSegment[] = $list->get($i);
+            }
+
+            return Phel::list([
+                $staticSymbol,
+                $classSymbol,
+                Phel::list($methodSegment)->copyLocationFrom($first),
+            ])->copyLocationFrom($list);
+        }
+
+        return $list;
+    }
+
+    private function isStaticCallShorthand(Symbol $symbol): bool
+    {
+        $ns = $symbol->getNamespace();
+        if (in_array($ns, [null, '', 'php'], true)) {
+            return false;
+        }
+
+        $method = $symbol->getName();
+        if ($method === '' || !$this->isIdentifierStartChar($method[0])) {
+            return false;
+        }
+
+        return $ns[0] === '\\'
+            || ($ns[0] >= 'A' && $ns[0] <= 'Z');
+    }
+
+    private function isMethodCallShorthandName(string $name): bool
+    {
+        $len = strlen($name);
+        if ($len < 2 || $name[0] !== '.' || $name[1] === '.' || $name[1] === '-') {
+            return false;
+        }
+
+        return $this->isIdentifierStartChar($name[1]);
+    }
+
+    private function isPropertyAccessShorthandName(string $name): bool
+    {
+        $len = strlen($name);
+        if ($len < 3 || $name[0] !== '.' || $name[1] !== '-') {
+            return false;
+        }
+
+        return $this->isIdentifierStartChar($name[2]);
+    }
+
+    private function isIdentifierStartChar(string $c): bool
+    {
+        return ($c >= 'a' && $c <= 'z')
+            || ($c >= 'A' && $c <= 'Z')
+            || $c === '_';
     }
 
     private function createSymbolAnalyzerByName(string $symbolName): SpecialFormAnalyzerInterface

--- a/tests/php/Integration/Fixtures/Call/class-slash-static-method.test
+++ b/tests/php/Integration/Fixtures/Call/class-slash-static-method.test
@@ -1,0 +1,4 @@
+--PHEL--
+(\DateTimeImmutable/createFromFormat "Y-m-d" "2024-01-15")
+--PHP--
+(\DateTimeImmutable::createFromFormat("Y-m-d", "2024-01-15"));

--- a/tests/php/Integration/Fixtures/Call/dot-method-call-no-args.test
+++ b/tests/php/Integration/Fixtures/Call/dot-method-call-no-args.test
@@ -1,0 +1,7 @@
+--PHEL--
+(.getTimestamp (php/new \DateTimeImmutable))
+--PHP--
+(function() {
+  $target_1 = (new \DateTimeImmutable());
+  return $target_1->getTimestamp();
+})();

--- a/tests/php/Integration/Fixtures/Call/dot-method-call.test
+++ b/tests/php/Integration/Fixtures/Call/dot-method-call.test
@@ -1,0 +1,7 @@
+--PHEL--
+(.modify (php/new \DateTimeImmutable) "9 msec")
+--PHP--
+(function() {
+  $target_1 = (new \DateTimeImmutable());
+  return $target_1->modify("9 msec");
+})();

--- a/tests/php/Integration/Fixtures/Call/dot-property-access.test
+++ b/tests/php/Integration/Fixtures/Call/dot-property-access.test
@@ -1,0 +1,8 @@
+--PHEL--
+(.-y (php/new \DateInterval "PT30S"))
+--PHP--
+(function() {
+  $target_1 = (new \DateInterval("PT30S"));
+  return $target_1->y;
+})();
+

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -145,6 +145,41 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
+    public function test_dot_method_shorthand_expands_to_object_call(): void
+    {
+        $list = Phel::list([
+            Symbol::create('.method'), '',
+        ]);
+        self::assertInstanceOf(
+            PhpObjectCallNode::class,
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
+        );
+    }
+
+    public function test_dot_dash_field_shorthand_expands_to_object_call(): void
+    {
+        $list = Phel::list([
+            Symbol::create('.-field'), '',
+        ]);
+        self::assertInstanceOf(
+            PhpObjectCallNode::class,
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
+        );
+    }
+
+    public function test_class_slash_method_shorthand_expands_to_static_call(): void
+    {
+        $list = Phel::list([
+            Symbol::createForNamespace('\\DateTimeImmutable', 'createFromFormat'),
+            'Y-m-d',
+            '2024-01-15',
+        ]);
+        self::assertInstanceOf(
+            PhpObjectCallNode::class,
+            $this->listAnalyzer->analyze($list, NodeEnvironment::empty()),
+        );
+    }
+
     public function test_symbol_with_name_php_object_static_call(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

Closes #1461.

Phel's interop currently requires the verbose `(php/-> obj (method args))`, `(php/-> obj prop)`, and `(php/:: Class (method args))` forms. Clojure users have muscle memory for `.method`, `.-field`, and `Class/method`, and `.cljc`-style shared code becomes awkward when every call site needs Phel-specific rewrites.

## 💡 Goal

Accept three new shorthand shapes that expand at analysis time:

- `(.method obj args...)` → `(php/-> obj (method args...))`
- `(.-field obj)` → `(php/-> obj field)`
- `(ClassName/method args...)` / `(\FQN\Class/method args...)` → `(php/:: ClassName (method args...))`

## 🔖 Changes

- `AnalyzePersistentList` gains `expandMemberAccessShorthand`, running after the existing `(ClassName. args)` constructor shorthand.
- Head-symbol recognition: `.name` needs an identifier start char (so `.`, `..`, `php/.` are left alone); `ClassName/method` triggers only when the namespace starts with `\` or an uppercase letter, so Phel namespaces (lowercase by convention) keep resolving as before.
- Unit tests in `AnalyzePersistentListTest` and integration fixtures under `Fixtures/Call/` cover all three shapes.
- `docs/php-interop.md` quick-reference and "Classes and Objects" examples updated with the new forms; the outdated `(php/-> obj -prop)` property docs replaced with the current `(php/-> obj prop)` form.
- CHANGELOG entry under `Unreleased` / `Added`.