### PR TITLE
feat: add #php tagged literal for PHP array instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `#php` reader literal: `#php [1 2 3]` expands to `(php-indexed-array 1 2 3)`; `#php {"a" 1 "b" 2}` expands to `(php-associative-array "a" 1 "b" 2)`. Non-recursive — nested Phel collections are left untouched.
 - Member-access shorthand: `(.method obj args)` / `(.-field obj)` expand to `(php/-> obj (method args))` / `(php/-> obj field)`; `(ClassName/method args)` (or `(\Class/method ...)` for FQN) expands to `(php/:: ClassName (method args))`.
 - `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.
 - `def` evaluates to a printable var reference (e.g. `#'user/my-var`) instead of `nil`, making REPL feedback explicit.

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -97,6 +97,10 @@ To keep calls short, capture the function reference with `def`:
 (def php-arr (php/array 1 2 3))
 (def assoc-arr (php-associative-array "name" "Alice" "age" 30))
 
+;; `#php` reader literal (non-recursive): next vector/map becomes a PHP array
+(def php-arr   #php [1 2 3])                    ; => (php-indexed-array 1 2 3)
+(def assoc-arr #php {"name" "Alice" "age" 30})  ; => (php-associative-array "name" "Alice" "age" 30)
+
 ;; Access elements
 (php/aget php-arr 0)              ; => 1
 (php/aget assoc-arr "name")       ; => "Alice"

--- a/src/php/Compiler/Application/Reader.php
+++ b/src/php/Compiler/Application/Reader.php
@@ -90,7 +90,7 @@ final class Reader implements ReaderInterface
         // discarded by the parser so their tags never reach this point.
         if ($node instanceof TaggedLiteralNode) {
             return $this->readerFactory
-                ->createTaggedLiteralReader()
+                ->createTaggedLiteralReader($this)
                 ->read($node, $root);
         }
 

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -4,32 +4,42 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Reader\ExpressionReader;
 
+use Phel;
+use Phel\Compiler\Application\Reader;
+use Phel\Compiler\Domain\Lexer\Token;
+use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
 
 use function preg_match;
 use function sprintf;
 use function strtolower;
 
 /**
- * Reads Phel's built-in tagged literals (e.g. `#uuid`). Unknown tags are
- * rejected here so they can still be silently discarded when they sit inside
- * an unselected reader-conditional branch (that discard happens earlier, in
- * the parser).
+ * Reads Phel's built-in tagged literals (e.g. `#uuid`, `#php`). Unknown tags
+ * are rejected here so they can still be silently discarded when they sit
+ * inside an unselected reader-conditional branch (that discard happens
+ * earlier, in the parser).
  */
-final class TaggedLiteralReader
+final readonly class TaggedLiteralReader
 {
     private const string UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    public function __construct(private Reader $reader) {}
 
     /**
      * @throws ReaderException
      */
-    public function read(TaggedLiteralNode $node, NodeInterface $root): string
+    public function read(TaggedLiteralNode $node, NodeInterface $root): mixed
     {
         return match ($node->getTag()) {
             'uuid' => $this->readUuid($node, $root),
+            'php' => $this->readPhp($node, $root),
             default => throw ReaderException::forNode(
                 $node,
                 $root,
@@ -67,5 +77,56 @@ final class TaggedLiteralReader
         }
 
         return strtolower($value);
+    }
+
+    /**
+     * @throws ReaderException
+     */
+    private function readPhp(TaggedLiteralNode $node, NodeInterface $root): PersistentListInterface
+    {
+        $form = $node->getForm();
+
+        if (!$form instanceof ListNode) {
+            throw ReaderException::forNode(
+                $node,
+                $root,
+                '#php expects a vector literal [..] or a map literal {..}.',
+            );
+        }
+
+        $tokenType = $form->getTokenType();
+        if ($tokenType === Token::T_OPEN_BRACKET) {
+            return $this->buildCall($node, 'php-indexed-array', $form);
+        }
+
+        if ($tokenType === Token::T_OPEN_BRACE) {
+            return $this->buildCall($node, 'php-associative-array', $form);
+        }
+
+        throw ReaderException::forNode(
+            $node,
+            $root,
+            '#php expects a vector literal [..] or a map literal {..}.',
+        );
+    }
+
+    /**
+     * @throws ReaderException
+     */
+    private function buildCall(TaggedLiteralNode $node, string $fnName, ListNode $form): PersistentListInterface
+    {
+        $elements = [Symbol::create($fnName)->setStartLocation($node->getStartLocation())];
+
+        foreach ($form->getChildren() as $child) {
+            if ($child instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            $elements[] = $this->reader->readExpression($child, $node);
+        }
+
+        return Phel::list($elements)
+            ->setStartLocation($node->getStartLocation())
+            ->setEndLocation($node->getEndLocation());
     }
 }

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactory.php
@@ -71,8 +71,8 @@ final class ExpressionReaderFactory implements ExpressionReaderFactoryInterface
         return new MapReader($reader);
     }
 
-    public function createTaggedLiteralReader(): TaggedLiteralReader
+    public function createTaggedLiteralReader(Reader $reader): TaggedLiteralReader
     {
-        return new TaggedLiteralReader();
+        return new TaggedLiteralReader($reader);
     }
 }

--- a/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReaderFactoryInterface.php
@@ -42,5 +42,5 @@ interface ExpressionReaderFactoryInterface
 
     public function createMetaReader(Reader $reader): MetaReader;
 
-    public function createTaggedLiteralReader(): TaggedLiteralReader;
+    public function createTaggedLiteralReader(Reader $reader): TaggedLiteralReader;
 }

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -11,6 +11,7 @@ use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
@@ -1330,6 +1331,32 @@ final class ReaderTest extends TestCase
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage("Unknown tagged literal '#something'");
         $this->read('#something "x"');
+    }
+
+    public function test_php_tagged_literal_on_vector_expands_to_indexed_array_call(): void
+    {
+        $form = $this->read('#php [1 2 3]');
+
+        self::assertInstanceOf(PersistentListInterface::class, $form);
+        self::assertSame('php-indexed-array', $form->get(0)->getName());
+        self::assertSame(1, $form->get(1));
+        self::assertSame(2, $form->get(2));
+        self::assertSame(3, $form->get(3));
+    }
+
+    public function test_php_tagged_literal_on_map_expands_to_associative_array_call(): void
+    {
+        $form = $this->read('#php {"a" 1 "b" 2}');
+
+        self::assertInstanceOf(PersistentListInterface::class, $form);
+        self::assertSame('php-associative-array', $form->get(0)->getName());
+    }
+
+    public function test_php_tagged_literal_rejects_non_collection_form(): void
+    {
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('#php expects a vector literal');
+        $this->read('#php 42');
     }
 
     private function read(string $string, bool $withLocation = true): float|bool|int|string|TypeInterface|null

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def arr #php {"a" 1 "b" 2})
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "arr",
+  (\Phel::getDefinition("phel\\core", "php-associative-array"))("a", 1, "b", 2),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/hash-php-map-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/hash-php-map-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 28
+    )
+  )
+);

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def arr #php [1 2 3])
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "arr",
+  (\Phel::getDefinition("phel\\core", "php-indexed-array"))(1, 2, 3),
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/hash-php-vector-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/hash-php-vector-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 22
+    )
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Closes #1462.

PHP interop code often has to instantiate native PHP arrays at the call site — e.g. `(php-associative-array "content-type" "text/html")` or `(php-indexed-array php/SIGINT php/SIGTERM)`. Those calls read awkwardly next to Phel's native vector/map literals. ClojureScript solves the equivalent problem with `#js` (non-recursive shorthand for the next data-literal converted to the host runtime's collection).

## 💡 Goal

Introduce an equivalent Phel reader literal that expands the next vector or map to a PHP array call:

- `#php [1 2 3]` → `(php-indexed-array 1 2 3)`
- `#php {"a" 1 "b" 2}` → `(php-associative-array "a" 1 "b" 2)`

Non-recursive — values inside are read normally, preserving Phel collections on nested forms.

## 🔖 Changes

- `TaggedLiteralReader` takes a `Reader` and handles a new `php` tag. Vector form routes to `php-indexed-array`, map form routes to `php-associative-array`; any other shape raises a `ReaderException` with a message pointing to the expected literal.
- `ExpressionReaderFactory` / `ExpressionReaderFactoryInterface` updated to pass the reader through.
- Integration fixtures `Def/hash-php-vector-literal.test` and `Def/hash-php-map-literal.test` lock in the compiled output; `ReaderTest` covers the expansion and error paths.
- `docs/php-interop.md` "Working with PHP Arrays" section shows the new syntax.
- CHANGELOG entry under `Unreleased` / `Added`.