### PR TITLE
feat(analyzer): PHEL011 for non-callable literals at call position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Calling a quoted symbol or non-callable literal (`('foo)`, `(42)`, `(nil)`, `("x")`) now raises `PHEL011` at analysis time with the source location, instead of a raw PHP `TypeError` stack trace from `eval()`.
 - `phel build` no longer leaks stdout from compiled programs during compilation.
 - Windows compiled-code cache crash: absolute cache paths with drive letters or UNC prefixes are no longer prefixed with the app root.
 - `phel\ai` `check-response` raises a `RuntimeException` with the provider error message instead of a PHP `TypeError` when the decoded error body is missing the nested `:error :message` path.

--- a/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
+++ b/src/php/Compiler/Domain/Analyzer/Exceptions/AnalyzerException.php
@@ -73,6 +73,24 @@ final class AnalyzerException extends AbstractLocatedException
         return $e;
     }
 
+    public static function notCallable(
+        string $displayValue,
+        string $typeName,
+        TypeInterface $location,
+        string $hint = '',
+    ): self {
+        $message = sprintf('Value %s of type %s is not callable.', $displayValue, $typeName);
+
+        if ($hint !== '') {
+            $message .= ' ' . $hint;
+        }
+
+        $e = self::withLocation($message, $location);
+        $e->setErrorCode(ErrorCode::NOT_CALLABLE);
+
+        return $e;
+    }
+
     public static function notEnoughArgsProvided(
         GlobalVarNode $f,
         PersistentListInterface $list,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -9,6 +9,8 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
@@ -16,11 +18,18 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
+use Phel\Printer\Printer;
 use RuntimeException;
 
 use function count;
+use function get_debug_type;
+use function is_bool;
 use function is_callable;
+use function is_float;
+use function is_int;
+use function is_string;
 use function sprintf;
 
 /**
@@ -31,6 +40,8 @@ use function sprintf;
 final class InvokeSymbol implements SpecialFormAnalyzerInterface
 {
     use WithAnalyzerTrait;
+
+    private const string UNHANDLED = "\0__phel_unhandled__";
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {
@@ -51,12 +62,49 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             $this->validateEnoughArgsProvided($f, $list);
         }
 
+        $this->rejectNonCallableLiteral($f, $list);
+
         return new CallNode(
             $env,
             $f,
             $this->arguments($list->rest(), $env),
             $list->getStartLocation(),
         );
+    }
+
+    /**
+     * Guards against call-position literals that PHP would reject with a raw
+     * `TypeError` at runtime (quoted symbols, numbers, strings, booleans,
+     * `nil`). Keywords and persistent maps/sets/vectors stay callable and are
+     * handled at runtime as before.
+     */
+    private function rejectNonCallableLiteral(AbstractNode $f, PersistentListInterface $list): void
+    {
+        $value = match (true) {
+            $f instanceof LiteralNode, $f instanceof QuoteNode => $f->getValue(),
+            default => self::UNHANDLED,
+        };
+
+        if ($value === self::UNHANDLED) {
+            return;
+        }
+
+        if ($value instanceof Symbol) {
+            throw AnalyzerException::notCallable(
+                Printer::readable()->print($value),
+                'Symbol',
+                $list,
+                'Did you quote or escape a symbol by mistake?',
+            );
+        }
+
+        if ($value === null || is_bool($value) || is_int($value) || is_float($value) || is_string($value)) {
+            throw AnalyzerException::notCallable(
+                Printer::readable()->print($value),
+                get_debug_type($value),
+                $list,
+            );
+        }
     }
 
     private function inlineMacro(

--- a/src/php/Compiler/Domain/Exceptions/ErrorCode.php
+++ b/src/php/Compiler/Domain/Exceptions/ErrorCode.php
@@ -27,6 +27,7 @@ enum ErrorCode: string
     case BINDING_ERROR = 'PHEL008';
     case INTERFACE_ERROR = 'PHEL009';
     case RECUR_ERROR = 'PHEL010';
+    case NOT_CALLABLE = 'PHEL011';
 
     // Parser errors (PHEL100-199)
     case UNTERMINATED_LIST = 'PHEL100';

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -98,6 +98,45 @@ final class InvokeSymbolTest extends TestCase
         $this->analyzer = new Analyzer($env);
     }
 
+    public function test_quoted_symbol_in_call_position_raises_phel011(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Value foobar of type Symbol is not callable. Did you quote or escape a symbol by mistake?');
+
+        $list = Phel::list([
+            Phel::list([
+                Symbol::create(Symbol::NAME_QUOTE),
+                Symbol::create('foobar'),
+            ]),
+        ]);
+
+        (new InvokeSymbol($this->analyzer))->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_integer_literal_in_call_position_raises_phel011(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Value 42 of type int is not callable.');
+
+        (new InvokeSymbol($this->analyzer))->analyze(Phel::list([42]), NodeEnvironment::empty());
+    }
+
+    public function test_string_literal_in_call_position_raises_phel011(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Value "foo" of type string is not callable.');
+
+        (new InvokeSymbol($this->analyzer))->analyze(Phel::list(['foo']), NodeEnvironment::empty());
+    }
+
+    public function test_nil_in_call_position_raises_phel011(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Value nil of type null is not callable.');
+
+        (new InvokeSymbol($this->analyzer))->analyze(Phel::list([null]), NodeEnvironment::empty());
+    }
+
     public function test_not_enough_args_provided_then_error(): void
     {
         $this->expectException(AnalyzerException::class);


### PR DESCRIPTION
## 🤔 Background

Closes #1470.

Calling an unresolved symbol already produces a friendly `PHEL001` error with suggestions. Calling a quoted symbol (or any literal that is not a function) fell through to PHP's `eval`, which surfaced a raw `TypeError` plus a ten-frame stack trace full of internal file paths. Terrible REPL UX, and confusing to new users who quoted by accident.

## 💡 Goal

Detect at analysis time and raise a proper located Phel error with the new `PHEL011` code. Catches `('foo)`, `(42)`, `("x")`, `(nil)`, `(true)`, etc. Keywords and persistent collections stay callable — runtime behaviour unchanged.

## 🔖 Changes

- New `ErrorCode::NOT_CALLABLE = 'PHEL011'`.
- `AnalyzerException::notCallable(displayValue, typeName, location, hint)` factory.
- `InvokeSymbol::analyze` runs `rejectNonCallableLiteral` before constructing the `CallNode`. Handles both `LiteralNode` and `QuoteNode` head values (Symbol, `null`, bool, int, float, string). Symbol case adds the hint "Did you quote or escape a symbol by mistake?".
- Unit tests in `InvokeSymbolTest` cover quoted symbol, int, string, and nil at call position.
- CHANGELOG entry under `Unreleased` / `Fixed`.