### PR TITLE
fix(repl): map eval runtime errors to Phel source location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- REPL runtime errors from `eval()` (e.g. `TypeError` from a `php/` interop call) point to the user's `string:N` source line via the embedded source map, instead of `InMemoryEvaluator.php:NN : eval()'d code`.
 - Calling a quoted symbol or non-callable literal (`('foo)`, `(42)`, `(nil)`, `("x")`) now raises `PHEL011` at analysis time with the source location, instead of a raw PHP `TypeError` stack trace from `eval()`.
 - `phel build` no longer leaks stdout from compiled programs during compilation.
 - Windows compiled-code cache crash: absolute cache paths with drive letters or UNC prefixes are no longer prefixed with the app root.

--- a/src/php/Command/Application/TextExceptionPrinter.php
+++ b/src/php/Command/Application/TextExceptionPrinter.php
@@ -9,6 +9,7 @@ use Phel\Command\Domain\Exceptions\ExceptionArgsPrinterInterface;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Exceptions\ErrorCode;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
@@ -93,6 +94,22 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
     public function getStackTraceString(Throwable $e): string
     {
         $str = '';
+
+        if ($e instanceof EvaluatedCodeException) {
+            $original = $e->getOriginalException();
+            $type = $original::class;
+            $msg = $original->getMessage();
+            $errorFile = $original->getFile();
+            $errorLine = $original->getLine();
+            $phelFile = $e->getPhelFile();
+            $phelLine = $e->getPhelLine();
+
+            $str .= $this->style->blue(sprintf('%s: %s', $type, $msg) . PHP_EOL);
+            $str .= sprintf('in %s:%d (gen: %s:%d)', $phelFile, $phelLine, $errorFile, $errorLine) . PHP_EOL . PHP_EOL;
+
+            return $str . $this->renderTrace($original);
+        }
+
         $type = $e::class;
         $msg = $e->getPrevious()?->getMessage() ?? $e->getMessage();
         $errorFile = $e->getPrevious()?->getFile() ?? $e->getFile();
@@ -101,6 +118,13 @@ final readonly class TextExceptionPrinter implements ExceptionPrinterInterface
 
         $str .= $this->style->blue(sprintf('%s: %s', $type, $msg) . PHP_EOL);
         $str .= sprintf('in %s:%d (gen: %s:%d)', $pos->filename(), $pos->line(), $errorFile, $errorLine) . PHP_EOL . PHP_EOL;
+
+        return $str . $this->renderTrace($e);
+    }
+
+    private function renderTrace(Throwable $e): string
+    {
+        $str = '';
 
         foreach ($e->getTrace() as $i => $frame) {
             $class = $frame['class'] ?? null;

--- a/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
+++ b/src/php/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeException.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Evaluator\Exceptions;
+
+use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapConsumer;
+use RuntimeException;
+use Throwable;
+
+use function explode;
+use function str_starts_with;
+use function substr;
+use function trim;
+
+/**
+ * Wraps a Throwable raised while running compiled Phel code via eval().
+ * Carries the original Phel source location resolved through the embedded source map,
+ * so error reporting can point to the user's `.phel` line instead of the eval'd code.
+ */
+final class EvaluatedCodeException extends RuntimeException
+{
+    private function __construct(
+        Throwable $original,
+        private readonly string $phelFile,
+        private readonly int $phelLine,
+    ) {
+        parent::__construct($original->getMessage(), 0, $original);
+    }
+
+    public static function fromThrowableAndCompiledCode(
+        Throwable $original,
+        string $compiledCode,
+        int $headerOffset = 0,
+    ): self {
+        [$file, $line] = self::extractSourceLocation($compiledCode, $original->getLine() - $headerOffset);
+
+        return new self($original, $file, $line);
+    }
+
+    public function getPhelFile(): string
+    {
+        return $this->phelFile;
+    }
+
+    public function getPhelLine(): int
+    {
+        return $this->phelLine;
+    }
+
+    public function getOriginalException(): Throwable
+    {
+        $previous = $this->getPrevious();
+
+        return $previous ?? $this;
+    }
+
+    /**
+     * @return array{0: string, 1: int}
+     */
+    private static function extractSourceLocation(string $compiledCode, int $generatedLine): array
+    {
+        $lines = explode("\n", $compiledCode, 3);
+        $filenameComment = $lines[0];
+        $sourceMapComment = $lines[1] ?? '';
+
+        $file = str_starts_with($filenameComment, '// ')
+            ? trim(substr($filenameComment, 3))
+            : 'string';
+
+        if (!str_starts_with($sourceMapComment, '// ;;')) {
+            return [$file, $generatedLine];
+        }
+
+        $mapping = trim(substr($sourceMapComment, 3));
+        if ($mapping === '' || $mapping === ';;') {
+            return [$file, $generatedLine];
+        }
+
+        $consumer = new SourceMapConsumer($mapping);
+        $originalLine = $consumer->getOriginalLine($generatedLine);
+
+        return [$file, $originalLine ?? $generatedLine];
+    }
+}

--- a/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php
+++ b/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php
@@ -6,7 +6,9 @@ namespace Phel\Compiler\Domain\Evaluator;
 
 use ParseError;
 use Phel\Compiler\Domain\Evaluator\Exceptions\CompiledCodeIsMalformedException;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Run\Infrastructure\Service\DebugLineTap;
+use Throwable;
 
 /**
  * Evaluates compiled PHP code in-memory using eval().
@@ -24,6 +26,9 @@ final class InMemoryEvaluator implements EvaluatorInterface
             return eval($phpCode);
         } catch (ParseError $parseError) {
             throw CompiledCodeIsMalformedException::fromThrowable($parseError);
+        } catch (Throwable $throwable) {
+            $headerOffset = substr_count($phpCode, "\n") - substr_count($code, "\n");
+            throw EvaluatedCodeException::fromThrowableAndCompiledCode($throwable, $code, $headerOffset);
         }
     }
 }

--- a/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
+++ b/tests/php/Unit/Command/Application/TextExceptionPrinterTest.php
@@ -10,14 +10,43 @@ use Phel\Command\Domain\Exceptions\ExceptionArgsPrinterInterface;
 use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 use Phel\Shared\ColorStyleInterface;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 final class TextExceptionPrinterTest extends TestCase
 {
+    public function test_renders_phel_source_location_for_evaluated_code_exception(): void
+    {
+        $original = new class('boom') extends TypeError {
+            public function __construct(string $message)
+            {
+                parent::__construct($message);
+                $this->line = 3;
+            }
+        };
+        $compiledCode = "// my-file.phel\n// ;;AAAA\nphp_body();";
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode($original, $compiledCode);
+
+        $exceptionPrinter = new TextExceptionPrinter(
+            $this->createStub(ExceptionArgsPrinterInterface::class),
+            $this->stubColorStyle(),
+            $this->createStub(MungeInterface::class),
+            $this->createStub(FilePositionExtractorInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        $output = $exceptionPrinter->getStackTraceString($exception);
+
+        self::assertStringContainsString('TypeError', $output);
+        self::assertStringContainsString('boom', $output);
+        self::assertStringContainsString('in my-file.phel:1', $output);
+    }
+
     public function test_print_exception(): void
     {
         $file = 'example-file.phel';

--- a/tests/php/Unit/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeExceptionTest.php
+++ b/tests/php/Unit/Compiler/Domain/Evaluator/Exceptions/EvaluatedCodeExceptionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Evaluator\Exceptions;
+
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TypeError;
+
+final class EvaluatedCodeExceptionTest extends TestCase
+{
+    public function test_falls_back_to_raw_line_when_no_source_map_header(): void
+    {
+        $original = new RuntimeException('boom');
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode($original, 'phpcode_no_header');
+
+        self::assertSame('string', $exception->getPhelFile());
+        self::assertSame($original->getLine(), $exception->getPhelLine());
+        self::assertSame('boom', $exception->getMessage());
+        self::assertSame($original, $exception->getOriginalException());
+    }
+
+    public function test_extracts_filename_when_only_source_comment_present(): void
+    {
+        $original = new RuntimeException('boom', 0);
+        $code = "// example.phel\n// no source map\n<?php // body";
+
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode($original, $code);
+
+        self::assertSame('example.phel', $exception->getPhelFile());
+    }
+
+    public function test_maps_generated_line_to_original_phel_line(): void
+    {
+        // Mapping `;;AAAA` decodes to: generated line 3 -> original line 1, column 0.
+        $compiledCode = "// my-file.phel\n// ;;AAAA\nphp_body();";
+
+        $original = $this->throwableAtLine(3);
+
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode($original, $compiledCode);
+
+        self::assertSame('my-file.phel', $exception->getPhelFile());
+        self::assertSame(1, $exception->getPhelLine());
+    }
+
+    public function test_subtracts_header_offset_from_generated_line(): void
+    {
+        // Same mapping as above, but exception line is shifted by a one-line prefix
+        // (e.g. when DebugLineTap prepends `declare(ticks=1);`).
+        $compiledCode = "// my-file.phel\n// ;;AAAA\nphp_body();";
+
+        $original = $this->throwableAtLine(4);
+
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode(
+            $original,
+            $compiledCode,
+            headerOffset: 1,
+        );
+
+        self::assertSame(1, $exception->getPhelLine());
+    }
+
+    public function test_preserves_original_throwable_message_and_class(): void
+    {
+        $original = new TypeError('argument must be int, string given');
+        $exception = EvaluatedCodeException::fromThrowableAndCompiledCode($original, '');
+
+        self::assertSame('argument must be int, string given', $exception->getMessage());
+        self::assertInstanceOf(TypeError::class, $exception->getOriginalException());
+    }
+
+    private function throwableAtLine(int $line): RuntimeException
+    {
+        return new class('boom', $line) extends RuntimeException {
+            public function __construct(string $message, int $line)
+            {
+                parent::__construct($message);
+                $this->line = $line;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🤔 Background

REPL runtime errors raised inside `eval()` (e.g. a `TypeError` from a `php/` interop call like `(php/number_format 0 "." "," 5)`) printed a stack trace pointing at the internal evaluator path:

```
TypeError: number_format(): Argument #2 ($decimals) must be of type int, string given
in /Users/.../src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(24) : eval()'d code:3
   (gen: /Users/.../src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(24) : eval()'d code:3)
```

`SourceMapExtractor` could not resolve the location because the "file" reported by PHP for eval'd code (`InMemoryEvaluator.php(24) : eval()'d code`) is not a real file with the source-map comment header — `file_exists()` is false, the lookup short-circuits, and the raw eval path leaks into output.

## 💡 Goal

Use the source-map header that the emitter already embeds in the compiled code (`// <source>\n// ;;<mapping>\n`) to report errors with their original `string:N` (or `<file>:N`) Phel location.

## 🔖 Changes

- New `EvaluatedCodeException` in `src/php/Compiler/Domain/Evaluator/Exceptions/`. Wraps the original `Throwable`, parses the embedded source-map header, and uses `SourceMapConsumer` to map the generated line back to the Phel source line. Accepts a `headerOffset` so prefixes added by `InMemoryEvaluator` (e.g. `declare(ticks=1);`) don't shift the lookup.
- `InMemoryEvaluator` now catches `Throwable` (in addition to `ParseError`) and rethrows as `EvaluatedCodeException` carrying the compiled code and any prefix offset.
- `TextExceptionPrinter::getStackTraceString()` recognises `EvaluatedCodeException` and renders `in <phel-file>:<phel-line> (gen: <eval-path>:<line>)` using the wrapped exception's class/message. Trace rendering is shared via a new `renderTrace()` private method.
- Unit tests for `EvaluatedCodeException` (header parsing, fallback, header-offset adjustment) and for the `TextExceptionPrinter` branch.
- CHANGELOG entry under `## Unreleased > Fixed`.

After this change, the same input yields:

```
TypeError: number_format(): Argument #2 ($decimals) must be of type int, string given
in string:1 (gen: .../InMemoryEvaluator.php(26) : eval()'d code:3)
```