### PR TITLE
feat(core): uuid helpers — uuid=, uuid-nil?, uuid-version, uuid-variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - `phel\ai`: configurable `:timeout`; per-call `opts` now accept `:provider`, `:timeout`, `:base-url`, `:api-key`, `:max-retries`.
 - `phel\ai`: `docs/ai-guide.md` usage guide.
 - `phel\ai`: `*http-post*` rebindable seam enables full behavior coverage of chat/complete/extract/chat-with-tools/embed/build-index/search without a live API.
+- `uuid=`, `uuid-nil?`, `uuid-version`, and `uuid-variant` helpers in `phel\core` for case-insensitive UUID comparison and field extraction.
 
 ### Fixed
 

--- a/src/phel/core/uuid.phel
+++ b/src/phel/core/uuid.phel
@@ -51,3 +51,50 @@
   (when (uuid? s)
     (php/strtolower s)))
 
+(def ^:private uuid-nil-value
+  "00000000-0000-0000-0000-000000000000")
+
+(defn uuid=
+  "Returns true if `a` and `b` are canonical UUID strings that compare
+  equal case-insensitively. Returns false if either argument is not a
+  valid UUID."
+  {:example "(uuid= \"550E8400-E29B-41D4-A716-446655440000\"
+         \"550e8400-e29b-41d4-a716-446655440000\") ; => true"
+   :see-also ["uuid?" "parse-uuid"]}
+  [a b]
+  (and (uuid? a)
+       (uuid? b)
+       (php/=== (php/strtolower a) (php/strtolower b))))
+
+(defn uuid-nil?
+  "Returns true if `x` is the nil UUID (all zeros), false otherwise."
+  {:example "(uuid-nil? \"00000000-0000-0000-0000-000000000000\") ; => true"
+   :see-also ["uuid?"]}
+  [x]
+  (and (uuid? x)
+       (php/=== (php/strtolower x) uuid-nil-value)))
+
+(defn uuid-version
+  "Returns the version digit (1-5) encoded in UUID `x`, or nil if `x` is
+  not a canonical UUID."
+  {:example "(uuid-version \"550e8400-e29b-41d4-a716-446655440000\") ; => 4"
+   :see-also ["uuid?" "uuid-variant"]}
+  [x]
+  (when (uuid? x)
+    (php/intval (php/mb_substr x 14 1) 16)))
+
+(defn uuid-variant
+  "Returns a keyword describing the variant field of UUID `x`: `:ncs`,
+  `:rfc-4122`, `:microsoft`, or `:reserved`. Returns nil if `x` is not a
+  canonical UUID."
+  {:example "(uuid-variant \"550e8400-e29b-41d4-a716-446655440000\") ; => :rfc-4122"
+   :see-also ["uuid?" "uuid-version"]}
+  [x]
+  (when (uuid? x)
+    (let [nibble (php/intval (php/mb_substr x 19 1) 16)]
+      (cond
+        (php/=== 0 (bit-and nibble 0x8)) :ncs
+        (php/=== 0 (bit-and nibble 0x4)) :rfc-4122
+        (php/=== 0 (bit-and nibble 0x2)) :microsoft
+        :else :reserved))))
+

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -112,6 +112,59 @@
   (is (uuid? #uuid "00000012-0034-0056-0078-000000000009")
       "#uuid result passes uuid?"))
 
+(deftest test-uuid=
+  (is (true? (uuid= "550E8400-E29B-41D4-A716-446655440000"
+                    "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid= is case-insensitive")
+  (is (true? (uuid= "550e8400-e29b-41d4-a716-446655440000"
+                    "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid= matches identical UUIDs")
+  (is (false? (uuid= "00000000-0000-0000-0000-000000000000"
+                     "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid= distinguishes different UUIDs")
+  (is (false? (uuid= "550e8400-e29b-41d4-a716-446655440000" "not-a-uuid"))
+      "uuid= rejects non-UUID argument")
+  (is (false? (uuid= nil "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid= rejects nil"))
+
+(deftest test-uuid-nil?
+  (is (true? (uuid-nil? "00000000-0000-0000-0000-000000000000"))
+      "uuid-nil? accepts nil UUID")
+  (is (true? (uuid-nil? "00000000-0000-0000-0000-000000000000"))
+      "uuid-nil? is case-insensitive on the nil UUID")
+  (is (false? (uuid-nil? "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid-nil? rejects non-nil UUID")
+  (is (false? (uuid-nil? "not-a-uuid"))
+      "uuid-nil? rejects invalid string")
+  (is (false? (uuid-nil? nil))
+      "uuid-nil? rejects nil"))
+
+(deftest test-uuid-version
+  (is (= 4 (uuid-version "550e8400-e29b-41d4-a716-446655440000"))
+      "uuid-version reads v4")
+  (is (= 1 (uuid-version "00000000-0000-1000-8000-000000000000"))
+      "uuid-version reads v1")
+  (is (= 4 (uuid-version (random-uuid)))
+      "uuid-version on random-uuid is 4")
+  (is (nil? (uuid-version "not-a-uuid"))
+      "uuid-version returns nil on invalid")
+  (is (nil? (uuid-version nil))
+      "uuid-version returns nil on nil"))
+
+(deftest test-uuid-variant
+  (is (= :rfc-4122 (uuid-variant "550e8400-e29b-41d4-a716-446655440000"))
+      "RFC 4122 variant (high nibble 1010)")
+  (is (= :rfc-4122 (uuid-variant (random-uuid)))
+      "random-uuid is RFC 4122")
+  (is (= :ncs (uuid-variant "00000000-0000-0000-0000-000000000000"))
+      "nil UUID has NCS variant (high nibble 0xxx)")
+  (is (= :microsoft (uuid-variant "00000000-0000-0000-c000-000000000000"))
+      "Microsoft variant (high nibble 110x)")
+  (is (= :reserved (uuid-variant "00000000-0000-0000-e000-000000000000"))
+      "Reserved variant (high nibble 111x)")
+  (is (nil? (uuid-variant "not-a-uuid"))
+      "uuid-variant returns nil on invalid"))
+
 ;; --- resolve ---
 
 (deftest test-resolve-known-symbol


### PR DESCRIPTION
## 🤔 Background

Phel represents UUIDs as plain strings (PHP has no native UUID type). The `#uuid` tagged literal already validates and lowercases the canonical form, but once you hold a UUID string, any comparison or field extraction has to be written by hand. Users coming from Clojure/ClojureScript expect a small helper surface (`uuid=`, version/variant accessors, nil-UUID check) rather than a `java.util.UUID` or `cljs.core/UUID` wrapper type.

This PR takes the light DX path: keep UUIDs as strings, add the helpers that remove the common boilerplate.

## 💡 Goal

Close the DX gap with Clojure/CLJS for UUID string handling without introducing a new Phel type.

## 🔖 Changes

- `uuid=` — case-insensitive equality; returns `false` if either argument is not a canonical UUID, so it never silently compares non-UUID values.
- `uuid-nil?` — predicate for the all-zero UUID `00000000-0000-0000-0000-000000000000`.
- `uuid-version` — returns the version digit (1–5) encoded at index 14 of the canonical form, or `nil` for non-UUID input.
- `uuid-variant` — returns `:ncs`, `:rfc-4122`, `:microsoft`, or `:reserved` from the variant nibble at index 19, or `nil` for non-UUID input.
- Tests in `tests/phel/test/core/utility-functions.phel` cover case-insensitive equality, nil-UUID detection, v1/v4 version extraction, and all four variant buckets.
- `CHANGELOG.md` entry under `## Unreleased → ### Added`.

No new PHP code or types; all logic lives in `src/phel/core/uuid.phel`.