### PR TITLE
feat(compiler): static member shorthand for bare Class/MEMBER symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `#php` reader literal: `#php [1 2 3]` expands to `(php-indexed-array 1 2 3)`; `#php {"a" 1 "b" 2}` expands to `(php-associative-array "a" 1 "b" 2)`. Non-recursive — nested Phel collections are left untouched.
 - Member-access shorthand: `(.method obj args)` / `(.-field obj)` expand to `(php/-> obj (method args))` / `(php/-> obj field)`; `(ClassName/method args)` (or `(\Class/method ...)` for FQN) expands to `(php/:: ClassName (method args))`.
+- Static member shorthand: bare `\Ns\Class/MEMBER` (or aliased `Class/MEMBER`) symbol expands to `(php/:: Class MEMBER)` for static property and class constant access.
 - `(new ClassName args...)` as an alias for `(php/new ClassName args...)`.
 - `def` evaluates to a printable var reference (e.g. `#'user/my-var`) instead of `nil`, making REPL feedback explicit.
 - REPL history vars: `*1`, `*2`, `*3` hold the three most recent results and `*e` holds the last thrown exception.

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -86,6 +86,10 @@ To keep calls short, capture the function reference with `def`:
 (php/:: DateTime (createFromFormat "Y-m-d" "2024-01-15"))
 (DateTime/createFromFormat "Y-m-d" "2024-01-15")   ; shorthand
 
+;; Static constants and properties — bare `Class/MEMBER` shorthand
+(php/:: \DateTimeImmutable ATOM)                   ; => "Y-m-d\\TH:i:sP"
+\DateTimeImmutable/ATOM                            ; shorthand
+
 ;; Access properties
 (php/-> obj propertyName)
 ```

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzeSymbol.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer;
 
+use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\SymbolSuggestionProvider;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
+
+use function in_array;
 
 final class AnalyzeSymbol
 {
@@ -48,16 +52,60 @@ final class AnalyzeSymbol
     {
         $globalResolve = $this->analyzer->resolve($symbol, $env);
 
-        if (!$globalResolve instanceof AbstractNode) {
-            $suggestions = $this->getSuggestionProvider()->findSimilar(
-                $symbol->getName(),
-                $this->analyzer->getAvailableSymbols(),
-            );
-
-            throw AnalyzerException::cannotResolveSymbol($symbol->getFullName(), $symbol, $suggestions);
+        if ($globalResolve instanceof AbstractNode) {
+            return $globalResolve;
         }
 
-        return $globalResolve;
+        if ($this->isStaticMemberShorthand($symbol)) {
+            return $this->analyzer->analyze(
+                $this->expandStaticMemberShorthand($symbol),
+                $env,
+            );
+        }
+
+        $suggestions = $this->getSuggestionProvider()->findSimilar(
+            $symbol->getName(),
+            $this->analyzer->getAvailableSymbols(),
+        );
+
+        throw AnalyzerException::cannotResolveSymbol($symbol->getFullName(), $symbol, $suggestions);
+    }
+
+    /**
+     * Bare `Class/MEMBER` symbol expands to `(php/:: Class MEMBER)` so a static
+     * property or constant access reads the same as the list-form static call
+     * shorthand handled by AnalyzePersistentList.
+     */
+    private function isStaticMemberShorthand(Symbol $symbol): bool
+    {
+        $ns = $symbol->getNamespace();
+        if (in_array($ns, [null, '', 'php'], true)) {
+            return false;
+        }
+
+        $name = $symbol->getName();
+        if ($name === '' || !$this->isIdentifierStartChar($name[0])) {
+            return false;
+        }
+
+        return $ns[0] === '\\'
+            || ($ns[0] >= 'A' && $ns[0] <= 'Z');
+    }
+
+    private function expandStaticMemberShorthand(Symbol $symbol): PersistentListInterface
+    {
+        $staticSymbol = Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL)->copyLocationFrom($symbol);
+        $classSymbol = Symbol::create((string) $symbol->getNamespace())->copyLocationFrom($symbol);
+        $memberSymbol = Symbol::create($symbol->getName())->copyLocationFrom($symbol);
+
+        return Phel::list([$staticSymbol, $classSymbol, $memberSymbol])->copyLocationFrom($symbol);
+    }
+
+    private function isIdentifierStartChar(string $c): bool
+    {
+        return ($c >= 'a' && $c <= 'z')
+            || ($c >= 'A' && $c <= 'Z')
+            || $c === '_';
     }
 
     private function getSuggestionProvider(): SymbolSuggestionProvider

--- a/tests/php/Integration/Fixtures/Call/class-slash-static-const.test
+++ b/tests/php/Integration/Fixtures/Call/class-slash-static-const.test
@@ -1,0 +1,4 @@
+--PHEL--
+\DateTimeImmutable/ATOM
+--PHP--
+(\DateTimeImmutable::ATOM);

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeSymbolTest.php
@@ -8,6 +8,7 @@ use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -20,9 +21,12 @@ final class AnalyzeSymbolTest extends TestCase
 {
     private AnalyzeSymbol $symbolAnalyzer;
 
+    private Analyzer $analyzer;
+
     protected function setUp(): void
     {
-        $this->symbolAnalyzer = new AnalyzeSymbol(new Analyzer(new GlobalEnvironment()));
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+        $this->symbolAnalyzer = new AnalyzeSymbol($this->analyzer);
         Phel::clear();
     }
 
@@ -123,5 +127,26 @@ final class AnalyzeSymbolTest extends TestCase
 
         $env = NodeEnvironment::empty();
         $symbolAnalyzer->analyze(Symbol::create('zzzzzzzzzzz'), $env);
+    }
+
+    public function test_fqn_class_slash_member_shorthand_expands_to_static_call(): void
+    {
+        $env = NodeEnvironment::empty();
+        $node = $this->analyzer->analyze(
+            Symbol::createForNamespace('\\DateTimeImmutable', 'ATOM'),
+            $env,
+        );
+
+        self::assertInstanceOf(PhpObjectCallNode::class, $node);
+        self::assertTrue($node->isStatic());
+    }
+
+    public function test_lowercase_namespace_does_not_expand_to_static_call(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage("Cannot resolve symbol 'foo/bar'");
+
+        $env = NodeEnvironment::empty();
+        $this->symbolAnalyzer->analyze(Symbol::createForNamespace('foo', 'bar'), $env);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Followup to #1471 / #1461. The list-form static call shorthand `(Class/method args)` shipped, but the bare-symbol form for static constants and properties still raised `[PHEL001] Cannot resolve symbol '\Amp\Http\HttpStatus/OK'` (see https://github.com/phel-lang/phel-lang/issues/1461#issuecomment-4276466862). Users had to fall back to `(php/:: \Amp\Http\HttpStatus OK)` for what reads naturally as `\Amp\Http\HttpStatus/OK`.

## 💡 Goal

Accept `\Ns\Class/MEMBER` (and aliased `Class/MEMBER`) as shorthand for `(php/:: Class MEMBER)`, so static constant and property access mirrors the list-form static call shorthand:

```phel
\DateTimeImmutable/ATOM            ; => "Y-m-d\TH:i:sP"
\Amp\Http\HttpStatus/OK            ; => 200
```

## 🔖 Changes

- `AnalyzeSymbol::createGlobalResolve` detects bare `Class/MEMBER` symbols when global resolution fails and dispatches them through the existing `(php/:: Class MEMBER)` path.
- Recognition predicate matches `AnalyzePersistentList::isStaticCallShorthand`: namespace must start with `\` or an uppercase letter (so Phel namespaces like `phel\core/map` keep resolving as before), member must be a valid identifier start.
- New unit tests in `AnalyzeSymbolTest` cover the FQN expansion and confirm lowercase-namespace symbols still raise `PHEL001`.
- Integration fixture `Fixtures/Call/class-slash-static-const.test` exercises the full pipeline (`\DateTimeImmutable/ATOM` → `(\DateTimeImmutable::ATOM);`).
- `docs/php-interop.md` quick-reference and CHANGELOG `Unreleased / Added` entry updated.