### PR TITLE
ref(compiler): replace OutputEmitterOptions string constants with EmitMode enum

### DIFF
--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -23,6 +23,7 @@ use Phel\Compiler\Domain\Compiler\EvalCompilerInterface;
 use Phel\Compiler\Domain\Emitter\FileEmitter;
 use Phel\Compiler\Domain\Emitter\FileEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\EmitMode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
@@ -129,13 +130,13 @@ final class CompilerFactory extends AbstractFactory
     {
         return new FileEmitter(
             new SourceMapGenerator(),
-            $this->createOutputEmitterWithMode(OutputEmitterOptions::EMIT_MODE_FILE, $enableSourceMaps),
+            $this->createOutputEmitterWithMode(EmitMode::File, $enableSourceMaps),
         );
     }
 
     public function createOutputEmitter(bool $enableSourceMaps = true): OutputEmitterInterface
     {
-        return $this->createOutputEmitterWithMode(OutputEmitterOptions::EMIT_MODE_STATEMENT, $enableSourceMaps);
+        return $this->createOutputEmitterWithMode(EmitMode::Statement, $enableSourceMaps);
     }
 
     public function createEvaluator(): EvaluatorInterface
@@ -178,11 +179,11 @@ final class CompilerFactory extends AbstractFactory
     {
         return new FileEmitter(
             new SourceMapGenerator(),
-            $this->createOutputEmitterWithMode(OutputEmitterOptions::EMIT_MODE_CACHE, $enableSourceMaps),
+            $this->createOutputEmitterWithMode(EmitMode::Cache, $enableSourceMaps),
         );
     }
 
-    private function createOutputEmitterWithMode(string $emitMode, bool $enableSourceMaps): OutputEmitter
+    private function createOutputEmitterWithMode(EmitMode $emitMode, bool $enableSourceMaps): OutputEmitter
     {
         return new OutputEmitter(
             $enableSourceMaps,

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/EmitMode.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/EmitMode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+enum EmitMode: string
+{
+    case File = 'EMIT_MODE_FILE';
+    case Statement = 'EMIT_MODE_STATEMENT';
+    case Cache = 'EMIT_MODE_CACHE';
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptions.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/OutputEmitterOptions.php
@@ -6,28 +6,22 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 final readonly class OutputEmitterOptions
 {
-    public const string EMIT_MODE_FILE = 'EMIT_MODE_FILE';
-
-    public const string EMIT_MODE_STATEMENT = 'EMIT_MODE_STATEMENT';
-
-    public const string EMIT_MODE_CACHE = 'EMIT_MODE_CACHE';
-
     public function __construct(
-        private string $emitMode = self::EMIT_MODE_STATEMENT,
+        private EmitMode $emitMode = EmitMode::Statement,
     ) {}
 
     public function isFileEmitMode(): bool
     {
-        return $this->emitMode === self::EMIT_MODE_FILE;
+        return $this->emitMode === EmitMode::File;
     }
 
     public function isStatementEmitMode(): bool
     {
-        return $this->emitMode === self::EMIT_MODE_STATEMENT;
+        return $this->emitMode === EmitMode::Statement;
     }
 
     public function isCacheEmitMode(): bool
     {
-        return $this->emitMode === self::EMIT_MODE_CACHE;
+        return $this->emitMode === EmitMode::Cache;
     }
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/OutputEmitterOptionsTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/OutputEmitterOptionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Compiler\Emitter\OutputEmitter;
 
+use Phel\Compiler\Domain\Emitter\OutputEmitter\EmitMode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ final class OutputEmitterOptionsTest extends TestCase
 
     public function test_is_file_emit_mode(): void
     {
-        $options = new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_FILE);
+        $options = new OutputEmitterOptions(EmitMode::File);
 
         self::assertTrue($options->isFileEmitMode());
         self::assertFalse($options->isStatementEmitMode());
@@ -29,7 +30,7 @@ final class OutputEmitterOptionsTest extends TestCase
 
     public function test_is_statement_emit_mode(): void
     {
-        $options = new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_STATEMENT);
+        $options = new OutputEmitterOptions(EmitMode::Statement);
 
         self::assertTrue($options->isStatementEmitMode());
         self::assertFalse($options->isFileEmitMode());
@@ -38,7 +39,7 @@ final class OutputEmitterOptionsTest extends TestCase
 
     public function test_is_cache_emit_mode(): void
     {
-        $options = new OutputEmitterOptions(OutputEmitterOptions::EMIT_MODE_CACHE);
+        $options = new OutputEmitterOptions(EmitMode::Cache);
 
         self::assertTrue($options->isCacheEmitMode());
         self::assertFalse($options->isStatementEmitMode());


### PR DESCRIPTION
## 🤔 Background

A codebase-wide audit looked for duplicated type definitions, repeated array shapes, and constant-based stringly-typed patterns that are better expressed as PHP 8.3 backed enums.

**What was found and why most was left alone:**

- **`FileIoInterface` across 4 modules** (Interop, Filesystem, Build, Formatter) — all four interfaces have completely different method signatures. The shared name is coincidental; each serves a distinct domain concern. Merging them would break module boundaries without benefit.
- **Namespace-environment array shapes** repeated across `NamespaceEnvironmentSerializer`, `CompilerFacadeInterface`, and `GlobalEnvironmentInterface` — these are doc-level `@return`/`@param` annotations. The shape cannot be consolidated into a real type alias at the PHP runtime level (PHP has no type aliases), and a `@psalm-type` approach would be novel to this codebase. The shapes are in two files (6 occurrences total) and are already co-located with their consumers; acceptable duplication.
- **`DocCommand` internal array shape** — repeated 3× within a single file, used only locally. Not a sharing concern.
- **`Token` int constants** — already on the right class; no duplication.
- **`BuildConstants`/`ReplConstants`/`CompilerConstants`** in `Shared` — each holds one constant, already in the correct place (Shared module, used cross-module). Converting to an enum would not make sense (they're not a closed set of alternatives).
- **HttpClient shapes** (`ResponseParser` vs `StreamTransport`) — slightly different key order, same module, not exposed through a facade.

**What was consolidated:**

`OutputEmitterOptions` held three `const string` values that served as a stringly-typed discriminant: `EMIT_MODE_FILE`, `EMIT_MODE_STATEMENT`, `EMIT_MODE_CACHE`. The private factory method `createOutputEmitterWithMode(string $emitMode, ...)` accepted a raw string, making passing an arbitrary value possible with no type check.

## 💡 Goal

Replace the three string constants with a proper backed enum `EmitMode`, making `createOutputEmitterWithMode` type-safe at the call site, and removing the open `string` parameter entirely.

## 🔖 Changes

- New `EmitMode: string` backed enum with cases `File`, `Statement`, `Cache` (values preserved for any serialised forms)
- `OutputEmitterOptions` constructor now takes `EmitMode` instead of `string`; the three old `const string` fields are gone
- `CompilerFactory::createOutputEmitterWithMode` signature tightened to `EmitMode $emitMode`
- Three call sites in `CompilerFactory` updated to use the enum cases
- `OutputEmitterOptionsTest` updated to use the new enum cases