### PR TITLE
ref(emitter): consolidate closure-use emission into ClosureEmitterHelper

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ClosureEmitterHelper.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ClosureEmitterHelper.php
@@ -14,8 +14,8 @@ use function count;
 /**
  * Shared helpers for emitting PHP anonymous classes that capture local variables.
  *
- * Used by FnAsClassEmitter and ReifyEmitter to avoid duplicating
- * the constructor-argument, property, and constructor-body patterns.
+ * Used by FnAsClassEmitter, ReifyEmitter, MultiFnAsClassEmitter, and MethodEmitter
+ * to centralize the use-normalization, property, and constructor-argument patterns.
  */
 final readonly class ClosureEmitterHelper
 {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function count;
 
-final class MethodEmitter
+final readonly class MethodEmitter
 {
-    use WithOutputEmitterTrait;
+    public function __construct(
+        private OutputEmitterInterface $outputEmitter,
+        private ClosureEmitterHelper $closureHelper,
+    ) {}
 
     public function emit(string $methodName, FnNode $node): void
     {
@@ -98,11 +102,7 @@ final class MethodEmitter
     private function emitMethodParametersExtraction(FnNode $node): void
     {
         foreach ($node->getUses() as $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $varName = $this->munge($normalizedUse);
+            $varName = $this->munge($this->closureHelper->normalizeUse($use, $node->getEnv()));
 
             $this->outputEmitter->emitLine(
                 '$' . $varName . ' = $this->' . $varName . ';',

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -18,6 +18,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
 {
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
+        private ClosureEmitterHelper $closureHelper,
     ) {}
 
     public function emit(AbstractNode $node): void
@@ -63,18 +64,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('new class(', $node->getStartSourceLocation());
 
-        $usesCount = count($uses);
-        foreach ($uses as $i => $use) {
-            $loc = $use->getStartLocation();
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitPhpVariable($normalizedUse, $loc);
-            if ($i < $usesCount - 1) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-            }
-        }
+        $this->closureHelper->emitConstructorArguments($uses, $node->getEnv(), $node->getStartSourceLocation());
 
         $this->outputEmitter->emitLine(') extends \\Phel\\Lang\\AbstractFn {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
@@ -89,16 +79,7 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
         $ns = addslashes($this->outputEmitter->mungeEncodeNs($node->getEnv()->getBoundTo()));
         $this->outputEmitter->emitLine('public const BOUND_TO = "' . $ns . '";', $node->getStartSourceLocation());
 
-        foreach ($uses as $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitLine(
-                'private $' . $this->outputEmitter->mungeEncode($normalizedUse->getName()) . ';',
-                $node->getStartSourceLocation(),
-            );
-        }
+        $this->closureHelper->emitProperties($uses, $node->getEnv(), $node->getStartSourceLocation());
 
         for ($i = 0; $i < $fnCount; ++$i) {
             $this->outputEmitter->emitLine('private $fn' . $i . ';', $node->getStartSourceLocation());
@@ -111,43 +92,36 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
      */
     private function emitConstructor(MultiFnNode $node, array $uses, array $fnNodes): void
     {
+        $loc = $node->getStartSourceLocation();
+        $env = $node->getEnv();
         $usesCount = count($uses);
+
         $this->outputEmitter->emitLine();
-        $this->outputEmitter->emitStr('public function __construct(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr('public function __construct(', $loc);
+
         foreach ($uses as $i => $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $this->outputEmitter->emitPhpVariable($normalizedUse, $node->getStartSourceLocation());
+            $this->outputEmitter->emitPhpVariable($this->closureHelper->normalizeUse($use, $env), $loc);
             if ($i < $usesCount - 1) {
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
+                $this->outputEmitter->emitStr(', ', $loc);
             }
         }
 
-        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine(') {', $loc);
         $this->outputEmitter->increaseIndentLevel();
 
         foreach ($uses as $use) {
-            /** @var Symbol $normalizedUse */
-            $normalizedUse = $node->getEnv()->getShadowed($use) instanceof Symbol
-                ? $node->getEnv()->getShadowed($use)
-                : $use;
-            $varName = $this->outputEmitter->mungeEncode($normalizedUse->getName());
-            $this->outputEmitter->emitLine(
-                '$this->' . $varName . ' = $' . $varName . ';',
-                $node->getStartSourceLocation(),
-            );
+            $varName = $this->outputEmitter->mungeEncode($this->closureHelper->normalizeUse($use, $env)->getName());
+            $this->outputEmitter->emitLine('$this->' . $varName . ' = $' . $varName . ';', $loc);
         }
 
         foreach ($fnNodes as $i => $fnNode) {
-            $this->outputEmitter->emitStr('$this->fn' . $i . ' = ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr('$this->fn' . $i . ' = ', $loc);
             $this->outputEmitter->emitNode($fnNode);
-            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+            $this->outputEmitter->emitLine(';', $loc);
         }
 
         $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('}', $loc);
         $this->outputEmitter->emitLine();
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitterFactory.php
@@ -150,7 +150,7 @@ final class NodeEmitterFactory
             MapNode::class => new MapEmitter($outputEmitter),
             SetVarNode::class => new SetVarEmitter($outputEmitter),
             DefInterfaceNode::class => new DefInterfaceEmitter($outputEmitter),
-            MultiFnNode::class => new MultiFnAsClassEmitter($outputEmitter),
+            MultiFnNode::class => new MultiFnAsClassEmitter($outputEmitter, $closureHelper),
             ReifyNode::class => new ReifyEmitter($outputEmitter, $methodEmitter, $closureHelper),
             default => throw NotSupportedAstException::withClassName($astNodeClassName),
         };
@@ -160,7 +160,7 @@ final class NodeEmitterFactory
     {
         $key = spl_object_id($outputEmitter);
 
-        return $this->methodEmitterCache[$key] ??= new MethodEmitter($outputEmitter);
+        return $this->methodEmitterCache[$key] ??= new MethodEmitter($outputEmitter, $this->getClosureHelper($outputEmitter));
     }
 
     private function getClosureHelper(OutputEmitterInterface $outputEmitter): ClosureEmitterHelper

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitterTest.php
@@ -23,10 +23,11 @@ final class FnAsClassEmitterTest extends TestCase
         $outputEmitter = (new CompilerFactory())
             ->createOutputEmitter();
 
+        $closureHelper = new ClosureEmitterHelper($outputEmitter);
         $this->fnAsClassEmitter = new FnAsClassEmitter(
             $outputEmitter,
-            new MethodEmitter($outputEmitter),
-            new ClosureEmitterHelper($outputEmitter),
+            new MethodEmitter($outputEmitter, $closureHelper),
+            $closureHelper,
         );
     }
 


### PR DESCRIPTION
## 🤔 Background

`MultiFnAsClassEmitter` emitted PHP closure scaffolding (constructor args, properties, ctor body, `__invoke` body) with the same `$env->getShadowed(...) instanceof Symbol ? ... : $use` normalization repeated four times, plus an identical constructor-args / property emission loop in `MethodEmitter` for the single-fn path.

## 💡 Goal

Pull the duplicated bits behind `ClosureEmitterHelper` so the emitter classes describe what they emit, not how `use` symbols are normalized.

## 🔖 Changes

- `ClosureEmitterHelper` gains `normalizeUse()`, `emitConstructorArguments()`, and `emitProperties()`.
- `MultiFnAsClassEmitter` accepts the helper via constructor injection and routes its four duplicated sites through it.
- `NodeEmitterFactory` wires the helper into `MultiFnAsClassEmitter`.
- `MethodEmitter` adopts the same helper for the property/use loop.
- `FnAsClassEmitterTest` updated where the constructor signature changed.

No public API change; entirely internal to the emitter pipeline. All 1579 unit + integration tests pass (excluding the 6 pre-existing env failures unrelated to this branch).