### PR TITLE
ref(deps): break Compiler→Run cycle, drop Lang→Printer hot path

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -35,6 +35,7 @@ return RectorConfig::configure()
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/GlobalVarEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php',
+            __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoadEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php',
             __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php',

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoadEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoadEmitter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
-use Phel\Build\BuildFacade;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LoadNode;
 use Phel\Compiler\Domain\Analyzer\Resolver\LoadClasspath;
@@ -189,11 +188,11 @@ final class LoadEmitter implements NodeEmitterInterface
     private function emitPhelSourceLoad(string $callerNamespace): void
     {
         $this->outputEmitter->emitLine('$__phelPrevNs = \\' . GlobalEnvironmentSingleton::class . '::getInstance()->getNs();');
-        $this->outputEmitter->emitLine('\\' . BuildFacade::class . '::enableBuildMode();');
+        $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::enableBuildMode();');
         $this->outputEmitter->emitLine('try {');
         $this->outputEmitter->increaseIndentLevel();
 
-        $this->outputEmitter->emitLine('(new \\' . BuildFacade::class . '())->evalFile($__phelLoadPath);');
+        $this->outputEmitter->emitLine('(new \\Phel\\Build\\BuildFacade())->evalFile($__phelLoadPath);');
 
         $this->outputEmitter->emitLine('$__phelLoadedNs = \\' . GlobalEnvironmentSingleton::class . '::getInstance()->getNs();');
         $this->outputEmitter->emitStr('if ($__phelLoadedNs !== ');
@@ -215,7 +214,7 @@ final class LoadEmitter implements NodeEmitterInterface
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('} finally {');
         $this->outputEmitter->increaseIndentLevel();
-        $this->outputEmitter->emitLine('\\' . BuildFacade::class . '::disableBuildMode();');
+        $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::disableBuildMode();');
         $this->outputEmitter->emitLine('\\' . GlobalEnvironmentSingleton::class . '::getInstance()->setNs($__phelPrevNs);');
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('}');

--- a/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php
+++ b/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Domain\Evaluator;
 use ParseError;
 use Phel\Compiler\Domain\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
-use Phel\Run\Infrastructure\Service\DebugLineTap;
+use Phel\Compiler\Infrastructure\Service\DebugLineTap;
 use Throwable;
 
 /**

--- a/src/php/Compiler/Domain/Evaluator/RequireEvaluator.php
+++ b/src/php/Compiler/Domain/Evaluator/RequireEvaluator.php
@@ -7,8 +7,8 @@ namespace Phel\Compiler\Domain\Evaluator;
 use ParseError;
 use Phel\Compiler\Domain\Evaluator\Exceptions\CompiledCodeIsMalformedException;
 use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
+use Phel\Compiler\Infrastructure\Service\DebugLineTap;
 use Phel\Filesystem\FilesystemFacadeInterface;
-use Phel\Run\Infrastructure\Service\DebugLineTap;
 
 use function function_exists;
 use function md5;

--- a/src/php/Compiler/Infrastructure/Service/DebugLineTap.php
+++ b/src/php/Compiler/Infrastructure/Service/DebugLineTap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel\Run\Infrastructure\Service;
+namespace Phel\Compiler\Infrastructure\Service;
 
 use function count;
 use function in_array;

--- a/src/php/Lang/AbstractFn.php
+++ b/src/php/Lang/AbstractFn.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
-use Phel\Printer\Printer;
+use ReflectionClass;
 use Stringable;
+
+use function is_string;
 
 abstract class AbstractFn implements FnInterface, MetaInterface, Stringable
 {
@@ -13,6 +15,17 @@ abstract class AbstractFn implements FnInterface, MetaInterface, Stringable
 
     public function __toString(): string
     {
-        return Printer::nonReadable()->print($this);
+        $boundTo = (new ReflectionClass($this))->getConstant('BOUND_TO');
+
+        if (!is_string($boundTo) || $boundTo === '') {
+            return '<function>';
+        }
+
+        $lastSeparator = strrpos($boundTo, '\\');
+        $encodedName = $lastSeparator !== false
+            ? substr($boundTo, $lastSeparator + 1)
+            : $boundTo;
+
+        return '<function:' . str_replace('_', '-', $encodedName) . '>';
     }
 }

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -38,6 +38,16 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
         return $obj[$this] ?? $default;
     }
 
+    #[Override]
+    public function __toString(): string
+    {
+        if ($this->namespace !== null && $this->namespace !== '') {
+            return ':' . $this->namespace . '/' . $this->name;
+        }
+
+        return ':' . $this->name;
+    }
+
     public static function create(string $name, ?string $namespace = null): self
     {
         $key = $namespace !== null && $namespace !== ''

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use Override;
+
 final class Symbol extends AbstractType implements IdenticalInterface, NamedInterface
 {
     use MetaTrait;
@@ -106,6 +108,12 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
         private readonly ?string $namespace,
         private readonly string $name,
     ) {}
+
+    #[Override]
+    public function __toString(): string
+    {
+        return $this->name;
+    }
 
     public static function create(string $name): self
     {

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -7,8 +7,8 @@ namespace Phel\Run\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Compiler\Infrastructure\Service\DebugLineTap;
 use Phel\Phel;
-use Phel\Run\Infrastructure\Service\DebugLineTap;
 use Phel\Run\RunFacade;
 use Phel\Shared\ResourceUsageFormatter;
 

--- a/tests/php/Unit/Compiler/Infrastructure/Service/DebugLineTapTest.php
+++ b/tests/php/Unit/Compiler/Infrastructure/Service/DebugLineTapTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit\Run\Infrastructure\Service;
+namespace PhelTest\Unit\Compiler\Infrastructure\Service;
 
-use Phel\Run\Infrastructure\Service\DebugLineTap;
+use Phel\Compiler\Infrastructure\Service\DebugLineTap;
 use PHPUnit\Framework\TestCase;
 
 use function strlen;


### PR DESCRIPTION
## 🤔 Background

`Compiler/Domain/Evaluator/InMemoryEvaluator` and `RequireEvaluator` both depended on `Phel\Run\Infrastructure\Service\DebugLineTap` — a Compiler→Run dependency that inverts the intended layering (Run consumes Compiler, never the reverse).

Separately, `Lang/AbstractType` and `Lang/AbstractFn` routed `__toString` through `Phel\Printer\Printer`, putting the Lang module — documented as a leaf — into a Lang→Printer→Lang cycle for the most common type-rendering path.

## 💡 Goal

Untangle without changing any user-visible behavior or printing output. Phel core tests (3668) must stay green.

## 🔖 Changes

- **Move `DebugLineTap`** to `Phel\Compiler\Infrastructure\Service` (PHPUnit test moved alongside). Its sole callers are now in-module. `RunCommand` updated to import from the new location.
- **`LoadEmitter`** previously interpolated `BuildFacade::class` into emitted code, forcing the Compiler emitter to import `Phel\Build\BuildFacade`. Replaced with a literal FQCN string, removing the import.
- **`AbstractFn::__toString`** inlines a small `BOUND_TO`-aware renderer so it no longer pulls in `Printer`. `Symbol::__toString` and `Keyword::__toString` get direct overrides that bypass the Printer round-trip while emitting the same readable form.
- **`AbstractType::__toString` left routing through `Printer`** — collection types (`PersistentVector`, `PersistentHashMap`, `PersistentHashSet`, …) need the recursive printer to render readably; inlining all of that here would duplicate the Printer module. The remaining Lang→Printer edge is hot-path-free for Symbol/Keyword/AbstractFn but persists for collections; flagged for a follow-up that introduces a printer interface in Lang and lets Printer register as an implementation.

## ✅ Validation

- `composer test-quality` clean
- `composer test-compiler` — 1579/1579 unit tests pass, integration matches main (6 pre-existing env failures unrelated to this branch)
- `composer test-core` — 3668/0 (full Phel core suite green)