### PR TITLE
ref(comments): drop code-restating comments in NodeEmitter slice

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -56,12 +56,10 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
         $ns = $this->outputEmitter->mungeEncodeNs($node->getNamespace());
         $fqcn = $ns . '\\' . $this->outputEmitter->mungeEncode($node->getName()->getName());
 
-        // Capture the class body at compile time
         ob_start();
         $this->emitClassBody($node);
         $classBody = (string) ob_get_clean();
 
-        // Emit: if (!class_exists(...)) { eval('namespace ...; <class body>'); }
         $this->outputEmitter->emitLine("if (!class_exists('" . $fqcn . "')) {", $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/InNsEmitter.php
@@ -21,7 +21,6 @@ final class InNsEmitter implements NodeEmitterInterface
     {
         assert($node instanceof InNsNode);
 
-        // Set the namespace in the global environment
         $this->outputEmitter->emitLine(
             '\\' . GlobalEnvironmentSingleton::class . '::getInstance()->setNs("' . addslashes($node->getNamespace()) . '");',
             $node->getStartSourceLocation(),
@@ -43,7 +42,6 @@ final class InNsEmitter implements NodeEmitterInterface
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine(');');
 
-        // Update *ns* definition
         $this->outputEmitter->emitLine('\\' . Phel::class . '::addDefinition(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');


### PR DESCRIPTION
## 🤔 Background

Continuation of the comment-cleanup track. The NodeEmitter subtree accumulated a handful of inline comments that restate what the immediately following line of code does, with no additional information.

## 💡 Goal

Remove noise comments; leave only genuine WHY-comments (non-obvious invariants, constraints, and workarounds).

## 🔖 Changes

**Dropped (code-restating, 0 information value):**
- `DefStructEmitter`: `// Capture the class body at compile time` (ob_start is self-explanatory)
- `DefStructEmitter`: `// Emit: if (!class_exists(...)) { eval('namespace ...; <class body>'); }` (duplicates the emitLine call on the next line)
- `InNsEmitter`: `// Set the namespace in the global environment` (method call name says the same)
- `InNsEmitter`: `// Update *ns* definition` (emitLine pattern is uniform; no extra WHY here)

**Kept (genuine WHY-comments):**
- `DefEmitter`: cache-mode GlobalEnvironment registration rationale (cache-miss handling)
- `DefStructEmitter` (PHPDoc): `shouldEmitViaEval` / `emitViaEval` / `emitInline` method docs explaining the eval-scope constraint
- `FnAsClassEmitter`: multi-arity child / IIFE self-binding invariant
- `InNsEmitter`: `*file*` update comment (explains why — path resolution for subsequent loads)
- `LoadEmitter`: two-convention comment (classpath-rooted vs prefix-rooted), pre-compiled sibling rationale
- `NsEmitter`: FILE+CACHE namespace declaration reason, cache-mode dependency-skip rationale
- `UseEmitter`: compile-time-only explanation with expression-position null emission

**Stats:** 4 slop lines dropped, 0 WHY-comments removed.