### PR TITLE
feat(repl): add intern, ns-interns, create-ns, find-ns, remove-ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - `phel\ai`: `docs/ai-guide.md` usage guide.
 - `phel\ai`: `*http-post*` rebindable seam enables full behavior coverage of chat/complete/extract/chat-with-tools/embed/build-index/search without a live API.
 - `uuid=`, `uuid-nil?`, `uuid-version`, and `uuid-variant` helpers in `phel\core` for case-insensitive UUID comparison and field extraction.
+- `phel\repl`: `find-ns`, `create-ns`, `remove-ns`, `intern`, and `ns-interns` for inspecting and mutating namespaces without switching `*ns*`.
 
 ### Fixed
 

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -362,10 +362,8 @@
   {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
-  (let [encoded  (munge-ns ns-str)
-        registry (php/:: Registry (getInstance))]
-    (when (php/-> registry (hasNamespace encoded))
-      ns-str)))
+  (when (php/:: Phel (hasNamespace (munge-ns ns-str)))
+    ns-str))
 
 (defn create-ns
   "Creates the given namespace if it does not already exist. Returns the
@@ -373,10 +371,8 @@
   {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
-  (let [encoded  (munge-ns ns-str)
-        registry (php/:: Registry (getInstance))]
-    (php/-> registry (registerNamespace encoded))
-    ns-str))
+  (php/:: Phel (registerNamespace (munge-ns ns-str)))
+  ns-str)
 
 (defn remove-ns
   "Removes the namespace and all of its definitions from the registry.
@@ -384,26 +380,21 @@
   {:example "(remove-ns \"my-app\\tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
-  (let [encoded  (munge-ns ns-str)
-        registry (php/:: Registry (getInstance))]
-    (php/-> registry (removeNamespace encoded))
-    nil))
+  (php/:: Phel (removeNamespace (munge-ns ns-str)))
+  nil)
 
 (defn intern
   "Finds or creates a definition named by name-str in namespace ns-str,
   setting its root value to val when supplied (defaults to nil). The
-  namespace is registered if it does not already exist. Returns the
-  fully qualified symbol naming the definition."
+  namespace is auto-registered by the underlying `addDefinition` call.
+  Returns the fully qualified symbol naming the definition."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
   (let [encoded-ns   (munge-ns ns-str)
-        munge        (php/new Munge)
-        encoded-name (php/-> munge (encode name-str))
-        value        (first rest)
-        registry     (php/:: Registry (getInstance))]
-    (php/-> registry (registerNamespace encoded-ns))
-    (php/-> registry (addDefinition encoded-ns encoded-name value nil))
+        encoded-name (php/-> (php/new Munge) (encode name-str))
+        value        (first rest)]
+    (php/:: Phel (addDefinition encoded-ns encoded-name value))
     (php/:: Symbol (createForNamespace ns-str name-str))))
 
 (defn ns-interns
@@ -413,10 +404,9 @@
   {:example "(ns-interns \"phel\\core\")"
    :see-also ["ns-publics" "intern" "find-ns"]}
   [ns-str]
-  (let [encoded (munge-ns ns-str)
-        defs    (php/:: Phel (getDefinitionInNamespace encoded))
-        munge   (php/new Munge)
-        result  (transient {})]
+  (let [defs   (php/:: Phel (getDefinitionInNamespace (munge-ns ns-str)))
+        munge  (php/new Munge)
+        result (transient {})]
     (foreach [fn-name value defs]
       (assoc! result (php/-> munge (decodeNs fn-name)) value))
     (persistent result)))

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -356,6 +356,71 @@
     (when resolved-sym
       `(get-source-code ~(namespace resolved-sym) ~(name resolved-sym)))))
 
+(defn find-ns
+  "Returns the namespace name if it is loaded, or nil if no namespace of
+  that name exists."
+  {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
+   :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
+  [ns-str]
+  (let [encoded  (munge-ns ns-str)
+        registry (php/:: Registry (getInstance))]
+    (when (php/-> registry (hasNamespace encoded))
+      ns-str)))
+
+(defn create-ns
+  "Creates the given namespace if it does not already exist. Returns the
+  namespace name. Existing namespaces are left untouched."
+  {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
+   :see-also ["find-ns" "remove-ns" "intern"]}
+  [ns-str]
+  (let [encoded  (munge-ns ns-str)
+        registry (php/:: Registry (getInstance))]
+    (php/-> registry (registerNamespace encoded))
+    ns-str))
+
+(defn remove-ns
+  "Removes the namespace and all of its definitions from the registry.
+  Use with caution. Returns nil."
+  {:example "(remove-ns \"my-app\\tmp\")"
+   :see-also ["find-ns" "create-ns"]}
+  [ns-str]
+  (let [encoded  (munge-ns ns-str)
+        registry (php/:: Registry (getInstance))]
+    (php/-> registry (removeNamespace encoded))
+    nil))
+
+(defn intern
+  "Finds or creates a definition named by name-str in namespace ns-str,
+  setting its root value to val when supplied (defaults to nil). The
+  namespace is registered if it does not already exist. Returns the
+  fully qualified symbol naming the definition."
+  {:example "(intern \"user\" \"x\" 42) ; => user/x"
+   :see-also ["find-ns" "create-ns" "ns-interns"]}
+  [ns-str name-str & rest]
+  (let [encoded-ns   (munge-ns ns-str)
+        munge        (php/new Munge)
+        encoded-name (php/-> munge (encode name-str))
+        value        (first rest)
+        registry     (php/:: Registry (getInstance))]
+    (php/-> registry (registerNamespace encoded-ns))
+    (php/-> registry (addDefinition encoded-ns encoded-name value nil))
+    (php/:: Symbol (createForNamespace ns-str name-str))))
+
+(defn ns-interns
+  "Returns a hash-map of {name => value} for every definition in the
+  given namespace, including private ones. Returns an empty map if the
+  namespace has no definitions."
+  {:example "(ns-interns \"phel\\core\")"
+   :see-also ["ns-publics" "intern" "find-ns"]}
+  [ns-str]
+  (let [encoded (munge-ns ns-str)
+        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        munge   (php/new Munge)
+        result  (transient {})]
+    (foreach [fn-name value defs]
+      (assoc! result (php/-> munge (decodeNs fn-name)) value))
+    (persistent result)))
+
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the
   given namespace string. Private definitions are excluded."

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -54,6 +54,24 @@ final class Registry
         return isset($this->definitions[$ns][$name]);
     }
 
+    public function hasNamespace(string $ns): bool
+    {
+        return isset($this->definitions[$ns]);
+    }
+
+    public function registerNamespace(string $ns): void
+    {
+        if (!isset($this->definitions[$ns])) {
+            $this->definitions[$ns] = [];
+            $this->definitionsMetaData[$ns] = [];
+        }
+    }
+
+    public function removeNamespace(string $ns): void
+    {
+        unset($this->definitions[$ns], $this->definitionsMetaData[$ns]);
+    }
+
     public function getDefinition(string $ns, string $name): mixed
     {
         return $this->definitions[$ns][$name] ?? null;

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -480,6 +480,23 @@
     (is (= {"answer" 42} (ns-interns ns)) "intern stores the value")
     (remove-ns ns)))
 
+(deftest test-intern-returns-fully-qualified-symbol
+  (let [ns  "phel-test-repl\\intern-return"
+        sym (intern ns "pointer" 1)]
+    (is (= "pointer" (php/-> sym (getName))) "symbol name matches")
+    (is (= ns (php/-> sym (getNamespace))) "symbol namespace matches")
+    (is (= (str ns "/pointer") (php/-> sym (getFullName)))
+        "symbol full name is ns/name")
+    (remove-ns ns)))
+
+(deftest test-intern-munges-dashes-in-name
+  (let [ns "phel-test-repl\\intern-munge"]
+    (remove-ns ns)
+    (intern ns "kebab-name" 1)
+    (is (= {"kebab-name" 1} (ns-interns ns))
+        "intern encodes dashes and ns-interns decodes them")
+    (remove-ns ns)))
+
 (deftest test-intern-defaults-to-nil-value
   (let [ns "phel-test-repl\\intern-nil"]
     (remove-ns ns)

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers find-fn test-ns eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns])
+  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers ns-interns find-fn test-ns eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns find-ns create-ns remove-ns intern])
   (:require phel\ai :as ai)
   (:require phel\string :as s)
   (:require phel\test :refer [deftest is]))
@@ -446,3 +446,74 @@
   (is (function? review) "review is defined")
   (is (function? embed-ns) "embed-ns is defined")
   (is (function? search-ns) "search-ns is defined"))
+
+;; ------------------
+;; find-ns / create-ns / remove-ns / intern / ns-interns
+;; ------------------
+
+(deftest test-find-ns-returns-nil-for-unknown
+  (is (nil? (find-ns "phel-test-repl-unknown-ns"))))
+
+(deftest test-create-ns-registers-empty-namespace
+  (let [ns "phel-test-repl\\create-ns-fixture"]
+    (remove-ns ns)
+    (is (nil? (find-ns ns)) "pre: namespace not registered")
+    (let [created (create-ns ns)]
+      (is (= ns created) "create-ns returns the namespace string")
+      (is (= ns (find-ns ns)) "namespace is now discoverable"))
+    (remove-ns ns)))
+
+(deftest test-create-ns-is-idempotent
+  (let [ns "phel-test-repl\\create-ns-idempotent"]
+    (create-ns ns)
+    (intern ns "keeper" 7)
+    (create-ns ns)
+    (is (= {"keeper" 7} (ns-interns ns))
+        "re-creating a namespace keeps existing definitions")
+    (remove-ns ns)))
+
+(deftest test-intern-stores-value-and-creates-namespace
+  (let [ns "phel-test-repl\\intern-fixture"]
+    (remove-ns ns)
+    (intern ns "answer" 42)
+    (is (= ns (find-ns ns)) "intern auto-registers the namespace")
+    (is (= {"answer" 42} (ns-interns ns)) "intern stores the value")
+    (remove-ns ns)))
+
+(deftest test-intern-defaults-to-nil-value
+  (let [ns "phel-test-repl\\intern-nil"]
+    (remove-ns ns)
+    (intern ns "placeholder")
+    (is (= {"placeholder" nil} (ns-interns ns))
+        "intern with no value uses nil")
+    (remove-ns ns)))
+
+(deftest test-intern-overwrites-existing-value
+  (let [ns "phel-test-repl\\intern-overwrite"]
+    (remove-ns ns)
+    (intern ns "x" 1)
+    (intern ns "x" 2)
+    (is (= {"x" 2} (ns-interns ns)) "subsequent intern replaces the value")
+    (remove-ns ns)))
+
+(deftest test-ns-interns-empty-for-missing-namespace
+  (is (= {} (ns-interns "phel-test-repl-missing"))
+      "ns-interns returns an empty map for unknown namespaces"))
+
+(deftest test-ns-interns-includes-private-definitions
+  (let [ns "phel-test-repl\\interns-all"]
+    (remove-ns ns)
+    (intern ns "pub" 1)
+    (intern ns "priv" 2)
+    (is (= {"pub" 1 "priv" 2} (ns-interns ns))
+        "ns-interns exposes every definition")
+    (remove-ns ns)))
+
+(deftest test-remove-ns-drops-all-definitions
+  (let [ns "phel-test-repl\\remove-me"]
+    (create-ns ns)
+    (intern ns "gone" 99)
+    (remove-ns ns)
+    (is (nil? (find-ns ns)) "find-ns returns nil after remove-ns")
+    (is (= {} (ns-interns ns))
+        "ns-interns returns an empty map after remove-ns")))

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -64,4 +64,48 @@ final class RegistryTest extends TestCase
         self::assertSame('my-var', $actual->getName());
         self::assertSame('my-ns/my-var', $actual->getFullName());
     }
+
+    public function test_has_namespace_false_when_missing(): void
+    {
+        self::assertFalse($this->registry->hasNamespace('missing-ns'));
+    }
+
+    public function test_has_namespace_true_after_add_definition(): void
+    {
+        $this->registry->addDefinition('ns-a', 'x', 1);
+
+        self::assertTrue($this->registry->hasNamespace('ns-a'));
+    }
+
+    public function test_register_namespace_creates_empty_namespace(): void
+    {
+        $this->registry->registerNamespace('empty-ns');
+
+        self::assertTrue($this->registry->hasNamespace('empty-ns'));
+        self::assertSame([], $this->registry->getDefinitionInNamespace('empty-ns'));
+    }
+
+    public function test_register_namespace_is_idempotent(): void
+    {
+        $this->registry->addDefinition('ns-b', 'y', 2);
+        $this->registry->registerNamespace('ns-b');
+
+        self::assertSame(2, $this->registry->getDefinition('ns-b', 'y'));
+    }
+
+    public function test_remove_namespace_drops_definitions(): void
+    {
+        $this->registry->addDefinition('ns-c', 'z', 3);
+        $this->registry->removeNamespace('ns-c');
+
+        self::assertFalse($this->registry->hasNamespace('ns-c'));
+        self::assertNull($this->registry->getDefinition('ns-c', 'z'));
+    }
+
+    public function test_remove_namespace_noop_when_missing(): void
+    {
+        $this->registry->removeNamespace('never-registered');
+
+        self::assertFalse($this->registry->hasNamespace('never-registered'));
+    }
 }


### PR DESCRIPTION
Closes #1480.

## 🤔 Background

Phel had read-only namespace helpers (`ns-publics`, `ns-aliases`, `ns-refers`, `loaded-namespaces`) but nothing to create, intern into, or drop a namespace from code without a `(ns ...)` switch.

## 💡 Goal

Add five namespace utilities to `phel\repl` that inspect and mutate the registry without switching `*ns*`.

## 🔖 Changes

New `phel\repl` functions:

- `(find-ns ns-str)`: returns `ns-str` when loaded, `nil` otherwise.
- `(create-ns ns-str)`: idempotently registers the namespace, returns `ns-str`.
- `(remove-ns ns-str)`: drops the namespace and all its definitions, returns `nil`.
- `(intern ns-str name-str & [val])`: creates or overwrites a definition (value defaults to `nil`), returns the `ns/name` symbol.
- `(ns-interns ns-str)`: `{name => value}` map for all definitions (public and private).

Supporting changes in `Phel\Lang\Registry`:

- `hasNamespace`, `registerNamespace`, `removeNamespace`. Exposed to Phel code through `\Phel::__callStatic`.

Tests:

- 6 new PHPUnit cases in `RegistryTest` covering the new methods.
- 10 `deftest` blocks in `tests/phel/test/repl.phel` covering each function, symbol return shape, idempotency, nil-default value, overwrite, private inclusion, dash round-trip.

Local results:

- `./vendor/bin/phpunit --testsuite=unit`: 530 pass.
- `composer test-core`: 3681 pass.
- `./bin/phel test tests/phel/test/repl.phel`: 132 pass.
- `composer test-quality`: clean.