### PR TITLE
ref(deps): break Lang to Compiler cycle by inlining struct key encoder

### DIFF
--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -40,11 +40,13 @@ This is a **foundational module** with no Facade, Factory, or DependencyProvider
 - **LinkedList/** — `PersistentList` (implements `PersistentListInterface`)
 - **HashSet/** — `PersistentHashSet` (implements `PersistentHashSetInterface`)
 - **LazySeq/** — `LazySeq` (implements `LazySeqInterface`)
-- **Struct/** — `AbstractPersistentStruct`
+- **Struct/** — `AbstractPersistentStruct`, `StructKeyEncoder` (mirrors compiler name-mangling)
 
 ## Dependencies
 
-None. This is a **leaf module** — it depends on nothing else in the project.
+This module aims to be a **leaf module** with no dependencies on other modules.
+
+The only remaining outbound import is `AbstractType::__toString()` calling `Phel\Printer\Printer::readable()` to render collection types; collapsing that edge requires installing a printer adapter at bootstrap and is tracked separately.
 
 ## Used By
 

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -7,14 +7,11 @@ namespace Phel\Lang\Collections\Struct;
 use InvalidArgumentException;
 use Override;
 use Phel;
-use Phel\Compiler\Application\Munge;
-use Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\Map\AbstractPersistentMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\TypeFactory;
-use Phel\Printer\Printer;
 use Traversable;
 
 use function count;
@@ -30,7 +27,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 {
     protected const array ALLOWED_KEYS = [];
 
-    private MungeInterface $munge;
+    private StructKeyEncoder $keyEncoder;
 
     public function __construct()
     {
@@ -39,7 +36,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
             TypeFactory::getInstance()->getEqualizer(),
             null,
         );
-        $this->munge = new Munge();
+        $this->keyEncoder = new StructKeyEncoder();
     }
 
     public function withMeta(?PersistentMapInterface $meta): static
@@ -86,7 +83,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     public function getIterator(): Traversable
     {
         foreach (static::ALLOWED_KEYS as $key) {
-            yield Phel::keyword($key) => $this->{$this->munge->encode($key)};
+            yield Phel::keyword($key) => $this->{$this->keyEncoder->encode($key)};
         }
     }
 
@@ -116,11 +113,10 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
     protected function validateKey(Keyword $key): string
     {
         if (in_array($key->getName(), static::ALLOWED_KEYS)) {
-            return $this->munge->encode($key->getName());
+            return $this->keyEncoder->encode($key->getName());
         }
 
-        $keyName = Printer::nonReadable()->print($key);
         $structName = static::class;
-        throw new InvalidArgumentException(sprintf("This key '%s' is not allowed for struct %s", $keyName, $structName));
+        throw new InvalidArgumentException(sprintf("This key '%s' is not allowed for struct %s", (string) $key, $structName));
     }
 }

--- a/src/php/Lang/Collections/Struct/StructKeyEncoder.php
+++ b/src/php/Lang/Collections/Struct/StructKeyEncoder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\Struct;
+
+/**
+ * Translates a struct key (Keyword name) to the PHP property name a defstruct
+ * emits. Mirrors the encoding used by the compiler's name-mangling so structs
+ * can resolve fields at runtime without depending on the Compiler module.
+ *
+ * The two encoders are kept in lockstep by tests; the mapping is part of the
+ * on-disk format and effectively frozen.
+ */
+final readonly class StructKeyEncoder
+{
+    private const array MAPPING = [
+        '-' => '_',
+        '.' => '_DOT_',
+        ':' => '_COLON_',
+        '+' => '_PLUS_',
+        '>' => '_GT_',
+        '<' => '_LT_',
+        '=' => '_EQ_',
+        '~' => '_TILDE_',
+        '!' => '_BANG_',
+        '@' => '_CIRCA_',
+        '#' => '_SHARP_',
+        "'" => '_SINGLEQUOTE_',
+        '"' => '_DOUBLEQUOTE_',
+        '%' => '_PERCENT_',
+        '^' => '_CARET_',
+        '&' => '_AMPERSAND_',
+        '*' => '_STAR_',
+        '|' => '_BAR_',
+        '{' => '_LBRACE_',
+        '}' => '_RBRACE_',
+        '[' => '_LBRACK_',
+        ']' => '_RBRACK_',
+        '/' => '_SLASH_',
+        '\\' => '_BSLASH_',
+        '?' => '_QMARK_',
+        '$' => '_DOLLAR_',
+    ];
+
+    public function encode(string $name): string
+    {
+        if ($name === 'this') {
+            return '__phel_this';
+        }
+
+        return str_replace(
+            array_keys(self::MAPPING),
+            array_values(self::MAPPING),
+            $name,
+        );
+    }
+}

--- a/tests/php/Unit/Lang/Collections/Struct/StructKeyEncoderTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructKeyEncoderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\Collections\Struct;
+
+use Phel\Compiler\Application\Munge;
+use Phel\Lang\Collections\Struct\StructKeyEncoder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StructKeyEncoderTest extends TestCase
+{
+    private const array MUNGED_CHARS = [
+        '-', '.', ':', '+', '>', '<', '=', '~', '!', '@', '#',
+        "'", '"', '%', '^', '&', '*', '|', '{', '}', '[', ']',
+        '/', '\\', '?', '$',
+    ];
+
+    public function test_encodes_special_marker_for_this(): void
+    {
+        self::assertSame('__phel_this', (new StructKeyEncoder())->encode('this'));
+    }
+
+    public function test_passthrough_for_plain_identifiers(): void
+    {
+        $encoder = new StructKeyEncoder();
+        self::assertSame('foo', $encoder->encode('foo'));
+        self::assertSame('foo123', $encoder->encode('foo123'));
+    }
+
+    /**
+     * Pin the encoding to Munge so any future drift breaks here. The mapping
+     * is part of the on-disk format because defstruct emits property names via
+     * Munge at compile time, then the runtime resolves them via this encoder.
+     */
+    #[DataProvider('provideMungedCharacters')]
+    public function test_matches_munge_encode_for_each_special_char(string $char): void
+    {
+        $munge = new Munge();
+        $encoder = new StructKeyEncoder();
+
+        $name = 'a' . $char . 'b';
+        self::assertSame($munge->encode($name), $encoder->encode($name));
+    }
+
+    public function test_matches_munge_for_combined_input(): void
+    {
+        $munge = new Munge();
+        $encoder = new StructKeyEncoder();
+
+        $name = implode('', self::MUNGED_CHARS);
+        self::assertSame($munge->encode($name), $encoder->encode($name));
+    }
+
+    public static function provideMungedCharacters(): iterable
+    {
+        foreach (self::MUNGED_CHARS as $char) {
+            yield $char => [$char];
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`src/php/Lang/CLAUDE.md` declares Lang a leaf module with no dependencies on other modules, but `AbstractPersistentStruct` reached across the boundary in two ways:

1. Imported `Phel\Compiler\Application\Munge` and `Phel\Compiler\Domain\Emitter\OutputEmitter\MungeInterface` to translate keyword names into struct property names at runtime. Combined with Compiler's existing dependency on Lang, this formed `Compiler -> Lang -> Compiler` at the class-import level.
2. Imported `Phel\Printer\Printer` only to render a `Keyword` inside an `InvalidArgumentException` message.

This continues the dependency-untangling work from #1484 (Compiler -> Run via `DebugLineTap`).

## 💡 Goal

Make Lang an actual leaf module on the Compiler axis, without disturbing the Phel-source-level `(:use Phel\Compiler\Application\Munge)` callers in `src/phel/**` (treated as a stable FQCN).

## 🔖 Changes

- Add `Phel\Lang\Collections\Struct\StructKeyEncoder`: small, frozen mapping that mirrors Munge's character substitutions plus the `'this' -> '__phel_this'` special case. Used by `AbstractPersistentStruct` to resolve property names at runtime.
- `AbstractPersistentStruct`:
  - Drop imports of `Munge`, `MungeInterface`, and `Printer`.
  - Use `StructKeyEncoder` in `getIterator` and `validateKey`.
  - Render the bad key in the `InvalidArgumentException` via `(string) $key` (Keyword's own `__toString` already produces `:name`, identical to `Printer::nonReadable()->print($key)` for keywords).
- New `StructKeyEncoderTest`: pins the encoder to `Munge::encode` for every special character in the mapping plus a combined fixture, so any future drift between compile-time emission and runtime lookup fails this test first.
- Update `src/php/Lang/CLAUDE.md` to mention `StructKeyEncoder` and to be honest about the one remaining outbound edge.

## What is left

`AbstractType::__toString()` still calls `Phel\Printer\Printer::readable()` to render collection types. Removing it cleanly needs a runtime-registered printer adapter (interface in Lang, default no-op fallback, real implementation installed by Printer at bootstrap) and careful ordering so an early `__toString` doesn't print garbage. Deferred to a follow-up.

## ✅ Verification

- `composer test-quality`: green
- `composer test-compiler`: same 9 pre-existing env failures as `origin/main` (3 LoadE2E, 6 listed in the wave brief), 0 new regressions
- `composer test-core`: 3668/3668 green