### PR TITLE
ref!: remove create-response-from-* deprecated http helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Deleted `GlobalEnvironmentNotInitializedException`, `PhelFileFinder`, and `PhelFileFinderInterface` — all unreferenced.
 - Removed `FileException::canNotCreateTempFile()`, `ExtractorException::duplicateNamespace()`, `EmitterResult::getSource()`, `TokenStream::getReadTokens()`, and `LoadClasspath::resetCache()` — static factories and methods with no callers.
+- `phel\http/create-response-from-map` and `phel\http/create-response-from-string` (use `response-from-map` / `response-from-string`).
 
 ### Added
 

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -342,15 +342,11 @@
         reason  (or reason (get response-phrases status) "")]
     (response status headers body version reason)))
 
-(def create-response-from-map {:deprecated "Use response-from-map"} response-from-map)
-
 (defn response-from-string
   "Create a response from a string."
   {:example "(response-from-string \"Hello World\") ; => (response 200 {} \"Hello World\" \"1.1\" \"OK\")"}
   [s]
   (response-from-map {:body s}))
-
-(def create-response-from-string {:deprecated "Use response-from-string"} response-from-string)
 
 (defn- emit-status-line [{:status status :reason reason :version version}]
   (when-not (php/headers_sent)


### PR DESCRIPTION
## 🤔 Background

`phel\http/create-response-from-map` and `phel\http/create-response-from-string` were marked `:deprecated` back in v0.6.0 (2022). They've been aliases for `response-from-map` / `response-from-string` ever since. Every in-tree caller already uses the canonical form.

## 💡 Goal

Drop the shims so there's one name per thing.

## 🔖 Changes

- `src/phel/http.phel`: remove the two `def ... {:deprecated ...}` aliases
- CHANGELOG `Unreleased` / `Removed` gets a one-line entry

## ✅ Validation

- `composer test-quality`: clean
- `composer test-compiler`: 1581/1581 unit green
- No in-tree call sites to update