### PR TITLE
fix(build): prune worktrees/ from namespace scans

### DIFF
--- a/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
+++ b/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
@@ -12,6 +12,15 @@ namespace Phel\Build\Domain\Extractor;
  */
 final readonly class ExcludedScanPaths
 {
+    /**
+     * Segments always pruned from a namespace scan regardless of scan root.
+     * Agent tooling (Claude Code, Codex, etc.) drops repo clones under a
+     * `worktrees/` directory whose `src/phel/` would shadow real sources.
+     */
+    private const array ALWAYS_EXCLUDED_SEGMENTS = [
+        DIRECTORY_SEPARATOR . 'worktrees' . DIRECTORY_SEPARATOR,
+    ];
+
     /** @var list<string> */
     private array $absolutePrefixes;
 
@@ -34,6 +43,12 @@ final readonly class ExcludedScanPaths
 
     public function contains(string $path, string $scanRoot): bool
     {
+        foreach (self::ALWAYS_EXCLUDED_SEGMENTS as $segment) {
+            if (str_contains($path, $segment)) {
+                return true;
+            }
+        }
+
         foreach ($this->absolutePrefixes as $prefix) {
             if (str_starts_with($path, $prefix)) {
                 return true;

--- a/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
@@ -54,6 +54,24 @@ final class ExcludedScanPathsTest extends TestCase
         self::assertFalse($paths->contains('/anything.phel', '/scan'));
     }
 
+    public function test_worktrees_subtree_is_always_pruned(): void
+    {
+        $paths = ExcludedScanPaths::none();
+
+        self::assertTrue($paths->contains(
+            '/repo/.claude/worktrees/agent-xyz/src/phel/http-client.phel',
+            '/repo/src/phel',
+        ));
+        self::assertTrue($paths->contains(
+            '/repo/.codex/worktrees/run-1/src/phel/http-client.phel',
+            '/repo/src/phel',
+        ));
+        self::assertFalse($paths->contains(
+            '/repo/src/phel/http-client.phel',
+            '/repo/src/phel',
+        ));
+    }
+
     public function test_unresolvable_excluded_directory_still_prunes_by_literal_prefix(): void
     {
         // Configured output dirs may not exist yet (e.g. before first build);


### PR DESCRIPTION
## 🤔 Background

Agent tooling (Claude Code, Codex, etc.) drops full repo clones under a `worktrees/` directory. When the namespace extractor walks the project recursively, it finds those copies and registers duplicate `phel\core/...` definitions, shadowing the real sources and making cache invalidation flaky.

## 💡 Goal

Always prune any `worktrees/` subtree from a recursive scan, regardless of which agent created it or which scan root the caller passes in.

## 🔖 Changes

- `ExcludedScanPaths::contains()` rejects any path containing `<DIRECTORY_SEPARATOR>worktrees<DIRECTORY_SEPARATOR>` before the existing prefix/destination checks
- Added `test_worktrees_subtree_is_always_pruned` covering both `.claude/worktrees/` and `.codex/worktrees/` layouts