### PR TITLE
fix(compiler): count hash-fn and all bracket types in paren balance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 #### REPL & Compiler
 - `eval()` runtime errors point to user's `string:N` line via source map
 - Non-callable literal calls (`('foo)`, `(42)`, `(nil)`, `("x")`) raise `PHEL011` at analysis time with source location
+- REPL multi-line buffer: `#(...)`, `|(...)`, `#?(...)`, `#?@(...)`, brackets `[]`, braces `{}`, and `#{...}` sets now count toward balance; no more premature eval of unclosed forms
 
 #### Build
 - `phel build` no longer leaks compiled-program stdout during compilation

--- a/src/php/Compiler/Application/ParenthesesChecker.php
+++ b/src/php/Compiler/Application/ParenthesesChecker.php
@@ -11,17 +11,38 @@ final readonly class ParenthesesChecker
 {
     public function hasBalancedParentheses(TokenStream $tokenStream): bool
     {
-        $open = 0;
-        $close = 0;
+        $parens = 0;
+        $brackets = 0;
+        $braces = 0;
 
         foreach ($tokenStream as $token) {
-            if ($token->getType() === Token::T_OPEN_PARENTHESIS) {
-                ++$open;
-            } elseif ($token->getType() === Token::T_CLOSE_PARENTHESIS) {
-                ++$close;
+            switch ($token->getType()) {
+                case Token::T_OPEN_PARENTHESIS:
+                case Token::T_FN:
+                case Token::T_HASH_FN:
+                case Token::T_READER_COND:
+                case Token::T_READER_COND_SPLICING:
+                    ++$parens;
+                    break;
+                case Token::T_CLOSE_PARENTHESIS:
+                    --$parens;
+                    break;
+                case Token::T_OPEN_BRACKET:
+                    ++$brackets;
+                    break;
+                case Token::T_CLOSE_BRACKET:
+                    --$brackets;
+                    break;
+                case Token::T_OPEN_BRACE:
+                case Token::T_HASH_OPEN_BRACE:
+                    ++$braces;
+                    break;
+                case Token::T_CLOSE_BRACE:
+                    --$braces;
+                    break;
             }
         }
 
-        return $close >= $open;
+        return $parens <= 0 && $brackets <= 0 && $braces <= 0;
     }
 }

--- a/tests/php/Unit/Compiler/Application/ParenthesesCheckerTest.php
+++ b/tests/php/Unit/Compiler/Application/ParenthesesCheckerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Application;
+
+use Phel\Compiler\Application\Lexer;
+use Phel\Compiler\Application\ParenthesesChecker;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ParenthesesCheckerTest extends TestCase
+{
+    private ParenthesesChecker $checker;
+
+    private Lexer $lexer;
+
+    protected function setUp(): void
+    {
+        $this->checker = new ParenthesesChecker();
+        $this->lexer = new Lexer();
+    }
+
+    #[DataProvider('balancedCases')]
+    public function test_balanced_input_is_detected_as_balanced(string $code): void
+    {
+        self::assertTrue($this->isBalanced($code), $code);
+    }
+
+    #[DataProvider('unbalancedCases')]
+    public function test_unbalanced_input_is_detected_as_unbalanced(string $code): void
+    {
+        self::assertFalse($this->isBalanced($code), $code);
+    }
+
+    public static function balancedCases(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'plain parens' => ['(+ 1 2)'];
+        yield 'nested parens' => ['(+ 1 (* 2 3))'];
+        yield 'vector' => ['[1 2 3]'];
+        yield 'map' => ['{:a 1 :b 2}'];
+        yield 'set literal' => ['#{1 2 3}'];
+        yield 'hash fn' => ['#(>= % 18)'];
+        yield 'hash fn inside thread' => ["(->> xs\n  (filter #(>= (:age %) 18)))"];
+        yield 'pipe fn (deprecated)' => ['|(+ $ 1)'];
+        yield 'reader conditional' => ['#?(:phel 1 :default 0)'];
+        yield 'reader conditional splicing' => ['[1 #?@(:phel [2 3])]'];
+        yield 'mixed brackets and parens' => ['(let [x 1] (+ x 1))'];
+        yield 'nested set and map' => ['{:s #{1 2} :v [1 2]}'];
+    }
+
+    public static function unbalancedCases(): iterable
+    {
+        yield 'missing close paren' => ['(+ 1 2'];
+        yield 'missing close in hash fn' => ['#(>= % 18'];
+        yield 'missing close in pipe fn' => ['|(+ $ 1'];
+        yield 'missing close in reader cond' => ['#?(:phel 1'];
+        yield 'missing close in reader cond splicing' => ['#?@(:phel [1'];
+        yield 'missing close bracket' => ['[1 2 3'];
+        yield 'missing close brace' => ['{:a 1'];
+        yield 'missing close in set' => ['#{1 2'];
+        yield 'multiline thread with hash fn unclosed' => ["(->> xs\n  (filter #(>= (:age %) 18))"];
+        yield 'multiline thread still open' => ["(->> users\n  (filter adult?)"];
+    }
+
+    private function isBalanced(string $code): bool
+    {
+        return $this->checker->hasBalancedParentheses($this->lexer->lexString($code));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`CompilerFacade::hasBalancedParentheses()` drives REPL multi-line buffering: while the input is unbalanced the REPL keeps reading; once balanced it evaluates.

`ParenthesesChecker` only counted `T_OPEN_PARENTHESIS` / `T_CLOSE_PARENTHESIS`. The lexer emits distinct tokens for reader macros that open with `(`:

- `#(` → `T_HASH_FN` (anonymous fn)
- `|(` → `T_FN` (deprecated short fn)
- `#?(` → `T_READER_COND`
- `#?@(` → `T_READER_COND_SPLICING`

Their matching `)` was still counted as close, so the balance went negative mid-form. Brackets `[]`, braces `{}`, and `#{...}` sets were never tracked at all.

### Repro in REPL

```
user:1> (->> [1 2 3]
....:2>   (filter #(> % 1)))
Unterminated list (EOF)
in string:2
```

REPL thought the form ended on line 2 because the `(` inside `#(` was invisible to the checker.

## 💡 Goal

Make `ParenthesesChecker` reflect all grouping constructs so the REPL correctly detects when a multi-line input is still open.

## 🔖 Changes

- `src/php/Compiler/Application/ParenthesesChecker.php`
  - Count `T_FN`, `T_HASH_FN`, `T_READER_COND`, `T_READER_COND_SPLICING` as paren opens.
  - Track brackets `[ ]` and braces `{ } #{ }` independently.
  - Return balanced only when all three counters are `<= 0`.
- `tests/php/Unit/Compiler/Application/ParenthesesCheckerTest.php`: 23 data-provided cases covering balanced and unbalanced inputs for parens, `#(...)`, `|(...)`, `#?(...)`, `#?@(...)`, vectors, maps, sets, and multi-line threading forms.
- `CHANGELOG.md`: entry under `Unreleased > Fixed > REPL & Compiler`.