### PR TITLE
feat(cli): read phel eval program from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 - History vars `*1`, `*2`, `*3`, and `*e` for last exception
 - Prompt shows current namespace and tracks `(ns ...)` switches
 
+#### CLI
+- `phel eval -` reads the expression from stdin (e.g. `echo '(+ 1 2)' | phel eval -`)
+
 #### Formatter
 - Aligns key/value pairs in `cond`, `case`, `condp`, and bindings of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let`
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ That creates `phel-config.php`, `src/phel/main.phel`, and a matching `tests/phel
 ./vendor/bin/phel build                    # compile to PHP for production
 ```
 
+Need a one-off snippet or shell pipeline? `phel eval` runs inline expressions and `phel eval -` reads the program from stdin:
+
+```sh
+./vendor/bin/phel eval '(+ 1 2)'           # prints 3
+echo '(println "hi")' | ./vendor/bin/phel eval -
+./vendor/bin/phel eval - < script.phel
+```
+
 For a single-file experiment or scratch project, use the root layout:
 
 ```sh

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,13 @@ Run it:
 # => Hello, World!
 ```
 
+Or evaluate a snippet without a file:
+```bash
+./vendor/bin/phel eval '(println "Hello, World!")'
+echo '(println "from stdin")' | ./vendor/bin/phel eval -
+./vendor/bin/phel eval - < src/hello.phel
+```
+
 ### 2. Interactive REPL (1 minute)
 
 Start the REPL:

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -53,10 +53,12 @@ Run/
 │   ├── Init/           NamespaceNormalizer, ProjectTemplateGenerator
 │   ├── Repl/           EvalResult, EvalError, ReplCommandIoInterface, ReplHistory, ReplPrompt, startup.phel
 │   ├── Runner/         NamespaceCollector, NamespaceRunnerInterface
-│   └── Test/           TestCommandOptions, CannotFindAnyTestsException
+│   ├── Test/           TestCommandOptions, CannotFindAnyTestsException
+│   └── StdinReaderInterface
 ├── Infrastructure/
 │   ├── Command/        DoctorCommand, EvalCommand, InitCommand, NsCommand, ReplCommand, RunCommand, TestCommand
-│   └── Service/        DebugLineTap
+│   ├── Service/        DebugLineTap
+│   └── PhpStdinReader
 └── Gacela files        RunFacade, RunFactory, RunConfig, RunProvider
 ```
 

--- a/src/php/Run/Domain/StdinReaderInterface.php
+++ b/src/php/Run/Domain/StdinReaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain;
+
+interface StdinReaderInterface
+{
+    public function read(): string;
+}

--- a/src/php/Run/Infrastructure/Command/EvalCommand.php
+++ b/src/php/Run/Infrastructure/Command/EvalCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Run\Domain\StdinReaderInterface;
 use Phel\Run\RunFacade;
 use Phel\Run\RunFactory;
 use Symfony\Component\Console\Command\Command;
@@ -23,14 +24,22 @@ final class EvalCommand extends Command
 {
     use ServiceResolverAwareTrait;
 
+    private const string STDIN_MARKER = '-';
+
+    public function __construct(
+        private ?StdinReaderInterface $stdinReader = null,
+    ) {
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this->setName('eval')
             ->setDescription('Evaluate a Phel expression and print the result')
             ->addArgument(
                 'expression',
-                InputArgument::REQUIRED,
-                'The Phel expression to evaluate',
+                InputArgument::OPTIONAL,
+                'The Phel expression to evaluate. Use "-" to read from stdin.',
             );
     }
 
@@ -38,11 +47,14 @@ final class EvalCommand extends Command
     {
         $this->getFacade()->loadPhelNamespaces();
 
-        $expression = $input->getArgument('expression');
+        $expression = (string) ($input->getArgument('expression') ?? '');
+        if ($expression === self::STDIN_MARKER) {
+            $expression = ($this->stdinReader ?? $this->getFactory()->createStdinReader())->read();
+        }
 
         $result = $this->getFactory()
             ->createEvalExecutor()
-            ->execute((string) $expression);
+            ->execute($expression);
 
         return $result ? self::SUCCESS : self::FAILURE;
     }

--- a/src/php/Run/Infrastructure/PhpStdinReader.php
+++ b/src/php/Run/Infrastructure/PhpStdinReader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure;
+
+use Phel\Run\Domain\StdinReaderInterface;
+
+use function defined;
+use function fopen;
+use function stream_get_contents;
+
+final class PhpStdinReader implements StdinReaderInterface
+{
+    /**
+     * @param resource|null $stream
+     */
+    public function __construct(private $stream = null) {}
+
+    public function read(): string
+    {
+        $stream = $this->stream ?? (defined('STDIN') ? STDIN : fopen('php://stdin', 'r'));
+        if ($stream === false) {
+            return '';
+        }
+
+        $contents = stream_get_contents($stream);
+
+        return $contents === false ? '' : $contents;
+    }
+}

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -22,6 +22,8 @@ use Phel\Run\Domain\Repl\ReplHistory;
 use Phel\Run\Domain\Repl\ReplPrompt;
 use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Run\Domain\Runner\NamespaceRunnerInterface;
+use Phel\Run\Domain\StdinReaderInterface;
+use Phel\Run\Infrastructure\PhpStdinReader;
 use Phel\Shared\ColorStyle;
 use Phel\Shared\ColorStyleInterface;
 use Phel\Shared\Facade\ApiFacadeInterface;
@@ -160,5 +162,10 @@ class RunFactory extends AbstractFactory
         return new EntryPointDetector(
             $this->getCommandFacade(),
         );
+    }
+
+    public function createStdinReader(): StdinReaderInterface
+    {
+        return new PhpStdinReader();
     }
 }

--- a/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Integration\Run\Command\Eval;
 
 use Phel\Phel;
 use Phel\Run\Infrastructure\Command\EvalCommand;
+use Phel\Run\Infrastructure\PhpStdinReader;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -48,6 +49,40 @@ final class EvalCommandTest extends AbstractTestCommand
         self::assertSame(1, $exitCode);
     }
 
+    public function test_eval_reads_from_stdin_when_dash_argument(): void
+    {
+        $command = new EvalCommand($this->stdinReader('(php/+ 10 20)'));
+
+        $this->expectOutputRegex('/30/');
+
+        $exitCode = $command->run(
+            $this->stubInput('-'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
+    public function test_eval_reads_multi_form_script_from_stdin(): void
+    {
+        $script = <<<'PHEL'
+            (ns stdin-script)
+            (def answer (php/+ 40 2))
+            answer
+            PHEL;
+
+        $command = new EvalCommand($this->stdinReader($script));
+
+        $this->expectOutputRegex('/42/');
+
+        $exitCode = $command->run(
+            $this->stubInput('-'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
     private function createEvalCommand(): EvalCommand
     {
         return new EvalCommand();
@@ -59,5 +94,15 @@ final class EvalCommandTest extends AbstractTestCommand
         $input->method('getArgument')->willReturn($expression);
 
         return $input;
+    }
+
+    private function stdinReader(string $contents): PhpStdinReader
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        return new PhpStdinReader($stream);
     }
 }

--- a/tests/php/Unit/Run/Infrastructure/PhpStdinReaderTest.php
+++ b/tests/php/Unit/Run/Infrastructure/PhpStdinReaderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure;
+
+use Phel\Run\Infrastructure\PhpStdinReader;
+use PHPUnit\Framework\TestCase;
+
+final class PhpStdinReaderTest extends TestCase
+{
+    public function test_reads_contents_from_injected_stream(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+
+        fwrite($stream, "(+ 1 2)\n(println :ok)");
+        rewind($stream);
+
+        $reader = new PhpStdinReader($stream);
+
+        self::assertSame("(+ 1 2)\n(println :ok)", $reader->read());
+    }
+
+    public function test_returns_empty_string_for_empty_stream(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+
+        $reader = new PhpStdinReader($stream);
+
+        self::assertSame('', $reader->read());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel eval` currently only accepts the expression as a CLI argument. Other Lisps (e.g. Clojure's `clj -`, Babashka) accept `-` as a conventional marker to read the program from stdin, which is handy for shell pipelines, heredocs, and sourcing a file without a dedicated namespace/runner.

## 💡 Goal

Let `phel eval` consume a full program from stdin so this works:

```sh
echo '(+ 1 2)' | ./bin/phel eval -
./bin/phel eval - < script.phel
./bin/phel eval - <<'PHEL'
(ns app)
(println (php/+ 40 2))
PHEL
```

## 🔖 Changes

- `EvalCommand` argument is now optional and accepts the `-` marker to read from stdin.
- New `StdinReaderInterface` (Run domain) with a default `PhpStdinReader` implementation. The command accepts a reader via constructor for testability; the production path still resolves it through `RunFactory::createStdinReader()`.
- Tests
  - Unit: `PhpStdinReaderTest` covers an injected in-memory stream and empty input.
  - Integration: new cases in `EvalCommandTest` for single-form and multi-form stdin scripts.
- Docs
  - `CHANGELOG.md` (Unreleased → CLI).
  - `README.md` and `docs/quickstart.md` show the new invocation styles.
  - `src/php/Run/CLAUDE.md` structure tree updated with the new files.