### PR TITLE
feat(agents): add-tests task recipe

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,40 @@
+# Phel Agent Docs
+
+Agent-agnostic entrypoint for AI coding assistants (Claude Code, Cursor, Codex, Gemini, Copilot, Aider) building apps **with** Phel.
+
+## Audience
+
+Developers using Phel to write applications, not contributors to the Phel compiler. Compiler contributor guidance lives in the repo root `AGENTS.md` and `src/php/**/CLAUDE.md`.
+
+## What agents should read
+
+Start at [`index.md`](index.md) — curated reading order by user intent.
+
+Task recipes live in [`tasks/`](tasks/). Each recipe is short and action-oriented: inputs, steps, expected output, pitfalls.
+
+Platform-specific skill files live in [`skills/<platform>/`](skills/).
+
+## Ground truth
+
+`.agents/` does **not** duplicate user docs. It points to them:
+
+| Topic | Source |
+|-------|--------|
+| Syntax basics, scaffolding | `docs/quickstart.md` |
+| Idiomatic patterns | `docs/patterns.md` |
+| PHP interop | `docs/php-interop.md` |
+| Framework integration (Symfony/Laravel) | `docs/framework-integration.md` |
+| Working examples | `docs/examples/*.phel` |
+| Core library docs | `(doc <fn-name>)` in REPL, `phel doc <fn>` CLI |
+
+## Sync policy
+
+`.agents/` evolves with the language:
+
+- **Hand-written** (`tasks/`, `skills/`, `README.md`, `index.md`): owner updates when public surface changes. PR template checklist enforces review.
+- **Generated** (`reference/`, future phase): auto-built from `:doc`/`:example` metadata of exported fns. Never edited by hand.
+- **CI** (future phase): every fenced ```phel``` block in `.agents/**.md` compiles, else fails.
+
+## Audience-matched tone
+
+Agents consume this directory. Write fragments, tables, code blocks. Skip narrative prose.

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -1,0 +1,50 @@
+# Agent Index
+
+Map user intent → docs to load.
+
+## User wants to...
+
+| Intent | Read first | Then |
+|--------|-----------|------|
+| Scaffold new Phel project | [`tasks/scaffold-project.md`](tasks/scaffold-project.md) | `docs/quickstart.md` |
+| Build HTTP app / API | [`tasks/http-app.md`](tasks/http-app.md) | `docs/framework-integration.md`, `docs/php-interop.md` |
+| Learn syntax fast | `docs/quickstart.md` | `docs/reader-shortcuts.md` |
+| Write idiomatic code | `docs/patterns.md` | `docs/examples/` |
+| Call PHP from Phel | `docs/php-interop.md` | — |
+| Call Phel from PHP | `docs/framework-integration.md` | `docs/php-interop.md` (§ Calling Phel from PHP) |
+| Add tests | `docs/quickstart.md` (§ Testing) | `docs/mocking-guide.md` |
+| Use REPL effectively | `docs/quickstart.md` (§ REPL Workflow) | — |
+| Understand data structures | `docs/data-structures-guide.md` | `docs/lazy-sequences.md` |
+| Migrate from Clojure | `docs/clojure-migration.md` | `docs/php-interop.md` (§ Tips for Clojure Developers) |
+| Write macros | `docs/patterns.md` (§ Writing Macros) | — |
+
+## Core workflow (every task)
+
+1. **Scaffold or verify layout**: `phel init` or inspect existing `phel-config.php`.
+2. **Explore unknowns in REPL**: `./vendor/bin/phel repl` → `(doc <fn>)`, `(require 'ns)`, `(in-ns 'ns)`.
+3. **Write code** under `src/phel/<ns>.phel` (default layout) or `src/<ns>.phel` (`--flat`).
+4. **Test** with `phel\test`: `deftest`, `is`. Run `./vendor/bin/phel test`.
+5. **Run** with `./vendor/bin/phel run src/...` or web entry point.
+
+## Hard rules
+
+- Never invent function names. Verify with `(doc <fn>)` or grep `src/phel/core/**`.
+- Immutability: `(conj v x)` returns new vec. `v` unchanged. Rebind with `def` or `let`.
+- Top-level side effects break `phel build`. Guard with `(when-not *build-mode* ...)`.
+- PHP call prefix is `php/` not `.` or `..`.
+- Collection ops: `->>` (thread-last). Object/map ops: `->` (thread-first).
+- Falsy values are only `false` and `nil`. `0`, `""`, `[]` are truthy.
+
+## Commands reference
+
+| Task | Command |
+|------|---------|
+| Scaffold project | `./vendor/bin/phel init [name] [--minimal|--flat]` |
+| Run script | `./vendor/bin/phel run <file.phel>` |
+| Eval expression | `./vendor/bin/phel eval '(+ 1 2)'` or `echo '(...)' \| phel eval -` |
+| REPL | `./vendor/bin/phel repl` |
+| Run tests | `./vendor/bin/phel test [path]` |
+| Build for prod | `./vendor/bin/phel build` |
+| Doc lookup | `./vendor/bin/phel doc <fn>` |
+| Format | `./vendor/bin/phel format <file>` |
+| List namespaces | `./vendor/bin/phel ns` |

--- a/.agents/skills/claude/phel-lang/SKILL.md
+++ b/.agents/skills/claude/phel-lang/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: phel-lang
+description: Use when building applications WITH Phel (Lisp compiling to PHP). Triggers on mentions of Phel, .phel files, phel-config.php, phel init/run/repl/test/build, or "lisp + php". Loads agent docs index for task-specific guidance. Skip when working on the Phel compiler internals (use `compiler-guide` or `phel-patterns` instead).
+---
+
+# Phel Language Skill
+
+Phel is a Lisp dialect that compiles to PHP. Clojure-influenced syntax and semantics, PHP interop via `php/` prefix.
+
+## Load first
+
+Always read these before coding:
+
+1. `.agents/index.md` — task-based reading map
+2. `.agents/README.md` — scope + sync policy
+
+## Core workflow
+
+For any Phel coding task:
+
+1. **Scaffold if empty**: `./vendor/bin/phel init [name] [--flat|--minimal]`. See `.agents/tasks/scaffold-project.md`.
+2. **Check unknowns in REPL**: `./vendor/bin/phel repl`. Use `(doc <fn>)` before guessing signatures.
+3. **Reference docs by intent** via `.agents/index.md` table.
+4. **Code** under `src/phel/<ns>.phel`.
+5. **Test** with `phel\test` (`deftest`, `is`). Run `./vendor/bin/phel test`.
+
+## Hard rules
+
+- **Verify fn names**: `(doc <fn>)` or grep `src/phel/core/` before using. Don't invent.
+- **Immutability**: `(conj v x)` returns new vec; `v` unchanged. Rebind with `def`/`let`.
+- **Build safety**: top-level side effects break `phel build`. Guard: `(when-not *build-mode* (main))`.
+- **PHP interop**: `php/fn-name`, `(php/-> obj (method args))`, `(php/:: Class (static args))`, `(php/new Class args)`.
+- **Threading**: `->` (first arg) for map/object ops, `->>` (last arg) for collection pipelines.
+- **Truthiness**: only `false` and `nil` are falsy. `0`, `""`, `[]` are truthy.
+- **Namespaces**: need ≥ 2 segments (`app\main`, not `main`).
+- **Comments**: `;` inline, `;;` standalone, `#_` form-comment, `#| |#` block.
+- **Parens count**: every fn call, every special form. `map square [1 2 3]` is not a call.
+
+## Task recipes
+
+- New project → `.agents/tasks/scaffold-project.md`
+- HTTP app / API → `.agents/tasks/http-app.md`
+- (more recipes land in phase 2)
+
+## Key docs (ground truth)
+
+| Need | File |
+|------|------|
+| Syntax fast | `docs/quickstart.md` |
+| Idioms | `docs/patterns.md` |
+| PHP interop | `docs/php-interop.md` |
+| Symfony/Laravel embedding | `docs/framework-integration.md` |
+| Examples | `docs/examples/*.phel` |
+| Reader shortcuts | `docs/reader-shortcuts.md` |
+| Data structures | `docs/data-structures-guide.md` |
+
+## CLI cheatsheet
+
+| Task | Command |
+|------|---------|
+| Scaffold | `./vendor/bin/phel init [name] [--flat\|--minimal]` |
+| Run | `./vendor/bin/phel run <file>` |
+| Eval | `./vendor/bin/phel eval '<expr>'` |
+| REPL | `./vendor/bin/phel repl` |
+| Test | `./vendor/bin/phel test [path]` |
+| Build AOT | `./vendor/bin/phel build` |
+| Doc | `./vendor/bin/phel doc <fn>` |
+| Format | `./vendor/bin/phel format <file>` |
+
+## Common gotchas
+
+- Forgot parens around fn call → not a call, silent bug
+- Mutated-in-place expectation → rebind needed
+- Used `.method obj` → use `(php/-> obj (method))` or shorthand `(.method obj)`
+- Used `{key val}` as PHP assoc array → need `#php {"k" "v"}` or `(php-associative-array ...)`
+- Top-level `(main)` blocks `phel build` → wrap in `(when-not *build-mode* ...)`
+- `require` of unknown ns → namespace must match file path under configured src dir

--- a/.agents/tasks/add-tests.md
+++ b/.agents/tasks/add-tests.md
@@ -1,0 +1,195 @@
+# Task: Add tests in Phel
+
+## Goal
+
+Write and run tests for Phel code with `phel\test`: `deftest`, `is`, `are`, `testing`, fixtures. Fast feedback via REPL.
+
+## Prereqs
+
+- Project scaffolded (see `.agents/tasks/scaffold-project.md`)
+- `./vendor/bin/phel` works
+
+## File layout
+
+| Project layout | Source | Test |
+|----------------|--------|------|
+| default | `src/phel/<name>.phel` | `tests/phel/<name>_test.phel` |
+| `--flat` | `src/<name>.phel` | `tests/<name>_test.phel` |
+| `--minimal` | `<name>.phel` | `<name>_test.phel` |
+
+Test namespace convention: `tests\<name>-test` (kebab-case suffix, matches file path under the configured test dir).
+
+## Steps
+
+### 1. Minimal example: `math` + `math-test`
+
+`src/phel/math.phel`:
+
+```phel
+(ns my-app\math)
+
+(defn add [a b]
+  (+ a b))
+
+(defn divide [a b]
+  (when (zero? b)
+    (throw (php/new \InvalidArgumentException "division by zero")))
+  (/ a b))
+```
+
+`tests/phel/math_test.phel`:
+
+```phel
+(ns tests\math-test
+  (:require phel\test :refer [deftest is are testing])
+  (:require my-app\math :refer [add divide]))
+
+(deftest test-add
+  (is (= 4 (add 2 2)))
+  (is (= 0 (add -1 1))))
+
+(deftest test-add-table
+  (are [x y sum] (= sum (add x y))
+    0 0 0
+    1 2 3
+    -1 1 0))
+
+(deftest test-divide-rejects-zero
+  (testing "guards divide by zero"
+    (is (thrown? \InvalidArgumentException (divide 1 0)))
+    (is (thrown-with-msg? \InvalidArgumentException "division by zero"
+          (divide 1 0)))))
+```
+
+### 2. Run tests
+
+```bash
+./vendor/bin/phel test                        # all tests under tests/
+./vendor/bin/phel test tests/phel/math_test.phel   # one file
+./vendor/bin/phel test --filter=test-add      # by test name substring
+./vendor/bin/phel test --testdox              # readable per-test output
+./vendor/bin/phel test --fail-fast            # stop on first failure
+```
+
+Full flag list: `./vendor/bin/phel test --help`.
+
+### 3. REPL-driven TDD loop
+
+```phel
+phel:1> (require 'tests\math-test :reload)   ; reload after edits
+phel:2> (tests\math-test/test-add)           ; run one deftest fn directly
+phel:3> (require 'phel\test :refer [run-tests])
+phel:4> (run-tests {} 'tests\math-test)      ; run the whole ns
+```
+
+Each `deftest` compiles to a zero-arg fn tagged `{:test true}`, so calling it directly re-runs only that test.
+
+## Assertion forms inside `is`
+
+| Form | What it asserts |
+|------|-----------------|
+| `(is (= expected actual))` | binary equality — reports both sides on failure |
+| `(is (pred x))` | unary predicate — `pos?`, `nil?`, `string?`, etc. |
+| `(is expr)` | truthy fallback (`:any`) for anything else |
+| `(is (not form))` | negated binary / predicate / any |
+| `(is (thrown? ExceptionClass body...))` | body throws `ExceptionClass` (or subclass) |
+| `(is (thrown? body...))` | body throws anything (`\Throwable`) |
+| `(is (thrown-with-msg? ExceptionClass "msg" body...))` | throws with exact message |
+| `(is (output? "expected" body))` | body prints exactly `"expected"` to stdout |
+| `(is form "message")` | optional message shown on failure |
+
+## `are` — table-driven assertions
+
+`argv` is the template vars; trailing args are consumed in groups of `(count argv)` and substituted at macro-expansion time:
+
+```phel
+(are [x y] (= x y)
+  2 (+ 1 1)
+  4 (* 2 2))
+```
+
+Incomplete trailing groups are dropped silently. Literal `()`/`[]`/`{}` cells are preserved as data, not evaluated as calls.
+
+## Fixtures: setup / teardown
+
+```phel
+(ns tests\db-test
+  (:require phel\test :refer [deftest is use-fixtures]))
+
+(def conn (atom nil))
+
+(use-fixtures :once
+  (fn [t]
+    (reset! conn (open-connection))
+    (t)
+    (close-connection @conn)))
+
+(use-fixtures :each
+  (fn [t]
+    (clear-tables @conn)
+    (t)))
+
+(deftest test-insert
+  (is (= 1 (insert @conn {:name "Alice"}))))
+```
+
+- `:once` — wraps the whole namespace run, fires once
+- `:each` — wraps every `deftest` individually
+- Multiple fixtures of the same kind compose outer-to-inner in registration order
+- `(use-fixtures :each)` with no fns clears fixtures of that type for the namespace
+
+## Extending `is` with custom assertions
+
+`phel\test/assert-expr` is a public multimethod dispatched on the first symbol of the form inside `is`. Register a `defmethod` that returns the code the outer `is` should expand to:
+
+```phel
+(ns tests\math-test
+  (:require phel\test :refer [deftest is]))
+
+(defmethod phel\test/assert-expr 'approx= [form message]
+  (let [a (second form)
+        b (second (next form))
+        epsilon 0.001]
+    `(is (< (php/abs (- ~a ~b)) ~epsilon) ~message)))
+
+(deftest test-approx
+  (is (approx= 1.0 1.0001)))
+```
+
+Qualify the multi as `phel\test/assert-expr` when registering from another namespace, otherwise the method lands in the wrong dispatch table. See `docs/patterns.md` § Writing Macros and `tests/phel/test/assert-expr-extensibility.phel` for a worked set.
+
+## Mocking
+
+Full reference: `docs/mocking-guide.md`. Five-line version:
+
+```phel
+(ns tests\user-test
+  (:require phel\test :refer [deftest is])
+  (:require phel\mock :refer [with-mocks mock called-with?])
+  (:require my-app\users :refer [fetch-user]))
+
+(deftest test-fetch-user-hits-endpoint
+  (with-mocks [http-get (mock {:id 1 :name "Alice"})]
+    (fetch-user 123)
+    (is (called-with? http-get "/users/123"))))
+```
+
+`with-mocks` auto-resets bindings after the body. Use `mock-fn`, `mock-returning`, `mock-throwing`, or `spy` for other patterns.
+
+## Gotchas
+
+- Test file name must end `_test.phel`; namespace must end `-test`. The runner discovers fns tagged `:test true`, but `init` and the published convention use this suffix.
+- Don't forget `:refer [deftest is]` — bare `phel\test` import won't bring them into scope.
+- `deftest` requires a symbol name: `(deftest test-foo ...)`, not a string.
+- `(thrown? body)` catches any `\Throwable`. Use `(thrown? \MyException body)` to be specific.
+- Fixtures are keyed by `*ns*` at `use-fixtures` time. Registering from another namespace won't wrap the target ns's tests.
+- Custom `assert-expr` methods must be loaded before any `is` form uses their dispatch symbol — put them at the top of the test file or require a helper ns first.
+- `are` drops trailing groups that don't fill `argv`. If you expect N assertions and see N-1, count your rows.
+
+## Next
+
+- `docs/quickstart.md` § Testing Your Code — narrative intro
+- `docs/mocking-guide.md` — full mock / spy reference
+- `docs/patterns.md` § Writing Macros — gensym, `&form`, `&env` for custom assertions
+- `src/phel/test.phel` — public API source of truth
+- `tests/phel/test/*.phel` — real-world coverage of every feature above

--- a/.agents/tasks/http-app.md
+++ b/.agents/tasks/http-app.md
@@ -1,0 +1,136 @@
+# Task: Build HTTP app in Phel
+
+## Goal
+
+Phel handles routes. PHP entry point dispatches requests. Runs on `php -S` or any PHP server.
+
+## Approach
+
+Two layers:
+
+1. **PHP entry** (`public/index.php`) — boots Phel, reads request, dispatches.
+2. **Phel handlers** (`src/phel/routes.phel`) — one fn per route, returns `Symfony\Component\HttpFoundation\Response`.
+
+## Steps
+
+### 1. Scaffold + install Symfony HTTP foundation
+
+```bash
+./vendor/bin/phel init my-api
+cd my-api
+composer require symfony/http-foundation
+```
+
+### 2. Route handlers
+
+`src/phel/routes.phel`:
+
+```phel
+(ns my-api\routes
+  (:use Symfony\Component\HttpFoundation\Response)
+  (:require phel\json :as json))
+
+(defn- json-response [data status]
+  (php/new Response
+    (json/encode data)
+    status
+    (php-associative-array "Content-Type" "application/json")))
+
+(defn handle-home [_request]
+  (php/new Response "<h1>Hello from Phel</h1>" 200))
+
+(defn handle-health [_request]
+  (json-response {:status "ok" :ts (php/time)} 200))
+
+(defn handle-greet [_request name]
+  (json-response {:message (str "Hello, " name "!")} 200))
+```
+
+### 3. PHP entry point
+
+`public/index.php`:
+
+```php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Phel\Run\RunFacade;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+RunFacade::initialize(__DIR__ . '/../');
+
+$request = Request::createFromGlobals();
+$path = $request->getPathInfo();
+
+$response = match (true) {
+    $path === '/'        => \Phel::callPhel('my-api\routes', 'handle-home', $request),
+    $path === '/health'  => \Phel::callPhel('my-api\routes', 'handle-health', $request),
+    (bool) preg_match('#^/greet/(\w+)$#', $path, $m)
+                         => \Phel::callPhel('my-api\routes', 'handle-greet', $request, $m[1]),
+    default              => new Response('Not Found', 404),
+};
+
+$response->send();
+```
+
+### 4. Run
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Test:
+
+```bash
+curl http://localhost:8000/
+curl http://localhost:8000/health
+curl http://localhost:8000/greet/Alice
+```
+
+### 5. Tests
+
+`tests/phel/routes_test.phel`:
+
+```phel
+(ns tests\routes-test
+  (:require phel\test :refer [deftest is])
+  (:require phel\json :as json)
+  (:require my-api\routes :refer [handle-health handle-greet]))
+
+(deftest health-returns-ok
+  (let [resp (handle-health nil)
+        body (php/-> resp (getContent))
+        data (json/decode body)]
+    (is (= "ok" (get data :status)))))
+
+(deftest greet-contains-name
+  (let [resp (handle-greet nil "Alice")
+        body (php/-> resp (getContent))]
+    (is (php/str_contains body "Alice"))))
+```
+
+Run: `./vendor/bin/phel test`.
+
+## Production
+
+For AOT compilation (compile once on deploy, zero compile per request):
+
+```bash
+./vendor/bin/phel build
+```
+
+Then replace `\Phel::callPhel(...)` path with `require 'build/<ns>/boot.php'` — see `docs/framework-integration.md`.
+
+## Gotchas
+
+- `json/encode` accepts Phel maps directly; no need to convert via `to-php-array` first.
+- `php-associative-array "k" "v"` for PHP assoc arrays; `#php {"k" "v"}` reader literal is equivalent.
+- Don't add top-level side effects — guard with `(when-not *build-mode* ...)` if you must call side-effecting code at load.
+- Unused request arg convention: prefix with `_` (`_request`).
+
+## Next
+
+- Routing library: consider `phel\http` (core) or bring a PHP router (FastRoute, Symfony Routing)
+- Framework integration: `docs/framework-integration.md` (Symfony, Laravel)
+- DB access: `docs/php-interop.md` (§ Database Access)

--- a/.agents/tasks/scaffold-project.md
+++ b/.agents/tasks/scaffold-project.md
@@ -1,0 +1,88 @@
+# Task: Scaffold new Phel project
+
+## Goal
+
+Bootstrap runnable Phel project with tests in < 30s.
+
+## Prereqs
+
+- PHP 8.3+ installed
+- Composer installed
+- Writable target directory
+
+## Steps
+
+### 1. Install Phel
+
+```bash
+composer require phel-lang/phel-lang
+```
+
+### 2. Scaffold
+
+Default layout (nested: `src/phel/`, `tests/phel/`):
+
+```bash
+./vendor/bin/phel init my-app
+```
+
+Flat layout (single-level `src/`, `tests/`):
+
+```bash
+./vendor/bin/phel init my-app --flat
+```
+
+Minimal layout (single `main.phel` at repo root — sandbox only):
+
+```bash
+./vendor/bin/phel init my-app --minimal
+```
+
+### 3. Verify
+
+```bash
+./vendor/bin/phel run src/phel/main.phel   # default layout
+./vendor/bin/phel test                     # runs tests
+./vendor/bin/phel repl                     # interactive
+```
+
+Expected: `Hello, World!` printed; one test passes.
+
+## Layouts — when to use
+
+| Flag | Files | Use when |
+|------|-------|----------|
+| (default) | `src/phel/main.phel`, `tests/phel/main_test.phel`, `phel-config.php` | Most apps; matches published convention |
+| `--flat` | `src/main.phel`, `tests/main_test.phel`, `phel-config.php` | Shorter paths; integrating into existing PHP project |
+| `--minimal` | `main.phel`, `main_test.phel`, `phel-config.php` | One-file experiments, sandbox, demos |
+
+## Generated files
+
+- `phel-config.php` — autodetected layout + namespace via `PhelConfig::forProject()`
+- `src/phel/main.phel` (or equivalent) — starter namespace
+- `tests/phel/main_test.phel` — one passing test
+- `.gitignore` — excludes `cache/`, `out/`, `vendor/`
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--flat`, `-f` | Flat layout |
+| `--minimal`, `-m` | Root layout |
+| `--no-tests` | Skip test scaffold |
+| `--no-gitignore` | Skip `.gitignore` |
+| `--dry-run` | Print plan, write nothing |
+| `--force` | Overwrite existing files |
+
+## Gotchas
+
+- Namespace needs ≥ 2 segments: `my-app\main`, not `main`. `phel init` handles this.
+- If `phel-config.php` exists, use `--force` or write manually.
+- Inside existing PHP project: use `--flat` and keep `phel-config.php` at project root.
+
+## Next
+
+- Add namespaces under `src/phel/<name>.phel`
+- Add matching tests under `tests/phel/<name>_test.phel`
+- See `tasks/http-app.md` for web apps
+- See `docs/framework-integration.md` for Symfony/Laravel integration


### PR DESCRIPTION
## 🤔 Background

`.agents/` hosts agent-agnostic docs for AI coding assistants building apps with Phel. Phase 1 (#1495) landed scaffolding and HTTP recipes; the testing story is the obvious next slice agents hit immediately after scaffolding.

Depends on #1495 (branches from `feat/agents-phase-1`).

## 💡 Goal

Give agents a single, scannable recipe for writing and running tests with `phel\test`: layout, imports, `deftest` / `is` / `are`, exception matching, REPL TDD loop, fixtures, custom assertions, and a 5-line pointer to mocking.

## 🔖 Changes

- New `.agents/tasks/add-tests.md` covering:
  - File layout under default / flat / minimal project layouts
  - Minimal `math` + `math-test` worked example that compiles
  - `./vendor/bin/phel test` invocations: all, single file, `--filter`, `--testdox`, `--fail-fast`
  - Full `is` assertion table: binary, predicate, `not`, `thrown?`, `thrown-with-msg?`, `output?`, message
  - `are` table-driven assertions with the actual substitution semantics
  - `use-fixtures :once` and `:each` composition rules
  - Extending `is` with `phel\test/assert-expr` defmethod, qualified name gotcha
  - Mocking pointer to `docs/mocking-guide.md`
  - Gotchas and Next links

One file only; no other changes. No CHANGELOG entry (agent-facing internal docs).