### PR TITLE
fix(build): exclude .agents/ subtrees from namespace scan

### DIFF
--- a/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
+++ b/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Extractor;
 
+use function strlen;
+
 /**
  * Prefixes that should be skipped during a recursive namespace scan. Combines
  * pre-resolved absolute directories with a basename that prunes
@@ -16,9 +18,12 @@ final readonly class ExcludedScanPaths
      * Segments always pruned from a namespace scan regardless of scan root.
      * Agent tooling (Claude Code, Codex, etc.) drops repo clones under a
      * `worktrees/` directory whose `src/phel/` would shadow real sources.
+     * `.agents/` ships bundled example projects whose tests share namespaces
+     * across projects and must not leak into the host repo's scan.
      */
     private const array ALWAYS_EXCLUDED_SEGMENTS = [
         DIRECTORY_SEPARATOR . 'worktrees' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . '.agents' . DIRECTORY_SEPARATOR,
     ];
 
     /** @var list<string> */
@@ -43,8 +48,12 @@ final readonly class ExcludedScanPaths
 
     public function contains(string $path, string $scanRoot): bool
     {
+        $relative = str_starts_with($path, $scanRoot)
+            ? substr($path, strlen($scanRoot))
+            : $path;
+
         foreach (self::ALWAYS_EXCLUDED_SEGMENTS as $segment) {
-            if (str_contains($path, $segment)) {
+            if (str_contains($relative, $segment)) {
                 return true;
             }
         }

--- a/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php
@@ -72,6 +72,30 @@ final class ExcludedScanPathsTest extends TestCase
         ));
     }
 
+    public function test_dot_agents_subtree_is_pruned_when_outside_scan_root(): void
+    {
+        $paths = ExcludedScanPaths::none();
+
+        self::assertTrue($paths->contains(
+            '/repo/.agents/examples/todo-app/tests/phel/handlers_test.phel',
+            '/repo/tests/phel',
+        ));
+        self::assertFalse($paths->contains(
+            '/repo/tests/phel/core/handlers_test.phel',
+            '/repo/tests/phel',
+        ));
+    }
+
+    public function test_dot_agents_not_pruned_when_scan_root_already_inside_it(): void
+    {
+        $paths = ExcludedScanPaths::none();
+
+        self::assertFalse($paths->contains(
+            '/repo/.agents/examples/todo-app/src/phel/store.phel',
+            '/repo/.agents/examples/todo-app/src/phel',
+        ));
+    }
+
     public function test_unresolvable_excluded_directory_still_prunes_by_literal_prefix(): void
     {
         // Configured output dirs may not exist yet (e.g. before first build);


### PR DESCRIPTION
## 🤔 Background

The recursive namespace scan walked into `.agents/` directories, picking up example `.phel` files that should never participate in the host repo's namespace resolution. When multiple projects under `.agents/examples/` shared a test namespace (common when docs ship example apps), compiler integration tests failed with `WARNING: Namespace '...' is defined in multiple locations`.

## 💡 Goal

- Prune `.agents/` from the always-excluded segment list, alongside `worktrees/`.
- Make the match relative to the current scan root so a project whose path itself contains `.agents/` still scans normally.

## 🔖 Changes

- `src/php/Build/Domain/Extractor/ExcludedScanPaths.php`: add `/.agents/` to `ALWAYS_EXCLUDED_SEGMENTS`; rewrite `contains()` to check the path relative to the scan root before falling back to the full path.
- `tests/php/Unit/Build/Domain/Extractor/ExcludedScanPathsTest.php`: two new cases covering the pruned-segment path and the "scan root is already inside .agents/" escape hatch.

Independent of the `.agents/` docs PR (#1495): useful on its own for any project vendoring or mirroring agent docs.