### PR TITLE
fix(build): prefer local src over phar:// bundle for duplicate namespaces

### DIFF
--- a/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
+++ b/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
@@ -44,7 +44,10 @@ final readonly class NamespaceFileGrouper
 
             if ($info->isPrimaryDefinition()) {
                 $primaryDefinitions[$namespace][] = $info->getFile();
-                $byNamespace[$namespace]['primary'] = $info;
+                $byNamespace[$namespace]['primary'] = $this->preferLocalOverPhar(
+                    $byNamespace[$namespace]['primary'],
+                    $info,
+                );
                 continue;
             }
 
@@ -54,6 +57,36 @@ final readonly class NamespaceFileGrouper
         $this->warnAboutDuplicateNamespaces($primaryDefinitions);
 
         return $this->flatten($byNamespace);
+    }
+
+    /**
+     * When the same namespace is defined both inside a PHAR (the bundled
+     * stdlib) and on the local filesystem, the user's local copy always
+     * wins — users put files on disk to override, not to be overridden
+     * by the bundle.
+     */
+    private function preferLocalOverPhar(
+        ?NamespaceInformation $current,
+        NamespaceInformation $candidate,
+    ): NamespaceInformation {
+        if ($current === null) {
+            return $candidate;
+        }
+
+        $currentInPhar = str_starts_with($current->getFile(), 'phar://');
+        $candidateInPhar = str_starts_with($candidate->getFile(), 'phar://');
+
+        if ($currentInPhar && !$candidateInPhar) {
+            return $candidate;
+        }
+
+        if (!$currentInPhar && $candidateInPhar) {
+            return $current;
+        }
+
+        // Same origin — keep last-wins behavior so genuine config duplicates
+        // still surface via warnAboutDuplicateNamespaces.
+        return $candidate;
     }
 
     /**
@@ -95,11 +128,12 @@ final readonly class NamespaceFileGrouper
     private function warnAboutDuplicateNamespaces(array $primaryDefinitions): void
     {
         foreach ($primaryDefinitions as $namespace => $files) {
-            if (count($files) <= 1) {
+            $effective = $this->dropPharShadowedFiles($files);
+            if (count($effective) <= 1) {
                 continue;
             }
 
-            $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $files));
+            $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $effective));
             fwrite(STDERR, sprintf(
                 "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
                 . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
@@ -107,5 +141,34 @@ final readonly class NamespaceFileGrouper
                 $fileList,
             ));
         }
+    }
+
+    /**
+     * Drop phar:// entries when a non-phar entry for the same namespace
+     * exists. The local copy already wins in the grouping step, so the
+     * warning would be noise for the user.
+     *
+     * @param list<string> $files
+     *
+     * @return list<string>
+     */
+    private function dropPharShadowedFiles(array $files): array
+    {
+        $hasLocal = false;
+        foreach ($files as $file) {
+            if (!str_starts_with($file, 'phar://')) {
+                $hasLocal = true;
+                break;
+            }
+        }
+
+        if (!$hasLocal) {
+            return $files;
+        }
+
+        return array_values(array_filter(
+            $files,
+            static fn(string $file): bool => !str_starts_with($file, 'phar://'),
+        ));
     }
 }

--- a/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
+++ b/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
@@ -69,7 +69,7 @@ final readonly class NamespaceFileGrouper
         ?NamespaceInformation $current,
         NamespaceInformation $candidate,
     ): NamespaceInformation {
-        if ($current === null) {
+        if (!$current instanceof NamespaceInformation) {
             return $candidate;
         }
 

--- a/tests/php/Integration/Phar/PharExecutionTest.php
+++ b/tests/php/Integration/Phar/PharExecutionTest.php
@@ -56,6 +56,31 @@ final class PharExecutionTest extends TestCase
         }
     }
 
+    public function test_phar_runs_from_directory_shadowing_bundled_namespaces_without_warnings(): void
+    {
+        // Shadow a bundled stdlib namespace with an empty local copy so the
+        // NamespaceExtractor sees the same `phel\html` namespace both inside
+        // the PHAR and on disk. main.phel does not touch phel\html, so the
+        // shadow is harmless for execution.
+        $shadowed = $this->tempProjectDir . '/src/phel';
+        mkdir($shadowed, 0755, true);
+        file_put_contents($shadowed . '/html.phel', "(ns phel\\html)\n");
+
+        $result = $this->runPhar(['run', 'main.phel']);
+
+        self::assertSame(
+            0,
+            $result['exit'],
+            sprintf("Non-zero exit.\nstdout:\n%s\nstderr:\n%s", $result['stdout'], $result['stderr']),
+        );
+
+        self::assertStringNotContainsString(
+            'defined in multiple locations',
+            $result['stderr'],
+            'PHAR-bundled stdlib must not warn when the user project shadows it on disk',
+        );
+    }
+
     public function test_phar_runs_from_external_directory_without_warnings(): void
     {
         $result = $this->runPhar(['run', 'main.phel']);

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceFileGrouperTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceFileGrouperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Domain\Extractor;
+
+use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
+use PHPUnit\Framework\TestCase;
+
+final class NamespaceFileGrouperTest extends TestCase
+{
+    private NamespaceFileGrouper $grouper;
+
+    protected function setUp(): void
+    {
+        $sorter = new class() implements NamespaceSorterInterface {
+            public function sort(array $namespaces, array $dependencies): array
+            {
+                return $namespaces;
+            }
+        };
+
+        $this->grouper = new NamespaceFileGrouper($sorter);
+    }
+
+    public function test_local_primary_wins_over_phar_bundle(): void
+    {
+        $pharInfo = new NamespaceInformation('phar:///tmp/phel.phar/src/phel/core.phel', 'phel\\core', []);
+        $localInfo = new NamespaceInformation('/workspace/src/phel/core.phel', 'phel\\core', []);
+
+        $result = $this->grouper->groupAndSort([$pharInfo, $localInfo]);
+
+        self::assertCount(1, $result);
+        self::assertSame('/workspace/src/phel/core.phel', $result[0]->getFile());
+    }
+
+    public function test_local_primary_wins_even_when_phar_iterated_last(): void
+    {
+        $localInfo = new NamespaceInformation('/workspace/src/phel/core.phel', 'phel\\core', []);
+        $pharInfo = new NamespaceInformation('phar:///tmp/phel.phar/src/phel/core.phel', 'phel\\core', []);
+
+        $result = $this->grouper->groupAndSort([$localInfo, $pharInfo]);
+
+        self::assertCount(1, $result);
+        self::assertSame('/workspace/src/phel/core.phel', $result[0]->getFile());
+    }
+
+    public function test_two_local_definitions_keep_last_wins_behavior(): void
+    {
+        $a = new NamespaceInformation('/workspace/src/user_a.phel', 'user', []);
+        $b = new NamespaceInformation('/workspace/src/user_b.phel', 'user', []);
+
+        $result = $this->grouper->groupAndSort([$a, $b]);
+
+        self::assertCount(1, $result);
+        self::assertSame('/workspace/src/user_b.phel', $result[0]->getFile());
+    }
+
+    public function test_two_phar_definitions_keep_last_wins_behavior(): void
+    {
+        $a = new NamespaceInformation('phar:///tmp/one.phar/src/x.phel', 'ns\\x', []);
+        $b = new NamespaceInformation('phar:///tmp/two.phar/src/x.phel', 'ns\\x', []);
+
+        $result = $this->grouper->groupAndSort([$a, $b]);
+
+        self::assertCount(1, $result);
+        self::assertSame('phar:///tmp/two.phar/src/x.phel', $result[0]->getFile());
+    }
+
+    public function test_local_secondaries_are_preserved_alongside_phar_primary(): void
+    {
+        $pharPrimary = new NamespaceInformation('phar:///tmp/phel.phar/src/phel/core.phel', 'phel\\core', []);
+        $localPrimary = new NamespaceInformation('/workspace/src/phel/core.phel', 'phel\\core', []);
+        $localSecondary = new NamespaceInformation(
+            '/workspace/src/phel/core_helpers.phel',
+            'phel\\core',
+            [],
+            isPrimaryDefinition: false,
+        );
+
+        $result = $this->grouper->groupAndSort([$pharPrimary, $localPrimary, $localSecondary]);
+
+        self::assertCount(2, $result);
+        self::assertSame('/workspace/src/phel/core.phel', $result[0]->getFile());
+        self::assertSame('/workspace/src/phel/core_helpers.phel', $result[1]->getFile());
+    }
+}


### PR DESCRIPTION
## TL;DR

Running `phel.phar` from a project that ships its own copy of a bundled stdlib namespace (e.g. the phel-lang repo itself has `src/phel/` on disk) warned about the collision on every startup and picked the primary via last-wins iteration order. Now the local copy always wins silently; warnings only fire for genuine duplicates (two local files or two phar:// files).

## 🤔 Background

`NamespaceFileGrouper` builds a map of `namespace → primary file + secondaries`. Whenever two entries share the same namespace it logged:

```
WARNING: Namespace 'phel\html' is defined in multiple locations:
  - phar:///path/phel.phar/src/phel/html.phel
  - /home/user/proj/src/phel/html.phel
The last one will be used. Check your phel-config.php srcDirs/testDirs settings.
```

That surfaces at every run for self-host scenarios (the phel-lang repo, anyone who uses `--with-docs` + overrides a stdlib ns, etc.) even though the behavior is exactly what the user wanted: the local file takes precedence.

## 🔖 Changes

- `NamespaceFileGrouper::preferLocalOverPhar()` replaces the `last-wins` overwrite inside `groupAndSort`. When a non-phar primary exists for a namespace, any `phar://` primary is ignored.
- `warnAboutDuplicateNamespaces()` filters `phar://` entries out of the duplicate list when a local entry exists for the same namespace; the warning survives only for two-local or two-phar conflicts.
- New `NamespaceFileGrouperTest` unit test: covers local-wins-regardless-of-iteration-order, two-local-still-wins-last, two-phar-still-wins-last, and local-secondaries-preserved.
- Extends `PharExecutionTest` with `test_phar_runs_from_directory_shadowing_bundled_namespaces_without_warnings`: builds the PHAR, writes a local `src/phel/html.phel` that duplicates the bundled `phel\html`, runs the PHAR, asserts stderr stays clean.

## Verify

```bash
./vendor/bin/phpunit --filter=NamespaceFileGrouperTest
./build/phar.sh
./vendor/bin/phpunit --testsuite=integration --filter=Phar

# Manual: run phel.phar from inside the phel-lang repo root
./build/out/phel.phar eval '(+ 1 2)'
# No "defined in multiple locations" spam
```