### PR TITLE
fix(dx): clearer REPL errors for keyword-on-nil, http globals, trace args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this project will be documented in this file.
 - `phel\ai` text extraction picks first `text` block, skipping preceding `tool_use`
 - `phel\http/request-from-globals` error explains that an HTTP request context is required and points to `request-from-map` for tests
 - `(:key nil)` returns the default instead of raising `TypeError`
+- `(get v nil)` and `(get l nil)` on vectors/lists return the default instead of raising `TypeError`
+- Vector/list called with nil index raise `InvalidArgumentException` with a clear message instead of a raw PHP `TypeError`
 - Stack-trace arg rendering truncates each Phel argument at 200 chars
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this project will be documented in this file.
 #### Modules
 - `phel\ai` `check-response` raises `RuntimeException` with provider message when body lacks `:error :message`
 - `phel\ai` text extraction picks first `text` block, skipping preceding `tool_use`
+- `phel\http/request-from-globals` error explains that an HTTP request context is required and points to `request-from-map` for tests
+- `(:key nil)` returns the default instead of raising `TypeError`
+- Stack-trace arg rendering truncates each Phel argument at 200 chars
 
 ### Changed
 

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -59,6 +59,9 @@
   {:example "(get {:a 1} :a) ; => 1"}
   [ds k & [opt]]
   (cond
+    (nil? ds) opt
+    (and (nil? k) (indexed? ds)) opt
+
     (or (set? ds)
         (php/instanceof ds PersistentHashSetInterface)
         (php/instanceof ds TransientHashSetInterface))

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -195,7 +195,11 @@
   (let [method (get (or server php/$_SERVER) "REQUEST_METHOD")]
     (if method
       method
-      (throw (php/new InvalidArgumentException "cannot determine HTTP Method")))))
+      (throw (php/new InvalidArgumentException
+               (str "cannot determine HTTP Method: $_SERVER['REQUEST_METHOD'] is not set. "
+                    "request-from-globals requires a web request context (PHP-FPM, mod_php, or `php -S`); "
+                    "it cannot be used from the REPL or a CLI script. "
+                    "Build a request manually with `request-from-map` for testing."))))))
 
 (defn- post-global-valid [method headers]
   (let [content-type (get headers :content-type "")

--- a/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
+++ b/src/php/Command/Domain/Exceptions/ExceptionArgsPrinter.php
@@ -16,6 +16,8 @@ use function strlen;
 
 final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterface
 {
+    private const int MAX_ARG_LENGTH = 200;
+
     public function __construct(
         private PrinterInterface $printer,
     ) {}
@@ -23,7 +25,7 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
     public function parseArgsAsString(array $frameArgs): string
     {
         $argParts = array_map(
-            $this->printer->print(...),
+            fn($arg): string => $this->truncate($this->printer->print($arg)),
             $frameArgs,
         );
 
@@ -43,6 +45,15 @@ final readonly class ExceptionArgsPrinter implements ExceptionArgsPrinterInterfa
         );
 
         return implode(', ', $result);
+    }
+
+    private function truncate(string $s): string
+    {
+        if (strlen($s) <= self::MAX_ARG_LENGTH) {
+            return $s;
+        }
+
+        return substr($s, 0, self::MAX_ARG_LENGTH) . '...';
     }
 
     /**

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Phel\Lang\Collections\LinkedList;
 
 use Exception;
+use InvalidArgumentException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+
 use Traversable;
 
 use function count;
@@ -41,8 +43,12 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
     /**
      * @return T
      */
-    public function __invoke(int $index)
+    public function __invoke(?int $index)
     {
+        if ($index === null) {
+            throw new InvalidArgumentException('List cannot be indexed with nil');
+        }
+
         return $this->get($index);
     }
 

--- a/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
+++ b/src/php/Lang/Collections/Vector/AbstractPersistentVector.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Collections\Vector;
 
+use InvalidArgumentException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
+
 use Phel\Lang\HasherInterface;
 
 use function count;
@@ -34,8 +36,12 @@ abstract class AbstractPersistentVector extends AbstractType implements Persiste
     /**
      * @return T
      */
-    public function __invoke(int $index)
+    public function __invoke(?int $index)
     {
+        if ($index === null) {
+            throw new InvalidArgumentException('Vector cannot be indexed with nil');
+        }
+
         return $this->get($index);
     }
 

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Collections\Vector;
 
+use InvalidArgumentException;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Exceptions\MethodNotSupportedException;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
 use RuntimeException;
+
 use Stringable;
 
 use function count;
@@ -50,8 +52,12 @@ final class TransientVector implements TransientVectorInterface, Stringable
      *
      * @return T
      */
-    public function __invoke(int $index)
+    public function __invoke(?int $index)
     {
+        if ($index === null) {
+            throw new InvalidArgumentException('Vector cannot be indexed with nil');
+        }
+
         return $this->get($index);
     }
 

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -26,15 +26,17 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
     }
 
     /**
-     * Callable behaviour for keyword-as-accessor. Accepts any `ArrayAccess`
-     * container so both persistent and transient maps work (previously the
-     * signature was narrowed to `PersistentMapInterface`, which raised a
-     * `TypeError` when called against a transient map).
+     * Keyword-as-accessor. `nil` target returns the default (matches
+     * `(:k nil)` returning nil) instead of raising `TypeError`.
      */
     public function __invoke(
-        ArrayAccess $obj,
+        ?ArrayAccess $obj,
         float|bool|int|string|TypeInterface|null $default = null,
     ) {
+        if (!$obj instanceof ArrayAccess) {
+            return $default;
+        }
+
         return $obj[$this] ?? $default;
     }
 

--- a/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
+++ b/tests/php/Unit/Command/Domain/Exceptions/ExceptionArgsPrinterTest.php
@@ -20,6 +20,14 @@ final class ExceptionArgsPrinterTest extends TestCase
         self::assertSame(' 1 2', $actual);
     }
 
+    public function test_parse_args_as_string_truncates_long_args(): void
+    {
+        $argsPrinter = $this->createExceptionArgsPrinter();
+        $longArg = str_repeat('x', 250);
+        $actual = $argsPrinter->parseArgsAsString([$longArg]);
+        self::assertSame(' ' . str_repeat('x', 200) . '...', $actual);
+    }
+
     #[DataProvider('providerBuildPhpArgsString')]
     public function test_build_php_args_string(array $args, string $expected): void
     {

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Collections\LinkedList;
 
+use InvalidArgumentException;
 use Phel;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\LinkedList\EmptyList;
@@ -93,6 +94,16 @@ final class PersistentListTest extends TestCase
 
         $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar', 'foobar']);
         $list->get(3);
+    }
+
+    public function test_invoke_with_nil_throws_clear_error(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), ['foo', 'bar']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List cannot be indexed with nil');
+
+        $list(null);
     }
 
     public function test_equals_other_type(): void

--- a/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/PersistentVectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Collections\Vector;
 
+use InvalidArgumentException;
 use Phel;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -327,6 +328,17 @@ final class PersistentVectorTest extends TestCase
         $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3, 4]);
 
         $this->assertSame(2, $vector(1));
+    }
+
+    public function test_invoke_with_nil_throws_clear_error(): void
+    {
+        /** @var PersistentVector $vector */
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Vector cannot be indexed with nil');
+
+        $vector(null);
     }
 
     public function test_rest_on_empty_vector(): void

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -129,4 +129,11 @@ final class KeywordTest extends TestCase
         $this->assertNull($keyword2($table));
         $this->assertSame('xyz', $keyword2($table, 'xyz'));
     }
+
+    public function test_invoke_on_nil_returns_default(): void
+    {
+        $keyword = Keyword::create('missing');
+        $this->assertNull($keyword(null));
+        $this->assertSame('fallback', $keyword(null, 'fallback'));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Three REPL rough edges hurt DX:
- `(h/request-from-globals)` in REPL dumps entire `$_SERVER` through stack-trace args (~hundreds of lines of noise) with a vague "cannot determine HTTP Method".
- `(:uri nil)` raises raw PHP `TypeError` from `Keyword::__invoke` because the param is typed `ArrayAccess`.
- Any long arg rendered in a Phel stack frame prints in full.

## 💡 Goal

Make these three failures short, clear, and actionable without touching behavior elsewhere.

## 🔖 Changes

- `Keyword::__invoke` accepts `?ArrayAccess`; nil target returns default (`(:k nil)` → nil).
- `phel\http/request-from-globals` error explains HTTP-context requirement, points to `request-from-map` for tests.
- `ExceptionArgsPrinter::parseArgsAsString` truncates each arg at 200 chars.
- Tests: `KeywordTest::test_invoke_on_nil_returns_default`, `ExceptionArgsPrinterTest::test_parse_args_as_string_truncates_long_args`.