### PR TITLE
test(build): capture duplicate-namespace warnings in unit test

### DIFF
--- a/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
+++ b/src/php/Build/Domain/Extractor/NamespaceFileGrouper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Extractor;
 
+use Closure;
+
 use function array_keys;
 use function array_map;
 use function count;
@@ -24,9 +26,20 @@ use const STDERR;
  */
 final readonly class NamespaceFileGrouper
 {
+    /** @var Closure(string): void */
+    private Closure $warningWriter;
+
+    /**
+     * @param (Closure(string): void)|null $warningWriter
+     */
     public function __construct(
         private NamespaceSorterInterface $namespaceSorter,
-    ) {}
+        ?Closure $warningWriter = null,
+    ) {
+        $this->warningWriter = $warningWriter ?? static function (string $message): void {
+            fwrite(STDERR, $message);
+        };
+    }
 
     /**
      * @param list<NamespaceInformation> $infos
@@ -134,7 +147,7 @@ final readonly class NamespaceFileGrouper
             }
 
             $fileList = implode("\n", array_map(static fn(string $f): string => '  - ' . $f, $effective));
-            fwrite(STDERR, sprintf(
+            ($this->warningWriter)(sprintf(
                 "\nWARNING: Namespace '%s' is defined in multiple locations:\n%s\n"
                 . "The last one will be used. Check your phel-config.php srcDirs/testDirs settings.\n",
                 $namespace,

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceFileGrouperTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceFileGrouperTest.php
@@ -13,6 +13,9 @@ final class NamespaceFileGrouperTest extends TestCase
 {
     private NamespaceFileGrouper $grouper;
 
+    /** @var list<string> */
+    private array $capturedWarnings = [];
+
     protected function setUp(): void
     {
         $sorter = new class() implements NamespaceSorterInterface {
@@ -22,7 +25,13 @@ final class NamespaceFileGrouperTest extends TestCase
             }
         };
 
-        $this->grouper = new NamespaceFileGrouper($sorter);
+        $this->capturedWarnings = [];
+        $this->grouper = new NamespaceFileGrouper(
+            $sorter,
+            function (string $message): void {
+                $this->capturedWarnings[] = $message;
+            },
+        );
     }
 
     public function test_local_primary_wins_over_phar_bundle(): void
@@ -34,6 +43,7 @@ final class NamespaceFileGrouperTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('/workspace/src/phel/core.phel', $result[0]->getFile());
+        self::assertSame([], $this->capturedWarnings);
     }
 
     public function test_local_primary_wins_even_when_phar_iterated_last(): void
@@ -45,6 +55,7 @@ final class NamespaceFileGrouperTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('/workspace/src/phel/core.phel', $result[0]->getFile());
+        self::assertSame([], $this->capturedWarnings);
     }
 
     public function test_two_local_definitions_keep_last_wins_behavior(): void
@@ -56,6 +67,8 @@ final class NamespaceFileGrouperTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('/workspace/src/user_b.phel', $result[0]->getFile());
+        self::assertCount(1, $this->capturedWarnings);
+        self::assertStringContainsString("Namespace 'user' is defined in multiple locations", $this->capturedWarnings[0]);
     }
 
     public function test_two_phar_definitions_keep_last_wins_behavior(): void
@@ -67,6 +80,8 @@ final class NamespaceFileGrouperTest extends TestCase
 
         self::assertCount(1, $result);
         self::assertSame('phar:///tmp/two.phar/src/x.phel', $result[0]->getFile());
+        self::assertCount(1, $this->capturedWarnings);
+        self::assertStringContainsString("Namespace 'ns\\x' is defined in multiple locations", $this->capturedWarnings[0]);
     }
 
     public function test_local_secondaries_are_preserved_alongside_phar_primary(): void


### PR DESCRIPTION
## 🤔 Background

`composer test` printed two `WARNING: Namespace '...' is defined in multiple locations:` blocks to STDERR, emitted from `NamespaceFileGrouperTest` cases that exercise the duplicate-namespace branch. Tests still passed, but the PHPUnit output was noisy and looked like a real failure.

## 💡 Goal

Keep the warning behavior for real users (duplicate-namespace detection is the whole point of the branch) while making the unit test deterministic and silent.

## 🔖 Changes

- `NamespaceFileGrouper` now accepts an optional `Closure(string): void` warning writer. Default stays `fwrite(STDERR, ...)`, so production behavior is unchanged.
- `NamespaceFileGrouperTest` injects a capturing closure and asserts on the emitted warning messages for the two duplicate-definition cases; adds negative assertions that the PHAR-shadowed cases emit nothing.
- `composer fix && composer test` now runs clean with no STDERR leakage.