### PR TITLE
docs(agents): refresh task recipes for latest phel modules

### DIFF
--- a/.agents/tasks/add-tests.md
+++ b/.agents/tasks/add-tests.md
@@ -81,13 +81,18 @@ Compose outer-to-inner. Keyed by `*ns*`.
 ## Mocking
 
 ```phel
-(:require phel\mock :refer [with-mocks mock called-with?])
+(:require phel\mock :refer [with-mocks mock mock-fn mock-returning mock-throwing spy
+                            called? called-with? called-once? never-called?
+                            call-count calls reset-mock!])
 
 (deftest hits-endpoint
   (with-mocks [http-get (mock {:id 1})]
     (fetch-user 123)
-    (is (called-with? http-get "/users/123"))))
+    (is (called-with? http-get "/users/123"))
+    (is (called-once? http-get))))
 ```
+
+Helpers: `mock` (fixed return), `mock-fn` (custom behavior), `mock-returning` (sequence), `mock-throwing` (error), `spy` (wrap real fn).
 
 Full: `docs/mocking-guide.md`.
 

--- a/.agents/tasks/cli-tool.md
+++ b/.agents/tasks/cli-tool.md
@@ -1,104 +1,219 @@
 # CLI tool
 
-Two shapes: `phel run` script, or PHP shim binary.
+Use `phel\cli` — data-driven wrapper over `symfony/console` (bundled, no extra deps). Describe commands as Phel maps; get subcommands, args, options, prompts, tables, progress bars, shell completion, signals, test helpers.
 
-## A. `phel run` script
+Full reference: `docs/cli-guide.md`. Module: `src/phel/cli.phel`.
+
+## Quickstart
 
 `src/main.phel`:
 
 ```phel
-(ns my-cli\main)
+(ns my-tool\main
+  (:require phel\cli :as cli))
 
-(defn -main [& args]
-  (println (str "Hello, " (or (first args) "World") "!"))
-  0)
+(defn- greet [ctx]
+  (let [name (or (cli/arg ctx "name")
+                 (cli/ask ctx "What's your name?" "world"))]
+    (cli/success ctx (str "Hello, " name "!"))))
 
-(when-not *build-mode*
-  (apply -main *argv*))
+(def app
+  (cli/application
+    {:name     "my-tool"
+     :version  "1.0.0"
+     :default  "greet"
+     :commands [{:name "greet"
+                 :doc  "Say hi"
+                 :args [{:name "name" :mode :optional :doc "Who to greet"}]
+                 :run  greet}]}))
+
+(when-not *build-mode* (php/exit (cli/run app)))
 ```
 
 ```bash
-./vendor/bin/phel run src/main.phel Alice
+./vendor/bin/phel run src/main.phel greet alice
+# [OK] Hello, alice!
 ```
 
-## B. Composer bin shim
+## Command spec keys
 
-`bin/greet`:
+| Key | Type | Purpose |
+|-----|------|---------|
+| `:name` | string (req) | Command name, e.g. `"build"` or `"app:build"` |
+| `:doc` | string | Short description (`list` output) |
+| `:help` | string | Long help (`<cmd> --help`) |
+| `:aliases` | vec string | Alternate names |
+| `:hidden?` | bool | Hide from `list` |
+| `:args` | vec map | Positional arg specs |
+| `:opts` | vec map | Option specs |
+| `:run` | fn (req) | `(fn [ctx] ...)` — see handler contract |
+
+## Arg / opt specs
+
+| Key | Arg mode | Opt mode |
+|-----|----------|----------|
+| `:mode` | `:required` `:optional` `:array` | `:none` `:required` `:optional` `:array` `:negatable` |
+| `:coerce` | `:int` `:float` `:bool` `:keyword` `:edn` | same |
+| `:name` `:doc` `:default` | yes | yes |
+| `:short` | — | single char, e.g. `"v"` |
+| `:complete` | `(fn [input] [...])` | `(fn [input] [...])` |
+
+Read inside handler: `(cli/arg ctx "name")` / `(cli/opt ctx "verbose")`. Coercion auto-applied.
+
+## Handler contract
+
+Receives context map:
+
+```phel
+{:input <InputInterface> :output <OutputInterface>
+ :arg-specs [...] :opt-specs [...] :style <SymfonyStyle>}
+```
+
+Return `nil`/`0` = success, any int = exit code. Uncaught `Throwable` → red `<error>` + exit `1`; `-v` adds stack trace.
+
+Never call `php/exit` in handlers (except signal handlers).
+
+## Output
+
+```phel
+(cli/writeln ctx "plain line")
+(cli/write   ctx "no newline")
+(cli/info    ctx "green info")
+(cli/comment-line ctx "yellow")
+(cli/error   ctx "red")
+
+;; Verbosity-aware (-v / -vv / -vvv)
+(cli/info-v  ctx "detail")
+(cli/info-vv ctx "more")
+(cli/debug   ctx "-vvv only")
+
+;; SymfonyStyle boxes
+(cli/title ctx "Report")  (cli/section ctx "Sub")
+(cli/success ctx "OK!")   (cli/warning ctx "!")
+(cli/note ctx "fyi")      (cli/caution ctx "danger")
+(cli/listing ctx ["a" "b" "c"])
+```
+
+## Prompts
+
+```phel
+(cli/ask        ctx "Your name?" "world")
+(cli/ask-hidden ctx "Password?")
+(cli/confirm    ctx "Deploy?" false)
+(cli/choice     ctx "Env?" ["dev" "stg" "prod"] "dev")
+```
+
+## Tables + progress
+
+```phel
+(cli/table ctx ["id" "name"] [[1 "alice"] [2 "bob"]]
+  {:style :markdown :widths [6 20]})
+
+;; Styles: :default :borderless :compact :symfony :box :box-double :markdown
+
+(cli/run-with-progress ctx files
+  (fn [f _bar] (process-file f)))
+
+(let [bar (cli/progress-bar ctx {:max 100 :format :verbose})]
+  (cli/progress-start bar)
+  (dotimes [_ 100] (do-work) (cli/progress-advance bar))
+  (cli/progress-finish bar))
+```
+
+## Stdin
+
+```phel
+;; cat data.txt | my-tool process
+(for [line :in (cli/stdin-lines) :when (not= line "")]
+  (handle-line line))
+```
+
+`stdin-lines` handles `php/fgets` false-at-EOF; don't reimplement.
+
+## Shell completion
+
+```phel
+{:args [{:name "env" :mode :required
+         :complete (fn [_input] ["dev" "staging" "prod"])}]}
+```
+
+Install: `my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool`.
+
+## Signal handling + hooks
+
+```phel
+(cli/application
+  {:name      "mytool"
+   :before    (fn [e] ...) ; ConsoleCommandEvent
+   :after     (fn [e] ...) ; ConsoleTerminateEvent
+   :on-error  (fn [e] ...) ; ConsoleErrorEvent
+   :on-signal {:sigint  (fn [_] (cleanup) (php/exit 130))
+               :sigterm (fn [_] (cleanup))}
+   :commands  [...]})
+```
+
+## Entry points
+
+`phel run`: `(when-not *build-mode* (php/exit (cli/run app)))`.
+
+Composer bin shim `bin/greet`:
 
 ```php
 #!/usr/bin/env php
 <?php
 require __DIR__ . '/../vendor/autoload.php';
-\Phel::run(__DIR__ . '/..', 'my-cli\\main', array_slice($argv, 1));
+\Phel::run(__DIR__ . '/..', 'my-tool\\main');
 ```
 
-```bash
-chmod +x bin/greet
-```
-
-`composer.json`:
-
-```json
-{ "bin": ["bin/greet"] }
-```
-
-`src/main.phel` same as A. `*argv*` holds user args only.
-
-## Stdin
-
-```phel
-(def stdin (php/fopen "php://stdin" "r"))
-
-(defn read-all []
-  (loop [acc ""]
-    (let [chunk (php/fgets stdin)]
-      (if (or (false? chunk) (nil? chunk))
-        acc
-        (recur (str acc chunk))))))
-
-(when-not *build-mode* (println (read-all)))
-```
-
-Never call blocking stdin at top level unguarded; `phel build` hangs.
-
-## Argv parsing
-
-```phel
-(let [[cmd & rest] *argv*]
-  (case cmd
-    "help"    (print-help)
-    "version" (println "1.0.0")
-    (exec rest)))
-```
-
-For flags, use Symfony Console via interop.
-
-## Exit codes
-
-Return int from `-main`. `(php/exit n)` forces immediate exit.
-
-## Output
-
-`println` / `print`. Stderr: `(php/fwrite php/STDERR (str msg "\n"))`.
+`composer.json`: `{ "bin": ["bin/greet"] }`, then `chmod +x bin/greet`.
 
 ## Tests
 
 ```phel
 (ns tests\main-test
   (:require phel\test :refer [deftest is])
-  (:require my-cli\main :refer [-main]))
+  (:require phel\cli  :as cli)
+  (:require my-tool\main :refer [app]))
 
 (deftest greets
-  (is (= 0 (-main "Alice"))))
-```
+  (let [input  (cli/argv ["greet" "alice"])
+        output (cli/buffered-output)
+        code   (cli/run app input output)]
+    (is (= 0 code))
+    (is (cli/output-contains? output "Hello, alice!"))))
 
-Runnable: `.agents/examples/cli-wordcount/`.
+(deftest prompts-canned-stdin
+  (let [input  (cli/argv-with-stdin ["greet"] "carol\n")
+        output (cli/buffered-output)]
+    (cli/run app input output)
+    (is (cli/output-contains? output "Hello, carol!"))))
+```
 
 ## Gotchas
 
-- `*argv*` under `phel run` excludes file path. Under shim, pass `array_slice($argv, 1)`.
-- `php/fgets` returns `false` at EOF, not `nil`.
+- `:auto-exit?` defaults to `false`; `(cli/run app)` returns exit code — wrap with `(php/exit ...)` at top level.
+- `:default` sets the command to run when no subcommand given.
+- `cli/arg` / `cli/opt` apply `:coerce` once — don't re-coerce in handler.
+- Spec validation is eager; bad maps throw `InvalidArgumentException` at build time.
+- Prefer `cli/success`, `cli/error` over raw ANSI.
+- Lift handlers to top-level `defn-` for testability.
+
+## Raw approach (minimal CLI, no Symfony)
+
+For a trivial script without subcommands, drop `phel\cli`:
+
+```phel
+(ns my-tool\main)
+
+(defn -main [& args]
+  (println (str "Hello, " (or (first args) "World") "!"))
+  0)
+
+(when-not *build-mode* (php/exit (apply -main *argv*)))
+```
+
+Example: `.agents/examples/cli-wordcount/`.
 
 ## Next
 
-`tasks/add-tests.md`, `docs/framework-integration.md`
+`docs/cli-guide.md`, `src/phel/cli.phel`, `tasks/add-tests.md`, `docs/framework-integration.md`

--- a/.agents/tasks/debug-errors.md
+++ b/.agents/tasks/debug-errors.md
@@ -82,9 +82,11 @@ Check `~`, `` ` ``, auto-gensym `name#`.
 
 ## Tools
 
-- `(doc sym)`, `(resolve 'sym)`, `(macroexpand-1 ...)`
+- `(doc sym)`, `(resolve 'sym)`, `(macroexpand-1 ...)`, `(macroexpand ...)`
+- `(require 'phel\pprint :refer [pprint])`, `(pprint x)`
 - `./vendor/bin/phel run --debug <file>`
-- `./vendor/bin/phel cache:clear`
+- `./vendor/bin/phel cache:clear` (stale cache after core/macro edits)
+- `./vendor/bin/phel doc <fn>` (no REPL needed)
 
 ## Gotchas
 

--- a/.agents/tasks/http-app.md
+++ b/.agents/tasks/http-app.md
@@ -1,6 +1,8 @@
 # HTTP app
 
-Bundled `phel\router` + `phel\http` + `phel\json`. Runnable: `.agents/examples/todo-app/`.
+Bundled modules: `phel\http` (req/res structs), `phel\router` (nested routes, middleware, URL gen), `phel\json`. Outbound HTTP: `phel\http-client`.
+
+Runnable: `.agents/examples/todo-app/`.
 
 ## Handlers
 
@@ -13,9 +15,9 @@ Bundled `phel\router` + `phel\http` + `phel\json`. Runnable: `.agents/examples/t
 
 (defn- json-response [status data]
   (h/response-from-map
-    {:status status
+    {:status  status
      :headers {:content-type "application/json"}
-     :body (json/encode data)}))
+     :body    (json/encode data)}))
 
 (defn home   [_req] (h/response-from-map {:status 200 :body "<h1>Phel</h1>"}))
 (defn health [_req] (json-response 200 {:status "ok" :ts (php/time)}))
@@ -37,12 +39,18 @@ Bundled `phel\router` + `phel\http` + `phel\json`. Runnable: `.agents/examples/t
   (r/router
     [["/"             {:get {:handler h/home}}]
      ["/health"       {:get {:handler h/health}}]
-     ["/greet/{name}" {:get {:handler h/greet}}]]))
+     ["/greet/{name}" {:name :greet :get {:handler h/greet}}]]))
 
 (def app-handler (r/handler app-router))
 ```
 
-Data keys: `:handler` (any-method), `:get`/`:post`/... (per-method `{:handler :middleware}`), `:middleware`, `:name`.
+Data keys per route:
+- `:handler` — method-agnostic `(fn [req] resp)`
+- `:get` / `:post` / `:put` / `:patch` / `:delete` / `:head` / `:options` — per-method `{:handler :middleware}`
+- `:middleware` — vec of `(fn [handler req])` applied at this level
+- `:name` — keyword, enables URL generation
+
+Nested children inherit path prefix and deep-merged data.
 
 ## Entry
 
@@ -79,11 +87,14 @@ php -S localhost:8000 -t public
 
 (def app-handler
   (r/handler app-router
-    {:middleware [log-mw]
-     :not-found  (fn [_] (h/response-from-map {:status 404 :body "nope"}))}))
+    {:middleware         [log-mw]
+     :not-found          (fn [_] (h/response-from-map {:status 404 :body "nope"}))
+     :method-not-allowed (fn [_] (h/response-from-map {:status 405 :body "no"}))
+     :not-acceptable     (fn [_] (h/response-from-map {:status 406 :body "no"}))
+     :default-handler    (fn [_] (h/response-from-map {:status 404}))}))
 ```
 
-Route-level in data: `{:middleware [auth-mw] :get {:handler ...}}`. Method-level inside the method map.
+Route-level: `{:middleware [auth-mw] :get {:handler ...}}`. Method-level goes inside the method map.
 
 ## Responses
 
@@ -95,9 +106,16 @@ Route-level in data: `{:middleware [auth-mw] :get {:handler ...}}`. Method-level
 ## URL generation
 
 ```phel
-(def tree [["/users/{id}" {:name :user-show :get {:handler show}}]])
-(r/generate app-router :user-show {:id 42})   ; => "/users/42"
+(:require phel\router :as r :refer [generate match-by-name])
+
+(def app-router
+  (r/router [["/users/{id}" {:name :user-show :get {:handler show}}]]))
+
+(generate app-router :user-show {:id 42})   ; => "/users/42"
+(match-by-name app-router :user-show)       ; => match struct
 ```
+
+`generate`, `match-by-name`, `match-by-path` are `Router` interface methods — call directly on the router.
 
 ## Compiled router (prod)
 
@@ -105,7 +123,21 @@ Route-level in data: `{:middleware [auth-mw] :get {:handler ...}}`. Method-level
 (def app-router (r/compiled-router [["/ping" {:get {:handler pong}}]]))
 ```
 
-Routes must be literal at call site. ~3x faster.
+Macro — routes must be literal at call site. ~3x faster matching + URL gen.
+
+## Outbound HTTP
+
+```phel
+(:require phel\http-client :as hc)
+
+(hc/get  "https://api.example.com/users/42")
+(hc/post "https://api.example.com/users"
+         {:json    {:name "Alice"}
+          :headers {:authorization (str "Bearer " token)}
+          :timeout 10.0})
+```
+
+Returns `h/response` struct. Opts: `:headers` `:body` `:json` `:query-params` `:timeout` `:follow-redirects` `:verify-ssl`.
 
 ## Tests
 
@@ -126,7 +158,7 @@ Routes must be literal at call site. ~3x faster.
     (is (= "Hello, Alice!" (get (json/decode (get resp :body)) :message)))))
 ```
 
-POST body tests: pass `:parsed-body` map. Production adds JSON-decode middleware.
+POST body: pass `:parsed-body` in the map. Production decodes JSON in middleware.
 
 ## Production
 
@@ -138,11 +170,13 @@ Swap `\Phel::run(...)` for `require` of compiled boot file.
 
 ## Gotchas
 
-- Handlers return structs, not PHP objects.
-- Path params at `[:attributes :match :path-params :<name>]`.
+- Handlers return `response` structs via `response-from-map`/`response-from-string`, not raw maps.
+- Path params at `[:attributes :match :path-params :<name>]`; route data at `[:attributes :route-data]`.
 - `*build-mode*` guard in `entry.phel` is mandatory.
-- `compiled-router` needs literal routes.
+- `compiled-router` needs literal routes (macro expansion).
+- Nil response from a matched handler triggers `:not-acceptable` (HTTP 406).
+- `:default-handler` is a fallback for any 404/405/406 not covered by a specific override.
 
 ## Next
 
-`src/phel/router.phel`, `src/phel/http.phel`, `tasks/use-php-libs.md`, `docs/framework-integration.md`
+`src/phel/router.phel`, `src/phel/http.phel`, `src/phel/http-client.phel`, `tasks/use-php-libs.md`, `docs/framework-integration.md`

--- a/.agents/tasks/repl-workflow.md
+++ b/.agents/tasks/repl-workflow.md
@@ -41,6 +41,8 @@ Shell: `./vendor/bin/phel doc <fn>`.
 
 Each `deftest` is a zero-arg fn tagged `{:test true}`.
 
+Shell: `./vendor/bin/phel test [path] [--filter=substring] [--testdox] [--fail-fast]`.
+
 ## State
 
 ```phel

--- a/.agents/tasks/scaffold-project.md
+++ b/.agents/tasks/scaffold-project.md
@@ -30,6 +30,15 @@ Verify:
 
 Namespaces need ≥ 2 segments (`my-app\main`, not `main`).
 
+## Shell completion (install skill adapters)
+
+```bash
+./vendor/bin/phel agent-install claude   # Claude / Claude Code
+./vendor/bin/phel agent-install --all    # every supported platform
+```
+
+Installs `.agents/` rules + task recipes + examples into your project so the assistant has Phel context.
+
 ## Next
 
-`tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/add-tests.md`
+`tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/add-tests.md`, `tasks/use-core-lib.md`

--- a/.agents/tasks/use-core-lib.md
+++ b/.agents/tasks/use-core-lib.md
@@ -97,7 +97,29 @@ Core: `(str a b c)`, `(name :k)`, `(keyword "x")`, `(symbol "x")`.
 - `phel\json`: `(json/encode m)`, `(json/decode s)`
 - `phel\pprint`: `(pprint x)`
 - `phel\walk`: `(postwalk f m)`, `(prewalk f m)`
+- `phel\base64`: `(encode s)`, `(decode s)`, `(encode-url s)`, `(decode-url s)`
 - File: `(php/file_get_contents p)`, `(php/file_put_contents p s)`
+
+## Bundled modules
+
+| Module | Purpose |
+|--------|---------|
+| `phel\core` | collections, threading, state, predicates |
+| `phel\string` (`:as str`) | string ops |
+| `phel\json` | encode / decode |
+| `phel\pprint` | pretty-print |
+| `phel\walk` | tree traversal |
+| `phel\base64` | base64 encode/decode (URL-safe variants) |
+| `phel\http` | request/response structs, `request-from-globals`, `emit-response` |
+| `phel\router` | nested routes, middleware, URL gen, `compiled-router` |
+| `phel\http-client` | outbound HTTP: `get`, `post`, `put`, `patch`, `delete`, `head` |
+| `phel\cli` | Symfony-console wrapper — see `tasks/cli-tool.md` |
+| `phel\html` | HTML templating |
+| `phel\test` | `deftest`, `is`, `are`, `testing`, fixtures |
+| `phel\mock` | `with-mocks`, `mock`, `spy`, `called-with?` |
+| `phel\async` | `future`, `async`, `await`, `delay` (AMPHP-backed fibers) |
+| `phel\ai` | LLM client (`complete`, `chat`, `configure`) |
+| `phel\repl` | REPL utilities |
 
 ## When to use what
 
@@ -120,4 +142,4 @@ git grep 'defn <fn>' src/phel/core
 
 ## Next
 
-`docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`
+`docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`, `docs/cli-guide.md`, `tasks/http-app.md`, `tasks/cli-tool.md`

--- a/.agents/tasks/use-php-libs.md
+++ b/.agents/tasks/use-php-libs.md
@@ -6,16 +6,18 @@
 
 | Task | Phel |
 |------|------|
-| Instantiate | `(php/new Class args)` / `(Class.)` |
+| Instantiate | `(php/new Class args)` / `(new Class args)` / `(Class. args)` |
 | Method | `(.method obj args)` / `(php/-> obj (method args))` |
 | Static | `(Class/method args)` / `(php/:: Class (method args))` |
-| Constant | `Class/CONST` |
+| Constant | `Class/CONST` / `(php/:: Class CONST)` |
 | Property | `(.-prop obj)` |
 | Fn (global) | `(php/strlen s)` |
 | Fn (namespaced) | `(php/Amp\trapSignal xs)` |
 | PHP array indexed | `#php [1 2 3]` |
 | PHP array assoc | `#php {"k" "v"}` |
 | Catch | `(catch php\SomeException e ...)` |
+
+Full table: `docs/php-interop.md`.
 
 ## Guzzle
 


### PR DESCRIPTION
## 🤔 Background

The `.agents/tasks/` recipes are pre-built guides the Phel assistant uses to answer "how do I X?" requests. Several of them pre-dated recent module additions (`phel\cli`, `phel\http-client`, `phel\async`, `phel\base64`, `phel\ai`) and were showing stale idioms: `cli-tool.md` still demoed raw \`*argv*\` + Symfony interop instead of the data-driven `phel\cli` API; `http-app.md` missed the outbound HTTP client, compiled-router nuance, and `:default-handler` / `:not-acceptable` options; core/interop recipes were missing recently-documented shortcuts.

## 💡 Goal

Bring every task recipe in line with the current source of `src/phel/` and the authoritative docs, so the agent surface ships accurate, copy-pastable code.

## 🔖 Changes

- `cli-tool.md`: full rewrite around `phel\cli` — `application`, `command`, `run`, spec-map keys, `arg`/`opt` coercion, SymfonyStyle writers (`success`, `warning`, `title`, `section`), prompts, `table` styles, progress bars, `stdin-lines`, shell completion, hooks, signal handling, and the `argv` / `buffered-output` / `output-contains?` test helpers. Raw `-main` + `*argv*` approach kept as a fallback pointer to `cli-wordcount`.
- `http-app.md`: document all `r/handler` options (`:middleware`, `:default-handler`, `:not-found`, `:method-not-allowed`, `:not-acceptable`), clarify URL generation uses the `Router` interface methods (`generate`, `match-by-name`, `match-by-path`), add an outbound HTTP section using `phel\http-client`, fix stale response-struct wording.
- `add-tests.md`: broaden the `phel\mock` surface (`mock-fn`, `mock-returning`, `mock-throwing`, `spy`, `called-once?`, `never-called?`, `call-count`, `reset-mock!`).
- `debug-errors.md`: extend the diagnostic toolbox (`macroexpand`, `pprint`, `phel doc`, cache-clear context).
- `use-core-lib.md`: add `phel\base64` section and a bundled-modules index covering `phel\cli`, `phel\http-client`, `phel\async`, `phel\ai`, `phel\mock`, `phel\repl`, `phel\html`.
- `use-php-libs.md`: add `(new Class)` and `(Class. args)` instantiation variants consistent with `docs/php-interop.md`, plus the `(php/:: Class CONST)` constant form.
- `repl-workflow.md`: note the shell `phel test` flags alongside REPL-driven runs.
- `scaffold-project.md`: document `phel agent-install` for installing assistant adapters.

Docs-only; no runtime behavior changes.