### PR TITLE
feat(nrepl): add bencode-over-TCP nREPL server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 #### CLI
 - `phel eval -` reads the expression from stdin (e.g. `echo '(+ 1 2)' | phel eval -`)
 - `phel agent-install [<platform>|--all]` writes skill files for Claude Code, Cursor, Codex, Gemini, Copilot, Aider; `--with-docs` also mirrors the bundled `.agents/` tree, `--dry-run` previews, `--force` skips backup
+- `phel nrepl --port=N --host=addr` starts a bencode-over-TCP nREPL server; supports `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, plus `completions`, `lookup`, `info`, and `eldoc` for editor tooling
 
 #### Agent docs
 - `.agents/` ships agent-agnostic docs with task recipes, per-platform adapters, and three runnable example projects (`todo-app`, `http-json-api`, `cli-wordcount`)

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -22,6 +22,7 @@ use Phel\Console\Application\VersionFinder;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
+use Phel\Nrepl\Infrastructure\Command\NreplCommand;
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
 use Phel\Run\Infrastructure\Command\EvalCommand;
@@ -73,6 +74,7 @@ final class ConsoleProvider extends AbstractProvider
             new ProfileReportCommand(),
             new ValidateConfigCommand(),
             new DoctorCommand(),
+            new NreplCommand(),
         ];
     }
 

--- a/src/php/Nrepl/Application/Op/CloneOp.php
+++ b/src/php/Nrepl/Application/Op/CloneOp.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+
+final readonly class CloneOp implements OpHandlerInterface
+{
+    public function __construct(private SessionRegistry $sessions) {}
+
+    public function name(): string
+    {
+        return 'clone';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $session = $this->sessions->create();
+
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            ['new-session' => $session->id],
+            ['done'],
+        )];
+    }
+}

--- a/src/php/Nrepl/Application/Op/CloseOp.php
+++ b/src/php/Nrepl/Application/Op/CloseOp.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+
+final readonly class CloseOp implements OpHandlerInterface
+{
+    public function __construct(private SessionRegistry $sessions) {}
+
+    public function name(): string
+    {
+        return 'close';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $target = $request->session ?? '';
+        $closed = $target !== '' && $this->sessions->close($target);
+
+        $status = $closed ? ['done', 'session-closed'] : ['done', 'error', 'unknown-session'];
+
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            [],
+            $status,
+        )];
+    }
+}

--- a/src/php/Nrepl/Application/Op/CompletionsOp.php
+++ b/src/php/Nrepl/Application/Op/CompletionsOp.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Shared\Facade\ApiFacadeInterface;
+
+final readonly class CompletionsOp implements OpHandlerInterface
+{
+    public function __construct(private ApiFacadeInterface $apiFacade) {}
+
+    public function name(): string
+    {
+        return 'completions';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $prefix = $request->stringParam('prefix');
+        $results = $this->apiFacade->replCompleteWithTypes($prefix);
+
+        $completions = [];
+        foreach ($results as $result) {
+            $completions[] = [
+                'candidate' => $result->candidate,
+                'type' => $result->type,
+            ];
+        }
+
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            ['completions' => $completions],
+            ['done'],
+        )];
+    }
+}

--- a/src/php/Nrepl/Application/Op/DescribeOp.php
+++ b/src/php/Nrepl/Application/Op/DescribeOp.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Shared\Facade\RunFacadeInterface;
+
+final readonly class DescribeOp implements OpHandlerInterface
+{
+    public function __construct(
+        private OpDispatcher $dispatcher,
+        private RunFacadeInterface $runFacade,
+    ) {}
+
+    public function name(): string
+    {
+        return 'describe';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $ops = [];
+        foreach ($this->dispatcher->knownOps() as $op) {
+            $ops[$op] = [];
+        }
+
+        $version = $this->runFacade->getVersion();
+
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            [
+                'ops' => $ops,
+                'versions' => [
+                    'phel' => ['version-string' => $version],
+                    'nrepl' => ['version-string' => '0.1.0', 'major' => 0, 'minor' => 1, 'incremental' => 0],
+                ],
+                'aux' => [],
+            ],
+            ['done'],
+        )];
+    }
+}

--- a/src/php/Nrepl/Application/Op/EvalOp.php
+++ b/src/php/Nrepl/Application/Op/EvalOp.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
+use Phel\Shared\Facade\RunFacadeInterface;
+
+use function sprintf;
+
+final readonly class EvalOp implements OpHandlerInterface
+{
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+        private PrinterInterface $printer,
+        private SessionRegistry $sessions,
+    ) {}
+
+    public function name(): string
+    {
+        return 'eval';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $code = $request->stringParam('code');
+        if ($code === '') {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Missing required "code" param for eval op.'],
+                ['error', 'eval-error', 'done'],
+            )];
+        }
+
+        $result = $this->runFacade->structuredEval($code, new CompileOptions());
+        $responses = [];
+
+        if ($result->output !== '') {
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                ['out' => $result->output],
+            );
+        }
+
+        if ($result->success) {
+            $sessionObject = $request->session !== null ? $this->sessions->get($request->session) : null;
+            $sessionObject?->recordValue($result->value);
+
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                [
+                    'ns' => $sessionObject?->namespace() ?? 'user',
+                    'value' => $this->printer->print($result->value),
+                ],
+            );
+
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                [],
+                ['done'],
+            );
+
+            return $responses;
+        }
+
+        if ($result->incomplete) {
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Incomplete form: unfinished parser input.'],
+                ['error', 'incomplete', 'done'],
+            );
+
+            return $responses;
+        }
+
+        $error = $result->error;
+        $message = $error instanceof EvalError ? $error->message : 'Evaluation failed.';
+        $exClass = $error instanceof EvalError ? $error->exceptionClass : 'Error';
+
+        $responses[] = OpResponse::build(
+            $request->id,
+            $request->session,
+            [
+                'ex' => $exClass,
+                'root-ex' => $exClass,
+                'err' => sprintf('%s: %s', $exClass, $message),
+            ],
+            ['eval-error'],
+        );
+
+        $responses[] = OpResponse::build(
+            $request->id,
+            $request->session,
+            [],
+            ['done'],
+        );
+
+        return $responses;
+    }
+}

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+
+final class InterruptOp implements OpHandlerInterface
+{
+    public function name(): string
+    {
+        return 'interrupt';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        // Phel evaluates synchronously; there is nothing to interrupt on the
+        // single-threaded request path. Acknowledge so editors stay happy.
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            [],
+            ['done', 'session-idle'],
+        )];
+    }
+}

--- a/src/php/Nrepl/Application/Op/LoadFileOp.php
+++ b/src/php/Nrepl/Application/Op/LoadFileOp.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
+use Phel\Shared\Facade\RunFacadeInterface;
+
+use function sprintf;
+
+final readonly class LoadFileOp implements OpHandlerInterface
+{
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+        private PrinterInterface $printer,
+        private SessionRegistry $sessions,
+    ) {}
+
+    public function name(): string
+    {
+        return 'load-file';
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $fileContent = $request->stringParam('file');
+        $fileName = $request->stringParam('file-name', 'NO_SOURCE_FILE');
+
+        if ($fileContent === '') {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Missing required "file" param for load-file op.'],
+                ['error', 'load-file-error', 'done'],
+            )];
+        }
+
+        $options = new CompileOptions();
+        $result = $this->runFacade->structuredEval($fileContent, $options);
+
+        $responses = [];
+
+        if ($result->output !== '') {
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                ['out' => $result->output],
+            );
+        }
+
+        if ($result->success) {
+            $sessionObject = $request->session !== null ? $this->sessions->get($request->session) : null;
+            $sessionObject?->recordValue($result->value);
+
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                [
+                    'ns' => $sessionObject?->namespace() ?? 'user',
+                    'value' => $this->printer->print($result->value),
+                ],
+            );
+
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                [],
+                ['done'],
+            );
+
+            return $responses;
+        }
+
+        $error = $result->error;
+        $message = $error instanceof EvalError ? $error->message : 'load-file failed.';
+        $exClass = $error instanceof EvalError ? $error->exceptionClass : 'Error';
+
+        $responses[] = OpResponse::build(
+            $request->id,
+            $request->session,
+            [
+                'ex' => $exClass,
+                'err' => sprintf('%s (%s): %s', $exClass, $fileName, $message),
+            ],
+            ['eval-error'],
+        );
+
+        $responses[] = OpResponse::build(
+            $request->id,
+            $request->session,
+            [],
+            ['done'],
+        );
+
+        return $responses;
+    }
+}

--- a/src/php/Nrepl/Application/Op/LookupOp.php
+++ b/src/php/Nrepl/Application/Op/LookupOp.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Api\Transfer\PhelFunction;
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Shared\Facade\ApiFacadeInterface;
+
+use function implode;
+
+/**
+ * Shared implementation for `lookup`, `info`, and `eldoc` ops.
+ * They all translate a symbol name to its documentation/signature record.
+ */
+final class LookupOp implements OpHandlerInterface
+{
+    /** @var list<PhelFunction>|null */
+    private ?array $cache = null;
+
+    public function __construct(
+        private readonly ApiFacadeInterface $apiFacade,
+        private readonly string $opName = 'lookup',
+    ) {}
+
+    public function name(): string
+    {
+        return $this->opName;
+    }
+
+    public function handle(OpRequest $request): array
+    {
+        $symbol = $request->stringParam('sym');
+        if ($symbol === '') {
+            $symbol = $request->stringParam('symbol');
+        }
+
+        if ($symbol === '') {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Missing required "sym" param for ' . $this->opName . ' op.'],
+                ['error', 'no-info', 'done'],
+            )];
+        }
+
+        $fn = $this->findFunction($symbol);
+        if (!$fn instanceof PhelFunction) {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                [],
+                ['done', 'no-info'],
+            )];
+        }
+
+        $info = [
+            'name' => $fn->name,
+            'ns' => $fn->namespace,
+            'doc' => $fn->doc,
+            'arglists-str' => implode(' ', $fn->signatures),
+            'file' => $fn->file,
+            'line' => $fn->line,
+        ];
+
+        return [OpResponse::build(
+            $request->id,
+            $request->session,
+            ['info' => $info, 'eldoc' => $fn->signatures],
+            ['done'],
+        )];
+    }
+
+    private function findFunction(string $symbol): ?PhelFunction
+    {
+        if ($this->cache === null) {
+            $this->cache = $this->apiFacade->getPhelFunctions();
+        }
+
+        foreach ($this->cache as $fn) {
+            if ($fn->nameWithNamespace() === $symbol) {
+                return $fn;
+            }
+
+            if ($fn->name === $symbol && ($fn->namespace === 'core' || $fn->namespace === '')) {
+                return $fn;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/php/Nrepl/CLAUDE.md
+++ b/src/php/Nrepl/CLAUDE.md
@@ -1,0 +1,55 @@
+# Nrepl Module
+
+nREPL protocol server: bencode-over-TCP wire protocol for editor tooling (Cursive, Calva, CIDER, Conjure).
+
+## Gacela Pattern
+
+- **Facade**: `NreplFacade` extends `AbstractFacade<NreplFactory>`
+- **Factory**: `NreplFactory` extends `AbstractFactory<NreplConfig>`
+- **Config**: `NreplConfig` — default port `7888`, default host `127.0.0.1`
+- **Provider**: `NreplProvider` — injects `FACADE_RUN` and `FACADE_API`
+
+## Public API (Facade)
+
+- `createSocketServer(int $port, string $host, ?callable $logger): NreplSocketServer`
+- `createOpDispatcher(): OpDispatcher` — exposed for testing and for reuse from non-socket transports
+- `loadPhelNamespaces(): void` — delegates to `RunFacade::loadPhelNamespaces`
+
+## CLI Command
+
+`./bin/phel nrepl --port=<N> --host=<addr>` — starts the TCP server.
+
+## Supported Ops
+
+- Core: `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt`
+- Tooling: `completions` (via `ApiFacade::replCompleteWithTypes`), `lookup`, `info`, `eldoc` (via `ApiFacade::getPhelFunctions`)
+
+## Dependencies
+
+- **Run** (`RunFacade`) — `structuredEval`, `getVersion`, `loadPhelNamespaces`
+- **Api** (`ApiFacade`) — `replCompleteWithTypes`, `getPhelFunctions`
+- **Printer** — `Printer::readable()` for serialising eval results
+- **Shared** — `RunFacadeInterface`, `ApiFacadeInterface`
+
+## Structure
+
+```
+Nrepl/
+|-- Application/Op/      CloneOp, CloseOp, DescribeOp, EvalOp, LoadFileOp, InterruptOp, CompletionsOp, LookupOp
+|-- Domain/
+|   |-- Bencode/         BencodeEncoder, BencodeDecoder, BencodeStreamDecoder, BencodeException
+|   |-- Op/              OpDispatcher, OpHandlerInterface, OpRequest, OpResponse
+|   |-- Session/         Session, SessionRegistry
+|   +-- Transport/       ClientConnection
+|-- Infrastructure/      NreplSocketServer, Command/NreplCommand
++-- Gacela files         NreplFacade, NreplFactory, NreplConfig, NreplProvider
+```
+
+## Key Constraints
+
+- The bencode codec is a pure library: zero dependencies on Gacela or other modules, reusable in isolation
+- Each op is a single-responsibility class implementing `OpHandlerInterface`; dispatch is a name-to-handler map
+- The accept loop uses PHP Fibers: one Fiber per connected client, cooperative yielding via `Fiber::suspend`
+- Eval delegates to `RunFacade::structuredEval` — never reimplements the compiler
+- Session state tracks id, namespace, and the last evaluated value (for future `*1`/`*2`/`*3` wiring)
+- `NreplSocketServer::run($maxIterations)` takes an iteration cap for test-driven runs; `0` means unbounded

--- a/src/php/Nrepl/Domain/Bencode/BencodeDecoder.php
+++ b/src/php/Nrepl/Domain/Bencode/BencodeDecoder.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Bencode;
+
+use function ctype_digit;
+use function sprintf;
+use function strlen;
+use function substr;
+
+final class BencodeDecoder
+{
+    /**
+     * Decode a bencode byte string into a PHP value.
+     *
+     * Integers become PHP int; byte strings become PHP string; lists become
+     * list<mixed>; dictionaries become associative array<string, mixed>.
+     *
+     * The whole input must be a single valid bencode value.
+     */
+    public function decode(string $input): mixed
+    {
+        $position = 0;
+        $value = $this->decodeAt($input, $position);
+
+        if ($position !== strlen($input)) {
+            throw BencodeException::invalidToken(sprintf('trailing bytes at %d', $position), $position);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Decode a bencode value starting at offset 0 and return the value plus
+     * the number of bytes consumed. Useful for streaming/framed parsing.
+     *
+     * @return array{0: mixed, 1: int}
+     */
+    public function decodeWithLength(string $input): array
+    {
+        $position = 0;
+        $value = $this->decodeAt($input, $position);
+
+        return [$value, $position];
+    }
+
+    private function decodeAt(string $input, int &$position): mixed
+    {
+        if ($position >= strlen($input)) {
+            throw BencodeException::unexpectedEndOfInput($position);
+        }
+
+        $marker = $input[$position];
+
+        if ($marker === 'i') {
+            return $this->decodeInteger($input, $position);
+        }
+
+        if ($marker === 'l') {
+            return $this->decodeList($input, $position);
+        }
+
+        if ($marker === 'd') {
+            return $this->decodeDict($input, $position);
+        }
+
+        if (ctype_digit($marker)) {
+            return $this->decodeString($input, $position);
+        }
+
+        throw BencodeException::invalidToken($marker, $position);
+    }
+
+    private function decodeInteger(string $input, int &$position): int
+    {
+        // skip 'i'
+        ++$position;
+        $end = $this->indexOf($input, 'e', $position);
+        $raw = substr($input, $position, $end - $position);
+
+        if ($raw === '' || $raw === '-') {
+            throw BencodeException::invalidInteger($raw, $position);
+        }
+
+        if ($raw === '-0') {
+            throw BencodeException::invalidInteger($raw, $position);
+        }
+
+        if (strlen($raw) > 1 && $raw[0] === '0') {
+            throw BencodeException::invalidInteger($raw, $position);
+        }
+
+        $start = $raw[0] === '-' ? 1 : 0;
+        for ($i = $start; $i < strlen($raw); ++$i) {
+            if (!ctype_digit($raw[$i])) {
+                throw BencodeException::invalidInteger($raw, $position);
+            }
+        }
+
+        $position = $end + 1;
+
+        return (int) $raw;
+    }
+
+    private function decodeString(string $input, int &$position): string
+    {
+        $colon = $this->indexOf($input, ':', $position);
+        $lengthRaw = substr($input, $position, $colon - $position);
+
+        if ($lengthRaw === '' || !ctype_digit($lengthRaw)) {
+            throw BencodeException::invalidStringLength($lengthRaw, $position);
+        }
+
+        $length = (int) $lengthRaw;
+        $start = $colon + 1;
+        if ($start + $length > strlen($input)) {
+            throw BencodeException::unexpectedEndOfInput($start + $length);
+        }
+
+        $value = substr($input, $start, $length);
+        $position = $start + $length;
+
+        return $value;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function decodeList(string $input, int &$position): array
+    {
+        // skip 'l'
+        ++$position;
+        $list = [];
+
+        while (true) {
+            if ($position >= strlen($input)) {
+                throw BencodeException::unexpectedEndOfInput($position);
+            }
+
+            if ($input[$position] === 'e') {
+                ++$position;
+                return $list;
+            }
+
+            $list[] = $this->decodeAt($input, $position);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeDict(string $input, int &$position): array
+    {
+        // skip 'd'
+        ++$position;
+        $dict = [];
+
+        while (true) {
+            if ($position >= strlen($input)) {
+                throw BencodeException::unexpectedEndOfInput($position);
+            }
+
+            if ($input[$position] === 'e') {
+                ++$position;
+                return $dict;
+            }
+
+            if (!ctype_digit($input[$position])) {
+                throw BencodeException::invalidToken($input[$position], $position);
+            }
+
+            $key = $this->decodeString($input, $position);
+            $dict[$key] = $this->decodeAt($input, $position);
+        }
+    }
+
+    private function indexOf(string $haystack, string $needle, int $from): int
+    {
+        $length = strlen($haystack);
+        for ($i = $from; $i < $length; ++$i) {
+            if ($haystack[$i] === $needle) {
+                return $i;
+            }
+        }
+
+        throw BencodeException::unexpectedEndOfInput($length);
+    }
+}

--- a/src/php/Nrepl/Domain/Bencode/BencodeEncoder.php
+++ b/src/php/Nrepl/Domain/Bencode/BencodeEncoder.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Bencode;
+
+use function array_is_list;
+use function array_keys;
+use function get_debug_type;
+use function gettype;
+use function is_array;
+use function is_bool;
+use function is_int;
+use function is_string;
+use function ksort;
+use function sprintf;
+use function strlen;
+
+final class BencodeEncoder
+{
+    /**
+     * Encode a PHP value to a bencode byte string.
+     *
+     * Supported types:
+     *   - int   → iNNNe
+     *   - string → N:xxxx (binary-safe, byte length)
+     *   - list array → l...e
+     *   - associative array → d...e (keys sorted lexicographically, must be strings)
+     *   - bool → encoded as 1 / 0 integers (nREPL convention for :done status etc.)
+     */
+    public function encode(mixed $value): string
+    {
+        if (is_int($value)) {
+            return sprintf('i%de', $value);
+        }
+
+        if (is_bool($value)) {
+            return sprintf('i%de', $value ? 1 : 0);
+        }
+
+        if (is_string($value)) {
+            return sprintf('%d:%s', strlen($value), $value);
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                // Ambiguous between list and dict — choose list as per bencode tradition.
+                return 'le';
+            }
+
+            if (array_is_list($value)) {
+                return $this->encodeList($value);
+            }
+
+            return $this->encodeDict($value);
+        }
+
+        throw BencodeException::unsupportedType(get_debug_type($value));
+    }
+
+    /**
+     * @param list<mixed> $list
+     */
+    private function encodeList(array $list): string
+    {
+        $out = 'l';
+        foreach ($list as $item) {
+            $out .= $this->encode($item);
+        }
+
+        return $out . 'e';
+    }
+
+    /**
+     * @param array<array-key, mixed> $dict
+     */
+    private function encodeDict(array $dict): string
+    {
+        // Bencode mandates string keys sorted lexicographically as raw bytes.
+        $stringKeyed = [];
+        foreach (array_keys($dict) as $key) {
+            if (!is_string($key)) {
+                throw BencodeException::dictKeyMustBeString(gettype($key));
+            }
+
+            $stringKeyed[$key] = $dict[$key];
+        }
+
+        ksort($stringKeyed, SORT_STRING);
+
+        $out = 'd';
+        foreach ($stringKeyed as $key => $val) {
+            $out .= sprintf('%d:%s', strlen($key), $key);
+            $out .= $this->encode($val);
+        }
+
+        return $out . 'e';
+    }
+}

--- a/src/php/Nrepl/Domain/Bencode/BencodeException.php
+++ b/src/php/Nrepl/Domain/Bencode/BencodeException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Bencode;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class BencodeException extends RuntimeException
+{
+    public static function unexpectedEndOfInput(int $position): self
+    {
+        return new self(sprintf('Unexpected end of input at position %d', $position));
+    }
+
+    public static function invalidToken(string $token, int $position): self
+    {
+        return new self(sprintf('Invalid token %s at position %d', $token, $position));
+    }
+
+    public static function invalidInteger(string $value, int $position): self
+    {
+        return new self(sprintf('Invalid integer "%s" at position %d', $value, $position));
+    }
+
+    public static function invalidStringLength(string $length, int $position): self
+    {
+        return new self(sprintf('Invalid string length "%s" at position %d', $length, $position));
+    }
+
+    public static function unsupportedType(string $type): self
+    {
+        return new self(sprintf('Cannot encode type %s', $type));
+    }
+
+    public static function dictKeyMustBeString(string $type): self
+    {
+        return new self(sprintf('Dictionary keys must be strings, got %s', $type));
+    }
+}

--- a/src/php/Nrepl/Domain/Bencode/BencodeStreamDecoder.php
+++ b/src/php/Nrepl/Domain/Bencode/BencodeStreamDecoder.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Bencode;
+
+use function strlen;
+use function substr;
+
+/**
+ * Stateful decoder for stream-oriented bencode consumption.
+ *
+ * Accumulates arbitrary byte chunks and yields complete messages
+ * as they become available. Leaves partial suffixes in the buffer
+ * until the next chunk arrives.
+ */
+final class BencodeStreamDecoder
+{
+    private string $buffer = '';
+
+    private readonly BencodeDecoder $decoder;
+
+    public function __construct(?BencodeDecoder $decoder = null)
+    {
+        $this->decoder = $decoder ?? new BencodeDecoder();
+    }
+
+    public function feed(string $chunk): void
+    {
+        $this->buffer .= $chunk;
+    }
+
+    /**
+     * Pop all complete messages currently in the buffer.
+     *
+     * @return list<mixed>
+     */
+    public function drain(): array
+    {
+        $messages = [];
+
+        while ($this->buffer !== '') {
+            try {
+                [$value, $consumed] = $this->decoder->decodeWithLength($this->buffer);
+            } catch (BencodeException) {
+                // Partial frame: keep buffered, wait for more bytes.
+                break;
+            }
+
+            if ($consumed <= 0 || $consumed > strlen($this->buffer)) {
+                break;
+            }
+
+            $messages[] = $value;
+            $this->buffer = substr($this->buffer, $consumed);
+        }
+
+        return $messages;
+    }
+
+    public function buffer(): string
+    {
+        return $this->buffer;
+    }
+}

--- a/src/php/Nrepl/Domain/Op/OpDispatcher.php
+++ b/src/php/Nrepl/Domain/Op/OpDispatcher.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Op;
+
+use function array_keys;
+use function is_array;
+
+/**
+ * Routes a decoded message to the right OpHandlerInterface based on "op" key.
+ * Unknown ops get an `unknown-op` status response.
+ */
+final class OpDispatcher
+{
+    /** @var array<string, OpHandlerInterface> */
+    private array $handlers = [];
+
+    /**
+     * @param iterable<OpHandlerInterface> $handlers
+     */
+    public function __construct(iterable $handlers = [])
+    {
+        foreach ($handlers as $handler) {
+            $this->register($handler);
+        }
+    }
+
+    public function register(OpHandlerInterface $handler): void
+    {
+        $this->handlers[$handler->name()] = $handler;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function knownOps(): array
+    {
+        return array_keys($this->handlers);
+    }
+
+    /**
+     * @param mixed $message decoded bencode value (expected to be an assoc array)
+     *
+     * @return list<OpResponse>
+     */
+    public function dispatch(mixed $message): array
+    {
+        if (!is_array($message)) {
+            return [new OpResponse([
+                'status' => ['error', 'invalid-message', 'done'],
+                'message' => 'Top-level nREPL message must be a dictionary.',
+            ])];
+        }
+
+        /** @var array<string, mixed> $message */
+        $request = OpRequest::fromMessage($message);
+
+        if ($request->op === '') {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Missing "op" key in request.'],
+                ['error', 'invalid-op', 'done'],
+            )];
+        }
+
+        $handler = $this->handlers[$request->op] ?? null;
+        if (!$handler instanceof OpHandlerInterface) {
+            return [OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Unknown op: ' . $request->op],
+                ['error', 'unknown-op', 'done'],
+            )];
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/php/Nrepl/Domain/Op/OpHandlerInterface.php
+++ b/src/php/Nrepl/Domain/Op/OpHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Op;
+
+interface OpHandlerInterface
+{
+    public function name(): string;
+
+    /**
+     * Handle a single op request.
+     *
+     * @return list<OpResponse>
+     */
+    public function handle(OpRequest $request): array;
+}

--- a/src/php/Nrepl/Domain/Op/OpRequest.php
+++ b/src/php/Nrepl/Domain/Op/OpRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Op;
+
+use function is_string;
+
+/**
+ * Read-only view over a decoded nREPL message.
+ */
+final readonly class OpRequest
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        public string $op,
+        public ?string $id,
+        public ?string $session,
+        public array $raw,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    public static function fromMessage(array $message): self
+    {
+        $op = isset($message['op']) && is_string($message['op']) ? $message['op'] : '';
+        $id = isset($message['id']) && is_string($message['id']) ? $message['id'] : null;
+        $session = isset($message['session']) && is_string($message['session']) ? $message['session'] : null;
+
+        return new self($op, $id, $session, $message);
+    }
+
+    public function stringParam(string $key, string $default = ''): string
+    {
+        $value = $this->raw[$key] ?? null;
+        return is_string($value) ? $value : $default;
+    }
+}

--- a/src/php/Nrepl/Domain/Op/OpResponse.php
+++ b/src/php/Nrepl/Domain/Op/OpResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Op;
+
+use function array_merge;
+
+/**
+ * A single nREPL response frame. A handler may emit several of these before
+ * the final one tagged with ["done"] in status.
+ */
+final readonly class OpResponse
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(public array $payload) {}
+
+    /**
+     * Convenience constructor merging routing metadata onto the payload.
+     *
+     * @param array<string, mixed> $body
+     * @param list<string>         $status
+     */
+    public static function build(
+        ?string $id,
+        ?string $session,
+        array $body,
+        array $status = [],
+    ): self {
+        $payload = $body;
+        if ($id !== null && $id !== '') {
+            $payload['id'] = $id;
+        }
+
+        if ($session !== null && $session !== '') {
+            $payload['session'] = $session;
+        }
+
+        if ($status !== []) {
+            $payload['status'] = $status;
+        }
+
+        return new self($payload);
+    }
+
+    public function withExtra(array $extra): self
+    {
+        return new self(array_merge($this->payload, $extra));
+    }
+}

--- a/src/php/Nrepl/Domain/Session/Session.php
+++ b/src/php/Nrepl/Domain/Session/Session.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Session;
+
+final class Session
+{
+    private mixed $lastValue = null;
+
+    public function __construct(
+        public readonly string $id,
+        private string $namespace = 'user',
+    ) {}
+
+    public function namespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function setNamespace(string $ns): void
+    {
+        $this->namespace = $ns;
+    }
+
+    public function lastValue(): mixed
+    {
+        return $this->lastValue;
+    }
+
+    public function recordValue(mixed $value): void
+    {
+        $this->lastValue = $value;
+    }
+}

--- a/src/php/Nrepl/Domain/Session/SessionRegistry.php
+++ b/src/php/Nrepl/Domain/Session/SessionRegistry.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Session;
+
+use function array_keys;
+use function bin2hex;
+use function random_bytes;
+
+final class SessionRegistry
+{
+    /** @var array<string, Session> */
+    private array $sessions = [];
+
+    public function create(): Session
+    {
+        $id = $this->generateId();
+        $session = new Session($id);
+        $this->sessions[$id] = $session;
+
+        return $session;
+    }
+
+    public function get(string $id): ?Session
+    {
+        return $this->sessions[$id] ?? null;
+    }
+
+    public function close(string $id): bool
+    {
+        if (!isset($this->sessions[$id])) {
+            return false;
+        }
+
+        unset($this->sessions[$id]);
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function ids(): array
+    {
+        return array_keys($this->sessions);
+    }
+
+    private function generateId(): string
+    {
+        // UUID-like 32-hex string, stable format.
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/src/php/Nrepl/Domain/Transport/ClientConnection.php
+++ b/src/php/Nrepl/Domain/Transport/ClientConnection.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Transport;
+
+use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
+use Phel\Nrepl\Domain\Bencode\BencodeStreamDecoder;
+
+use function fclose;
+use function feof;
+use function fread;
+use function fwrite;
+use function is_resource;
+use function stream_set_blocking;
+use function strlen;
+use function substr;
+
+/**
+ * Wraps a live socket resource with bencode framing.
+ */
+final class ClientConnection
+{
+    private readonly BencodeStreamDecoder $decoder;
+
+    private readonly BencodeEncoder $encoder;
+
+    /** @var resource|null */
+    private mixed $stream;
+
+    /**
+     * @param resource $stream
+     */
+    public function __construct(
+        mixed $stream,
+        ?BencodeStreamDecoder $decoder = null,
+        ?BencodeEncoder $encoder = null,
+    ) {
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        if (is_resource($stream)) {
+            stream_set_blocking($stream, false);
+        }
+
+        $this->stream = $stream;
+        $this->decoder = $decoder ?? new BencodeStreamDecoder();
+        $this->encoder = $encoder ?? new BencodeEncoder();
+    }
+
+    /**
+     * Read whatever is available and return any completed bencode messages.
+     *
+     * @return list<mixed>
+     */
+    public function readMessages(): array
+    {
+        if (!is_resource($this->stream)) {
+            return [];
+        }
+
+        $chunk = @fread($this->stream, 8192);
+        if ($chunk === false || $chunk === '') {
+            return [];
+        }
+
+        $this->decoder->feed($chunk);
+
+        return $this->decoder->drain();
+    }
+
+    public function isClosed(): bool
+    {
+        if (!is_resource($this->stream)) {
+            return true;
+        }
+
+        return feof($this->stream);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function send(array $payload): void
+    {
+        if (!is_resource($this->stream)) {
+            return;
+        }
+
+        $encoded = $this->encoder->encode($payload);
+        $total = strlen($encoded);
+        $written = 0;
+        while ($written < $total) {
+            $bytes = @fwrite($this->stream, substr($encoded, $written));
+            if ($bytes === false || $bytes === 0) {
+                return;
+            }
+
+            $written += $bytes;
+        }
+    }
+
+    public function close(): void
+    {
+        /** @psalm-suppress InvalidPropertyAssignmentValue */
+        if (is_resource($this->stream)) {
+            @fclose($this->stream);
+        }
+
+        $this->stream = null;
+    }
+}

--- a/src/php/Nrepl/Infrastructure/Command/NreplCommand.php
+++ b/src/php/Nrepl/Infrastructure/Command/NreplCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel;
+use Phel\Nrepl\NreplConfig;
+use Phel\Nrepl\NreplFacade;
+use Phel\Nrepl\NreplFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function sprintf;
+
+#[ServiceMap(method: 'getFacade', className: NreplFacade::class)]
+#[ServiceMap(method: 'getFactory', className: NreplFactory::class)]
+#[ServiceMap(method: 'getConfig', className: NreplConfig::class)]
+final class NreplCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const string COMMAND_NAME = 'nrepl';
+
+    public function __construct()
+    {
+        parent::__construct(self::COMMAND_NAME);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Start an nREPL server for editor tooling (bencode-over-TCP protocol).')
+            ->addOption(
+                'port',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'TCP port to listen on (default 7888). Use 0 to bind a random free port.',
+                (string) NreplConfig::defaultPort(),
+            )
+            ->addOption(
+                'host',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Host/address to bind (default 127.0.0.1).',
+                NreplConfig::defaultHost(),
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $port = (int) $input->getOption('port');
+        $host = (string) $input->getOption('host');
+
+        // Normalise runtime args so loaded code sees a clean argv.
+        Phel::setupRuntimeArgs('nrepl', []);
+        $this->getFacade()->loadPhelNamespaces();
+
+        try {
+            $server = $this->getFactory()->createSocketServer(
+                $port,
+                $host,
+                static function (string $line) use ($output): void {
+                    $output->writeln($line);
+                },
+            );
+            $server->start();
+            $output->writeln(sprintf('nREPL server started on %s:%d', $host, $server->port()));
+            $output->writeln('Connect your editor via the bencode-over-TCP nREPL protocol.');
+            $server->run();
+
+            return self::SUCCESS;
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>%s</error>', $throwable->getMessage()));
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/php/Nrepl/Infrastructure/NreplSocketServer.php
+++ b/src/php/Nrepl/Infrastructure/NreplSocketServer.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Infrastructure;
+
+use Closure;
+use Fiber;
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Domain\Transport\ClientConnection;
+use RuntimeException;
+use Throwable;
+
+use function fclose;
+use function is_resource;
+use function sprintf;
+use function stream_context_create;
+use function stream_set_blocking;
+use function stream_socket_accept;
+use function stream_socket_get_name;
+use function stream_socket_server;
+use function strrpos;
+use function substr;
+use function usleep;
+
+/**
+ * TCP nREPL server. Accepts bencode-framed connections on a port and
+ * dispatches op messages through OpDispatcher.
+ *
+ * Uses one Fiber per connected client. The main accept loop yields between
+ * iterations so Fibers can run cooperatively without blocking each other.
+ */
+final class NreplSocketServer
+{
+    /** @var resource|null */
+    private mixed $server = null;
+
+    private bool $running = false;
+
+    /** @var list<Fiber> */
+    private array $clientFibers = [];
+
+    private readonly ?Closure $logger;
+
+    public function __construct(
+        private readonly OpDispatcher $dispatcher,
+        private readonly int $port,
+        private readonly string $host = '127.0.0.1',
+        ?callable $logger = null,
+    ) {
+        $this->logger = $logger === null ? null : Closure::fromCallable($logger);
+    }
+
+    public function port(): int
+    {
+        if (is_resource($this->server)) {
+            $name = stream_socket_get_name($this->server, false);
+            if ($name !== false) {
+                $colon = strrpos($name, ':');
+                if ($colon !== false) {
+                    return (int) substr($name, $colon + 1);
+                }
+            }
+        }
+
+        return $this->port;
+    }
+
+    public function start(): void
+    {
+        $errno = 0;
+        $errstr = '';
+        $context = stream_context_create();
+        $address = sprintf('tcp://%s:%d', $this->host, $this->port);
+        $server = @stream_socket_server($address, $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $context);
+
+        if ($server === false) {
+            throw new RuntimeException(sprintf(
+                'Cannot bind nREPL server to %s (errno %d): %s',
+                $address,
+                $errno,
+                $errstr,
+            ));
+        }
+
+        stream_set_blocking($server, false);
+        $this->server = $server;
+        $this->running = true;
+        $this->log(sprintf('nREPL server listening on %s:%d', $this->host, $this->port()));
+    }
+
+    public function stop(): void
+    {
+        $this->running = false;
+        /** @psalm-suppress InvalidPropertyAssignmentValue */
+        if (is_resource($this->server)) {
+            @fclose($this->server);
+        }
+
+        $this->server = null;
+    }
+
+    /**
+     * Run the accept loop. Terminates when stop() is called or the socket
+     * is closed. `$maxIterations` bounds test-driven runs; 0 means unbounded.
+     */
+    public function run(int $maxIterations = 0): void
+    {
+        if (!is_resource($this->server)) {
+            throw new RuntimeException('Server not started.');
+        }
+
+        $iter = 0;
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        while ($this->running && is_resource($this->server)) {
+            $this->acceptOnce();
+            $this->stepFibers();
+
+            ++$iter;
+            if ($maxIterations > 0 && $iter >= $maxIterations) {
+                break;
+            }
+
+            usleep(1000);
+        }
+    }
+
+    /**
+     * One tick of the accept loop: check for a new client, if any wire it
+     * into a Fiber.
+     */
+    public function acceptOnce(): void
+    {
+        if (!is_resource($this->server)) {
+            return;
+        }
+
+        $clientStream = @stream_socket_accept($this->server, 0);
+        if ($clientStream === false) {
+            return;
+        }
+
+        $connection = new ClientConnection($clientStream);
+        $fiber = new Fiber(function (ClientConnection $conn): void {
+            $this->serveClient($conn);
+        });
+
+        $fiber->start($connection);
+        if (!$fiber->isTerminated()) {
+            $this->clientFibers[] = $fiber;
+        }
+    }
+
+    public function stepFibers(): void
+    {
+        $remaining = [];
+        foreach ($this->clientFibers as $fiber) {
+            $alive = $this->advanceFiber($fiber);
+            if ($alive) {
+                $remaining[] = $fiber;
+            }
+        }
+
+        $this->clientFibers = $remaining;
+    }
+
+    /**
+     * Returns true if the fiber is still alive and should be retained.
+     */
+    private function advanceFiber(Fiber $fiber): bool
+    {
+        if ($fiber->isTerminated()) {
+            return false;
+        }
+
+        if (!$fiber->isSuspended()) {
+            return true;
+        }
+
+        try {
+            $fiber->resume();
+        } catch (Throwable $throwable) {
+            $this->log('Client fiber error: ' . $throwable->getMessage());
+            return false;
+        }
+
+        return $fiber->isSuspended();
+    }
+
+    private function serveClient(ClientConnection $connection): void
+    {
+        while (!$connection->isClosed()) {
+            $messages = $connection->readMessages();
+
+            foreach ($messages as $message) {
+                $responses = $this->dispatcher->dispatch($message);
+                foreach ($responses as $response) {
+                    $connection->send($response->payload);
+                }
+            }
+
+            Fiber::suspend();
+        }
+
+        $connection->close();
+    }
+
+    private function log(string $message): void
+    {
+        if ($this->logger instanceof Closure) {
+            ($this->logger)($message);
+        }
+    }
+}

--- a/src/php/Nrepl/NreplConfig.php
+++ b/src/php/Nrepl/NreplConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl;
+
+use Gacela\Framework\AbstractConfig;
+
+final class NreplConfig extends AbstractConfig
+{
+    private const int DEFAULT_PORT = 7888;
+
+    private const string DEFAULT_HOST = '127.0.0.1';
+
+    public static function defaultPort(): int
+    {
+        return self::DEFAULT_PORT;
+    }
+
+    public static function defaultHost(): string
+    {
+        return self::DEFAULT_HOST;
+    }
+}

--- a/src/php/Nrepl/NreplFacade.php
+++ b/src/php/Nrepl/NreplFacade.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Infrastructure\NreplSocketServer;
+
+/**
+ * @extends AbstractFacade<NreplFactory>
+ */
+final class NreplFacade extends AbstractFacade
+{
+    public function createSocketServer(
+        int $port,
+        string $host,
+        ?callable $logger = null,
+    ): NreplSocketServer {
+        return $this->getFactory()->createSocketServer($port, $host, $logger);
+    }
+
+    public function createOpDispatcher(): OpDispatcher
+    {
+        return $this->getFactory()->createOpDispatcher();
+    }
+
+    public function loadPhelNamespaces(): void
+    {
+        $this->getFactory()
+            ->getRunFacade()
+            ->loadPhelNamespaces();
+    }
+}

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Api\ApiFacade;
+use Phel\Nrepl\Application\Op\CloneOp;
+use Phel\Nrepl\Application\Op\CloseOp;
+use Phel\Nrepl\Application\Op\CompletionsOp;
+use Phel\Nrepl\Application\Op\DescribeOp;
+use Phel\Nrepl\Application\Op\EvalOp;
+use Phel\Nrepl\Application\Op\InterruptOp;
+use Phel\Nrepl\Application\Op\LoadFileOp;
+use Phel\Nrepl\Application\Op\LookupOp;
+use Phel\Nrepl\Domain\Bencode\BencodeDecoder;
+use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Nrepl\Infrastructure\NreplSocketServer;
+use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\RunFacade;
+
+/**
+ * @extends AbstractFactory<NreplConfig>
+ */
+final class NreplFactory extends AbstractFactory
+{
+    public function createSocketServer(
+        int $port,
+        string $host,
+        ?callable $logger = null,
+    ): NreplSocketServer {
+        return new NreplSocketServer(
+            $this->createOpDispatcher(),
+            $port,
+            $host,
+            $logger,
+        );
+    }
+
+    public function createOpDispatcher(): OpDispatcher
+    {
+        $sessions = $this->createSessionRegistry();
+        $dispatcher = new OpDispatcher();
+
+        $dispatcher->register(new CloneOp($sessions));
+        $dispatcher->register(new CloseOp($sessions));
+        $dispatcher->register(new EvalOp(
+            $this->getRunFacade(),
+            $this->createPrinter(),
+            $sessions,
+        ));
+        $dispatcher->register(new LoadFileOp(
+            $this->getRunFacade(),
+            $this->createPrinter(),
+            $sessions,
+        ));
+        $dispatcher->register(new InterruptOp());
+        $dispatcher->register(new CompletionsOp($this->getApiFacade()));
+        $dispatcher->register(new LookupOp($this->getApiFacade(), 'lookup'));
+        $dispatcher->register(new LookupOp($this->getApiFacade(), 'info'));
+        $dispatcher->register(new LookupOp($this->getApiFacade(), 'eldoc'));
+
+        // Describe needs to inspect known ops, register last.
+        $dispatcher->register(new DescribeOp($dispatcher, $this->getRunFacade()));
+
+        return $dispatcher;
+    }
+
+    public function createSessionRegistry(): SessionRegistry
+    {
+        return new SessionRegistry();
+    }
+
+    public function createBencodeEncoder(): BencodeEncoder
+    {
+        return new BencodeEncoder();
+    }
+
+    public function createBencodeDecoder(): BencodeDecoder
+    {
+        return new BencodeDecoder();
+    }
+
+    public function createPrinter(): PrinterInterface
+    {
+        return Printer::readable();
+    }
+
+    public function getRunFacade(): RunFacade
+    {
+        return $this->getProvidedDependency(NreplProvider::FACADE_RUN);
+    }
+
+    public function getApiFacade(): ApiFacade
+    {
+        return $this->getProvidedDependency(NreplProvider::FACADE_API);
+    }
+}

--- a/src/php/Nrepl/NreplProvider.php
+++ b/src/php/Nrepl/NreplProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use Phel\Api\ApiFacade;
+use Phel\Run\RunFacade;
+
+final class NreplProvider extends AbstractProvider
+{
+    public const string FACADE_RUN = 'FACADE_RUN';
+
+    public const string FACADE_API = 'FACADE_API';
+
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
+    {
+        return $container->getLocator()->getRequired(RunFacade::class);
+    }
+
+    #[Provides(self::FACADE_API)]
+    public function apiFacade(Container $container): ApiFacade
+    {
+        return $container->getLocator()->getRequired(ApiFacade::class);
+    }
+}

--- a/tests/php/Integration/Nrepl/NreplServerTest.php
+++ b/tests/php/Integration/Nrepl/NreplServerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Nrepl;
+
+use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
+use Phel\Nrepl\Domain\Bencode\BencodeStreamDecoder;
+use Phel\Nrepl\Infrastructure\NreplSocketServer;
+use Phel\Nrepl\NreplFacade;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function count;
+use function fclose;
+use function fread;
+use function fwrite;
+use function in_array;
+use function is_array;
+use function sprintf;
+use function stream_set_blocking;
+use function stream_set_timeout;
+use function stream_socket_client;
+use function strlen;
+use function usleep;
+
+final class NreplServerTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_it_handles_describe_clone_eval_and_close_over_a_live_socket(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $facade = new NreplFacade();
+        $facade->loadPhelNamespaces();
+
+        $server = $facade->createSocketServer(0, '127.0.0.1');
+        $server->start();
+
+        $port = $server->port();
+
+        $client = @stream_socket_client(
+            sprintf('tcp://127.0.0.1:%d', $port),
+            $errno,
+            $errstr,
+            2.0,
+        );
+        if ($client === false) {
+            $server->stop();
+            self::fail(sprintf('Could not connect to server: %s', $errstr));
+        }
+
+        stream_set_blocking($client, false);
+        stream_set_timeout($client, 2);
+
+        $encoder = new BencodeEncoder();
+        $decoder = new BencodeStreamDecoder();
+
+        // describe
+        $this->writeMessage($client, $encoder->encode(['op' => 'describe', 'id' => 'd1']));
+        $this->pump($server);
+        $describe = $this->readUntil($client, $decoder, $server, 1);
+        self::assertCount(1, $describe);
+        self::assertSame('d1', $describe[0]['id']);
+        self::assertContains('done', $describe[0]['status']);
+
+        // clone
+        $this->writeMessage($client, $encoder->encode(['op' => 'clone', 'id' => 'c1']));
+        $this->pump($server);
+        $clone = $this->readUntil($client, $decoder, $server, 1);
+        $sessionId = $clone[0]['new-session'];
+        self::assertNotEmpty($sessionId);
+
+        // eval
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'eval',
+            'id' => 'e1',
+            'session' => $sessionId,
+            'code' => '(+ 1 2)',
+        ]));
+        $this->pump($server);
+        $eval = $this->readUntil($client, $decoder, $server, 2);
+
+        $valueMsg = $this->firstWithKey($eval, 'value');
+        self::assertNotNull($valueMsg);
+        self::assertSame('3', $valueMsg['value']);
+
+        $doneMsg = $this->firstWithStatus($eval, 'done');
+        self::assertNotNull($doneMsg);
+
+        // close
+        $this->writeMessage($client, $encoder->encode([
+            'op' => 'close',
+            'id' => 'x1',
+            'session' => $sessionId,
+        ]));
+        $this->pump($server);
+        $close = $this->readUntil($client, $decoder, $server, 1);
+        self::assertContains('session-closed', $close[0]['status']);
+
+        fclose($client);
+        $server->stop();
+    }
+
+    /**
+     * @param resource $client
+     */
+    private function writeMessage($client, string $message): void
+    {
+        $written = 0;
+        $length = strlen($message);
+        while ($written < $length) {
+            $bytes = @fwrite($client, substr($message, $written));
+            if ($bytes === false) {
+                throw new RuntimeException('Failed to write to client socket.');
+            }
+
+            if ($bytes === 0) {
+                usleep(1000);
+            } else {
+                $written += $bytes;
+            }
+        }
+    }
+
+    /**
+     * @param resource $client
+     * @param mixed    $server
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function readUntil($client, BencodeStreamDecoder $decoder, NreplSocketServer $server, int $minMessages, int $timeoutMs = 3000): array
+    {
+        $start = (int) (microtime(true) * 1000);
+        $collected = [];
+
+        while (true) {
+            $this->pump($server);
+            $chunk = @fread($client, 8192);
+            if ($chunk !== false && $chunk !== '') {
+                $decoder->feed($chunk);
+                foreach ($decoder->drain() as $msg) {
+                    if (is_array($msg)) {
+                        $collected[] = $msg;
+                    }
+                }
+            }
+
+            if (count($collected) >= $minMessages) {
+                return $collected;
+            }
+
+            $elapsed = (int) (microtime(true) * 1000) - $start;
+            if ($elapsed > $timeoutMs) {
+                self::fail(sprintf(
+                    'Timed out waiting for %d messages (got %d).',
+                    $minMessages,
+                    count($collected),
+                ));
+            }
+
+            usleep(2000);
+        }
+    }
+
+    private function pump(NreplSocketServer $server): void
+    {
+        // Drive the server loop a few times without blocking.
+        for ($i = 0; $i < 5; ++$i) {
+            $server->acceptOnce();
+            $server->stepFibers();
+        }
+    }
+
+    /**
+     * @param list<array<string, mixed>> $msgs
+     *
+     * @return array<string, mixed>|null
+     */
+    private function firstWithKey(array $msgs, string $key): ?array
+    {
+        foreach ($msgs as $msg) {
+            if (isset($msg[$key])) {
+                return $msg;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $msgs
+     *
+     * @return array<string, mixed>|null
+     */
+    private function firstWithStatus(array $msgs, string $status): ?array
+    {
+        foreach ($msgs as $msg) {
+            if (isset($msg['status']) && is_array($msg['status']) && in_array($status, $msg['status'], true)) {
+                return $msg;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/php/Integration/Nrepl/phel-config.php
+++ b/tests/php/Integration/Nrepl/phel-config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'src-dirs' => [
+        '../../../../src/phel/',
+    ],
+    'test-dirs' => [],
+    'vendor' => '../../../../../vendor/',
+];

--- a/tests/php/Unit/Nrepl/Domain/Bencode/BencodeDecoderTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Bencode/BencodeDecoderTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Bencode;
+
+use Phel\Nrepl\Domain\Bencode\BencodeDecoder;
+use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
+use Phel\Nrepl\Domain\Bencode\BencodeException;
+use PHPUnit\Framework\TestCase;
+
+final class BencodeDecoderTest extends TestCase
+{
+    private BencodeDecoder $decoder;
+
+    protected function setUp(): void
+    {
+        $this->decoder = new BencodeDecoder();
+    }
+
+    public function test_it_decodes_zero(): void
+    {
+        self::assertSame(0, $this->decoder->decode('i0e'));
+    }
+
+    public function test_it_decodes_positive_integers(): void
+    {
+        self::assertSame(42, $this->decoder->decode('i42e'));
+        self::assertSame(9999999, $this->decoder->decode('i9999999e'));
+    }
+
+    public function test_it_decodes_negative_integers(): void
+    {
+        self::assertSame(-1, $this->decoder->decode('i-1e'));
+        self::assertSame(-123, $this->decoder->decode('i-123e'));
+    }
+
+    public function test_it_rejects_integers_with_leading_zero(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('i01e');
+    }
+
+    public function test_it_rejects_negative_zero(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('i-0e');
+    }
+
+    public function test_it_rejects_empty_integer(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('ie');
+    }
+
+    public function test_it_rejects_non_numeric_integer(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('ixe');
+    }
+
+    public function test_it_decodes_empty_string(): void
+    {
+        self::assertSame('', $this->decoder->decode('0:'));
+    }
+
+    public function test_it_decodes_ascii_strings(): void
+    {
+        self::assertSame('hello', $this->decoder->decode('5:hello'));
+        self::assertSame('hello world', $this->decoder->decode('11:hello world'));
+    }
+
+    public function test_it_decodes_binary_strings(): void
+    {
+        $expected = "\x00\x01\xff";
+        self::assertSame($expected, $this->decoder->decode('3:' . $expected));
+    }
+
+    public function test_it_decodes_empty_list(): void
+    {
+        self::assertSame([], $this->decoder->decode('le'));
+    }
+
+    public function test_it_decodes_flat_lists(): void
+    {
+        self::assertSame([1, 2, 3], $this->decoder->decode('li1ei2ei3ee'));
+        self::assertSame(['spam', 42], $this->decoder->decode('l4:spami42ee'));
+    }
+
+    public function test_it_decodes_empty_dict(): void
+    {
+        self::assertSame([], $this->decoder->decode('de'));
+    }
+
+    public function test_it_decodes_dictionaries(): void
+    {
+        self::assertSame(
+            ['code' => '(+ 1 2)', 'op' => 'eval'],
+            $this->decoder->decode('d4:code7:(+ 1 2)2:op4:evale'),
+        );
+    }
+
+    public function test_it_decodes_nested_structures(): void
+    {
+        $encoded = 'd2:id3:abc6:statusl4:doneee';
+        self::assertSame(['id' => 'abc', 'status' => ['done']], $this->decoder->decode($encoded));
+    }
+
+    public function test_it_round_trips_deeply_nested_values(): void
+    {
+        $msg = [
+            'id' => '42',
+            'ops' => ['eval' => [], 'clone' => []],
+            'list' => [1, 2, [3, 4]],
+        ];
+
+        $encoder = new BencodeEncoder();
+        $encoded = $encoder->encode($msg);
+        /** @var array<string, mixed> $decoded */
+        $decoded = $this->decoder->decode($encoded);
+
+        self::assertSame('42', $decoded['id']);
+        self::assertSame([1, 2, [3, 4]], $decoded['list']);
+        self::assertArrayHasKey('eval', $decoded['ops']);
+    }
+
+    public function test_it_rejects_trailing_bytes(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('i1eX');
+    }
+
+    public function test_it_rejects_unterminated_list(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('li1ei2e');
+    }
+
+    public function test_it_rejects_unterminated_dict(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('d3:key5:valu');
+    }
+
+    public function test_it_rejects_string_with_bad_length(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('10:short');
+    }
+
+    public function test_it_rejects_empty_input(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('');
+    }
+
+    public function test_it_rejects_unknown_token(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->decoder->decode('x');
+    }
+
+    public function test_decode_with_length_returns_consumed_bytes(): void
+    {
+        [$value, $consumed] = $this->decoder->decodeWithLength('i42ei1e');
+        self::assertSame(42, $value);
+        self::assertSame(4, $consumed);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Bencode/BencodeEncoderTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Bencode/BencodeEncoderTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Bencode;
+
+use Phel\Nrepl\Domain\Bencode\BencodeEncoder;
+use Phel\Nrepl\Domain\Bencode\BencodeException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class BencodeEncoderTest extends TestCase
+{
+    private BencodeEncoder $encoder;
+
+    protected function setUp(): void
+    {
+        $this->encoder = new BencodeEncoder();
+    }
+
+    public function test_it_encodes_positive_integers(): void
+    {
+        self::assertSame('i0e', $this->encoder->encode(0));
+        self::assertSame('i42e', $this->encoder->encode(42));
+        self::assertSame('i9999999999e', $this->encoder->encode(9999999999));
+    }
+
+    public function test_it_encodes_negative_integers(): void
+    {
+        self::assertSame('i-1e', $this->encoder->encode(-1));
+        self::assertSame('i-123e', $this->encoder->encode(-123));
+    }
+
+    public function test_it_encodes_booleans_as_integers(): void
+    {
+        self::assertSame('i1e', $this->encoder->encode(true));
+        self::assertSame('i0e', $this->encoder->encode(false));
+    }
+
+    public function test_it_encodes_ascii_strings_with_byte_length_prefix(): void
+    {
+        self::assertSame('0:', $this->encoder->encode(''));
+        self::assertSame('5:hello', $this->encoder->encode('hello'));
+        self::assertSame('11:hello world', $this->encoder->encode('hello world'));
+    }
+
+    public function test_it_encodes_binary_strings_by_byte_length(): void
+    {
+        $binary = "\x00\x01\xff";
+        self::assertSame('3:' . $binary, $this->encoder->encode($binary));
+    }
+
+    public function test_it_encodes_empty_array_as_list(): void
+    {
+        self::assertSame('le', $this->encoder->encode([]));
+    }
+
+    public function test_it_encodes_lists_of_mixed_scalars(): void
+    {
+        self::assertSame('li1ei2ei3ee', $this->encoder->encode([1, 2, 3]));
+        self::assertSame('l4:spami42ee', $this->encoder->encode(['spam', 42]));
+    }
+
+    public function test_it_encodes_dictionaries_with_sorted_keys(): void
+    {
+        $dict = ['op' => 'eval', 'code' => '(+ 1 2)'];
+        self::assertSame('d4:code7:(+ 1 2)2:op4:evale', $this->encoder->encode($dict));
+    }
+
+    public function test_it_sorts_dictionary_keys_lexicographically(): void
+    {
+        $dict = ['zebra' => 1, 'apple' => 2, 'mango' => 3];
+        self::assertSame(
+            'd5:applei2e5:mangoi3e5:zebrai1ee',
+            $this->encoder->encode($dict),
+        );
+    }
+
+    public function test_it_encodes_nested_dictionaries_and_lists(): void
+    {
+        $msg = [
+            'id' => 'abc',
+            'status' => ['done'],
+            'value' => [
+                'kind' => 'int',
+                'data' => [1, 2],
+            ],
+        ];
+        $encoded = $this->encoder->encode($msg);
+        self::assertSame(
+            'd2:id3:abc6:statusl4:donee5:valued4:datali1ei2ee4:kind3:intee',
+            $encoded,
+        );
+    }
+
+    public function test_it_rejects_non_string_dict_keys(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->encoder->encode([0 => 'x', 'a' => 'y']);
+    }
+
+    public function test_it_rejects_unsupported_types(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->encoder->encode(new stdClass());
+    }
+
+    public function test_it_rejects_floats(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->encoder->encode(1.5);
+    }
+
+    public function test_it_rejects_null_values(): void
+    {
+        $this->expectException(BencodeException::class);
+        $this->encoder->encode(null);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Bencode/BencodeStreamDecoderTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Bencode/BencodeStreamDecoderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Bencode;
+
+use Phel\Nrepl\Domain\Bencode\BencodeStreamDecoder;
+use PHPUnit\Framework\TestCase;
+
+final class BencodeStreamDecoderTest extends TestCase
+{
+    public function test_it_returns_nothing_until_a_frame_is_complete(): void
+    {
+        $stream = new BencodeStreamDecoder();
+        $stream->feed('d2:op');
+        self::assertSame([], $stream->drain());
+    }
+
+    public function test_it_drains_a_complete_frame(): void
+    {
+        $stream = new BencodeStreamDecoder();
+        $stream->feed('d2:op4:evale');
+        self::assertSame([['op' => 'eval']], $stream->drain());
+        self::assertSame('', $stream->buffer());
+    }
+
+    public function test_it_splits_multiple_framed_messages(): void
+    {
+        $stream = new BencodeStreamDecoder();
+        $stream->feed('d2:op5:cloneed2:op5:closee');
+
+        $drained = $stream->drain();
+
+        self::assertCount(2, $drained);
+        self::assertSame(['op' => 'clone'], $drained[0]);
+        self::assertSame(['op' => 'close'], $drained[1]);
+    }
+
+    public function test_it_keeps_trailing_partial_data_buffered(): void
+    {
+        $stream = new BencodeStreamDecoder();
+        $stream->feed('d2:op5:cloneed2:op');
+
+        $drained = $stream->drain();
+
+        self::assertCount(1, $drained);
+        self::assertSame('d2:op', $stream->buffer());
+
+        $stream->feed('4:evale');
+        $drained2 = $stream->drain();
+        self::assertCount(1, $drained2);
+        self::assertSame(['op' => 'eval'], $drained2[0]);
+        self::assertSame('', $stream->buffer());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/CloneOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/CloneOpTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\CloneOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class CloneOpTest extends TestCase
+{
+    public function test_it_creates_a_new_session_and_echoes_its_id(): void
+    {
+        $registry = new SessionRegistry();
+        $op = new CloneOp($registry);
+        $responses = $op->handle(new OpRequest('clone', 'req-1', null, ['op' => 'clone']));
+
+        self::assertCount(1, $responses);
+        $payload = $responses[0]->payload;
+
+        self::assertArrayHasKey('new-session', $payload);
+        self::assertSame('req-1', $payload['id']);
+        self::assertContains('done', $payload['status']);
+        self::assertNotEmpty($registry->get($payload['new-session']));
+    }
+
+    public function test_op_name_is_clone(): void
+    {
+        $op = new CloneOp(new SessionRegistry());
+        self::assertSame('clone', $op->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/CloseOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/CloseOpTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\CloseOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class CloseOpTest extends TestCase
+{
+    public function test_it_closes_existing_session(): void
+    {
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+        $op = new CloseOp($registry);
+
+        $responses = $op->handle(new OpRequest('close', 'r1', $session->id, ['op' => 'close']));
+
+        self::assertCount(1, $responses);
+        self::assertContains('session-closed', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[0]->payload['status']);
+        self::assertNull($registry->get($session->id));
+    }
+
+    public function test_it_reports_error_for_unknown_session(): void
+    {
+        $registry = new SessionRegistry();
+        $op = new CloseOp($registry);
+
+        $responses = $op->handle(new OpRequest('close', 'r1', 'no-such', ['op' => 'close']));
+
+        self::assertCount(1, $responses);
+        self::assertContains('error', $responses[0]->payload['status']);
+        self::assertContains('unknown-session', $responses[0]->payload['status']);
+    }
+
+    public function test_op_name_is_close(): void
+    {
+        $op = new CloseOp(new SessionRegistry());
+        self::assertSame('close', $op->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/CompletionsOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/CompletionsOpTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Api\Transfer\CompletionResultTransfer;
+use Phel\Nrepl\Application\Op\CompletionsOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Shared\Facade\ApiFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class CompletionsOpTest extends TestCase
+{
+    public function test_it_delegates_to_api_facade_complete_with_types(): void
+    {
+        $api = $this->createStub(ApiFacadeInterface::class);
+        $api->method('replCompleteWithTypes')->willReturn([
+            new CompletionResultTransfer('map', 'function'),
+            new CompletionResultTransfer('map?', 'function'),
+        ]);
+
+        $op = new CompletionsOp($api);
+        $responses = $op->handle(new OpRequest('completions', 'r1', null, [
+            'op' => 'completions',
+            'prefix' => 'ma',
+        ]));
+
+        self::assertCount(1, $responses);
+        $completions = $responses[0]->payload['completions'];
+        self::assertCount(2, $completions);
+        self::assertSame(['candidate' => 'map', 'type' => 'function'], $completions[0]);
+        self::assertContains('done', $responses[0]->payload['status']);
+    }
+
+    public function test_op_name_is_completions(): void
+    {
+        $op = new CompletionsOp($this->createStub(ApiFacadeInterface::class));
+        self::assertSame('completions', $op->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/DescribeOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/DescribeOpTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\CloneOp;
+use Phel\Nrepl\Application\Op\DescribeOp;
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Shared\Facade\RunFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class DescribeOpTest extends TestCase
+{
+    public function test_it_advertises_known_ops_and_versions(): void
+    {
+        $dispatcher = new OpDispatcher([new CloneOp(new SessionRegistry())]);
+
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('getVersion')->willReturn('v0.99.0');
+
+        $op = new DescribeOp($dispatcher, $run);
+        $dispatcher->register($op);
+
+        $responses = $op->handle(new OpRequest('describe', 'r1', null, ['op' => 'describe']));
+
+        self::assertCount(1, $responses);
+        $payload = $responses[0]->payload;
+        self::assertArrayHasKey('ops', $payload);
+        self::assertArrayHasKey('clone', $payload['ops']);
+        self::assertArrayHasKey('describe', $payload['ops']);
+        self::assertSame('v0.99.0', $payload['versions']['phel']['version-string']);
+        self::assertSame('0.1.0', $payload['versions']['nrepl']['version-string']);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Nrepl\Application\Op\EvalOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
+use Phel\Run\Domain\Repl\EvalResult;
+use Phel\Shared\Facade\RunFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EvalOpTest extends TestCase
+{
+    public function test_it_returns_value_and_done_on_success(): void
+    {
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::success(3));
+
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('3');
+
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+
+        $op = new EvalOp($run, $printer, $registry);
+        $responses = $op->handle(new OpRequest('eval', 'r1', $session->id, [
+            'op' => 'eval',
+            'code' => '(+ 1 2)',
+        ]));
+
+        self::assertCount(2, $responses);
+        self::assertSame('3', $responses[0]->payload['value']);
+        self::assertSame('user', $responses[0]->payload['ns']);
+        self::assertContains('done', $responses[1]->payload['status']);
+        self::assertSame(3, $session->lastValue());
+    }
+
+    public function test_it_emits_stdout_before_value(): void
+    {
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::success(null, 'side effect'));
+
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('nil');
+
+        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $responses = $op->handle(new OpRequest('eval', 'r1', null, [
+            'op' => 'eval',
+            'code' => '(println "x")',
+        ]));
+
+        self::assertCount(3, $responses);
+        self::assertSame('side effect', $responses[0]->payload['out']);
+        self::assertSame('nil', $responses[1]->payload['value']);
+        self::assertContains('done', $responses[2]->payload['status']);
+    }
+
+    public function test_it_reports_error_on_failure(): void
+    {
+        $error = new EvalError(
+            exceptionClass: 'CompilerException',
+            message: 'unbound symbol',
+            errorCode: null,
+            file: null,
+            line: null,
+            column: null,
+            endLine: null,
+            endColumn: null,
+            codeSnippet: null,
+            stackTrace: '',
+            phase: 'compile',
+            frames: [],
+        );
+
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::failure($error));
+
+        $printer = $this->createStub(PrinterInterface::class);
+
+        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $responses = $op->handle(new OpRequest('eval', 'r1', null, [
+            'op' => 'eval',
+            'code' => 'xx',
+        ]));
+
+        self::assertCount(2, $responses);
+        self::assertSame('CompilerException', $responses[0]->payload['ex']);
+        self::assertContains('eval-error', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[1]->payload['status']);
+    }
+
+    public function test_it_reports_incomplete_form(): void
+    {
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::incomplete());
+
+        $op = new EvalOp($run, $this->createStub(PrinterInterface::class), new SessionRegistry());
+        $responses = $op->handle(new OpRequest('eval', 'r1', null, [
+            'op' => 'eval',
+            'code' => '(+ 1',
+        ]));
+
+        self::assertContains('incomplete', $responses[0]->payload['status']);
+    }
+
+    public function test_it_rejects_missing_code_param(): void
+    {
+        $op = new EvalOp(
+            $this->createStub(RunFacadeInterface::class),
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+        $responses = $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval']));
+
+        self::assertContains('eval-error', $responses[0]->payload['status']);
+    }
+
+    public function test_it_passes_compile_options(): void
+    {
+        $run = $this->createMock(RunFacadeInterface::class);
+        $run->expects(self::once())
+            ->method('structuredEval')
+            ->with('(+ 1 2)', self::isInstanceOf(CompileOptions::class))
+            ->willReturn(EvalResult::success(3));
+
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('3');
+
+        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval', 'code' => '(+ 1 2)']));
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/InterruptOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/InterruptOpTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\InterruptOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use PHPUnit\Framework\TestCase;
+
+final class InterruptOpTest extends TestCase
+{
+    public function test_it_acknowledges_the_request(): void
+    {
+        $op = new InterruptOp();
+        $responses = $op->handle(new OpRequest('interrupt', 'r1', 's1', ['op' => 'interrupt']));
+
+        self::assertCount(1, $responses);
+        self::assertContains('done', $responses[0]->payload['status']);
+        self::assertContains('session-idle', $responses[0]->payload['status']);
+    }
+
+    public function test_op_name_is_interrupt(): void
+    {
+        self::assertSame('interrupt', (new InterruptOp())->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Application\Op\LoadFileOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalResult;
+use Phel\Shared\Facade\RunFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LoadFileOpTest extends TestCase
+{
+    public function test_it_evaluates_file_content(): void
+    {
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::success(42));
+
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('42');
+
+        $op = new LoadFileOp($run, $printer, new SessionRegistry());
+        $responses = $op->handle(new OpRequest('load-file', 'r1', null, [
+            'op' => 'load-file',
+            'file' => '(def x 42) x',
+            'file-name' => 'x.phel',
+        ]));
+
+        self::assertCount(2, $responses);
+        self::assertSame('42', $responses[0]->payload['value']);
+        self::assertContains('done', $responses[1]->payload['status']);
+    }
+
+    public function test_it_rejects_missing_file_param(): void
+    {
+        $op = new LoadFileOp(
+            $this->createStub(RunFacadeInterface::class),
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+        $responses = $op->handle(new OpRequest('load-file', 'r1', null, ['op' => 'load-file']));
+
+        self::assertContains('load-file-error', $responses[0]->payload['status']);
+    }
+
+    public function test_op_name_is_load_file(): void
+    {
+        $op = new LoadFileOp(
+            $this->createStub(RunFacadeInterface::class),
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+        self::assertSame('load-file', $op->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/LookupOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/LookupOpTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Api\Transfer\PhelFunction;
+use Phel\Nrepl\Application\Op\LookupOp;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Shared\Facade\ApiFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LookupOpTest extends TestCase
+{
+    public function test_it_returns_info_for_qualified_symbol(): void
+    {
+        $fn = new PhelFunction(
+            namespace: 'string',
+            name: 'upper-case',
+            doc: 'Uppercases s',
+            signatures: ['(upper-case s)'],
+            description: '',
+            file: 'src/phel/string.phel',
+            line: 10,
+        );
+
+        $api = $this->createStub(ApiFacadeInterface::class);
+        $api->method('getPhelFunctions')->willReturn([$fn]);
+
+        $op = new LookupOp($api);
+        $responses = $op->handle(new OpRequest('lookup', 'r1', null, [
+            'op' => 'lookup',
+            'sym' => 'string/upper-case',
+        ]));
+
+        self::assertCount(1, $responses);
+        $info = $responses[0]->payload['info'];
+        self::assertSame('upper-case', $info['name']);
+        self::assertSame('string', $info['ns']);
+        self::assertSame('(upper-case s)', $info['arglists-str']);
+        self::assertSame('src/phel/string.phel', $info['file']);
+        self::assertSame(10, $info['line']);
+    }
+
+    public function test_it_returns_info_for_core_symbol_without_namespace(): void
+    {
+        $fn = new PhelFunction(
+            namespace: 'core',
+            name: 'map',
+            doc: 'Maps',
+            signatures: ['(map f xs)'],
+            description: '',
+        );
+
+        $api = $this->createStub(ApiFacadeInterface::class);
+        $api->method('getPhelFunctions')->willReturn([$fn]);
+
+        $op = new LookupOp($api);
+        $responses = $op->handle(new OpRequest('lookup', 'r1', null, [
+            'op' => 'lookup',
+            'sym' => 'map',
+        ]));
+
+        self::assertSame('map', $responses[0]->payload['info']['name']);
+    }
+
+    public function test_it_reports_no_info_for_unknown_symbol(): void
+    {
+        $api = $this->createStub(ApiFacadeInterface::class);
+        $api->method('getPhelFunctions')->willReturn([]);
+
+        $op = new LookupOp($api);
+        $responses = $op->handle(new OpRequest('lookup', 'r1', null, [
+            'op' => 'lookup',
+            'sym' => 'ghost',
+        ]));
+
+        self::assertContains('no-info', $responses[0]->payload['status']);
+    }
+
+    public function test_it_rejects_missing_sym_param(): void
+    {
+        $op = new LookupOp($this->createStub(ApiFacadeInterface::class));
+        $responses = $op->handle(new OpRequest('lookup', 'r1', null, ['op' => 'lookup']));
+
+        self::assertContains('error', $responses[0]->payload['status']);
+    }
+
+    public function test_it_uses_configured_op_name(): void
+    {
+        $op = new LookupOp($this->createStub(ApiFacadeInterface::class), 'info');
+        self::assertSame('info', $op->name());
+
+        $op2 = new LookupOp($this->createStub(ApiFacadeInterface::class), 'eldoc');
+        self::assertSame('eldoc', $op2->name());
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/OpDispatcherTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/OpDispatcherTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Domain\Op\OpDispatcher;
+use Phel\Nrepl\Domain\Op\OpHandlerInterface;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use PHPUnit\Framework\TestCase;
+
+final class OpDispatcherTest extends TestCase
+{
+    public function test_it_routes_to_the_registered_handler(): void
+    {
+        $handler = new class() implements OpHandlerInterface {
+            public function name(): string
+            {
+                return 'ping';
+            }
+
+            public function handle(OpRequest $request): array
+            {
+                return [OpResponse::build($request->id, $request->session, ['pong' => true], ['done'])];
+            }
+        };
+
+        $dispatcher = new OpDispatcher([$handler]);
+        $responses = $dispatcher->dispatch(['op' => 'ping', 'id' => '1', 'session' => 's']);
+
+        self::assertCount(1, $responses);
+        self::assertSame('1', $responses[0]->payload['id']);
+        self::assertSame('s', $responses[0]->payload['session']);
+        self::assertTrue($responses[0]->payload['pong']);
+        self::assertSame(['done'], $responses[0]->payload['status']);
+    }
+
+    public function test_it_reports_unknown_op(): void
+    {
+        $dispatcher = new OpDispatcher();
+        $responses = $dispatcher->dispatch(['op' => 'no-such-op', 'id' => '7']);
+
+        self::assertCount(1, $responses);
+        self::assertContains('unknown-op', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[0]->payload['status']);
+    }
+
+    public function test_it_reports_missing_op_key(): void
+    {
+        $dispatcher = new OpDispatcher();
+        $responses = $dispatcher->dispatch(['id' => '1']);
+
+        self::assertCount(1, $responses);
+        self::assertContains('invalid-op', $responses[0]->payload['status']);
+    }
+
+    public function test_it_reports_invalid_message(): void
+    {
+        $dispatcher = new OpDispatcher();
+        $responses = $dispatcher->dispatch('not-a-dict');
+
+        self::assertCount(1, $responses);
+        self::assertContains('invalid-message', $responses[0]->payload['status']);
+    }
+
+    public function test_known_ops_returns_registered_names(): void
+    {
+        $handlerA = $this->createMockHandler('a');
+        $handlerB = $this->createMockHandler('b');
+
+        $dispatcher = new OpDispatcher([$handlerA, $handlerB]);
+
+        self::assertSame(['a', 'b'], $dispatcher->knownOps());
+    }
+
+    private function createMockHandler(string $name): OpHandlerInterface
+    {
+        return new readonly class($name) implements OpHandlerInterface {
+            public function __construct(private string $opName) {}
+
+            public function name(): string
+            {
+                return $this->opName;
+            }
+
+            public function handle(OpRequest $request): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Session/SessionRegistryTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Session/SessionRegistryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Session;
+
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class SessionRegistryTest extends TestCase
+{
+    public function test_it_creates_new_session_with_unique_id(): void
+    {
+        $registry = new SessionRegistry();
+        $a = $registry->create();
+        $b = $registry->create();
+
+        self::assertNotSame($a->id, $b->id);
+        self::assertNotEmpty($a->id);
+    }
+
+    public function test_it_retrieves_created_session(): void
+    {
+        $registry = new SessionRegistry();
+        $created = $registry->create();
+
+        self::assertSame($created, $registry->get($created->id));
+    }
+
+    public function test_it_returns_null_for_unknown_id(): void
+    {
+        $registry = new SessionRegistry();
+
+        self::assertNull($registry->get('does-not-exist'));
+    }
+
+    public function test_it_closes_existing_session(): void
+    {
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+
+        self::assertTrue($registry->close($session->id));
+        self::assertNull($registry->get($session->id));
+    }
+
+    public function test_it_returns_false_when_closing_unknown_session(): void
+    {
+        $registry = new SessionRegistry();
+
+        self::assertFalse($registry->close('does-not-exist'));
+    }
+
+    public function test_session_tracks_namespace_and_last_value(): void
+    {
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+
+        self::assertSame('user', $session->namespace());
+        self::assertNull($session->lastValue());
+
+        $session->setNamespace('phel\\core');
+        $session->recordValue(42);
+
+        self::assertSame('phel\\core', $session->namespace());
+        self::assertSame(42, $session->lastValue());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel has all the REPL pieces (`eval-capturing`, `macroexpand`, `doc`, `source`, `*1`/`*2`/`*3`/`*e`) but no wire protocol, so editor integrations like Cursive, Calva, CIDER, and Conjure have no way to talk to a running Phel process. nREPL (bencode over TCP) is the de-facto standard for that bridge.

This PR is item #1 on the `local/todo/clojure-parity-roadmap.md` tier-1 list: the highest-leverage DX feature, unblocking in-buffer eval, the future LSP, and editor tooling in general.

## 💡 Goal

Ship a minimal but real nREPL server that editors can connect to today, built as a new Gacela module reusing the existing `Run` and `Api` facades for evaluation and introspection.

## 🔖 Changes

- New `Phel\\Nrepl` module under `src/php/Nrepl/` with Facade / Factory / Config / Provider
- Bencode codec as a pure library: `BencodeEncoder`, `BencodeDecoder`, `BencodeStreamDecoder`, `BencodeException`, zero framework dependencies
- Op dispatcher: strategy pattern, each op is a single-responsibility class implementing `OpHandlerInterface`
- Core ops: `clone`, `close`, `describe`, `eval`, `load-file`, `interrupt`
- Tooling ops backed by `ApiFacade`: `completions`, `lookup`, `info`, `eldoc`
- `NreplSocketServer`: Fiber-per-client accept loop using `Fiber::suspend` for cooperative I/O
- CLI entry: `./bin/phel nrepl --port=N --host=addr` (default port 7888, default host 127.0.0.1)
- Unit tests for the codec, session registry, dispatcher, and every op handler; integration test spins up a server on a random port and exercises `describe` / `clone` / `eval` / `close` round-trips via a local bencode client
- New `src/php/Nrepl/CLAUDE.md` documenting the module
- `CHANGELOG.md` under Unreleased describes the new CLI command
