### PR TITLE
feat(api): expose user-code semantic analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - `phel eval -` reads the expression from stdin (e.g. `echo '(+ 1 2)' | phel eval -`)
 - `phel agent-install [<platform>|--all]` writes skill files for Claude Code, Cursor, Codex, Gemini, Copilot, Aider; `--with-docs` also mirrors the bundled `.agents/` tree, `--dry-run` previews, `--force` skips backup
 - `phel nrepl --port=N --host=addr` starts a bencode-over-TCP nREPL server; supports `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, plus `completions`, `lookup`, `info`, and `eldoc` for editor tooling
+- `phel analyze <file>` prints JSON semantic diagnostics; `phel index <dir>... [--out=file.json]` builds a project symbol table; `phel api-daemon` exposes the Api facade over newline-delimited JSON-RPC on stdio
+- `ApiFacade` gains `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint` for editor and linter tooling
 
 #### Agent docs
 - `.agents/` ships agent-agnostic docs with task recipes, per-platform adapters, and three runnable example projects (`todo-app`, `http-json-api`, `cli-wordcount`)

--- a/src/php/Api/ApiFacade.php
+++ b/src/php/Api/ApiFacade.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace Phel\Api;
 
 use Gacela\Framework\AbstractFacade;
+use Phel\Api\Infrastructure\Daemon\ApiDaemon;
+use Phel\Api\Transfer\Completion;
 use Phel\Api\Transfer\CompletionResultTransfer;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Api\Transfer\Location;
 use Phel\Api\Transfer\PhelFunction;
+use Phel\Api\Transfer\ProjectIndex;
 use Phel\Shared\Facade\ApiFacadeInterface;
 
 /**
@@ -46,5 +52,68 @@ final class ApiFacade extends AbstractFacade implements ApiFacadeInterface
         return $this->getFactory()
             ->createPhelFnNormalizer()
             ->getPhelFunctions($namespaces);
+    }
+
+    /**
+     * Run Parser + Analyzer without emit and return semantic diagnostics.
+     *
+     * @return list<Diagnostic>
+     */
+    public function analyzeSource(string $source, string $uri): array
+    {
+        return $this->getFactory()
+            ->createSourceAnalyzer()
+            ->analyze($source, $uri);
+    }
+
+    /**
+     * Build a project-level symbol index from one or more source directories.
+     *
+     * @param list<string> $srcDirs
+     */
+    public function indexProject(array $srcDirs): ProjectIndex
+    {
+        return $this->getFactory()
+            ->createProjectIndexer()
+            ->index($srcDirs);
+    }
+
+    /**
+     * Resolve a symbol to its defining site ("jump to definition").
+     */
+    public function resolveSymbol(ProjectIndex $index, string $namespace, string $symbol): ?Definition
+    {
+        return $this->getFactory()
+            ->createSymbolResolver()
+            ->resolve($index, $namespace, $symbol);
+    }
+
+    /**
+     * Find reference sites of a given symbol.
+     *
+     * @return list<Location>
+     */
+    public function findReferences(ProjectIndex $index, string $namespace, string $symbol): array
+    {
+        return $this->getFactory()
+            ->createReferenceFinder()
+            ->find($index, $namespace, $symbol);
+    }
+
+    /**
+     * Context-aware completion at a given point in source (locals + project defs + phel-core).
+     *
+     * @return list<Completion>
+     */
+    public function completeAtPoint(string $source, int $line, int $col, ProjectIndex $index): array
+    {
+        return $this->getFactory()
+            ->createPointCompleter()
+            ->completeAtPoint($source, $line, $col, $index);
+    }
+
+    public function createApiDaemon(): ApiDaemon
+    {
+        return $this->getFactory()->createApiDaemon($this);
     }
 }

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -5,15 +5,30 @@ declare(strict_types=1);
 namespace Phel\Api;
 
 use Gacela\Framework\AbstractFactory;
+use Phel\Api\Application\Analysis\LexAndParseStage;
+use Phel\Api\Application\Analysis\ReadAndAnalyzeStage;
 use Phel\Api\Application\PhelFnGroupKeyGenerator;
 use Phel\Api\Application\PhelFnNormalizer;
+use Phel\Api\Application\PointCompleter;
+use Phel\Api\Application\ProjectIndexer;
+use Phel\Api\Application\ReferenceFinder;
 use Phel\Api\Application\ReplCompleter;
+use Phel\Api\Application\SourceAnalyzer;
+use Phel\Api\Application\SymbolExtractor;
+use Phel\Api\Application\SymbolResolver;
 use Phel\Api\Domain\PhelFnGroupKeyGeneratorInterface;
 use Phel\Api\Domain\PhelFnLoaderInterface;
 use Phel\Api\Domain\PhelFnNormalizerInterface;
+use Phel\Api\Domain\PointCompleterInterface;
+use Phel\Api\Domain\ProjectIndexerInterface;
+use Phel\Api\Domain\ReferenceFinderInterface;
 use Phel\Api\Domain\ReplCompleterInterface;
+use Phel\Api\Domain\SourceAnalyzerInterface;
+use Phel\Api\Domain\SymbolResolverInterface;
+use Phel\Api\Infrastructure\Daemon\ApiDaemon;
 use Phel\Api\Infrastructure\PhelFnLoader;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Shared\Facade\CompilerFacadeInterface;
 
 /**
  * @extends AbstractFactory<ApiConfig>
@@ -38,6 +53,53 @@ final class ApiFactory extends AbstractFactory
         );
     }
 
+    public function createSourceAnalyzer(): SourceAnalyzerInterface
+    {
+        $compilerFacade = $this->getCompilerFacade();
+
+        return new SourceAnalyzer([
+            new LexAndParseStage($compilerFacade),
+            new ReadAndAnalyzeStage($compilerFacade),
+        ]);
+    }
+
+    public function createProjectIndexer(): ProjectIndexerInterface
+    {
+        return new ProjectIndexer(
+            $this->createSymbolExtractor(),
+        );
+    }
+
+    public function createSymbolResolver(): SymbolResolverInterface
+    {
+        return new SymbolResolver();
+    }
+
+    public function createReferenceFinder(): ReferenceFinderInterface
+    {
+        return new ReferenceFinder();
+    }
+
+    public function createPointCompleter(): PointCompleterInterface
+    {
+        return new PointCompleter(
+            $this->getCompilerFacade(),
+            $this->createPhelFnNormalizer(),
+        );
+    }
+
+    public function createApiDaemon(ApiFacade $facade): ApiDaemon
+    {
+        return new ApiDaemon($facade);
+    }
+
+    public function createSymbolExtractor(): SymbolExtractor
+    {
+        return new SymbolExtractor(
+            $this->getCompilerFacade(),
+        );
+    }
+
     private function createPhelFnLoader(): PhelFnLoaderInterface
     {
         return new PhelFnLoader(
@@ -48,5 +110,13 @@ final class ApiFactory extends AbstractFactory
     private function createPhelFnGroupKeyGenerator(): PhelFnGroupKeyGeneratorInterface
     {
         return new PhelFnGroupKeyGenerator();
+    }
+
+    private function getCompilerFacade(): CompilerFacadeInterface
+    {
+        /** @var CompilerFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(ApiProvider::FACADE_COMPILER);
+
+        return $facade;
     }
 }

--- a/src/php/Api/ApiProvider.php
+++ b/src/php/Api/ApiProvider.php
@@ -7,15 +7,24 @@ namespace Phel\Api;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
+use Phel\Compiler\CompilerFacade;
 use Phel\Run\RunFacade;
 
 final class ApiProvider extends AbstractProvider
 {
     public const string FACADE_RUN = 'FACADE_RUN';
 
+    public const string FACADE_COMPILER = 'FACADE_COMPILER';
+
     #[Provides(self::FACADE_RUN)]
     public function runFacade(Container $container): RunFacade
     {
         return $container->getLocator()->getRequired(RunFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
+    {
+        return $container->getLocator()->getRequired(CompilerFacade::class);
     }
 }

--- a/src/php/Api/Application/Analysis/LexAndParseStage.php
+++ b/src/php/Api/Application/Analysis/LexAndParseStage.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application\Analysis;
+
+use Phel\Api\Domain\AnalysisStageInterface;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Compiler\Domain\Exceptions\ErrorCode;
+use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+/**
+ * First stage of the analysis pipeline: lex + parse the source.
+ *
+ * Collects parse-tree nodes into $context['parseTrees'] for later stages.
+ */
+final readonly class LexAndParseStage implements AnalysisStageInterface
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    public function run(string $source, string $uri, array &$context): array
+    {
+        $diagnostics = [];
+        $parseTrees = [];
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($source, $uri);
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException $e) {
+                    $diagnostics[] = $this->parseErrorDiagnostic($e, $uri);
+                    break;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    break;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                $parseTrees[] = $parseTree;
+            }
+        } catch (LexerValueException $lexerValueException) {
+            $diagnostics[] = new Diagnostic(
+                code: ErrorCode::LEXER_ERROR->value,
+                severity: Diagnostic::SEVERITY_ERROR,
+                message: $lexerValueException->getMessage(),
+                uri: $uri,
+                startLine: 1,
+                startCol: 1,
+                endLine: 1,
+                endCol: 1,
+            );
+        }
+
+        $context['parseTrees'] = $parseTrees;
+
+        return $diagnostics;
+    }
+
+    private function parseErrorDiagnostic(AbstractParserException $e, string $uri): Diagnostic
+    {
+        $start = $e->getStartLocation();
+        $end = $e->getEndLocation();
+
+        return new Diagnostic(
+            code: ($e->getErrorCode() ?? ErrorCode::PARSER_ERROR)->value,
+            severity: Diagnostic::SEVERITY_ERROR,
+            message: $e->getMessage(),
+            uri: $uri,
+            startLine: $start?->getLine() ?? 1,
+            startCol: $start?->getColumn() ?? 1,
+            endLine: $end?->getLine() ?? ($start?->getLine() ?? 1),
+            endCol: $end?->getColumn() ?? ($start?->getColumn() ?? 1),
+        );
+    }
+}

--- a/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
+++ b/src/php/Api/Application/Analysis/ReadAndAnalyzeStage.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application\Analysis;
+
+use Phel\Api\Domain\AnalysisStageInterface;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Exceptions\ErrorCode;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+/**
+ * Second stage: read each parse tree into a Phel value, then analyze
+ * it into an AST node. Emits diagnostics for analyzer/reader errors
+ * but keeps going across top-level forms so one bad form doesn't
+ * hide following ones.
+ */
+final readonly class ReadAndAnalyzeStage implements AnalysisStageInterface
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    public function run(string $source, string $uri, array &$context): array
+    {
+        $diagnostics = [];
+        $parseTrees = $context['parseTrees'] ?? [];
+
+        foreach ($parseTrees as $parseTree) {
+            if (!$parseTree instanceof NodeInterface) {
+                continue;
+            }
+
+            try {
+                $readerResult = $this->compilerFacade->read($parseTree);
+                $this->compilerFacade->analyze(
+                    $readerResult->getAst(),
+                    NodeEnvironment::empty()->withReturnContext(),
+                );
+            } catch (ReaderException $e) {
+                $diagnostics[] = $this->diagnosticFromLocation(
+                    code: ($e->getErrorCode() ?? ErrorCode::READER_ERROR)->value,
+                    message: $e->getMessage(),
+                    uri: $uri,
+                    startLine: $e->getStartLocation()?->getLine(),
+                    startCol: $e->getStartLocation()?->getColumn(),
+                    endLine: $e->getEndLocation()?->getLine(),
+                    endCol: $e->getEndLocation()?->getColumn(),
+                );
+            } catch (AnalyzerException $e) {
+                $diagnostics[] = $this->diagnosticFromLocation(
+                    code: ($e->getErrorCode() ?? ErrorCode::INVALID_SPECIAL_FORM)->value,
+                    message: $e->getMessage(),
+                    uri: $uri,
+                    startLine: $e->getStartLocation()?->getLine(),
+                    startCol: $e->getStartLocation()?->getColumn(),
+                    endLine: $e->getEndLocation()?->getLine(),
+                    endCol: $e->getEndLocation()?->getColumn(),
+                );
+            }
+        }
+
+        return $diagnostics;
+    }
+
+    private function diagnosticFromLocation(
+        string $code,
+        string $message,
+        string $uri,
+        ?int $startLine,
+        ?int $startCol,
+        ?int $endLine,
+        ?int $endCol,
+    ): Diagnostic {
+        $sl = $startLine ?? 1;
+        $sc = $startCol ?? 1;
+
+        return new Diagnostic(
+            code: $code,
+            severity: Diagnostic::SEVERITY_ERROR,
+            message: $message,
+            uri: $uri,
+            startLine: $sl,
+            startCol: $sc,
+            endLine: $endLine ?? $sl,
+            endCol: $endCol ?? $sc,
+        );
+    }
+}

--- a/src/php/Api/Application/PointCompleter.php
+++ b/src/php/Api/Application/PointCompleter.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\PhelFnNormalizerInterface;
+use Phel\Api\Domain\PointCompleterInterface;
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+use Throwable;
+
+use function count;
+use function in_array;
+use function str_starts_with;
+
+/**
+ * Context-aware completion: scans the source parse tree for bindings
+ * in scope at the given point, then unions that with
+ * project-index definitions and the public phel-core API.
+ */
+final readonly class PointCompleter implements PointCompleterInterface
+{
+    private const array BINDING_FORMS = ['let', 'loop', 'for', 'binding', 'if-let', 'when-let'];
+
+    private const array FN_FORMS = ['fn', 'defn', 'defn-', 'defmacro', 'defmacro-'];
+
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+        private PhelFnNormalizerInterface $phelFnNormalizer,
+    ) {}
+
+    /**
+     * @return list<Completion>
+     */
+    public function completeAtPoint(string $source, int $line, int $col, ProjectIndex $index): array
+    {
+        $prefix = $this->extractPrefix($source, $line, $col);
+
+        $locals = $this->collectLocalsAtPoint($source, $line, $col);
+        $projectDefs = $this->collectProjectDefinitions($index);
+        $coreFns = $this->collectCoreFunctions();
+
+        $results = [];
+        $seen = [];
+
+        foreach ($locals as $local) {
+            if (($prefix === '' || str_starts_with($local, $prefix)) && !isset($seen[$local])) {
+                $seen[$local] = true;
+                $results[] = new Completion(
+                    label: $local,
+                    kind: Completion::KIND_LOCAL,
+                    detail: 'local binding',
+                );
+            }
+        }
+
+        foreach ($projectDefs as $completion) {
+            if ($prefix !== '' && !str_starts_with($completion->label, $prefix)) {
+                continue;
+            }
+
+            if (!isset($seen[$completion->label])) {
+                $seen[$completion->label] = true;
+                $results[] = $completion;
+            }
+        }
+
+        foreach ($coreFns as $completion) {
+            if ($prefix !== '' && !str_starts_with($completion->label, $prefix)) {
+                continue;
+            }
+
+            if (!isset($seen[$completion->label])) {
+                $seen[$completion->label] = true;
+                $results[] = $completion;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectLocalsAtPoint(string $source, int $line, int $col): array
+    {
+        $locals = [];
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($source, 'point');
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException) {
+                    break;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    break;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                try {
+                    $readerResult = $this->compilerFacade->read($parseTree);
+                } catch (ReaderException) {
+                    continue;
+                }
+
+                $this->walk($readerResult->getAst(), $line, $col, [], $locals);
+            }
+        } catch (Throwable) {
+            // Best-effort only
+        }
+
+        return array_values(array_unique($locals));
+    }
+
+    /**
+     * Recursive walker that tracks current-scope bindings and, if the point
+     * is inside the given form, appends the scope to $collected.
+     *
+     * @param list<string> $scope
+     * @param list<string> $collected
+     */
+    private function walk(mixed $form, int $line, int $col, array $scope, array &$collected): void
+    {
+        if ($form instanceof PersistentListInterface) {
+            if (!$this->pointInside($form, $line, $col)) {
+                return;
+            }
+
+            $newScope = $scope;
+            $head = count($form) > 0 ? $form->get(0) : null;
+            if ($head instanceof Symbol && in_array($head->getName(), self::BINDING_FORMS, true)) {
+                $newScope = $this->extractBindings($form, $scope);
+            } elseif ($head instanceof Symbol && in_array($head->getName(), self::FN_FORMS, true)) {
+                $newScope = $this->extractFnParams($form, $scope);
+            }
+
+            $collected = array_values(array_unique([...$collected, ...$newScope]));
+
+            foreach ($form as $child) {
+                $this->walk($child, $line, $col, $newScope, $collected);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $line, $col, $scope, $collected);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $line, $col, $scope, $collected);
+                $this->walk($v, $line, $col, $scope, $collected);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $scope
+     *
+     * @return list<string>
+     */
+    private function extractBindings(PersistentListInterface $form, array $scope): array
+    {
+        if (count($form) < 2) {
+            return $scope;
+        }
+
+        $bindingVec = $form->get(1);
+        if (!$bindingVec instanceof PersistentVectorInterface) {
+            return $scope;
+        }
+
+        $result = $scope;
+        $size = count($bindingVec);
+        for ($i = 0; $i < $size; $i += 2) {
+            $binding = $bindingVec->get($i);
+            if ($binding instanceof Symbol) {
+                $result[] = $binding->getName();
+            } elseif ($binding instanceof PersistentVectorInterface) {
+                foreach ($binding as $sym) {
+                    if ($sym instanceof Symbol) {
+                        $result[] = $sym->getName();
+                    }
+                }
+            } elseif ($binding instanceof PersistentMapInterface) {
+                foreach ($binding as $v) {
+                    if ($v instanceof Symbol) {
+                        $result[] = $v->getName();
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($result));
+    }
+
+    /**
+     * @param list<string> $scope
+     *
+     * @return list<string>
+     */
+    private function extractFnParams(PersistentListInterface $form, array $scope): array
+    {
+        $result = $scope;
+        $counter = count($form);
+        for ($i = 1; $i < $counter; ++$i) {
+            $child = $form->get($i);
+            if ($child instanceof PersistentVectorInterface) {
+                foreach ($child as $param) {
+                    if ($param instanceof Symbol && $param->getName() !== '&') {
+                        $result[] = $param->getName();
+                    }
+                }
+
+                break;
+            }
+
+            if ($child instanceof PersistentListInterface && count($child) > 0) {
+                $head = $child->get(0);
+                if ($head instanceof PersistentVectorInterface) {
+                    foreach ($head as $param) {
+                        if ($param instanceof Symbol && $param->getName() !== '&') {
+                            $result[] = $param->getName();
+                        }
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($result));
+    }
+
+    private function pointInside(PersistentListInterface|PersistentVectorInterface|PersistentMapInterface $form, int $line, int $col): bool
+    {
+        $start = $form->getStartLocation();
+        $end = $form->getEndLocation();
+        if (!$start instanceof SourceLocation || !$end instanceof SourceLocation) {
+            return true;
+        }
+
+        if ($line < $start->getLine() || $line > $end->getLine()) {
+            return false;
+        }
+
+        if ($line === $start->getLine() && $col < $start->getColumn()) {
+            return false;
+        }
+
+        return !($line === $end->getLine() && $col > $end->getColumn());
+    }
+
+    /**
+     * @return list<Completion>
+     */
+    private function collectProjectDefinitions(ProjectIndex $index): array
+    {
+        $result = [];
+        foreach ($index->definitions as $def) {
+            $result[] = new Completion(
+                label: $def->name,
+                kind: $def->kind === Definition::KIND_DEFMACRO ? Completion::KIND_MACRO : Completion::KIND_GLOBAL,
+                detail: $def->namespace,
+                documentation: $def->docstring,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<Completion>
+     */
+    private function collectCoreFunctions(): array
+    {
+        $result = [];
+        try {
+            foreach ($this->phelFnNormalizer->getPhelFunctions(['phel\\core']) as $fn) {
+                $result[] = new Completion(
+                    label: $fn->name,
+                    kind: Completion::KIND_GLOBAL,
+                    detail: $fn->namespace,
+                    documentation: $fn->description,
+                );
+            }
+        } catch (Throwable) {
+            // Core not loaded in this environment: ignore quietly so callers still get locals.
+        }
+
+        return $result;
+    }
+
+    private function extractPrefix(string $source, int $line, int $col): string
+    {
+        $lines = preg_split('/\r?\n/', $source) ?: [];
+        if (!isset($lines[$line - 1])) {
+            return '';
+        }
+
+        $slice = substr($lines[$line - 1], 0, max(0, $col - 1));
+        if (!preg_match('/([A-Za-z0-9\-_?!*+<>=\/]+)$/', $slice, $matches)) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+}

--- a/src/php/Api/Application/ProjectIndexer.php
+++ b/src/php/Api/Application/ProjectIndexer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\ProjectIndexerInterface;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
+
+use function file_get_contents;
+use function is_dir;
+use function realpath;
+
+/**
+ * Walks a list of source directories, reads every .phel file and aggregates
+ * Definitions and references into a ProjectIndex.
+ *
+ * Caching hook: results could be keyed on a file-hash -> Definition mapping and
+ * stored under `.phel/api-index-cache/`. For v1 we re-index from scratch.
+ */
+final readonly class ProjectIndexer implements ProjectIndexerInterface
+{
+    public function __construct(
+        private SymbolExtractor $extractor,
+    ) {}
+
+    public function index(array $srcDirs): ProjectIndex
+    {
+        /** @var array<string, Definition> $definitions */
+        $definitions = [];
+        /** @var array<string, list<Location>> $references */
+        $references = [];
+
+        foreach ($srcDirs as $dir) {
+            $real = realpath($dir);
+            if ($real === false) {
+                continue;
+            }
+
+            if (!is_dir($real)) {
+                continue;
+            }
+
+            foreach ($this->iteratePhelFiles($real) as $file) {
+                $contents = @file_get_contents($file);
+                if ($contents === false) {
+                    continue;
+                }
+
+                $result = $this->extractor->extract($contents, $file);
+
+                foreach ($result['definitions'] as $definition) {
+                    $definitions[$definition->fullName()] = $definition;
+                }
+
+                foreach ($result['references'] as $key => $locations) {
+                    if (!isset($references[$key])) {
+                        $references[$key] = [];
+                    }
+
+                    foreach ($locations as $location) {
+                        $references[$key][] = $location;
+                    }
+                }
+            }
+        }
+
+        return new ProjectIndex($definitions, $references);
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function iteratePhelFiles(string $directory): iterable
+    {
+        try {
+            $dirIterator = new RecursiveDirectoryIterator($directory);
+            $iterator = new RecursiveIteratorIterator($dirIterator);
+            $regex = new RegexIterator($iterator, '/^.+\.phel$/i', RegexIterator::GET_MATCH);
+        } catch (UnexpectedValueException) {
+            return [];
+        }
+
+        foreach ($regex as $match) {
+            yield $match[0];
+        }
+    }
+}

--- a/src/php/Api/Application/ReferenceFinder.php
+++ b/src/php/Api/Application/ReferenceFinder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\ReferenceFinderInterface;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+
+final readonly class ReferenceFinder implements ReferenceFinderInterface
+{
+    /**
+     * @return list<Location>
+     */
+    public function find(ProjectIndex $index, string $namespace, string $symbol): array
+    {
+        $key = $symbol;
+        if (!str_contains($symbol, '/')) {
+            $key = $namespace === '' ? $symbol : $namespace . '/' . $symbol;
+        }
+
+        $locations = $index->references[$key] ?? [];
+
+        // Also try unqualified lookup for same-file references
+        if ($locations === [] && str_contains($key, '/')) {
+            $short = substr($key, (int) strrpos($key, '/') + 1);
+            $locations = $index->references[$short] ?? [];
+        }
+
+        return $locations;
+    }
+}

--- a/src/php/Api/Application/SourceAnalyzer.php
+++ b/src/php/Api/Application/SourceAnalyzer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\AnalysisStageInterface;
+use Phel\Api\Domain\SourceAnalyzerInterface;
+use Phel\Api\Transfer\Diagnostic;
+
+/**
+ * Pipeline runner that executes each analysis stage in sequence,
+ * accumulating diagnostics. Stages are pluggable via the constructor.
+ */
+final readonly class SourceAnalyzer implements SourceAnalyzerInterface
+{
+    /**
+     * @param list<AnalysisStageInterface> $stages
+     */
+    public function __construct(
+        private array $stages,
+    ) {}
+
+    /**
+     * @return list<Diagnostic>
+     */
+    public function analyze(string $source, string $uri): array
+    {
+        $diagnostics = [];
+        $context = [];
+
+        foreach ($this->stages as $stage) {
+            foreach ($stage->run($source, $uri, $context) as $diagnostic) {
+                $diagnostics[] = $diagnostic;
+            }
+        }
+
+        return $diagnostics;
+    }
+}

--- a/src/php/Api/Application/SymbolExtractor.php
+++ b/src/php/Api/Application/SymbolExtractor.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Location;
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+use Throwable;
+
+use function count;
+use function in_array;
+use function is_string;
+
+/**
+ * Reads a single .phel source string and extracts:
+ * - the primary namespace (if any),
+ * - a list of top-level Definitions,
+ * - reference Locations (every symbol usage inside bodies).
+ */
+final readonly class SymbolExtractor
+{
+    private const array DEFINITION_FORMS = [
+        'def' => Definition::KIND_DEF,
+        'def-' => Definition::KIND_DEF,
+        'defn' => Definition::KIND_DEFN,
+        'defn-' => Definition::KIND_DEFN,
+        'defmacro' => Definition::KIND_DEFMACRO,
+        'defmacro-' => Definition::KIND_DEFMACRO,
+        'defstruct' => Definition::KIND_DEFSTRUCT,
+        'defstruct*' => Definition::KIND_DEFSTRUCT,
+        'definterface' => Definition::KIND_DEFINTERFACE,
+        'defprotocol' => Definition::KIND_DEFPROTOCOL,
+        'defexception' => Definition::KIND_DEFEXCEPTION,
+    ];
+
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    /**
+     * @return array{
+     *     namespace: string,
+     *     definitions: list<Definition>,
+     *     references: array<string, list<Location>>,
+     * }
+     */
+    public function extract(string $source, string $uri): array
+    {
+        $namespace = '';
+        $definitions = [];
+        /** @var array<string, list<Location>> $references */
+        $references = [];
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($source, $uri);
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException) {
+                    break;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    break;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                try {
+                    $readerResult = $this->compilerFacade->read($parseTree);
+                } catch (ReaderException) {
+                    continue;
+                }
+
+                $form = $readerResult->getAst();
+
+                if ($namespace === '') {
+                    $maybeNs = $this->tryExtractNamespace($form);
+                    if ($maybeNs !== '') {
+                        $namespace = $maybeNs;
+                        continue;
+                    }
+                }
+
+                $definition = $this->tryExtractDefinition($form, $namespace, $uri);
+                if ($definition instanceof Definition) {
+                    $definitions[] = $definition;
+                }
+
+                $this->collectSymbolReferences($form, $uri, $namespace, $references);
+            }
+        } catch (Throwable) {
+            // Best-effort extractor: if anything fails we just return what we have.
+        }
+
+        return [
+            'namespace' => $namespace,
+            'definitions' => $definitions,
+            'references' => $references,
+        ];
+    }
+
+    /**
+     * Helper so tests/callers with a raw form (already read) can pull a definition directly.
+     *
+     * @internal
+     */
+    public function definitionFromForm(
+        TypeInterface|string|float|int|bool|null $form,
+        string $namespace,
+        string $uri,
+    ): ?Definition {
+        return $this->tryExtractDefinition($form, $namespace, $uri);
+    }
+
+    private function tryExtractNamespace(mixed $form): string
+    {
+        if (!$form instanceof PersistentListInterface || count($form) === 0) {
+            return '';
+        }
+
+        $first = $form->get(0);
+        if (!$first instanceof Symbol || $first->getName() !== Symbol::NAME_NS) {
+            return '';
+        }
+
+        if (count($form) < 2) {
+            return '';
+        }
+
+        $name = $form->get(1);
+        if (!$name instanceof Symbol) {
+            return '';
+        }
+
+        return $name->getFullName();
+    }
+
+    private function tryExtractDefinition(mixed $form, string $namespace, string $uri): ?Definition
+    {
+        if (!$form instanceof PersistentListInterface || count($form) === 0) {
+            return null;
+        }
+
+        $first = $form->get(0);
+        if (!$first instanceof Symbol) {
+            return null;
+        }
+
+        $formName = $first->getName();
+        if (!isset(self::DEFINITION_FORMS[$formName])) {
+            return null;
+        }
+
+        if (count($form) < 2) {
+            return null;
+        }
+
+        $name = $form->get(1);
+        if (!$name instanceof Symbol) {
+            return null;
+        }
+
+        $start = $name->getStartLocation() ?? $first->getStartLocation();
+
+        return new Definition(
+            namespace: $namespace,
+            name: $name->getName(),
+            uri: $uri,
+            line: $start?->getLine() ?? 0,
+            col: $start?->getColumn() ?? 0,
+            kind: self::DEFINITION_FORMS[$formName],
+            signature: $this->extractSignature($form, $formName),
+            docstring: $this->extractDocstring($form, $formName),
+            private: $this->isPrivate($form, $formName),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractSignature(PersistentListInterface $form, string $formName): array
+    {
+        if (count($form) < 3) {
+            return [];
+        }
+
+        $arities = [];
+        $counter = count($form);
+        // Scan for either a vector (single arity) or nested lists (multi-arity)
+        for ($i = 2; $i < $counter; ++$i) {
+            $child = $form->get($i);
+            if ($child instanceof PersistentVectorInterface) {
+                $arities[] = $this->vectorToSignature($child);
+                break;
+            }
+
+            if ($child instanceof PersistentListInterface) {
+                $head = count($child) > 0 ? $child->get(0) : null;
+                if ($head instanceof PersistentVectorInterface) {
+                    $arities[] = $this->vectorToSignature($head);
+                }
+            }
+        }
+
+        if ($arities === [] && isset(self::DEFINITION_FORMS[$formName]) && self::DEFINITION_FORMS[$formName] === Definition::KIND_DEF) {
+            // plain def has no param list
+            return [];
+        }
+
+        return $arities;
+    }
+
+    private function vectorToSignature(PersistentVectorInterface $vector): string
+    {
+        $parts = [];
+        foreach ($vector as $item) {
+            if ($item instanceof Symbol) {
+                $parts[] = $item->getName();
+            } elseif ($item instanceof Keyword) {
+                $parts[] = ':' . $item->getName();
+            } elseif (is_string($item)) {
+                $parts[] = '"' . $item . '"';
+            }
+        }
+
+        return '[' . implode(' ', $parts) . ']';
+    }
+
+    private function extractDocstring(PersistentListInterface $form, string $formName): string
+    {
+        if (!in_array(self::DEFINITION_FORMS[$formName] ?? '', [
+            Definition::KIND_DEFN,
+            Definition::KIND_DEFMACRO,
+        ], true)) {
+            return '';
+        }
+
+        if (count($form) < 3) {
+            return '';
+        }
+
+        $candidate = $form->get(2);
+        if (is_string($candidate)) {
+            return $candidate;
+        }
+
+        return '';
+    }
+
+    private function isPrivate(PersistentListInterface $form, string $formName): bool
+    {
+        if (str_ends_with($formName, '-')) {
+            return true;
+        }
+
+        if (count($form) < 3) {
+            return false;
+        }
+
+        $counter = count($form);
+
+        // Look for metadata map attached between name and value
+        for ($i = 2; $i < $counter; ++$i) {
+            $child = $form->get($i);
+            if ($child instanceof PersistentMapInterface) {
+                $priv = $child->find(Keyword::create('private'));
+                if ($priv === true) {
+                    return true;
+                }
+            } elseif ($child instanceof PersistentVectorInterface) {
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, list<Location>> $references
+     */
+    private function collectSymbolReferences(mixed $form, string $uri, string $namespace, array &$references): void
+    {
+        if ($form instanceof Symbol) {
+            $full = $form->getFullName();
+            if ($full === '' || $full === '/') {
+                return;
+            }
+
+            $location = $form->getStartLocation();
+            if (!$location instanceof SourceLocation) {
+                return;
+            }
+
+            $key = $this->refKey($form, $namespace);
+            if ($key === null) {
+                return;
+            }
+
+            $references[$key][] = new Location(
+                uri: $uri,
+                line: $location->getLine(),
+                col: $location->getColumn(),
+            );
+
+            return;
+        }
+
+        if ($form instanceof PersistentListInterface
+            || $form instanceof PersistentVectorInterface
+        ) {
+            foreach ($form as $child) {
+                $this->collectSymbolReferences($child, $uri, $namespace, $references);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->collectSymbolReferences($k, $uri, $namespace, $references);
+                $this->collectSymbolReferences($v, $uri, $namespace, $references);
+            }
+        }
+    }
+
+    /**
+     * Build the "ns/name" reference key for a symbol:
+     * - if it's qualified (foo/bar) use it as-is,
+     * - otherwise anchor it to the current file namespace (so same-file references resolve).
+     */
+    private function refKey(Symbol $sym, string $namespace): ?string
+    {
+        $ns = $sym->getNamespace();
+        $name = $sym->getName();
+
+        if ($name === '' || !$this->isPlainIdentifier($name)) {
+            return null;
+        }
+
+        if ($ns !== null && $ns !== '') {
+            return $ns . '/' . $name;
+        }
+
+        if ($namespace === '') {
+            return $name;
+        }
+
+        return $namespace . '/' . $name;
+    }
+
+    private function isPlainIdentifier(string $name): bool
+    {
+        // Ignore purely syntactic markers (`&`, `.`, etc.) that appear in fn params.
+        return $name !== '&' && $name !== '.';
+    }
+}

--- a/src/php/Api/Application/SymbolResolver.php
+++ b/src/php/Api/Application/SymbolResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use Phel\Api\Domain\SymbolResolverInterface;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+
+final readonly class SymbolResolver implements SymbolResolverInterface
+{
+    public function resolve(ProjectIndex $index, string $namespace, string $symbol): ?Definition
+    {
+        // Qualified form foo/bar wins if provided outright.
+        $key = $symbol;
+        if (!str_contains($symbol, '/')) {
+            $key = $namespace === '' ? $symbol : $namespace . '/' . $symbol;
+        }
+
+        if (isset($index->definitions[$key])) {
+            return $index->definitions[$key];
+        }
+
+        // Fallback: search by unqualified name across namespaces — first match wins.
+        foreach ($index->definitions as $def) {
+            if ($def->name === $symbol) {
+                return $def;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -1,35 +1,64 @@
 # Api Module
 
-Tooling support layer for REPL autocompletion, function introspection, and documentation.
+Tooling support layer: REPL autocompletion, function introspection, documentation, and user-code semantic analysis (diagnostics, project index, jump-to-def, find-references, completion at point).
 
 ## Gacela Pattern
 
 - **Facade**: `ApiFacade` implements `ApiFacadeInterface`
 - **Factory**: `ApiFactory` extends `AbstractFactory<ApiConfig>`
 - **Config**: `ApiConfig` — lists all documented namespaces (`phel\core`, `phel\string`, etc.)
-- **Provider**: `ApiProvider` — injects `RunFacade` as `FACADE_RUN`
+- **Provider**: `ApiProvider` — injects `RunFacade` (`FACADE_RUN`) and `CompilerFacade` (`FACADE_COMPILER`)
 
 ## Public API (Facade)
 
-- `replComplete(string $input): array` — basic REPL autocompletion (candidate strings)
-- `replCompleteWithTypes(string $input): array` — extended completion returning `CompletionResultTransfer` with type annotations
-- `getPhelFunctions(array $namespaces = []): array` — all public Phel functions as `PhelFunction` transfers
+**Documentation & Completion**
+- `replComplete(string $input): list<string>` — basic REPL autocompletion
+- `replCompleteWithTypes(string $input): list<CompletionResultTransfer>` — extended completion with type annotations
+- `getPhelFunctions(array $namespaces = []): list<PhelFunction>` — all public Phel functions
+
+**User-code Semantic Analysis**
+- `analyzeSource(string $source, string $uri): list<Diagnostic>` — run Parser + Analyzer, return semantic diagnostics
+- `indexProject(list<string> $srcDirs): ProjectIndex` — project-level symbol table + references
+- `resolveSymbol(ProjectIndex, string $namespace, string $symbol): ?Definition` — jump to definition
+- `findReferences(ProjectIndex, string $namespace, string $symbol): list<Location>` — reverse index
+- `completeAtPoint(string $source, int $line, int $col, ProjectIndex): list<Completion>` — context-aware completion (locals + project defs + phel-core)
+- `createApiDaemon(): ApiDaemon` — long-running JSON-RPC daemon (stdio)
+
+## CLI Commands
+
+- `./bin/phel doc` — browse core function docs
+- `./bin/phel analyze <file>` — JSON diagnostics for a single file
+- `./bin/phel index <dir>... [--out=file.json]` — build project index summary (optionally persist)
+- `./bin/phel api-daemon` — long-running JSON-RPC daemon over stdio
 
 ## Dependencies
 
 - **Run** (`RunFacade`) — namespace resolution, directory listing, file evaluation
-- **Compiler** (`GlobalEnvironmentSingleton`) — alias resolution, current namespace, referred symbols
+- **Compiler** (`CompilerFacade`) — lex, parse, read, analyze used by semantic analysis
 - **Lang** (`Phel`, `Keyword`, `Symbol`, `FnInterface`) — runtime type introspection
 
 ## Structure
 
 ```
 Api/
-├── Application/        ReplCompleter, PhelFnNormalizer, PhelFnGroupKeyGenerator
-├── Domain/             Interfaces (ReplCompleterInterface, PhelFnNormalizerInterface, etc.)
-├── Infrastructure/     PhelFnLoader (loads functions, native symbol docs)
-├── Transfer/           PhelFunction, CompletionResultTransfer
-└── Gacela files        ApiFacade, ApiFactory, ApiConfig, ApiProvider
+├── Application/
+│   ├── Analysis/              LexAndParseStage, ReadAndAnalyzeStage
+│   ├── PhelFnGroupKeyGenerator, PhelFnNormalizer, ReplCompleter
+│   ├── SourceAnalyzer         pipeline runner over AnalysisStageInterface
+│   ├── SymbolExtractor        per-file def/ref extractor (read + traverse forms)
+│   ├── ProjectIndexer         aggregates SymbolExtractor output across dirs
+│   ├── SymbolResolver         jump-to-def on ProjectIndex
+│   ├── ReferenceFinder        reverse index lookup on ProjectIndex
+│   └── PointCompleter         context-aware completion at a source point
+├── Domain/                    interfaces for each Application class
+├── Infrastructure/
+│   ├── Command/               DocCommand, AnalyzeCommand, IndexCommand, ApiDaemonCommand
+│   ├── Daemon/                ApiDaemon, JsonRpcFraming, JsonRpcDispatcher, UnknownMethodException
+│   └── PhelFnLoader           native symbol docs + runtime fn loading
+├── Transfer/
+│   ├── PhelFunction, CompletionResultTransfer
+│   └── Diagnostic, Definition, Location, Completion, ProjectIndex
+└── Gacela files               ApiFacade, ApiFactory, ApiConfig, ApiProvider
 ```
 
 ## Key Constraints
@@ -38,3 +67,7 @@ Api/
 - Supports dual-context completion: PHP symbols (when input starts with `php/`) and Phel symbols
 - `PhelFnLoader` provides hard-coded docs for ~40 native symbols/special forms
 - `PhelFnNormalizer` filters private functions and removes duplicates
+- `SourceAnalyzer` is a pipeline of `AnalysisStageInterface`; add stages without rewriting the runner
+- `ProjectIndexer` is stateless: v1 re-indexes from scratch; hook for file-hash caching lives at the `SymbolExtractor` call-site
+- JSON-RPC daemon uses newline-delimited JSON framing for stdio (one request per line, one response per line); transport framing is isolated in `JsonRpcFraming`
+- Semantic analysis never re-implements compiler phases: all lex/parse/read/analyze calls go through `CompilerFacade`

--- a/src/php/Api/Domain/AnalysisStageInterface.php
+++ b/src/php/Api/Domain/AnalysisStageInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\Diagnostic;
+
+interface AnalysisStageInterface
+{
+    /**
+     * Run this stage against source + uri. Each stage can emit
+     * diagnostics or feed state into following stages via $context.
+     *
+     * @param array<string, mixed> $context shared state between stages
+     *
+     * @return list<Diagnostic>
+     */
+    public function run(string $source, string $uri, array &$context): array;
+}

--- a/src/php/Api/Domain/PointCompleterInterface.php
+++ b/src/php/Api/Domain/PointCompleterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\ProjectIndex;
+
+interface PointCompleterInterface
+{
+    /**
+     * @return list<Completion>
+     */
+    public function completeAtPoint(string $source, int $line, int $col, ProjectIndex $index): array;
+}

--- a/src/php/Api/Domain/ProjectIndexerInterface.php
+++ b/src/php/Api/Domain/ProjectIndexerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\ProjectIndex;
+
+interface ProjectIndexerInterface
+{
+    /**
+     * @param list<string> $srcDirs
+     */
+    public function index(array $srcDirs): ProjectIndex;
+}

--- a/src/php/Api/Domain/ReferenceFinderInterface.php
+++ b/src/php/Api/Domain/ReferenceFinderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+
+interface ReferenceFinderInterface
+{
+    /**
+     * @return list<Location>
+     */
+    public function find(ProjectIndex $index, string $namespace, string $symbol): array;
+}

--- a/src/php/Api/Domain/SourceAnalyzerInterface.php
+++ b/src/php/Api/Domain/SourceAnalyzerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\Diagnostic;
+
+interface SourceAnalyzerInterface
+{
+    /**
+     * @return list<Diagnostic>
+     */
+    public function analyze(string $source, string $uri): array;
+}

--- a/src/php/Api/Domain/SymbolResolverInterface.php
+++ b/src/php/Api/Domain/SymbolResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Domain;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+
+interface SymbolResolverInterface
+{
+    public function resolve(ProjectIndex $index, string $namespace, string $symbol): ?Definition;
+}

--- a/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
+++ b/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Diagnostic;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_get_contents;
+use function is_file;
+use function json_encode;
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+
+#[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
+final class AnalyzeCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('analyze')
+            ->setDescription('Run semantic analysis on a single Phel source file and emit JSON diagnostics')
+            ->addArgument('file', InputArgument::REQUIRED, 'Path to a .phel source file');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = (string) $input->getArgument('file');
+
+        if (!is_file($file)) {
+            $output->writeln(sprintf('<error>File not found: %s</error>', $file));
+            return self::FAILURE;
+        }
+
+        $source = file_get_contents($file);
+        if ($source === false) {
+            $output->writeln(sprintf('<error>Unable to read file: %s</error>', $file));
+            return self::FAILURE;
+        }
+
+        $diagnostics = $this->getFacade()->analyzeSource($source, $file);
+        $payload = array_map(static fn(Diagnostic $d): array => $d->toArray(), $diagnostics);
+
+        $output->writeln(json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/php/Api/Infrastructure/Command/ApiDaemonCommand.php
+++ b/src/php/Api/Infrastructure/Command/ApiDaemonCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Api\ApiFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function sprintf;
+
+#[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
+final class ApiDaemonCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('api-daemon')
+            ->setDescription(
+                'Long-running JSON-RPC daemon exposing the Api semantic analysis facade over newline-delimited JSON (stdio).',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $daemon = $this->getFacade()->createApiDaemon();
+            $daemon->run();
+
+            return self::SUCCESS;
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>%s</error>', $throwable->getMessage()));
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/php/Api/Infrastructure/Command/IndexCommand.php
+++ b/src/php/Api/Infrastructure/Command/IndexCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Api\ApiFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_put_contents;
+use function is_string;
+use function json_encode;
+
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+
+#[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
+final class IndexCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    protected function configure(): void
+    {
+        $this->setName('index')
+            ->setDescription('Build a project-level symbol index across one or more source directories')
+            ->addArgument(
+                'dirs',
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                'Directories to scan for .phel files',
+            )
+            ->addOption(
+                'out',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Optional path to persist the full index as JSON',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var list<string> $dirs */
+        $dirs = (array) $input->getArgument('dirs');
+
+        $index = $this->getFacade()->indexProject($dirs);
+
+        $summary = [
+            'namespaces' => $index->countNamespaces(),
+            'definitions' => $index->countDefinitions(),
+            'dirs' => $dirs,
+        ];
+
+        $output->writeln(json_encode($summary, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        $out = $input->getOption('out');
+        if (is_string($out) && $out !== '') {
+            $written = @file_put_contents(
+                $out,
+                json_encode($index->toArray(), JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+            );
+            if ($written === false) {
+                $output->writeln(sprintf('<error>Unable to write index to: %s</error>', $out));
+                return self::FAILURE;
+            }
+
+            $output->writeln(sprintf('Index persisted to: %s', $out));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/php/Api/Infrastructure/Daemon/ApiDaemon.php
+++ b/src/php/Api/Infrastructure/Daemon/ApiDaemon.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Daemon;
+
+use Phel\Api\ApiFacade;
+
+use Throwable;
+
+/**
+ * Long-running JSON-RPC daemon speaking newline-delimited JSON over a pair
+ * of streams. Typically stdin/stdout for editor-side integration.
+ *
+ * Run via `./bin/phel api-daemon` (see ApiDaemonCommand).
+ */
+final class ApiDaemon
+{
+    private readonly JsonRpcFraming $framing;
+
+    private readonly JsonRpcDispatcher $dispatcher;
+
+    /** @var resource */
+    private $input;
+
+    /** @var resource */
+    private $output;
+
+    /**
+     * @param resource|null $input
+     * @param resource|null $output
+     */
+    public function __construct(
+        ApiFacade $facade,
+        $input = null,
+        $output = null,
+    ) {
+        $this->framing = new JsonRpcFraming();
+        $this->dispatcher = new JsonRpcDispatcher($facade);
+        /** @var resource $in */
+        $in = $input ?? STDIN;
+        /** @var resource $out */
+        $out = $output ?? STDOUT;
+        $this->input = $in;
+        $this->output = $out;
+    }
+
+    public function getDispatcher(): JsonRpcDispatcher
+    {
+        return $this->dispatcher;
+    }
+
+    public function run(int $maxIterations = 0): void
+    {
+        $iterations = 0;
+        while (!feof($this->input)) {
+            if ($maxIterations > 0 && $iterations >= $maxIterations) {
+                return;
+            }
+
+            try {
+                $message = $this->framing->readMessage($this->input);
+            } catch (Throwable $e) {
+                $this->framing->writeMessage($this->output, [
+                    'id' => null,
+                    'error' => ['code' => -32700, 'message' => $e->getMessage()],
+                ]);
+                ++$iterations;
+                continue;
+            }
+
+            if ($message === null) {
+                return;
+            }
+
+            if ($message === []) {
+                ++$iterations;
+                continue;
+            }
+
+            $response = $this->dispatcher->dispatch($message);
+            $this->framing->writeMessage($this->output, $response);
+
+            ++$iterations;
+        }
+    }
+
+    public function closeStreams(): void
+    {
+        /** @psalm-suppress InvalidPropertyAssignmentValue */
+        @fclose($this->input);
+        /** @psalm-suppress InvalidPropertyAssignmentValue */
+        @fclose($this->output);
+    }
+}

--- a/src/php/Api/Infrastructure/Daemon/JsonRpcDispatcher.php
+++ b/src/php/Api/Infrastructure/Daemon/JsonRpcDispatcher.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Daemon;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+use Throwable;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+
+/**
+ * Dispatches a JSON-RPC-style request to the ApiFacade.
+ *
+ * Request shape:  {"id": <any>, "method": "analyzeSource", "params": {...}}
+ * Response shape: {"id": <any>, "result": ...} | {"id": <any>, "error": {code, message}}
+ *
+ * The dispatcher owns a single in-memory ProjectIndex created by `indexProject`
+ * or `setIndex` so subsequent resolveSymbol / findReferences / completeAtPoint
+ * calls can reference it by a session-stable handle rather than re-sending a
+ * serialized index on every request.
+ */
+final class JsonRpcDispatcher
+{
+    private ?ProjectIndex $cachedIndex = null;
+
+    public function __construct(
+        private readonly ApiFacade $facade,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $request
+     *
+     * @return array<string, mixed>
+     */
+    public function dispatch(array $request): array
+    {
+        $id = $request['id'] ?? null;
+        $method = $request['method'] ?? '';
+        $params = $request['params'] ?? [];
+        if (!is_array($params)) {
+            $params = [];
+        }
+
+        if (!is_string($method) || $method === '') {
+            return $this->errorResponse($id, -32600, 'Missing method');
+        }
+
+        try {
+            $result = $this->invoke($method, $params);
+            return [
+                'id' => $id,
+                'result' => $result,
+            ];
+        } catch (UnknownMethodException $e) {
+            return $this->errorResponse($id, -32601, $e->getMessage());
+        } catch (Throwable $e) {
+            return $this->errorResponse($id, -32000, $e->getMessage());
+        }
+    }
+
+    public function setIndex(ProjectIndex $index): void
+    {
+        $this->cachedIndex = $index;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function invoke(string $method, array $params): mixed
+    {
+        return match ($method) {
+            'analyzeSource' => array_map(
+                static fn(Diagnostic $d): array => $d->toArray(),
+                $this->facade->analyzeSource(
+                    (string) ($params['source'] ?? ''),
+                    (string) ($params['uri'] ?? ''),
+                ),
+            ),
+            'indexProject' => $this->indexProject($params),
+            'resolveSymbol' => $this->resolveSymbol($params),
+            'findReferences' => $this->findReferences($params),
+            'completeAtPoint' => $this->completeAtPoint($params),
+            default => throw new UnknownMethodException(sprintf('Unknown method: %s', $method)),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    private function indexProject(array $params): array
+    {
+        /** @var list<string> $dirs */
+        $dirs = [];
+        $raw = $params['srcDirs'] ?? [];
+        if (is_array($raw)) {
+            foreach ($raw as $dir) {
+                if (is_string($dir)) {
+                    $dirs[] = $dir;
+                }
+            }
+        }
+
+        $this->cachedIndex = $this->facade->indexProject($dirs);
+
+        return $this->cachedIndex->toArray();
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function resolveSymbol(array $params): ?array
+    {
+        $index = $this->requireIndex();
+        $definition = $this->facade->resolveSymbol(
+            $index,
+            (string) ($params['namespace'] ?? ''),
+            (string) ($params['symbol'] ?? ''),
+        );
+
+        return $definition?->toArray();
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function findReferences(array $params): array
+    {
+        $index = $this->requireIndex();
+        $locations = $this->facade->findReferences(
+            $index,
+            (string) ($params['namespace'] ?? ''),
+            (string) ($params['symbol'] ?? ''),
+        );
+
+        return array_map(static fn(Location $loc): array => $loc->toArray(), $locations);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function completeAtPoint(array $params): array
+    {
+        $index = $this->requireIndex();
+
+        $completions = $this->facade->completeAtPoint(
+            (string) ($params['source'] ?? ''),
+            is_int($params['line'] ?? null) ? $params['line'] : 1,
+            is_int($params['col'] ?? null) ? $params['col'] : 1,
+            $index,
+        );
+
+        return array_map(static fn(Completion $c): array => $c->toArray(), $completions);
+    }
+
+    private function requireIndex(): ProjectIndex
+    {
+        if (!$this->cachedIndex instanceof ProjectIndex) {
+            $this->cachedIndex = new ProjectIndex([], []);
+        }
+
+        return $this->cachedIndex;
+    }
+
+    /**
+     * @return array{id: mixed, error: array{code: int, message: string}}
+     */
+    private function errorResponse(mixed $id, int $code, string $message): array
+    {
+        return [
+            'id' => $id,
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ];
+    }
+}

--- a/src/php/Api/Infrastructure/Daemon/JsonRpcFraming.php
+++ b/src/php/Api/Infrastructure/Daemon/JsonRpcFraming.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Daemon;
+
+use RuntimeException;
+
+use function is_array;
+use function json_decode;
+use function json_encode;
+use function rtrim;
+use function strlen;
+
+/**
+ * Newline-delimited JSON framing for the Api daemon.
+ *
+ * Each request is a single JSON object on a line terminated by \n; responses
+ * use the same framing. This is simpler than Content-Length framing and works
+ * cleanly over stdio for editors that prefer line-oriented IPC.
+ */
+final class JsonRpcFraming
+{
+    /**
+     * @param resource $stream
+     *
+     * @return array<string, mixed>|null
+     */
+    public function readMessage($stream): ?array
+    {
+        $line = fgets($stream);
+        if ($line === false) {
+            return null;
+        }
+
+        $trimmed = rtrim($line, "\r\n");
+        if ($trimmed === '') {
+            return [];
+        }
+
+        $decoded = json_decode($trimmed, true);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON payload received by daemon');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param resource             $stream
+     * @param array<string, mixed> $message
+     */
+    public function writeMessage($stream, array $message): void
+    {
+        $json = json_encode($message, JSON_THROW_ON_ERROR);
+        fwrite($stream, $json . "\n");
+        fflush($stream);
+    }
+
+    public function frameLength(string $json): int
+    {
+        return strlen($json) + 1;
+    }
+}

--- a/src/php/Api/Infrastructure/Daemon/UnknownMethodException.php
+++ b/src/php/Api/Infrastructure/Daemon/UnknownMethodException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure\Daemon;
+
+use RuntimeException;
+
+final class UnknownMethodException extends RuntimeException {}

--- a/src/php/Api/Transfer/Completion.php
+++ b/src/php/Api/Transfer/Completion.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+final readonly class Completion
+{
+    public const string KIND_LOCAL = 'local';
+
+    public const string KIND_GLOBAL = 'global';
+
+    public const string KIND_REQUIRE = 'require';
+
+    public const string KIND_MACRO = 'macro';
+
+    public const string KIND_KEYWORD = 'keyword';
+
+    public function __construct(
+        public string $label,
+        public string $kind,
+        public string $detail = '',
+        public string $documentation = '',
+    ) {}
+
+    /**
+     * @return array{label: string, kind: string, detail: string, documentation: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'kind' => $this->kind,
+            'detail' => $this->detail,
+            'documentation' => $this->documentation,
+        ];
+    }
+}

--- a/src/php/Api/Transfer/Definition.php
+++ b/src/php/Api/Transfer/Definition.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+final readonly class Definition
+{
+    public const string KIND_DEFN = 'defn';
+
+    public const string KIND_DEF = 'def';
+
+    public const string KIND_DEFMACRO = 'defmacro';
+
+    public const string KIND_DEFSTRUCT = 'defstruct';
+
+    public const string KIND_DEFPROTOCOL = 'defprotocol';
+
+    public const string KIND_DEFINTERFACE = 'definterface';
+
+    public const string KIND_DEFEXCEPTION = 'defexception';
+
+    public const string KIND_UNKNOWN = 'unknown';
+
+    /**
+     * @param list<string> $signature
+     */
+    public function __construct(
+        public string $namespace,
+        public string $name,
+        public string $uri,
+        public int $line,
+        public int $col,
+        public string $kind,
+        public array $signature,
+        public string $docstring,
+        public bool $private,
+    ) {}
+
+    public function fullName(): string
+    {
+        return $this->namespace . '/' . $this->name;
+    }
+
+    /**
+     * @return array{
+     *     namespace: string,
+     *     name: string,
+     *     uri: string,
+     *     line: int,
+     *     col: int,
+     *     kind: string,
+     *     signature: list<string>,
+     *     docstring: string,
+     *     private: bool,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'namespace' => $this->namespace,
+            'name' => $this->name,
+            'uri' => $this->uri,
+            'line' => $this->line,
+            'col' => $this->col,
+            'kind' => $this->kind,
+            'signature' => $this->signature,
+            'docstring' => $this->docstring,
+            'private' => $this->private,
+        ];
+    }
+}

--- a/src/php/Api/Transfer/Diagnostic.php
+++ b/src/php/Api/Transfer/Diagnostic.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+final readonly class Diagnostic
+{
+    public const string SEVERITY_ERROR = 'error';
+
+    public const string SEVERITY_WARNING = 'warning';
+
+    public const string SEVERITY_INFO = 'info';
+
+    public const string SEVERITY_HINT = 'hint';
+
+    public function __construct(
+        public string $code,
+        public string $severity,
+        public string $message,
+        public string $uri,
+        public int $startLine,
+        public int $startCol,
+        public int $endLine,
+        public int $endCol,
+    ) {}
+
+    /**
+     * @return array{
+     *     code: string,
+     *     severity: string,
+     *     message: string,
+     *     uri: string,
+     *     startLine: int,
+     *     startCol: int,
+     *     endLine: int,
+     *     endCol: int,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'code' => $this->code,
+            'severity' => $this->severity,
+            'message' => $this->message,
+            'uri' => $this->uri,
+            'startLine' => $this->startLine,
+            'startCol' => $this->startCol,
+            'endLine' => $this->endLine,
+            'endCol' => $this->endCol,
+        ];
+    }
+}

--- a/src/php/Api/Transfer/Location.php
+++ b/src/php/Api/Transfer/Location.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+final readonly class Location
+{
+    public function __construct(
+        public string $uri,
+        public int $line,
+        public int $col,
+        public int $endLine = 0,
+        public int $endCol = 0,
+    ) {}
+
+    /**
+     * @return array{uri: string, line: int, col: int, endLine: int, endCol: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'uri' => $this->uri,
+            'line' => $this->line,
+            'col' => $this->col,
+            'endLine' => $this->endLine,
+            'endCol' => $this->endCol,
+        ];
+    }
+}

--- a/src/php/Api/Transfer/ProjectIndex.php
+++ b/src/php/Api/Transfer/ProjectIndex.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Transfer;
+
+use function array_filter;
+use function array_keys;
+use function array_unique;
+use function array_values;
+use function count;
+
+/**
+ * Immutable symbol table keyed by `namespace/name`.
+ *
+ * Caching hook: a future implementation can key this by file-hash via
+ * `ProjectIndexer` so that incremental reindexing avoids redoing parses
+ * for unchanged files. For v1 the index is built from scratch each time.
+ */
+final readonly class ProjectIndex
+{
+    /**
+     * @param array<string, Definition>     $definitions keyed by `namespace/name`
+     * @param array<string, list<Location>> $references  keyed by `namespace/name`
+     */
+    public function __construct(
+        public array $definitions,
+        public array $references = [],
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function namespaces(): array
+    {
+        $namespaces = [];
+        foreach ($this->definitions as $def) {
+            $namespaces[] = $def->namespace;
+        }
+
+        return array_values(array_unique($namespaces));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function definitionKeys(): array
+    {
+        return array_keys($this->definitions);
+    }
+
+    /**
+     * @return list<Definition>
+     */
+    public function definitionsInNamespace(string $namespace): array
+    {
+        $result = array_filter(
+            $this->definitions,
+            static fn(Definition $d): bool => $d->namespace === $namespace,
+        );
+
+        return array_values($result);
+    }
+
+    public function countDefinitions(): int
+    {
+        return count($this->definitions);
+    }
+
+    public function countNamespaces(): int
+    {
+        return count($this->namespaces());
+    }
+
+    /**
+     * @return array{
+     *     namespaces: int,
+     *     definitions: int,
+     *     symbols: array<string, array{
+     *         namespace: string,
+     *         name: string,
+     *         uri: string,
+     *         line: int,
+     *         col: int,
+     *         kind: string,
+     *         signature: list<string>,
+     *         docstring: string,
+     *         private: bool,
+     *     }>,
+     *     references: array<string, list<array{uri: string, line: int, col: int, endLine: int, endCol: int}>>,
+     * }
+     */
+    public function toArray(): array
+    {
+        $symbols = [];
+        foreach ($this->definitions as $key => $def) {
+            $symbols[$key] = $def->toArray();
+        }
+
+        $references = [];
+        foreach ($this->references as $key => $locations) {
+            $references[$key] = array_map(
+                static fn(Location $loc): array => $loc->toArray(),
+                $locations,
+            );
+        }
+
+        return [
+            'namespaces' => $this->countNamespaces(),
+            'definitions' => $this->countDefinitions(),
+            'symbols' => $symbols,
+            'references' => $references,
+        ];
+    }
+}

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -15,7 +15,10 @@ use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
+use Phel\Api\Infrastructure\Command\AnalyzeCommand;
+use Phel\Api\Infrastructure\Command\ApiDaemonCommand;
 use Phel\Api\Infrastructure\Command\DocCommand;
+use Phel\Api\Infrastructure\Command\IndexCommand;
 use Phel\Build\Infrastructure\Command\BuildCommand;
 use Phel\Build\Infrastructure\Command\CacheClearCommand;
 use Phel\Console\Application\VersionFinder;
@@ -64,6 +67,9 @@ final class ConsoleProvider extends AbstractProvider
             new RunCommand(),
             new TestCommand(),
             new DocCommand(),
+            new AnalyzeCommand(),
+            new IndexCommand(),
+            new ApiDaemonCommand(),
             new BuildCommand(),
             new CacheClearCommand(),
             new CacheWarmCommand(),

--- a/tests/php/Integration/Api/AnalyzeCommandTest.php
+++ b/tests/php/Integration/Api/AnalyzeCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Api;
+
+use Phel;
+use Phel\Api\Infrastructure\Command\AnalyzeCommand;
+use Phel\Api\Infrastructure\Command\ApiDaemonCommand;
+use Phel\Api\Infrastructure\Command\IndexCommand;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function json_decode;
+
+final class AnalyzeCommandTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_analyze_command_prints_json_diagnostics(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new AnalyzeCommand());
+        $exit = $tester->execute(['file' => __DIR__ . '/Fixtures/arity_mismatch.phel']);
+        self::assertSame(0, $exit);
+
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($decoded);
+        self::assertNotEmpty($decoded);
+        self::assertArrayHasKey('code', $decoded[0]);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_analyze_command_fails_when_file_missing(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new AnalyzeCommand());
+        $exit = $tester->execute(['file' => '/nonexistent/file.phel']);
+
+        self::assertSame(1, $exit);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_index_command_prints_summary(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new IndexCommand());
+        $exit = $tester->execute(['dirs' => [__DIR__ . '/Fixtures']]);
+        self::assertSame(0, $exit);
+
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('definitions', $decoded);
+        self::assertGreaterThan(0, $decoded['definitions']);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_api_daemon_command_is_registered(): void
+    {
+        $command = new ApiDaemonCommand();
+        self::assertSame('api-daemon', $command->getName());
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+}

--- a/tests/php/Integration/Api/ApiDaemonTest.php
+++ b/tests/php/Integration/Api/ApiDaemonTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Api;
+
+use Phel;
+use Phel\Api\ApiFacade;
+use Phel\Api\Infrastructure\Daemon\ApiDaemon;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+use function fwrite;
+use function json_decode;
+use function json_encode;
+use function rewind;
+use function stream_get_contents;
+
+final class ApiDaemonTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_dispatches_two_json_rpc_requests_over_in_memory_streams(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $facade = new ApiFacade();
+
+        $in = fopen('php://temp', 'r+');
+        $out = fopen('php://temp', 'r+');
+        self::assertNotFalse($in);
+        self::assertNotFalse($out);
+
+        // 1. analyzeSource with a broken source -> expect non-empty error diagnostics
+        fwrite($in, json_encode([
+            'id' => 1,
+            'method' => 'analyzeSource',
+            'params' => [
+                'source' => '(ns user) (unclosed',
+                'uri' => 'user.phel',
+            ],
+        ]) . "\n");
+
+        // 2. indexProject on the fixtures dir -> expect a definitions map
+        fwrite($in, json_encode([
+            'id' => 2,
+            'method' => 'indexProject',
+            'params' => [
+                'srcDirs' => [__DIR__ . '/Fixtures'],
+            ],
+        ]) . "\n");
+
+        rewind($in);
+
+        $daemon = new ApiDaemon($facade, $in, $out);
+        $daemon->run(2);
+
+        rewind($out);
+        $contents = stream_get_contents($out);
+        self::assertIsString($contents);
+
+        $lines = array_values(array_filter(explode("\n", $contents), static fn($l): bool => $l !== ''));
+        self::assertCount(2, $lines);
+
+        $first = json_decode($lines[0], true);
+        self::assertIsArray($first);
+        self::assertSame(1, $first['id']);
+        self::assertArrayHasKey('result', $first);
+        self::assertNotEmpty($first['result']);
+
+        $second = json_decode($lines[1], true);
+        self::assertIsArray($second);
+        self::assertSame(2, $second['id']);
+        self::assertArrayHasKey('result', $second);
+        self::assertGreaterThanOrEqual(1, $second['result']['definitions']);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_returns_an_error_response_for_unknown_method(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        $facade = new ApiFacade();
+
+        $in = fopen('php://temp', 'r+');
+        $out = fopen('php://temp', 'r+');
+        self::assertNotFalse($in);
+        self::assertNotFalse($out);
+
+        fwrite($in, json_encode([
+            'id' => 99,
+            'method' => 'nope',
+            'params' => [],
+        ]) . "\n");
+        rewind($in);
+
+        $daemon = new ApiDaemon($facade, $in, $out);
+        $daemon->run(1);
+
+        rewind($out);
+        $contents = stream_get_contents($out);
+        self::assertIsString($contents);
+        $decoded = json_decode(trim($contents), true);
+        self::assertIsArray($decoded);
+        self::assertSame(99, $decoded['id']);
+        self::assertArrayHasKey('error', $decoded);
+        self::assertSame(-32601, $decoded['error']['code']);
+    }
+}

--- a/tests/php/Integration/Api/Fixtures/arity_mismatch.phel
+++ b/tests/php/Integration/Api/Fixtures/arity_mismatch.phel
@@ -1,0 +1,3 @@
+(ns fixtures\arity)
+
+(if true 1 2 3)

--- a/tests/php/Integration/Api/Fixtures/bar.phel
+++ b/tests/php/Integration/Api/Fixtures/bar.phel
@@ -1,0 +1,5 @@
+(ns fixtures\bar
+  (:require fixtures\foo :as foo))
+
+(defn consumer []
+  (foo/greet "world"))

--- a/tests/php/Integration/Api/Fixtures/foo.phel
+++ b/tests/php/Integration/Api/Fixtures/foo.phel
@@ -1,0 +1,13 @@
+(ns fixtures\foo)
+
+(defn greet
+  "Greets the given name."
+  [name]
+  (str "Hello, " name "!"))
+
+(def answer 42)
+
+(defmacro noop
+  "Macro that does nothing."
+  [& body]
+  nil)

--- a/tests/php/Integration/Api/SemanticAnalysisTest.php
+++ b/tests/php/Integration/Api/SemanticAnalysisTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Api;
+
+use Phel;
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class SemanticAnalysisTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_reports_invalid_special_form_diagnostic_for_if_with_too_many_args(): void
+    {
+        $this->bootstrap();
+        $facade = new ApiFacade();
+
+        $source = file_get_contents(__DIR__ . '/Fixtures/arity_mismatch.phel');
+        self::assertNotFalse($source);
+
+        $diagnostics = $facade->analyzeSource($source, 'arity_mismatch.phel');
+
+        self::assertNotEmpty($diagnostics);
+        $codes = array_map(static fn(Diagnostic $d): string => $d->code, $diagnostics);
+        self::assertContains('PHEL007', $codes);
+
+        $first = $diagnostics[0];
+        self::assertGreaterThan(0, $first->startLine);
+        self::assertGreaterThanOrEqual(0, $first->startCol);
+        self::assertSame('arity_mismatch.phel', $first->uri);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_reports_unresolved_symbol_diagnostic(): void
+    {
+        $this->bootstrap();
+        $facade = new ApiFacade();
+
+        $diagnostics = $facade->analyzeSource('(ns user) (undef-symbol)', 'user.phel');
+
+        $codes = array_map(static fn(Diagnostic $d): string => $d->code, $diagnostics);
+        self::assertContains('PHEL001', $codes);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_indexes_fixture_directory_and_resolves_symbols(): void
+    {
+        $this->bootstrap();
+        $facade = new ApiFacade();
+
+        $index = $facade->indexProject([__DIR__ . '/Fixtures']);
+
+        self::assertGreaterThanOrEqual(4, $index->countDefinitions());
+        self::assertGreaterThanOrEqual(2, $index->countNamespaces());
+
+        $greet = $facade->resolveSymbol($index, 'fixtures\\foo', 'greet');
+        self::assertNotNull($greet);
+        self::assertSame('greet', $greet->name);
+        self::assertSame('fixtures\\foo', $greet->namespace);
+        self::assertSame(Definition::KIND_DEFN, $greet->kind);
+
+        $noop = $facade->resolveSymbol($index, 'fixtures\\foo', 'noop');
+        self::assertNotNull($noop);
+        self::assertSame(Definition::KIND_DEFMACRO, $noop->kind);
+
+        $answer = $facade->resolveSymbol($index, 'fixtures\\foo', 'answer');
+        self::assertNotNull($answer);
+        self::assertSame(Definition::KIND_DEF, $answer->kind);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_finds_references_to_a_symbol_across_files(): void
+    {
+        $this->bootstrap();
+        $facade = new ApiFacade();
+
+        $index = $facade->indexProject([__DIR__ . '/Fixtures']);
+
+        $refs = $facade->findReferences($index, 'fixtures\\foo', 'greet');
+
+        self::assertNotEmpty($refs);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_completes_local_bindings_inside_a_let(): void
+    {
+        $this->bootstrap();
+        $facade = new ApiFacade();
+
+        $source = <<<PHEL
+(ns user)
+(defn my-fn [x y]
+  (let [z (+ x y)
+        k 42]
+    z))
+PHEL;
+
+        $empty = new ProjectIndex([], []);
+        $completions = $facade->completeAtPoint($source, 5, 5, $empty);
+
+        $locals = array_values(array_filter(
+            $completions,
+            static fn(Completion $c): bool => $c->kind === 'local',
+        ));
+        $labels = array_map(static fn(Completion $c): string => $c->label, $locals);
+
+        self::assertContains('x', $labels);
+        self::assertContains('y', $labels);
+        self::assertContains('z', $labels);
+        self::assertContains('k', $labels);
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+}

--- a/tests/php/Unit/Api/Application/ReferenceFinderTest.php
+++ b/tests/php/Unit/Api/Application/ReferenceFinderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\ReferenceFinder;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+use PHPUnit\Framework\TestCase;
+
+final class ReferenceFinderTest extends TestCase
+{
+    public function test_it_returns_matching_references_for_qualified_key(): void
+    {
+        $finder = new ReferenceFinder();
+        $index = new ProjectIndex(
+            [],
+            ['user\\foo/bar' => [new Location('x.phel', 10, 2)]],
+        );
+
+        $refs = $finder->find($index, 'user\\foo', 'bar');
+
+        self::assertCount(1, $refs);
+        self::assertSame(10, $refs[0]->line);
+    }
+
+    public function test_it_returns_empty_when_no_references_known(): void
+    {
+        $finder = new ReferenceFinder();
+        $index = new ProjectIndex([], []);
+
+        self::assertSame([], $finder->find($index, 'user', 'unknown'));
+    }
+
+    public function test_it_falls_back_to_unqualified_reference_key(): void
+    {
+        $finder = new ReferenceFinder();
+        $index = new ProjectIndex(
+            [],
+            ['bar' => [new Location('x.phel', 1, 1)]],
+        );
+
+        $refs = $finder->find($index, 'user\\foo', 'bar');
+
+        self::assertCount(1, $refs);
+    }
+}

--- a/tests/php/Unit/Api/Application/SourceAnalyzerTest.php
+++ b/tests/php/Unit/Api/Application/SourceAnalyzerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\SourceAnalyzer;
+use Phel\Api\Domain\AnalysisStageInterface;
+use Phel\Api\Transfer\Diagnostic;
+use PHPUnit\Framework\TestCase;
+
+final class SourceAnalyzerTest extends TestCase
+{
+    public function test_it_runs_all_stages_and_aggregates_diagnostics(): void
+    {
+        $stage1 = $this->stageEmitting([
+            new Diagnostic('A1', Diagnostic::SEVERITY_WARNING, 'from stage 1', 'u', 1, 1, 1, 2),
+        ]);
+        $stage2 = $this->stageEmitting([
+            new Diagnostic('B1', Diagnostic::SEVERITY_ERROR, 'from stage 2', 'u', 2, 2, 2, 3),
+        ]);
+
+        $analyzer = new SourceAnalyzer([$stage1, $stage2]);
+
+        $result = $analyzer->analyze('(ns u)', 'u');
+
+        self::assertCount(2, $result);
+        self::assertSame('A1', $result[0]->code);
+        self::assertSame('B1', $result[1]->code);
+    }
+
+    public function test_it_returns_empty_list_when_no_stages_report(): void
+    {
+        $analyzer = new SourceAnalyzer([$this->stageEmitting([])]);
+
+        self::assertSame([], $analyzer->analyze('source', 'uri'));
+    }
+
+    /**
+     * @param list<Diagnostic> $output
+     */
+    private function stageEmitting(array $output): AnalysisStageInterface
+    {
+        return new readonly class($output) implements AnalysisStageInterface {
+            /**
+             * @param list<Diagnostic> $output
+             */
+            public function __construct(
+                private array $output,
+            ) {}
+
+            public function run(string $source, string $uri, array &$context): array
+            {
+                return $this->output;
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Api/Application/SymbolResolverTest.php
+++ b/tests/php/Unit/Api/Application/SymbolResolverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\SymbolResolver;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolResolverTest extends TestCase
+{
+    public function test_it_resolves_qualified_symbol(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = $this->indexWith([$this->makeDefinition('user\\foo', 'bar')]);
+
+        $def = $resolver->resolve($index, 'user\\other', 'user\\foo/bar');
+
+        self::assertNotNull($def);
+        self::assertSame('user\\foo/bar', $def->fullName());
+    }
+
+    public function test_it_resolves_in_current_namespace(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = $this->indexWith([$this->makeDefinition('user\\foo', 'bar')]);
+
+        $def = $resolver->resolve($index, 'user\\foo', 'bar');
+
+        self::assertNotNull($def);
+        self::assertSame('bar', $def->name);
+    }
+
+    public function test_it_falls_back_to_unqualified_lookup(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = $this->indexWith([$this->makeDefinition('user\\foo', 'unique-name')]);
+
+        $def = $resolver->resolve($index, 'other', 'unique-name');
+
+        self::assertNotNull($def);
+    }
+
+    public function test_it_returns_null_for_missing_symbol(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = $this->indexWith([]);
+
+        self::assertNull($resolver->resolve($index, 'user', 'missing'));
+    }
+
+    /**
+     * @param list<Definition> $definitions
+     */
+    private function indexWith(array $definitions): ProjectIndex
+    {
+        $map = [];
+        foreach ($definitions as $def) {
+            $map[$def->fullName()] = $def;
+        }
+
+        return new ProjectIndex($map);
+    }
+
+    private function makeDefinition(string $namespace, string $name): Definition
+    {
+        return new Definition(
+            namespace: $namespace,
+            name: $name,
+            uri: 'x.phel',
+            line: 1,
+            col: 1,
+            kind: Definition::KIND_DEFN,
+            signature: [],
+            docstring: '',
+            private: false,
+        );
+    }
+}

--- a/tests/php/Unit/Api/Infrastructure/Daemon/JsonRpcFramingTest.php
+++ b/tests/php/Unit/Api/Infrastructure/Daemon/JsonRpcFramingTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Infrastructure\Daemon;
+
+use Phel\Api\Infrastructure\Daemon\JsonRpcFraming;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class JsonRpcFramingTest extends TestCase
+{
+    public function test_it_reads_a_newline_delimited_json_message(): void
+    {
+        $framing = new JsonRpcFraming();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, '{"id":1,"method":"ping"}' . "\n");
+        rewind($stream);
+
+        $message = $framing->readMessage($stream);
+        fclose($stream);
+
+        self::assertSame(['id' => 1, 'method' => 'ping'], $message);
+    }
+
+    public function test_it_returns_null_when_stream_is_exhausted(): void
+    {
+        $framing = new JsonRpcFraming();
+        $stream = fopen('php://memory', 'r+');
+        rewind($stream);
+
+        self::assertNull($framing->readMessage($stream));
+        fclose($stream);
+    }
+
+    public function test_it_raises_on_invalid_json_payload(): void
+    {
+        $framing = new JsonRpcFraming();
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, "not-json\n");
+        rewind($stream);
+
+        try {
+            $framing->readMessage($stream);
+            self::fail('Expected RuntimeException');
+        } catch (RuntimeException) {
+            self::assertTrue(true);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function test_it_writes_a_newline_delimited_response(): void
+    {
+        $framing = new JsonRpcFraming();
+        $stream = fopen('php://memory', 'r+');
+        $framing->writeMessage($stream, ['id' => 1, 'result' => 'ok']);
+        rewind($stream);
+        $line = fgets($stream);
+        fclose($stream);
+
+        self::assertSame('{"id":1,"result":"ok"}' . "\n", $line);
+    }
+}

--- a/tests/php/Unit/Api/Transfer/DefinitionTest.php
+++ b/tests/php/Unit/Api/Transfer/DefinitionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Transfer;
+
+use Phel\Api\Transfer\Definition;
+use PHPUnit\Framework\TestCase;
+
+final class DefinitionTest extends TestCase
+{
+    public function test_it_builds_full_name_from_namespace_and_name(): void
+    {
+        $definition = $this->makeDefinition('user\\foo', 'bar');
+
+        self::assertSame('user\\foo/bar', $definition->fullName());
+    }
+
+    public function test_it_serializes_to_array(): void
+    {
+        $definition = new Definition(
+            namespace: 'user\\foo',
+            name: 'bar',
+            uri: 'foo.phel',
+            line: 3,
+            col: 5,
+            kind: Definition::KIND_DEFN,
+            signature: ['[x y]'],
+            docstring: 'adds',
+            private: false,
+        );
+
+        self::assertSame([
+            'namespace' => 'user\\foo',
+            'name' => 'bar',
+            'uri' => 'foo.phel',
+            'line' => 3,
+            'col' => 5,
+            'kind' => 'defn',
+            'signature' => ['[x y]'],
+            'docstring' => 'adds',
+            'private' => false,
+        ], $definition->toArray());
+    }
+
+    private function makeDefinition(string $namespace, string $name): Definition
+    {
+        return new Definition(
+            namespace: $namespace,
+            name: $name,
+            uri: 'x.phel',
+            line: 1,
+            col: 1,
+            kind: Definition::KIND_DEFN,
+            signature: [],
+            docstring: '',
+            private: false,
+        );
+    }
+}

--- a/tests/php/Unit/Api/Transfer/DiagnosticTest.php
+++ b/tests/php/Unit/Api/Transfer/DiagnosticTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Transfer;
+
+use Phel\Api\Transfer\Diagnostic;
+use PHPUnit\Framework\TestCase;
+
+final class DiagnosticTest extends TestCase
+{
+    public function test_it_exposes_fields_via_readonly_props(): void
+    {
+        $diagnostic = new Diagnostic(
+            code: 'PHEL001',
+            severity: Diagnostic::SEVERITY_ERROR,
+            message: 'something broke',
+            uri: 'user.phel',
+            startLine: 1,
+            startCol: 2,
+            endLine: 3,
+            endCol: 4,
+        );
+
+        self::assertSame('PHEL001', $diagnostic->code);
+        self::assertSame(Diagnostic::SEVERITY_ERROR, $diagnostic->severity);
+        self::assertSame('something broke', $diagnostic->message);
+        self::assertSame('user.phel', $diagnostic->uri);
+        self::assertSame(1, $diagnostic->startLine);
+        self::assertSame(2, $diagnostic->startCol);
+        self::assertSame(3, $diagnostic->endLine);
+        self::assertSame(4, $diagnostic->endCol);
+    }
+
+    public function test_it_serializes_to_array(): void
+    {
+        $diagnostic = new Diagnostic(
+            code: 'PHEL002',
+            severity: Diagnostic::SEVERITY_WARNING,
+            message: 'arity',
+            uri: 'f.phel',
+            startLine: 10,
+            startCol: 11,
+            endLine: 12,
+            endCol: 13,
+        );
+
+        self::assertSame([
+            'code' => 'PHEL002',
+            'severity' => 'warning',
+            'message' => 'arity',
+            'uri' => 'f.phel',
+            'startLine' => 10,
+            'startCol' => 11,
+            'endLine' => 12,
+            'endCol' => 13,
+        ], $diagnostic->toArray());
+    }
+}

--- a/tests/php/Unit/Api/Transfer/ProjectIndexTest.php
+++ b/tests/php/Unit/Api/Transfer/ProjectIndexTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Transfer;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectIndexTest extends TestCase
+{
+    public function test_it_reports_namespace_and_definition_counts(): void
+    {
+        $definitions = [
+            'user\\foo/a' => $this->makeDefinition('user\\foo', 'a'),
+            'user\\foo/b' => $this->makeDefinition('user\\foo', 'b'),
+            'user\\bar/c' => $this->makeDefinition('user\\bar', 'c'),
+        ];
+
+        $index = new ProjectIndex($definitions);
+
+        self::assertSame(3, $index->countDefinitions());
+        self::assertSame(2, $index->countNamespaces());
+        self::assertSame(['user\\foo', 'user\\bar'], $index->namespaces());
+    }
+
+    public function test_it_filters_definitions_by_namespace(): void
+    {
+        $definitions = [
+            'user\\foo/a' => $this->makeDefinition('user\\foo', 'a'),
+            'user\\bar/c' => $this->makeDefinition('user\\bar', 'c'),
+        ];
+
+        $index = new ProjectIndex($definitions);
+
+        self::assertCount(1, $index->definitionsInNamespace('user\\foo'));
+        self::assertCount(1, $index->definitionsInNamespace('user\\bar'));
+        self::assertCount(0, $index->definitionsInNamespace('unknown'));
+    }
+
+    public function test_it_serializes_to_array_including_references(): void
+    {
+        $index = new ProjectIndex(
+            ['user\\foo/a' => $this->makeDefinition('user\\foo', 'a')],
+            ['user\\foo/a' => [new Location('foo.phel', 1, 2)]],
+        );
+
+        $arr = $index->toArray();
+        self::assertSame(1, $arr['definitions']);
+        self::assertArrayHasKey('symbols', $arr);
+        self::assertArrayHasKey('user\\foo/a', $arr['references']);
+    }
+
+    private function makeDefinition(string $namespace, string $name): Definition
+    {
+        return new Definition(
+            namespace: $namespace,
+            name: $name,
+            uri: 'x.phel',
+            line: 1,
+            col: 1,
+            kind: Definition::KIND_DEFN,
+            signature: [],
+            docstring: '',
+            private: false,
+        );
+    }
+}


### PR DESCRIPTION
## Background

The `Api` module already surfaces core-API metadata (feeds `phel-lang.org/api.json`, drives IntelliJ completion). It does not cover user-code introspection, so every linter/LSP/editor has to reimplement the parser/analyzer to get diagnostics, jump-to-def, and references.

This PR closes that gap by exposing the Lexer -> Parser -> Analyzer output plus a project-level symbol index through the existing `ApiFacade`, matching roadmap item Tier 1 #2.

## Goal

Give one single source of truth for user-code semantic analysis that downstream tools (the future `phel lint`, LSP, IntelliJ bridge) can consume.

## Changes

- `ApiFacade` gains: `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint`, `createApiDaemon`.
- New transfer DTOs under `src/php/Api/Transfer/`: `Diagnostic`, `Definition`, `Location`, `Completion`, `ProjectIndex` (all `final readonly`).
- `SourceAnalyzer` is a stage pipeline (`LexAndParseStage`, `ReadAndAnalyzeStage`) consuming `CompilerFacade` directly, never re-implementing compiler phases.
- `ProjectIndexer` + `SymbolExtractor` walk `.phel` files, collecting `defn/def/defmacro/defstruct/definterface/defprotocol/defexception` with arity signatures, docstrings, `private` flag. Caching hook documented at the extractor call-site.
- `SymbolResolver` / `ReferenceFinder` work over the index; both qualified and short-name lookups supported.
- `PointCompleter` tracks `let`/`loop`/`for`/`binding`/`if-let`/`when-let`/`fn`/`defn` scope and merges locals with project defs and `phel\core` public API.
- Two delivery modes on top of the facade:
  - CLI sub-commands: `phel analyze <file>` (JSON diagnostics) and `phel index <dir>... [--out=file.json]` (summary + optional persistence).
  - Long-running daemon: `phel api-daemon` speaks newline-delimited JSON-RPC over stdio; framing and dispatch live in dedicated classes under `Infrastructure/Daemon/`.
- `ApiProvider` now also injects `CompilerFacade`; existing public API remains intact.
- Unit tests for DTOs, resolver, reference finder, analyzer pipeline, JSON-RPC framing.
- Integration tests for arity/unresolved diagnostics, project index + resolve + references, `completeAtPoint` on a `let`, CLI smoke, in-process daemon JSON-RPC round-trip.
- `src/php/Api/CLAUDE.md` documents the new surface.

CI on this PR runs `composer fix`, `composer test-quality`, `composer test-compiler`, `composer test-core` green locally.