### PR TITLE
feat(lint): add ./bin/phel lint semantic linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `phel nrepl --port=N --host=addr` starts a bencode-over-TCP nREPL server; supports `eval`, `clone`, `close`, `describe`, `load-file`, `interrupt`, plus `completions`, `lookup`, `info`, and `eldoc` for editor tooling
 - `phel analyze <file>` prints JSON semantic diagnostics; `phel index <dir>... [--out=file.json]` builds a project symbol table; `phel api-daemon` exposes the Api facade over newline-delimited JSON-RPC on stdio
 - `ApiFacade` gains `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint` for editor and linter tooling
+- `phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]` runs read-only semantic rules: unresolved-symbol, arity-mismatch, unused-binding, unused-require, unused-import, shadowed-binding, redundant-do, duplicate-key, invalid-destructuring, discouraged-var; configurable via `phel-lint.phel` with per-rule severity and glob opt-outs
 
 #### Agent docs
 - `.agents/` ships agent-agnostic docs with task recipes, per-platform adapters, and three runnable example projects (`todo-app`, `http-json-api`, `cli-wordcount`)

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -25,6 +25,7 @@ use Phel\Console\Application\VersionFinder;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
+use Phel\Lint\Infrastructure\Command\LintCommand;
 use Phel\Nrepl\Infrastructure\Command\NreplCommand;
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
@@ -81,6 +82,7 @@ final class ConsoleProvider extends AbstractProvider
             new ValidateConfigCommand(),
             new DoctorCommand(),
             new NreplCommand(),
+            new LintCommand(),
         ];
     }
 

--- a/src/php/Lint/Application/Cache/LintCache.php
+++ b/src/php/Lint/Application/Cache/LintCache.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Cache;
+
+use Phel\Api\Transfer\Diagnostic;
+
+use Throwable;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_array;
+use function is_dir;
+use function json_decode;
+use function json_encode;
+
+use function md5_file;
+use function mkdir;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Incremental lint cache: keyed by file-hash + analyzer version + rule-set
+ * fingerprint so stale entries self-invalidate. Stores per-file diagnostic
+ * payloads under `.phel/lint-cache/`. v1 uses a single JSON index file.
+ *
+ * The cache is opt-in: callers pass an absolute base directory (usually
+ * the project root + `.phel/lint-cache/`). When the directory cannot be
+ * created we degrade silently — lint still works, just without caching.
+ */
+final class LintCache
+{
+    private const string INDEX_FILE = 'index.json';
+
+    /** @var array<string, array{hash: string, fingerprint: string, diagnostics: list<array<string, mixed>>}>|null */
+    private ?array $index = null;
+
+    public function __construct(
+        private readonly string $cacheDir,
+        private readonly string $fingerprint,
+    ) {}
+
+    /**
+     * @return ?list<Diagnostic>
+     */
+    public function get(string $filePath): ?array
+    {
+        $this->ensureLoaded();
+        if (!isset($this->index[$filePath])) {
+            return null;
+        }
+
+        $entry = $this->index[$filePath];
+        if ($entry['fingerprint'] !== $this->fingerprint) {
+            return null;
+        }
+
+        $currentHash = $this->hashOf($filePath);
+        if ($currentHash === null || $currentHash !== $entry['hash']) {
+            return null;
+        }
+
+        $diagnostics = [];
+        foreach ($entry['diagnostics'] as $data) {
+            $diagnostics[] = new Diagnostic(
+                code: (string) ($data['code'] ?? ''),
+                severity: (string) ($data['severity'] ?? Diagnostic::SEVERITY_WARNING),
+                message: (string) ($data['message'] ?? ''),
+                uri: (string) ($data['uri'] ?? $filePath),
+                startLine: (int) ($data['startLine'] ?? 1),
+                startCol: (int) ($data['startCol'] ?? 1),
+                endLine: (int) ($data['endLine'] ?? 1),
+                endCol: (int) ($data['endCol'] ?? 1),
+            );
+        }
+
+        return $diagnostics;
+    }
+
+    /**
+     * @param list<Diagnostic> $diagnostics
+     */
+    public function put(string $filePath, array $diagnostics): void
+    {
+        $this->ensureLoaded();
+        $hash = $this->hashOf($filePath);
+        if ($hash === null) {
+            return;
+        }
+
+        $payload = [];
+        foreach ($diagnostics as $diagnostic) {
+            $payload[] = $diagnostic->toArray();
+        }
+
+        $this->index[$filePath] = [
+            'hash' => $hash,
+            'fingerprint' => $this->fingerprint,
+            'diagnostics' => $payload,
+        ];
+    }
+
+    public function flush(): void
+    {
+        if ($this->index === null) {
+            return;
+        }
+
+        if (!$this->ensureCacheDir()) {
+            return;
+        }
+
+        $indexPath = $this->indexPath();
+        @file_put_contents(
+            $indexPath,
+            json_encode($this->index, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function ensureLoaded(): void
+    {
+        if ($this->index !== null) {
+            return;
+        }
+
+        $this->index = [];
+        $indexPath = $this->indexPath();
+        if (!file_exists($indexPath)) {
+            return;
+        }
+
+        $raw = @file_get_contents($indexPath);
+        if ($raw === false) {
+            return;
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return;
+        }
+
+        if (!is_array($decoded)) {
+            return;
+        }
+
+        /** @var array<string, array{hash: string, fingerprint: string, diagnostics: list<array<string, mixed>>}> $decoded */
+        $this->index = $decoded;
+    }
+
+    private function hashOf(string $filePath): ?string
+    {
+        $hash = @md5_file($filePath);
+
+        return $hash === false ? null : $hash;
+    }
+
+    private function ensureCacheDir(): bool
+    {
+        if (is_dir($this->cacheDir)) {
+            return true;
+        }
+
+        return @mkdir($this->cacheDir, 0o755, true) || is_dir($this->cacheDir);
+    }
+
+    private function indexPath(): string
+    {
+        return rtrim($this->cacheDir, '/') . '/' . self::INDEX_FILE;
+    }
+}

--- a/src/php/Lint/Application/Config/ConfigLoader.php
+++ b/src/php/Lint/Application/Config/ConfigLoader.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Config;
+
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+use Throwable;
+
+use function count;
+use function file_get_contents;
+use function is_file;
+use function is_string;
+
+/**
+ * Loads a `.phel-lint.phel` EDN-style config into a `RuleSettings`
+ * instance. Missing files are not an error: callers just get defaults.
+ *
+ * Expected shape (Phel map of keywords):
+ *
+ * ```phel
+ * {:rules {:phel/unused-binding :off
+ *          :phel/arity-mismatch :error}
+ *  :exclude {:phel/unused-binding ["src/phel/local.phel" "phel.experimental.*"]}}
+ * ```
+ */
+final readonly class ConfigLoader
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    public function load(string $path, RuleSettings $defaults): RuleSettings
+    {
+        if (!is_file($path)) {
+            return $defaults;
+        }
+
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            return $defaults;
+        }
+
+        $map = $this->parseMap($contents, $path);
+        if (!$map instanceof PersistentMapInterface) {
+            return $defaults;
+        }
+
+        $severities = $this->extractSeverities($map);
+        $excludes = $this->extractExcludes($map);
+
+        return $defaults->withOverrides($severities, $excludes);
+    }
+
+    private function parseMap(string $source, string $uri): ?PersistentMapInterface
+    {
+        try {
+            $tokenStream = $this->compilerFacade->lexString($source, $uri);
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException) {
+                    return null;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    return null;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                try {
+                    $readerResult = $this->compilerFacade->read($parseTree);
+                } catch (ReaderException) {
+                    return null;
+                }
+
+                $form = $readerResult->getAst();
+                if ($form instanceof PersistentMapInterface) {
+                    return $form;
+                }
+
+                return null;
+            }
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function extractSeverities(PersistentMapInterface $map): array
+    {
+        $rulesNode = $map->find(Keyword::create('rules'));
+        if (!$rulesNode instanceof PersistentMapInterface) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($rulesNode as $key => $value) {
+            $code = $this->keywordOrStringName($key);
+            $severity = $this->keywordOrStringName($value);
+            if ($code === null) {
+                continue;
+            }
+
+            if ($severity === null) {
+                continue;
+            }
+
+            $result[$code] = $severity;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function extractExcludes(PersistentMapInterface $map): array
+    {
+        $excludesNode = $map->find(Keyword::create('exclude'));
+        if (!$excludesNode instanceof PersistentMapInterface) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($excludesNode as $key => $value) {
+            $code = $this->keywordOrStringName($key);
+            if ($code === null) {
+                continue;
+            }
+
+            $patterns = $this->collectStringPatterns($value);
+            if ($patterns !== []) {
+                $result[$code] = $patterns;
+            }
+        }
+
+        return $result;
+    }
+
+    private function keywordOrStringName(mixed $value): ?string
+    {
+        if ($value instanceof Keyword) {
+            $ns = $value->getNamespace();
+            $name = $value->getName();
+
+            return $ns === null || $ns === '' ? $name : $ns . '/' . $name;
+        }
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectStringPatterns(mixed $value): array
+    {
+        $result = [];
+        if ($value instanceof PersistentVectorInterface || $value instanceof PersistentListInterface) {
+            $size = count($value);
+            for ($i = 0; $i < $size; ++$i) {
+                $item = $value->get($i);
+                if (is_string($item) && $item !== '') {
+                    $result[] = $item;
+                }
+            }
+        } elseif (is_string($value) && $value !== '') {
+            $result[] = $value;
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Lint/Application/Config/RuleRegistry.php
+++ b/src/php/Lint/Application/Config/RuleRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Config;
+
+/**
+ * Stable list of all lint rule codes shipped in v1. Centralised so every
+ * consumer (defaults, config loader, formatters, tests) shares one vocabulary.
+ */
+final class RuleRegistry
+{
+    public const string UNRESOLVED_SYMBOL = 'phel/unresolved-symbol';
+
+    public const string ARITY_MISMATCH = 'phel/arity-mismatch';
+
+    public const string UNUSED_BINDING = 'phel/unused-binding';
+
+    public const string UNUSED_REQUIRE = 'phel/unused-require';
+
+    public const string UNUSED_IMPORT = 'phel/unused-import';
+
+    public const string SHADOWED_BINDING = 'phel/shadowed-binding';
+
+    public const string REDUNDANT_DO = 'phel/redundant-do';
+
+    public const string DUPLICATE_KEY = 'phel/duplicate-key';
+
+    public const string INVALID_DESTRUCTURING = 'phel/invalid-destructuring';
+
+    public const string DISCOURAGED_VAR = 'phel/discouraged-var';
+
+    /**
+     * @return list<string>
+     */
+    public static function allCodes(): array
+    {
+        return [
+            self::UNRESOLVED_SYMBOL,
+            self::ARITY_MISMATCH,
+            self::UNUSED_BINDING,
+            self::UNUSED_REQUIRE,
+            self::UNUSED_IMPORT,
+            self::SHADOWED_BINDING,
+            self::REDUNDANT_DO,
+            self::DUPLICATE_KEY,
+            self::INVALID_DESTRUCTURING,
+            self::DISCOURAGED_VAR,
+        ];
+    }
+}

--- a/src/php/Lint/Application/Config/RuleSettings.php
+++ b/src/php/Lint/Application/Config/RuleSettings.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Config;
+
+use Phel\Api\Transfer\Diagnostic;
+
+use function array_key_exists;
+use function fnmatch;
+use function in_array;
+
+/**
+ * Per-rule severities plus opt-out patterns. Values are the constants
+ * defined on `Diagnostic` (`error`, `warning`, `info`, `hint`) plus
+ * `off` which disables the rule entirely.
+ */
+final readonly class RuleSettings
+{
+    public const string SEVERITY_OFF = 'off';
+
+    private const array VALID_SEVERITIES = [
+        Diagnostic::SEVERITY_ERROR,
+        Diagnostic::SEVERITY_WARNING,
+        Diagnostic::SEVERITY_INFO,
+        Diagnostic::SEVERITY_HINT,
+        self::SEVERITY_OFF,
+    ];
+
+    /**
+     * @param array<string, string>       $severities   ruleCode => severity
+     * @param array<string, list<string>> $excludeGlobs ruleCode => list of glob patterns (file path OR namespace)
+     */
+    public function __construct(
+        public array $severities,
+        public array $excludeGlobs = [],
+    ) {}
+
+    /**
+     * @param array<string, string> $map
+     */
+    public static function fromMap(array $map): self
+    {
+        $severities = [];
+        foreach ($map as $code => $severity) {
+            if (in_array($severity, self::VALID_SEVERITIES, true)) {
+                $severities[$code] = $severity;
+            }
+        }
+
+        return new self($severities, []);
+    }
+
+    /**
+     * Merge another set of settings on top of this one (other wins).
+     *
+     * @param array<string, string>       $severities
+     * @param array<string, list<string>> $excludeGlobs
+     */
+    public function withOverrides(array $severities, array $excludeGlobs): self
+    {
+        $merged = $this->severities;
+        foreach ($severities as $code => $sev) {
+            if (in_array($sev, self::VALID_SEVERITIES, true)) {
+                $merged[$code] = $sev;
+            }
+        }
+
+        $mergedGlobs = $this->excludeGlobs;
+        foreach ($excludeGlobs as $code => $patterns) {
+            $existing = $mergedGlobs[$code] ?? [];
+            foreach ($patterns as $pattern) {
+                if (!in_array($pattern, $existing, true)) {
+                    $existing[] = $pattern;
+                }
+            }
+
+            $mergedGlobs[$code] = $existing;
+        }
+
+        return new self($merged, $mergedGlobs);
+    }
+
+    public function severityFor(string $ruleCode): string
+    {
+        return $this->severities[$ruleCode] ?? self::SEVERITY_OFF;
+    }
+
+    public function isEnabled(string $ruleCode): bool
+    {
+        return array_key_exists($ruleCode, $this->severities)
+            && $this->severities[$ruleCode] !== self::SEVERITY_OFF;
+    }
+
+    /**
+     * Should diagnostics for this rule be suppressed for the given file or namespace?
+     */
+    public function isExcluded(string $ruleCode, string $filePath, string $namespace): bool
+    {
+        $patterns = $this->excludeGlobs[$ruleCode] ?? [];
+        if ($patterns === []) {
+            return false;
+        }
+
+        foreach ($patterns as $pattern) {
+            if ($this->matchesPattern($pattern, $filePath, $namespace)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesPattern(string $pattern, string $filePath, string $namespace): bool
+    {
+        if ($pattern === '') {
+            return false;
+        }
+
+        // A pattern may match either the file path or the namespace; we try
+        // both so a user doesn't have to know which representation we compare.
+        // `FNM_NOESCAPE` keeps `\\` literal so Phel namespaces like
+        // `phel\\core` match without the caller needing to escape them.
+        if (fnmatch($pattern, $filePath, FNM_NOESCAPE)) {
+            return true;
+        }
+
+        return $namespace !== '' && fnmatch($pattern, $namespace, FNM_NOESCAPE);
+    }
+}

--- a/src/php/Lint/Application/FileCollector.php
+++ b/src/php/Lint/Application/FileCollector.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
+
+use function is_dir;
+use function is_file;
+use function realpath;
+
+/**
+ * Expands a mix of files and directories on the CLI into a deduplicated
+ * flat list of `.phel` file paths. Directories are walked recursively.
+ */
+final class FileCollector
+{
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    public function collect(array $paths): array
+    {
+        $files = [];
+        $seen = [];
+
+        foreach ($paths as $path) {
+            $real = realpath($path);
+            if ($real === false) {
+                continue;
+            }
+
+            if (is_file($real)) {
+                if (!isset($seen[$real])) {
+                    $files[] = $real;
+                    $seen[$real] = true;
+                }
+
+                continue;
+            }
+
+            if (is_dir($real)) {
+                foreach ($this->iteratePhelFiles($real) as $file) {
+                    if (!isset($seen[$file])) {
+                        $files[] = $file;
+                        $seen[$file] = true;
+                    }
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function iteratePhelFiles(string $directory): iterable
+    {
+        try {
+            $dirIterator = new RecursiveDirectoryIterator($directory);
+            $iterator = new RecursiveIteratorIterator($dirIterator);
+            $regex = new RegexIterator($iterator, '/^.+\.phel$/i', RegexIterator::GET_MATCH);
+        } catch (UnexpectedValueException) {
+            return [];
+        }
+
+        foreach ($regex as $match) {
+            yield $match[0];
+        }
+    }
+}

--- a/src/php/Lint/Application/Formatter/FormatterRegistry.php
+++ b/src/php/Lint/Application/Formatter/FormatterRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Formatter;
+
+use InvalidArgumentException;
+use Phel\Lint\Domain\DiagnosticFormatterInterface;
+
+use function sprintf;
+
+/**
+ * Small, open-for-extension lookup: add a new formatter by instantiating
+ * it and calling `register()`. Callers ask by name (`human`, `json`,
+ * `github`, ...).
+ */
+final class FormatterRegistry
+{
+    /** @var array<string, DiagnosticFormatterInterface> */
+    private array $formatters = [];
+
+    public function register(DiagnosticFormatterInterface $formatter): void
+    {
+        $this->formatters[$formatter->name()] = $formatter;
+    }
+
+    public function get(string $name): DiagnosticFormatterInterface
+    {
+        if (!isset($this->formatters[$name])) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown lint formatter: %s. Known: %s.',
+                $name,
+                implode(', ', array_keys($this->formatters)),
+            ));
+        }
+
+        return $this->formatters[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->formatters[$name]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return array_keys($this->formatters);
+    }
+}

--- a/src/php/Lint/Application/Formatter/GithubFormatter.php
+++ b/src/php/Lint/Application/Formatter/GithubFormatter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Formatter;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Domain\DiagnosticFormatterInterface;
+use Phel\Lint\Transfer\LintResult;
+
+use function sprintf;
+use function str_replace;
+
+/**
+ * Emits the GitHub Actions workflow-command annotation format:
+ *
+ *     ::warning file=path,line=N,col=M,title=CODE::message
+ *
+ * One diagnostic per line. Values are sanitised per the GitHub spec:
+ * `%`, `\r`, `\n` in messages are percent-encoded.
+ */
+final class GithubFormatter implements DiagnosticFormatterInterface
+{
+    public const string NAME = 'github';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function format(LintResult $result): string
+    {
+        $lines = [];
+        foreach ($result->diagnostics as $diagnostic) {
+            $lines[] = $this->formatDiagnostic($diagnostic);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function formatDiagnostic(Diagnostic $diagnostic): string
+    {
+        $level = match ($diagnostic->severity) {
+            Diagnostic::SEVERITY_ERROR => 'error',
+            Diagnostic::SEVERITY_INFO, Diagnostic::SEVERITY_HINT => 'notice',
+            default => 'warning',
+        };
+
+        return sprintf(
+            '::%s file=%s,line=%d,col=%d,endLine=%d,endColumn=%d,title=%s::%s',
+            $level,
+            $this->encodeProperty($diagnostic->uri),
+            $diagnostic->startLine,
+            $diagnostic->startCol,
+            $diagnostic->endLine,
+            $diagnostic->endCol,
+            $this->encodeProperty($diagnostic->code),
+            $this->encodeData($diagnostic->message),
+        );
+    }
+
+    /**
+     * GitHub property values escape `%`, `\r`, `\n`, `:`, `,`.
+     */
+    private function encodeProperty(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n", ':', ','],
+            ['%25', '%0D', '%0A', '%3A', '%2C'],
+            $value,
+        );
+    }
+
+    /**
+     * Message data escapes `%`, `\r`, `\n` only.
+     */
+    private function encodeData(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n"],
+            ['%25', '%0D', '%0A'],
+            $value,
+        );
+    }
+}

--- a/src/php/Lint/Application/Formatter/HumanFormatter.php
+++ b/src/php/Lint/Application/Formatter/HumanFormatter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Formatter;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Domain\DiagnosticFormatterInterface;
+use Phel\Lint\Transfer\LintResult;
+
+use function sprintf;
+
+/**
+ * Human-readable single-line-per-diagnostic format:
+ *
+ *     file:line:col severity code message
+ */
+final class HumanFormatter implements DiagnosticFormatterInterface
+{
+    public const string NAME = 'human';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function format(LintResult $result): string
+    {
+        if ($result->diagnostics === []) {
+            return 'No lint issues found.';
+        }
+
+        $lines = [];
+        foreach ($result->diagnostics as $diagnostic) {
+            $lines[] = $this->formatDiagnostic($diagnostic);
+        }
+
+        $lines[] = '';
+        $lines[] = sprintf(
+            '%d issue(s): %d error(s), %d warning(s), %d info.',
+            $result->totalCount(),
+            $result->errorCount(),
+            $result->warningCount(),
+            $result->infoCount(),
+        );
+
+        return implode("\n", $lines);
+    }
+
+    private function formatDiagnostic(Diagnostic $diagnostic): string
+    {
+        return sprintf(
+            '%s:%d:%d %s %s %s',
+            $diagnostic->uri,
+            $diagnostic->startLine,
+            $diagnostic->startCol,
+            $this->severityLabel($diagnostic->severity),
+            $diagnostic->code,
+            $diagnostic->message,
+        );
+    }
+
+    private function severityLabel(string $severity): string
+    {
+        return match ($severity) {
+            Diagnostic::SEVERITY_ERROR => '[error]',
+            Diagnostic::SEVERITY_WARNING => '[warning]',
+            Diagnostic::SEVERITY_INFO => '[info]',
+            Diagnostic::SEVERITY_HINT => '[hint]',
+            default => '[' . $severity . ']',
+        };
+    }
+}

--- a/src/php/Lint/Application/Formatter/JsonFormatter.php
+++ b/src/php/Lint/Application/Formatter/JsonFormatter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Formatter;
+
+use Phel\Lint\Domain\DiagnosticFormatterInterface;
+use Phel\Lint\Transfer\LintResult;
+
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * Stable JSON array of diagnostic objects.
+ * Keys match `Diagnostic::toArray()` for editor/CI consumption.
+ */
+final class JsonFormatter implements DiagnosticFormatterInterface
+{
+    public const string NAME = 'json';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function format(LintResult $result): string
+    {
+        return json_encode(
+            $result->toArray(),
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES,
+        );
+    }
+}

--- a/src/php/Lint/Application/LintRunner.php
+++ b/src/php/Lint/Application/LintRunner.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Transfer\LintResult;
+
+use function file_get_contents;
+use function is_dir;
+
+/**
+ * Orchestrator: takes a mix of paths + settings, expands to `.phel` files,
+ * fetches a project index, analyses each file, runs the rule pipeline,
+ * and returns a single `LintResult`.
+ *
+ * Caching is optional: when a `LintCache` is injected, files whose hash
+ * and rule fingerprint match the cache bypass the pipeline entirely.
+ */
+final readonly class LintRunner
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private FileCollector $fileCollector,
+        private SourceReader $sourceReader,
+        private RulePipeline $pipeline,
+        private ?LintCache $cache = null,
+    ) {}
+
+    /**
+     * @param list<string> $paths
+     */
+    public function run(array $paths, RuleSettings $settings): LintResult
+    {
+        $files = $this->fileCollector->collect($paths);
+        if ($files === []) {
+            return new LintResult([], []);
+        }
+
+        $projectIndex = $this->buildProjectIndex($paths);
+
+        $allDiagnostics = [];
+        foreach ($files as $file) {
+            $cached = $this->cache?->get($file);
+            if ($cached !== null) {
+                foreach ($cached as $diagnostic) {
+                    $allDiagnostics[] = $diagnostic;
+                }
+
+                continue;
+            }
+
+            $source = @file_get_contents($file);
+            if ($source === false) {
+                continue;
+            }
+
+            $read = $this->sourceReader->read($source, $file);
+            $semantic = $this->apiFacade->analyzeSource($source, $file);
+
+            $analysis = new FileAnalysis(
+                uri: $file,
+                namespace: $read['namespace'],
+                source: $source,
+                forms: $read['forms'],
+                projectIndex: $projectIndex,
+                semanticDiagnostics: $semantic,
+            );
+
+            $fileDiagnostics = $this->pipeline->run($analysis, $settings);
+            $this->cache?->put($file, $fileDiagnostics);
+
+            foreach ($fileDiagnostics as $diagnostic) {
+                $allDiagnostics[] = $diagnostic;
+            }
+        }
+
+        $this->cache?->flush();
+
+        return new LintResult($allDiagnostics, $files);
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private function buildProjectIndex(array $paths): ProjectIndex
+    {
+        $dirs = [];
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                $dirs[] = $path;
+            }
+        }
+
+        if ($dirs === []) {
+            return new ProjectIndex([], []);
+        }
+
+        return $this->apiFacade->indexProject($dirs);
+    }
+}

--- a/src/php/Lint/Application/Rule/ArityMismatchRule.php
+++ b/src/php/Lint/Application/Rule/ArityMismatchRule.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Compiler\Domain\Exceptions\ErrorCode;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function sprintf;
+
+/**
+ * Two-track arity check:
+ *
+ * 1. Promotes any `PHEL002` arity diagnostic the analyzer already raised
+ *    (wrong arity on special forms like `if`, `let`, etc.).
+ * 2. Scans same-file call-sites against locally-defined `defn`/`defn-`
+ *    signatures and flags obvious arity mismatches the analyzer cannot
+ *    surface (ordering-dependent, Analyzer sees the call before the def).
+ *
+ * Cross-namespace arity (via `ProjectIndex`) is deferred to v2 — the
+ * v1 index stores formatted signatures, not parsed parameter lists.
+ */
+final readonly class ArityMismatchRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::ARITY_MISMATCH;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = $this->promoteSemanticArityErrors($analysis);
+
+        $localFns = $this->collectLocalFunctions($analysis->forms);
+        if ($localFns === []) {
+            return $result;
+        }
+
+        foreach ($analysis->forms as $form) {
+            $this->inspectCalls($form, $localFns, $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<Diagnostic>
+     */
+    private function promoteSemanticArityErrors(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->semanticDiagnostics as $diagnostic) {
+            if ($diagnostic->code !== ErrorCode::ARITY_ERROR->value) {
+                continue;
+            }
+
+            $result[] = new Diagnostic(
+                code: $this->code(),
+                severity: $diagnostic->severity,
+                message: $diagnostic->message,
+                uri: $diagnostic->uri,
+                startLine: $diagnostic->startLine,
+                startCol: $diagnostic->startCol,
+                endLine: $diagnostic->endLine,
+                endCol: $diagnostic->endCol,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<mixed> $forms
+     *
+     * @return array<string, array{min:int, max:int}>
+     */
+    private function collectLocalFunctions(array $forms): array
+    {
+        $fns = [];
+        foreach ($forms as $form) {
+            if (!$form instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($form) < 3) {
+                continue;
+            }
+
+            $head = $form->get(0);
+            if (!$head instanceof Symbol) {
+                continue;
+            }
+
+            $name = $head->getName();
+            if ($name !== 'defn' && $name !== 'defn-') {
+                continue;
+            }
+
+            $defName = $form->get(1);
+            if (!$defName instanceof Symbol) {
+                continue;
+            }
+
+            $arities = $this->collectArities($form);
+            if ($arities === null) {
+                continue;
+            }
+
+            $fns[$defName->getName()] = $arities;
+        }
+
+        return $fns;
+    }
+
+    /**
+     * @return ?array{min:int, max:int}
+     */
+    private function collectArities(PersistentListInterface $form): ?array
+    {
+        $size = count($form);
+        $minArity = PHP_INT_MAX;
+        $maxArity = 0;
+        $variadic = false;
+        $found = false;
+
+        for ($i = 2; $i < $size; ++$i) {
+            $child = $form->get($i);
+
+            if ($child instanceof PersistentVectorInterface) {
+                [$arity, $isVariadic] = $this->analyseArityVector($child);
+                $found = true;
+                $minArity = min($minArity, $arity);
+                $maxArity = max($maxArity, $arity);
+                if ($isVariadic) {
+                    $variadic = true;
+                }
+
+                break; // single-arity form: first vector is the param list.
+            }
+
+            if ($child instanceof PersistentListInterface && count($child) > 0) {
+                $head = $child->get(0);
+                if ($head instanceof PersistentVectorInterface) {
+                    [$arity, $isVariadic] = $this->analyseArityVector($head);
+                    $found = true;
+                    $minArity = min($minArity, $arity);
+                    $maxArity = max($maxArity, $arity);
+                    if ($isVariadic) {
+                        $variadic = true;
+                    }
+                }
+            }
+        }
+
+        if (!$found) {
+            return null;
+        }
+
+        return [
+            'min' => $minArity,
+            'max' => $variadic ? PHP_INT_MAX : $maxArity,
+        ];
+    }
+
+    /**
+     * @return array{int, bool}
+     */
+    private function analyseArityVector(PersistentVectorInterface $params): array
+    {
+        $count = count($params);
+        $variadic = false;
+
+        for ($i = 0; $i < $count; ++$i) {
+            $p = $params->get($i);
+            if ($p instanceof Symbol && $p->getName() === '&') {
+                $variadic = true;
+                // Arity excludes the `&` marker and collects all before it as fixed arity.
+                $count = $i;
+
+                break;
+            }
+        }
+
+        return [$count, $variadic];
+    }
+
+    /**
+     * @param array<string, array{min:int, max:int}> $localFns
+     * @param list<Diagnostic>                       $result
+     */
+    private function inspectCalls(mixed $form, array $localFns, string $uri, array &$result): void
+    {
+        if ($form instanceof PersistentListInterface && count($form) > 0) {
+            $head = $form->get(0);
+            if ($head instanceof Symbol && $head->getNamespace() === null) {
+                $name = $head->getName();
+                if (isset($localFns[$name])) {
+                    $given = count($form) - 1;
+                    $min = $localFns[$name]['min'];
+                    $max = $localFns[$name]['max'];
+
+                    if ($given < $min || $given > $max) {
+                        $expected = $max === PHP_INT_MAX ? ($min . '+') : (string) $min;
+                        $message = sprintf(
+                            "Wrong number of arguments for '%s'. Expected %s, given %d.",
+                            $name,
+                            $expected,
+                            $given,
+                        );
+                        $result[] = DiagnosticBuilder::fromForm(
+                            $this->code(),
+                            $message,
+                            $uri,
+                            $form,
+                        );
+                    }
+                }
+            }
+
+            foreach ($form as $child) {
+                $this->inspectCalls($child, $localFns, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->inspectCalls($child, $localFns, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->inspectCalls($k, $localFns, $uri, $result);
+                $this->inspectCalls($v, $localFns, $uri, $result);
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/DiagnosticBuilder.php
+++ b/src/php/Lint/Application/Rule/DiagnosticBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\TypeInterface;
+
+/**
+ * Small helper so each rule can produce a Diagnostic without repeating
+ * location-extraction logic. Severity is a placeholder at rule time
+ * (`Diagnostic::SEVERITY_WARNING`); the facade rewrites it based on
+ * the configured severity for the rule code.
+ */
+final class DiagnosticBuilder
+{
+    public static function fromForm(
+        string $code,
+        string $message,
+        string $uri,
+        TypeInterface|string|float|int|bool|null $form,
+    ): Diagnostic {
+        [$startLine, $startCol, $endLine, $endCol] = self::locationOf($form);
+
+        return new Diagnostic(
+            code: $code,
+            severity: Diagnostic::SEVERITY_WARNING,
+            message: $message,
+            uri: $uri,
+            startLine: $startLine,
+            startCol: $startCol,
+            endLine: $endLine,
+            endCol: $endCol,
+        );
+    }
+
+    /**
+     * @return array{int, int, int, int}
+     */
+    private static function locationOf(mixed $form): array
+    {
+        if ($form instanceof TypeInterface) {
+            $start = $form->getStartLocation();
+            $end = $form->getEndLocation();
+
+            $startLine = $start instanceof SourceLocation ? $start->getLine() : 1;
+            $startCol = $start instanceof SourceLocation ? $start->getColumn() : 1;
+            $endLine = $end instanceof SourceLocation ? $end->getLine() : $startLine;
+            $endCol = $end instanceof SourceLocation ? $end->getColumn() : $startCol;
+
+            return [$startLine, $startCol, $endLine, $endCol];
+        }
+
+        return [1, 1, 1, 1];
+    }
+}

--- a/src/php/Lint/Application/Rule/DiscouragedVarRule.php
+++ b/src/php/Lint/Application/Rule/DiscouragedVarRule.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function in_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * Flags references to definitions marked `^:deprecated` or
+ * `^:no-doc` in the project index. The index is built by the upstream
+ * `ApiFacade::indexProject` call; we just consume its definitions.
+ *
+ * In v1 the compiler does not yet record arbitrary user metadata on
+ * definitions, so this rule acts on definitions whose *docstring or
+ * name* match a small, stable deprecated-marker vocabulary:
+ *   - name starts with `!deprecated-`
+ *   - docstring mentions `Deprecated:` or `DEPRECATED`
+ * Future passes can extend this without editing the rule signature.
+ */
+final readonly class DiscouragedVarRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::DISCOURAGED_VAR;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $discouraged = $this->collectDiscouraged($analysis);
+        if ($discouraged === []) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($analysis->forms as $form) {
+            $this->walk($form, $discouraged, $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, string> symbolName => reason
+     */
+    private function collectDiscouraged(FileAnalysis $analysis): array
+    {
+        $map = [];
+        foreach ($analysis->projectIndex->definitions as $def) {
+            $name = $def->name;
+            $docstring = $def->docstring;
+
+            if (str_starts_with($name, '!deprecated-')) {
+                $map[$name] = 'deprecated by name';
+
+                continue;
+            }
+
+            if (preg_match('/\bdeprecated\b/i', $docstring) === 1) {
+                $map[$name] = 'marked deprecated in docstring';
+            }
+        }
+
+        // Also scan local forms for `^{:deprecated true}` metadata.
+        foreach ($analysis->forms as $form) {
+            $this->collectLocalDeprecations($form, $map);
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, string> $map
+     */
+    private function collectLocalDeprecations(mixed $form, array &$map): void
+    {
+        if (!$form instanceof PersistentListInterface || count($form) < 3) {
+            return;
+        }
+
+        $head = $form->get(0);
+        if (!$head instanceof Symbol) {
+            return;
+        }
+
+        $name = $head->getName();
+        if (!in_array($name, ['def', 'defn', 'defn-', 'defmacro', 'defmacro-'], true)) {
+            return;
+        }
+
+        $ident = $form->get(1);
+        if (!$ident instanceof Symbol) {
+            return;
+        }
+
+        $size = count($form);
+        for ($i = 2; $i < $size; ++$i) {
+            $meta = $form->get($i);
+            if ($meta instanceof PersistentMapInterface) {
+                $value = $meta->find(Keyword::create('deprecated'));
+                if ($value === true || (is_string($value) && $value !== '')) {
+                    $map[$ident->getName()] = 'marked deprecated';
+                }
+            } elseif ($meta instanceof PersistentVectorInterface) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, string> $discouraged
+     * @param list<Diagnostic>      $result
+     */
+    private function walk(mixed $form, array $discouraged, string $uri, array &$result): void
+    {
+        if ($form instanceof Symbol) {
+            $name = $form->getName();
+            if (isset($discouraged[$name])) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Use of discouraged var '%s' (%s).", $name, $discouraged[$name]),
+                    $uri,
+                    $form,
+                );
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentListInterface || $form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $discouraged, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $discouraged, $uri, $result);
+                $this->walk($v, $discouraged, $uri, $result);
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/DuplicateKeyRule.php
+++ b/src/php/Lint/Application/Rule/DuplicateKeyRule.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Compiler\Domain\Lexer\Token;
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\InnerNodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\KeywordNode;
+use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\NumberNode;
+use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
+use Phel\Compiler\Domain\Parser\ParserNode\SymbolNode;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Scans literal map `{...}` parse-tree nodes for duplicate keys. Works on
+ * the pre-read parse tree because the reader silently de-duplicates
+ * literal maps — so by the time the read form reaches rules, duplicates
+ * are gone.
+ */
+final readonly class DuplicateKeyRule implements LintRuleInterface
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    public function code(): string
+    {
+        return RuleRegistry::DUPLICATE_KEY;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($analysis->source, $analysis->uri);
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException) {
+                    break;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    break;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                $this->walkParse($parseTree, $analysis->uri, $result);
+            }
+        } catch (Throwable) {
+            // Best effort: if lexing fails, other rules will already flag it.
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function walkParse(NodeInterface $node, string $uri, array &$result): void
+    {
+        if ($node instanceof ListNode) {
+            if ($node->getTokenType() === Token::T_OPEN_BRACE) {
+                $this->inspectMapLiteral($node, $uri, $result);
+            }
+
+            foreach ($node->getChildren() as $child) {
+                $this->walkParse($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($node instanceof InnerNodeInterface) {
+            foreach ($node->getChildren() as $child) {
+                $this->walkParse($child, $uri, $result);
+            }
+        }
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function inspectMapLiteral(ListNode $mapNode, string $uri, array &$result): void
+    {
+        $keys = [];
+        $expectingKey = true;
+        foreach ($mapNode->getChildren() as $child) {
+            if ($child instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            if ($expectingKey) {
+                $keys[] = $child;
+            }
+
+            $expectingKey = !$expectingKey;
+        }
+
+        $seen = [];
+        foreach ($keys as $key) {
+            $repr = $this->keyRepr($key);
+            if ($repr === null) {
+                continue;
+            }
+
+            if (isset($seen[$repr])) {
+                $start = $key->getStartLocation();
+                $end = $key->getEndLocation();
+
+                $result[] = new Diagnostic(
+                    code: $this->code(),
+                    severity: Diagnostic::SEVERITY_WARNING,
+                    message: sprintf('Duplicate map key: %s.', $repr),
+                    uri: $uri,
+                    startLine: $start->getLine(),
+                    startCol: $start->getColumn(),
+                    endLine: $end->getLine(),
+                    endCol: $end->getColumn(),
+                );
+            } else {
+                $seen[$repr] = true;
+            }
+        }
+    }
+
+    private function keyRepr(NodeInterface $node): ?string
+    {
+        if ($node instanceof KeywordNode) {
+            $value = $node->getValue();
+            $ns = $value->getNamespace();
+
+            return ':' . ($ns === null || $ns === '' ? '' : $ns . '/') . $value->getName();
+        }
+
+        if ($node instanceof SymbolNode) {
+            $value = $node->getValue();
+            $ns = $value->getNamespace();
+
+            return ($ns === null || $ns === '' ? '' : $ns . '/') . $value->getName();
+        }
+
+        if ($node instanceof StringNode) {
+            return '"' . $node->getValue() . '"';
+        }
+
+        if ($node instanceof NumberNode) {
+            return (string) $node->getValue();
+        }
+
+        return null;
+    }
+}

--- a/src/php/Lint/Application/Rule/FormWalker.php
+++ b/src/php/Lint/Application/Rule/FormWalker.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+/**
+ * Shared depth-first traversal for rules that need to visit every nested
+ * form, regardless of collection type. Callers pass a visitor callable
+ * and may short-circuit by returning false.
+ */
+final class FormWalker
+{
+    /**
+     * Visitor returns false to skip descending into the current form;
+     * any other return value (including `null` / `void`) continues.
+     *
+     * @param callable(mixed):mixed $visit
+     */
+    public static function walk(mixed $form, callable $visit): void
+    {
+        $proceed = $visit($form);
+        if ($proceed === false) {
+            return;
+        }
+
+        if ($form instanceof PersistentListInterface || $form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                self::walk($child, $visit);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                self::walk($k, $visit);
+                self::walk($v, $visit);
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
+++ b/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function in_array;
+
+/**
+ * Structural checks on binding forms:
+ *
+ * - `(let bindings ...)` where the binding vector has an odd element count
+ *   (one value missing its name).
+ * - Variadic marker `&` appearing in an invalid position (anything but
+ *   exactly one-symbol-before-the-end).
+ */
+final readonly class InvalidDestructuringRule implements LintRuleInterface
+{
+    private const array LET_LIKE_FORMS = ['let', 'loop', 'for', 'if-let', 'when-let', 'binding'];
+
+    private const array FN_FORMS = ['fn', 'defn', 'defn-', 'defmacro', 'defmacro-'];
+
+    public function code(): string
+    {
+        return RuleRegistry::INVALID_DESTRUCTURING;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->forms as $form) {
+            $this->walk($form, $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function walk(mixed $form, string $uri, array &$result): void
+    {
+        if ($form instanceof PersistentListInterface && count($form) > 0) {
+            $head = $form->get(0);
+            if ($head instanceof Symbol) {
+                $name = $head->getName();
+                if (in_array($name, self::LET_LIKE_FORMS, true)) {
+                    $this->inspectLet($form, $uri, $result);
+                } elseif (in_array($name, self::FN_FORMS, true)) {
+                    $this->inspectFn($form, $uri, $result);
+                }
+            }
+
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $uri, $result);
+                $this->walk($v, $uri, $result);
+            }
+        }
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function inspectLet(PersistentListInterface $form, string $uri, array &$result): void
+    {
+        if (count($form) < 2) {
+            return;
+        }
+
+        $bindings = $form->get(1);
+        if (!$bindings instanceof PersistentVectorInterface) {
+            $result[] = DiagnosticBuilder::fromForm(
+                $this->code(),
+                'Binding form expects a vector of name/value pairs.',
+                $uri,
+                $form,
+            );
+
+            return;
+        }
+
+        if (count($bindings) % 2 !== 0) {
+            $result[] = DiagnosticBuilder::fromForm(
+                $this->code(),
+                'Binding vector has an odd number of forms; every name must be paired with a value.',
+                $uri,
+                $bindings,
+            );
+        }
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function inspectFn(PersistentListInterface $form, string $uri, array &$result): void
+    {
+        $size = count($form);
+        for ($i = 1; $i < $size; ++$i) {
+            $child = $form->get($i);
+            if ($child instanceof PersistentVectorInterface) {
+                $this->validateParamVector($child, $uri, $result);
+
+                break;
+            }
+
+            if ($child instanceof PersistentListInterface && count($child) > 0) {
+                $head = $child->get(0);
+                if ($head instanceof PersistentVectorInterface) {
+                    $this->validateParamVector($head, $uri, $result);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function validateParamVector(PersistentVectorInterface $params, string $uri, array &$result): void
+    {
+        $count = count($params);
+        for ($i = 0; $i < $count; ++$i) {
+            $item = $params->get($i);
+            if ($item instanceof Symbol && $item->getName() === '&') {
+                $remaining = $count - $i - 1;
+                if ($remaining !== 1) {
+                    $result[] = DiagnosticBuilder::fromForm(
+                        $this->code(),
+                        "Invalid destructuring: '&' must be followed by exactly one binding symbol.",
+                        $uri,
+                        $item,
+                    );
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/RedundantDoRule.php
+++ b/src/php/Lint/Application/Rule/RedundantDoRule.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+
+/**
+ * Flags redundant `(do ...)` forms:
+ *
+ * - a `do` with zero or one body form (returns nil / a single value)
+ * - a `do` that is the sole expression inside another implicit-do
+ *   position (`defn` body, `let` body, `fn` body, `when`, `try`, etc.)
+ */
+final readonly class RedundantDoRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::REDUNDANT_DO;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->forms as $form) {
+            $this->walk($form, $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function walk(mixed $form, string $uri, array &$result): void
+    {
+        if ($form instanceof PersistentListInterface && count($form) > 0) {
+            $head = $form->get(0);
+            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_DO) {
+                $bodyCount = count($form) - 1;
+                if ($bodyCount <= 1) {
+                    $result[] = DiagnosticBuilder::fromForm(
+                        $this->code(),
+                        'Redundant `do`: fewer than two body forms.',
+                        $uri,
+                        $form,
+                    );
+                }
+            }
+
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $uri, $result);
+                $this->walk($v, $uri, $result);
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/ShadowedBindingRule.php
+++ b/src/php/Lint/Application/Rule/ShadowedBindingRule.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function in_array;
+use function sprintf;
+
+/**
+ * Flags new `let`/`fn`/`defn` bindings that shadow a previously-bound
+ * local with the same name (outer scope still reachable, easy foot-gun).
+ */
+final readonly class ShadowedBindingRule implements LintRuleInterface
+{
+    private const array LET_FORMS = ['let', 'loop', 'for', 'if-let', 'when-let'];
+
+    private const array FN_FORMS = ['fn', 'defn', 'defn-', 'defmacro', 'defmacro-'];
+
+    public function code(): string
+    {
+        return RuleRegistry::SHADOWED_BINDING;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->forms as $form) {
+            $this->walk($form, [], $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string>     $scope
+     * @param list<Diagnostic> $result
+     */
+    private function walk(mixed $form, array $scope, string $uri, array &$result): void
+    {
+        if ($form instanceof PersistentListInterface && count($form) > 0) {
+            $head = $form->get(0);
+            if ($head instanceof Symbol) {
+                $name = $head->getName();
+                if (in_array($name, self::LET_FORMS, true)) {
+                    $scope = $this->handleLet($form, $scope, $uri, $result);
+                } elseif (in_array($name, self::FN_FORMS, true)) {
+                    $scope = $this->handleFn($form, $scope, $uri, $result);
+                }
+            }
+
+            foreach ($form as $child) {
+                $this->walk($child, $scope, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $scope, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $scope, $uri, $result);
+                $this->walk($v, $scope, $uri, $result);
+            }
+        }
+    }
+
+    /**
+     * @param list<string>     $scope
+     * @param list<Diagnostic> $result
+     *
+     * @return list<string>
+     */
+    private function handleLet(PersistentListInterface $form, array $scope, string $uri, array &$result): array
+    {
+        if (count($form) < 2) {
+            return $scope;
+        }
+
+        $bindings = $form->get(1);
+        if (!$bindings instanceof PersistentVectorInterface) {
+            return $scope;
+        }
+
+        $size = count($bindings);
+        $newScope = $scope;
+        for ($i = 0; $i < $size; $i += 2) {
+            $sym = $bindings->get($i);
+            if (!$sym instanceof Symbol) {
+                continue;
+            }
+
+            $name = $sym->getName();
+            if ($name === '&') {
+                continue;
+            }
+
+            if ($name === '_') {
+                continue;
+            }
+
+            if (in_array($name, $newScope, true)) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Shadowed binding: '%s' shadows a local with the same name.", $name),
+                    $uri,
+                    $sym,
+                );
+            }
+
+            $newScope[] = $name;
+        }
+
+        return $newScope;
+    }
+
+    /**
+     * @param list<string>     $scope
+     * @param list<Diagnostic> $result
+     *
+     * @return list<string>
+     */
+    private function handleFn(PersistentListInterface $form, array $scope, string $uri, array &$result): array
+    {
+        $newScope = $scope;
+        $size = count($form);
+
+        for ($i = 1; $i < $size; ++$i) {
+            $child = $form->get($i);
+
+            if ($child instanceof PersistentVectorInterface) {
+                $newScope = $this->walkParams($child, $newScope, $uri, $result);
+
+                break;
+            }
+
+            if ($child instanceof PersistentListInterface && count($child) > 0) {
+                $head = $child->get(0);
+                if ($head instanceof PersistentVectorInterface) {
+                    // Each arity introduces its own scope extension at analyze-time;
+                    // still flag inner shadowing of the outer scope.
+                    $this->walkParams($head, $newScope, $uri, $result);
+                }
+            }
+        }
+
+        return $newScope;
+    }
+
+    /**
+     * @param list<string>     $scope
+     * @param list<Diagnostic> $result
+     *
+     * @return list<string>
+     */
+    private function walkParams(PersistentVectorInterface $params, array $scope, string $uri, array &$result): array
+    {
+        $newScope = $scope;
+        $count = count($params);
+        for ($i = 0; $i < $count; ++$i) {
+            $sym = $params->get($i);
+            if (!$sym instanceof Symbol) {
+                continue;
+            }
+
+            $name = $sym->getName();
+            if ($name === '&') {
+                continue;
+            }
+
+            if ($name === '_') {
+                continue;
+            }
+
+            if (in_array($name, $newScope, true)) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Shadowed binding: '%s' shadows a local with the same name.", $name),
+                    $uri,
+                    $sym,
+                );
+            }
+
+            $newScope[] = $name;
+        }
+
+        return $newScope;
+    }
+}

--- a/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
+++ b/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Compiler\Domain\Exceptions\ErrorCode;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+/**
+ * Promotes the analyzer's native `PHEL001` undefined-symbol diagnostic
+ * into a lint-rule diagnostic so the standard severity/opt-out plumbing
+ * applies. Reads from the shared `FileAnalysis::$semanticDiagnostics`
+ * cache so the Parser + Analyzer only runs once per file.
+ */
+final readonly class UnresolvedSymbolRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::UNRESOLVED_SYMBOL;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->semanticDiagnostics as $diagnostic) {
+            if ($diagnostic->code !== ErrorCode::UNDEFINED_SYMBOL->value) {
+                continue;
+            }
+
+            $result[] = new Diagnostic(
+                code: $this->code(),
+                severity: $diagnostic->severity,
+                message: $diagnostic->message,
+                uri: $diagnostic->uri,
+                startLine: $diagnostic->startLine,
+                startCol: $diagnostic->startCol,
+                endLine: $diagnostic->endLine,
+                endCol: $diagnostic->endCol,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Lint/Application/Rule/UnusedBindingRule.php
+++ b/src/php/Lint/Application/Rule/UnusedBindingRule.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function in_array;
+use function sprintf;
+use function str_starts_with;
+
+/**
+ * Flags symbols bound in `(let [x ...])` / `(loop [x ...])` whose body
+ * never mentions them. Ignores names starting with `_` (idiomatic
+ * placeholder) and `&` (variadic marker). Destructuring binding forms
+ * are best-effort: only the top-level names are tracked.
+ */
+final readonly class UnusedBindingRule implements LintRuleInterface
+{
+    private const array BINDING_FORMS = ['let', 'loop', 'for', 'when-let', 'if-let'];
+
+    public function code(): string
+    {
+        return RuleRegistry::UNUSED_BINDING;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $result = [];
+        foreach ($analysis->forms as $form) {
+            $this->walk($form, $analysis->uri, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function walk(mixed $form, string $uri, array &$result): void
+    {
+        if ($form instanceof PersistentListInterface && count($form) > 0) {
+            $head = $form->get(0);
+            if ($head instanceof Symbol && in_array($head->getName(), self::BINDING_FORMS, true)) {
+                $this->inspectLet($form, $uri, $result);
+            }
+
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentVectorInterface) {
+            foreach ($form as $child) {
+                $this->walk($child, $uri, $result);
+            }
+
+            return;
+        }
+
+        if ($form instanceof PersistentMapInterface) {
+            foreach ($form as $k => $v) {
+                $this->walk($k, $uri, $result);
+                $this->walk($v, $uri, $result);
+            }
+        }
+    }
+
+    /**
+     * @param list<Diagnostic> $result
+     */
+    private function inspectLet(PersistentListInterface $form, string $uri, array &$result): void
+    {
+        if (count($form) < 2) {
+            return;
+        }
+
+        $bindings = $form->get(1);
+        if (!$bindings instanceof PersistentVectorInterface) {
+            return;
+        }
+
+        $bindingSyms = [];
+        $size = count($bindings);
+        for ($i = 0; $i < $size; $i += 2) {
+            $sym = $bindings->get($i);
+            if ($sym instanceof Symbol && $this->trackable($sym->getName())) {
+                $bindingSyms[] = $sym;
+            }
+        }
+
+        if ($bindingSyms === []) {
+            return;
+        }
+
+        $usageCounts = [];
+        $formSize = count($form);
+        for ($i = 2; $i < $formSize; ++$i) {
+            $body = $form->get($i);
+            FormWalker::walk($body, static function (mixed $val) use (&$usageCounts): void {
+                if ($val instanceof Symbol && $val->getNamespace() === null) {
+                    $name = $val->getName();
+                    $usageCounts[$name] = ($usageCounts[$name] ?? 0) + 1;
+                }
+            });
+        }
+
+        foreach ($bindingSyms as $sym) {
+            $name = $sym->getName();
+            if (!isset($usageCounts[$name])) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Unused binding: '%s'.", $name),
+                    $uri,
+                    $sym,
+                );
+            }
+        }
+    }
+
+    private function trackable(string $name): bool
+    {
+        return $name !== '&' && !str_starts_with($name, '_');
+    }
+}

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function explode;
+use function sprintf;
+
+/**
+ * Flags `(:use Foo\Bar)` or `(:use Foo\Bar :as B)` entries whose imported
+ * class alias is never referenced in the file body.
+ */
+final readonly class UnusedImportRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::UNUSED_IMPORT;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $nsForm = $this->findNsForm($analysis->forms);
+        if (!$nsForm instanceof PersistentListInterface) {
+            return [];
+        }
+
+        $imports = $this->collectImports($nsForm);
+        if ($imports === []) {
+            return [];
+        }
+
+        $used = $this->collectSymbolUses($analysis->forms, $nsForm);
+
+        $result = [];
+        foreach ($imports as $entry) {
+            if (!isset($used[$entry['alias']])) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Unused import: '%s'.", $entry['display']),
+                    $analysis->uri,
+                    $entry['anchor'],
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<mixed> $forms
+     */
+    private function findNsForm(array $forms): ?PersistentListInterface
+    {
+        foreach ($forms as $form) {
+            if (!$form instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($form) === 0) {
+                continue;
+            }
+
+            $head = $form->get(0);
+            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_NS) {
+                return $form;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array{alias:string, display:string, anchor: mixed}>
+     */
+    private function collectImports(PersistentListInterface $nsForm): array
+    {
+        $result = [];
+        $size = count($nsForm);
+
+        for ($i = 2; $i < $size; ++$i) {
+            $child = $nsForm->get($i);
+            if (!$child instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($child) < 2) {
+                continue;
+            }
+
+            $head = $child->get(0);
+            if (!$head instanceof Keyword) {
+                continue;
+            }
+
+            if ($head->getName() !== 'use') {
+                continue;
+            }
+
+            $inner = count($child);
+            for ($j = 1; $j < $inner; ++$j) {
+                $item = $child->get($j);
+                if (!$item instanceof Symbol) {
+                    continue;
+                }
+
+                $target = $item;
+                $alias = null;
+
+                // Look ahead for `:as Alias`.
+                if ($j + 1 < $inner) {
+                    $maybeKey = $child->get($j + 1);
+                    if ($maybeKey instanceof Keyword && $maybeKey->getName() === 'as' && $j + 2 < $inner) {
+                        $aliasCandidate = $child->get($j + 2);
+                        if ($aliasCandidate instanceof Symbol) {
+                            $alias = $aliasCandidate->getName();
+                            $j += 2;
+                        }
+                    }
+                }
+
+                $result[] = [
+                    'alias' => $alias ?? $this->defaultAlias($target),
+                    'display' => $target->getName(),
+                    'anchor' => $target,
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    private function defaultAlias(Symbol $symbol): string
+    {
+        $name = $symbol->getName();
+        $parts = explode('\\', $name);
+
+        return $parts[count($parts) - 1];
+    }
+
+    /**
+     * @param list<mixed> $forms
+     *
+     * @return array<string, true>
+     */
+    private function collectSymbolUses(array $forms, PersistentListInterface $nsForm): array
+    {
+        $seen = [];
+        $visit = static function (mixed $value) use (&$seen): void {
+            if ($value instanceof Symbol) {
+                $seen[$value->getName()] = true;
+                $ns = $value->getNamespace();
+                if ($ns !== null && $ns !== '') {
+                    $seen[$ns] = true;
+                }
+            }
+        };
+
+        foreach ($forms as $form) {
+            if ($form === $nsForm) {
+                continue;
+            }
+
+            FormWalker::walk($form, static function (mixed $value) use ($visit): void {
+                $visit($value);
+            });
+        }
+
+        return $seen;
+    }
+}

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function sprintf;
+
+/**
+ * Flags `(:require foo)` or `(:require foo :refer [bar])` entries whose
+ * alias and referred symbols are never mentioned anywhere else in the file.
+ */
+final readonly class UnusedRequireRule implements LintRuleInterface
+{
+    public function code(): string
+    {
+        return RuleRegistry::UNUSED_REQUIRE;
+    }
+
+    public function apply(FileAnalysis $analysis): array
+    {
+        $nsForm = $this->findNsForm($analysis->forms);
+        if (!$nsForm instanceof PersistentListInterface) {
+            return [];
+        }
+
+        $requires = $this->collectRequires($nsForm);
+        if ($requires === []) {
+            return [];
+        }
+
+        $usedSymbols = $this->collectSymbolUses($analysis->forms, $nsForm);
+
+        $result = [];
+        foreach ($requires as $entry) {
+            $alias = $entry['alias'];
+            $refers = $entry['refers'];
+            $anchor = $entry['anchor'];
+
+            $aliasUsed = $alias !== '' && $this->symbolUsed($alias, $usedSymbols);
+            $referUsed = false;
+
+            foreach ($refers as $refer) {
+                if ($this->symbolUsed($refer, $usedSymbols)) {
+                    $referUsed = true;
+
+                    break;
+                }
+            }
+
+            if (!$aliasUsed && !$referUsed && $refers === []) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Unused require: '%s'.", $entry['display']),
+                    $analysis->uri,
+                    $anchor,
+                );
+            } elseif (!$aliasUsed && $refers !== [] && !$referUsed) {
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Unused require: '%s' (no referred symbols or alias are used).", $entry['display']),
+                    $analysis->uri,
+                    $anchor,
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<mixed> $forms
+     */
+    private function findNsForm(array $forms): ?PersistentListInterface
+    {
+        foreach ($forms as $form) {
+            if (!$form instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($form) < 1) {
+                continue;
+            }
+
+            $head = $form->get(0);
+            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_NS) {
+                return $form;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array{alias:string, refers:list<string>, display:string, anchor: mixed}>
+     */
+    private function collectRequires(PersistentListInterface $nsForm): array
+    {
+        $result = [];
+        $size = count($nsForm);
+
+        for ($i = 2; $i < $size; ++$i) {
+            $child = $nsForm->get($i);
+            if (!$child instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($child) === 0) {
+                continue;
+            }
+
+            $head = $child->get(0);
+            if (!$head instanceof Keyword) {
+                continue;
+            }
+
+            if ($head->getName() !== 'require') {
+                continue;
+            }
+
+            foreach ($this->parseRequireClauseEntries($child) as $entry) {
+                $result[] = $entry;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<array{alias:string, refers:list<string>, display:string, anchor: mixed}>
+     */
+    private function parseRequireClauseEntries(PersistentListInterface $clause): array
+    {
+        $entries = [];
+        $size = count($clause);
+
+        for ($i = 1; $i < $size; ++$i) {
+            $item = $clause->get($i);
+
+            if ($item instanceof PersistentVectorInterface) {
+                $entries[] = $this->parseVectorEntry($item);
+
+                continue;
+            }
+
+            if ($item instanceof Symbol) {
+                [$entry, $advance] = $this->parseFlatEntry($clause, $i);
+                $entries[] = $entry;
+                $i = $advance - 1;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return array{alias:string, refers:list<string>, display:string, anchor: mixed}
+     */
+    private function parseVectorEntry(PersistentVectorInterface $vector): array
+    {
+        $target = null;
+        $alias = null;
+        $refers = [];
+
+        $count = count($vector);
+        for ($i = 0; $i < $count; ++$i) {
+            $item = $vector->get($i);
+
+            if ($i === 0 && $item instanceof Symbol) {
+                $target = $item;
+
+                continue;
+            }
+
+            if (!$item instanceof Keyword) {
+                continue;
+            }
+
+            $next = $i + 1 < $count ? $vector->get($i + 1) : null;
+            if ($item->getName() === 'as' && $next instanceof Symbol) {
+                $alias = $next->getName();
+                ++$i;
+            } elseif ($item->getName() === 'refer' && $next instanceof PersistentVectorInterface) {
+                foreach ($next as $r) {
+                    if ($r instanceof Symbol) {
+                        $refers[] = $r->getName();
+                    }
+                }
+
+                ++$i;
+            }
+        }
+
+        return [
+            'alias' => $alias ?? $this->defaultAlias($target),
+            'refers' => $refers,
+            'display' => $target instanceof Symbol ? $target->getName() : 'unknown',
+            'anchor' => $vector,
+        ];
+    }
+
+    /**
+     * @return array{0: array{alias:string, refers:list<string>, display:string, anchor: mixed}, 1: int}
+     */
+    private function parseFlatEntry(PersistentListInterface $clause, int $startIndex): array
+    {
+        $size = count($clause);
+        $target = $clause->get($startIndex);
+        $alias = null;
+        $refers = [];
+        $i = $startIndex + 1;
+
+        while ($i < $size) {
+            $item = $clause->get($i);
+            if ($item instanceof Symbol || $item instanceof PersistentVectorInterface) {
+                break;
+            }
+
+            if (!$item instanceof Keyword) {
+                break;
+            }
+
+            $next = $i + 1 < $size ? $clause->get($i + 1) : null;
+            if ($item->getName() === 'as' && $next instanceof Symbol) {
+                $alias = $next->getName();
+                $i += 2;
+
+                continue;
+            }
+
+            if ($item->getName() === 'refer' && $next instanceof PersistentVectorInterface) {
+                foreach ($next as $r) {
+                    if ($r instanceof Symbol) {
+                        $refers[] = $r->getName();
+                    }
+                }
+
+                $i += 2;
+
+                continue;
+            }
+
+            $i += 2;
+        }
+
+        return [[
+            'alias' => $alias ?? $this->defaultAlias($target),
+            'refers' => $refers,
+            'display' => $target instanceof Symbol ? $target->getName() : 'unknown',
+            'anchor' => $target,
+        ], $i];
+    }
+
+    private function defaultAlias(mixed $target): string
+    {
+        if (!$target instanceof Symbol) {
+            return '';
+        }
+
+        $name = $target->getName();
+        $parts = explode('\\', $name);
+
+        return $parts[count($parts) - 1];
+    }
+
+    /**
+     * @param list<mixed> $forms
+     *
+     * @return array<string, true>
+     */
+    private function collectSymbolUses(array $forms, PersistentListInterface $nsForm): array
+    {
+        $seen = [];
+
+        $visit = static function (mixed $value) use (&$seen): void {
+            if ($value instanceof Symbol) {
+                $seen[$value->getName()] = true;
+                $ns = $value->getNamespace();
+                if ($ns !== null && $ns !== '') {
+                    $seen[$ns] = true;
+                }
+            }
+        };
+
+        foreach ($forms as $form) {
+            if ($form === $nsForm) {
+                continue;
+            }
+
+            FormWalker::walk($form, static function (mixed $value) use ($visit): void {
+                $visit($value);
+            });
+        }
+
+        return $seen;
+    }
+
+    /**
+     * @param array<string, true> $usedSymbols
+     */
+    private function symbolUsed(string $name, array $usedSymbols): bool
+    {
+        return $name !== '' && isset($usedSymbols[$name]);
+    }
+}

--- a/src/php/Lint/Application/RulePipeline.php
+++ b/src/php/Lint/Application/RulePipeline.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+
+use Throwable;
+
+/**
+ * Runs every registered rule against a `FileAnalysis` and rewrites the
+ * severity on each produced diagnostic based on the configured
+ * `RuleSettings`. Rules set to `off` or excluded by glob are skipped
+ * entirely; rules that throw are isolated so one bad rule cannot kill
+ * the whole run.
+ */
+final readonly class RulePipeline
+{
+    /**
+     * @param list<LintRuleInterface> $rules
+     */
+    public function __construct(
+        private array $rules,
+    ) {}
+
+    /**
+     * @return list<Diagnostic>
+     */
+    public function run(FileAnalysis $analysis, RuleSettings $settings): array
+    {
+        $result = [];
+        foreach ($this->rules as $rule) {
+            $code = $rule->code();
+            if (!$settings->isEnabled($code)) {
+                continue;
+            }
+
+            if ($settings->isExcluded($code, $analysis->uri, $analysis->namespace)) {
+                continue;
+            }
+
+            try {
+                $diagnostics = $rule->apply($analysis);
+            } catch (Throwable) {
+                // Isolate a failing rule so the rest of the pipeline keeps running.
+                continue;
+            }
+
+            $severity = $settings->severityFor($code);
+            foreach ($diagnostics as $diagnostic) {
+                $result[] = new Diagnostic(
+                    code: $diagnostic->code,
+                    severity: $severity,
+                    message: $diagnostic->message,
+                    uri: $diagnostic->uri,
+                    startLine: $diagnostic->startLine,
+                    startCol: $diagnostic->startCol,
+                    endLine: $diagnostic->endLine,
+                    endCol: $diagnostic->endCol,
+                );
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Lint/Application/SourceReader.php
+++ b/src/php/Lint/Application/SourceReader.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application;
+
+use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+
+use Throwable;
+
+use function count;
+
+/**
+ * Lex, parse and read a Phel source string into a list of top-level forms
+ * ready for rule inspection. Never throws: best-effort only, so rules can
+ * still operate on partial input when later forms are broken.
+ */
+final readonly class SourceReader
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    /**
+     * @return array{
+     *     namespace: string,
+     *     forms: list<bool|float|int|string|TypeInterface|null>,
+     * }
+     */
+    public function read(string $source, string $uri): array
+    {
+        $forms = [];
+        $namespace = '';
+
+        try {
+            $tokenStream = $this->compilerFacade->lexString($source, $uri);
+            while (true) {
+                try {
+                    $parseTree = $this->compilerFacade->parseNext($tokenStream);
+                } catch (AbstractParserException) {
+                    break;
+                }
+
+                if (!$parseTree instanceof NodeInterface) {
+                    break;
+                }
+
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
+                }
+
+                try {
+                    $readerResult = $this->compilerFacade->read($parseTree);
+                } catch (ReaderException) {
+                    continue;
+                }
+
+                $form = $readerResult->getAst();
+
+                if ($namespace === '') {
+                    $found = $this->maybeNamespace($form);
+                    if ($found !== '') {
+                        $namespace = $found;
+                    }
+                }
+
+                $forms[] = $form;
+            }
+        } catch (Throwable) {
+            // Best-effort: return what we managed to read.
+        }
+
+        return [
+            'namespace' => $namespace,
+            'forms' => $forms,
+        ];
+    }
+
+    private function maybeNamespace(mixed $form): string
+    {
+        if (!$form instanceof PersistentListInterface || count($form) < 2) {
+            return '';
+        }
+
+        $head = $form->get(0);
+        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_NS) {
+            return '';
+        }
+
+        $name = $form->get(1);
+        if (!$name instanceof Symbol) {
+            return '';
+        }
+
+        return $name->getFullName();
+    }
+}

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -1,0 +1,96 @@
+# Lint Module
+
+Read-only semantic linter built on top of `ApiFacade`: emits diagnostics on Phel sources without rewriting files.
+
+## Gacela Pattern
+
+- **Facade**: `LintFacade` extends `AbstractFacade<LintFactory>`
+- **Factory**: `LintFactory` extends `AbstractFactory<LintConfig>`
+- **Config**: `LintConfig` — default severities, cache dir, config filename
+- **Provider**: `LintProvider` — injects `FACADE_API`, `FACADE_COMPILER`, `FACADE_COMMAND`
+
+## Public API (Facade)
+
+- `lint(list<string> $paths, RuleSettings $settings, ?LintCache $cache): LintResult`
+- `loadSettings(string $configPath, RuleSettings $defaults): RuleSettings`
+- `defaultSettings(): RuleSettings`
+- `formatters(): FormatterRegistry`
+- `createCache(string $baseDir): LintCache`
+
+## CLI Command
+
+`./bin/phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]`
+
+Exit codes: `0` = clean or warnings only, `1` = one or more errors, `2` = invocation error.
+
+## Rule Set (v1)
+
+- `phel/unresolved-symbol` (error)
+- `phel/arity-mismatch` (error)
+- `phel/invalid-destructuring` (error)
+- `phel/duplicate-key` (error)
+- `phel/unused-binding` (warning)
+- `phel/unused-require` (warning)
+- `phel/unused-import` (warning)
+- `phel/shadowed-binding` (warning)
+- `phel/redundant-do` (warning)
+- `phel/discouraged-var` (warning)
+
+Each rule is a single `LintRuleInterface` class in `Application/Rule/`. Adding a rule is `new RuleClass()` in `LintFactory::createRules()` plus a code constant in `RuleRegistry` — no edits to existing rules.
+
+## Config File
+
+`phel-lint.phel` in the project root (override with `--config`). EDN-like Phel map parsed by the existing reader:
+
+```phel
+{:rules {:phel/unused-binding :off
+         :phel/arity-mismatch :error}
+ :exclude {:phel/unused-binding ["src/phel/local.phel" "phel.experimental.*"]}}
+```
+
+Severities: `:error`, `:warning`, `:info`, `:hint`, `:off`. Exclude patterns match file path when they contain `/` or `.phel`, otherwise they match the namespace name via `fnmatch`.
+
+## Cache
+
+Optional, enabled by default. Stores per-file diagnostics under `.phel/lint-cache/index.json` keyed by MD5 file hash + rule fingerprint. Disable with `--no-cache`.
+
+## Output Formats
+
+- `human` — `file:line:col [severity] code message` plus a summary line
+- `json` — stable JSON array of `Diagnostic` objects
+- `github` — `::warning file=X,line=Y,col=Z,title=CODE::message` annotations
+
+Formatters implement `DiagnosticFormatterInterface` and are registered on `FormatterRegistry`.
+
+## Dependencies
+
+- **Api** (`ApiFacade`) — `analyzeSource`, `indexProject`
+- **Compiler** (`CompilerFacade`) — `lexString`, `parseNext`, `read`
+- **Command** (`CommandFacade`) — default source directories
+
+## Structure
+
+```
+Lint/
+|-- Application/
+|   |-- Cache/           LintCache (file-hash + rule-fingerprint keyed JSON index)
+|   |-- Config/          RuleRegistry, RuleSettings, ConfigLoader
+|   |-- Formatter/       HumanFormatter, JsonFormatter, GithubFormatter, FormatterRegistry
+|   |-- Rule/            One class per rule + FormWalker + DiagnosticBuilder
+|   |-- FileCollector, SourceReader, RulePipeline, LintRunner
+|-- Domain/              LintRuleInterface, DiagnosticFormatterInterface, FileAnalysis
+|-- Infrastructure/
+|   +-- Command/         LintCommand (Symfony console)
+|-- Transfer/            LintResult
++-- Gacela files         LintFacade, LintFactory, LintConfig, LintProvider
+```
+
+## Key Constraints
+
+- Lint is **read-only**: never rewrites source; `fmt` owns whitespace/indent
+- Semantic diagnostics (`unresolved-symbol`, analyzer-detected `arity-mismatch`) are fetched via `ApiFacade::analyzeSource` and shared across rules through `FileAnalysis::$semanticDiagnostics` so the analyzer runs once per file
+- Rule pipeline is open/closed: `LintFactory::createRules()` is the only edit point to add a rule
+- `FormatterRegistry` is also open/closed: register new formatter names without editing existing ones
+- `LintCache` fingerprint is derived from `RuleRegistry::allCodes()` — adding/removing rules auto-invalidates the cache
+- Failing rules are isolated in `RulePipeline`: one bad rule never kills the run
+- `DuplicateKeyRule` scans the parse tree (not read forms) because the reader silently de-duplicates map literals

--- a/src/php/Lint/Domain/DiagnosticFormatterInterface.php
+++ b/src/php/Lint/Domain/DiagnosticFormatterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain;
+
+use Phel\Lint\Transfer\LintResult;
+
+interface DiagnosticFormatterInterface
+{
+    /**
+     * Format key used to select this formatter on the CLI.
+     */
+    public function name(): string;
+
+    public function format(LintResult $result): string;
+}

--- a/src/php/Lint/Domain/FileAnalysis.php
+++ b/src/php/Lint/Domain/FileAnalysis.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lang\TypeInterface;
+
+/**
+ * Immutable data handed to every rule for a single file. Rules must not
+ * mutate this — it is shared across the rule pipeline.
+ *
+ * `semanticDiagnostics` is the cached output of `ApiFacade::analyzeSource`
+ * for this file: rules that consume analyzer diagnostics reuse it so the
+ * pipeline only pays for one analyze pass per file.
+ */
+final readonly class FileAnalysis
+{
+    /**
+     * @param list<bool|float|int|string|TypeInterface|null> $forms               top-level read forms
+     * @param list<Diagnostic>                               $semanticDiagnostics analyzer output
+     */
+    public function __construct(
+        public string $uri,
+        public string $namespace,
+        public string $source,
+        public array $forms,
+        public ProjectIndex $projectIndex,
+        public array $semanticDiagnostics = [],
+    ) {}
+}

--- a/src/php/Lint/Domain/LintRuleInterface.php
+++ b/src/php/Lint/Domain/LintRuleInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Domain;
+
+use Phel\Api\Transfer\Diagnostic;
+
+interface LintRuleInterface
+{
+    /**
+     * Stable identifier used for config lookups and output.
+     */
+    public function code(): string;
+
+    /**
+     * @return list<Diagnostic>
+     */
+    public function apply(FileAnalysis $analysis): array;
+}

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\Formatter\HumanFormatter;
+use Phel\Lint\LintConfig;
+use Phel\Lint\LintFacade;
+use Phel\Lint\LintFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function getcwd;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function rtrim;
+use function sprintf;
+
+/**
+ * `./bin/phel lint <paths>` — read-only semantic linter. Exits with:
+ *   0 — no errors
+ *   1 — one or more errors (warnings/infos do not fail)
+ *   2 — invocation error (bad flags, no readable files).
+ */
+#[ServiceMap(method: 'getFacade', className: LintFacade::class)]
+#[ServiceMap(method: 'getFactory', className: LintFactory::class)]
+#[ServiceMap(method: 'getConfig', className: LintConfig::class)]
+final class LintCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    public const int EXIT_INVOCATION_ERROR = 2;
+
+    private const string COMMAND_NAME = 'lint';
+
+    private const string ARG_PATHS = 'paths';
+
+    private const string OPT_FORMAT = 'format';
+
+    private const string OPT_CONFIG = 'config';
+
+    private const string OPT_NO_CACHE = 'no-cache';
+
+    public function __construct()
+    {
+        parent::__construct(self::COMMAND_NAME);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Run the semantic linter on one or more Phel files or directories.')
+            ->addArgument(
+                self::ARG_PATHS,
+                InputArgument::IS_ARRAY,
+                'Files or directories to lint (defaults to the configured source dirs).',
+                [],
+            )
+            ->addOption(
+                self::OPT_FORMAT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Output format: human, json, github.',
+                HumanFormatter::NAME,
+            )
+            ->addOption(
+                self::OPT_CONFIG,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to a .phel-lint.phel config (defaults to <cwd>/phel-lint.phel).',
+            )
+            ->addOption(
+                self::OPT_NO_CACHE,
+                null,
+                InputOption::VALUE_NONE,
+                'Disable the incremental lint cache for this run.',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var list<string> $paths */
+        $paths = (array) $input->getArgument(self::ARG_PATHS);
+        if ($paths === []) {
+            $paths = $this->defaultPaths();
+        }
+
+        $paths = $this->filterExistingPaths($paths);
+        if ($paths === []) {
+            $output->writeln('<error>No readable .phel files or directories found to lint.</error>');
+
+            return self::EXIT_INVOCATION_ERROR;
+        }
+
+        $format = (string) $input->getOption(self::OPT_FORMAT);
+        $formatters = $this->getFacade()->formatters();
+        if (!$formatters->has($format)) {
+            $output->writeln(sprintf(
+                '<error>Unknown format: %s. Known: %s.</error>',
+                $format,
+                implode(', ', $formatters->names()),
+            ));
+
+            return self::EXIT_INVOCATION_ERROR;
+        }
+
+        $settings = $this->loadSettings($input);
+        $cache = $this->maybeCache($input);
+
+        // Load phel core so analyzeSource() resolves core symbols like
+        // `defn`, `let`, etc. Without this the linter's first diagnostic
+        // on any well-formed file is "cannot resolve symbol defn".
+        $this->getFactory()->getRunFacade()->loadPhelNamespaces();
+
+        try {
+            $result = $this->getFacade()->lint($paths, $settings, $cache);
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>Lint failed: %s</error>', $throwable->getMessage()));
+
+            return self::EXIT_INVOCATION_ERROR;
+        }
+
+        $output->write($formatters->get($format)->format($result));
+        $output->writeln('');
+
+        return $result->hasErrors() ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function defaultPaths(): array
+    {
+        $cmd = $this->getFactory()->getCommandFacade();
+
+        return $cmd->getSourceDirectories();
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function filterExistingPaths(array $paths): array
+    {
+        $filtered = [];
+        foreach ($paths as $path) {
+            if (is_file($path) || is_dir($path)) {
+                $filtered[] = $path;
+            }
+        }
+
+        return $filtered;
+    }
+
+    private function loadSettings(InputInterface $input): RuleSettings
+    {
+        $defaults = $this->getFacade()->defaultSettings();
+        $configPath = $input->getOption(self::OPT_CONFIG);
+        if (!is_string($configPath) || $configPath === '') {
+            $configPath = $this->defaultConfigPath();
+        }
+
+        return $this->getFacade()->loadSettings($configPath, $defaults);
+    }
+
+    private function defaultConfigPath(): string
+    {
+        $cwd = getcwd();
+        if ($cwd === false) {
+            return LintConfig::defaultConfigFilename();
+        }
+
+        return rtrim($cwd, '/') . '/' . LintConfig::defaultConfigFilename();
+    }
+
+    private function maybeCache(InputInterface $input): ?LintCache
+    {
+        if ($input->getOption(self::OPT_NO_CACHE)) {
+            return null;
+        }
+
+        $cwd = getcwd();
+        if ($cwd === false) {
+            return null;
+        }
+
+        $cacheDir = rtrim($cwd, '/') . '/' . LintConfig::defaultCacheDir();
+
+        return $this->getFacade()->createCache($cacheDir);
+    }
+}

--- a/src/php/Lint/LintConfig.php
+++ b/src/php/Lint/LintConfig.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint;
+
+use Gacela\Framework\AbstractConfig;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Config\RuleSettings;
+
+final class LintConfig extends AbstractConfig
+{
+    public const string DEFAULT_CONFIG_FILENAME = 'phel-lint.phel';
+
+    public const string CACHE_DIR = '.phel/lint-cache';
+
+    /**
+     * Default severities for every rule shipped in v1. Rules not listed
+     * here are disabled by default and must be opted into via config.
+     *
+     * @return array<string, string>
+     */
+    public static function defaultSeverities(): array
+    {
+        return [
+            RuleRegistry::UNRESOLVED_SYMBOL => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::ARITY_MISMATCH => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::INVALID_DESTRUCTURING => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::DUPLICATE_KEY => Diagnostic::SEVERITY_ERROR,
+            RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::UNUSED_REQUIRE => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::UNUSED_IMPORT => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::SHADOWED_BINDING => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::REDUNDANT_DO => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::DISCOURAGED_VAR => Diagnostic::SEVERITY_WARNING,
+        ];
+    }
+
+    public static function defaultConfigFilename(): string
+    {
+        return self::DEFAULT_CONFIG_FILENAME;
+    }
+
+    public static function defaultCacheDir(): string
+    {
+        return self::CACHE_DIR;
+    }
+
+    public function defaultSettings(): RuleSettings
+    {
+        return RuleSettings::fromMap(self::defaultSeverities());
+    }
+}

--- a/src/php/Lint/LintFacade.php
+++ b/src/php/Lint/LintFacade.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\Formatter\FormatterRegistry;
+use Phel\Lint\Transfer\LintResult;
+
+/**
+ * @extends AbstractFacade<LintFactory>
+ */
+final class LintFacade extends AbstractFacade
+{
+    /**
+     * @param list<string> $paths
+     */
+    public function lint(array $paths, RuleSettings $settings, ?LintCache $cache = null): LintResult
+    {
+        return $this->getFactory()
+            ->createLintRunner($cache)
+            ->run($paths, $settings);
+    }
+
+    public function loadSettings(string $configPath, RuleSettings $defaults): RuleSettings
+    {
+        return $this->getFactory()
+            ->createConfigLoader()
+            ->load($configPath, $defaults);
+    }
+
+    public function defaultSettings(): RuleSettings
+    {
+        return $this->getFactory()->defaultSettings();
+    }
+
+    public function formatters(): FormatterRegistry
+    {
+        return $this->getFactory()->createFormatterRegistry();
+    }
+
+    public function createCache(string $baseDir): LintCache
+    {
+        return $this->getFactory()->createLintCache($baseDir);
+    }
+}

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Api\ApiFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Lint\Application\Cache\LintCache;
+use Phel\Lint\Application\Config\ConfigLoader;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\FileCollector;
+use Phel\Lint\Application\Formatter\FormatterRegistry;
+use Phel\Lint\Application\Formatter\GithubFormatter;
+use Phel\Lint\Application\Formatter\HumanFormatter;
+use Phel\Lint\Application\Formatter\JsonFormatter;
+use Phel\Lint\Application\LintRunner;
+use Phel\Lint\Application\Rule\ArityMismatchRule;
+use Phel\Lint\Application\Rule\DiscouragedVarRule;
+use Phel\Lint\Application\Rule\DuplicateKeyRule;
+use Phel\Lint\Application\Rule\InvalidDestructuringRule;
+use Phel\Lint\Application\Rule\RedundantDoRule;
+use Phel\Lint\Application\Rule\ShadowedBindingRule;
+use Phel\Lint\Application\Rule\UnresolvedSymbolRule;
+use Phel\Lint\Application\Rule\UnusedBindingRule;
+use Phel\Lint\Application\Rule\UnusedImportRule;
+use Phel\Lint\Application\Rule\UnusedRequireRule;
+use Phel\Lint\Application\RulePipeline;
+use Phel\Lint\Application\SourceReader;
+use Phel\Lint\Domain\LintRuleInterface;
+use Phel\Run\RunFacade;
+
+use function implode;
+use function md5;
+use function sort;
+
+/**
+ * @extends AbstractFactory<LintConfig>
+ */
+final class LintFactory extends AbstractFactory
+{
+    public function createLintRunner(?LintCache $cache = null): LintRunner
+    {
+        return new LintRunner(
+            $this->getApiFacade(),
+            $this->createFileCollector(),
+            $this->createSourceReader(),
+            $this->createRulePipeline(),
+            $cache,
+        );
+    }
+
+    public function createRulePipeline(): RulePipeline
+    {
+        return new RulePipeline($this->createRules());
+    }
+
+    /**
+     * @return list<LintRuleInterface>
+     */
+    public function createRules(): array
+    {
+        return [
+            new UnresolvedSymbolRule(),
+            new ArityMismatchRule(),
+            new UnusedBindingRule(),
+            new UnusedRequireRule(),
+            new UnusedImportRule(),
+            new ShadowedBindingRule(),
+            new RedundantDoRule(),
+            new DuplicateKeyRule($this->getCompilerFacade()),
+            new InvalidDestructuringRule(),
+            new DiscouragedVarRule(),
+        ];
+    }
+
+    public function defaultSettings(): RuleSettings
+    {
+        return $this->getConfig()->defaultSettings();
+    }
+
+    public function createFormatterRegistry(): FormatterRegistry
+    {
+        $registry = new FormatterRegistry();
+        $registry->register(new HumanFormatter());
+        $registry->register(new JsonFormatter());
+        $registry->register(new GithubFormatter());
+
+        return $registry;
+    }
+
+    public function createConfigLoader(): ConfigLoader
+    {
+        return new ConfigLoader($this->getCompilerFacade());
+    }
+
+    public function createSourceReader(): SourceReader
+    {
+        return new SourceReader($this->getCompilerFacade());
+    }
+
+    public function createFileCollector(): FileCollector
+    {
+        return new FileCollector();
+    }
+
+    public function createLintCache(string $cacheDir): LintCache
+    {
+        return new LintCache($cacheDir, $this->ruleFingerprint());
+    }
+
+    public function getApiFacade(): ApiFacade
+    {
+        return $this->getProvidedDependency(LintProvider::FACADE_API);
+    }
+
+    public function getCompilerFacade(): CompilerFacade
+    {
+        return $this->getProvidedDependency(LintProvider::FACADE_COMPILER);
+    }
+
+    public function getCommandFacade(): CommandFacade
+    {
+        return $this->getProvidedDependency(LintProvider::FACADE_COMMAND);
+    }
+
+    public function getRunFacade(): RunFacade
+    {
+        return $this->getProvidedDependency(LintProvider::FACADE_RUN);
+    }
+
+    /**
+     * Deterministic fingerprint covering the rule set. Drives cache
+     * invalidation when rules are added, removed, or reordered.
+     */
+    private function ruleFingerprint(): string
+    {
+        $codes = RuleRegistry::allCodes();
+        sort($codes);
+
+        return md5(implode('|', $codes));
+    }
+}

--- a/src/php/Lint/LintProvider.php
+++ b/src/php/Lint/LintProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use Phel\Api\ApiFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Run\RunFacade;
+
+final class LintProvider extends AbstractProvider
+{
+    public const string FACADE_API = 'FACADE_API';
+
+    public const string FACADE_COMPILER = 'FACADE_COMPILER';
+
+    public const string FACADE_COMMAND = 'FACADE_COMMAND';
+
+    public const string FACADE_RUN = 'FACADE_RUN';
+
+    #[Provides(self::FACADE_API)]
+    public function apiFacade(Container $container): ApiFacade
+    {
+        return $container->getLocator()->getRequired(ApiFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
+    {
+        return $container->getLocator()->getRequired(CompilerFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
+    {
+        return $container->getLocator()->getRequired(CommandFacade::class);
+    }
+
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
+    {
+        return $container->getLocator()->getRequired(RunFacade::class);
+    }
+}

--- a/src/php/Lint/Transfer/LintResult.php
+++ b/src/php/Lint/Transfer/LintResult.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Transfer;
+
+use Phel\Api\Transfer\Diagnostic;
+
+use function array_map;
+use function count;
+
+/**
+ * Aggregate outcome of a lint run: the flat list of diagnostics plus
+ * per-severity counters used to drive the process exit code.
+ */
+final readonly class LintResult
+{
+    /**
+     * @param list<Diagnostic> $diagnostics
+     * @param list<string>     $scannedFiles
+     */
+    public function __construct(
+        public array $diagnostics,
+        public array $scannedFiles = [],
+    ) {}
+
+    public function errorCount(): int
+    {
+        return $this->countBySeverity(Diagnostic::SEVERITY_ERROR);
+    }
+
+    public function warningCount(): int
+    {
+        return $this->countBySeverity(Diagnostic::SEVERITY_WARNING);
+    }
+
+    public function infoCount(): int
+    {
+        return $this->countBySeverity(Diagnostic::SEVERITY_INFO);
+    }
+
+    public function hintCount(): int
+    {
+        return $this->countBySeverity(Diagnostic::SEVERITY_HINT);
+    }
+
+    public function hasErrors(): bool
+    {
+        return $this->errorCount() > 0;
+    }
+
+    public function totalCount(): int
+    {
+        return count($this->diagnostics);
+    }
+
+    /**
+     * @return list<array{
+     *     code: string,
+     *     severity: string,
+     *     message: string,
+     *     uri: string,
+     *     startLine: int,
+     *     startCol: int,
+     *     endLine: int,
+     *     endCol: int,
+     * }>
+     */
+    public function toArray(): array
+    {
+        return array_map(static fn(Diagnostic $d): array => $d->toArray(), $this->diagnostics);
+    }
+
+    private function countBySeverity(string $severity): int
+    {
+        $count = 0;
+        foreach ($this->diagnostics as $diagnostic) {
+            if ($diagnostic->severity === $severity) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/tests/php/Integration/Lint/Fixtures/clean.phel
+++ b/tests/php/Integration/Lint/Fixtures/clean.phel
@@ -1,0 +1,4 @@
+(ns fixtures\clean)
+
+(defn greet [name]
+  (str "Hello, " name))

--- a/tests/php/Integration/Lint/Fixtures/unused_binding.phel
+++ b/tests/php/Integration/Lint/Fixtures/unused_binding.phel
@@ -1,0 +1,6 @@
+(ns fixtures\unused-binding)
+
+(defn demo []
+  (let [x 1
+        y 2]
+    y))

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Lint;
+
+use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Lint\Infrastructure\Command\LintCommand;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function json_decode;
+
+final class LintCommandTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_emits_json_diagnostics_for_unused_binding_fixture(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/unused_binding.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        self::assertContains($exit, [0, 1]);
+        $payload = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($payload);
+
+        $codes = array_map(static fn(array $d): string => $d['code'], $payload);
+        self::assertContains('phel/unused-binding', $codes);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_returns_zero_on_clean_fixture(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/clean.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        self::assertSame(0, $exit);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_fails_with_invocation_error_on_unknown_format(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/clean.phel'],
+            '--format' => 'bogus',
+        ]);
+
+        self::assertSame(LintCommand::EXIT_INVOCATION_ERROR, $exit);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_fails_with_invocation_error_when_no_readable_paths(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => ['/nonexistent/path/does/not/exist.phel'],
+        ]);
+
+        self::assertSame(LintCommand::EXIT_INVOCATION_ERROR, $exit);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_github_format_emits_annotation_commands(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/unused_binding.phel'],
+            '--format' => 'github',
+            '--no-cache' => true,
+        ]);
+
+        $out = $tester->getDisplay();
+        self::assertStringContainsString('::', $out);
+        self::assertMatchesRegularExpression('/^::(error|warning|notice) /m', $out);
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+}

--- a/tests/php/Integration/Lint/LintConfigFileTest.php
+++ b/tests/php/Integration/Lint/LintConfigFileTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Lint;
+
+use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Lint\Infrastructure\Command\LintCommand;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function file_put_contents;
+use function json_decode;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+/**
+ * End-to-end check that a `.phel-lint.phel` config opt-out silences
+ * a rule that would otherwise report diagnostics on the fixture.
+ */
+final class LintConfigFileTest extends TestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_config_file_can_disable_a_rule(): void
+    {
+        $this->bootstrap();
+
+        $configPath = tempnam(sys_get_temp_dir(), 'lint-cfg-');
+        self::assertIsString($configPath);
+        file_put_contents(
+            $configPath,
+            "{:rules {:phel/unused-binding :off}}\n",
+        );
+
+        try {
+            $tester = new CommandTester(new LintCommand());
+            $tester->execute([
+                'paths' => [__DIR__ . '/Fixtures/unused_binding.phel'],
+                '--format' => 'json',
+                '--config' => $configPath,
+                '--no-cache' => true,
+            ]);
+
+            $payload = json_decode(trim($tester->getDisplay()), true);
+            self::assertIsArray($payload);
+
+            $codes = array_map(static fn(array $d): string => $d['code'], $payload);
+            self::assertNotContains('phel/unused-binding', $codes);
+        } finally {
+            @unlink($configPath);
+        }
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+}

--- a/tests/php/Unit/Lint/Application/Config/RuleSettingsTest.php
+++ b/tests/php/Unit/Lint/Application/Config/RuleSettingsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Config;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Config\RuleSettings;
+use PHPUnit\Framework\TestCase;
+
+final class RuleSettingsTest extends TestCase
+{
+    public function test_it_builds_from_a_severity_map_and_drops_invalid_entries(): void
+    {
+        $settings = RuleSettings::fromMap([
+            RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING,
+            RuleRegistry::ARITY_MISMATCH => 'bogus-severity',
+        ]);
+
+        self::assertTrue($settings->isEnabled(RuleRegistry::UNUSED_BINDING));
+        self::assertFalse($settings->isEnabled(RuleRegistry::ARITY_MISMATCH));
+    }
+
+    public function test_it_merges_overrides_and_off_disables_a_rule(): void
+    {
+        $base = RuleSettings::fromMap([
+            RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING,
+        ]);
+
+        $merged = $base->withOverrides(
+            [RuleRegistry::UNUSED_BINDING => RuleSettings::SEVERITY_OFF],
+            [],
+        );
+
+        self::assertFalse($merged->isEnabled(RuleRegistry::UNUSED_BINDING));
+    }
+
+    public function test_it_matches_path_glob_exclusion(): void
+    {
+        $settings = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: [RuleRegistry::UNUSED_BINDING => ['src/phel/*.phel']],
+        );
+
+        self::assertTrue($settings->isExcluded(
+            RuleRegistry::UNUSED_BINDING,
+            'src/phel/local.phel',
+            'phel\\local',
+        ));
+    }
+
+    public function test_it_matches_namespace_glob_exclusion(): void
+    {
+        $settings = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: [RuleRegistry::UNUSED_BINDING => ['phel\\experimental*']],
+        );
+
+        self::assertTrue($settings->isExcluded(
+            RuleRegistry::UNUSED_BINDING,
+            '/tmp/foo.phel',
+            'phel\\experimental\\sub',
+        ));
+    }
+
+    public function test_it_falls_back_to_off_for_unknown_rule_code(): void
+    {
+        $settings = RuleSettings::fromMap([]);
+
+        self::assertSame(RuleSettings::SEVERITY_OFF, $settings->severityFor('phel/nope'));
+        self::assertFalse($settings->isEnabled('phel/nope'));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Formatter/FormatterRegistryTest.php
+++ b/tests/php/Unit/Lint/Application/Formatter/FormatterRegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Formatter;
+
+use InvalidArgumentException;
+use Phel\Lint\Application\Formatter\FormatterRegistry;
+use Phel\Lint\Application\Formatter\HumanFormatter;
+use Phel\Lint\Application\Formatter\JsonFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class FormatterRegistryTest extends TestCase
+{
+    public function test_it_looks_up_registered_formatters_by_name(): void
+    {
+        $registry = new FormatterRegistry();
+        $registry->register(new HumanFormatter());
+        $registry->register(new JsonFormatter());
+
+        self::assertTrue($registry->has('human'));
+        self::assertTrue($registry->has('json'));
+        self::assertInstanceOf(HumanFormatter::class, $registry->get('human'));
+    }
+
+    public function test_it_throws_on_unknown_formatter(): void
+    {
+        $registry = new FormatterRegistry();
+
+        $this->expectException(InvalidArgumentException::class);
+        $registry->get('nope');
+    }
+
+    public function test_it_reports_registered_names(): void
+    {
+        $registry = new FormatterRegistry();
+        $registry->register(new HumanFormatter());
+
+        self::assertContains('human', $registry->names());
+    }
+}

--- a/tests/php/Unit/Lint/Application/Formatter/GithubFormatterTest.php
+++ b/tests/php/Unit/Lint/Application/Formatter/GithubFormatterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Formatter;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Formatter\GithubFormatter;
+use Phel\Lint\Transfer\LintResult;
+use PHPUnit\Framework\TestCase;
+
+final class GithubFormatterTest extends TestCase
+{
+    public function test_it_emits_github_annotation_command_per_diagnostic(): void
+    {
+        $formatter = new GithubFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/a', Diagnostic::SEVERITY_ERROR, 'boom', '/f.phel', 7, 3, 7, 9),
+        ]);
+
+        $out = $formatter->format($result);
+
+        self::assertStringStartsWith('::error ', $out);
+        self::assertStringContainsString('file=/f.phel', $out);
+        self::assertStringContainsString('line=7', $out);
+        self::assertStringContainsString('col=3', $out);
+        self::assertStringContainsString('title=phel/a', $out);
+        self::assertStringContainsString('::boom', $out);
+    }
+
+    public function test_it_maps_warning_severity_to_warning_level(): void
+    {
+        $formatter = new GithubFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/b', Diagnostic::SEVERITY_WARNING, 'x', 'f.phel', 1, 1, 1, 2),
+        ]);
+
+        self::assertStringStartsWith('::warning ', $formatter->format($result));
+    }
+
+    public function test_it_maps_info_severity_to_notice_level(): void
+    {
+        $formatter = new GithubFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/c', Diagnostic::SEVERITY_INFO, 'x', 'f.phel', 1, 1, 1, 2),
+        ]);
+
+        self::assertStringStartsWith('::notice ', $formatter->format($result));
+    }
+
+    public function test_it_encodes_special_characters_in_messages(): void
+    {
+        $formatter = new GithubFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/d', Diagnostic::SEVERITY_WARNING, "one\ntwo%", 'f.phel', 1, 1, 1, 2),
+        ]);
+
+        $out = $formatter->format($result);
+
+        self::assertStringContainsString('one%0Atwo%25', $out);
+    }
+}

--- a/tests/php/Unit/Lint/Application/Formatter/HumanFormatterTest.php
+++ b/tests/php/Unit/Lint/Application/Formatter/HumanFormatterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Formatter;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Formatter\HumanFormatter;
+use Phel\Lint\Transfer\LintResult;
+use PHPUnit\Framework\TestCase;
+
+final class HumanFormatterTest extends TestCase
+{
+    public function test_it_formats_one_line_per_diagnostic_plus_summary(): void
+    {
+        $formatter = new HumanFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/a', Diagnostic::SEVERITY_ERROR, 'bad', '/f.phel', 2, 4, 2, 6),
+            new Diagnostic('phel/b', Diagnostic::SEVERITY_WARNING, 'meh', '/f.phel', 3, 1, 3, 5),
+        ]);
+
+        $output = $formatter->format($result);
+
+        self::assertStringContainsString('/f.phel:2:4 [error] phel/a bad', $output);
+        self::assertStringContainsString('/f.phel:3:1 [warning] phel/b meh', $output);
+        self::assertStringContainsString('1 error(s)', $output);
+        self::assertStringContainsString('1 warning(s)', $output);
+    }
+
+    public function test_it_reports_clean_run(): void
+    {
+        $formatter = new HumanFormatter();
+
+        self::assertSame('No lint issues found.', $formatter->format(new LintResult([])));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Formatter/JsonFormatterTest.php
+++ b/tests/php/Unit/Lint/Application/Formatter/JsonFormatterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Formatter;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Application\Formatter\JsonFormatter;
+use Phel\Lint\Transfer\LintResult;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+final class JsonFormatterTest extends TestCase
+{
+    public function test_it_serialises_diagnostics_as_stable_json_array(): void
+    {
+        $formatter = new JsonFormatter();
+        $result = new LintResult([
+            new Diagnostic('phel/a', Diagnostic::SEVERITY_ERROR, 'msg', '/f.phel', 2, 4, 2, 6),
+        ]);
+
+        $decoded = json_decode($formatter->format($result), true);
+
+        self::assertIsArray($decoded);
+        self::assertCount(1, $decoded);
+        self::assertSame('phel/a', $decoded[0]['code']);
+        self::assertSame(Diagnostic::SEVERITY_ERROR, $decoded[0]['severity']);
+        self::assertSame(2, $decoded[0]['startLine']);
+    }
+
+    public function test_it_returns_empty_array_for_clean_run(): void
+    {
+        $formatter = new JsonFormatter();
+
+        self::assertSame('[]', $formatter->format(new LintResult([])));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/ArityMismatchRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/ArityMismatchRuleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\ArityMismatchRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class ArityMismatchRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_wrong_arity_for_same_file_defn(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<PHEL
+(ns user)
+
+(defn add [x y] (+ x y))
+
+(add 1 2 3)
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertNotEmpty($diagnostics);
+        self::assertSame(RuleRegistry::ARITY_MISMATCH, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_allows_variadic_arity(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<PHEL
+(ns user)
+
+(defn vara [x & rest] x)
+
+(vara 1 2 3 4)
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_correct_arity(): void
+    {
+        $rule = new ArityMismatchRule();
+        $source = <<<PHEL
+(ns user)
+
+(defn add [x y] (+ x y))
+
+(add 1 2)
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/DuplicateKeyRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/DuplicateKeyRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\DuplicateKeyRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class DuplicateKeyRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_duplicate_keyword_keys(): void
+    {
+        $rule = new DuplicateKeyRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("{:a 1 :a 2}\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertNotEmpty($diagnostics);
+        self::assertSame(RuleRegistry::DUPLICATE_KEY, $diagnostics[0]->code);
+        self::assertStringContainsString(':a', $diagnostics[0]->message);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_duplicate_string_keys(): void
+    {
+        $rule = new DuplicateKeyRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("{\"x\" 1 \"x\" 2}\n");
+
+        self::assertNotEmpty($rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_distinct_keys(): void
+    {
+        $rule = new DuplicateKeyRule($this->compilerFacade());
+        $analysis = $this->buildAnalysis("{:a 1 :b 2}\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/InvalidDestructuringRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/InvalidDestructuringRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\InvalidDestructuringRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class InvalidDestructuringRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_odd_binding_vector(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(let [x 1 y] x)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::INVALID_DESTRUCTURING, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_invalid_variadic_marker_in_fn(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(fn [a & b c] a)\n");
+
+        self::assertNotEmpty($rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_accepts_well_formed_variadic_fn(): void
+    {
+        $rule = new InvalidDestructuringRule();
+        $analysis = $this->buildAnalysis("(fn [a & rest] a)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/RedundantDoRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/RedundantDoRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\RedundantDoRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class RedundantDoRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_do_with_zero_body_forms(): void
+    {
+        $rule = new RedundantDoRule();
+        $analysis = $this->buildAnalysis("(do)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::REDUNDANT_DO, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_do_with_single_body_form(): void
+    {
+        $rule = new RedundantDoRule();
+        $analysis = $this->buildAnalysis("(do 1)\n");
+
+        self::assertCount(1, $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_multi_form_do(): void
+    {
+        $rule = new RedundantDoRule();
+        $analysis = $this->buildAnalysis("(do 1 2 3)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/RuleTestCase.php
+++ b/tests/php/Unit/Lint/Application/Rule/RuleTestCase.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
+use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
+use Phel\Lint\Domain\FileAnalysis;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+abstract class RuleTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+
+    protected function compilerFacade(): CompilerFacade
+    {
+        return new CompilerFacade();
+    }
+
+    protected function buildAnalysis(string $source, string $uri = 'test.phel'): FileAnalysis
+    {
+        $compiler = $this->compilerFacade();
+        $forms = [];
+        $namespace = '';
+
+        $tokenStream = $compiler->lexString($source, $uri);
+        while (true) {
+            $parseTree = $compiler->parseNext($tokenStream);
+            if (!$parseTree instanceof NodeInterface) {
+                break;
+            }
+
+            if ($parseTree instanceof TriviaNodeInterface) {
+                continue;
+            }
+
+            $readerResult = $compiler->read($parseTree);
+            $form = $readerResult->getAst();
+
+            if ($namespace === '') {
+                $maybe = $this->extractNamespace($form);
+                if ($maybe !== '') {
+                    $namespace = $maybe;
+                }
+            }
+
+            $forms[] = $form;
+        }
+
+        return new FileAnalysis(
+            uri: $uri,
+            namespace: $namespace,
+            source: $source,
+            forms: $forms,
+            projectIndex: new ProjectIndex([], []),
+        );
+    }
+
+    /**
+     * @param bool|float|int|string|TypeInterface|null $form
+     */
+    private function extractNamespace(mixed $form): string
+    {
+        if (!$form instanceof PersistentListInterface || count($form) < 2) {
+            return '';
+        }
+
+        $head = $form->get(0);
+        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_NS) {
+            return '';
+        }
+
+        $name = $form->get(1);
+        if (!$name instanceof Symbol) {
+            return '';
+        }
+
+        return $name->getFullName();
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/ShadowedBindingRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/ShadowedBindingRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\ShadowedBindingRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class ShadowedBindingRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_shadowed_binding_in_nested_let(): void
+    {
+        $rule = new ShadowedBindingRule();
+        $analysis = $this->buildAnalysis("(let [x 1] (let [x 2] x))\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::SHADOWED_BINDING, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_distinct_bindings(): void
+    {
+        $rule = new ShadowedBindingRule();
+        $analysis = $this->buildAnalysis("(let [x 1] (let [y 2] (+ x y)))\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_fn_param_shadowing_outer_binding(): void
+    {
+        $rule = new ShadowedBindingRule();
+        $analysis = $this->buildAnalysis("(let [x 1] (fn [x] x))\n");
+
+        self::assertNotEmpty($rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/UnusedBindingRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/UnusedBindingRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\UnusedBindingRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class UnusedBindingRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_unused_let_binding(): void
+    {
+        $rule = new UnusedBindingRule();
+        $analysis = $this->buildAnalysis("(let [x 1] 42)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(RuleRegistry::UNUSED_BINDING, $diagnostics[0]->code);
+        self::assertStringContainsString("'x'", $diagnostics[0]->message);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_used_binding(): void
+    {
+        $rule = new UnusedBindingRule();
+        $analysis = $this->buildAnalysis("(let [x 1] x)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_ignores_underscore_bindings(): void
+    {
+        $rule = new UnusedBindingRule();
+        $analysis = $this->buildAnalysis("(let [_ 1] 42)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/UnusedImportRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/UnusedImportRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\UnusedImportRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class UnusedImportRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_unused_php_import(): void
+    {
+        $rule = new UnusedImportRule();
+        $source = <<<PHEL
+(ns user
+  (:use DateTime))
+
+42
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertNotEmpty($diagnostics);
+        self::assertSame(RuleRegistry::UNUSED_IMPORT, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_used_import(): void
+    {
+        $rule = new UnusedImportRule();
+        $source = <<<PHEL
+(ns user
+  (:use DateTime))
+
+(php/new DateTime)
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/UnusedRequireRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/UnusedRequireRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lint\Application\Config\RuleRegistry;
+use Phel\Lint\Application\Rule\UnusedRequireRule;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+final class UnusedRequireRuleTest extends RuleTestCase
+{
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_require_whose_alias_is_never_used(): void
+    {
+        $rule = new UnusedRequireRule();
+        $source = <<<PHEL
+(ns user
+  (:require foo\\bar :as b))
+
+42
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertNotEmpty($diagnostics);
+        self::assertSame(RuleRegistry::UNUSED_REQUIRE, $diagnostics[0]->code);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_require_whose_alias_is_used(): void
+    {
+        $rule = new UnusedRequireRule();
+        $source = <<<PHEL
+(ns user
+  (:require foo\\bar :as b))
+
+(b/call 1)
+PHEL;
+        $analysis = $this->buildAnalysis($source);
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+}

--- a/tests/php/Unit/Lint/Application/RulePipelineTest.php
+++ b/tests/php/Unit/Lint/Application/RulePipelineTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lint\Application\Config\RuleSettings;
+use Phel\Lint\Application\RulePipeline;
+use Phel\Lint\Domain\FileAnalysis;
+use Phel\Lint\Domain\LintRuleInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class RulePipelineTest extends TestCase
+{
+    public function test_it_skips_rules_set_to_off(): void
+    {
+        $rule = $this->ruleReturning('phel/a', [
+            $this->placeholder('phel/a', 'x'),
+        ]);
+        $pipeline = new RulePipeline([$rule]);
+
+        $settings = new RuleSettings(
+            severities: ['phel/a' => RuleSettings::SEVERITY_OFF],
+        );
+
+        $result = $pipeline->run($this->analysis(), $settings);
+
+        self::assertSame([], $result);
+    }
+
+    public function test_it_rewrites_severity_from_settings(): void
+    {
+        $rule = $this->ruleReturning('phel/a', [
+            $this->placeholder('phel/a', 'x'),
+        ]);
+        $pipeline = new RulePipeline([$rule]);
+
+        $settings = new RuleSettings(
+            severities: ['phel/a' => Diagnostic::SEVERITY_ERROR],
+        );
+
+        $result = $pipeline->run($this->analysis(), $settings);
+
+        self::assertCount(1, $result);
+        self::assertSame(Diagnostic::SEVERITY_ERROR, $result[0]->severity);
+    }
+
+    public function test_it_isolates_failing_rule(): void
+    {
+        $bad = new class() implements LintRuleInterface {
+            public function code(): string
+            {
+                return 'phel/bad';
+            }
+
+            public function apply(FileAnalysis $analysis): array
+            {
+                throw new RuntimeException('boom');
+            }
+        };
+        $good = $this->ruleReturning('phel/good', [
+            $this->placeholder('phel/good', 'msg'),
+        ]);
+
+        $pipeline = new RulePipeline([$bad, $good]);
+        $settings = new RuleSettings(
+            severities: [
+                'phel/bad' => Diagnostic::SEVERITY_WARNING,
+                'phel/good' => Diagnostic::SEVERITY_WARNING,
+            ],
+        );
+
+        $result = $pipeline->run($this->analysis(), $settings);
+
+        self::assertCount(1, $result);
+        self::assertSame('phel/good', $result[0]->code);
+    }
+
+    public function test_it_respects_per_rule_excludes(): void
+    {
+        $rule = $this->ruleReturning('phel/a', [
+            $this->placeholder('phel/a', 'x'),
+        ]);
+        $pipeline = new RulePipeline([$rule]);
+
+        $settings = new RuleSettings(
+            severities: ['phel/a' => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: ['phel/a' => ['*excluded*']],
+        );
+
+        $analysis = new FileAnalysis(
+            uri: '/path/to/excluded/file.phel',
+            namespace: 'phel\\test',
+            source: '',
+            forms: [],
+            projectIndex: new ProjectIndex([], []),
+        );
+
+        self::assertSame([], $pipeline->run($analysis, $settings));
+    }
+
+    private function analysis(): FileAnalysis
+    {
+        return new FileAnalysis(
+            uri: 'f.phel',
+            namespace: 'user',
+            source: '',
+            forms: [],
+            projectIndex: new ProjectIndex([], []),
+        );
+    }
+
+    private function placeholder(string $code, string $message): Diagnostic
+    {
+        return new Diagnostic($code, Diagnostic::SEVERITY_WARNING, $message, 'f.phel', 1, 1, 1, 1);
+    }
+
+    /**
+     * @param list<Diagnostic> $output
+     */
+    private function ruleReturning(string $code, array $output): LintRuleInterface
+    {
+        return new readonly class($code, $output) implements LintRuleInterface {
+            /**
+             * @param list<Diagnostic> $output
+             */
+            public function __construct(
+                private string $ruleCode,
+                private array $output,
+            ) {}
+
+            public function code(): string
+            {
+                return $this->ruleCode;
+            }
+
+            public function apply(FileAnalysis $analysis): array
+            {
+                return $this->output;
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Lint/Transfer/LintResultTest.php
+++ b/tests/php/Unit/Lint/Transfer/LintResultTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Transfer;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Transfer\LintResult;
+use PHPUnit\Framework\TestCase;
+
+final class LintResultTest extends TestCase
+{
+    public function test_it_counts_diagnostics_by_severity(): void
+    {
+        $result = new LintResult([
+            $this->diagnostic(Diagnostic::SEVERITY_ERROR),
+            $this->diagnostic(Diagnostic::SEVERITY_ERROR),
+            $this->diagnostic(Diagnostic::SEVERITY_WARNING),
+            $this->diagnostic(Diagnostic::SEVERITY_INFO),
+            $this->diagnostic(Diagnostic::SEVERITY_HINT),
+        ]);
+
+        self::assertSame(2, $result->errorCount());
+        self::assertSame(1, $result->warningCount());
+        self::assertSame(1, $result->infoCount());
+        self::assertSame(1, $result->hintCount());
+        self::assertSame(5, $result->totalCount());
+        self::assertTrue($result->hasErrors());
+    }
+
+    public function test_it_reports_no_errors_when_all_warnings(): void
+    {
+        $result = new LintResult([$this->diagnostic(Diagnostic::SEVERITY_WARNING)]);
+
+        self::assertFalse($result->hasErrors());
+    }
+
+    public function test_it_serialises_each_diagnostic_via_to_array(): void
+    {
+        $result = new LintResult([$this->diagnostic(Diagnostic::SEVERITY_WARNING)]);
+
+        $payload = $result->toArray();
+        self::assertCount(1, $payload);
+        self::assertArrayHasKey('code', $payload[0]);
+        self::assertSame('phel/test', $payload[0]['code']);
+    }
+
+    private function diagnostic(string $severity): Diagnostic
+    {
+        return new Diagnostic(
+            code: 'phel/test',
+            severity: $severity,
+            message: 'msg',
+            uri: 'f.phel',
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 1,
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Tier 1 item #3 of the Clojure-parity roadmap: Phel ships `./bin/phel fmt` (whitespace only) but has no semantic linter, so correctness issues surface only at run time. This PR delivers a read-only `lint` command on top of the `ApiFacade::analyzeSource` + `indexProject` plumbing that landed in #1508.

## 💡 Goal

Emit stable, configurable diagnostics for common Phel code smells and analysis errors, with JSON output for editors/CI and GitHub Actions annotation output for PR checks.

## 🔖 Changes

- New `Phel\Lint` Gacela module under `src/php/Lint/`: `LintFacade`, `LintFactory`, `LintConfig`, `LintProvider`, `LintRunner`, `RulePipeline`, `FileAnalysis` transfer, `LintResult` transfer
- Ten v1 rules, one class each, plugged in via `LintFactory::createRules()`:
  - `phel/unresolved-symbol` (error), `phel/arity-mismatch` (error), `phel/invalid-destructuring` (error), `phel/duplicate-key` (error)
  - `phel/unused-binding`, `phel/unused-require`, `phel/unused-import`, `phel/shadowed-binding`, `phel/redundant-do`, `phel/discouraged-var` (warning by default)
- Three formatters behind `DiagnosticFormatterInterface`: `human` (default), `json`, `github` (Actions annotation syntax)
- `phel-lint.phel` EDN-like config with `:rules` map (per-rule severity including `:off`) and `:exclude` map (glob patterns matched against file path or namespace)
- Optional file-hash + rule-fingerprint cache under `.phel/lint-cache/index.json`, disable with `--no-cache`
- Exit codes: `0` clean/warn-only, `1` errors, `2` invocation error (bad flag, no readable paths)
- New CLI: `./bin/phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]` registered in `ConsoleProvider`
- Unit tests per rule, per formatter, for `RuleSettings`, `RulePipeline`, `LintResult`; integration tests cover the CLI, config file opt-out, and GitHub format output
- `CHANGELOG.md` Unreleased updated
- `src/php/Lint/CLAUDE.md` documents the Gacela pattern, public API, rules, config, and constraints