### PR TITLE
docs: improve agent docs with gotchas and new features reference

### DIFF
--- a/.agents/RULES.md
+++ b/.agents/RULES.md
@@ -15,6 +15,33 @@ Single source for every skill adapter.
 9. PHP assoc array: `#php {"k" "v"}` or `(to-php-array m)`. Not `{:k "v"}`.
 10. Catch PHP: `(catch php\SomeException e ...)`.
 
+## New features (v0.30 – main)
+
+Use these when appropriate — they are stable and tested.
+
+| Feature | Syntax | Since |
+|---------|--------|-------|
+| Records | `(defrecord Point [x y])` → `(->Point 1 2)`, `(map->Point {:x 1 :y 2})` | v0.32 |
+| Protocols | `(defprotocol Drawable (draw [this]))` + `(extend-type :string Drawable (draw [s] ...))` | v0.31 |
+| Multimethods | `(defmulti area :shape)` + `(defmethod area :circle [{:radius r}] ...)` | v0.30 |
+| Transducers | `(into [] (filter odd?) [1 2 3])`, `(transduce (map inc) + 0 coll)` | v0.31 |
+| Regex literals | `#"^\d+$"`, `(re-find #"\d+" "abc123")` → `"123"` | v0.31 |
+| Pretty-print | `(require phel\pprint)` → `(pprint data)` | v0.30 |
+| Sorted colls | `(sorted-map :a 1 :b 2)`, `(sorted-set 3 1 2)` | v0.32 |
+| `condp` | `(condp = x 1 "one" 2 "two" "other")` | v0.32 |
+| `defrecord` w/ protocols | `(defrecord Foo [x] MyProto (my-fn [this] ...))` | v0.32 |
+| `doseq` | `(doseq [x :in coll] (println x))` — side-effecting iteration | v0.31 |
+| `for` comprehension | `(for [x :in xs :when (odd? x)] (* x x))` — builds sequence | v0.31 |
+
+## Gotchas
+
+See [`tasks/common-gotchas.md`](tasks/common-gotchas.md) for details. Quick summary:
+
+- **CLI args**: use `*argv*` (vec of strings after script path), not `php/$argv`.
+- **`transduce` + `max`/`min`**: these don't support 0-arity; pass explicit init: `(transduce xf (fn [a b] (max a b)) 0 coll)`.
+- **`for` vs `doseq`**: `for` builds a sequence (lazy); `doseq` is for side effects. Don't use `for` for `println` loops.
+- **`phel\string`**: was `phel\str` before v0.33.
+
 ## CLI
 
 | Task | Command |

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -13,6 +13,7 @@ Rules + CLI: [`RULES.md`](RULES.md).
 | REPL | [`tasks/repl-workflow.md`](tasks/repl-workflow.md) | `src/phel/repl.phel` |
 | Find core fn | [`tasks/use-core-lib.md`](tasks/use-core-lib.md) | `(phel doc <fn>)`, `docs/patterns.md` |
 | Debug errors | [`tasks/debug-errors.md`](tasks/debug-errors.md) | `docs/patterns.md` § Error Handling |
+| Common pitfalls | [`tasks/common-gotchas.md`](tasks/common-gotchas.md) | `RULES.md` § Gotchas |
 | Use a PHP library | [`tasks/use-php-libs.md`](tasks/use-php-libs.md) | `docs/php-interop.md` |
 | Syntax reference | — | `docs/quickstart.md`, `docs/reader-shortcuts.md` |
 | Idioms | — | `docs/patterns.md`, `docs/examples/` |

--- a/.agents/skills/claude/phel-lang/SKILL.md
+++ b/.agents/skills/claude/phel-lang/SKILL.md
@@ -9,11 +9,63 @@ Lisp dialect that compiles to PHP. PHP interop via `php/` prefix.
 
 ## Load order
 
-1. `.agents/RULES.md` — hard rules and CLI cheatsheet
-2. `.agents/index.md` — task map
-3. `.agents/tasks/<intent>.md` — recipe for the current task
-4. `src/phel/` and `docs/` only when a recipe points there
+1. `.agents/RULES.md` — hard rules, new features reference, and CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code to avoid common pitfalls
+3. `.agents/index.md` — task map
+4. `.agents/tasks/<intent>.md` — recipe for the current task
+5. `src/phel/` and `docs/` only when a recipe points there
+
+## Before you start coding
+
+- Read `.agents/RULES.md` § Gotchas — saves 5-10 min of debugging
+- Use `*argv*` for CLI args, NOT `php/$argv`
+- Use `doseq` for side effects, `for` for building sequences
+- String module is `phel\string` (not `phel\str`)
+- Use `defrecord`, `defprotocol`, `defmulti` for structured code — they are stable since v0.30-0.32
 
 ## Working examples
 
 `.agents/examples/{todo-app, http-json-api, cli-wordcount}/` — copy, adapt, run.
+
+## Quick syntax reference
+
+```phel
+;; Define + call
+(defn greet [name] (str "Hello, " name "!"))
+(greet "World")
+
+;; Records
+(defrecord Todo [id text done])
+(->Todo 1 "Buy milk" false)            ; positional constructor
+(map->Todo {:id 1 :text "X" :done false}) ; map constructor
+
+;; Protocols
+(defprotocol Showable (show [this]))
+(extend-type Todo Showable (show [t] (str "#" (get t :id) " " (get t :text))))
+
+;; Multimethods
+(defmulti handle-cmd (fn [cmd & _] cmd))
+(defmethod handle-cmd "add" [_ text] (add-item text))
+(defmethod handle-cmd :default [cmd & _] (println "Unknown:" cmd))
+
+;; Transducers
+(into [] (comp (filter odd?) (map inc)) [1 2 3 4 5])  ; => [2 4 6]
+(transduce (map :score) + 0 items)
+
+;; Regex
+(re-find #"\d+" "abc123")  ; => "123"
+
+;; JSON
+(:require phel\json :as json)
+(json/encode {:a 1})  ; => "{\"a\":1}"
+(json/decode "{\"a\":1}")  ; => {:a 1}
+
+;; File I/O
+(slurp "data.txt")
+(spit "out.txt" "content")
+
+;; PHP interop
+(php/new \DateTime "now")
+(php/-> obj (method args))
+(php/:: Class (staticMethod))
+```

--- a/.agents/tasks/common-gotchas.md
+++ b/.agents/tasks/common-gotchas.md
@@ -1,0 +1,113 @@
+# Common gotchas
+
+Pitfalls encountered during real-world Phel app development. Read before writing your first app.
+
+## 1. CLI argument access
+
+**Wrong** — `php/$argv` is `null` inside `phel run`:
+
+```phel
+;; DON'T: this fails at runtime
+(let [args php/$argv] ...)
+```
+
+**Right** — use `*argv*`, which returns a Phel vector of strings (args after the script path):
+
+```phel
+(let [args *argv*]
+  (println "First arg:" (first args)))
+```
+
+For the full `phel\cli` module (subcommands, options, prompts), see `tasks/cli-tool.md`.
+
+## 2. `transduce` with `max` / `min`
+
+`max` and `min` don't support 0-arity (no identity value), so they can't be used as bare reducing functions with `transduce`:
+
+```phel
+;; DON'T: fails — max needs 2 args, transduce calls (max) for init
+(transduce (map :score) max items)
+
+;; DO: wrap and provide init
+(transduce (map :score) (fn [a b] (max a b)) 0 items)
+```
+
+## 3. `for` vs `doseq`
+
+`for` is a **list comprehension** — it builds a lazy sequence. `doseq` is for **side effects**.
+
+```phel
+;; DON'T: for returns a sequence, side effects are incidental
+(for [t :in todos] (println t))
+
+;; DO: doseq when you want side effects
+(doseq [t :in todos] (println t))
+
+;; DO: for when you want to build a collection
+(for [x :in xs :when (odd? x)] (* x x))
+```
+
+## 4. `phel\string` (not `phel\str`)
+
+Since v0.33, the string module is `phel\string`:
+
+```phel
+;; DON'T
+(:require phel\str :as str)
+
+;; DO
+(:require phel\string :as string)
+```
+
+## 5. Namespace segment count
+
+Namespaces need at least 2 segments. Single-segment namespaces cause a compile error:
+
+```phel
+;; DON'T
+(ns main)
+
+;; DO
+(ns my-app\main)
+```
+
+## 6. Top-level side effects and `phel build`
+
+Code at the top level runs during compilation. Wrap side effects:
+
+```phel
+;; DON'T: breaks phel build
+(println "starting...")
+(start-server)
+
+;; DO
+(when-not *build-mode*
+  (println "starting...")
+  (start-server))
+```
+
+## 7. Converting PHP arrays to Phel collections
+
+PHP arrays from interop are not Phel collections. Convert them:
+
+```phel
+;; PHP array → Phel vector
+(vec (php/explode "," "a,b,c"))
+
+;; Phel collection → PHP array (for passing to PHP functions)
+(to-php-array ["a" "b" "c"])
+```
+
+Don't try `to-list` (doesn't exist) or `to-vec` (doesn't exist). Use `vec`.
+
+## 8. Record fields are accessed with `get`
+
+`defrecord` fields use keyword access via `get`, not dot notation:
+
+```phel
+(defrecord Point [x y])
+(let [p (->Point 1 2)]
+  ;; DON'T: (.-x p) — this is PHP property access
+  ;; DO:
+  (get p :x))
+```


### PR DESCRIPTION
## Summary

Based on real DX feedback from building a CLI todo app with Phel (Claude-assisted). An AI agent spent ~10 of 23 minutes just learning the language by scraping docs and debugging avoidable pitfalls. These changes would have cut that to near-zero.

**Changes:**
- **`RULES.md`**: Added "New features (v0.30 – main)" table covering `defrecord`, `defprotocol`, `defmulti`, transducers, regex literals, `pprint`, `sorted-map/set`, `condp`, `doseq`, and `for`. Added "Gotchas" summary section linking to the new task file.
- **`tasks/common-gotchas.md`** (new): 8 documented pitfalls with DO/DON'T code examples:
  1. CLI `$argv` access (`*argv*` vs `php/$argv`)
  2. `transduce` + `max`/`min` 0-arity incompatibility
  3. `for` vs `doseq` confusion
  4. `phel\string` rename from `phel\str`
  5. Namespace 2-segment requirement
  6. Top-level side effects and `phel build`
  7. PHP array → Phel collection conversion (`vec`, not `to-list`)
  8. Record field access via `get` with keywords
- **`index.md`**: Added "Common pitfalls" entry to intent map
- **`skills/claude/phel-lang/SKILL.md`**: Enhanced with gotchas in load order, "Before you start coding" checklist, and quick syntax reference covering new features (records, protocols, multimethods, transducers, regex, JSON, file I/O, PHP interop)

## Context

While building a [todo app](https://github.com/CosmeValera/phel-repo) with Phel, these were the specific friction points:
- `php/$argv` is `null` inside `phel run` — spent ~3 min discovering `php/$GLOBALS` workaround (didn't know about `*argv*`)
- Guessed `to-list` (doesn't exist) before finding `vec` — 1 min
- `transduce` + `max` fails silently with 0-arity — 2 min debugging
- New features (`defrecord`, `defprotocol`, `defmulti`) required reading compiler source to understand — 5+ min
- Docs say PHP 8.3+ but composer requires 8.4 — 3 min Docker image swap

## Test plan

- [ ] Verify all Phel code examples in `common-gotchas.md` are syntactically correct
- [ ] Verify links in `index.md` and `RULES.md` point to existing files
- [ ] Run `composer test-agents` if available