### PR TITLE
feat(match): add core.match pattern matching macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - `phel\core`: `uuid=`, `uuid-nil?`, `uuid-version`, `uuid-variant`
 - `phel\repl`: `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`
 - `phel\cli`: spec-map wrapper over `symfony/console` with prompts, tables, progress, coercion, hooks, signals, and test helpers. See `docs/cli-guide.md`
+- `phel\match`: `match` macro with literal, vector, map, wildcard, `:as`, `:guard`, `:or`, and rest-binding patterns; matches left-to-right and raises on no-match when no `:else` is given
 
 ### Fixed
 

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -1,0 +1,337 @@
+(ns phel\match
+  (:require phel\core))
+
+;; Pattern matching macro that expands to nested `cond` + `let` bindings.
+;;
+;; `(match [t1 t2 ...] pat1 expr1 pat2 expr2 ... :else default)`
+;;
+;; Each pattern is a vector whose length must equal the target count.
+;; A pattern element may be a literal, a wildcard `_`, a bare symbol
+;; (binding), a nested vector or map pattern, `(x :guard pred)`,
+;; `(x :as name)`, or `(:or alt1 alt2 ...)`. Vectors may end with
+;; `& rest` to bind the remaining slice.
+;;
+;; Internally `compile-pattern` is a dispatcher: each pattern kind has
+;; its own compiler returning `{:check expr :bindings [sym val ...]}`
+;; where `expr` is a self-contained check evaluated against the target
+;; symbol, and `bindings` are the let-bindings exposed to the clause
+;; body.
+
+(declare compile-pattern)
+
+(def- or-keyword :or)
+(def- as-keyword :as)
+(def- guard-keyword :guard)
+(def- else-keyword :else)
+(def- rest-symbol '&)
+(def- wildcard-symbol '_)
+
+(defn- binding-symbol?
+  "A bare symbol that is neither the wildcard nor the rest marker."
+  [form]
+  (and (symbol? form)
+       (not (= form wildcard-symbol))
+       (not (= form rest-symbol))))
+
+(defn- scalar-literal?
+  "Primitives we should match by equality."
+  [form]
+  (or (php/=== form nil)
+      (php/is_bool form)
+      (php/is_int form)
+      (php/is_float form)
+      (php/is_string form)
+      (keyword? form)))
+
+(defn- or-pattern? [form]
+  (and (list? form)
+       (not (empty? form))
+       (= (first form) or-keyword)))
+
+(defn- guard-pattern? [form]
+  (and (list? form)
+       (= (count form) 3)
+       (= (get form 1) guard-keyword)))
+
+(defn- as-pattern? [form]
+  (and (list? form)
+       (= (count form) 3)
+       (= (get form 1) as-keyword)
+       (symbol? (get form 2))))
+
+(defn- sequential-shape-check
+  "Runtime predicate accepting vectors, lists, and PHP arrays."
+  [target]
+  `(or (vector? ~target) (list? ~target) (php/is_array ~target)))
+
+(defn- and-checks
+  "Combines a seq of boolean checks into a single expression, skipping
+  `true` and collapsing a single check."
+  [checks]
+  (let [effective (apply vector (filter (fn [c] (not (= c true))) checks))]
+    (case (count effective)
+      0 true
+      1 (first effective)
+      `(and ~@effective))))
+
+(defn- compile-wildcard [_target _pattern]
+  {:check true :bindings []})
+
+(defn- compile-binding [target pattern]
+  {:check true :bindings [pattern target]})
+
+(defn- compile-literal [target pattern]
+  {:check `(= ~target '~pattern) :bindings []})
+
+(defn- compile-as
+  "(inner :as name): bind target to name, recurse on inner."
+  [target pattern]
+  (let [inner (first pattern)
+        name  (get pattern 2)
+        sub   (compile-pattern target inner)]
+    {:check    (get sub :check)
+     :bindings (apply vector (concat [name target] (get sub :bindings)))}))
+
+(defn- compile-guard
+  "(inner :guard pred): compile inner, and-combine with (pred target)
+  evaluated in the context of the inner bindings so the guard can see
+  bound symbols."
+  [target pattern]
+  (let [inner      (first pattern)
+        pred       (get pattern 2)
+        sub        (compile-pattern target inner)
+        sub-check  (get sub :check)
+        bindings   (get sub :bindings)
+        pred-expr  (if (empty? bindings)
+                     `(~pred ~target)
+                     `(let ~bindings (~pred ~target)))
+        combined   (and-checks [sub-check pred-expr])]
+    {:check combined :bindings bindings}))
+
+(defn- compile-or
+  "(:or p1 p2 ...): succeeds if any alternative matches. Alternatives
+  may not introduce bindings (keeps v1 simple and predictable)."
+  [target pattern]
+  (let [alts (apply vector (next pattern))]
+    (when (empty? alts)
+      (throw (php/new \InvalidArgumentException
+                      "match :or pattern requires at least one alternative")))
+    (let [compiled (for [a :in alts] (compile-pattern target a))]
+      (doseq [c :in compiled]
+        (when-not (empty? (get c :bindings))
+          (throw (php/new \InvalidArgumentException
+                          "match :or alternatives must not introduce bindings"))))
+      (let [checks (for [c :in compiled] (get c :check))]
+        {:check `(or ~@checks) :bindings []}))))
+
+(defn- index-of-rest
+  "Linear scan for `&` inside a vector, comparing with `=` so that
+  freshly-read symbols match the `'&` literal. Returns the index or
+  nil."
+  [pattern]
+  (loop [i 0]
+    (if (>= i (count pattern))
+      nil
+      (if (= (get pattern i) rest-symbol)
+        i
+        (recur (+ i 1))))))
+
+(defn- split-vector-pattern
+  "Splits a vector pattern around `&`. Returns `[head tail-sym-or-nil]`.
+  Errors if `&` is not followed by exactly one symbol."
+  [pattern]
+  (let [n   (count pattern)
+        idx (index-of-rest pattern)]
+    (if (nil? idx)
+      [pattern nil]
+      (do
+        (when-not (= (+ idx 2) n)
+          (throw (php/new \InvalidArgumentException
+                          (str "match vector pattern: `&` must be followed by exactly one binding, got "
+                               pattern))))
+        (let [tail (get pattern (+ idx 1))]
+          (when-not (symbol? tail)
+            (throw (php/new \InvalidArgumentException
+                            (str "match vector pattern: `&` binding must be a symbol, got " tail))))
+          [(apply vector (take idx pattern)) tail])))))
+
+(defn- compile-vector
+  "Vector pattern: shape + length check, recursively compile each
+  element, optionally bind the rest of the slice."
+  [target pattern]
+  (let [[head tail-sym] (split-vector-pattern pattern)
+        fixed-len  (count head)
+        shape      (sequential-shape-check target)
+        length-ok  (if tail-sym
+                     `(>= (count ~target) ~fixed-len)
+                     `(= (count ~target) ~fixed-len))
+        elem-specs (apply vector
+                          (for [i :range [0 fixed-len]]
+                            (let [elem-target `(get ~target ~i)
+                                  sub         (compile-pattern elem-target
+                                                               (get head i))]
+                              {:index    i
+                               :check    (get sub :check)
+                               :bindings (get sub :bindings)})))
+        inner-checks (for [e :in elem-specs] (get e :check))
+        combined-inner (and-checks (cons length-ok inner-checks))
+        ;; Gate the inner check on the shape predicate so `get` /
+        ;; `count` never see a non-sequential target.
+        outer-check  `(if ~shape ~combined-inner false)
+        elem-bindings (apply concat
+                             (for [e :in elem-specs]
+                               (get e :bindings)))
+        tail-binding  (if tail-sym
+                        [tail-sym `(vec (slice ~target ~fixed-len))]
+                        [])
+        all-bindings  (apply vector (concat elem-bindings tail-binding))]
+    {:check outer-check :bindings all-bindings}))
+
+(defn- compile-map
+  "Map pattern: shape check, key-presence check, recurse on each value."
+  [target pattern]
+  (let [entries    (apply vector
+                          (for [[k v] :pairs pattern] [k v]))
+        shape      `(map? ~target)
+        key-specs  (apply vector
+                          (for [e :in entries]
+                            (let [k   (first e)
+                                  p   (get e 1)
+                                  val `(get ~target ~k)
+                                  sub (compile-pattern val p)]
+                              {:key      k
+                               :check    (get sub :check)
+                               :bindings (get sub :bindings)})))
+        contains-checks (for [k :in key-specs]
+                          `(contains? ~target ~(get k :key)))
+        value-checks    (for [k :in key-specs] (get k :check))
+        combined-inner  (and-checks (apply vector (concat contains-checks value-checks)))
+        outer-check     `(if ~shape ~combined-inner false)
+        all-bindings    (apply vector
+                               (apply concat
+                                      (for [k :in key-specs]
+                                        (get k :bindings))))]
+    {:check outer-check :bindings all-bindings}))
+
+(defn- compile-pattern
+  "Dispatches on pattern shape and delegates to the kind-specific
+  compiler. Returns `{:check expr :bindings [sym val ...]}`."
+  [target pattern]
+  (cond
+    (= pattern wildcard-symbol) (compile-wildcard target pattern)
+    (scalar-literal? pattern)   (compile-literal target pattern)
+    (as-pattern? pattern)       (compile-as target pattern)
+    (guard-pattern? pattern)    (compile-guard target pattern)
+    (or-pattern? pattern)       (compile-or target pattern)
+    (binding-symbol? pattern)   (compile-binding target pattern)
+    (vector? pattern)           (compile-vector target pattern)
+    (map? pattern)              (compile-map target pattern)
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "match: unsupported pattern shape: " pattern)))))
+
+(defn- compile-clause
+  "Compiles one clause row into `[check bindings]`."
+  [target-syms patterns]
+  (when-not (= (count target-syms) (count patterns))
+    (throw (php/new \InvalidArgumentException
+                    (str "match: pattern count (" (count patterns)
+                         ") does not match target count (" (count target-syms)
+                         "): " patterns))))
+  (let [subs     (apply vector
+                        (for [i :range [0 (count patterns)]]
+                          (compile-pattern (get target-syms i) (get patterns i))))
+        checks   (for [s :in subs] (get s :check))
+        bindings (apply vector
+                        (apply concat
+                               (for [s :in subs] (get s :bindings))))]
+    [(and-checks checks) bindings]))
+
+(defn- parse-clauses
+  "Walks the body splitting it into `[clauses default]`. `clauses` is a
+  vector of `[pattern-vec expr]`, `default` is the `:else` expression
+  or `nil`."
+  [body]
+  (loop [remaining body
+         clauses   []
+         default   nil]
+    (cond
+      (empty? remaining)
+      [clauses default]
+
+      (= (first remaining) else-keyword)
+      (do
+        (when-not (= (count remaining) 2)
+          (throw (php/new \InvalidArgumentException
+                          "match: :else must be followed by exactly one expression and must come last")))
+        [clauses (get remaining 1)])
+
+      :else
+      (do
+        (when (< (count remaining) 2)
+          (throw (php/new \InvalidArgumentException
+                          "match: every pattern must be paired with an expression")))
+        (let [pat  (first remaining)
+              expr (get remaining 1)
+              rest (apply vector (drop 2 remaining))]
+          (when-not (vector? pat)
+            (throw (php/new \InvalidArgumentException
+                            (str "match: pattern must be a vector, got " pat))))
+          (recur rest
+                 (conj clauses [pat expr])
+                 default))))))
+
+(defmacro match
+  "Matches a vector of targets against pattern/expression clauses and
+  returns the first matching expression.
+
+  Supported patterns:
+  - literal values (numbers, strings, keywords, booleans, nil)
+  - `_` wildcard
+  - bare symbol: binds the value to that name in the clause body
+  - vector pattern `[a b c]`, with optional rest `[a & tail]`
+  - map pattern `{:k1 p1 :k2 p2}` — keys must be present in the target
+  - `(inner :guard pred)` — matches if `(pred bound)` is truthy
+  - `(inner :as name)` — binds the whole value to `name`
+  - `(:or p1 p2 ...)` — matches any alternative (no inner bindings)
+
+  A trailing `:else expr` provides the default branch; without it a
+  no-match raises `\\RuntimeException`."
+  {:doc "Pattern matching over a vector of targets."
+   :see-also ["cond" "case" "condp"]
+   :example "(match [x y] [0 _] :zero-x [_ 0] :zero-y [a b] [:both a b])"}
+  [targets & body]
+  (when-not (vector? targets)
+    (throw (php/new \InvalidArgumentException
+                    (str "match: target list must be a vector, got " targets))))
+  (let [n           (count targets)
+        target-syms (apply vector
+                           (for [_ :range [0 n]]
+                             (gensym "__m")))
+        target-binds (apply vector
+                            (apply concat
+                                   (for [i :range [0 n]]
+                                     [(get target-syms i) (get targets i)])))
+        [clauses default] (parse-clauses (apply vector body))
+        compiled    (for [c :in clauses]
+                      (let [pat  (first c)
+                            expr (get c 1)
+                            [check bindings] (compile-clause target-syms pat)]
+                        [check bindings expr]))
+        no-match    (if (nil? default)
+                      `(throw (php/new \RuntimeException
+                                       (str "match: no matching clause for " [~@target-syms])))
+                      default)
+        cond-body   (apply concat
+                           (concat
+                            (for [c :in compiled]
+                              (let [check    (first c)
+                                    bindings (get c 1)
+                                    expr     (get c 2)
+                                    body-expr (if (empty? bindings)
+                                                expr
+                                                `(let ~bindings ~expr))]
+                                [check body-expr]))
+                            [[:else no-match]]))]
+    `(let ~target-binds
+       (cond ~@cond-body))))

--- a/tests/phel/test/match.phel
+++ b/tests/phel/test/match.phel
@@ -1,0 +1,177 @@
+(ns phel-test\test\match
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\match :refer [match]))
+
+(deftest test-literal-patterns
+  (testing "integers"
+    (is (= :one   (match [1]   [1] :one :else :else))     "match int")
+    (is (= :else  (match [2]   [1] :one :else :else))     "no match int"))
+  (testing "strings"
+    (is (= :hi    (match ["x"] ["x"] :hi :else :else))    "match string")
+    (is (= :else  (match ["y"] ["x"] :hi :else :else))    "no match string"))
+  (testing "keywords"
+    (is (= :kw    (match [:a]  [:a] :kw :else :else))     "match keyword")
+    (is (= :else  (match [:b]  [:a] :kw :else :else))     "no match keyword"))
+  (testing "booleans and nil"
+    (is (= :t     (match [true]  [true]  :t :else :else)) "match true")
+    (is (= :f     (match [false] [false] :f :else :else)) "match false")
+    (is (= :n     (match [nil]   [nil]   :n :else :else)) "match nil")
+    (is (= :else  (match [nil]   [false] :n :else :else)) "false and nil are distinct")))
+
+(deftest test-wildcard
+  (is (= :any (match [42]  [_] :any :else :else))   "wildcard matches int")
+  (is (= :any (match [nil] [_] :any :else :else))   "wildcard matches nil")
+  (is (= :any (match [[1 2 3]] [_] :any :else :else)) "wildcard matches vector"))
+
+(deftest test-binding-symbol
+  (is (= 5 (match [5] [x] x :else :else)) "binds target to symbol")
+  (is (= 10 (match [5] [x] (* 2 x) :else :else)) "bound value usable in expression"))
+
+(deftest test-vector-pattern
+  (testing "fixed length"
+    (is (= 15 (match [[5 10]] [[a b]] (+ a b) :else :else)) "two-element destructure")
+    (is (= :else (match [[1 2 3]] [[a b]] :matched :else :else)) "length mismatch falls through")
+    (is (= :else (match [[1]]     [[a b]] :matched :else :else)) "too-short falls through"))
+  (testing "ignore vs bind"
+    (is (= 4 (match [[1 2 3]] [[a _ b]] (+ a b) :else :else)) "wildcard mid-vector binds around it"))
+  (testing "non-vector target"
+    (is (= :else (match ["abc"] [[a b c]] :matched :else :else)) "string is not a vector")
+    (is (= :else (match [nil]   [[a]]     :matched :else :else)) "nil is not a vector"))
+  (testing "list target still matches"
+    (is (= [1 2 3] (match [(list 1 2 3)] [[a b c]] [a b c] :else :else))
+        "vector pattern matches lists too")))
+
+(deftest test-nested-vector
+  (is (= [1 2 3 4] (match [[[1 2] [3 4]]] [[[a b] [c d]]] [a b c d] :else :else))
+      "nested vectors")
+  (is (= :else (match [[[1 2] [3 4 5]]] [[[a b] [c d]]] [a b c d] :else :else))
+      "nested length mismatch")
+  (is (= [:x 1 2] (match [[:x [1 2]]] [[tag [a b]]] [tag a b] :else :else))
+      "mixed head + nested tail"))
+
+(deftest test-map-pattern
+  (testing "key presence"
+    (is (= 3 (match [{:x 1 :y 2}] [{:x a :y b}] (+ a b) :else :else)) "both keys present")
+    (is (= :else (match [{:x 1}] [{:x a :y b}] :matched :else :else)) "missing key falls through")
+    (is (= 1 (match [{:x 1 :z 99}] [{:x a}] a :else :else)) "extra keys ignored"))
+  (testing "non-map target"
+    (is (= :else (match [[1 2]] [{:x a}] :matched :else :else)) "vector is not a map")
+    (is (= :else (match [nil]   [{:x a}] :matched :else :else)) "nil is not a map"))
+  (testing "nested map"
+    (is (= 2 (match [{:user {:id 1 :count 2}}]
+                    [{:user {:id _ :count c}}] c :else :else)))))
+
+(deftest test-guard-pattern
+  (testing "predicate pass/fail"
+    (is (= 5  (match [5]  [(x :guard pos?)] x :else :else))     "guard passes")
+    (is (= :else (match [-3] [(x :guard pos?)] x :else :else))  "guard fails falls through")
+    (is (= :neg (match [-3]
+                       [(x :guard pos?)] :pos
+                       [(x :guard neg?)] :neg
+                       :else :else))
+        "second guard matches"))
+  (testing "guard uses bound symbol"
+    (is (= 20 (match [10] [(x :guard (fn [v] (> v 5)))] (* 2 x) :else :else))))
+  (testing "guard on wildcard"
+    (is (= :ok (match [42] [(_ :guard even?)] :ok :else :else))
+        "guard composes with wildcard")))
+
+(deftest test-as-pattern
+  (testing "binds whole value"
+    (is (= [1 2 [1 2]] (match [[1 2]] [([a b] :as v)] [a b v] :else :else)))
+    (is (= {:x 1 :y 2} (match [{:x 1 :y 2}]
+                              [({:x _ :y _} :as m)] m :else :else))))
+  (testing ":as + shape mismatch still fails"
+    (is (= :else (match [[1]] [([a b] :as v)] v :else :else)))))
+
+(deftest test-or-pattern
+  (testing "alternatives"
+    (is (= :ok (match [1] [(:or 1 2 3)] :ok :else :else))  "first alternative")
+    (is (= :ok (match [2] [(:or 1 2 3)] :ok :else :else))  "middle alternative")
+    (is (= :ok (match [3] [(:or 1 2 3)] :ok :else :else))  "last alternative")
+    (is (= :else (match [4] [(:or 1 2 3)] :ok :else :else)) "no alternative"))
+  (testing "mixed alternatives"
+    (is (= :kw (match [:a] [(:or :a :b)] :kw :else :else)))
+    (is (= :str (match ["x"] [(:or "x" "y")] :str :else :else)))))
+
+(deftest test-rest-binding
+  (is (= [1 [2 3 4 5]] (match [[1 2 3 4 5]] [[a & more]] [a more] :else :else))
+      "rest captures tail")
+  (is (= [1 []] (match [[1]] [[a & more]] [a more] :else :else))
+      "rest captures empty tail")
+  (is (= [1 2 [3]] (match [[1 2 3]] [[a b & more]] [a b more] :else :else))
+      "rest after two fixed")
+  (is (= :else (match [[]] [[a & more]] [a more] :else :else))
+      "rest still requires at least the fixed head"))
+
+(deftest test-clause-order
+  (is (= :first (match [1]
+                       [1] :first
+                       [_] :second
+                       :else :else))
+      "earlier clause wins")
+  (is (= :second (match [2]
+                        [1] :first
+                        [_] :second
+                        :else :else))
+      "second clause when first fails")
+  (is (= :else (match [nil]
+                      [1] :first
+                      [2] :second
+                      :else :else))
+      "else when none match"))
+
+(deftest test-multi-target
+  (is (= :zero-x (match [0 5]
+                        [0 _] :zero-x
+                        [_ 0] :zero-y
+                        :else :else))
+      "first target is zero")
+  (is (= :zero-y (match [5 0]
+                        [0 _] :zero-x
+                        [_ 0] :zero-y
+                        :else :else))
+      "second target is zero")
+  (is (= [:both 3 4] (match [3 4]
+                            [0 _] :zero-x
+                            [_ 0] :zero-y
+                            [a b] [:both a b]
+                            :else :else))
+      "binds from multi-target row"))
+
+(deftest test-no-match-without-else-throws
+  (is (thrown? \RuntimeException (match [99] [1] :never))
+      "missing :else raises RuntimeException"))
+
+(deftest test-target-count-mismatch-throws-at-expand
+  ;; Target-count errors are macro-expansion time, not runtime, so the
+  ;; expression under test itself would fail to expand. Verify the
+  ;; error via `macroexpand-1` instead.
+  (is (thrown? \InvalidArgumentException
+               (macroexpand-1 '(phel\match/match [1 2] [1 2 3] :x :else :y)))
+      "mismatched target/pattern count raises at expansion"))
+
+(deftest test-invalid-pattern-shapes-throw-at-expand
+  (is (thrown? \InvalidArgumentException
+               (macroexpand-1 '(phel\match/match "not-a-vector" [1] :x :else :y)))
+      "non-vector target list raises")
+  (is (thrown? \InvalidArgumentException
+               (macroexpand-1 '(phel\match/match [1] :not-a-vector-pattern :x :else :y)))
+      "non-vector pattern raises"))
+
+(deftest test-target-evaluated-once
+  (let [counter (atom 0)
+        bump    (fn [] (swap! counter inc) 1)]
+    (match [(bump)]
+           [1] :ok
+           :else :fail)
+    (is (= 1 (deref counter)) "target expression runs exactly once")))
+
+(deftest test-side-effect-expressions
+  (let [results (atom [])]
+    (match [:hit]
+           [:miss] (swap! results conj :miss-branch)
+           [:hit]  (swap! results conj :hit-branch)
+           :else   (swap! results conj :else-branch))
+    (is (= [:hit-branch] (deref results))
+        "only the matching branch runs")))

--- a/tests/php/Integration/Phel/MatchTest.php
+++ b/tests/php/Integration/Phel/MatchTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Phel;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function proc_close;
+use function proc_open;
+use function sprintf;
+use function stream_get_contents;
+
+/**
+ * Runs `./bin/phel test tests/phel/test/match.phel` end-to-end so
+ * `composer test-compiler` exercises the core.match macro on every CI
+ * run (not only `composer test-core`).
+ */
+final class MatchTest extends TestCase
+{
+    public function test_match_test_suite_passes(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $command = sprintf(
+            '%s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($repoRoot . '/bin/phel'),
+            escapeshellarg('test') . ' ' . escapeshellarg('tests/phel/test/match.phel'),
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes, $repoRoot);
+        self::assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        $exitCode = proc_close($process);
+
+        self::assertSame(
+            0,
+            $exitCode,
+            sprintf(
+                "`phel test tests/phel/test/match.phel` failed.\nSTDOUT:\n%s\nSTDERR:\n%s",
+                $stdout,
+                $stderr,
+            ),
+        );
+        self::assertStringContainsString('Failed: 0', $stdout);
+        self::assertStringContainsString('Error: 0', $stdout);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Tier 1 item #4 of the Clojure-parity roadmap. Phel has `cond`, `case`, and `condp` but no destructure-and-match primitive, so patterns like `(match [x y] [0 _] :zero-x [_ 0] :zero-y [a b] [:both a b])` had to be hand-rolled with nested destructuring plus cond. This closes that gap with a pure library.

## 💡 Goal

Ship a single `match` macro in a new `phel\match` namespace that expands to nested `cond` + `let` bindings; no compiler or runtime changes, no interop. First version is linear expansion (no DFA compilation), which is fine for AST walking, HTTP routing, protocol dispatch, and parsing, the motivating use cases.

## 🔖 Changes

- `src/phel/match.phel`: new namespace exposing the `match` macro plus private pattern-kind compilers (literal, wildcard, binding, vector, map, `:or`, `:guard`, `:as`) dispatched through `compile-pattern`
- Patterns supported v1:
  - literal values (int, float, string, keyword, boolean, nil)
  - `_` wildcard
  - bare symbol, binds target to that name in the clause body
  - `[a b c]` vector pattern with optional rest `[a b & tail]`
  - `{:k1 p1 :k2 p2}` map pattern, keys must be present in the target
  - `(inner :guard pred)`, matches if `(pred bound)` is truthy
  - `(inner :as name)`, binds the whole matched form to `name`
  - `(:or p1 p2 ...)`, matches any alternative (no inner bindings)
  - nested patterns: vectors-in-vectors, maps-in-vectors, vectors-in-maps
- API: `(match [target1 target2 ...] pattern1 expr1 pattern2 expr2 ... :else default-expr)`, first matching clause wins; target vector length must equal every pattern tuple length; trailing `:else` provides the default, otherwise no-match raises `RuntimeException`
- `tests/phel/test/match.phel`: 61 assertions covering each pattern kind plus positive/negative cases, nested patterns, clause ordering, multi-target rows, no-match error, target-count mismatch at macro-expansion time, target-evaluated-once guarantee, and side-effect isolation
- `tests/php/Integration/Phel/MatchTest.php`: shells out to `./bin/phel test tests/phel/test/match.phel` so `composer test-compiler` exercises the suite on every CI run
- `CHANGELOG.md` under Unreleased describes the new module