### PR TITLE
feat(watch): add ./bin/phel watch hot-reload command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `phel analyze <file>` prints JSON semantic diagnostics; `phel index <dir>... [--out=file.json]` builds a project symbol table; `phel api-daemon` exposes the Api facade over newline-delimited JSON-RPC on stdio
 - `ApiFacade` gains `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint` for editor and linter tooling
 - `phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]` runs read-only semantic rules: unresolved-symbol, arity-mismatch, unused-binding, unused-require, unused-import, shadowed-binding, redundant-do, duplicate-key, invalid-destructuring, discouraged-var; configurable via `phel-lint.phel` with per-rule severity and glob opt-outs
+- `phel watch [paths]... [-b backend] [--poll=500] [--debounce=100]` watches `.phel` files and reloads changed namespaces in dependency order; inotify, fswatch, or polling backend auto-picked; `(watch! ["src/"])` in REPL via `phel\watch`
 
 #### Agent docs
 - `.agents/` ships agent-agnostic docs with task recipes, per-platform adapters, and three runnable example projects (`todo-app`, `http-json-api`, `cli-wordcount`)

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -1,0 +1,51 @@
+(ns phel\watch
+  (:use Phel)
+  (:use Phel\Watch\WatchFacade))
+
+(def- on-reload-hooks (atom {}))
+
+(defn register-on-reload
+  "Registers a zero-arg function to run every time `namespace` is
+  reloaded by the watcher. Replaces any previously registered hook
+  with the same `name`."
+  {:example "(register-on-reload \"my-app\\core\" :refresh (fn [] (println \"reloaded\")))"}
+  [namespace name hook-fn]
+  (swap! on-reload-hooks
+         (fn [m]
+           (let [entry (or (get m namespace) {})]
+             (assoc m namespace (assoc entry name hook-fn))))))
+
+(defn clear-on-reload
+  "Removes every hook registered for `namespace`."
+  {:example "(clear-on-reload \"my-app\\core\")"}
+  [namespace]
+  (swap! on-reload-hooks (fn [m] (assoc m namespace {}))))
+
+(defn run-on-reload-hooks
+  "Executes every hook registered for `namespace`. Returns the
+  number of hooks that fired."
+  {:example "(run-on-reload-hooks \"my-app\\core\")"}
+  [namespace]
+  (let [entry (get (deref on-reload-hooks) namespace {})]
+    (foreach [_ hook entry]
+      (try
+        (hook)
+        (catch \Throwable _e nil)))
+    (count entry)))
+
+(defn watch!
+  "Starts the file watcher on the given vector of paths. Blocks until
+  the watcher is stopped (e.g. Ctrl+C). Reloads changed namespaces in
+  dependency order and runs any hooks registered with `register-on-reload`."
+  {:example "(watch! [\"src/\" \"tests/\"])"}
+  [paths & [opts]]
+  (let [facade (php/new WatchFacade)
+        phpOpts (php/array)]
+    (when (and opts (get opts :backend))
+      (php/aset phpOpts "backend" (get opts :backend)))
+    (when (and opts (get opts :poll))
+      (php/aset phpOpts "poll" (get opts :poll)))
+    (when (and opts (get opts :debounce))
+      (php/aset phpOpts "debounce" (get opts :debounce)))
+    (php/-> facade (watch (to-php-array paths) phpOpts))
+    nil))

--- a/src/php/Api/ApiConfig.php
+++ b/src/php/Api/ApiConfig.php
@@ -23,6 +23,7 @@ final class ApiConfig extends AbstractConfig
             'phel\\repl',
             'phel\\string',
             'phel\\test',
+            'phel\\watch',
         ];
     }
 }

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -35,6 +35,7 @@ use Phel\Run\Infrastructure\Command\NsCommand;
 use Phel\Run\Infrastructure\Command\ReplCommand;
 use Phel\Run\Infrastructure\Command\RunCommand;
 use Phel\Run\Infrastructure\Command\TestCommand;
+use Phel\Watch\Infrastructure\Command\WatchCommand;
 
 final class ConsoleProvider extends AbstractProvider
 {
@@ -83,6 +84,7 @@ final class ConsoleProvider extends AbstractProvider
             new DoctorCommand(),
             new NreplCommand(),
             new LintCommand(),
+            new WatchCommand(),
         ];
     }
 

--- a/src/php/Watch/Application/ApiProjectReindexer.php
+++ b/src/php/Watch/Application/ApiProjectReindexer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Api\ApiFacade;
+use Phel\Watch\Domain\ProjectReindexerInterface;
+use Throwable;
+
+final readonly class ApiProjectReindexer implements ProjectReindexerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+    ) {}
+
+    public function reindex(array $srcDirs): void
+    {
+        try {
+            $this->apiFacade->indexProject($srcDirs);
+        } catch (Throwable) {
+            // Reindexing is best-effort.
+        }
+    }
+}

--- a/src/php/Watch/Application/MtimeFileSystemScanner.php
+++ b/src/php/Watch/Application/MtimeFileSystemScanner.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
+
+use function clearstatcache;
+use function filemtime;
+use function filesize;
+use function is_dir;
+use function is_file;
+
+/**
+ * Filesystem scanner that walks directories recursively and returns a
+ * snapshot of `.phel` files keyed by realpath with mtime + size.
+ */
+final class MtimeFileSystemScanner implements FileSystemScannerInterface
+{
+    private const string PHEL_FILE_REGEX = '/^.+\.(phel|cljc)$/i';
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return array<string, array{mtime:int, size:int}>
+     */
+    public function snapshot(array $paths): array
+    {
+        clearstatcache();
+        $snapshot = [];
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                $this->statInto($snapshot, $path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->walkDirInto($snapshot, $path);
+            }
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param array<string, array{mtime:int, size:int}> $snapshot
+     */
+    private function walkDirInto(array &$snapshot, string $dir): void
+    {
+        try {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+            $filtered = new RegexIterator($iterator, self::PHEL_FILE_REGEX, RegexIterator::GET_MATCH);
+
+            foreach ($filtered as $match) {
+                if (!isset($match[0])) {
+                    continue;
+                }
+
+                $this->statInto($snapshot, (string) $match[0]);
+            }
+        } catch (UnexpectedValueException) {
+            // Unreadable directories are silently skipped — same convention as
+            // NamespaceExtractor.
+        }
+    }
+
+    /**
+     * @param array<string, array{mtime:int, size:int}> $snapshot
+     */
+    private function statInto(array &$snapshot, string $file): void
+    {
+        $mtime = @filemtime($file);
+        $size = @filesize($file);
+        if ($mtime === false || $size === false) {
+            return;
+        }
+
+        $snapshot[$file] = ['mtime' => $mtime, 'size' => $size];
+    }
+}

--- a/src/php/Watch/Application/NamespaceResolver.php
+++ b/src/php/Watch/Application/NamespaceResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Watch\Domain\NamespaceResolverInterface;
+use Throwable;
+
+use function file_exists;
+use function file_get_contents;
+use function in_array;
+use function is_string;
+use function preg_match;
+use function str_replace;
+use function strlen;
+use function trim;
+
+/**
+ * Extracts the fully-qualified Phel namespace from a source string or file.
+ *
+ * Uses a regex over the first balanced `ns` / `in-ns` form. The compiler's
+ * NamespaceExtractor gives identical results but drags the full parse/read
+ * pipeline into a watcher hot path; this lightweight resolver is enough to
+ * decide which namespace changed.
+ */
+final class NamespaceResolver implements NamespaceResolverInterface
+{
+    private const string NS_FORM_REGEX = '/\(\s*(?:ns|in-ns)\s+\'?([A-Za-z0-9_\-*+!?\\\\.\/]+)/A';
+
+    public function resolveFromFile(string $filePath): ?string
+    {
+        if (!file_exists($filePath)) {
+            return null;
+        }
+
+        $content = @file_get_contents($filePath);
+        if (!is_string($content) || $content === '') {
+            return null;
+        }
+
+        return $this->resolveFromSource($content);
+    }
+
+    public function resolveFromSource(string $source): ?string
+    {
+        $code = $this->stripLeadingTrivia($source);
+        if ($code === '') {
+            return null;
+        }
+
+        try {
+            $ok = preg_match(self::NS_FORM_REGEX, $code, $matches);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($ok !== 1) {
+            return null;
+        }
+
+        $raw = $matches[1];
+        // Phel source uses either backslash or forward slash as namespace
+        // separator; normalise to backslash for the Phel runtime.
+        $normalised = str_replace('/', '\\', $raw);
+
+        return trim($normalised);
+    }
+
+    /**
+     * Drops line comments, whitespace, and shebang lines before the first
+     * open-paren so the regex anchors on the very first form.
+     */
+    private function stripLeadingTrivia(string $source): string
+    {
+        $len = strlen($source);
+        $i = 0;
+
+        while ($i < $len) {
+            $c = $source[$i];
+
+            // Shebang or line comment.
+            if ($c === '#' && $i + 1 < $len && $source[$i + 1] === '!') {
+                $nl = strpos($source, "\n", $i);
+                if ($nl === false) {
+                    return '';
+                }
+
+                $i = $nl + 1;
+                continue;
+            }
+
+            if ($c === ';') {
+                $nl = strpos($source, "\n", $i);
+                if ($nl === false) {
+                    return '';
+                }
+
+                $i = $nl + 1;
+                continue;
+            }
+
+            if (in_array($c, [' ', "\t", "\n", "\r"], true)) {
+                ++$i;
+                continue;
+            }
+
+            break;
+        }
+
+        return substr($source, $i);
+    }
+}

--- a/src/php/Watch/Application/NullReloadEventPublisher.php
+++ b/src/php/Watch/Application/NullReloadEventPublisher.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Watch\Domain\ReloadEventPublisherInterface;
+
+/**
+ * Default publisher: swallows every event. Replaced when the watcher is
+ * hosted inside an nREPL process.
+ */
+final class NullReloadEventPublisher implements ReloadEventPublisherInterface
+{
+    public function publish(array $events, array $reloadedNamespaces): void {}
+}

--- a/src/php/Watch/Application/ReloadOrchestrator.php
+++ b/src/php/Watch/Application/ReloadOrchestrator.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Phel\Watch\Domain\NamespaceResolverInterface;
+use Phel\Watch\Domain\ProjectReindexerInterface;
+use Phel\Watch\Domain\ReloadEventPublisherInterface;
+use Phel\Watch\Domain\ReloadOrchestratorInterface;
+use Phel\Watch\Transfer\WatchEvent;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Given a batch of file-change events, figures out the affected namespaces,
+ * reloads them in dependency order, re-runs the `:on-reload` tests in each,
+ * publishes a reload event, and re-indexes the project for tooling.
+ */
+final readonly class ReloadOrchestrator implements ReloadOrchestratorInterface
+{
+    public function __construct(
+        private NamespaceResolverInterface $namespaceResolver,
+        private RunFacadeInterface $runFacade,
+        private BuildFacadeInterface $buildFacade,
+        private ProjectReindexerInterface $reindexer,
+        private ReloadEventPublisherInterface $publisher,
+    ) {}
+
+    /**
+     * @param list<WatchEvent> $events
+     * @param list<string>     $srcDirs
+     *
+     * @return list<string>
+     */
+    public function handleChanges(array $events, array $srcDirs): array
+    {
+        if ($events === []) {
+            return [];
+        }
+
+        $namespaces = $this->resolveNamespaces($events);
+        if ($namespaces === []) {
+            $this->publisher->publish($events, []);
+            return [];
+        }
+
+        $reloaded = $this->reloadNamespaces($namespaces, $srcDirs);
+        $this->runReloadHooks($reloaded);
+        $this->reindex($srcDirs);
+        $this->publisher->publish($events, $reloaded);
+
+        return $reloaded;
+    }
+
+    /**
+     * @param list<WatchEvent> $events
+     *
+     * @return list<string>
+     */
+    private function resolveNamespaces(array $events): array
+    {
+        /** @var array<string, bool> $seen */
+        $seen = [];
+        $namespaces = [];
+
+        foreach ($events as $event) {
+            if ($event->kind === WatchEvent::KIND_DELETED) {
+                continue;
+            }
+
+            $ns = $this->namespaceResolver->resolveFromFile($event->path);
+            if ($ns === null) {
+                continue;
+            }
+
+            if (isset($seen[$ns])) {
+                continue;
+            }
+
+            $seen[$ns] = true;
+            $namespaces[] = $ns;
+        }
+
+        return $namespaces;
+    }
+
+    /**
+     * @param list<string> $namespaces
+     * @param list<string> $srcDirs
+     *
+     * @return list<string>
+     */
+    private function reloadNamespaces(array $namespaces, array $srcDirs): array
+    {
+        try {
+            $deps = $this->buildFacade->getDependenciesForNamespace($srcDirs, $namespaces);
+        } catch (Throwable) {
+            return [];
+        }
+
+        $reloaded = [];
+        foreach ($deps as $info) {
+            try {
+                $this->runFacade->evalFile($info);
+            } catch (Throwable) {
+                // Keep going so one broken file doesn't prevent the rest of
+                // the chain from reloading.
+                continue;
+            }
+
+            $reloaded[] = $info->getNamespace();
+        }
+
+        return $reloaded;
+    }
+
+    /**
+     * @param list<string> $reloadedNamespaces
+     */
+    private function runReloadHooks(array $reloadedNamespaces): void
+    {
+        foreach ($reloadedNamespaces as $namespace) {
+            $code = sprintf('(phel\watch/run-on-reload-hooks "%s")', $namespace);
+            try {
+                $this->runFacade->structuredEval($code, new CompileOptions());
+            } catch (Throwable) {
+                // Hooks are best-effort. Do not fail the watch loop.
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $srcDirs
+     */
+    private function reindex(array $srcDirs): void
+    {
+        $this->reindexer->reindex($srcDirs);
+    }
+}

--- a/src/php/Watch/Application/SystemClock.php
+++ b/src/php/Watch/Application/SystemClock.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Watch\Domain\ClockInterface;
+
+use function microtime;
+use function usleep;
+
+final class SystemClock implements ClockInterface
+{
+    public function nowMs(): int
+    {
+        return (int) (microtime(true) * 1000.0);
+    }
+
+    public function sleepMs(int $ms): void
+    {
+        if ($ms <= 0) {
+            return;
+        }
+
+        usleep($ms * 1000);
+    }
+}

--- a/src/php/Watch/Application/WatchRunner.php
+++ b/src/php/Watch/Application/WatchRunner.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application;
+
+use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Watch\Application\Watcher\FileWatcherBuilder;
+use Phel\Watch\Domain\ReloadOrchestratorInterface;
+use Phel\Watch\Transfer\WatchEvent;
+
+use function array_unique;
+use function array_values;
+use function is_dir;
+use function is_file;
+
+/**
+ * Orchestrates one full watch session: picks a backend, resolves source
+ * directories, wires the reload orchestrator, and blocks in the watcher
+ * loop. Lives in the Application layer so `WatchFacade::watch()` stays a
+ * single-delegation.
+ */
+final readonly class WatchRunner
+{
+    public function __construct(
+        private FileWatcherBuilder $builder,
+        private ReloadOrchestratorInterface $orchestrator,
+        private CommandFacadeInterface $commandFacade,
+    ) {}
+
+    /**
+     * @param list<string>                                      $paths
+     * @param array{backend?:?string,poll?:?int,debounce?:?int} $options
+     */
+    public function run(array $paths, array $options = []): void
+    {
+        $paths = $this->filterExistingPaths($paths);
+        if ($paths === []) {
+            return;
+        }
+
+        $watcher = $this->builder->create($options['backend'] ?? null);
+        $srcDirs = $this->srcDirs($paths);
+
+        $orchestrator = $this->orchestrator;
+        $watcher->watch($paths, static function (array $events) use ($orchestrator, $srcDirs): void {
+            /** @var list<WatchEvent> $events */
+            $orchestrator->handleChanges($events, $srcDirs);
+        });
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function filterExistingPaths(array $paths): array
+    {
+        $filtered = [];
+        foreach ($paths as $path) {
+            if (is_file($path) || is_dir($path)) {
+                $filtered[] = $path;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function srcDirs(array $paths): array
+    {
+        $dirs = $this->commandFacade->getAllPhelDirectories();
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                $dirs[] = $path;
+            }
+        }
+
+        return array_values(array_unique($dirs));
+    }
+}

--- a/src/php/Watch/Application/Watcher/FileWatcherBuilder.php
+++ b/src/php/Watch/Application/Watcher/FileWatcherBuilder.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application\Watcher;
+
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Domain\FileWatcherInterface;
+
+use function in_array;
+use function strtolower;
+use function substr;
+
+/**
+ * Picks the best-available watcher backend for the host OS.
+ */
+final readonly class FileWatcherBuilder
+{
+    public function __construct(
+        private FileSystemScannerInterface $scanner,
+        private ClockInterface $clock,
+        private int $pollIntervalMs = 500,
+        private int $debounceMs = 100,
+    ) {}
+
+    public function create(?string $preferred = null): FileWatcherInterface
+    {
+        $preferred = $preferred === null ? null : strtolower($preferred);
+
+        if ($preferred === PollingWatcher::NAME) {
+            return $this->polling();
+        }
+
+        if ($preferred === FswatchWatcher::NAME && FswatchWatcher::isAvailable()) {
+            return $this->fswatch();
+        }
+
+        if ($preferred === InotifyWatcher::NAME && InotifyWatcher::isAvailable()) {
+            return $this->inotify();
+        }
+
+        // Auto-detect by OS.
+        $os = strtolower(substr(PHP_OS_FAMILY, 0, 10));
+        if ($os === 'linux' && InotifyWatcher::isAvailable()) {
+            return $this->inotify();
+        }
+
+        if (in_array($os, ['darwin', 'bsd'], true) && FswatchWatcher::isAvailable()) {
+            return $this->fswatch();
+        }
+
+        return $this->polling();
+    }
+
+    public function polling(): PollingWatcher
+    {
+        return new PollingWatcher(
+            $this->scanner,
+            $this->clock,
+            $this->pollIntervalMs,
+            $this->debounceMs,
+        );
+    }
+
+    public function inotify(): InotifyWatcher
+    {
+        return new InotifyWatcher(
+            $this->scanner,
+            $this->clock,
+            'inotifywait',
+            $this->debounceMs,
+        );
+    }
+
+    public function fswatch(): FswatchWatcher
+    {
+        return new FswatchWatcher(
+            $this->scanner,
+            $this->clock,
+            'fswatch',
+            $this->debounceMs,
+        );
+    }
+}

--- a/src/php/Watch/Application/Watcher/FswatchWatcher.php
+++ b/src/php/Watch/Application/Watcher/FswatchWatcher.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application\Watcher;
+
+use Phel\Watch\Application\SystemClock;
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Domain\FileWatcherInterface;
+use Phel\Watch\Transfer\WatchEvent;
+
+use function escapeshellarg;
+use function fgets;
+use function implode;
+use function is_resource;
+use function pclose;
+use function popen;
+use function proc_close;
+use function proc_get_status;
+use function proc_open;
+use function proc_terminate;
+use function stream_set_blocking;
+use function trim;
+
+/**
+ * macOS-friendly watcher. Pipes events out of the `fswatch` binary and hands
+ * them off through the same debounce logic as `PollingWatcher`. Falls back to
+ * the polling watcher when `fswatch` is not available.
+ */
+final class FswatchWatcher implements FileWatcherInterface
+{
+    public const string NAME = 'fswatch';
+
+    /** @var resource|null */
+    private mixed $process = null;
+
+    /** @var resource|null */
+    private mixed $stdout = null;
+
+    /** @var resource|null */
+    private mixed $stderr = null;
+
+    /** @var array<int, resource> */
+    private array $pipes = [];
+
+    private bool $running = false;
+
+    public function __construct(
+        private readonly FileSystemScannerInterface $scanner,
+        private readonly ClockInterface $clock = new SystemClock(),
+        private readonly string $binaryPath = 'fswatch',
+        private readonly int $debounceMs = 100,
+    ) {}
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * @param list<string>                    $paths
+     * @param callable(list<WatchEvent>):void $onChange
+     */
+    public function watch(array $paths, callable $onChange): void
+    {
+        $this->running = true;
+
+        $cmd = $this->buildCommand($paths);
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'r'],
+            2 => ['pipe', 'r'],
+        ];
+
+        $process = @proc_open($cmd, $descriptors, $this->pipes);
+        if (!is_resource($process)) {
+            return;
+        }
+
+        $this->process = $process;
+        $this->stdout = $this->pipes[1];
+        $this->stderr = $this->pipes[2];
+        stream_set_blocking($this->stdout, false);
+        stream_set_blocking($this->stderr, false);
+
+        // Prime the snapshot so the resolver can mtime-diff if needed.
+        $this->scanner->snapshot($paths);
+
+        /** @var list<WatchEvent> $pending */
+        $pending = [];
+        $lastEventAt = 0;
+
+        /** @psalm-suppress RedundantCondition */
+        while ($this->running && $this->isAlive()) {
+            $line = @fgets($this->stdout);
+            if ($line !== false) {
+                $path = trim($line);
+                if ($path !== '') {
+                    $pending[] = new WatchEvent($path, WatchEvent::KIND_MODIFIED);
+                    $lastEventAt = $this->clock->nowMs();
+                }
+            }
+
+            if ($pending !== [] && $this->clock->nowMs() - $lastEventAt >= $this->debounceMs) {
+                $onChange($this->coalesce($pending));
+                $pending = [];
+            } else {
+                $this->clock->sleepMs(50);
+            }
+        }
+
+        $this->close();
+    }
+
+    public function stop(): void
+    {
+        $this->running = false;
+        $this->close();
+    }
+
+    /**
+     * Detect whether `fswatch` is available on PATH.
+     */
+    public static function isAvailable(string $binary = 'fswatch'): bool
+    {
+        $handle = @popen('command -v ' . escapeshellarg($binary) . ' 2>/dev/null', 'r');
+        if (!is_resource($handle)) {
+            return false;
+        }
+
+        $out = (string) fgets($handle);
+        pclose($handle);
+
+        return trim($out) !== '';
+    }
+
+    /**
+     * @param list<WatchEvent> $events
+     *
+     * @return list<WatchEvent>
+     */
+    private function coalesce(array $events): array
+    {
+        /** @var array<string, WatchEvent> $byPath */
+        $byPath = [];
+        foreach ($events as $event) {
+            $byPath[$event->path] = $event;
+        }
+
+        return array_values($byPath);
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private function buildCommand(array $paths): string
+    {
+        $args = [];
+        foreach ($paths as $path) {
+            $args[] = escapeshellarg($path);
+        }
+
+        return escapeshellarg($this->binaryPath)
+            . ' -r -0 -L -0 --event-flags '
+            . '--event Created --event Updated --event Removed --event Renamed '
+            . '--include=\'\\.phel$\' --include=\'\\.cljc$\' --exclude=\'.*\' '
+            . implode(' ', $args);
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function isAlive(): bool
+    {
+        if (!is_resource($this->process)) {
+            return false;
+        }
+
+        $status = @proc_get_status($this->process);
+        return $status['running'];
+    }
+
+    private function close(): void
+    {
+        foreach ($this->pipes as $pipe) {
+            /** @psalm-suppress RedundantConditionGivenDocblockType */
+            if (is_resource($pipe)) {
+                @fclose($pipe);
+            }
+        }
+
+        $this->pipes = [];
+        $this->stdout = null;
+        $this->stderr = null;
+
+        if (is_resource($this->process)) {
+            @proc_terminate($this->process);
+            @proc_close($this->process);
+        }
+
+        $this->process = null;
+    }
+}

--- a/src/php/Watch/Application/Watcher/InotifyWatcher.php
+++ b/src/php/Watch/Application/Watcher/InotifyWatcher.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application\Watcher;
+
+use Phel\Watch\Application\SystemClock;
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Domain\FileWatcherInterface;
+use Phel\Watch\Transfer\WatchEvent;
+
+use function count;
+use function escapeshellarg;
+use function extension_loaded;
+use function fgets;
+use function implode;
+use function is_resource;
+use function preg_match;
+use function proc_close;
+use function proc_get_status;
+use function proc_open;
+use function proc_terminate;
+use function rtrim;
+use function stream_set_blocking;
+use function trim;
+
+/**
+ * Linux-friendly watcher. Shell-outs to the `inotifywait` binary (part of
+ * `inotify-tools`) and streams events. The pure-`ext-inotify` path is not
+ * implemented here; the shell-out is portable, works across distros, and
+ * matches the behaviour of the macOS `fswatch` backend.
+ */
+final class InotifyWatcher implements FileWatcherInterface
+{
+    public const string NAME = 'inotify';
+
+    /** @var resource|null */
+    private mixed $process = null;
+
+    /** @var resource|null */
+    private mixed $stdout = null;
+
+    /** @var array<int, resource> */
+    private array $pipes = [];
+
+    private bool $running = false;
+
+    public function __construct(
+        private readonly FileSystemScannerInterface $scanner,
+        private readonly ClockInterface $clock = new SystemClock(),
+        private readonly string $binaryPath = 'inotifywait',
+        private readonly int $debounceMs = 100,
+    ) {}
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * True when either the `inotify` PHP extension is loaded or the
+     * `inotifywait` CLI is available on PATH. The latter is the default
+     * transport.
+     */
+    public static function isAvailable(string $binary = 'inotifywait'): bool
+    {
+        if (extension_loaded('inotify')) {
+            return true;
+        }
+
+        $handle = @popen('command -v ' . escapeshellarg($binary) . ' 2>/dev/null', 'r');
+        if (!is_resource($handle)) {
+            return false;
+        }
+
+        $out = (string) fgets($handle);
+        pclose($handle);
+
+        return trim($out) !== '';
+    }
+
+    public function watch(array $paths, callable $onChange): void
+    {
+        $this->running = true;
+        $cmd = $this->buildCommand($paths);
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'r'],
+            2 => ['pipe', 'r'],
+        ];
+
+        $process = @proc_open($cmd, $descriptors, $this->pipes);
+        if (!is_resource($process)) {
+            return;
+        }
+
+        $this->process = $process;
+        $this->stdout = $this->pipes[1];
+        stream_set_blocking($this->stdout, false);
+
+        $this->scanner->snapshot($paths);
+
+        /** @var list<WatchEvent> $pending */
+        $pending = [];
+        $lastEventAt = 0;
+
+        /** @psalm-suppress RedundantCondition */
+        while ($this->running && $this->isAlive()) {
+            $line = @fgets($this->stdout);
+            if ($line !== false) {
+                $event = $this->parseLine($line);
+                if ($event instanceof WatchEvent) {
+                    $pending[] = $event;
+                    $lastEventAt = $this->clock->nowMs();
+                }
+            }
+
+            if ($pending !== [] && $this->clock->nowMs() - $lastEventAt >= $this->debounceMs) {
+                $onChange($this->coalesce($pending));
+                $pending = [];
+            } else {
+                $this->clock->sleepMs(50);
+            }
+        }
+
+        $this->close();
+    }
+
+    public function stop(): void
+    {
+        $this->running = false;
+        $this->close();
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private function buildCommand(array $paths): string
+    {
+        $args = [];
+        foreach ($paths as $path) {
+            $args[] = escapeshellarg($path);
+        }
+
+        // `-m` monitor, `-r` recursive, events close_write/create/delete/move,
+        // format "<file>\t<event>" so parsing stays simple.
+        return escapeshellarg($this->binaryPath)
+            . ' -m -r --format \'%w%f\t%e\' --quiet '
+            . '-e close_write -e create -e delete -e move '
+            . implode(' ', $args);
+    }
+
+    private function parseLine(string $line): ?WatchEvent
+    {
+        $line = rtrim($line);
+        if ($line === '') {
+            return null;
+        }
+
+        $parts = explode("\t", $line, 2);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        [$path, $events] = $parts;
+        if (preg_match('/\.(phel|cljc)$/', $path) !== 1) {
+            return null;
+        }
+
+        if (str_contains($events, 'DELETE')) {
+            $kind = WatchEvent::KIND_DELETED;
+        } elseif (str_contains($events, 'CREATE')) {
+            $kind = WatchEvent::KIND_CREATED;
+        } else {
+            $kind = WatchEvent::KIND_MODIFIED;
+        }
+
+        return new WatchEvent($path, $kind);
+    }
+
+    /**
+     * @param list<WatchEvent> $events
+     *
+     * @return list<WatchEvent>
+     */
+    private function coalesce(array $events): array
+    {
+        /** @var array<string, WatchEvent> $byPath */
+        $byPath = [];
+        foreach ($events as $event) {
+            $byPath[$event->path] = $event;
+        }
+
+        return array_values($byPath);
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function isAlive(): bool
+    {
+        if (!is_resource($this->process)) {
+            return false;
+        }
+
+        $status = @proc_get_status($this->process);
+        return $status['running'];
+    }
+
+    private function close(): void
+    {
+        foreach ($this->pipes as $pipe) {
+            /** @psalm-suppress RedundantConditionGivenDocblockType */
+            if (is_resource($pipe)) {
+                @fclose($pipe);
+            }
+        }
+
+        $this->pipes = [];
+        $this->stdout = null;
+
+        if (is_resource($this->process)) {
+            @proc_terminate($this->process);
+            @proc_close($this->process);
+        }
+
+        $this->process = null;
+    }
+}

--- a/src/php/Watch/Application/Watcher/PollingWatcher.php
+++ b/src/php/Watch/Application/Watcher/PollingWatcher.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application\Watcher;
+
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Domain\FileWatcherInterface;
+use Phel\Watch\Transfer\WatchEvent;
+
+/**
+ * Stat-based fallback watcher. Walks the given paths every `$pollIntervalMs`
+ * and diffs the mtime + size snapshot with the previous one. Events emitted
+ * in the same `$debounceMs` window are coalesced into a single callback
+ * invocation (which stops editor-save-induced double triggers).
+ */
+final class PollingWatcher implements FileWatcherInterface
+{
+    public const string NAME = 'polling';
+
+    private bool $running = false;
+
+    /** @var array<string, array{mtime:int, size:int}> */
+    private array $lastSnapshot = [];
+
+    public function __construct(
+        private readonly FileSystemScannerInterface $scanner,
+        private readonly ClockInterface $clock,
+        private readonly int $pollIntervalMs = 500,
+        private readonly int $debounceMs = 100,
+        private readonly int $maxIterations = 0,
+    ) {}
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function watch(array $paths, callable $onChange): void
+    {
+        $this->running = true;
+        $this->lastSnapshot = $this->scanner->snapshot($paths);
+
+        /** @var list<WatchEvent> $pending */
+        $pending = [];
+        $lastEventAt = 0;
+        $iterations = 0;
+
+        /** @psalm-suppress RedundantCondition */
+        while ($this->running) {
+            $this->clock->sleepMs($this->pollIntervalMs);
+
+            $currentSnapshot = $this->scanner->snapshot($paths);
+            $events = $this->diff($this->lastSnapshot, $currentSnapshot);
+            $this->lastSnapshot = $currentSnapshot;
+
+            if ($events !== []) {
+                foreach ($events as $event) {
+                    $pending[] = $event;
+                }
+
+                $lastEventAt = $this->clock->nowMs();
+            }
+
+            $pending = $this->flushIfReady($pending, $lastEventAt, $onChange);
+
+            ++$iterations;
+            if ($this->maxIterations > 0 && $iterations >= $this->maxIterations) {
+                $this->running = false;
+                // Flush any outstanding events so callers can assert on them.
+                $this->flushIfReady($pending, $lastEventAt, $onChange, true);
+                break;
+            }
+        }
+    }
+
+    public function stop(): void
+    {
+        $this->running = false;
+    }
+
+    /**
+     * @param list<WatchEvent>                $pending
+     * @param callable(list<WatchEvent>):void $onChange
+     *
+     * @return list<WatchEvent>
+     */
+    private function flushIfReady(array $pending, int $lastEventAt, callable $onChange, bool $force = false): array
+    {
+        if ($pending === []) {
+            return [];
+        }
+
+        if (!$force) {
+            $elapsed = $this->clock->nowMs() - $lastEventAt;
+            if ($elapsed < $this->debounceMs) {
+                return $pending;
+            }
+        }
+
+        $unique = $this->coalesce($pending);
+        $onChange($unique);
+
+        return [];
+    }
+
+    /**
+     * Coalesce multiple events for the same path into a single entry.
+     *
+     * @param list<WatchEvent> $events
+     *
+     * @return list<WatchEvent>
+     */
+    private function coalesce(array $events): array
+    {
+        /** @var array<string, WatchEvent> $byPath */
+        $byPath = [];
+        foreach ($events as $event) {
+            // Creations trump modifications for the same file; deletions trump
+            // creations. Later wins only when the kind is stronger.
+            $existing = $byPath[$event->path] ?? null;
+            if ($existing === null) {
+                $byPath[$event->path] = $event;
+                continue;
+            }
+
+            if ($existing->kind === WatchEvent::KIND_DELETED) {
+                continue;
+            }
+
+            $byPath[$event->path] = $event;
+        }
+
+        return array_values($byPath);
+    }
+
+    /**
+     * @param array<string, array{mtime:int, size:int}> $previous
+     * @param array<string, array{mtime:int, size:int}> $current
+     *
+     * @return list<WatchEvent>
+     */
+    private function diff(array $previous, array $current): array
+    {
+        $events = [];
+        foreach ($current as $path => $stat) {
+            if (!isset($previous[$path])) {
+                $events[] = new WatchEvent($path, WatchEvent::KIND_CREATED);
+                continue;
+            }
+
+            if ($previous[$path]['mtime'] !== $stat['mtime'] || $previous[$path]['size'] !== $stat['size']) {
+                $events[] = new WatchEvent($path, WatchEvent::KIND_MODIFIED);
+            }
+        }
+
+        foreach (array_keys($previous) as $path) {
+            if (!isset($current[$path])) {
+                $events[] = new WatchEvent($path, WatchEvent::KIND_DELETED);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/php/Watch/CLAUDE.md
+++ b/src/php/Watch/CLAUDE.md
@@ -1,0 +1,68 @@
+# Watch Module
+
+Hot-reload and file-watch: detects `.phel` changes and re-evaluates the affected namespaces in dependency order.
+
+## Gacela Pattern
+
+- **Facade**: `WatchFacade` extends `AbstractFacade<WatchFactory>`
+- **Factory**: `WatchFactory` extends `AbstractFactory<WatchConfig>`
+- **Config**: `WatchConfig` - default poll interval (500ms), debounce (100ms), backend `auto`
+- **Provider**: `WatchProvider` - injects `FACADE_RUN`, `FACADE_BUILD`, `FACADE_API`, `FACADE_COMPILER`, `FACADE_COMMAND`
+
+## Public API (Facade)
+
+- `watch(list<string> $paths, array $options = []): void` - blocking watch loop
+- `createFileWatcher(?string $backend, ?int $poll, ?int $debounce): FileWatcherInterface`
+- `createFileWatcherFactory(?int $poll, ?int $debounce): FileWatcherFactory`
+- `createReloadOrchestrator(?ReloadEventPublisherInterface $publisher): ReloadOrchestratorInterface`
+- `createNamespaceResolver(): NamespaceResolverInterface`
+
+`$options`: `backend` (`auto|inotify|fswatch|polling`), `poll` (ms), `debounce` (ms), `publisher` (optional `ReloadEventPublisherInterface`).
+
+## CLI Command
+
+`./bin/phel watch [paths]... [-b backend] [--poll=500] [--debounce=100]` - starts the watcher.
+
+## Watcher Backends
+
+Strategy pattern. The factory picks the best available:
+
+- `InotifyWatcher` - Linux, shells out to `inotifywait`
+- `FswatchWatcher` - macOS/BSD, shells out to `fswatch`
+- `PollingWatcher` - portable fallback, mtime + size diff every poll interval
+
+All three implement `FileWatcherInterface { watch(list<string> $paths, callable $onChange): void; stop(): void; name(): string }`.
+
+## Dependencies
+
+- **Run** (`RunFacade`) - `evalFile`, `structuredEval`, `loadPhelNamespaces`
+- **Build** (`BuildFacade`) - `getDependenciesForNamespace`
+- **Api** (`ApiFacade`) - `indexProject` for incremental re-index
+- **Compiler** (`CompilerFacade`) - CompileOptions
+- **Command** (`CommandFacade`) - source-directory defaults
+
+## Structure
+
+```
+Watch/
+|-- Application/
+|   |-- Watcher/                 InotifyWatcher, FswatchWatcher, PollingWatcher, FileWatcherFactory
+|   |-- NamespaceResolver        parses `ns`/`in-ns` from source
+|   |-- ReloadOrchestrator       resolves ns, reloads in dep order, publishes event, re-indexes
+|   |-- MtimeFileSystemScanner   mtime + size snapshot
+|   |-- SystemClock, NullReloadEventPublisher
+|-- Domain/                      FileWatcherInterface, ClockInterface, FileSystemScannerInterface,
+|                                NamespaceResolverInterface, ReloadOrchestratorInterface,
+|                                ReloadEventPublisherInterface
+|-- Infrastructure/Command/      WatchCommand (Symfony console)
+|-- Transfer/                    WatchEvent
++-- Gacela files                 WatchFacade, WatchFactory, WatchConfig, WatchProvider
+```
+
+## Key Constraints
+
+- Debounce coalesces events in a 100ms window so editor saves that touch the same file twice trigger a single reload cycle
+- `PollingWatcher` is the only backend exercised in CI; `fswatch`/`inotify` availability is probed at runtime but their behaviour relies on external binaries and is not unit-tested
+- `ReloadOrchestrator` is the only side-effect surface: reload, run `phel\watch/run-on-reload-hooks`, re-index, publish
+- `NullReloadEventPublisher` is the default; swap in an nREPL-aware publisher when the watcher runs inside an nREPL process
+- `NamespaceResolver` uses a lightweight regex (not the full parser) since this runs on every file change

--- a/src/php/Watch/Domain/ClockInterface.php
+++ b/src/php/Watch/Domain/ClockInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+/**
+ * Monotonic clock indirection so unit tests can freeze time.
+ */
+interface ClockInterface
+{
+    /**
+     * Current time in milliseconds since the Unix epoch.
+     */
+    public function nowMs(): int;
+
+    /**
+     * Sleep for the given number of milliseconds.
+     */
+    public function sleepMs(int $ms): void;
+}

--- a/src/php/Watch/Domain/FileSystemScannerInterface.php
+++ b/src/php/Watch/Domain/FileSystemScannerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+/**
+ * Scans a list of paths and returns a mtime + size snapshot keyed by file path.
+ * Injected into `PollingWatcher` so tests can fake the filesystem.
+ */
+interface FileSystemScannerInterface
+{
+    /**
+     * @param list<string> $paths
+     *
+     * @return array<string, array{mtime:int, size:int}>
+     */
+    public function snapshot(array $paths): array;
+}

--- a/src/php/Watch/Domain/FileWatcherInterface.php
+++ b/src/php/Watch/Domain/FileWatcherInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+use Phel\Watch\Transfer\WatchEvent;
+
+/**
+ * Strategy contract for the OS-specific file-watching backends.
+ */
+interface FileWatcherInterface
+{
+    /**
+     * Start watching the given paths. The callback is invoked once per batch
+     * of coalesced WatchEvents. Implementations block until {@see stop()} is
+     * called or the watcher is otherwise terminated.
+     *
+     * @param list<string>                    $paths
+     * @param callable(list<WatchEvent>):void $onChange
+     */
+    public function watch(array $paths, callable $onChange): void;
+
+    /**
+     * Request termination of an in-flight watch loop. Safe to call from a
+     * signal handler or another fiber.
+     */
+    public function stop(): void;
+
+    /**
+     * Short human-readable backend name (e.g. `polling`, `fswatch`).
+     */
+    public function name(): string;
+}

--- a/src/php/Watch/Domain/NamespaceResolverInterface.php
+++ b/src/php/Watch/Domain/NamespaceResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+/**
+ * Resolves the fully-qualified Phel namespace defined by a given source file.
+ */
+interface NamespaceResolverInterface
+{
+    /**
+     * Returns the fully-qualified namespace declared by the file (via `ns` or
+     * `in-ns`) or `null` when the file does not declare one.
+     */
+    public function resolveFromFile(string $filePath): ?string;
+
+    /**
+     * Returns the namespace declared in the given source string, or `null`
+     * when none is found.
+     */
+    public function resolveFromSource(string $source): ?string;
+}

--- a/src/php/Watch/Domain/ProjectReindexerInterface.php
+++ b/src/php/Watch/Domain/ProjectReindexerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+/**
+ * Re-indexes the project for editor/linter tooling after a reload cycle.
+ * Abstracted here so `ReloadOrchestrator` can be unit-tested without the
+ * concrete `ApiFacade`.
+ */
+interface ProjectReindexerInterface
+{
+    /**
+     * @param list<string> $srcDirs
+     */
+    public function reindex(array $srcDirs): void;
+}

--- a/src/php/Watch/Domain/ReloadEventPublisherInterface.php
+++ b/src/php/Watch/Domain/ReloadEventPublisherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+use Phel\Watch\Transfer\WatchEvent;
+
+/**
+ * Fan-out hook for reload events. The default implementation is a no-op; a
+ * future nREPL integration publishes a `reload` event to every connected
+ * session.
+ */
+interface ReloadEventPublisherInterface
+{
+    /**
+     * @param list<WatchEvent> $events
+     * @param list<string>     $reloadedNamespaces
+     */
+    public function publish(array $events, array $reloadedNamespaces): void;
+}

--- a/src/php/Watch/Domain/ReloadOrchestratorInterface.php
+++ b/src/php/Watch/Domain/ReloadOrchestratorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Domain;
+
+use Phel\Watch\Transfer\WatchEvent;
+
+/**
+ * Handles the "on-change" side effects: resolve namespace, reload dependency
+ * chain, re-run `:on-reload` tests, publish an event, re-index for tooling.
+ */
+interface ReloadOrchestratorInterface
+{
+    /**
+     * @param list<WatchEvent> $events
+     * @param list<string>     $srcDirs
+     *
+     * @return list<string> Reloaded namespaces (in reload order)
+     */
+    public function handleChanges(array $events, array $srcDirs): array;
+}

--- a/src/php/Watch/Infrastructure/Command/WatchCommand.php
+++ b/src/php/Watch/Infrastructure/Command/WatchCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel;
+use Phel\Watch\WatchConfig;
+use Phel\Watch\WatchFacade;
+use Phel\Watch\WatchFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function implode;
+use function is_dir;
+use function is_file;
+use function sprintf;
+
+/**
+ * `./bin/phel watch [paths]...` — watch `.phel` files and reload them on
+ * change. Uses inotify on Linux, fswatch on macOS, polling on Windows.
+ */
+#[ServiceMap(method: 'getFacade', className: WatchFacade::class)]
+#[ServiceMap(method: 'getFactory', className: WatchFactory::class)]
+#[ServiceMap(method: 'getConfig', className: WatchConfig::class)]
+final class WatchCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const string COMMAND_NAME = 'watch';
+
+    private const string ARG_PATHS = 'paths';
+
+    private const string OPT_BACKEND = 'backend';
+
+    private const string OPT_POLL = 'poll';
+
+    private const string OPT_DEBOUNCE = 'debounce';
+
+    public function __construct()
+    {
+        parent::__construct(self::COMMAND_NAME);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Watch Phel files and reload namespaces on change.')
+            ->addArgument(
+                self::ARG_PATHS,
+                InputArgument::IS_ARRAY,
+                'Files or directories to watch (defaults to the configured source dirs).',
+                [],
+            )
+            ->addOption(
+                self::OPT_BACKEND,
+                'b',
+                InputOption::VALUE_REQUIRED,
+                'Watcher backend: auto, inotify, fswatch, polling.',
+                WatchConfig::defaultBackend(),
+            )
+            ->addOption(
+                self::OPT_POLL,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Polling interval in milliseconds (polling backend only).',
+                (string) WatchConfig::defaultPollIntervalMs(),
+            )
+            ->addOption(
+                self::OPT_DEBOUNCE,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Debounce window in milliseconds.',
+                (string) WatchConfig::defaultDebounceMs(),
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var list<string> $paths */
+        $paths = (array) $input->getArgument(self::ARG_PATHS);
+        if ($paths === []) {
+            $paths = $this->defaultPaths();
+        }
+
+        $paths = $this->filterExistingPaths($paths);
+        if ($paths === []) {
+            $output->writeln('<error>No readable paths to watch.</error>');
+            return self::FAILURE;
+        }
+
+        $backend = (string) $input->getOption(self::OPT_BACKEND);
+        $backend = $backend === WatchConfig::defaultBackend() ? null : $backend;
+
+        $poll = (int) $input->getOption(self::OPT_POLL);
+        $debounce = (int) $input->getOption(self::OPT_DEBOUNCE);
+
+        Phel::setupRuntimeArgs('watch', []);
+        $this->getFactory()->getRunFacade()->loadPhelNamespaces();
+
+        $watcher = $this->getFactory()->createFileWatcher($backend, $poll, $debounce);
+        $output->writeln(sprintf(
+            '<info>Watching %s via %s backend (poll %dms, debounce %dms). Press Ctrl+C to stop.</info>',
+            implode(', ', $paths),
+            $watcher->name(),
+            $poll,
+            $debounce,
+        ));
+
+        try {
+            $this->getFacade()->watch($paths, [
+                'backend' => $backend,
+                'poll' => $poll,
+                'debounce' => $debounce,
+            ]);
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>%s</error>', $throwable->getMessage()));
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function defaultPaths(): array
+    {
+        $cmd = $this->getFactory()->getCommandFacade();
+
+        return $cmd->getSourceDirectories();
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<string>
+     */
+    private function filterExistingPaths(array $paths): array
+    {
+        $filtered = [];
+        foreach ($paths as $path) {
+            if (is_file($path) || is_dir($path)) {
+                $filtered[] = $path;
+            }
+        }
+
+        return $filtered;
+    }
+}

--- a/src/php/Watch/Transfer/WatchEvent.php
+++ b/src/php/Watch/Transfer/WatchEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Transfer;
+
+/**
+ * A detected change on a watched path.
+ */
+final readonly class WatchEvent
+{
+    public const string KIND_MODIFIED = 'modified';
+
+    public const string KIND_CREATED = 'created';
+
+    public const string KIND_DELETED = 'deleted';
+
+    public function __construct(
+        public string $path,
+        public string $kind = self::KIND_MODIFIED,
+    ) {}
+}

--- a/src/php/Watch/WatchConfig.php
+++ b/src/php/Watch/WatchConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch;
+
+use Gacela\Framework\AbstractConfig;
+
+final class WatchConfig extends AbstractConfig
+{
+    private const int DEFAULT_POLL_INTERVAL_MS = 500;
+
+    private const int DEFAULT_DEBOUNCE_MS = 100;
+
+    private const string BACKEND_AUTO = 'auto';
+
+    public static function defaultPollIntervalMs(): int
+    {
+        return self::DEFAULT_POLL_INTERVAL_MS;
+    }
+
+    public static function defaultDebounceMs(): int
+    {
+        return self::DEFAULT_DEBOUNCE_MS;
+    }
+
+    public static function defaultBackend(): string
+    {
+        return self::BACKEND_AUTO;
+    }
+}

--- a/src/php/Watch/WatchFacade.php
+++ b/src/php/Watch/WatchFacade.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Watch\Application\Watcher\FileWatcherBuilder;
+use Phel\Watch\Domain\FileWatcherInterface;
+use Phel\Watch\Domain\NamespaceResolverInterface;
+use Phel\Watch\Domain\ReloadEventPublisherInterface;
+use Phel\Watch\Domain\ReloadOrchestratorInterface;
+
+/**
+ * @extends AbstractFacade<WatchFactory>
+ */
+final class WatchFacade extends AbstractFacade
+{
+    /**
+     * Watch the given paths and trigger hot reloads. Blocks until the watcher
+     * is stopped.
+     *
+     * @param list<string>                                                                                $paths
+     * @param array{backend?:?string,poll?:?int,debounce?:?int,publisher?:?ReloadEventPublisherInterface} $options
+     */
+    public function watch(array $paths, array $options = []): void
+    {
+        $this->getFactory()
+            ->createWatchRunner(
+                $options['publisher'] ?? null,
+                $options['poll'] ?? null,
+                $options['debounce'] ?? null,
+            )
+            ->run($paths, [
+                'backend' => $options['backend'] ?? null,
+                'poll' => $options['poll'] ?? null,
+                'debounce' => $options['debounce'] ?? null,
+            ]);
+    }
+
+    public function createFileWatcher(?string $preferred = null, ?int $pollIntervalMs = null, ?int $debounceMs = null): FileWatcherInterface
+    {
+        return $this->getFactory()->createFileWatcher($preferred, $pollIntervalMs, $debounceMs);
+    }
+
+    public function createFileWatcherBuilder(?int $pollIntervalMs = null, ?int $debounceMs = null): FileWatcherBuilder
+    {
+        return $this->getFactory()->createFileWatcherBuilder($pollIntervalMs, $debounceMs);
+    }
+
+    public function createReloadOrchestrator(?ReloadEventPublisherInterface $publisher = null): ReloadOrchestratorInterface
+    {
+        return $this->getFactory()->createReloadOrchestrator($publisher);
+    }
+
+    public function createNamespaceResolver(): NamespaceResolverInterface
+    {
+        return $this->getFactory()->createNamespaceResolver();
+    }
+}

--- a/src/php/Watch/WatchFactory.php
+++ b/src/php/Watch/WatchFactory.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Api\ApiFacade;
+use Phel\Build\BuildFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Run\RunFacade;
+use Phel\Watch\Application\ApiProjectReindexer;
+use Phel\Watch\Application\MtimeFileSystemScanner;
+use Phel\Watch\Application\NamespaceResolver;
+use Phel\Watch\Application\NullReloadEventPublisher;
+use Phel\Watch\Application\ReloadOrchestrator;
+use Phel\Watch\Application\SystemClock;
+use Phel\Watch\Application\Watcher\FileWatcherBuilder;
+use Phel\Watch\Application\WatchRunner;
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Domain\FileWatcherInterface;
+use Phel\Watch\Domain\NamespaceResolverInterface;
+use Phel\Watch\Domain\ProjectReindexerInterface;
+use Phel\Watch\Domain\ReloadEventPublisherInterface;
+use Phel\Watch\Domain\ReloadOrchestratorInterface;
+
+/**
+ * @extends AbstractFactory<WatchConfig>
+ */
+final class WatchFactory extends AbstractFactory
+{
+    public function createWatchRunner(?ReloadEventPublisherInterface $publisher = null, ?int $pollIntervalMs = null, ?int $debounceMs = null): WatchRunner
+    {
+        return new WatchRunner(
+            $this->createFileWatcherBuilder($pollIntervalMs, $debounceMs),
+            $this->createReloadOrchestrator($publisher),
+            $this->getCommandFacade(),
+        );
+    }
+
+    public function createFileWatcher(?string $preferred = null, ?int $pollIntervalMs = null, ?int $debounceMs = null): FileWatcherInterface
+    {
+        return $this->createFileWatcherBuilder($pollIntervalMs, $debounceMs)->create($preferred);
+    }
+
+    public function createFileWatcherBuilder(?int $pollIntervalMs = null, ?int $debounceMs = null): FileWatcherBuilder
+    {
+        return new FileWatcherBuilder(
+            $this->createFileSystemScanner(),
+            $this->createClock(),
+            $pollIntervalMs ?? WatchConfig::defaultPollIntervalMs(),
+            $debounceMs ?? WatchConfig::defaultDebounceMs(),
+        );
+    }
+
+    public function createReloadOrchestrator(?ReloadEventPublisherInterface $publisher = null): ReloadOrchestratorInterface
+    {
+        return new ReloadOrchestrator(
+            $this->createNamespaceResolver(),
+            $this->getRunFacade(),
+            $this->getBuildFacade(),
+            $this->createProjectReindexer(),
+            $publisher ?? $this->createDefaultPublisher(),
+        );
+    }
+
+    public function createProjectReindexer(): ProjectReindexerInterface
+    {
+        return new ApiProjectReindexer($this->getApiFacade());
+    }
+
+    public function createNamespaceResolver(): NamespaceResolverInterface
+    {
+        return new NamespaceResolver();
+    }
+
+    public function createFileSystemScanner(): FileSystemScannerInterface
+    {
+        return new MtimeFileSystemScanner();
+    }
+
+    public function createClock(): ClockInterface
+    {
+        return new SystemClock();
+    }
+
+    public function createDefaultPublisher(): ReloadEventPublisherInterface
+    {
+        return new NullReloadEventPublisher();
+    }
+
+    public function getRunFacade(): RunFacade
+    {
+        return $this->getProvidedDependency(WatchProvider::FACADE_RUN);
+    }
+
+    public function getBuildFacade(): BuildFacade
+    {
+        return $this->getProvidedDependency(WatchProvider::FACADE_BUILD);
+    }
+
+    public function getApiFacade(): ApiFacade
+    {
+        return $this->getProvidedDependency(WatchProvider::FACADE_API);
+    }
+
+    public function getCompilerFacade(): CompilerFacade
+    {
+        return $this->getProvidedDependency(WatchProvider::FACADE_COMPILER);
+    }
+
+    public function getCommandFacade(): CommandFacade
+    {
+        return $this->getProvidedDependency(WatchProvider::FACADE_COMMAND);
+    }
+}

--- a/src/php/Watch/WatchProvider.php
+++ b/src/php/Watch/WatchProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use Phel\Api\ApiFacade;
+use Phel\Build\BuildFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Run\RunFacade;
+
+final class WatchProvider extends AbstractProvider
+{
+    public const string FACADE_RUN = 'FACADE_RUN';
+
+    public const string FACADE_BUILD = 'FACADE_BUILD';
+
+    public const string FACADE_API = 'FACADE_API';
+
+    public const string FACADE_COMPILER = 'FACADE_COMPILER';
+
+    public const string FACADE_COMMAND = 'FACADE_COMMAND';
+
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
+    {
+        return $container->getLocator()->getRequired(RunFacade::class);
+    }
+
+    #[Provides(self::FACADE_BUILD)]
+    public function buildFacade(Container $container): BuildFacade
+    {
+        return $container->getLocator()->getRequired(BuildFacade::class);
+    }
+
+    #[Provides(self::FACADE_API)]
+    public function apiFacade(Container $container): ApiFacade
+    {
+        return $container->getLocator()->getRequired(ApiFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
+    {
+        return $container->getLocator()->getRequired(CompilerFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
+    {
+        return $container->getLocator()->getRequired(CommandFacade::class);
+    }
+}

--- a/tests/php/Integration/Watch/PollingWatcherIntegrationTest.php
+++ b/tests/php/Integration/Watch/PollingWatcherIntegrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Watch;
+
+use Phel\Watch\Application\MtimeFileSystemScanner;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function mkdir;
+use function sys_get_temp_dir;
+use function touch;
+use function uniqid;
+use function unlink;
+
+/**
+ * Integration-style coverage of the polling-backend primitives without
+ * depending on wall-clock timing. The deterministic behaviour of
+ * `PollingWatcher` itself is covered by the unit tests with a fake clock;
+ * here we sanity-check the real scanner against a real filesystem.
+ */
+final class PollingWatcherIntegrationTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/phel-watch-' . uniqid('', true);
+        @mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanDir($this->tmpDir);
+    }
+
+    public function test_scanner_detects_mtime_or_size_change(): void
+    {
+        $file = $this->tmpDir . '/app.phel';
+        file_put_contents($file, "(ns app)\n");
+        touch($file, time() - 5);
+
+        $scanner = new MtimeFileSystemScanner();
+        $before = $scanner->snapshot([$this->tmpDir]);
+        self::assertArrayHasKey($file, $before);
+
+        file_put_contents($file, "(ns app)\n;; changed\n");
+        touch($file, time() + 5);
+
+        $after = $scanner->snapshot([$this->tmpDir]);
+        self::assertArrayHasKey($file, $after);
+        self::assertNotSame(
+            [$before[$file]['mtime'], $before[$file]['size']],
+            [$after[$file]['mtime'], $after[$file]['size']],
+        );
+    }
+
+    public function test_scanner_only_reports_phel_files(): void
+    {
+        file_put_contents($this->tmpDir . '/ignored.txt', 'plain text');
+        file_put_contents($this->tmpDir . '/keep.phel', "(ns keep)\n");
+
+        $snapshot = (new MtimeFileSystemScanner())->snapshot([$this->tmpDir]);
+        $paths = array_keys($snapshot);
+
+        self::assertCount(1, $paths);
+        self::assertStringEndsWith('keep.phel', $paths[0]);
+    }
+
+    private function cleanDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = @scandir($dir) ?: [];
+        foreach ($files as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->cleanDir($path);
+                continue;
+            }
+
+            @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Integration/Watch/WatchCommandTest.php
+++ b/tests/php/Integration/Watch/WatchCommandTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Watch;
+
+use Phel\Watch\Infrastructure\Command\WatchCommand;
+use PHPUnit\Framework\TestCase;
+
+final class WatchCommandTest extends TestCase
+{
+    public function test_it_registers_the_watch_command_with_expected_options(): void
+    {
+        $command = new WatchCommand();
+
+        self::assertSame('watch', $command->getName());
+        self::assertStringContainsString('Watch Phel files', $command->getDescription());
+
+        $definition = $command->getDefinition();
+        self::assertTrue($definition->hasOption('backend'));
+        self::assertTrue($definition->hasOption('poll'));
+        self::assertTrue($definition->hasOption('debounce'));
+        self::assertTrue($definition->hasArgument('paths'));
+    }
+}

--- a/tests/php/Unit/Watch/Application/NamespaceResolverTest.php
+++ b/tests/php/Unit/Watch/Application/NamespaceResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Watch\Application;
+
+use Phel\Watch\Application\NamespaceResolver;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class NamespaceResolverTest extends TestCase
+{
+    private NamespaceResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new NamespaceResolver();
+    }
+
+    public function test_it_resolves_ns_form_from_source(): void
+    {
+        $source = "(ns my-app\\core)\n(defn foo [] 1)";
+        self::assertSame('my-app\\core', $this->resolver->resolveFromSource($source));
+    }
+
+    public function test_it_resolves_in_ns_form(): void
+    {
+        $source = "(in-ns 'my-app\\core)";
+        self::assertSame('my-app\\core', $this->resolver->resolveFromSource($source));
+    }
+
+    public function test_it_normalises_forward_slash_separator_to_backslash(): void
+    {
+        $source = '(ns my-app/core)';
+        self::assertSame('my-app\\core', $this->resolver->resolveFromSource($source));
+    }
+
+    public function test_it_skips_shebang_and_leading_line_comments(): void
+    {
+        $source = "#!/usr/bin/env phel\n;; top comment\n;; another\n(ns app\\main)";
+        self::assertSame('app\\main', $this->resolver->resolveFromSource($source));
+    }
+
+    public function test_it_returns_null_when_no_ns_form(): void
+    {
+        self::assertNull($this->resolver->resolveFromSource('(defn foo [] 1)'));
+        self::assertNull($this->resolver->resolveFromSource(''));
+    }
+
+    public function test_it_resolves_from_file(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'watch-ns-');
+        self::assertNotFalse($path);
+
+        try {
+            file_put_contents($path, "(ns demo\\core)\n");
+            self::assertSame('demo\\core', $this->resolver->resolveFromFile($path));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_it_returns_null_for_missing_file(): void
+    {
+        self::assertNull($this->resolver->resolveFromFile('/non/existent/path.phel'));
+    }
+}

--- a/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
+++ b/tests/php/Unit/Watch/Application/ReloadOrchestratorTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Watch\Application;
+
+use Gacela\Framework\Health\ModuleHealthCheckInterface;
+use Phel\Build\Domain\Compile\BuildOptions;
+use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Run\Domain\Repl\EvalResult;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Phel\Watch\Application\NamespaceResolver;
+use Phel\Watch\Application\ReloadOrchestrator;
+use Phel\Watch\Domain\ProjectReindexerInterface;
+use Phel\Watch\Domain\ReloadEventPublisherInterface;
+use Phel\Watch\Transfer\WatchEvent;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class ReloadOrchestratorTest extends TestCase
+{
+    public function test_it_reloads_changed_namespace_and_dependencies_in_order(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'watch-ro-');
+        self::assertNotFalse($file);
+
+        try {
+            file_put_contents($file, "(ns app\\core)\n");
+
+            $infoA = new NamespaceInformation($file, 'app\\core', []);
+            $infoB = new NamespaceInformation($file . '-b', 'app\\consumer', ['app\\core']);
+
+            $build = new FakeBuildFacade([$infoA, $infoB]);
+            $run = new FakeRunFacade();
+            $reindexer = new FakeProjectReindexer();
+            $publisher = new RecordingPublisher();
+
+            $orchestrator = new ReloadOrchestrator(
+                new NamespaceResolver(),
+                $run,
+                $build,
+                $reindexer,
+                $publisher,
+            );
+
+            $reloaded = $orchestrator->handleChanges(
+                [new WatchEvent($file, WatchEvent::KIND_MODIFIED)],
+                ['/src'],
+            );
+
+            self::assertSame(['app\\core', 'app\\consumer'], $reloaded);
+            self::assertSame(['app\\core', 'app\\consumer'], $publisher->lastNamespaces);
+            self::assertSame(2, $run->evalFileCount);
+            self::assertSame(1, $reindexer->count);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function test_it_skips_deleted_files(): void
+    {
+        $build = new FakeBuildFacade([]);
+        $run = new FakeRunFacade();
+        $reindexer = new FakeProjectReindexer();
+        $publisher = new RecordingPublisher();
+
+        $orchestrator = new ReloadOrchestrator(
+            new NamespaceResolver(),
+            $run,
+            $build,
+            $reindexer,
+            $publisher,
+        );
+
+        $reloaded = $orchestrator->handleChanges(
+            [new WatchEvent('/gone.phel', WatchEvent::KIND_DELETED)],
+            ['/src'],
+        );
+
+        self::assertSame([], $reloaded);
+        self::assertSame([], $publisher->lastNamespaces);
+        self::assertSame(0, $run->evalFileCount);
+        self::assertSame(0, $reindexer->count);
+    }
+
+    public function test_it_tolerates_eval_failures_without_aborting_chain(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'watch-ro-');
+        self::assertNotFalse($file);
+
+        try {
+            file_put_contents($file, "(ns app\\broken)\n");
+
+            $infoA = new NamespaceInformation($file, 'app\\broken', []);
+            $infoB = new NamespaceInformation($file . '-b', 'app\\healthy', ['app\\broken']);
+
+            $build = new FakeBuildFacade([$infoA, $infoB]);
+            $run = new FakeRunFacade(throwOnCall: 1);
+            $reindexer = new FakeProjectReindexer();
+            $publisher = new RecordingPublisher();
+
+            $orchestrator = new ReloadOrchestrator(
+                new NamespaceResolver(),
+                $run,
+                $build,
+                $reindexer,
+                $publisher,
+            );
+
+            $reloaded = $orchestrator->handleChanges(
+                [new WatchEvent($file, WatchEvent::KIND_MODIFIED)],
+                ['/src'],
+            );
+
+            self::assertSame(['app\\healthy'], $reloaded);
+        } finally {
+            @unlink($file);
+        }
+    }
+}
+
+final readonly class FakeBuildFacade implements BuildFacadeInterface
+{
+    /**
+     * @param list<NamespaceInformation> $dependencies
+     */
+    public function __construct(
+        private array $dependencies,
+    ) {}
+
+    public function getDependenciesForNamespace(array $directories, array $ns): array
+    {
+        return $this->dependencies;
+    }
+
+    public function getNamespaceFromFile(string $filename): NamespaceInformation
+    {
+        throw new RuntimeException('not implemented');
+    }
+
+    public function getNamespaceFromDirectories(array $directories): array
+    {
+        return [];
+    }
+
+    public function compileFile(string $src, string $dest): CompiledFile
+    {
+        throw new RuntimeException('not implemented');
+    }
+
+    public function evalFile(string $src): CompiledFile
+    {
+        throw new RuntimeException('not implemented');
+    }
+
+    public function compileProject(BuildOptions $options): array
+    {
+        return [];
+    }
+
+    public function clearCache(): array
+    {
+        return [];
+    }
+
+    public function getHealthCheck(): ModuleHealthCheckInterface
+    {
+        throw new RuntimeException('not implemented');
+    }
+
+    public function getOutputDirectory(): string
+    {
+        return '';
+    }
+}
+
+final class FakeRunFacade implements RunFacadeInterface
+{
+    public int $evalFileCount = 0;
+
+    public function __construct(
+        private readonly int $throwOnCall = 0,
+    ) {}
+
+    public function evalFile(NamespaceInformation $info): void
+    {
+        ++$this->evalFileCount;
+        if ($this->evalFileCount === $this->throwOnCall) {
+            throw new RuntimeException('boom');
+        }
+    }
+
+    public function structuredEval(string $phelCode, CompileOptions $compileOptions): EvalResult
+    {
+        return EvalResult::success(null);
+    }
+
+    public function runNamespace(string $namespace): void {}
+
+    public function runFile(string $filename): void {}
+
+    public function eval(string $phelCode, CompileOptions $compileOptions): mixed
+    {
+        return null;
+    }
+
+    public function getAllPhelDirectories(): array
+    {
+        return [];
+    }
+
+    public function getDependenciesForNamespace(array $directories, array $ns): array
+    {
+        return [];
+    }
+
+    public function getDependenciesFromPaths(array $paths): array
+    {
+        return [];
+    }
+
+    public function getNamespaceFromFile(string $fileOrPath): NamespaceInformation
+    {
+        throw new RuntimeException('not implemented');
+    }
+
+    public function writeLocatedException(OutputInterface $output, CompilerException $e): void {}
+
+    public function writeStackTrace(OutputInterface $output, Throwable $e): void {}
+
+    public function getLoadedNamespaces(): array
+    {
+        return [];
+    }
+
+    public function getVersion(): string
+    {
+        return 'test';
+    }
+
+    public function loadPhelNamespaces(?string $replStartupFile = null): void {}
+}
+
+final class FakeProjectReindexer implements ProjectReindexerInterface
+{
+    public int $count = 0;
+
+    public function reindex(array $srcDirs): void
+    {
+        ++$this->count;
+    }
+}
+
+final class RecordingPublisher implements ReloadEventPublisherInterface
+{
+    /** @var list<string> */
+    public array $lastNamespaces = [];
+
+    /** @var list<WatchEvent> */
+    public array $lastEvents = [];
+
+    public function publish(array $events, array $reloadedNamespaces): void
+    {
+        $this->lastEvents = $events;
+        $this->lastNamespaces = $reloadedNamespaces;
+    }
+}

--- a/tests/php/Unit/Watch/Application/Watcher/PollingWatcherTest.php
+++ b/tests/php/Unit/Watch/Application/Watcher/PollingWatcherTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Watch\Application\Watcher;
+
+use Phel\Watch\Application\Watcher\PollingWatcher;
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Domain\FileSystemScannerInterface;
+use Phel\Watch\Transfer\WatchEvent;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+final class PollingWatcherTest extends TestCase
+{
+    public function test_it_detects_modified_file(): void
+    {
+        $scanner = new FakeScanner([
+            ['/a.phel' => ['mtime' => 1, 'size' => 10]],
+            ['/a.phel' => ['mtime' => 2, 'size' => 12]],
+        ]);
+        $clock = new FakeClock();
+        $watcher = new PollingWatcher($scanner, $clock, pollIntervalMs: 10, debounceMs: 50, maxIterations: 3);
+
+        /** @var list<list<WatchEvent>> $calls */
+        $calls = [];
+        $watcher->watch(['/a.phel'], static function (array $events) use (&$calls): void {
+            $calls[] = $events;
+        });
+
+        self::assertNotEmpty($calls);
+        $flat = array_merge(...$calls);
+        self::assertSame('/a.phel', $flat[0]->path);
+        self::assertSame(WatchEvent::KIND_MODIFIED, $flat[0]->kind);
+    }
+
+    public function test_it_detects_created_and_deleted_files(): void
+    {
+        $scanner = new FakeScanner([
+            ['/a.phel' => ['mtime' => 1, 'size' => 10]],
+            [
+                '/a.phel' => ['mtime' => 1, 'size' => 10],
+                '/b.phel' => ['mtime' => 1, 'size' => 20],
+            ],
+            ['/b.phel' => ['mtime' => 1, 'size' => 20]],
+        ]);
+        $clock = new FakeClock();
+        $watcher = new PollingWatcher($scanner, $clock, pollIntervalMs: 10, debounceMs: 20, maxIterations: 4);
+
+        $allEvents = [];
+        $watcher->watch(['/watch'], static function (array $events) use (&$allEvents): void {
+            foreach ($events as $event) {
+                $allEvents[] = $event;
+            }
+        });
+
+        $paths = array_map(static fn(WatchEvent $e): string => $e->path, $allEvents);
+        $kinds = array_map(static fn(WatchEvent $e): string => $e->kind, $allEvents);
+
+        self::assertContains('/b.phel', $paths);
+        self::assertContains(WatchEvent::KIND_CREATED, $kinds);
+        self::assertContains(WatchEvent::KIND_DELETED, $kinds);
+    }
+
+    public function test_it_debounces_multiple_changes_into_one_callback(): void
+    {
+        // Three consecutive changes should coalesce into one callback when
+        // debounce has not elapsed between them.
+        $scanner = new FakeScanner([
+            ['/a.phel' => ['mtime' => 1, 'size' => 10]],
+            ['/a.phel' => ['mtime' => 2, 'size' => 12]],
+            ['/a.phel' => ['mtime' => 3, 'size' => 14]],
+            ['/a.phel' => ['mtime' => 3, 'size' => 14]],
+        ]);
+        $clock = new FakeClock();
+        $watcher = new PollingWatcher($scanner, $clock, pollIntervalMs: 10, debounceMs: 25, maxIterations: 5);
+
+        $callbackCount = 0;
+        $totalEvents = 0;
+        $watcher->watch(['/a.phel'], static function (array $events) use (&$callbackCount, &$totalEvents): void {
+            ++$callbackCount;
+            $totalEvents += count($events);
+        });
+
+        self::assertGreaterThan(0, $callbackCount);
+        self::assertSame(1, $totalEvents, 'coalesce duplicate path events into one per batch');
+    }
+
+    public function test_it_stops_when_stop_is_called(): void
+    {
+        $scanner = new FakeScanner([[], []]);
+        $clock = new FakeClock();
+        $watcher = new PollingWatcher($scanner, $clock, pollIntervalMs: 10, debounceMs: 20, maxIterations: 1);
+
+        $watcher->stop();
+        $watcher->watch(['/nothing'], static function (array $_events): void {});
+
+        // Reaching here without looping indefinitely is the assertion.
+        self::assertSame('polling', $watcher->name());
+    }
+}
+
+final class FakeScanner implements FileSystemScannerInterface
+{
+    private int $index = 0;
+
+    /**
+     * @param list<array<string, array{mtime:int, size:int}>> $snapshots
+     */
+    public function __construct(private array $snapshots) {}
+
+    public function snapshot(array $paths): array
+    {
+        $snap = $this->snapshots[$this->index] ?? end($this->snapshots);
+        if ($this->index < count($this->snapshots) - 1) {
+            ++$this->index;
+        }
+
+        return $snap;
+    }
+}
+
+final class FakeClock implements ClockInterface
+{
+    private int $now = 0;
+
+    public function nowMs(): int
+    {
+        return $this->now;
+    }
+
+    public function sleepMs(int $ms): void
+    {
+        $this->now += max(0, $ms);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Point #5 of the Clojure-parity roadmap: hot reload / file watch. Until now Phel offered `load-file` and `require :reload` but no watcher, forcing REPL users to restart on every source change.

## 💡 Goal

Ship `./bin/phel watch` (and a REPL-level `(watch! [\"src/\"])` helper) that watches `.phel` files, detects changes, and re-evaluates the affected namespaces in dependency order. Complete the REPL-driven loop now that the nREPL server (#1) and project indexer (#2) are in place.

## 🔖 Changes

- New `Watch` Gacela module under `src/php/Watch/`
  - `WatchFacade::watch(list<string> \$paths, array \$options)` blocking loop
  - Strategy pattern behind `FileWatcherInterface`: `InotifyWatcher` (Linux), `FswatchWatcher` (macOS/BSD), `PollingWatcher` (portable fallback, 500ms stat diff)
  - `FileWatcherBuilder` auto-detects the best backend per host OS
  - `ReloadOrchestrator` resolves the namespace for each changed file, reloads the dependency chain via `BuildFacade::getDependenciesForNamespace`, runs `phel\watch/run-on-reload-hooks`, re-indexes through `ApiFacade::indexProject`, and publishes via `ReloadEventPublisherInterface`
  - `NamespaceResolver` parses `ns`/`in-ns` from source with a lightweight regex (full parser avoided on hot path)
  - Debounce window (default 100ms) coalesces editor-save-induced double triggers
- `./bin/phel watch [paths]... [-b backend] [--poll=500] [--debounce=100]` Symfony console command registered in `ConsoleProvider`
- REPL-side `phel\watch` namespace: `watch!`, `register-on-reload`, `clear-on-reload`, `run-on-reload-hooks`
- `ApiConfig` exposes `phel\watch` for tooling discovery
- `src/php/Watch/CLAUDE.md` documents the module
- Unit tests: `NamespaceResolverTest`, `PollingWatcherTest` (fake clock + scanner, asserts debounce), `ReloadOrchestratorTest` (facade fakes, covers dep-order reload, deleted-file skip, eval-failure tolerance)
- Integration tests: `PollingWatcherIntegrationTest` (real filesystem snapshot), `WatchCommandTest` (CLI option wiring). External `fswatch`/`inotifywait` binaries are deliberately not exercised in CI.
- `CHANGELOG.md` updated under `## Unreleased`