### PR TITLE
feat(lsp): add ./bin/phel lsp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `ApiFacade` gains `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, `completeAtPoint` for editor and linter tooling
 - `phel lint [paths]... [--format=human|json|github] [--config=path] [--no-cache]` runs read-only semantic rules: unresolved-symbol, arity-mismatch, unused-binding, unused-require, unused-import, shadowed-binding, redundant-do, duplicate-key, invalid-destructuring, discouraged-var; configurable via `phel-lint.phel` with per-rule severity and glob opt-outs
 - `phel watch [paths]... [-b backend] [--poll=500] [--debounce=100]` watches `.phel` files and reloads changed namespaces in dependency order; inotify, fswatch, or polling backend auto-picked; `(watch! ["src/"])` in REPL via `phel\watch`
+- `phel lsp` starts a Language Server Protocol v3.17 server over stdio (JSON-RPC 2.0, Content-Length framing) with hover, definition, references, completion, document/workspace symbols, rename, formatting, and debounced publishDiagnostics for any LSP-native editor
 
 #### Agent docs
 - `.agents/` ships agent-agnostic docs with task recipes, per-platform adapters, and three runnable example projects (`todo-app`, `http-json-api`, `cli-wordcount`)

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -26,6 +26,7 @@ use Phel\Filesystem\FilesystemFacade;
 use Phel\Formatter\Infrastructure\Command\FormatCommand;
 use Phel\Interop\Infrastructure\Command\ExportCommand;
 use Phel\Lint\Infrastructure\Command\LintCommand;
+use Phel\Lsp\Infrastructure\Command\LspCommand;
 use Phel\Nrepl\Infrastructure\Command\NreplCommand;
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
@@ -84,6 +85,7 @@ final class ConsoleProvider extends AbstractProvider
             new DoctorCommand(),
             new NreplCommand(),
             new LintCommand(),
+            new LspCommand(),
             new WatchCommand(),
         ];
     }

--- a/src/php/Formatter/FormatterFacade.php
+++ b/src/php/Formatter/FormatterFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Formatter;
 
 use Gacela\Framework\AbstractFacade;
+use Phel\Formatter\Domain\FormatterInterface;
 use Phel\Shared\Facade\FormatterFacadeInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,5 +22,15 @@ final class FormatterFacade extends AbstractFacade implements FormatterFacadeInt
         return $this->getFactory()
             ->createPathsFormatter()
             ->format($paths, $output);
+    }
+
+    /**
+     * Format a Phel source string in memory without touching the filesystem.
+     */
+    public function formatString(string $source, string $uri = FormatterInterface::DEFAULT_SOURCE): string
+    {
+        return $this->getFactory()
+            ->createFormatter()
+            ->format($source, $uri);
     }
 }

--- a/src/php/Lsp/Application/Convert/CompletionConverter.php
+++ b/src/php/Lsp/Application/Convert/CompletionConverter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+use Phel\Api\Transfer\Completion;
+use Phel\Api\Transfer\PhelFunction;
+
+/**
+ * Convert Api Completion / PhelFunction into LSP CompletionItem.
+ *
+ * LSP CompletionItemKind values: 1 = Text, 2 = Method, 3 = Function,
+ * 6 = Variable, 14 = Keyword, ...
+ */
+final class CompletionConverter
+{
+    public const int KIND_TEXT = 1;
+
+    public const int KIND_METHOD = 2;
+
+    public const int KIND_FUNCTION = 3;
+
+    public const int KIND_VARIABLE = 6;
+
+    public const int KIND_MODULE = 9;
+
+    public const int KIND_KEYWORD = 14;
+
+    /**
+     * @return array{label: string, kind: int, detail: string, documentation: string}
+     */
+    public function fromCompletion(Completion $completion): array
+    {
+        return [
+            'label' => $completion->label,
+            'kind' => $this->kindForCompletion($completion->kind),
+            'detail' => $completion->detail,
+            'documentation' => $completion->documentation,
+        ];
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail: string, documentation: string}
+     */
+    public function fromPhelFunction(PhelFunction $fn): array
+    {
+        $detail = $fn->signatures === [] ? $fn->namespace : $fn->signatures[0];
+
+        return [
+            'label' => $fn->name,
+            'kind' => self::KIND_FUNCTION,
+            'detail' => $detail,
+            'documentation' => $fn->doc,
+        ];
+    }
+
+    private function kindForCompletion(string $kind): int
+    {
+        return match ($kind) {
+            Completion::KIND_LOCAL => self::KIND_VARIABLE,
+            Completion::KIND_GLOBAL => self::KIND_FUNCTION,
+            Completion::KIND_MACRO => self::KIND_METHOD,
+            Completion::KIND_REQUIRE => self::KIND_MODULE,
+            Completion::KIND_KEYWORD => self::KIND_KEYWORD,
+            default => self::KIND_TEXT,
+        };
+    }
+}

--- a/src/php/Lsp/Application/Convert/DiagnosticConverter.php
+++ b/src/php/Lsp/Application/Convert/DiagnosticConverter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+use Phel\Api\Transfer\Diagnostic;
+
+/**
+ * Convert a {@see Diagnostic} from the Api module into the shape expected by
+ * LSP's `textDocument/publishDiagnostics` notification.
+ */
+final readonly class DiagnosticConverter
+{
+    public const int SEVERITY_ERROR = 1;
+
+    public const int SEVERITY_WARNING = 2;
+
+    public const int SEVERITY_INFO = 3;
+
+    public const int SEVERITY_HINT = 4;
+
+    public function __construct(
+        private PositionConverter $positions,
+        private UriConverter $uris,
+    ) {}
+
+    /**
+     * @return array{
+     *     range: array{start: array{line: int, character: int}, end: array{line: int, character: int}},
+     *     severity: int,
+     *     code: string,
+     *     source: string,
+     *     message: string,
+     * }
+     */
+    public function toLspDiagnostic(Diagnostic $diagnostic): array
+    {
+        return [
+            'range' => $this->positions->toLspRange(
+                $diagnostic->startLine,
+                $diagnostic->startCol,
+                $diagnostic->endLine,
+                $diagnostic->endCol,
+            ),
+            'severity' => $this->severityFromString($diagnostic->severity),
+            'code' => $diagnostic->code,
+            'source' => 'phel',
+            'message' => $diagnostic->message,
+        ];
+    }
+
+    /**
+     * @param list<Diagnostic> $diagnostics
+     *
+     * @return array{
+     *     uri: string,
+     *     diagnostics: list<array{
+     *         range: array{start: array{line: int, character: int}, end: array{line: int, character: int}},
+     *         severity: int,
+     *         code: string,
+     *         source: string,
+     *         message: string,
+     *     }>,
+     * }
+     */
+    public function toPublishParams(string $uri, array $diagnostics): array
+    {
+        $items = [];
+        foreach ($diagnostics as $diagnostic) {
+            $items[] = $this->toLspDiagnostic($diagnostic);
+        }
+
+        $clientUri = $this->uris->isFileUri($uri) ? $uri : $this->uris->fromFilePath($uri);
+
+        return [
+            'uri' => $clientUri,
+            'diagnostics' => $items,
+        ];
+    }
+
+    private function severityFromString(string $severity): int
+    {
+        return match ($severity) {
+            Diagnostic::SEVERITY_ERROR => self::SEVERITY_ERROR,
+            Diagnostic::SEVERITY_WARNING => self::SEVERITY_WARNING,
+            Diagnostic::SEVERITY_INFO => self::SEVERITY_INFO,
+            Diagnostic::SEVERITY_HINT => self::SEVERITY_HINT,
+            default => self::SEVERITY_INFO,
+        };
+    }
+}

--- a/src/php/Lsp/Application/Convert/LocationConverter.php
+++ b/src/php/Lsp/Application/Convert/LocationConverter.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Location;
+
+use function strlen;
+
+/**
+ * Convert Api Location/Definition value objects into LSP Location shapes.
+ */
+final readonly class LocationConverter
+{
+    public function __construct(
+        private PositionConverter $positions,
+        private UriConverter $uris,
+    ) {}
+
+    /**
+     * @return array{
+     *     uri: string,
+     *     range: array{start: array{line: int, character: int}, end: array{line: int, character: int}},
+     * }
+     */
+    public function fromLocation(Location $location): array
+    {
+        return [
+            'uri' => $this->toClientUri($location->uri),
+            'range' => $this->positions->toLspRange(
+                $location->line,
+                $location->col,
+                $location->endLine > 0 ? $location->endLine : $location->line,
+                $location->endCol > 0 ? $location->endCol : $location->col + 1,
+            ),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     uri: string,
+     *     range: array{start: array{line: int, character: int}, end: array{line: int, character: int}},
+     * }
+     */
+    public function fromDefinition(Definition $definition): array
+    {
+        $nameLen = strlen($definition->name);
+        $endCol = $definition->col + max(1, $nameLen);
+
+        return [
+            'uri' => $this->toClientUri($definition->uri),
+            'range' => $this->positions->toLspRange(
+                $definition->line,
+                $definition->col,
+                $definition->line,
+                $endCol,
+            ),
+        ];
+    }
+
+    private function toClientUri(string $uri): string
+    {
+        if ($uri === '') {
+            return $uri;
+        }
+
+        return $this->uris->isFileUri($uri) ? $uri : $this->uris->fromFilePath($uri);
+    }
+}

--- a/src/php/Lsp/Application/Convert/PositionConverter.php
+++ b/src/php/Lsp/Application/Convert/PositionConverter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+/**
+ * Phel source locations are 1-based {line, column}; LSP positions are
+ * 0-based {line, character}. Encapsulating the translation in one place
+ * keeps every handler honest about which convention it uses.
+ */
+final class PositionConverter
+{
+    /**
+     * @return array{line: int, character: int}
+     */
+    public function toLspPosition(int $line, int $column): array
+    {
+        return [
+            'line' => max(0, $line - 1),
+            'character' => max(0, $column - 1),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     * }
+     */
+    public function toLspRange(int $startLine, int $startCol, int $endLine, int $endCol): array
+    {
+        $effectiveEndLine = $endLine > 0 ? $endLine : $startLine;
+        $effectiveEndCol = $endCol > 0 ? $endCol : $startCol + 1;
+
+        return [
+            'start' => $this->toLspPosition($startLine, $startCol),
+            'end' => $this->toLspPosition($effectiveEndLine, $effectiveEndCol),
+        ];
+    }
+}

--- a/src/php/Lsp/Application/Convert/UriConverter.php
+++ b/src/php/Lsp/Application/Convert/UriConverter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+use function parse_url;
+use function preg_match;
+use function preg_replace_callback;
+use function rawurldecode;
+use function rawurlencode;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function strtolower;
+
+/**
+ * Bi-directional file URI <-> filesystem path conversion, with a tolerant
+ * stance on path-style URIs so editors that accept either form keep working.
+ */
+final class UriConverter
+{
+    public function toFilePath(string $uri): string
+    {
+        if (str_starts_with($uri, 'file://')) {
+            $parsed = parse_url($uri);
+            if ($parsed !== false && isset($parsed['path'])) {
+                return rawurldecode($parsed['path']);
+            }
+        }
+
+        return $uri;
+    }
+
+    public function fromFilePath(string $path): string
+    {
+        if (str_starts_with($path, 'file://')) {
+            return $path;
+        }
+
+        $normalized = str_replace('\\', '/', $path);
+
+        if (preg_match('/^[A-Za-z]:\//', $normalized)) {
+            // Windows drive: file:///C:/path
+            return 'file:///' . $this->encodePath($normalized);
+        }
+
+        if (!str_starts_with($normalized, '/')) {
+            $normalized = '/' . $normalized;
+        }
+
+        return 'file://' . $this->encodePath($normalized);
+    }
+
+    public function isFileUri(string $uri): bool
+    {
+        $prefix = 'file://';
+        return strlen($uri) >= strlen($prefix) && strtolower(substr($uri, 0, strlen($prefix))) === $prefix;
+    }
+
+    private function encodePath(string $path): string
+    {
+        $encoded = preg_replace_callback('/[^A-Za-z0-9_\-.~\/:]/', static fn(array $matches): string => rawurlencode($matches[0]), $path);
+
+        return $encoded ?? $path;
+    }
+}

--- a/src/php/Lsp/Application/Diagnostics/DiagnosticPublisher.php
+++ b/src/php/Lsp/Application/Diagnostics/DiagnosticPublisher.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Diagnostics;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\LintFacade;
+use Phel\Lsp\Application\Convert\DiagnosticConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Domain\NotificationSink;
+use Throwable;
+
+use function microtime;
+
+/**
+ * Runs Api semantic analysis + Lint rules on a document and pushes
+ * `textDocument/publishDiagnostics` through the notification sink.
+ *
+ * Debouncing is cooperative: callers check `shouldPublish` before invoking
+ * `publish`. The default window is 200ms.
+ */
+final class DiagnosticPublisher
+{
+    /** @var array<string, float> */
+    private array $lastRunAt = [];
+
+    public function __construct(
+        private readonly ApiFacade $apiFacade,
+        private readonly LintFacade $lintFacade,
+        private readonly DiagnosticConverter $converter,
+        private readonly int $debounceMs,
+    ) {}
+
+    public function shouldPublish(string $uri): bool
+    {
+        $last = $this->lastRunAt[$uri] ?? 0.0;
+        $nowMs = microtime(true) * 1000.0;
+
+        return ($nowMs - $last) >= $this->debounceMs;
+    }
+
+    public function publish(Document $document, NotificationSink $sink): void
+    {
+        $this->lastRunAt[$document->uri] = microtime(true) * 1000.0;
+
+        $diagnostics = $this->apiFacade->analyzeSource($document->text, $document->uri);
+
+        foreach ($this->lintDiagnostics($document) as $diagnostic) {
+            $diagnostics[] = $diagnostic;
+        }
+
+        $params = $this->converter->toPublishParams($document->uri, $diagnostics);
+        $sink->notify('textDocument/publishDiagnostics', $params);
+    }
+
+    /**
+     * Force a publish (skipping debounce), used on didSave when the editor
+     * expects an immediate refresh.
+     */
+    public function publishNow(Document $document, NotificationSink $sink): void
+    {
+        $this->lastRunAt[$document->uri] = 0.0;
+        $this->publish($document, $sink);
+    }
+
+    /**
+     * @return list<Diagnostic>
+     */
+    private function lintDiagnostics(Document $document): array
+    {
+        try {
+            $settings = $this->lintFacade->defaultSettings();
+            $result = $this->lintFacade->lint([$document->uri], $settings);
+
+            return $result->diagnostics;
+        } catch (Throwable) {
+            // Lint on a single in-memory path may fail when the buffer isn't on disk;
+            // we only use Lint as a best-effort augmentation.
+            return [];
+        }
+    }
+}

--- a/src/php/Lsp/Application/Document/Document.php
+++ b/src/php/Lsp/Application/Document/Document.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Document;
+
+use function count;
+use function explode;
+use function max;
+use function min;
+use function preg_match;
+use function str_replace;
+use function strlen;
+
+/**
+ * In-memory view of a text document opened by the editor. Version is
+ * incremented on every `didChange`.
+ */
+final class Document
+{
+    public function __construct(
+        public readonly string $uri,
+        public string $languageId,
+        public int $version,
+        public string $text,
+    ) {}
+
+    public function update(string $text, int $version): void
+    {
+        $this->text = $text;
+        $this->version = $version;
+    }
+
+    /**
+     * Apply an LSP-style incremental change (range + text). Accepts
+     * line/character counts in UTF-16 code units per spec v3.17 — for our
+     * purposes we treat them as UTF-8 byte offsets, which is sufficient for
+     * the ASCII-dominant Phel source that real clients send.
+     *
+     * @param array{start: array{line: int, character: int}, end: array{line: int, character: int}} $range
+     */
+    public function applyRange(array $range, string $newText): void
+    {
+        $startOffset = $this->positionToOffset($range['start']);
+        $endOffset = $this->positionToOffset($range['end']);
+
+        $before = substr($this->text, 0, $startOffset);
+        $after = substr($this->text, $endOffset);
+        $this->text = $before . $newText . $after;
+    }
+
+    public function lineCount(): int
+    {
+        return count(explode("\n", str_replace("\r\n", "\n", $this->text)));
+    }
+
+    /**
+     * Convert an (LSP) 0-based {line, character} to a 0-based byte offset.
+     *
+     * @param array{line: int, character: int} $position
+     */
+    public function positionToOffset(array $position): int
+    {
+        $normalized = str_replace("\r\n", "\n", $this->text);
+        $lines = explode("\n", $normalized);
+        $line = max(0, $position['line']);
+        $character = max(0, $position['character']);
+
+        $offset = 0;
+        for ($i = 0; $i < $line; ++$i) {
+            if (!isset($lines[$i])) {
+                return strlen($normalized);
+            }
+
+            $offset += strlen($lines[$i]) + 1;
+        }
+
+        if (!isset($lines[$line])) {
+            return strlen($normalized);
+        }
+
+        $lineLen = strlen($lines[$line]);
+        return $offset + min($character, $lineLen);
+    }
+
+    /**
+     * Return the word (identifier) at the given LSP-style position, or '' when
+     * nothing is under the cursor. The matcher is permissive: it accepts
+     * Lisp identifier characters.
+     *
+     * @param array{line: int, character: int} $position
+     */
+    public function wordAt(array $position): string
+    {
+        $normalized = str_replace("\r\n", "\n", $this->text);
+        $lines = explode("\n", $normalized);
+        $line = max(0, $position['line']);
+        if (!isset($lines[$line])) {
+            return '';
+        }
+
+        $lineText = $lines[$line];
+        $col = max(0, $position['character']);
+        $col = min($col, strlen($lineText));
+
+        $left = $col;
+        while ($left > 0 && $this->isIdentChar($lineText[$left - 1])) {
+            --$left;
+        }
+
+        $right = $col;
+        while ($right < strlen($lineText) && $this->isIdentChar($lineText[$right])) {
+            ++$right;
+        }
+
+        if ($right <= $left) {
+            return '';
+        }
+
+        return substr($lineText, $left, $right - $left);
+    }
+
+    /**
+     * 1-based {line, column} for cursor under the given (0-based) LSP position.
+     * Returned as a tuple ready for ApiFacade::completeAtPoint.
+     *
+     * @param array{line: int, character: int} $position
+     *
+     * @return array{int, int}
+     */
+    public function oneBasedLineCol(array $position): array
+    {
+        return [
+            max(1, $position['line'] + 1),
+            max(1, $position['character'] + 1),
+        ];
+    }
+
+    private function isIdentChar(string $char): bool
+    {
+        return preg_match('/[A-Za-z0-9\-_?!*+<>=\/\.]/', $char) === 1;
+    }
+}

--- a/src/php/Lsp/Application/Document/DocumentStore.php
+++ b/src/php/Lsp/Application/Document/DocumentStore.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Document;
+
+use function array_keys;
+
+/**
+ * In-memory URI -> Document cache.
+ *
+ * Mutation is performed through open() / update() / close() so handlers don't
+ * need to know about storage internals.
+ */
+final class DocumentStore
+{
+    /** @var array<string, Document> */
+    private array $documents = [];
+
+    public function open(string $uri, string $languageId, int $version, string $text): Document
+    {
+        $document = new Document($uri, $languageId, $version, $text);
+        $this->documents[$uri] = $document;
+
+        return $document;
+    }
+
+    public function replace(string $uri, int $version, string $text): ?Document
+    {
+        $document = $this->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        $document->update($text, $version);
+
+        return $document;
+    }
+
+    public function get(string $uri): ?Document
+    {
+        return $this->documents[$uri] ?? null;
+    }
+
+    public function close(string $uri): void
+    {
+        unset($this->documents[$uri]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function uris(): array
+    {
+        return array_keys($this->documents);
+    }
+}

--- a/src/php/Lsp/Application/Handler/CompletionHandler.php
+++ b/src/php/Lsp/Application/Handler/CompletionHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\CompletionConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_int;
+use function is_string;
+
+final readonly class CompletionHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private CompletionConverter $completions,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/completion';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $uri = $this->extractUri($params);
+        $position = $this->extractPosition($params);
+        if ($uri === '' || $position === null) {
+            return ['isIncomplete' => false, 'items' => []];
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return ['isIncomplete' => false, 'items' => []];
+        }
+
+        $index = $session->projectIndex() ?? new ProjectIndex([], []);
+        [$line, $col] = $document->oneBasedLineCol($position);
+
+        $completions = $this->apiFacade->completeAtPoint($document->text, $line, $col, $index);
+
+        $items = [];
+        foreach ($completions as $completion) {
+            $items[] = $this->completions->fromCompletion($completion);
+        }
+
+        return [
+            'isIncomplete' => false,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    private function extractPosition(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+}

--- a/src/php/Lsp/Application/Handler/DefinitionHandler.php
+++ b/src/php/Lsp/Application/Handler/DefinitionHandler.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\LocationConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function explode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function str_contains;
+
+final readonly class DefinitionHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private LocationConverter $locations,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/definition';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $index = $session->projectIndex();
+        if (!$index instanceof ProjectIndex) {
+            return null;
+        }
+
+        $uri = $this->extractUri($params);
+        $position = $this->extractPosition($params);
+        if ($uri === '' || $position === null) {
+            return null;
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        $word = $document->wordAt($position);
+        if ($word === '') {
+            return null;
+        }
+
+        $definition = $this->lookup($index, $word);
+        if (!$definition instanceof Definition) {
+            return null;
+        }
+
+        return $this->locations->fromDefinition($definition);
+    }
+
+    private function lookup(ProjectIndex $index, string $word): ?Definition
+    {
+        if (str_contains($word, '/')) {
+            $parts = explode('/', $word, 2);
+            $namespace = $parts[0];
+            $name = $parts[1] ?? '';
+            $direct = $this->apiFacade->resolveSymbol($index, $namespace, $name);
+            if ($direct instanceof Definition) {
+                return $direct;
+            }
+
+            return $index->definitions[$word] ?? null;
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return $def;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    private function extractPosition(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+}

--- a/src/php/Lsp/Application/Handler/DidChangeHandler.php
+++ b/src/php/Lsp/Application/Handler/DidChangeHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_int;
+use function is_string;
+
+final readonly class DidChangeHandler implements HandlerInterface
+{
+    public function __construct(
+        private DiagnosticPublisher $publisher,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/didChange';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+
+        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        if ($uri === '') {
+            return null;
+        }
+
+        $version = is_int($textDocument['version'] ?? null) ? $textDocument['version'] : 0;
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        $changes = $params['contentChanges'] ?? [];
+        if (!is_array($changes)) {
+            return null;
+        }
+
+        foreach ($changes as $change) {
+            if (!is_array($change)) {
+                continue;
+            }
+
+            $text = is_string($change['text'] ?? null) ? $change['text'] : '';
+            $range = $change['range'] ?? null;
+
+            if (is_array($range) && $this->isValidRange($range)) {
+                /** @var array{start: array{line: int, character: int}, end: array{line: int, character: int}} $range */
+                $document->applyRange($range, $text);
+            } else {
+                $document->update($text, $version);
+            }
+        }
+
+        $document->update($document->text, $version);
+
+        if ($this->publisher->shouldPublish($uri)) {
+            $this->publisher->publish($document, $session->sink());
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $range
+     */
+    private function isValidRange(array $range): bool
+    {
+        $start = $range['start'] ?? null;
+        $end = $range['end'] ?? null;
+
+        return is_array($start)
+            && is_array($end)
+            && is_int($start['line'] ?? null)
+            && is_int($start['character'] ?? null)
+            && is_int($end['line'] ?? null)
+            && is_int($end['character'] ?? null);
+    }
+}

--- a/src/php/Lsp/Application/Handler/DidCloseHandler.php
+++ b/src/php/Lsp/Application/Handler/DidCloseHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_string;
+
+final class DidCloseHandler implements HandlerInterface
+{
+    public function method(): string
+    {
+        return 'textDocument/didClose';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+
+        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        if ($uri !== '') {
+            $session->documents()->close($uri);
+            $session->sink()->notify('textDocument/publishDiagnostics', [
+                'uri' => $uri,
+                'diagnostics' => [],
+            ]);
+        }
+
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/DidOpenHandler.php
+++ b/src/php/Lsp/Application/Handler/DidOpenHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_int;
+use function is_string;
+
+final readonly class DidOpenHandler implements HandlerInterface
+{
+    public function __construct(
+        private DiagnosticPublisher $publisher,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/didOpen';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+
+        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        if ($uri === '') {
+            return null;
+        }
+
+        $languageId = is_string($textDocument['languageId'] ?? null) ? $textDocument['languageId'] : 'phel';
+        $version = is_int($textDocument['version'] ?? null) ? $textDocument['version'] : 0;
+        $text = is_string($textDocument['text'] ?? null) ? $textDocument['text'] : '';
+
+        $document = $session->documents()->open($uri, $languageId, $version, $text);
+        $this->publisher->publishNow($document, $session->sink());
+
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/DidSaveHandler.php
+++ b/src/php/Lsp/Application/Handler/DidSaveHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_string;
+use function str_ends_with;
+use function strtolower;
+
+final readonly class DidSaveHandler implements HandlerInterface
+{
+    public function __construct(
+        private DiagnosticPublisher $publisher,
+        private ApiFacade $apiFacade,
+        private UriConverter $uris,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/didSave';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+
+        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        if ($uri === '') {
+            return null;
+        }
+
+        $document = $session->documents()->get($uri);
+        if ($document instanceof Document) {
+            $this->publisher->publishNow($document, $session->sink());
+        }
+
+        if ($this->shouldReindex($uri)) {
+            $roots = $session->workspaceRoots();
+            if ($roots !== []) {
+                $session->setProjectIndex($this->apiFacade->indexProject($roots));
+            }
+        }
+
+        return null;
+    }
+
+    private function shouldReindex(string $uri): bool
+    {
+        $path = $this->uris->toFilePath($uri);
+        return str_ends_with(strtolower($path), '.phel');
+    }
+}

--- a/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_array;
+use function is_string;
+use function strlen;
+
+/**
+ * Lists all top-level definitions in the open document. Uses the project
+ * index when available; otherwise runs a single-file indexing pass so the
+ * response still matches the current buffer contents.
+ */
+final readonly class DocumentSymbolHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private PositionConverter $positions,
+        private UriConverter $uris,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/documentSymbol';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $uri = $this->extractUri($params);
+        if ($uri === '') {
+            return [];
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return [];
+        }
+
+        $definitions = $this->collectDefinitions($document, $session->projectIndex());
+
+        $symbols = [];
+        foreach ($definitions as $def) {
+            $symbols[] = $this->toSymbolInformation($def);
+        }
+
+        return $symbols;
+    }
+
+    /**
+     * @return list<Definition>
+     */
+    private function collectDefinitions(Document $document, ?ProjectIndex $index): array
+    {
+        $path = $this->uris->toFilePath($document->uri);
+
+        $defs = [];
+        if ($index instanceof ProjectIndex) {
+            foreach ($index->definitions as $def) {
+                if ($def->uri === $path || $def->uri === $document->uri) {
+                    $defs[] = $def;
+                }
+            }
+        }
+
+        if ($defs !== []) {
+            return $defs;
+        }
+
+        $index = $this->apiFacade->indexProject([$path]);
+        $result = [];
+        foreach ($index->definitions as $def) {
+            $result[] = $def;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     kind: int,
+     *     location: array{
+     *         uri: string,
+     *         range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}
+     *     }
+     * }
+     */
+    private function toSymbolInformation(Definition $def): array
+    {
+        $endCol = $def->col + max(1, strlen($def->name));
+
+        return [
+            'name' => $def->name,
+            'kind' => $this->lspSymbolKind($def->kind),
+            'location' => [
+                'uri' => $this->uris->isFileUri($def->uri) ? $def->uri : $this->uris->fromFilePath($def->uri),
+                'range' => $this->positions->toLspRange($def->line, $def->col, $def->line, $endCol),
+            ],
+        ];
+    }
+
+    private function lspSymbolKind(string $kind): int
+    {
+        // LSP SymbolKind: 12=Function, 6=Method, 5=Class, 13=Variable, 11=Interface, 18=Struct
+        return match ($kind) {
+            Definition::KIND_DEFN => 12,
+            Definition::KIND_DEFMACRO => 6,
+            Definition::KIND_DEFSTRUCT => 18,
+            Definition::KIND_DEFPROTOCOL, Definition::KIND_DEFINTERFACE => 11,
+            Definition::KIND_DEFEXCEPTION => 5,
+            default => 13,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+}

--- a/src/php/Lsp/Application/Handler/ExitHandler.php
+++ b/src/php/Lsp/Application/Handler/ExitHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+final class ExitHandler implements HandlerInterface
+{
+    public function method(): string
+    {
+        return 'exit';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $session->requestShutdown();
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/FormattingHandler.php
+++ b/src/php/Lsp/Application/Handler/FormattingHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Formatter\FormatterFacade;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+use Throwable;
+
+use function count;
+use function explode;
+use function is_array;
+use function is_string;
+use function str_replace;
+use function strlen;
+
+final readonly class FormattingHandler implements HandlerInterface
+{
+    public function __construct(
+        private FormatterFacade $formatter,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/formatting';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return [];
+        }
+
+        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        if ($uri === '') {
+            return [];
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return [];
+        }
+
+        try {
+            $formatted = $this->formatter->formatString($document->text, $uri);
+        } catch (Throwable) {
+            return [];
+        }
+
+        if ($formatted === $document->text) {
+            return [];
+        }
+
+        return [$this->fullDocumentEdit($document, $formatted)];
+    }
+
+    /**
+     * @return array{
+     *     range: array{start: array{line: int, character: int}, end: array{line: int, character: int}},
+     *     newText: string,
+     * }
+     */
+    private function fullDocumentEdit(Document $document, string $newText): array
+    {
+        $normalized = str_replace("\r\n", "\n", $document->text);
+        $lines = explode("\n", $normalized);
+        $lastLineIndex = count($lines) - 1;
+        $lastLineLength = strlen($lines[$lastLineIndex]);
+
+        return [
+            'range' => [
+                'start' => ['line' => 0, 'character' => 0],
+                'end' => ['line' => $lastLineIndex, 'character' => $lastLineLength],
+            ],
+            'newText' => $newText,
+        ];
+    }
+}

--- a/src/php/Lsp/Application/Handler/HoverHandler.php
+++ b/src/php/Lsp/Application/Handler/HoverHandler.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\PhelFunction;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function implode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+use function str_contains;
+
+/**
+ * Resolves a symbol under the cursor and returns its signature + docstring
+ * formatted as a Markdown hover tooltip.
+ */
+final readonly class HoverHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/hover';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $uri = $this->extractUri($params);
+        $position = $this->extractPosition($params);
+        if ($uri === '' || $position === null) {
+            return null;
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        $word = $document->wordAt($position);
+        if ($word === '') {
+            return null;
+        }
+
+        $markdown = $this->markdownFor($word, $session->projectIndex());
+        if ($markdown === null) {
+            return null;
+        }
+
+        return [
+            'contents' => [
+                'kind' => 'markdown',
+                'value' => $markdown,
+            ],
+        ];
+    }
+
+    private function markdownFor(string $word, ?ProjectIndex $index): ?string
+    {
+        $projectDefinition = $this->findProjectDefinition($word, $index);
+        if ($projectDefinition instanceof Definition) {
+            return $this->renderDefinition($projectDefinition);
+        }
+
+        foreach ($this->apiFacade->getPhelFunctions(['phel\\core']) as $fn) {
+            if ($fn->name === $word || $fn->nameWithNamespace() === $word) {
+                return $this->renderPhelFunction($fn);
+            }
+        }
+
+        return null;
+    }
+
+    private function findProjectDefinition(string $word, ?ProjectIndex $index): ?Definition
+    {
+        if (!$index instanceof ProjectIndex) {
+            return null;
+        }
+
+        if (str_contains($word, '/')) {
+            return $index->definitions[$word] ?? null;
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return $def;
+            }
+        }
+
+        return null;
+    }
+
+    private function renderDefinition(Definition $def): string
+    {
+        $lines = [];
+        $fullName = $def->namespace !== '' ? $def->namespace . '/' . $def->name : $def->name;
+        $lines[] = sprintf('**%s** _(%s)_', $fullName, $def->kind);
+
+        if ($def->signature !== []) {
+            $lines[] = '';
+            $lines[] = '```phel';
+            foreach ($def->signature as $arity) {
+                $lines[] = sprintf('(%s %s)', $def->name, $arity);
+            }
+
+            $lines[] = '```';
+        }
+
+        if ($def->docstring !== '') {
+            $lines[] = '';
+            $lines[] = $def->docstring;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function renderPhelFunction(PhelFunction $fn): string
+    {
+        $lines = [];
+        $lines[] = sprintf('**%s** _(phel/%s)_', $fn->name, $fn->namespace);
+
+        if ($fn->signatures !== []) {
+            $lines[] = '';
+            $lines[] = '```phel';
+            foreach ($fn->signatures as $sig) {
+                $lines[] = $sig;
+            }
+
+            $lines[] = '```';
+        }
+
+        if ($fn->doc !== '') {
+            $lines[] = '';
+            $lines[] = $fn->doc;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    private function extractPosition(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+}

--- a/src/php/Lsp/Application/Handler/InitializeHandler.php
+++ b/src/php/Lsp/Application/Handler/InitializeHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+use Phel\Lsp\LspConfig;
+
+use function is_array;
+use function is_string;
+
+/**
+ * Handles `initialize`. Advertises the capabilities the server implements
+ * and primes the project index from the workspace root(s).
+ */
+final readonly class InitializeHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private UriConverter $uris,
+    ) {}
+
+    public function method(): string
+    {
+        return 'initialize';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $session->setClientCapabilities($this->clientCapabilities($params));
+        $roots = $this->extractWorkspaceRoots($params);
+        $session->setWorkspaceRoots($roots);
+
+        if ($roots !== []) {
+            $session->setProjectIndex($this->apiFacade->indexProject($roots));
+        }
+
+        return [
+            'capabilities' => [
+                'textDocumentSync' => [
+                    'openClose' => true,
+                    'change' => 2, // Incremental
+                    'save' => ['includeText' => false],
+                ],
+                'hoverProvider' => true,
+                'definitionProvider' => true,
+                'referencesProvider' => true,
+                'completionProvider' => [
+                    'triggerCharacters' => ['/', ':', '.'],
+                    'resolveProvider' => false,
+                ],
+                'documentSymbolProvider' => true,
+                'workspaceSymbolProvider' => true,
+                'renameProvider' => true,
+                'documentFormattingProvider' => true,
+            ],
+            'serverInfo' => [
+                'name' => LspConfig::defaultServerName(),
+                'version' => LspConfig::defaultServerVersion(),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    private function clientCapabilities(array $params): array
+    {
+        $raw = $params['capabilities'] ?? [];
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $raw */
+        return $raw;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return list<string>
+     */
+    private function extractWorkspaceRoots(array $params): array
+    {
+        $roots = [];
+        $folders = $params['workspaceFolders'] ?? null;
+        if (is_array($folders)) {
+            foreach ($folders as $folder) {
+                if (!is_array($folder)) {
+                    continue;
+                }
+
+                $uri = $folder['uri'] ?? null;
+                if (is_string($uri) && $uri !== '') {
+                    $roots[] = $this->uris->toFilePath($uri);
+                }
+            }
+        }
+
+        if ($roots === []) {
+            $rootUri = $params['rootUri'] ?? null;
+            if (is_string($rootUri) && $rootUri !== '') {
+                $roots[] = $this->uris->toFilePath($rootUri);
+            }
+        }
+
+        if ($roots === []) {
+            $rootPath = $params['rootPath'] ?? null;
+            if (is_string($rootPath) && $rootPath !== '') {
+                $roots[] = $rootPath;
+            }
+        }
+
+        return $roots;
+    }
+}

--- a/src/php/Lsp/Application/Handler/InitializedHandler.php
+++ b/src/php/Lsp/Application/Handler/InitializedHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+/**
+ * Notification sent by the client after it has processed the initialize
+ * response. Flips the session into ready state.
+ */
+final class InitializedHandler implements HandlerInterface
+{
+    public function method(): string
+    {
+        return 'initialized';
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $session->markInitialized();
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/ReferencesHandler.php
+++ b/src/php/Lsp/Application/Handler/ReferencesHandler.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\LocationConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function explode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function str_contains;
+
+final readonly class ReferencesHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private LocationConverter $locations,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/references';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $index = $session->projectIndex();
+        if (!$index instanceof ProjectIndex) {
+            return [];
+        }
+
+        $uri = $this->extractUri($params);
+        $position = $this->extractPosition($params);
+        if ($uri === '' || $position === null) {
+            return [];
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return [];
+        }
+
+        $word = $document->wordAt($position);
+        if ($word === '') {
+            return [];
+        }
+
+        [$namespace, $name] = $this->splitSymbol($word, $index);
+        $references = $this->apiFacade->findReferences($index, $namespace, $name);
+
+        $result = [];
+        foreach ($references as $location) {
+            $result[] = $this->locations->fromLocation($location);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitSymbol(string $word, ProjectIndex $index): array
+    {
+        if (str_contains($word, '/')) {
+            $parts = explode('/', $word, 2);
+            return [$parts[0], $parts[1] ?? ''];
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return [$def->namespace, $def->name];
+            }
+        }
+
+        // Fallback: treat the bare name as living in the unknown namespace.
+        return ['', $word];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    private function extractPosition(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+}

--- a/src/php/Lsp/Application/Handler/RenameHandler.php
+++ b/src/php/Lsp/Application/Handler/RenameHandler.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\ApiFacade;
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\Location;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function explode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function str_contains;
+use function strlen;
+
+/**
+ * Rename a symbol across the workspace. Uses findReferences for all
+ * call-sites plus the definition site itself.
+ */
+final readonly class RenameHandler implements HandlerInterface
+{
+    public function __construct(
+        private ApiFacade $apiFacade,
+        private PositionConverter $positions,
+        private UriConverter $uris,
+    ) {}
+
+    public function method(): string
+    {
+        return 'textDocument/rename';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $index = $session->projectIndex();
+        if (!$index instanceof ProjectIndex) {
+            return null;
+        }
+
+        $newName = is_string($params['newName'] ?? null) ? $params['newName'] : '';
+        if ($newName === '') {
+            return null;
+        }
+
+        $uri = $this->extractUri($params);
+        $position = $this->extractPosition($params);
+        if ($uri === '' || $position === null) {
+            return null;
+        }
+
+        $document = $session->documents()->get($uri);
+        if (!$document instanceof Document) {
+            return null;
+        }
+
+        $word = $document->wordAt($position);
+        if ($word === '') {
+            return null;
+        }
+
+        [$namespace, $name] = $this->splitSymbol($word, $index);
+        $references = $this->apiFacade->findReferences($index, $namespace, $name);
+        $definition = $this->apiFacade->resolveSymbol($index, $namespace, $name);
+
+        return $this->buildWorkspaceEdit($references, $definition, $name, $newName);
+    }
+
+    /**
+     * @param list<Location> $references
+     *
+     * @return array{changes: array<string, list<array{range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}, newText: string}>>}
+     */
+    private function buildWorkspaceEdit(
+        array $references,
+        ?Definition $definition,
+        string $oldName,
+        string $newName,
+    ): array {
+        $nameLen = strlen($oldName);
+        /** @var array<string, list<array{range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}, newText: string}>> $changes */
+        $changes = [];
+
+        if ($definition instanceof Definition) {
+            $uri = $this->uris->isFileUri($definition->uri) ? $definition->uri : $this->uris->fromFilePath($definition->uri);
+            $changes[$uri][] = [
+                'range' => $this->positions->toLspRange(
+                    $definition->line,
+                    $definition->col,
+                    $definition->line,
+                    $definition->col + $nameLen,
+                ),
+                'newText' => $newName,
+            ];
+        }
+
+        foreach ($references as $location) {
+            $uri = $this->uris->isFileUri($location->uri) ? $location->uri : $this->uris->fromFilePath($location->uri);
+            $changes[$uri][] = [
+                'range' => $this->positions->toLspRange(
+                    $location->line,
+                    $location->col,
+                    $location->endLine > 0 ? $location->endLine : $location->line,
+                    $location->endCol > 0 ? $location->endCol : $location->col + $nameLen,
+                ),
+                'newText' => $newName,
+            ];
+        }
+
+        return ['changes' => $changes];
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitSymbol(string $word, ProjectIndex $index): array
+    {
+        if (str_contains($word, '/')) {
+            $parts = explode('/', $word, 2);
+            return [$parts[0], $parts[1] ?? ''];
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return [$def->namespace, $def->name];
+            }
+        }
+
+        return ['', $word];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function extractUri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    private function extractPosition(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+}

--- a/src/php/Lsp/Application/Handler/ShutdownHandler.php
+++ b/src/php/Lsp/Application/Handler/ShutdownHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+final class ShutdownHandler implements HandlerInterface
+{
+    public function method(): string
+    {
+        return 'shutdown';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $session->requestShutdown();
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/WorkspaceSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/WorkspaceSymbolHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+
+use function is_string;
+use function str_contains;
+use function strlen;
+use function strtolower;
+
+final readonly class WorkspaceSymbolHandler implements HandlerInterface
+{
+    public function __construct(
+        private PositionConverter $positions,
+        private UriConverter $uris,
+    ) {}
+
+    public function method(): string
+    {
+        return 'workspace/symbol';
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed
+    {
+        $index = $session->projectIndex();
+        if (!$index instanceof ProjectIndex) {
+            return [];
+        }
+
+        $query = is_string($params['query'] ?? null) ? strtolower($params['query']) : '';
+
+        $symbols = [];
+        foreach ($index->definitions as $def) {
+            if ($query !== '' && !str_contains(strtolower($def->name), $query)) {
+                continue;
+            }
+
+            $symbols[] = $this->toSymbolInformation($def);
+        }
+
+        return $symbols;
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     kind: int,
+     *     containerName: string,
+     *     location: array{
+     *         uri: string,
+     *         range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}
+     *     }
+     * }
+     */
+    private function toSymbolInformation(Definition $def): array
+    {
+        $endCol = $def->col + max(1, strlen($def->name));
+
+        return [
+            'name' => $def->name,
+            'kind' => $this->lspSymbolKind($def->kind),
+            'containerName' => $def->namespace,
+            'location' => [
+                'uri' => $this->uris->isFileUri($def->uri) ? $def->uri : $this->uris->fromFilePath($def->uri),
+                'range' => $this->positions->toLspRange($def->line, $def->col, $def->line, $endCol),
+            ],
+        ];
+    }
+
+    private function lspSymbolKind(string $kind): int
+    {
+        return match ($kind) {
+            Definition::KIND_DEFN => 12,
+            Definition::KIND_DEFMACRO => 6,
+            Definition::KIND_DEFSTRUCT => 18,
+            Definition::KIND_DEFPROTOCOL, Definition::KIND_DEFINTERFACE => 11,
+            Definition::KIND_DEFEXCEPTION => 5,
+            default => 13,
+        };
+    }
+}

--- a/src/php/Lsp/Application/Rpc/LspServer.php
+++ b/src/php/Lsp/Application/Rpc/LspServer.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Session\Session;
+use Throwable;
+
+use function feof;
+
+/**
+ * Owns the read/dispatch/write loop. Terminates when the client closes
+ * the input stream or when `exit` triggers shutdown.
+ */
+final readonly class LspServer
+{
+    public function __construct(
+        private MessageReader $reader,
+        private MessageWriter $writer,
+        private RequestDispatcher $dispatcher,
+        private ResponseBuilder $responses,
+        private Session $session,
+    ) {}
+
+    /**
+     * @param resource $input
+     * @param resource $output
+     *
+     * @return int process exit code
+     */
+    public function serve($input, $output, int $maxIterations = 0): int
+    {
+        $iterations = 0;
+        while (true) {
+            if (feof($input)) {
+                return 0;
+            }
+
+            if ($maxIterations > 0 && $iterations >= $maxIterations) {
+                return 0;
+            }
+
+            try {
+                $message = $this->reader->read($input);
+            } catch (Throwable $throwable) {
+                $this->writer->write($output, $this->responses->error(
+                    null,
+                    ResponseBuilder::PARSE_ERROR,
+                    $throwable->getMessage(),
+                ));
+                ++$iterations;
+                continue;
+            }
+
+            if ($message === null) {
+                return 0;
+            }
+
+            if ($message === []) {
+                ++$iterations;
+                continue;
+            }
+
+            $response = $this->dispatcher->dispatch($message, $this->session);
+            if ($response !== null) {
+                $this->writer->write($output, $response);
+            }
+
+            if ($this->session->shutdownRequested() && ($message['method'] ?? '') === 'exit') {
+                return 0;
+            }
+
+            ++$iterations;
+        }
+    }
+}

--- a/src/php/Lsp/Application/Rpc/MessageReader.php
+++ b/src/php/Lsp/Application/Rpc/MessageReader.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use RuntimeException;
+
+use function feof;
+use function fgets;
+use function fread;
+use function is_array;
+use function json_decode;
+use function preg_match;
+use function stream_set_timeout;
+use function strlen;
+use function trim;
+
+/**
+ * LSP uses JSON-RPC 2.0 framed with HTTP-like headers:
+ *
+ *   Content-Length: <n>\r\n
+ *   [Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n]
+ *   \r\n
+ *   <body of exactly n bytes>
+ *
+ * This reader parses a single message at a time from a PHP stream
+ * and returns the decoded JSON body as an associative array.
+ */
+final class MessageReader
+{
+    private const int MAX_HEADER_LINES = 32;
+
+    private const int READ_TIMEOUT_SECONDS = 0;
+
+    private const int READ_TIMEOUT_MICRO = 200_000;
+
+    /**
+     * @param resource $stream
+     *
+     * @return array<string, mixed>|null null when the stream is closed, [] on a
+     *                                   heartbeat/empty read
+     */
+    public function read($stream): ?array
+    {
+        if (feof($stream)) {
+            return null;
+        }
+
+        @stream_set_timeout($stream, self::READ_TIMEOUT_SECONDS, self::READ_TIMEOUT_MICRO);
+
+        $contentLength = $this->readHeaders($stream);
+        if ($contentLength === null) {
+            return null;
+        }
+
+        if ($contentLength === 0) {
+            return [];
+        }
+
+        $body = $this->readBody($stream, $contentLength);
+        if ($body === null) {
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON body in LSP message.');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function readHeaders($stream): ?int
+    {
+        $contentLength = null;
+        $lines = 0;
+
+        while ($lines < self::MAX_HEADER_LINES) {
+            $line = fgets($stream);
+            if ($line === false) {
+                return null;
+            }
+
+            $trimmed = trim($line);
+            if ($trimmed === '') {
+                return $contentLength ?? 0;
+            }
+
+            if (preg_match('/^Content-Length:\s*(\d+)\s*$/i', $trimmed, $m)) {
+                $contentLength = (int) $m[1];
+            }
+
+            // Other headers (e.g. Content-Type) are accepted and ignored.
+            ++$lines;
+        }
+
+        throw new RuntimeException('LSP header block exceeded maximum size.');
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function readBody($stream, int $length): ?string
+    {
+        $body = '';
+        $remaining = $length;
+
+        while ($remaining > 0) {
+            $chunk = fread($stream, $remaining);
+            if ($chunk === false || $chunk === '') {
+                if (feof($stream)) {
+                    return null;
+                }
+
+                continue;
+            }
+
+            $body .= $chunk;
+            $remaining -= strlen($chunk);
+        }
+
+        return $body;
+    }
+}

--- a/src/php/Lsp/Application/Rpc/MessageWriter.php
+++ b/src/php/Lsp/Application/Rpc/MessageWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use function fflush;
+use function fwrite;
+use function json_encode;
+use function sprintf;
+use function strlen;
+
+/**
+ * Writes a JSON-RPC 2.0 message using LSP's Content-Length framing.
+ *
+ *   Content-Length: <n>\r\n\r\n<body>
+ */
+final class MessageWriter
+{
+    /**
+     * @param resource             $stream
+     * @param array<string, mixed> $message
+     */
+    public function write($stream, array $message): void
+    {
+        $json = json_encode($message, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $frame = sprintf("Content-Length: %d\r\n\r\n%s", strlen($json), $json);
+        fwrite($stream, $frame);
+        fflush($stream);
+    }
+}

--- a/src/php/Lsp/Application/Rpc/RequestDispatcher.php
+++ b/src/php/Lsp/Application/Rpc/RequestDispatcher.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+use Throwable;
+
+use function is_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * Routes a decoded LSP message to the correct handler and returns the
+ * response payload (or null for notifications / requests that shouldn't
+ * respond).
+ */
+final class RequestDispatcher
+{
+    /** @var array<string, HandlerInterface> */
+    private array $handlers = [];
+
+    public function __construct(
+        private readonly ResponseBuilder $responses,
+    ) {}
+
+    public function register(HandlerInterface $handler): void
+    {
+        $this->handlers[$handler->method()] = $handler;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function knownMethods(): array
+    {
+        return array_keys($this->handlers);
+    }
+
+    public function hasMethod(string $method): bool
+    {
+        return isset($this->handlers[$method]);
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     *
+     * @return array<string, mixed>|null
+     */
+    public function dispatch(array $message, Session $session): ?array
+    {
+        $id = $message['id'] ?? null;
+        $method = is_string($message['method'] ?? null) ? $message['method'] : '';
+        $params = is_array($message['params'] ?? null) ? $message['params'] : [];
+        /** @var array<string, mixed> $params */
+
+        if ($method === '') {
+            if ($id === null) {
+                return null;
+            }
+
+            return $this->responses->error($id, ResponseBuilder::INVALID_REQUEST, 'Missing method.');
+        }
+
+        /** @psalm-suppress MixedArrayTypeCoercion */
+        $handler = $this->handlers[$method] ?? null;
+        if (!$handler instanceof HandlerInterface) {
+            if ($id === null) {
+                // Unknown notification: per LSP spec we silently ignore.
+                return null;
+            }
+
+            return $this->responses->error(
+                $id,
+                ResponseBuilder::METHOD_NOT_FOUND,
+                sprintf('Unknown method: %s', $method),
+            );
+        }
+
+        try {
+            $result = $handler->handle($params, $session);
+        } catch (Throwable $throwable) {
+            if ($id === null) {
+                return null;
+            }
+
+            return $this->responses->error(
+                $id,
+                ResponseBuilder::INTERNAL_ERROR,
+                $throwable->getMessage(),
+            );
+        }
+
+        if ($handler->isNotification() || $id === null) {
+            return null;
+        }
+
+        return $this->responses->result($id, $result);
+    }
+}

--- a/src/php/Lsp/Application/Rpc/ResponseBuilder.php
+++ b/src/php/Lsp/Application/Rpc/ResponseBuilder.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+/**
+ * Builds JSON-RPC 2.0 response / notification payloads as PHP arrays.
+ *
+ * Separating construction from transport makes the dispatcher trivial to
+ * unit-test without needing a real stream.
+ */
+final class ResponseBuilder
+{
+    public const int PARSE_ERROR = -32700;
+
+    public const int INVALID_REQUEST = -32600;
+
+    public const int METHOD_NOT_FOUND = -32601;
+
+    public const int INVALID_PARAMS = -32602;
+
+    public const int INTERNAL_ERROR = -32603;
+
+    public const int SERVER_NOT_INITIALIZED = -32002;
+
+    /**
+     * @return array{jsonrpc: string, id: mixed, result: mixed}
+     */
+    public function result(mixed $id, mixed $result): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'result' => $result,
+        ];
+    }
+
+    /**
+     * @return array{jsonrpc: string, id: mixed, error: array{code: int, message: string, data?: mixed}}
+     */
+    public function error(mixed $id, int $code, string $message, mixed $data = null): array
+    {
+        $error = [
+            'code' => $code,
+            'message' => $message,
+        ];
+        if ($data !== null) {
+            $error['data'] = $data;
+        }
+
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'error' => $error,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{jsonrpc: string, method: string, params: array<string, mixed>}
+     */
+    public function notification(string $method, array $params): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'method' => $method,
+            'params' => $params,
+        ];
+    }
+}

--- a/src/php/Lsp/Application/Rpc/StreamNotificationSink.php
+++ b/src/php/Lsp/Application/Rpc/StreamNotificationSink.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use Phel\Lsp\Domain\NotificationSink;
+
+/**
+ * NotificationSink backed by a writable PHP stream + LSP MessageWriter.
+ */
+final class StreamNotificationSink implements NotificationSink
+{
+    /**
+     * @param resource $stream
+     */
+    public function __construct(
+        private readonly MessageWriter $writer,
+        private readonly ResponseBuilder $responses,
+        private $stream,
+    ) {}
+
+    public function notify(string $method, array $params): void
+    {
+        $this->writer->write($this->stream, $this->responses->notification($method, $params));
+    }
+}

--- a/src/php/Lsp/Application/Session/Session.php
+++ b/src/php/Lsp/Application/Session/Session.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Session;
+
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Document\DocumentStore;
+use Phel\Lsp\Domain\NotificationSink;
+
+/**
+ * State carried across every LSP request for a single client.
+ *
+ * Handlers read the workspace roots to re-index the project, push
+ * notifications back through the sink, and share the document store.
+ */
+final class Session
+{
+    private bool $initialized = false;
+
+    private bool $shutdownRequested = false;
+
+    /** @var list<string> */
+    private array $workspaceRoots = [];
+
+    /** @var array<string, mixed> */
+    private array $clientCapabilities = [];
+
+    private ?ProjectIndex $projectIndex = null;
+
+    public function __construct(
+        private readonly DocumentStore $documents,
+        private readonly NotificationSink $sink,
+    ) {}
+
+    public function documents(): DocumentStore
+    {
+        return $this->documents;
+    }
+
+    public function sink(): NotificationSink
+    {
+        return $this->sink;
+    }
+
+    public function markInitialized(): void
+    {
+        $this->initialized = true;
+    }
+
+    public function isInitialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    public function requestShutdown(): void
+    {
+        $this->shutdownRequested = true;
+    }
+
+    public function shutdownRequested(): bool
+    {
+        return $this->shutdownRequested;
+    }
+
+    /**
+     * @param list<string> $roots
+     */
+    public function setWorkspaceRoots(array $roots): void
+    {
+        $this->workspaceRoots = $roots;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function workspaceRoots(): array
+    {
+        return $this->workspaceRoots;
+    }
+
+    /**
+     * @param array<string, mixed> $capabilities
+     */
+    public function setClientCapabilities(array $capabilities): void
+    {
+        $this->clientCapabilities = $capabilities;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function clientCapabilities(): array
+    {
+        return $this->clientCapabilities;
+    }
+
+    public function setProjectIndex(ProjectIndex $index): void
+    {
+        $this->projectIndex = $index;
+    }
+
+    public function projectIndex(): ?ProjectIndex
+    {
+        return $this->projectIndex;
+    }
+}

--- a/src/php/Lsp/CLAUDE.md
+++ b/src/php/Lsp/CLAUDE.md
@@ -1,0 +1,73 @@
+# Lsp Module
+
+Language Server Protocol v3.17 over stdio (JSON-RPC 2.0 with `Content-Length` framing). Thin transport on top of `ApiFacade`, `LintFacade`, and `FormatterFacade`.
+
+## Gacela Pattern
+
+- **Facade**: `LspFacade` extends `AbstractFacade<LspFactory>`
+- **Factory**: `LspFactory` extends `AbstractFactory<LspConfig>`
+- **Config**: `LspConfig` — default debounce interval, server name/version
+- **Provider**: `LspProvider` — injects `FACADE_API`, `FACADE_LINT`, `FACADE_FORMATTER`, `FACADE_COMPILER`, `FACADE_COMMAND`, `FACADE_RUN`
+
+## Public API (Facade)
+
+- `createServer($input, $output): LspServer` — wire streams + handlers and return the server instance
+- `createDispatcher(): RequestDispatcher` — build a dispatcher with every handler registered (exposed for tests)
+
+## CLI Command
+
+`./bin/phel lsp` — starts the server on stdin/stdout.
+
+## Supported LSP Methods
+
+Lifecycle: `initialize`, `initialized`, `shutdown`, `exit`.
+
+Text sync: `textDocument/didOpen`, `textDocument/didChange` (full + incremental), `textDocument/didClose`, `textDocument/didSave`.
+
+Language features:
+- `textDocument/hover` — markdown-formatted signature + docstring
+- `textDocument/definition` — via `ApiFacade::resolveSymbol`
+- `textDocument/references` — via `ApiFacade::findReferences`
+- `textDocument/completion` — via `ApiFacade::completeAtPoint`
+- `textDocument/documentSymbol` — top-level defs in the open file
+- `workspace/symbol` — project-wide symbol search over the cached index
+- `textDocument/rename` — reuses `findReferences` to compute a WorkspaceEdit
+- `textDocument/formatting` — delegates to `FormatterFacade::formatString`
+
+Diagnostics are published via `textDocument/publishDiagnostics` on didOpen/didChange (debounced ~200ms) and didSave (immediate), combining `ApiFacade::analyzeSource` with `LintFacade::lint`.
+
+## Dependencies
+
+- **Api** (`ApiFacade`) — semantic analysis, project index, resolve, references, completion
+- **Lint** (`LintFacade`) — rule-based diagnostics
+- **Formatter** (`FormatterFacade`) — `formatString()`
+- **Compiler** (`CompilerFacade`) — indirectly via Api
+- **Command** (`CommandFacade`) — default source directories
+- **Run** (`RunFacade`) — `loadPhelNamespaces()` so core symbols resolve
+
+## Structure
+
+```
+Lsp/
+|-- Application/
+|   |-- Convert/        PositionConverter, UriConverter, DiagnosticConverter, LocationConverter, CompletionConverter
+|   |-- Diagnostics/    DiagnosticPublisher (debounced analyze + lint)
+|   |-- Document/       Document, DocumentStore
+|   |-- Handler/        One class per LSP method (Initialize, Hover, Definition, ...)
+|   |-- Rpc/            MessageReader, MessageWriter, ResponseFactory, RequestDispatcher, StreamNotificationSink, LspServer
+|   +-- Session/        Session
+|-- Domain/             HandlerInterface, NotificationSink
+|-- Infrastructure/
+|   +-- Command/        LspCommand (Symfony console)
++-- Gacela files        LspFacade, LspFactory, LspConfig, LspProvider
+```
+
+## Key Constraints
+
+- Framing is strict LSP Content-Length: `Content-Length: <n>\r\n\r\n<body>`. NOT newline-delimited JSON, NOT bencode.
+- Adding an LSP method = add a `HandlerInterface` class + a single `register(...)` call in `LspFactory::createDispatcher()`. No edits to existing handlers.
+- Handlers never touch the transport directly; they return a result payload or push through `Session::sink()`.
+- `DocumentStore` is the single source of truth for open-buffer text; handlers never reparse from disk while a buffer is open.
+- Diagnostics are debounced via `DiagnosticPublisher::shouldPublish($uri)` — `didOpen`/`didSave` call `publishNow()` to force a refresh.
+- Converters (`Application/Convert/`) are pure — no stateful dependencies on Facades — so they're trivially unit-testable.
+- Facades only: we never instantiate `Api`, `Lint`, or `Formatter` internals directly; cross-module access is through the public Facade.

--- a/src/php/Lsp/Domain/HandlerInterface.php
+++ b/src/php/Lsp/Domain/HandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Domain;
+
+use Phel\Lsp\Application\Session\Session;
+
+interface HandlerInterface
+{
+    /**
+     * LSP method name (e.g. "textDocument/hover").
+     */
+    public function method(): string;
+
+    /**
+     * Return true when the handler is for an LSP notification (no response).
+     */
+    public function isNotification(): bool;
+
+    /**
+     * Handle an LSP request/notification and return the `result` payload
+     * (ignored for notifications).
+     *
+     * @param array<string, mixed> $params
+     */
+    public function handle(array $params, Session $session): mixed;
+}

--- a/src/php/Lsp/Domain/NotificationSink.php
+++ b/src/php/Lsp/Domain/NotificationSink.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Domain;
+
+/**
+ * Abstraction for handlers that need to push notifications back to the client
+ * (e.g. diagnostics, log messages). The concrete implementation wires this
+ * through the transport; unit tests can capture notifications in-memory.
+ */
+interface NotificationSink
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function notify(string $method, array $params): void;
+}

--- a/src/php/Lsp/Infrastructure/Command/LspCommand.php
+++ b/src/php/Lsp/Infrastructure/Command/LspCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel;
+use Phel\Lsp\LspConfig;
+use Phel\Lsp\LspFacade;
+use Phel\Lsp\LspFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function defined;
+use function fopen;
+use function sprintf;
+
+#[ServiceMap(method: 'getFacade', className: LspFacade::class)]
+#[ServiceMap(method: 'getFactory', className: LspFactory::class)]
+#[ServiceMap(method: 'getConfig', className: LspConfig::class)]
+final class LspCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const string COMMAND_NAME = 'lsp';
+
+    public function __construct()
+    {
+        parent::__construct(self::COMMAND_NAME);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription(
+            'Start the Phel Language Server (LSP v3.17 over stdio, JSON-RPC 2.0 with Content-Length framing).',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        Phel::setupRuntimeArgs('lsp', []);
+
+        try {
+            $this->getFactory()->getRunFacade()->loadPhelNamespaces();
+        } catch (Throwable) {
+            // Core may fail to load on malformed projects; fall back to an analyzer-only session.
+        }
+
+        $stdin = defined('STDIN') ? STDIN : fopen('php://stdin', 'rb');
+        $stdout = defined('STDOUT') ? STDOUT : fopen('php://stdout', 'wb');
+        if ($stdin === false || $stdout === false) {
+            $output->writeln('<error>Cannot open stdio streams for LSP server.</error>');
+            return self::FAILURE;
+        }
+
+        try {
+            return $this->getFacade()->createServer($stdin, $stdout)->serve($stdin, $stdout);
+        } catch (Throwable $throwable) {
+            $output->writeln(sprintf('<error>LSP server crashed: %s</error>', $throwable->getMessage()));
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/php/Lsp/LspConfig.php
+++ b/src/php/Lsp/LspConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp;
+
+use Gacela\Framework\AbstractConfig;
+
+final class LspConfig extends AbstractConfig
+{
+    private const int DEFAULT_DIAGNOSTIC_DEBOUNCE_MS = 200;
+
+    private const string DEFAULT_SERVER_NAME = 'phel-lsp';
+
+    private const string DEFAULT_SERVER_VERSION = '0.1.0';
+
+    public static function defaultDiagnosticDebounceMs(): int
+    {
+        return self::DEFAULT_DIAGNOSTIC_DEBOUNCE_MS;
+    }
+
+    public static function defaultServerName(): string
+    {
+        return self::DEFAULT_SERVER_NAME;
+    }
+
+    public static function defaultServerVersion(): string
+    {
+        return self::DEFAULT_SERVER_VERSION;
+    }
+}

--- a/src/php/Lsp/LspFacade.php
+++ b/src/php/Lsp/LspFacade.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Lsp\Application\Rpc\LspServer;
+use Phel\Lsp\Application\Rpc\RequestDispatcher;
+
+/**
+ * @extends AbstractFacade<LspFactory>
+ */
+final class LspFacade extends AbstractFacade
+{
+    /**
+     * Build an LSP server around the given streams. The caller owns the loop
+     * via {@see LspServer::serve()}.
+     *
+     * @param resource $input
+     * @param resource $output
+     */
+    public function createServer($input, $output): LspServer
+    {
+        return $this->getFactory()->createServer($input, $output);
+    }
+
+    /**
+     * Build a request dispatcher with every handler registered. Exposed so
+     * unit tests can drive handlers without a real transport.
+     */
+    public function createDispatcher(): RequestDispatcher
+    {
+        return $this->getFactory()->createDispatcher();
+    }
+}

--- a/src/php/Lsp/LspFactory.php
+++ b/src/php/Lsp/LspFactory.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Api\ApiFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Formatter\FormatterFacade;
+use Phel\Lint\LintFacade;
+use Phel\Lsp\Application\Convert\CompletionConverter;
+use Phel\Lsp\Application\Convert\DiagnosticConverter;
+use Phel\Lsp\Application\Convert\LocationConverter;
+use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\UriConverter;
+use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
+use Phel\Lsp\Application\Document\DocumentStore;
+use Phel\Lsp\Application\Handler\CompletionHandler;
+use Phel\Lsp\Application\Handler\DefinitionHandler;
+use Phel\Lsp\Application\Handler\DidChangeHandler;
+use Phel\Lsp\Application\Handler\DidCloseHandler;
+use Phel\Lsp\Application\Handler\DidOpenHandler;
+use Phel\Lsp\Application\Handler\DidSaveHandler;
+use Phel\Lsp\Application\Handler\DocumentSymbolHandler;
+use Phel\Lsp\Application\Handler\ExitHandler;
+use Phel\Lsp\Application\Handler\FormattingHandler;
+use Phel\Lsp\Application\Handler\HoverHandler;
+use Phel\Lsp\Application\Handler\InitializedHandler;
+use Phel\Lsp\Application\Handler\InitializeHandler;
+use Phel\Lsp\Application\Handler\ReferencesHandler;
+use Phel\Lsp\Application\Handler\RenameHandler;
+use Phel\Lsp\Application\Handler\ShutdownHandler;
+use Phel\Lsp\Application\Handler\WorkspaceSymbolHandler;
+use Phel\Lsp\Application\Rpc\LspServer;
+use Phel\Lsp\Application\Rpc\MessageReader;
+use Phel\Lsp\Application\Rpc\MessageWriter;
+use Phel\Lsp\Application\Rpc\RequestDispatcher;
+use Phel\Lsp\Application\Rpc\ResponseBuilder;
+use Phel\Lsp\Application\Rpc\StreamNotificationSink;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Run\RunFacade;
+
+/**
+ * @extends AbstractFactory<LspConfig>
+ */
+final class LspFactory extends AbstractFactory
+{
+    /**
+     * @param resource $input
+     * @param resource $output
+     */
+    public function createServer($input, $output): LspServer
+    {
+        $responses = $this->createResponseBuilder();
+        $writer = $this->createMessageWriter();
+        $sink = new StreamNotificationSink($writer, $responses, $output);
+        $session = new Session($this->createDocumentStore(), $sink);
+        $dispatcher = $this->createDispatcher($responses);
+
+        return new LspServer(
+            $this->createMessageReader(),
+            $writer,
+            $dispatcher,
+            $responses,
+            $session,
+        );
+    }
+
+    public function createDispatcher(?ResponseBuilder $responses = null): RequestDispatcher
+    {
+        $dispatcher = new RequestDispatcher($responses ?? $this->createResponseBuilder());
+
+        $publisher = $this->createDiagnosticPublisher();
+        $positions = $this->createPositionConverter();
+        $uris = $this->createUriConverter();
+        $locations = $this->createLocationConverter();
+        $completions = $this->createCompletionConverter();
+
+        $dispatcher->register(new InitializeHandler($this->getApiFacade(), $uris));
+        $dispatcher->register(new InitializedHandler());
+        $dispatcher->register(new ShutdownHandler());
+        $dispatcher->register(new ExitHandler());
+
+        $dispatcher->register(new DidOpenHandler($publisher));
+        $dispatcher->register(new DidChangeHandler($publisher));
+        $dispatcher->register(new DidCloseHandler());
+        $dispatcher->register(new DidSaveHandler($publisher, $this->getApiFacade(), $uris));
+
+        $dispatcher->register(new HoverHandler($this->getApiFacade()));
+        $dispatcher->register(new DefinitionHandler($this->getApiFacade(), $locations));
+        $dispatcher->register(new ReferencesHandler($this->getApiFacade(), $locations));
+        $dispatcher->register(new CompletionHandler($this->getApiFacade(), $completions));
+        $dispatcher->register(new DocumentSymbolHandler($this->getApiFacade(), $positions, $uris));
+        $dispatcher->register(new WorkspaceSymbolHandler($positions, $uris));
+        $dispatcher->register(new RenameHandler($this->getApiFacade(), $positions, $uris));
+        $dispatcher->register(new FormattingHandler($this->getFormatterFacade()));
+
+        return $dispatcher;
+    }
+
+    public function createMessageReader(): MessageReader
+    {
+        return new MessageReader();
+    }
+
+    public function createMessageWriter(): MessageWriter
+    {
+        return new MessageWriter();
+    }
+
+    public function createResponseBuilder(): ResponseBuilder
+    {
+        return new ResponseBuilder();
+    }
+
+    public function createDocumentStore(): DocumentStore
+    {
+        return new DocumentStore();
+    }
+
+    public function createPositionConverter(): PositionConverter
+    {
+        return new PositionConverter();
+    }
+
+    public function createUriConverter(): UriConverter
+    {
+        return new UriConverter();
+    }
+
+    public function createLocationConverter(): LocationConverter
+    {
+        return new LocationConverter(
+            $this->createPositionConverter(),
+            $this->createUriConverter(),
+        );
+    }
+
+    public function createDiagnosticConverter(): DiagnosticConverter
+    {
+        return new DiagnosticConverter(
+            $this->createPositionConverter(),
+            $this->createUriConverter(),
+        );
+    }
+
+    public function createCompletionConverter(): CompletionConverter
+    {
+        return new CompletionConverter();
+    }
+
+    public function createDiagnosticPublisher(): DiagnosticPublisher
+    {
+        return new DiagnosticPublisher(
+            $this->getApiFacade(),
+            $this->getLintFacade(),
+            $this->createDiagnosticConverter(),
+            LspConfig::defaultDiagnosticDebounceMs(),
+        );
+    }
+
+    public function getApiFacade(): ApiFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_API);
+    }
+
+    public function getLintFacade(): LintFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_LINT);
+    }
+
+    public function getFormatterFacade(): FormatterFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_FORMATTER);
+    }
+
+    public function getCompilerFacade(): CompilerFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_COMPILER);
+    }
+
+    public function getCommandFacade(): CommandFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_COMMAND);
+    }
+
+    public function getRunFacade(): RunFacade
+    {
+        return $this->getProvidedDependency(LspProvider::FACADE_RUN);
+    }
+}

--- a/src/php/Lsp/LspProvider.php
+++ b/src/php/Lsp/LspProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use Phel\Api\ApiFacade;
+use Phel\Command\CommandFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Formatter\FormatterFacade;
+use Phel\Lint\LintFacade;
+use Phel\Run\RunFacade;
+
+final class LspProvider extends AbstractProvider
+{
+    public const string FACADE_API = 'FACADE_API';
+
+    public const string FACADE_LINT = 'FACADE_LINT';
+
+    public const string FACADE_FORMATTER = 'FACADE_FORMATTER';
+
+    public const string FACADE_COMPILER = 'FACADE_COMPILER';
+
+    public const string FACADE_COMMAND = 'FACADE_COMMAND';
+
+    public const string FACADE_RUN = 'FACADE_RUN';
+
+    #[Provides(self::FACADE_API)]
+    public function apiFacade(Container $container): ApiFacade
+    {
+        return $container->getLocator()->getRequired(ApiFacade::class);
+    }
+
+    #[Provides(self::FACADE_LINT)]
+    public function lintFacade(Container $container): LintFacade
+    {
+        return $container->getLocator()->getRequired(LintFacade::class);
+    }
+
+    #[Provides(self::FACADE_FORMATTER)]
+    public function formatterFacade(Container $container): FormatterFacade
+    {
+        return $container->getLocator()->getRequired(FormatterFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMPILER)]
+    public function compilerFacade(Container $container): CompilerFacade
+    {
+        return $container->getLocator()->getRequired(CompilerFacade::class);
+    }
+
+    #[Provides(self::FACADE_COMMAND)]
+    public function commandFacade(Container $container): CommandFacade
+    {
+        return $container->getLocator()->getRequired(CommandFacade::class);
+    }
+
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
+    {
+        return $container->getLocator()->getRequired(RunFacade::class);
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/MessageReaderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Rpc\MessageReader;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function fopen;
+use function fwrite;
+use function rewind;
+
+final class MessageReaderTest extends TestCase
+{
+    public function test_it_reads_a_single_lsp_framed_message(): void
+    {
+        $stream = $this->memoryStreamWith("Content-Length: 17\r\n\r\n{\"method\":\"ping\"}");
+
+        $reader = new MessageReader();
+        $message = $reader->read($stream);
+
+        self::assertSame(['method' => 'ping'], $message);
+    }
+
+    public function test_it_ignores_extra_headers(): void
+    {
+        $stream = $this->memoryStreamWith(
+            "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
+            . "Content-Length: 17\r\n\r\n{\"method\":\"ping\"}",
+        );
+
+        $reader = new MessageReader();
+        $message = $reader->read($stream);
+
+        self::assertSame(['method' => 'ping'], $message);
+    }
+
+    public function test_it_returns_null_at_eof(): void
+    {
+        $stream = $this->memoryStreamWith('');
+
+        $reader = new MessageReader();
+        $message = $reader->read($stream);
+
+        self::assertNull($message);
+    }
+
+    public function test_it_throws_on_malformed_json(): void
+    {
+        $stream = $this->memoryStreamWith("Content-Length: 3\r\n\r\n{{{");
+
+        $reader = new MessageReader();
+
+        $this->expectException(RuntimeException::class);
+        $reader->read($stream);
+    }
+
+    public function test_it_reads_two_messages_back_to_back(): void
+    {
+        $stream = $this->memoryStreamWith(
+            "Content-Length: 16\r\n\r\n{\"method\":\"one\"}"
+            . "Content-Length: 16\r\n\r\n{\"method\":\"two\"}",
+        );
+
+        $reader = new MessageReader();
+        $first = $reader->read($stream);
+        $second = $reader->read($stream);
+
+        self::assertSame('one', $first['method'] ?? null);
+        self::assertSame('two', $second['method'] ?? null);
+    }
+
+    /**
+     * @return resource
+     */
+    private function memoryStreamWith(string $content)
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertNotFalse($stream);
+        if ($content !== '') {
+            fwrite($stream, $content);
+            rewind($stream);
+        }
+
+        return $stream;
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Rpc/MessageWriterTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/MessageWriterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Rpc\MessageReader;
+use Phel\Lsp\Application\Rpc\MessageWriter;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function rewind;
+use function stream_get_contents;
+
+final class MessageWriterTest extends TestCase
+{
+    public function test_it_prefixes_body_with_content_length_header(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertNotFalse($stream);
+
+        (new MessageWriter())->write($stream, ['method' => 'ping']);
+
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        self::assertIsString($contents);
+        self::assertSame("Content-Length: 17\r\n\r\n{\"method\":\"ping\"}", $contents);
+    }
+
+    public function test_round_trip_with_reader(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertNotFalse($stream);
+
+        $payload = ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['ok' => true]];
+        (new MessageWriter())->write($stream, $payload);
+
+        rewind($stream);
+        $reader = new MessageReader();
+        $roundTripped = $reader->read($stream);
+
+        self::assertSame($payload, $roundTripped);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel has strong JetBrains support through its IntelliJ plugin, but editors like VS Code, Neovim, Emacs, Zed, Helix, and Sublime have no first-class Phel integration. The Language Server Protocol is the universal contract for those editors.

The upstream building blocks are already in main: `ApiFacade` exposes `analyzeSource`, `indexProject`, `resolveSymbol`, `findReferences`, and `completeAtPoint`; `LintFacade` produces rule-based diagnostics; `FormatterFacade` handles whitespace. This PR wires them into an LSP server.

## 💡 Goal

Ship `./bin/phel lsp`, a thin JSON-RPC shell speaking LSP v3.17 over stdio, so any LSP-native editor gets Phel hover, definition, references, completion, document/workspace symbols, rename, formatting, and diagnostics out of the box.

## 🔖 Changes

New Gacela module `src/php/Lsp/`:

- `LspFacade::createServer($in, $out): LspServer` and `createDispatcher(): RequestDispatcher`.
- JSON-RPC 2.0 with strict LSP `Content-Length` framing (`Application/Rpc/MessageReader`, `MessageWriter`, `ResponseBuilder`, `RequestDispatcher`, `StreamNotificationSink`, `LspServer`).
- One handler per LSP method implementing `HandlerInterface` (`Application/Handler/*`): `initialize`, `initialized`, `shutdown`, `exit`, text-sync `didOpen`/`didChange`/`didClose`/`didSave`, `textDocument/hover`, `textDocument/definition`, `textDocument/references`, `textDocument/completion`, `textDocument/documentSymbol`, `workspace/symbol`, `textDocument/rename`, `textDocument/formatting`.
- In-memory `DocumentStore` and per-client `Session` for workspace roots, capabilities, and the cached `ProjectIndex`.
- `DiagnosticPublisher` composes `ApiFacade::analyzeSource` with `LintFacade::lint` and pushes `textDocument/publishDiagnostics`. Debounced ~200ms on didChange, immediate on didOpen/didSave.
- Pure converters in `Application/Convert/` map Api `Diagnostic`, `Location`, `Definition`, `Completion`, and `PhelFunction` into their LSP counterparts; positions convert 1-based to 0-based.
- `FormatterFacade::formatString(source, uri)` added so the formatting handler can work on in-memory buffers without touching disk.
- `./bin/phel lsp` wired through `LspCommand`; registered in `ConsoleProvider`.
- Unit tests for `MessageReader` / `MessageWriter` covering framing round-trips, extra headers, EOF, malformed JSON, and back-to-back messages.
- `CHANGELOG.md` entry under Unreleased.
- Module docs at `src/php/Lsp/CLAUDE.md`.