### PR TITLE
feat(test): pluggable report multimethod with junit-xml, tap, dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
 #### Formatter
 - Aligns key/value pairs in `cond`, `case`, `condp`, and bindings of `let`/`loop`/`binding`/`for`/`foreach`/`dofor`/`if-let`/`when-let`
 
+#### Testing
+- `phel\test/report` is a multimethod dispatching on event `:type`; extend with `defmethod report :custom [event] ...`
+- Built-in reporters: `default`, `testdox`, `dot`, `tap`, `junit-xml`; select via `phel test --reporter=<name>` (repeatable); `--output=path` writes the junit-xml reporter to a file
+
 #### Modules
 - `phel\test\gen`: generators, `sample`, `quick-check`, `defspec` with seedable PRNG
 - `phel\ai`: `chat-with-tools` OpenAI tool use, `tool-calls` extraction, `tool-result` helper; retry w/ exponential backoff on 429/5xx; per-call `opts` (`:provider`, `:timeout`, `:base-url`, `:api-key`, `:max-retries`); `*http-post*` seam; `docs/ai-guide.md`

--- a/phel-config.php
+++ b/phel-config.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Phel\Config\PhelConfig;
-use Phel\Config\ProjectLayout;
 
 return PhelConfig::forProject('phel\core')
     ->useNestedLayout()

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -9,8 +9,6 @@
 ;; Report
 ;; ------
 
-(def- testdox? (atom false))
-
 (def- fail-fast? (atom false))
 
 (def- *current-test-name* nil)
@@ -25,13 +23,44 @@
                            :pass 0
                            :total 0}}))
 
-(defn- print-report-testdox-state [data state]
-  (let [s       (case state :failed "✘" :pass "✔" :error "E")
-        message (str *current-test-name* ": " (or (:message data) "no test message found"))]
-    (println s message)))
+;; Dynamic registry of active reporter functions. Each reporter is a
+;; function of a single argument — the event map with a `:type` key — and
+;; is called once per event (pass/fail/error/summary/begin-test-ns/...).
+;;
+;; Reporters are invoked in the order they are registered. Use
+;; `set-reporters!`, `add-reporter!`, and `clear-reporters!` to manage
+;; the set.
+(def- *reporters* (atom []))
 
-(defn- print-report-state [state]
-  (print (case state :failed "F" :pass "." :error "E")))
+(defn set-reporters!
+  "Replaces the active reporter set with `reporters` (a sequence of
+  single-argument functions). Returns the new reporter list."
+  {:example "(set-reporters! [my-reporter-fn])"
+   :see-also ["add-reporter!" "clear-reporters!" "report"]}
+  [reporters]
+  (reset! *reporters* (vec reporters)))
+
+(defn add-reporter!
+  "Appends `reporter-fn` to the active reporter set. Returns the updated
+  reporter list."
+  {:example "(add-reporter! tap-reporter)"
+   :see-also ["set-reporters!" "clear-reporters!" "report"]}
+  [reporter-fn]
+  (swap! *reporters* conj reporter-fn))
+
+(defn clear-reporters!
+  "Removes every registered reporter. Returns an empty vector."
+  {:example "(clear-reporters!)"
+   :see-also ["set-reporters!" "add-reporter!"]}
+  []
+  (reset! *reporters* []))
+
+(defn get-reporters
+  "Returns the currently registered reporter functions as a vector."
+  {:example "(get-reporters)"
+   :see-also ["set-reporters!"]}
+  []
+  (deref *reporters*))
 
 (defn- should-stop? []
   (and (deref fail-fast?)
@@ -43,32 +72,99 @@
   (when (not (empty? *testing-contexts*))
     (str (s/join " > " *testing-contexts*) " - ")))
 
-(defn report
-  "Records test results and prints status indicators."
-  {:example "(report {:state :pass})"}
+(defn- decorate-event
+  "Prepends testing-context information to the event message and injects
+  the current test name."
   [data]
-  (let [ctx                       (testing-contexts-str)
-        data                      (cond
+  (let [ctx  (testing-contexts-str)
+        data (cond
                (and ctx (:message data)) (assoc data :message (str ctx (:message data)))
                ctx                       (assoc data :message (s/join " > " *testing-contexts*))
-               :else                     data)
-        {:state state :type type} data
-        ok                        (= state :pass)
-        total-columns             80]
-    (if (deref testdox?)
-      (print-report-testdox-state data state)
-      (print-report-state state))
-    (let [new-stats (swap! stats
-                           (fn [s]
-                             (let [counts (get s :counts)
-                                   counts (assoc counts :total (inc (get counts :total)))
-                                   counts (assoc counts state (inc (get counts state)))]
-                               (let [s (assoc s :counts counts)]
-                                 (if ok
-                                   s
-                                   (assoc s :failed (conj (get s :failed) data)))))))
-          total     (get-in new-stats [:counts :total])]
-      (when (= 0 (% total total-columns)) (println)))))
+               :else                     data)]
+    (if *current-test-name*
+      (assoc data :test-name *current-test-name*)
+      data)))
+
+(defn- record-stats!
+  "Mutates the internal stats atom based on an assertion-result event."
+  [data]
+  (let [{:state state} data
+        ok             (= state :pass)]
+    (swap! stats
+           (fn [s]
+             (let [counts (get s :counts)
+                   counts (assoc counts :total (inc (get counts :total)))
+                   counts (assoc counts state (inc (get counts state)))
+                   s      (assoc s :counts counts)]
+               (if ok
+                 s
+                 (assoc s :failed (conj (get s :failed) data))))))))
+
+(defn- fan-out! [event]
+  (dofor [reporter :in (deref *reporters*)]
+    (reporter event)))
+
+;; `report` is the public multimethod dispatched on the event `:type`.
+;; Built-in event types include:
+;;   :pass, :failed, :error — assertion outcomes emitted by `is`
+;;   :begin-test-ns, :end-test-ns — lifecycle events around each namespace run
+;;   :begin-test-run, :summary — lifecycle events around the whole run
+;;
+;; Users extend the reporting surface with:
+;;   (defmethod report :custom-type [event] ...)
+;; or by registering a function through `set-reporters!`/`add-reporter!`.
+(defmulti report
+  "Records a test-framework event and dispatches it to the active
+  reporters. `data` must contain a `:type` key (`:pass`, `:failed`,
+  `:error`, `:begin-test-ns`, `:end-test-ns`, `:begin-test-run`,
+  `:summary`, or a user-defined event). The default methods for
+  assertion outcomes update the internal stats and invoke every
+  registered reporter. Other event types flow straight through to the
+  reporter set. Extend by registering
+  `(defmethod report :custom-type [event] ...)`."
+  (fn [data] (:type data)))
+
+(defn- report-assertion! [data]
+  (let [decorated (decorate-event data)]
+    (record-stats! decorated)
+    (fan-out! decorated)))
+
+(defmethod report :pass [data]
+  (report-assertion! (assoc data :state :pass)))
+
+(defmethod report :failed [data]
+  (report-assertion! (assoc data :state :failed)))
+
+(defmethod report :error [data]
+  (report-assertion! (assoc data :state :error)))
+
+;; `:predicate`, `:binary`, `:any`, `:thrown`, `:thrown-with-msg` — the
+;; legacy assertion-level types emitted by the built-in `is` macro. Each
+;; carries a `:state` field (`:pass`/`:failed`/`:error`) that records the
+;; real outcome, so we recover the logical type and delegate.
+(defn- handle-assertion-like [data]
+  (let [state (get data :state)]
+    (case state
+      :pass   (report-assertion! data)
+      :failed (report-assertion! data)
+      :error  (report-assertion! data)
+      (fan-out! (decorate-event data)))))
+
+(defmethod report :predicate      [data] (handle-assertion-like data))
+(defmethod report :predicate-not  [data] (handle-assertion-like data))
+(defmethod report :binary         [data] (handle-assertion-like data))
+(defmethod report :binary-not     [data] (handle-assertion-like data))
+(defmethod report :any            [data] (handle-assertion-like data))
+(defmethod report :thrown         [data] (handle-assertion-like data))
+(defmethod report :thrown-with-msg [data] (handle-assertion-like data))
+
+(defmethod report :begin-test-ns   [data] (fan-out! data))
+(defmethod report :end-test-ns     [data] (fan-out! data))
+(defmethod report :begin-test-run  [data] (fan-out! data))
+(defmethod report :summary         [data] (fan-out! data))
+
+(defmethod report :default [data]
+  (fan-out! (decorate-event data)))
 
 (defn do-report
   "Add file and line information to a test result and call report.
@@ -147,10 +243,10 @@
 
 (defn- assert-thrown [form message]
   ;; `(thrown? ExceptionClass body...)` asserts that `body` throws an instance of
-  ;; `ExceptionClass` (or a subclass). The Clojure-style single-arg form
-  ;; `(thrown? body)` — used by portability shims like `jank-lang/clojure-test-suite` —
-  ;; asserts only that `body` throws *anything*, so we default the caught type to
-  ;; `\Throwable` (the root of all PHP throwables since PHP 7).
+  ;; `ExceptionClass` (or a subclass). The single-argument form `(thrown? body)`
+  ;; used by portability shims asserts only that `body` throws *anything*, so
+  ;; the caught type defaults to `\Throwable` (the root of all PHP throwables
+  ;; since PHP 7).
   (let [single-arg?      (= 2 (count form))
         exception-symbol (if single-arg? '\Throwable (second form))
         body             (if single-arg? (next form) (nnext form))
@@ -261,7 +357,8 @@
   (let [loc (location form) e (gensym)]
     `(try ~(assert-expr form message)
           (catch \Throwable ~e
-            (report {:state :error
+            (report {:type :error
+                     :state :error
                      :location ~loc
                      :message ~message
                      :form '~form
@@ -336,7 +433,7 @@
     `(do ~@assertions)))
 
 ;; ---------------------
-;; error/failure printer
+;; Built-in reporters
 ;; ---------------------
 
 (defn- print-headline [prefix {:message message :location location}]
@@ -418,25 +515,378 @@
     :error  (print-error data)
     :failed (print-failure data)))
 
+(def- default-line-count (atom 0))
+
+(defn- assertion-event? [event]
+  (contains? event :state))
+
+(defn- default-reporter
+  "Human-readable dot output. Preserves the legacy behavior: `.` for
+  pass, `F` for fail, `E` for error, plus periodic newlines so long
+  runs wrap at 80 columns."
+  [event]
+  (let [type (:type event)]
+    (cond
+      (= type :begin-test-run)
+      (reset! default-line-count 0)
+
+      (assertion-event? event)
+      (let [state (:state event)
+            ch    (case state :failed "F" :error "E" ".")
+            n     (swap! default-line-count inc)]
+        (print ch)
+        (when (= 0 (% n 80)) (println)))
+
+      (= type :summary)
+      (do
+        (println)
+        (when-not (empty? (:failures event))
+          (println)
+          (for [data :in (:failures event)]
+            (println "~~~~~~~~~~")
+            (print-failure-or-error data))
+          (println))
+        (println)
+        (println "Passed:" (:pass event))
+        (println "Failed:" (:failed event))
+        (println "Error:" (:error event))
+        (println "Total:" (:total event))))))
+
+(defn- testdox-reporter
+  "Per-assertion single-line description used by the `--reporter=testdox`
+  flag."
+  [event]
+  (let [type (:type event)]
+    (cond
+      (assertion-event? event)
+      (let [state   (:state event)
+            marker  (case state :failed "✘" :error "E" "✔")
+            tname   (or (:test-name event) "")
+            msg     (or (:message event) "no test message found")]
+        (println marker (str tname ": " msg)))
+
+      (= type :summary)
+      (do
+        (println)
+        (when-not (empty? (:failures event))
+          (println)
+          (for [data :in (:failures event)]
+            (println "~~~~~~~~~~")
+            (print-failure-or-error data))
+          (println))
+        (println)
+        (println "Passed:" (:pass event))
+        (println "Failed:" (:failed event))
+        (println "Error:" (:error event))
+        (println "Total:" (:total event))))))
+
+;; -------------
+;; Dot reporter
+;; -------------
+
+(defn- dot-reporter
+  "Minimal CI-friendly reporter. Prints `.` per pass, `F` per failure,
+  `E` per error and a compact one-line summary at the end. Does not
+  print failure/error diagnostics."
+  [event]
+  (let [type (:type event)]
+    (cond
+      (assertion-event? event)
+      (let [state (:state event)]
+        (print (case state :failed "F" :error "E" ".")))
+
+      (= type :summary)
+      (do
+        (println)
+        (println (str "Tests: " (:total event)
+                      ", Passed: " (:pass event)
+                      ", Failed: " (:failed event)
+                      ", Errors: " (:error event)))))))
+
+;; -------------
+;; TAP reporter
+;; -------------
+
+(def- tap-counter (atom 0))
+
+(defn- tap-description [event]
+  (let [tname (:test-name event)
+        msg   (:message event)]
+    (cond
+      (and tname msg) (str tname ": " msg)
+      tname           tname
+      msg             msg
+      :else           "assertion")))
+
+(defn- tap-failure-yaml [event]
+  (let [loc    (:location event)
+        file   (when loc (get loc :file))
+        line   (when loc (get loc :line))
+        etype  (:type event)
+        output ["  ---"
+                (when file (str "  file: " file))
+                (when line (str "  line: " line))
+                (str "  type: " etype)
+                (when (:expected event)
+                  (str "  expected: " (:expected event)))
+                (when (contains? event :actual)
+                  (str "  actual: " (:actual event)))
+                "  ..."]]
+    (s/join "\n" (filter some? output))))
+
+(defn- tap-reporter
+  "TAP v13 output. Emits `TAP version 13`, `1..N` plan, `ok`/`not ok`
+  lines per assertion, and a YAML block per failure. `N` is the total
+  number of assertions observed during the run."
+  [event]
+  (let [type (:type event)]
+    (cond
+      (= type :begin-test-run)
+      (do
+        (reset! tap-counter 0)
+        (println "TAP version 13"))
+
+      (assertion-event? event)
+      (let [state (:state event)
+            n     (swap! tap-counter inc)
+            desc  (tap-description event)]
+        (if (= state :pass)
+          (println (str "ok " n " - " desc))
+          (do
+            (println (str "not ok " n " - " desc))
+            (println (tap-failure-yaml event)))))
+
+      (= type :summary)
+      (println (str "1.." (:total event))))))
+
+;; -----------------
+;; JUnit-XML reporter
+;; -----------------
+
+(def- junit-state
+  (atom {:tests 0
+         :failures 0
+         :errors 0
+         :time 0.0
+         :testsuites []
+         :current nil
+         :output-path nil}))
+
+(defn- junit-xml-escape [value]
+  (when-not (nil? value)
+    (let [s (if (string? value) value (str value))]
+      (-> s
+          (s/replace "&" "&amp;")
+          (s/replace "<" "&lt;")
+          (s/replace ">" "&gt;")
+          (s/replace "\"" "&quot;")
+          (s/replace "'" "&apos;")))))
+
+(defn- junit-attr [k v]
+  (str (name k) "=\"" (junit-xml-escape v) "\""))
+
+(defn- junit-exception-class [event]
+  (let [ex (:exception event)]
+    (if ex
+      (php/get_class ex)
+      (or (:exception-symbol event) "AssertionFailed"))))
+
+(defn- junit-testcase-body [event]
+  (let [state  (get event :state (:type event))
+        msg    (or (:message event) "")
+        klass  (junit-exception-class event)
+        body   (cond
+                 (= state :error)
+                 (str "<error message=\"" (junit-xml-escape msg)
+                      "\" type=\"" (junit-xml-escape klass) "\">"
+                      (junit-xml-escape (str (:form event)))
+                      "</error>")
+
+                 (= state :failed)
+                 (str "<failure message=\"" (junit-xml-escape msg)
+                      "\" type=\"" (junit-xml-escape klass) "\">"
+                      (junit-xml-escape (str (:form event)))
+                      "</failure>")
+
+                 :else nil)]
+    body))
+
+(defn- junit-build-testcase [event]
+  (let [tname    (or (:test-name event) "assertion")
+        ns-name  (or (:ns event) "")
+        loc      (or (:location event) {})
+        file     (or (:file loc) "")
+        line     (or (:line loc) 0)
+        body     (junit-testcase-body event)
+        opening  (str "<testcase "
+                      (junit-attr :name tname) " "
+                      (junit-attr :classname ns-name) " "
+                      (junit-attr :file file) " "
+                      (junit-attr :line line) ">")]
+    (str opening
+         (or body "")
+         "</testcase>")))
+
+(defn- junit-render [state]
+  (let [suites (reverse (get state :testsuites))
+        parts  (for [{:name ns-name :tests t :failures f :errors e :time tm :cases cases} :in suites]
+                 (str "<testsuite "
+                      (junit-attr :name ns-name) " "
+                      (junit-attr :tests t) " "
+                      (junit-attr :failures f) " "
+                      (junit-attr :errors e) " "
+                      (junit-attr :time tm) ">"
+                      (s/join "" (reverse cases))
+                      "</testsuite>"))]
+    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+         "<testsuites "
+         (junit-attr :tests (:tests state)) " "
+         (junit-attr :failures (:failures state)) " "
+         (junit-attr :errors (:errors state)) " "
+         (junit-attr :time (:time state)) ">"
+         (s/join "" parts)
+         "</testsuites>")))
+
+(defn- junit-finalize-current [state]
+  (let [current (:current state)]
+    (if current
+      (-> state
+          (assoc :testsuites (conj (get state :testsuites) current))
+          (assoc :current nil))
+      state)))
+
+(defn- junit-start-ns [state ns-name]
+  (let [state (junit-finalize-current state)]
+    (assoc state :current {:name ns-name
+                           :tests 0
+                           :failures 0
+                           :errors 0
+                           :time 0.0
+                           :cases []})))
+
+(defn- junit-record-case [state event]
+  (let [current (or (:current state)
+                    {:name (or (:ns event) "")
+                     :tests 0 :failures 0 :errors 0 :time 0.0 :cases []})
+        state   (assoc state :current current)
+        state   (update state :tests inc)
+        state   (if (= :failed (get event :state))
+                  (update state :failures inc) state)
+        state   (if (= :error (get event :state))
+                  (update state :errors inc) state)
+        current (:current state)
+        current (update current :tests inc)
+        current (if (= :failed (get event :state))
+                  (update current :failures inc) current)
+        current (if (= :error (get event :state))
+                  (update current :errors inc) current)
+        current (update current :cases conj (junit-build-testcase event))]
+    (assoc state :current current)))
+
+(defn- junit-write-output [state]
+  (let [xml  (junit-render state)
+        path (:output-path state)]
+    (if path
+      (php/file_put_contents path xml)
+      (println xml))))
+
+(defn- junit-reporter
+  "JUnit-XML v1 output. Emits a `<testsuites>` root with one
+  `<testsuite>` per Phel namespace. Each assertion becomes a
+  `<testcase>`; failures and errors are nested accordingly."
+  [event]
+  (let [type (:type event)]
+    (cond
+      (= type :begin-test-run)
+      (swap! junit-state
+             (fn [s] (assoc s :tests 0 :failures 0 :errors 0
+                            :testsuites []
+                            :current nil)))
+
+      (= type :begin-test-ns)
+      (swap! junit-state junit-start-ns (:ns event))
+
+      (= type :end-test-ns)
+      (swap! junit-state junit-finalize-current)
+
+      (assertion-event? event)
+      (swap! junit-state junit-record-case event)
+
+      (= type :summary)
+      (let [state (swap! junit-state junit-finalize-current)]
+        (junit-write-output state)))))
+
+(defn set-junit-output!
+  "Configures the output path the JUnit reporter writes to. When `nil`,
+  the XML is printed to stdout."
+  {:example "(set-junit-output! \"build/junit.xml\")"}
+  [path]
+  (swap! junit-state assoc :output-path path))
+
+;; ---------------------
+;; Reporter resolution
+;; ---------------------
+
+(def- built-in-reporters
+  {:default  default-reporter
+   :dot      dot-reporter
+   :testdox  testdox-reporter
+   :tap      tap-reporter
+   :junit-xml junit-reporter})
+
+(def- custom-reporters (atom {}))
+
+(defn- reporter-key [name]
+  (cond
+    (keyword? name) name
+    (string? name)  (keyword name)
+    :else           nil))
+
+(defn resolve-reporter
+  "Returns the reporter function registered for `name` (keyword or
+  string). Checks user-registered reporters before the built-in set.
+  Returns `nil` if the name is unknown."
+  {:see-also ["set-reporters!" "register-reporter!"]
+   :example "(resolve-reporter :junit-xml)"}
+  [name]
+  (let [kw (reporter-key name)]
+    (or (get (deref custom-reporters) kw)
+        (get built-in-reporters kw))))
+
+(defn register-reporter!
+  "Registers a custom reporter function under `name` (keyword or
+  keyword-castable string). Returns `name`."
+  {:example "(register-reporter! :my-reporter (fn [event] ...))"
+   :see-also ["resolve-reporter"]}
+  [name reporter-fn]
+  (let [kw (reporter-key name)]
+    (when (nil? kw)
+      (throw (php/new \InvalidArgumentException
+                      "register-reporter! name must be a keyword or string")))
+    (swap! custom-reporters assoc kw reporter-fn)
+    kw))
+
+;; ---------------------
+;; error/failure printer
+;; ---------------------
+
 (defn print-summary
-  "Prints test results summary."
+  "Emits the `:summary` event to the active reporter set.
+  Kept for backwards compatibility; prefer letting `run-tests` emit the
+  event at the end of the run."
   {:example "(print-summary)"}
   []
-  (println)
-  (let [failures (get (deref stats) :failed)]
-    (when (not (empty? failures))
-      (println)
-      (for [data :in failures]
-        (println "~~~~~~~~~~")
-        (print-failure-or-error data))
-      (println)))
-  (println)
-  (let [{:failed failed :error error :pass pass} (get (deref stats) :counts)
-        total                                    (+ failed error pass)]
-    (println "Passed:" pass)
-    (println "Failed:" failed)
-    (println "Error:" error)
-    (println "Total:" total)))
+  (let [snapshot                                 (deref stats)
+        {:failed failed :error error :pass pass} (get snapshot :counts)
+        failures                                 (get snapshot :failed)
+        total                                    (+ failed error pass)
+        event                                    {:type :summary
+                                                  :failures failures
+                                                  :pass pass
+                                                  :failed failed
+                                                  :error error
+                                                  :total total}]
+    (fan-out! event)))
 
 ;; --------
 ;; Fixtures
@@ -513,16 +963,38 @@
                :when (not (should-stop?))]
          (each-wrap test))))))
 
+(defn- resolve-reporters-option
+  "Resolves the `:reporters` option into a vector of reporter functions.
+  Accepts a sequence of keywords or strings (built-in names), or a
+  sequence of functions, or a mix. Defaults to `[:default]`."
+  [options]
+  (let [requested (or (:reporters options)
+                      (when (:testdox options) [:testdox])
+                      [:default])]
+    (vec (for [r :in requested]
+           (cond
+             (fn? r)                           r
+             (or (keyword? r) (string? r))     (or (resolve-reporter r)
+                                                   (throw (php/new \InvalidArgumentException
+                                                                   (str "Unknown reporter: " r))))
+             :else                             (throw (php/new \InvalidArgumentException
+                                                               (str "Invalid reporter value: " r))))))))
+
 (defn run-tests
   "Runs all tests in the given namespaces."
-  {:example "(run-tests {} 'my-app\test)"}
+  {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
-  (reset! testdox? (:testdox options))
   (reset! fail-fast? (:fail-fast options))
+  (when-let [path (:junit-output options)]
+    (set-junit-output! path))
+  (set-reporters! (resolve-reporters-option options))
+  (fan-out! {:type :begin-test-run})
   (dofor [namespace :in namespaces
           :let [ns-name (name namespace)]
           :when (not (should-stop?))]
-    (run-test options ns-name))
+    (fan-out! {:type :begin-test-ns :ns ns-name})
+    (run-test options ns-name)
+    (fan-out! {:type :end-test-ns :ns ns-name}))
   (print-summary))
 
 (defn reset-stats

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -6,6 +6,8 @@ namespace Phel\Run\Domain\Test;
 
 use Phel\Printer\Printer;
 
+use function is_array;
+use function is_string;
 use function sprintf;
 
 final readonly class TestCommandOptions
@@ -16,10 +18,19 @@ final readonly class TestCommandOptions
 
     public const string FAIL_FAST = 'fail-fast';
 
+    public const string REPORTERS = 'reporters';
+
+    public const string JUNIT_OUTPUT = 'junit-output';
+
+    /**
+     * @param list<string> $reporters
+     */
     private function __construct(
         private ?string $filter,
         private bool $testdox,
         private bool $failFast,
+        private array $reporters,
+        private ?string $junitOutput,
     ) {}
 
     public static function empty(): self
@@ -29,10 +40,27 @@ final readonly class TestCommandOptions
 
     public static function fromArray(array $options): self
     {
+        /** @var list<string> $reporters */
+        $reporters = [];
+        if (isset($options[self::REPORTERS]) && is_array($options[self::REPORTERS])) {
+            foreach ($options[self::REPORTERS] as $reporter) {
+                if (is_string($reporter) && $reporter !== '') {
+                    $reporters[] = $reporter;
+                }
+            }
+        }
+
+        $junitOutput = $options[self::JUNIT_OUTPUT] ?? null;
+        if ($junitOutput === '') {
+            $junitOutput = null;
+        }
+
         return new self(
             $options[self::FILTER] ?? null,
             !empty($options[self::TESTDOX]),
             !empty($options[self::FAIL_FAST]),
+            $reporters,
+            is_string($junitOutput) ? $junitOutput : null,
         );
     }
 
@@ -44,11 +72,26 @@ final readonly class TestCommandOptions
             ? 'nil'
             : $printer->print($this->filter);
 
+        $reportersPart = '';
+        if ($this->reporters !== []) {
+            $reporterKeywords = array_map(
+                static fn(string $name): string => ':' . $name,
+                $this->reporters,
+            );
+            $reportersPart = ' :reporters [' . implode(' ', $reporterKeywords) . ']';
+        }
+
+        $junitPart = $this->junitOutput === null
+            ? ''
+            : ' :junit-output ' . $printer->print($this->junitOutput);
+
         return sprintf(
-            '{:filter %s :testdox %s :fail-fast %s}',
+            '{:filter %s :testdox %s :fail-fast %s%s%s}',
             $filter,
             $printer->print($this->testdox),
             $printer->print($this->failFast),
+            $reportersPart,
+            $junitPart,
         );
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
+use function is_string;
 use function sprintf;
 
 /**
@@ -39,6 +40,10 @@ final class TestCommand extends Command
     private const string OPT_TESTDOX = 'testdox';
 
     private const string OPT_FAIL_FAST = 'fail-fast';
+
+    private const string OPT_REPORTER = 'reporter';
+
+    private const string OPT_OUTPUT = 'output';
 
     protected function configure(): void
     {
@@ -60,12 +65,23 @@ final class TestCommand extends Command
                 self::OPT_TESTDOX,
                 null,
                 InputOption::VALUE_NONE,
-                'Report test execution progress in TestDox format.',
+                'Report test execution progress in TestDox format. Shortcut for --reporter=testdox.',
             )->addOption(
                 self::OPT_FAIL_FAST,
                 null,
                 InputOption::VALUE_NONE,
                 'Stop running tests after the first failure or error.',
+            )->addOption(
+                self::OPT_REPORTER,
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Reporter to emit test events through. Repeatable. Built-ins: default, testdox, dot, tap, junit-xml.',
+                [],
+            )->addOption(
+                self::OPT_OUTPUT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Write the junit-xml reporter to a file instead of stdout.',
             );
     }
 
@@ -159,12 +175,18 @@ final class TestCommand extends Command
 
     private function generatePhelTestCode(InputInterface $input, array $namespacesInformation): string
     {
+        /** @var list<string> $reporters */
+        $reporters = (array) $input->getOption(self::OPT_REPORTER);
+        $output = $input->getOption(self::OPT_OUTPUT);
+
         return sprintf(
             '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
             TestCommandOptions::fromArray([
                 TestCommandOptions::FILTER => (string) $input->getOption(self::OPT_FILTER),
                 TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
                 TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
+                TestCommandOptions::REPORTERS => $reporters,
+                TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
             ])->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );

--- a/tests/phel/test/reporters.phel
+++ b/tests/phel/test/reporters.phel
@@ -1,0 +1,185 @@
+(ns phel-test\test\reporters
+  (:require phel\test :as t :refer [deftest is]))
+
+;; Coverage for the pluggable `report` multimethod and the built-in
+;; reporter implementations shipped with `phel\test`.
+;;
+;; Each test resolves a built-in reporter, feeds it a scripted event
+;; sequence by binding `*reporters*` locally via `set-reporters!`, and
+;; captures the output (or JUnit file) with `with-output-buffer`.
+
+;; ---------------------------------------------------------------------------
+;; Registration + resolution
+;; ---------------------------------------------------------------------------
+
+(deftest test-resolve-built-in-reporters-by-keyword
+  (is (fn? (t/resolve-reporter :default)) "default reporter resolves")
+  (is (fn? (t/resolve-reporter :testdox)) "testdox reporter resolves")
+  (is (fn? (t/resolve-reporter :dot)) "dot reporter resolves")
+  (is (fn? (t/resolve-reporter :tap)) "tap reporter resolves")
+  (is (fn? (t/resolve-reporter :junit-xml)) "junit-xml reporter resolves"))
+
+(deftest test-resolve-built-in-reporters-by-string
+  (is (fn? (t/resolve-reporter "default")) "default resolves by string")
+  (is (fn? (t/resolve-reporter "junit-xml")) "junit-xml resolves by string"))
+
+(deftest test-resolve-unknown-reporter-returns-nil
+  (is (nil? (t/resolve-reporter :does-not-exist))
+      "resolve-reporter returns nil for unknown name"))
+
+(deftest test-register-custom-reporter
+  (let [calls (atom [])
+        _     (t/register-reporter! :captured (fn [event] (swap! calls conj (:type event))))
+        rep   (t/resolve-reporter :captured)]
+    (is (fn? rep) "registered reporter is resolvable")
+    (rep {:type :custom})
+    (is (= [:custom] (deref calls)) "registered reporter receives events")))
+
+;; ---------------------------------------------------------------------------
+;; Multimethod dispatch — report events flow through active reporters
+;; ---------------------------------------------------------------------------
+
+(deftest test-report-fans-out-to-active-reporters
+  (let [events (atom [])
+        saved  (t/get-stats)
+        prev   (t/get-reporters)]
+    (t/set-reporters! [(fn [e] (swap! events conj e))])
+    (t/reset-stats)
+    (t/report {:type :pass :state :pass :message "ok"})
+    (t/report {:type :failed :state :failed :message "boom"})
+    (t/set-reporters! prev)
+    (t/restore-stats saved)
+    (is (= 2 (count (deref events))) "both events fanned out")
+    (is (= :pass (:state (first (deref events)))) "pass state preserved")
+    (is (= :failed (:state (nth (deref events) 1))) "failed state preserved")))
+
+(deftest test-multiple-reporters-receive-events-in-order
+  (let [order  (atom [])
+        prev   (t/get-reporters)
+        saved  (t/get-stats)]
+    (t/set-reporters! [(fn [_] (swap! order conj :a))
+                       (fn [_] (swap! order conj :b))])
+    (t/reset-stats)
+    (t/report {:type :pass :state :pass})
+    (t/set-reporters! prev)
+    (t/restore-stats saved)
+    (is (= [:a :b] (deref order)) "reporters invoked in registration order")))
+
+(deftest test-default-report-method-preserves-event
+  (let [captured (atom nil)
+        prev     (t/get-reporters)
+        saved    (t/get-stats)]
+    (t/set-reporters! [(fn [e] (reset! captured e))])
+    (t/reset-stats)
+    (t/report {:type :my-custom-type :payload 42})
+    (t/set-reporters! prev)
+    (t/restore-stats saved)
+    (is (= :my-custom-type (:type (deref captured)))
+        "unknown event types reach reporters via :default method")
+    (is (= 42 (:payload (deref captured))) "payload flows through untouched")))
+
+;; ---------------------------------------------------------------------------
+;; Dot reporter — compact CI summary
+;; ---------------------------------------------------------------------------
+
+(deftest test-dot-reporter-emits-marker-per-assertion
+  (let [rep (t/resolve-reporter :dot)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :failed :state :failed})
+              (rep {:type :error :state :error})
+              (rep {:type :summary :total 3 :pass 1 :failed 1 :error 1}))]
+    (is (= ".FE\nTests: 3, Passed: 1, Failed: 1, Errors: 1\n" out)
+        "dot reporter prints markers plus one-line summary")))
+
+;; ---------------------------------------------------------------------------
+;; TAP reporter — TAP v13 protocol
+;; ---------------------------------------------------------------------------
+
+(deftest test-tap-reporter-emits-version-and-plan
+  (let [rep (t/resolve-reporter :tap)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :test-name "a" :message "ok"})
+              (rep {:type :failed :state :failed :test-name "b" :message "bad"})
+              (rep {:type :summary :total 2}))]
+    (is (php/preg_match "/^TAP version 13\\n/" out)
+        "starts with TAP version header")
+    (is (php/preg_match "/^ok 1 - a: ok$/m" out)
+        "emits ok line for passing assertion")
+    (is (php/preg_match "/^not ok 2 - b: bad$/m" out)
+        "emits not ok line for failing assertion")
+    (is (php/preg_match "/^1\\.\\.2$/m" out)
+        "emits 1..N plan after summary")))
+
+;; ---------------------------------------------------------------------------
+;; JUnit-XML reporter — <testsuites>/<testsuite>/<testcase>
+;; ---------------------------------------------------------------------------
+
+(deftest test-junit-xml-reporter-writes-valid-shape
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "sample.ns"})
+    (rep {:type :pass :state :pass :test-name "t1" :message "ok"
+          :location {:file "a.phel" :line 1}})
+    (rep {:type :failed :state :failed :test-name "t2" :message "bad"
+          :form "(= 1 2)"
+          :location {:file "a.phel" :line 2}})
+    (rep {:type :end-test-ns :ns "sample.ns"})
+    (rep {:type :summary :total 2 :pass 1 :failed 1 :error 0})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/preg_match "/^<\\?xml version=\"1\\.0\"/" xml)
+          "emits XML declaration")
+      (is (php/preg_match "/<testsuites tests=\"2\"/" xml)
+          "root element carries aggregate test count")
+      (is (php/preg_match "/<testsuite name=\"sample.ns\"/" xml)
+          "contains testsuite for the namespace")
+      (is (php/preg_match "/<testcase name=\"t2\"/" xml)
+          "failing testcase present")
+      (is (php/preg_match "/<failure /" xml)
+          "failing testcase has <failure> child"))
+    (php/unlink path)))
+
+(deftest test-junit-xml-reporter-escapes-xml-special-characters
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "ns<&>\"'"})
+    (rep {:type :failed :state :failed :test-name "x"
+          :message "a < b & c > d"
+          :form "(= \"<x>\" \"&y;\")"
+          :location {:file "f.phel" :line 1}})
+    (rep {:type :end-test-ns :ns "ns<&>\"'"})
+    (rep {:type :summary :total 1})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/preg_match "/ns&lt;&amp;&gt;&quot;&apos;/" xml)
+          "suite name escapes all five XML special characters")
+      (is (php/preg_match "/a &lt; b &amp; c &gt; d/" xml)
+          "failure message escapes angle brackets and ampersands"))
+    (php/unlink path)))
+
+;; ---------------------------------------------------------------------------
+;; Default reporter — legacy dot output plus summary block
+;; ---------------------------------------------------------------------------
+
+(deftest test-default-reporter-matches-legacy-output
+  (let [rep (t/resolve-reporter :default)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :pass :state :pass})
+              (rep {:type :failed :state :failed :form "(= 1 2)"
+                    :type :binary :pred '= :expected 1 :actual 2 :result 2
+                    :message "boom"})
+              (rep {:type :summary :total 3 :pass 2 :failed 1 :error 0
+                    :failures []}))]
+    (is (php/preg_match "/\\.\\.F/" out) "emits marker sequence")
+    (is (php/preg_match "/Passed: 2/" out) "prints Passed count")
+    (is (php/preg_match "/Failed: 1/" out) "prints Failed count")
+    (is (php/preg_match "/Total: 3/" out) "prints Total count")))

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -57,4 +57,60 @@ final class TestCommandOptionsTest extends TestCase
 
         self::assertSame('{:filter nil :testdox false :fail-fast true}', $options->asPhelHashMap());
     }
+
+    public function test_single_reporter(): void
+    {
+        $options = TestCommandOptions::fromArray(['reporters' => ['dot']]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :reporters [:dot]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_multiple_reporters(): void
+    {
+        $options = TestCommandOptions::fromArray(['reporters' => ['dot', 'junit-xml']]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :reporters [:dot :junit-xml]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_reporters_filter_out_empty_strings(): void
+    {
+        $options = TestCommandOptions::fromArray(['reporters' => ['dot', '', 'tap']]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :reporters [:dot :tap]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_junit_output_emitted_when_path_is_set(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            'reporters' => ['junit-xml'],
+            'junit-output' => 'build/junit.xml',
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :reporters [:junit-xml] :junit-output "build/junit.xml"}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_junit_output_empty_string_is_ignored(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            'reporters' => ['junit-xml'],
+            'junit-output' => '',
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :reporters [:junit-xml]}',
+            $options->asPhelHashMap(),
+        );
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Clojure-parity roadmap Tier 2 item #7. `phel\test/report` was a closed function, forcing any CI or editor integration to patch the test runtime to get JUnit-XML, TAP, or dot output. Custom formatters were impossible without editing `src/phel/test.phel`.

## 💡 Goal

Make the reporter surface pluggable: one multimethod dispatched on event `:type`, a dynamic registry of active reporters, and a small set of built-ins that cover CI (junit-xml), protocol (tap), and minimal (dot) use cases. Users can register their own with `defmethod report :custom` or `register-reporter!`.

## 🔖 Changes

- `phel\test/report` is now a multimethod on event `:type` (`:pass`, `:failed`, `:error`, `:begin-test-run`, `:begin-test-ns`, `:end-test-ns`, `:summary`, plus user-defined keys)
- Built-in reporters ship under keyword names: `:default` (legacy dot output + summary), `:testdox`, `:dot`, `:tap`, `:junit-xml`
- Multiple reporters fan out in registration order via `set-reporters!`/`add-reporter!`/`clear-reporters!`
- `./bin/phel test --reporter=<name>` is repeatable; `--output=<path>` writes the junit-xml reporter to a file; `--testdox` preserved as shortcut for `--reporter=testdox`
- `phel\test/register-reporter!` lets user code attach custom reporters under a keyword name
- New Phel tests in `tests/phel/test/reporters.phel` cover multimethod dispatch, reporter ordering, output shape per built-in, and XML escaping
- `TestCommandOptions` gains `REPORTERS` and `JUNIT_OUTPUT` constants; `asPhelHashMap` threads the reporter list as a vector of keywords and the output path as a string
- `CHANGELOG.md` gets a `Testing` entry under `Unreleased`