### PR TITLE
Add test selectors and tags to phel test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 #### Testing
 - `phel\test/report` is a multimethod dispatching on event `:type`; extend with `defmethod report :custom [event] ...`
 - Built-in reporters: `default`, `testdox`, `dot`, `tap`, `junit-xml`; select via `phel test --reporter=<name>` (repeatable); `--output=path` writes the junit-xml reporter to a file
+- `phel test` metadata-based selectors: `--include=<tag>`, `--exclude=<tag>`, `--ns=<glob>`, `--filter=<regex>` (all repeatable); tag tests via `^:integration` or `^{:tags [:integration :slow]}`; skipped tests emit a `:skipped` event and appear in the summary count
 
 #### Modules
 - `phel\test\gen`: generators, `sample`, `quick-check`, `defspec` with seedable PRNG

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -418,17 +418,30 @@ final class PharBuilder
         $excludeFiles = $this->excludeFiles;
         $excludeExtensions = $this->excludeExtensions;
         $versionedDocPattern = $this->versionedDocPattern;
+        $rootLen = \strlen($this->root);
 
         $filter = static function ($current) use (
             $excludeDirMap,
             $excludeFiles,
             $excludeExtensions,
             $versionedDocPattern,
+            $rootLen,
         ): bool {
             $basename = $current->getBasename();
 
             if ($current->isDir()) {
-                return !isset($excludeDirMap[$basename]);
+                if (!isset($excludeDirMap[$basename])) {
+                    return true;
+                }
+
+                // `src/phel/test/` is a stdlib source tree (phel\test\gen,
+                // phel\test\selector). Keep it despite the generic 'test' exclude.
+                $relative = str_replace('\\', '/', substr($current->getPathname(), $rootLen));
+                if ($basename === 'test' && str_starts_with($relative, '/src/phel/')) {
+                    return true;
+                }
+
+                return false;
             }
 
             if (isset($excludeFiles[$basename])) {

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -3,7 +3,8 @@
   (:use Phel\Lang\SourceLocationInterface)
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Command\CommandFacade)
-  (:require phel\string :as s))
+  (:require phel\string :as s)
+  (:require phel\test\selector :as selector))
 
 ;; ------
 ;; Report
@@ -18,9 +19,11 @@
   [])
 
 (def- stats (atom {:failed []
+                  :skipped []
                   :counts {:failed 0
                            :error 0
                            :pass 0
+                           :skipped 0
                            :total 0}}))
 
 ;; Dynamic registry of active reporter functions. Each reporter is a
@@ -158,10 +161,21 @@
 (defmethod report :thrown         [data] (handle-assertion-like data))
 (defmethod report :thrown-with-msg [data] (handle-assertion-like data))
 
+(defn- record-skip! [data]
+  (swap! stats
+         (fn [s]
+           (let [counts (get s :counts)
+                 counts (assoc counts :skipped (inc (get counts :skipped)))
+                 s      (assoc s :counts counts)]
+             (assoc s :skipped (conj (get s :skipped) data))))))
+
 (defmethod report :begin-test-ns   [data] (fan-out! data))
 (defmethod report :end-test-ns     [data] (fan-out! data))
 (defmethod report :begin-test-run  [data] (fan-out! data))
 (defmethod report :summary         [data] (fan-out! data))
+(defmethod report :skipped         [data]
+  (record-skip! data)
+  (fan-out! data))
 
 (defmethod report :default [data]
   (fan-out! (decorate-event data)))
@@ -369,16 +383,24 @@
 ;; --------------
 
 (defmacro deftest
-  "Defines a test function."
+  "Defines a test function.
+
+  Metadata attached to `test-name` is forwarded to the defined function
+  so selectors can inspect it at runtime. `^:integration` (shorthand
+  for `{:integration true}`) and `^{:tags [:integration :slow]}`
+  multi-tag maps are both honoured."
   {:example "(deftest test-add)"}
   [test-name & body]
   (when-not (symbol? test-name)
     (throw (php/new \InvalidArgumentException
                     (str "deftest requires a symbol name as its first argument, got "
                          (type test-name) ". Example: (deftest test-add ...)."))))
-  `(defn ~test-name {:test true :test-name ~(name test-name)} []
-     (binding [*current-test-name* ~(name test-name)]
-       ~@body)))
+  (let [sym-meta (or (php/-> test-name (getMeta)) {})
+        base     {:test true :test-name (name test-name)}
+        merged   (merge sym-meta base)]
+    `(defn ~test-name ~merged []
+       (binding [*current-test-name* ~(name test-name)]
+         ~@body))))
 
 (defmacro testing
   "Adds a testing context string. Used inside deftest to describe a group of assertions.
@@ -523,7 +545,7 @@
 (defn- default-reporter
   "Human-readable dot output. Preserves the legacy behavior: `.` for
   pass, `F` for fail, `E` for error, plus periodic newlines so long
-  runs wrap at 80 columns."
+  runs wrap at 80 columns. `S` marks a skipped test."
   [event]
   (let [type (:type event)]
     (cond
@@ -535,6 +557,11 @@
             ch    (case state :failed "F" :error "E" ".")
             n     (swap! default-line-count inc)]
         (print ch)
+        (when (= 0 (% n 80)) (println)))
+
+      (= type :skipped)
+      (let [n (swap! default-line-count inc)]
+        (print "S")
         (when (= 0 (% n 80)) (println)))
 
       (= type :summary)
@@ -550,6 +577,8 @@
         (println "Passed:" (:pass event))
         (println "Failed:" (:failed event))
         (println "Error:" (:error event))
+        (when (pos? (or (:skipped event) 0))
+          (println "Skipped:" (:skipped event)))
         (println "Total:" (:total event))))))
 
 (defn- testdox-reporter
@@ -565,6 +594,10 @@
             msg     (or (:message event) "no test message found")]
         (println marker (str tname ": " msg)))
 
+      (= type :skipped)
+      (let [tname (or (:test-name event) "")]
+        (println "↷" (str tname " (skipped)")))
+
       (= type :summary)
       (do
         (println)
@@ -578,6 +611,8 @@
         (println "Passed:" (:pass event))
         (println "Failed:" (:failed event))
         (println "Error:" (:error event))
+        (when (pos? (or (:skipped event) 0))
+          (println "Skipped:" (:skipped event)))
         (println "Total:" (:total event))))))
 
 ;; -------------
@@ -586,8 +621,8 @@
 
 (defn- dot-reporter
   "Minimal CI-friendly reporter. Prints `.` per pass, `F` per failure,
-  `E` per error and a compact one-line summary at the end. Does not
-  print failure/error diagnostics."
+  `E` per error, `S` per skipped test, and a compact one-line summary
+  at the end. Does not print failure/error diagnostics."
   [event]
   (let [type (:type event)]
     (cond
@@ -595,13 +630,20 @@
       (let [state (:state event)]
         (print (case state :failed "F" :error "E" ".")))
 
+      (= type :skipped)
+      (print "S")
+
       (= type :summary)
       (do
         (println)
-        (println (str "Tests: " (:total event)
-                      ", Passed: " (:pass event)
-                      ", Failed: " (:failed event)
-                      ", Errors: " (:error event)))))))
+        (let [skipped (or (:skipped event) 0)
+              base    (str "Tests: " (:total event)
+                           ", Passed: " (:pass event)
+                           ", Failed: " (:failed event)
+                           ", Errors: " (:error event))]
+          (if (pos? skipped)
+            (println (str base ", Skipped: " skipped))
+            (println base)))))))
 
 ;; -------------
 ;; TAP reporter
@@ -876,16 +918,20 @@
   event at the end of the run."
   {:example "(print-summary)"}
   []
-  (let [snapshot                                 (deref stats)
-        {:failed failed :error error :pass pass} (get snapshot :counts)
-        failures                                 (get snapshot :failed)
-        total                                    (+ failed error pass)
-        event                                    {:type :summary
-                                                  :failures failures
-                                                  :pass pass
-                                                  :failed failed
-                                                  :error error
-                                                  :total total}]
+  (let [snapshot (deref stats)
+        {:failed failed :error error :pass pass :skipped skipped}
+        (get snapshot :counts)
+        failures (get snapshot :failed)
+        skips    (get snapshot :skipped)
+        total    (+ failed error pass)
+        event    {:type :summary
+                  :failures failures
+                  :skips skips
+                  :pass pass
+                  :failed failed
+                  :error error
+                  :skipped (or skipped 0)
+                  :total total}]
     (fan-out! event)))
 
 ;; --------
@@ -945,23 +991,79 @@
 ;; Running tests
 ;; -------------
 
-(defn- find-test-fns [ns {:filter filter}]
+(defn- legacy-filter-matches?
+  "Back-compat: the original `--filter` option accepted a single
+  substring matched against the test name. When selectors are also
+  active, this check still applies so existing callers keep behaving."
+  [filter-value test-name]
+  (or (nil? filter-value)
+      (s/contains? (or test-name "") filter-value)))
+
+(defn- find-test-vars
+  "Discovers every `deftest`-defined function in `ns` and returns a
+  vector of `{:fn <callable> :meta <map>}` entries. The caller is
+  responsible for applying selectors."
+  [ns]
   (let [munge    (php/new Munge)
         munge-ns (php/-> munge (encodeNs ns))]
-    (for [fn-name :keys (php/:: Phel (getDefinitionInNamespace munge-ns))
-          :let [meta (php/:: Phel (getDefinitionMetaData munge-ns fn-name))]
-          :when (and (:test meta) (or (nil? filter) (s/contains? (:test-name meta) filter)))]
-      (php/:: Phel (getDefinition munge-ns fn-name)))))
+    (vec (for [fn-name :keys (php/:: Phel (getDefinitionInNamespace munge-ns))
+               :let [meta (php/:: Phel (getDefinitionMetaData munge-ns fn-name))]
+               :when (:test meta)]
+           {:fn   (php/:: Phel (getDefinition munge-ns fn-name))
+            :meta meta}))))
+
+(defn- selector-options
+  "Extracts the selector subset from the full options map."
+  [options]
+  {:include     (:include options)
+   :exclude     (:exclude options)
+   :ns-patterns (:ns-patterns options)
+   :filters     (:filters options)})
+
+(defn- partition-tests
+  "Splits the discovered tests into a `{:keep [...] :skip [...]}` map
+  using the selector options. `:keep` preserves original order; each
+  `:skip` entry is annotated with its metadata so reporters can surface
+  skip events."
+  [options ns-name tests]
+  (let [sel-opts  (selector-options options)
+        filter-v  (:filter options)]
+    (reduce
+     (fn [acc {:fn f :meta m}]
+       (cond
+         (not (legacy-filter-matches? filter-v (:test-name m)))
+         (update acc :skip conj {:fn f :meta m :reason :filtered})
+
+         (not (selector/keep-test? sel-opts ns-name m))
+         (update acc :skip conj {:fn f :meta m :reason :selector})
+
+         :else
+         (update acc :keep conj {:fn f :meta m})))
+     {:keep [] :skip []}
+     tests)))
+
+(defn- emit-skip-events! [ns-name skipped]
+  (dofor [{:meta m :reason reason} :in skipped]
+    (report {:type :skipped
+             :ns ns-name
+             :test-name (:test-name m)
+             :reason reason
+             :tags (:tags m)})))
 
 (defn- run-test [options ns]
-  (let [tests     (find-test-fns ns options)
+  (let [all-tests (find-test-vars ns)
+        parts     (partition-tests options ns all-tests)
+        keeps     (:keep parts)
+        skips     (:skip parts)
         each-wrap (join-fixtures (fixtures-for ns :each-fixtures))
         once-wrap (join-fixtures (fixtures-for ns :once-fixtures))]
-    (once-wrap
-     (fn []
-       (dofor [test :in tests
-               :when (not (should-stop?))]
-         (each-wrap test))))))
+    (emit-skip-events! ns skips)
+    (when-not (empty? keeps)
+      (once-wrap
+       (fn []
+         (dofor [{:fn f} :in keeps
+                 :when (not (should-stop?))]
+           (each-wrap f)))))))
 
 (defn- resolve-reporters-option
   "Resolves the `:reporters` option into a vector of reporter functions.
@@ -1003,9 +1105,11 @@
   {:example "(reset-stats)"}
   []
   (reset! stats {:failed []
+                 :skipped []
                  :counts {:failed 0
                           :error 0
                           :pass 0
+                          :skipped 0
                           :total 0}}))
 
 (defn successful?

--- a/src/phel/test/selector.phel
+++ b/src/phel/test/selector.phel
@@ -1,0 +1,230 @@
+(ns phel\test\selector)
+
+;; Pure test-selection helpers used by `phel\test/run-tests` to filter the
+;; set of test vars that will actually be invoked for a run. All functions
+;; are side-effect-free: they accept a normalized option map and a
+;; metadata map for a single test, and return booleans. Composition is
+;; done by `keep-test?`, which applies every gate that was actually
+;; specified — omitted selectors are no-ops.
+;;
+;; Selector rules implemented here:
+;;
+;;   * `:include` — vector of tag names (strings or keywords). If empty,
+;;     no restriction. Otherwise match when ANY tag in the vector is
+;;     truthy on the test's metadata (OR semantics).
+;;   * `:exclude` — vector of tag names. If ANY tag in the vector is
+;;     truthy on the test's metadata, the test is dropped. Exclude wins
+;;     over include.
+;;   * `:ns-patterns` — vector of glob patterns matched against the
+;;     test's namespace name. If empty, no restriction. Otherwise match
+;;     when ANY pattern matches (OR semantics).
+;;   * `:filters` — vector of regex patterns matched against the test's
+;;     name. If empty, no restriction. Otherwise match when ANY regex
+;;     matches (OR semantics).
+;;
+;; Every selector that is specified must pass (AND across selectors).
+
+;; ---------------------------------------------------------------------------
+;; Tag extraction
+;; ---------------------------------------------------------------------------
+
+(defn- tag-key
+  "Coerces a selector tag (keyword or string) into the keyword form used
+  to look up metadata. Returns `nil` for other inputs."
+  [tag]
+  (cond
+    (keyword? tag) tag
+    (string? tag)  (keyword tag)
+    :else          nil))
+
+(defn- truthy-tag?
+  "True when `meta` contains a truthy value at `kw`. Also accepts
+  vector-valued `:tags` metadata, checking membership by keyword."
+  [meta kw]
+  (let [direct (get meta kw)
+        tags   (get meta :tags)]
+    (or (and (not (nil? direct)) (not (false? direct)))
+        (and (vector? tags)
+             (truthy? (some (fn [t] (= kw (tag-key t))) tags))))))
+
+(defn has-tag?
+  "Returns `true` when `meta` carries `tag` (a keyword or a string
+  treated as a keyword). Single-keyword metadata (`^:integration`) and
+  map-based multi-tag metadata (`^{:tags [:integration :slow]}`) both
+  match."
+  {:example "(has-tag? {:integration true} :integration)"
+   :see-also ["matches-include?" "matches-exclude?"]}
+  [meta tag]
+  (let [kw (tag-key tag)]
+    (and (not (nil? kw))
+         (truthy-tag? meta kw))))
+
+;; ---------------------------------------------------------------------------
+;; Include / exclude by tag
+;; ---------------------------------------------------------------------------
+
+(defn matches-include?
+  "Returns `true` when `includes` is empty (no restriction) or when any
+  tag in `includes` is truthy on `meta`."
+  {:example "(matches-include? [:integration] {:integration true})"
+   :see-also ["matches-exclude?" "keep-test?"]}
+  [includes meta]
+  (or (nil? includes)
+      (empty? includes)
+      (truthy? (some (fn [tag] (has-tag? meta tag)) includes))))
+
+(defn matches-exclude?
+  "Returns `true` when any tag in `excludes` is truthy on `meta`. An
+  empty or nil `excludes` vector always returns `false` (nothing
+  excluded)."
+  {:example "(matches-exclude? [:slow] {:slow true})"
+   :see-also ["matches-include?" "keep-test?"]}
+  [excludes meta]
+  (and (not (nil? excludes))
+       (not (empty? excludes))
+       (truthy? (some (fn [tag] (has-tag? meta tag)) excludes))))
+
+;; ---------------------------------------------------------------------------
+;; Namespace glob matching
+;; ---------------------------------------------------------------------------
+
+(defn- glob->regex
+  "Converts a namespace glob (`phel.http.*`) into an anchored PCRE
+  pattern. `.` is treated literally, `*` matches any run of non-`.`
+  characters, `**` matches anything. The glob is case-sensitive."
+  [pattern]
+  (let [len   (php/strlen pattern)
+        out   (atom "")
+        i     (atom 0)]
+    (loop []
+      (when (< (deref i) len)
+        (let [ch (php/substr pattern (deref i) 1)]
+          (cond
+            ;; `**` expands to `.*` (matches anything, including dots).
+            (and (= ch "*")
+                 (< (+ (deref i) 1) len)
+                 (= (php/substr pattern (+ (deref i) 1) 1) "*"))
+            (do (swap! out str ".*")
+                (swap! i + 2))
+
+            ;; `*` expands to `[^.]*` (single segment).
+            (= ch "*")
+            (do (swap! out str "[^.]*")
+                (swap! i + 1))
+
+            ;; `.` is escaped to match a literal dot.
+            (= ch ".")
+            (do (swap! out str "\\.")
+                (swap! i + 1))
+
+            ;; Any other regex meta-char is escaped; plain chars pass
+            ;; through untouched.
+            :else
+            (do (swap! out str (php/preg_quote ch))
+                (swap! i + 1))))
+        (recur)))
+    (str "/^" (deref out) "$/")))
+
+(defn- normalize-ns
+  "Normalizes a namespace name so both `phel\\test\\foo` and
+  `phel.test.foo` are interchangeable for glob matching."
+  [ns-name]
+  (when (not (nil? ns-name))
+    (php/str_replace "\\" "." (str ns-name))))
+
+(defn ns-matches?
+  "Returns `true` when `ns-name` matches the glob `pattern`. Supports
+  `*` (single segment) and `**` (any run). Backslash-separated
+  namespaces (`phel\\http\\client`) are treated as dotted
+  (`phel.http.client`) so globs stay portable."
+  {:example "(ns-matches? \"phel.http.*\" \"phel\\\\http\\\\client\")"
+   :see-also ["matches-ns?"]}
+  [pattern ns-name]
+  (and (not (nil? pattern))
+       (not (nil? ns-name))
+       (= 1 (php/preg_match (glob->regex (normalize-ns pattern))
+                            (normalize-ns ns-name)))))
+
+(defn matches-ns?
+  "Returns `true` when `patterns` is empty (no restriction) or when any
+  glob in `patterns` matches `ns-name`."
+  {:example "(matches-ns? [\"phel.http.*\"] \"phel.http.client\")"
+   :see-also ["ns-matches?" "keep-test?"]}
+  [patterns ns-name]
+  (or (nil? patterns)
+      (empty? patterns)
+      (truthy? (some (fn [p] (ns-matches? p ns-name)) patterns))))
+
+;; ---------------------------------------------------------------------------
+;; Name-regex matching
+;; ---------------------------------------------------------------------------
+
+(defn- compile-filter-regex
+  "Wraps a user-supplied regex body in PCRE delimiters when it is not
+  already a `/.../` pattern. Treats bare fragments as substring
+  matchers."
+  [pattern]
+  (if (and (string? pattern)
+           (> (php/strlen pattern) 1)
+           (= (php/substr pattern 0 1) "/")
+           (= (php/substr pattern (- (php/strlen pattern) 1) 1) "/"))
+    pattern
+    (str "/" (php/preg_quote pattern "/") "/")))
+
+(defn name-matches?
+  "Returns `true` when `pattern` (a PCRE `/.../` string or a plain
+  substring) matches `test-name`."
+  {:example "(name-matches? \"add-\" \"test-add-one\")"
+   :see-also ["matches-filter?"]}
+  [pattern test-name]
+  (and (not (nil? pattern))
+       (not (nil? test-name))
+       (= 1 (php/preg_match (compile-filter-regex pattern) test-name))))
+
+(defn matches-filter?
+  "Returns `true` when `patterns` is empty (no restriction) or when any
+  entry in `patterns` matches `test-name`."
+  {:example "(matches-filter? [\"add-\"] \"test-add-one\")"
+   :see-also ["name-matches?" "keep-test?"]}
+  [patterns test-name]
+  (or (nil? patterns)
+      (empty? patterns)
+      (truthy? (some (fn [p] (name-matches? p test-name)) patterns))))
+
+;; ---------------------------------------------------------------------------
+;; Composed predicate
+;; ---------------------------------------------------------------------------
+
+(defn keep-test?
+  "Returns `true` when the test described by `meta` and `ns-name`
+  should be run under `options`. `options` is a map that may carry any
+  of `:include`, `:exclude`, `:ns-patterns`, `:filters`. Selectors that
+  are absent or empty impose no restriction; specified selectors are
+  AND'd together."
+  {:example "(keep-test? {:include [:integration]} \"my.ns\" {:integration true :test-name \"t\"})"
+   :see-also ["matches-include?" "matches-exclude?" "matches-ns?" "matches-filter?"]}
+  [options ns-name meta]
+  (let [includes    (get options :include)
+        excludes    (get options :exclude)
+        ns-patterns (get options :ns-patterns)
+        filters     (get options :filters)
+        tname       (get meta :test-name)]
+    (and (matches-include? includes meta)
+         (not (matches-exclude? excludes meta))
+         (matches-ns? ns-patterns ns-name)
+         (matches-filter? filters tname))))
+
+(defn has-selectors?
+  "Returns `true` when `options` contains at least one non-empty
+  selector key."
+  {:example "(has-selectors? {:include [:integration]})"
+   :see-also ["keep-test?"]}
+  [options]
+  (or (and (not (nil? (get options :include)))
+           (not (empty? (get options :include))))
+      (and (not (nil? (get options :exclude)))
+           (not (empty? (get options :exclude))))
+      (and (not (nil? (get options :ns-patterns)))
+           (not (empty? (get options :ns-patterns))))
+      (and (not (nil? (get options :filters)))
+           (not (empty? (get options :filters))))))

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -22,8 +22,20 @@ final readonly class TestCommandOptions
 
     public const string JUNIT_OUTPUT = 'junit-output';
 
+    public const string INCLUDE = 'include';
+
+    public const string EXCLUDE = 'exclude';
+
+    public const string NS_PATTERNS = 'ns-patterns';
+
+    public const string FILTERS = 'filters';
+
     /**
      * @param list<string> $reporters
+     * @param list<string> $filters
+     * @param list<string> $includes
+     * @param list<string> $excludes
+     * @param list<string> $nsPatterns
      */
     private function __construct(
         private ?string $filter,
@@ -31,6 +43,10 @@ final readonly class TestCommandOptions
         private bool $failFast,
         private array $reporters,
         private ?string $junitOutput,
+        private array $includes,
+        private array $excludes,
+        private array $nsPatterns,
+        private array $filters,
     ) {}
 
     public static function empty(): self
@@ -41,14 +57,7 @@ final readonly class TestCommandOptions
     public static function fromArray(array $options): self
     {
         /** @var list<string> $reporters */
-        $reporters = [];
-        if (isset($options[self::REPORTERS]) && is_array($options[self::REPORTERS])) {
-            foreach ($options[self::REPORTERS] as $reporter) {
-                if (is_string($reporter) && $reporter !== '') {
-                    $reporters[] = $reporter;
-                }
-            }
-        }
+        $reporters = self::normalizeStringList($options[self::REPORTERS] ?? null);
 
         $junitOutput = $options[self::JUNIT_OUTPUT] ?? null;
         if ($junitOutput === '') {
@@ -61,6 +70,10 @@ final readonly class TestCommandOptions
             !empty($options[self::FAIL_FAST]),
             $reporters,
             is_string($junitOutput) ? $junitOutput : null,
+            self::normalizeStringList($options[self::INCLUDE] ?? null),
+            self::normalizeStringList($options[self::EXCLUDE] ?? null),
+            self::normalizeStringList($options[self::NS_PATTERNS] ?? null),
+            self::normalizeStringList($options[self::FILTERS] ?? null),
         );
     }
 
@@ -85,13 +98,76 @@ final readonly class TestCommandOptions
             ? ''
             : ' :junit-output ' . $printer->print($this->junitOutput);
 
+        $includesPart = $this->keywordVector(':include', $this->includes);
+        $excludesPart = $this->keywordVector(':exclude', $this->excludes);
+        $nsPart = $this->stringVector(':ns-patterns', $this->nsPatterns);
+        $filtersPart = $this->stringVector(':filters', $this->filters);
+
         return sprintf(
-            '{:filter %s :testdox %s :fail-fast %s%s%s}',
+            '{:filter %s :testdox %s :fail-fast %s%s%s%s%s%s%s}',
             $filter,
             $printer->print($this->testdox),
             $printer->print($this->failFast),
             $reportersPart,
             $junitPart,
+            $includesPart,
+            $excludesPart,
+            $nsPart,
+            $filtersPart,
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function normalizeStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $item) {
+            if (is_string($item) && $item !== '') {
+                $result[] = $item;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function keywordVector(string $key, array $values): string
+    {
+        if ($values === []) {
+            return '';
+        }
+
+        $keywords = array_map(
+            static fn(string $name): string => ':' . $name,
+            $values,
+        );
+
+        return ' ' . $key . ' [' . implode(' ', $keywords) . ']';
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function stringVector(string $key, array $values): string
+    {
+        if ($values === []) {
+            return '';
+        }
+
+        $printer = Printer::readable();
+        $printed = array_map(
+            $printer->print(...),
+            $values,
+        );
+
+        return ' ' . $key . ' [' . implode(' ', $printed) . ']';
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -45,6 +45,12 @@ final class TestCommand extends Command
 
     private const string OPT_OUTPUT = 'output';
 
+    private const string OPT_INCLUDE = 'include';
+
+    private const string OPT_EXCLUDE = 'exclude';
+
+    private const string OPT_NS = 'ns';
+
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
@@ -59,8 +65,9 @@ final class TestCommand extends Command
             )->addOption(
                 self::OPT_FILTER,
                 'f',
-                InputOption::VALUE_OPTIONAL,
-                'Filter by test names.',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                "Regex or substring matched against test names. Repeatable; matches are OR'd.",
+                [],
             )->addOption(
                 self::OPT_TESTDOX,
                 null,
@@ -82,6 +89,24 @@ final class TestCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Write the junit-xml reporter to a file instead of stdout.',
+            )->addOption(
+                self::OPT_INCLUDE,
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                "Tag name (e.g. integration). Only tests carrying this tag run. Repeatable; tags are OR'd.",
+                [],
+            )->addOption(
+                self::OPT_EXCLUDE,
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Tag name (e.g. slow). Tests carrying this tag are skipped. Repeatable; wins over --include.',
+                [],
+            )->addOption(
+                self::OPT_NS,
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                "Namespace glob (e.g. phel.http.*). Repeatable; globs are OR'd. `*` matches one segment, `**` any.",
+                [],
             );
     }
 
@@ -178,15 +203,27 @@ final class TestCommand extends Command
         /** @var list<string> $reporters */
         $reporters = (array) $input->getOption(self::OPT_REPORTER);
         $output = $input->getOption(self::OPT_OUTPUT);
+        /** @var list<string> $filters */
+        $filters = (array) $input->getOption(self::OPT_FILTER);
+        /** @var list<string> $includes */
+        $includes = (array) $input->getOption(self::OPT_INCLUDE);
+        /** @var list<string> $excludes */
+        $excludes = (array) $input->getOption(self::OPT_EXCLUDE);
+        /** @var list<string> $nsPatterns */
+        $nsPatterns = (array) $input->getOption(self::OPT_NS);
 
         return sprintf(
             '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
             TestCommandOptions::fromArray([
-                TestCommandOptions::FILTER => (string) $input->getOption(self::OPT_FILTER),
+                TestCommandOptions::FILTER => null,
                 TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
                 TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
                 TestCommandOptions::REPORTERS => $reporters,
                 TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
+                TestCommandOptions::INCLUDE => $includes,
+                TestCommandOptions::EXCLUDE => $excludes,
+                TestCommandOptions::NS_PATTERNS => $nsPatterns,
+                TestCommandOptions::FILTERS => $filters,
             ])->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );

--- a/tests/phel/test/fixtures/tagged-tests.phel
+++ b/tests/phel/test/fixtures/tagged-tests.phel
@@ -1,0 +1,19 @@
+(ns phel-test\test\fixtures\tagged-tests
+  (:require phel\test :refer [deftest is]))
+
+;; Fixture namespace consumed by `tests/phel/test/selectors-runtime.phel`.
+;;
+;; Three tests with varied metadata shapes cover the selector surface:
+;; a single-keyword unit tag, a single-keyword integration tag, and a
+;; multi-tag map form. None of the assertions ever fail — the
+;; runtime-selector tests inspect which tests ran vs were skipped, not
+;; the outcome.
+
+(deftest ^:unit fixture-unit-passes
+  (is (= 1 1) "unit fixture assertion"))
+
+(deftest ^:integration fixture-integration-passes
+  (is (= 2 2) "integration fixture assertion"))
+
+(deftest ^{:tags [:integration :slow]} fixture-slow-integration-passes
+  (is (= 3 3) "slow integration fixture assertion"))

--- a/tests/phel/test/selectors-runtime.phel
+++ b/tests/phel/test/selectors-runtime.phel
@@ -1,0 +1,160 @@
+(ns phel-test\test\selectors-runtime
+  (:require phel\test :as t :refer [deftest is testing])
+  (:require phel-test\test\fixtures\tagged-tests))
+
+;; End-to-end coverage for selectors in `run-tests`.
+;;
+;; The fixture namespace `phel-test\test\fixtures\tagged-tests` defines
+;; three tests with distinct metadata shapes. Each scenario runs that
+;; namespace with a scripted option map, captures every emitted event
+;; (via a temporary reporter), then restores the outer suite's stats
+;; and reporter set.
+
+(def- fixture-ns 'phel-test\test\fixtures\tagged-tests)
+
+(defn- snapshot-run [options]
+  (let [saved-reporters (t/get-reporters)
+        saved-stats     (t/get-stats)
+        events          (atom [])
+        capture         (fn [e] (swap! events conj e))
+        run-options     (assoc options :reporters
+                               (conj (vec (:reporters options)) capture))]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests run-options fixture-ns))
+    (let [snapshot (t/get-stats)]
+      (t/set-reporters! saved-reporters)
+      (t/restore-stats saved-stats)
+      {:events (deref events)
+       :stats  snapshot})))
+
+(defn- events-of [events type]
+  (vec (for [e :in events :when (= type (:type e))] e)))
+
+(defn- skipped-names [events]
+  (vec (for [e :in (events-of events :skipped)] (:test-name e))))
+
+(defn- passing-count [events]
+  (count (for [e :in events :when (and (= :pass (:state e))
+                                       (not= :skipped (:type e)))])))
+
+(defn- names-skipped-set [events]
+  (let [skipped (skipped-names events)]
+    (into (hash-set) skipped)))
+
+;; ---------------------------------------------------------------------------
+;; Baseline: no selectors — every fixture runs, none skipped
+;; ---------------------------------------------------------------------------
+
+(deftest test-run-with-no-selectors-runs-every-fixture
+  (let [{:events events} (snapshot-run {:reporters []})]
+    (is (= 0 (count (skipped-names events))) "no tests are skipped")
+    (is (= 3 (passing-count events))
+        "all three fixtures run and pass")))
+
+;; ---------------------------------------------------------------------------
+;; Include — only fixtures tagged :integration run
+;; ---------------------------------------------------------------------------
+
+(deftest test-include-only-runs-matching-tag
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :include [:integration]})
+        skipped          (names-skipped-set events)]
+    (is (contains? skipped "fixture-unit-passes")
+        "unit-only fixture is skipped")
+    (is (not (contains? skipped "fixture-integration-passes"))
+        "integration fixture is not skipped")
+    (is (not (contains? skipped "fixture-slow-integration-passes"))
+        "tags-vector integration fixture is not skipped")))
+
+;; ---------------------------------------------------------------------------
+;; Exclude — slow fixtures skipped even if included
+;; ---------------------------------------------------------------------------
+
+(deftest test-exclude-wins-over-include
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :include [:integration]
+                                        :exclude [:slow]})
+        skipped          (names-skipped-set events)]
+    (is (contains? skipped "fixture-unit-passes")
+        "unit fixture skipped (not in include)")
+    (is (contains? skipped "fixture-slow-integration-passes")
+        "slow integration fixture skipped (exclude wins)")
+    (is (not (contains? skipped "fixture-integration-passes"))
+        "non-slow integration fixture still runs")))
+
+;; ---------------------------------------------------------------------------
+;; Namespace glob — selector restricts by namespace
+;; ---------------------------------------------------------------------------
+
+(deftest test-ns-glob-skips-everything-when-no-match
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :ns-patterns ["does.not.match.*"]})
+        skipped          (skipped-names events)]
+    (is (= 3 (count skipped))
+        "every fixture is skipped when the ns glob doesn't match")))
+
+(deftest test-ns-glob-keeps-everything-when-match
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :ns-patterns ["phel-test.test.**"]})
+        skipped          (skipped-names events)]
+    (is (= 0 (count skipped))
+        "every fixture runs when the ns glob matches the namespace")))
+
+;; ---------------------------------------------------------------------------
+;; Filter by test name — regex/substring OR semantics
+;; ---------------------------------------------------------------------------
+
+(deftest test-filter-by-name-substring
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :filters ["slow"]})
+        skipped          (names-skipped-set events)]
+    (is (contains? skipped "fixture-unit-passes")
+        "unit fixture skipped (name doesn't match)")
+    (is (contains? skipped "fixture-integration-passes")
+        "integration fixture skipped (name doesn't match)")
+    (is (not (contains? skipped "fixture-slow-integration-passes"))
+        "slow integration fixture runs (name contains 'slow')")))
+
+;; ---------------------------------------------------------------------------
+;; Backwards compat — no selectors behave identical to pre-feature run
+;; ---------------------------------------------------------------------------
+
+(deftest test-backwards-compat-empty-selector-options-ignored
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :include []
+                                        :exclude []
+                                        :ns-patterns []
+                                        :filters []})]
+    (is (= 0 (count (skipped-names events)))
+        "all-empty selector vectors impose no restriction")
+    (is (= 3 (passing-count events))
+        "all fixtures still run")))
+
+;; ---------------------------------------------------------------------------
+;; Skip events carry identifying data
+;; ---------------------------------------------------------------------------
+
+(deftest test-skip-event-carries-test-name-and-reason
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :include [:integration]})
+        skip-events      (events-of events :skipped)
+        unit-skip        (first (for [e :in skip-events
+                                      :when (= "fixture-unit-passes"
+                                               (:test-name e))]
+                                  e))]
+    (is (not (nil? unit-skip)) "skip event emitted for filtered fixture")
+    (is (= :selector (:reason unit-skip))
+        "skip event reason is :selector")))
+
+;; ---------------------------------------------------------------------------
+;; Skip count flows through to the :summary event
+;; ---------------------------------------------------------------------------
+
+(deftest test-summary-includes-skipped-count
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :include [:integration]})
+        summary          (first (events-of events :summary))]
+    (is (not (nil? summary)) "summary event emitted")
+    (is (= 1 (:skipped summary))
+        "summary :skipped reflects filtered-out tests")))

--- a/tests/phel/test/selectors.phel
+++ b/tests/phel/test/selectors.phel
@@ -1,0 +1,214 @@
+(ns phel-test\test\selectors
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\test\selector :as selector))
+
+;; Coverage for the pure test-selection helpers in `phel\test\selector`.
+;;
+;; Every predicate is exercised in isolation using hand-rolled metadata
+;; maps (no macro expansion), so the tests are independent of the
+;; runtime registry. Combined scenarios cover the composition rule:
+;; specified selectors AND together; absent selectors are no-ops.
+
+;; ---------------------------------------------------------------------------
+;; has-tag? — keyword truthy + vector-of-tags metadata
+;; ---------------------------------------------------------------------------
+
+(deftest test-has-tag-keyword-form
+  (is (selector/has-tag? {:integration true} :integration)
+      "keyword metadata set to true reports present")
+  (is (not (selector/has-tag? {:integration false} :integration))
+      "keyword metadata set to false reports absent")
+  (is (not (selector/has-tag? {} :integration))
+      "missing metadata reports absent")
+  (is (not (selector/has-tag? {:other true} :integration))
+      "unrelated metadata reports absent"))
+
+(deftest test-has-tag-string-form-coerced-to-keyword
+  (is (selector/has-tag? {:integration true} "integration")
+      "string tag name is coerced to the matching keyword"))
+
+(deftest test-has-tag-vector-tags-metadata
+  (is (selector/has-tag? {:tags [:integration :slow]} :slow)
+      "tags vector contains the keyword")
+  (is (selector/has-tag? {:tags ["integration" "slow"]} :slow)
+      "tags vector entries compared as keywords")
+  (is (not (selector/has-tag? {:tags [:a :b]} :c))
+      "tags vector without the keyword reports absent"))
+
+;; ---------------------------------------------------------------------------
+;; matches-include?
+;; ---------------------------------------------------------------------------
+
+(deftest test-matches-include-empty-list-includes-all
+  (is (selector/matches-include? [] {:integration true})
+      "empty include list imposes no restriction")
+  (is (selector/matches-include? nil {:integration true})
+      "nil include list imposes no restriction"))
+
+(deftest test-matches-include-or-semantics
+  (is (selector/matches-include? [:integration :slow] {:slow true})
+      "any matching tag passes")
+  (is (not (selector/matches-include? [:integration :slow] {:unit true}))
+      "no matching tag fails"))
+
+;; ---------------------------------------------------------------------------
+;; matches-exclude?
+;; ---------------------------------------------------------------------------
+
+(deftest test-matches-exclude-empty-excludes-nothing
+  (is (not (selector/matches-exclude? [] {:slow true}))
+      "empty exclude list excludes nothing")
+  (is (not (selector/matches-exclude? nil {:slow true}))
+      "nil exclude list excludes nothing"))
+
+(deftest test-matches-exclude-any-tag-wins
+  (is (selector/matches-exclude? [:slow :flaky] {:slow true})
+      "any matching tag excludes")
+  (is (selector/matches-exclude? [:slow :flaky] {:tags [:flaky]})
+      "tags-vector form also excludes"))
+
+;; ---------------------------------------------------------------------------
+;; matches-ns? — glob support
+;; ---------------------------------------------------------------------------
+
+(deftest test-matches-ns-empty-list
+  (is (selector/matches-ns? [] "phel.http.client")
+      "empty patterns list imposes no restriction")
+  (is (selector/matches-ns? nil "phel.http.client")
+      "nil patterns list imposes no restriction"))
+
+(deftest test-matches-ns-exact-match
+  (is (selector/matches-ns? ["phel.http.client"] "phel.http.client")
+      "exact namespace name matches"))
+
+(deftest test-matches-ns-single-segment-wildcard
+  (is (selector/matches-ns? ["phel.http.*"] "phel.http.client")
+      "single-segment wildcard matches immediate child")
+  (is (not (selector/matches-ns? ["phel.http.*"] "phel.http.client.sub"))
+      "single-segment wildcard does not cross dots"))
+
+(deftest test-matches-ns-double-star-wildcard
+  (is (selector/matches-ns? ["phel.http.**"] "phel.http.client")
+      "double-star matches immediate child")
+  (is (selector/matches-ns? ["phel.http.**"] "phel.http.client.sub")
+      "double-star crosses dots"))
+
+(deftest test-matches-ns-or-semantics-multiple-patterns
+  (is (selector/matches-ns? ["a.*" "phel.*"] "phel.core")
+      "any matching glob passes")
+  (is (not (selector/matches-ns? ["a.*" "b.*"] "c.x"))
+      "no matching glob fails"))
+
+;; ---------------------------------------------------------------------------
+;; matches-filter? — regex / substring on test-name
+;; ---------------------------------------------------------------------------
+
+(deftest test-matches-filter-empty-list
+  (is (selector/matches-filter? [] "anything")
+      "empty filter list imposes no restriction")
+  (is (selector/matches-filter? nil "anything")
+      "nil filter list imposes no restriction"))
+
+(deftest test-matches-filter-substring-match
+  (is (selector/matches-filter? ["add"] "test-add-two")
+      "bare substring matches anywhere in the name")
+  (is (not (selector/matches-filter? ["xyz"] "test-add-two"))
+      "substring miss fails"))
+
+(deftest test-matches-filter-regex-form
+  (is (selector/matches-filter? ["/^test-/"] "test-anything")
+      "delimited regex anchors as written")
+  (is (not (selector/matches-filter? ["/^test-/"] "other-test"))
+      "anchored regex respects position"))
+
+(deftest test-matches-filter-or-semantics
+  (is (selector/matches-filter? ["add" "sub"] "test-sub")
+      "any matching filter passes")
+  (is (not (selector/matches-filter? ["add" "sub"] "test-mul"))
+      "no matching filter fails"))
+
+;; ---------------------------------------------------------------------------
+;; keep-test? — composition rules
+;; ---------------------------------------------------------------------------
+
+(deftest test-keep-test-no-selectors-keeps-everything
+  (is (selector/keep-test? {} "any.ns" {:test-name "t"})
+      "empty options keeps every test")
+  (is (selector/keep-test? {:include [] :exclude [] :ns-patterns [] :filters []}
+                           "any.ns"
+                           {:test-name "t"})
+      "all-empty options keeps every test"))
+
+(deftest test-keep-test-include-only
+  (is (selector/keep-test? {:include [:integration]}
+                           "my.ns"
+                           {:integration true :test-name "t"})
+      "include match keeps test")
+  (is (not (selector/keep-test? {:include [:integration]}
+                                "my.ns"
+                                {:unit true :test-name "t"}))
+      "include miss drops test"))
+
+(deftest test-keep-test-exclude-overrides-include
+  (is (not (selector/keep-test? {:include [:integration] :exclude [:slow]}
+                                "my.ns"
+                                {:integration true :slow true :test-name "t"}))
+      "exclude drops a test that also matches include"))
+
+(deftest test-keep-test-ns-gate
+  (is (selector/keep-test? {:ns-patterns ["phel.http.*"]}
+                           "phel.http.client"
+                           {:test-name "t"})
+      "ns glob match keeps test")
+  (is (not (selector/keep-test? {:ns-patterns ["phel.http.*"]}
+                                "phel.core"
+                                {:test-name "t"}))
+      "ns glob miss drops test"))
+
+(deftest test-keep-test-filter-gate
+  (is (selector/keep-test? {:filters ["add"]}
+                           "my.ns"
+                           {:test-name "test-add-two"})
+      "name filter match keeps test")
+  (is (not (selector/keep-test? {:filters ["add"]}
+                                "my.ns"
+                                {:test-name "test-mul"}))
+      "name filter miss drops test"))
+
+(deftest test-keep-test-all-gates-and
+  (testing "all gates specified and satisfied"
+    (is (selector/keep-test? {:include [:integration]
+                              :exclude [:slow]
+                              :ns-patterns ["phel.http.*"]
+                              :filters ["get"]}
+                             "phel.http.client"
+                             {:integration true :test-name "test-get-url"})
+        "passes every gate"))
+  (testing "any one gate failing drops the test"
+    (is (not (selector/keep-test? {:include [:integration]
+                                   :ns-patterns ["phel.http.*"]}
+                                  "phel.core"
+                                  {:integration true :test-name "t"}))
+        "ns gate fails")
+    (is (not (selector/keep-test? {:include [:integration]
+                                   :filters ["^never-matches$"]}
+                                  "phel.http.client"
+                                  {:integration true :test-name "test-get"}))
+        "filter gate fails")))
+
+;; ---------------------------------------------------------------------------
+;; has-selectors?
+;; ---------------------------------------------------------------------------
+
+(deftest test-has-selectors-reports-presence
+  (is (not (selector/has-selectors? {})) "empty map has no selectors")
+  (is (not (selector/has-selectors? {:include [] :exclude []}))
+      "all-empty vectors counted as no selectors")
+  (is (selector/has-selectors? {:include [:integration]})
+      "non-empty include counts")
+  (is (selector/has-selectors? {:ns-patterns ["a.*"]})
+      "non-empty ns-patterns counts")
+  (is (selector/has-selectors? {:filters ["foo"]})
+      "non-empty filters counts")
+  (is (selector/has-selectors? {:exclude [:slow]})
+      "non-empty exclude counts"))

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -23,6 +23,97 @@ final class TestCommandOptionsTest extends TestCase
         self::assertSame('{:filter "example" :testdox false :fail-fast false}', $options->asPhelHashMap());
     }
 
+    public function test_include_tag_list(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['integration', 'smoke'],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :include [:integration :smoke]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_exclude_tag_list(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::EXCLUDE => ['slow'],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :exclude [:slow]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_ns_pattern_list(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::NS_PATTERNS => ['phel.http.*', 'phel.json.**'],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :ns-patterns ["phel.http.*" "phel.json.**"]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_filters_list(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::FILTERS => ['foo-'],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :filters ["foo-"]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_all_selectors_combined(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['integration'],
+            TestCommandOptions::EXCLUDE => ['slow'],
+            TestCommandOptions::NS_PATTERNS => ['phel.http.*'],
+            TestCommandOptions::FILTERS => ['get-'],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :include [:integration] :exclude [:slow] :ns-patterns ["phel.http.*"] :filters ["get-"]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_selector_empty_strings_are_dropped(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['integration', '', 'smoke'],
+            TestCommandOptions::EXCLUDE => [''],
+            TestCommandOptions::NS_PATTERNS => ['', 'phel.http.*'],
+            TestCommandOptions::FILTERS => [''],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :include [:integration :smoke] :ns-patterns ["phel.http.*"]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_non_array_selector_is_ignored(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => 'not-an-array',
+            TestCommandOptions::EXCLUDE => null,
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false}',
+            $options->asPhelHashMap(),
+        );
+    }
+
     public function test_no_testdox(): void
     {
         $options = TestCommandOptions::fromArray([]);

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure\Command;
+
+use Phel\Run\Infrastructure\Command\TestCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+final class TestCommandOptionsWiringTest extends TestCase
+{
+    public function test_it_declares_repeatable_include_option(): void
+    {
+        $option = $this->optionFor('include');
+
+        self::assertTrue($option->isArray(), 'include option is repeatable');
+        self::assertTrue($option->isValueRequired(), 'include requires a value');
+    }
+
+    public function test_it_declares_repeatable_exclude_option(): void
+    {
+        $option = $this->optionFor('exclude');
+
+        self::assertTrue($option->isArray(), 'exclude option is repeatable');
+        self::assertTrue($option->isValueRequired(), 'exclude requires a value');
+    }
+
+    public function test_it_declares_repeatable_ns_option(): void
+    {
+        $option = $this->optionFor('ns');
+
+        self::assertTrue($option->isArray(), 'ns option is repeatable');
+        self::assertTrue($option->isValueRequired(), 'ns requires a value');
+    }
+
+    public function test_it_declares_repeatable_filter_option(): void
+    {
+        $option = $this->optionFor('filter');
+
+        self::assertTrue($option->isArray(), 'filter option is now repeatable');
+        self::assertTrue($option->isValueRequired(), 'filter requires a value');
+    }
+
+    public function test_default_selector_values_are_empty_arrays(): void
+    {
+        $definition = $this->definition();
+
+        self::assertSame([], $definition->getOption('include')->getDefault());
+        self::assertSame([], $definition->getOption('exclude')->getDefault());
+        self::assertSame([], $definition->getOption('ns')->getDefault());
+        self::assertSame([], $definition->getOption('filter')->getDefault());
+    }
+
+    public function test_description_mentions_selector_semantics(): void
+    {
+        $include = $this->optionFor('include');
+        $exclude = $this->optionFor('exclude');
+        $ns = $this->optionFor('ns');
+
+        self::assertStringContainsString('tag', strtolower($include->getDescription()));
+        self::assertStringContainsString('skip', strtolower($exclude->getDescription()));
+        self::assertStringContainsString('glob', strtolower($ns->getDescription()));
+    }
+
+    private function definition(): InputDefinition
+    {
+        $command = new TestCommand();
+
+        return $command->getDefinition();
+    }
+
+    private function optionFor(string $name): InputOption
+    {
+        return $this->definition()->getOption($name);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Large Phel test suites previously had no way to narrow a run to a subset of tests. `phel test --filter=<substring>` existed but only matched test names, and there was no way to tag tests by trait (integration, slow, flaky, db, etc.) or restrict by namespace. Full suites become too slow for inner-loop feedback, so developers end up commenting tests out or running single files manually.

## 💡 Goal

Tier 2 item #8 of the Clojure-parity roadmap: metadata-based test selection on `./bin/phel test`, supporting include/exclude tags, namespace globs, and test-name regex. Tests that do not match are actually skipped (not run-then-hidden), so stats are accurate.

## 🔖 Changes

### Phel

- New `phel\test\selector` module with pure, composable helpers: `has-tag?`, `matches-include?`, `matches-exclude?`, `matches-ns?`, `matches-filter?`, `keep-test?`, `has-selectors?`. Namespace globs accept `*` (single segment) and `**` (any run); backslash-separated namespaces are normalised to dotted form.
- `deftest` now forwards the symbol's metadata to the defined function. Both `^:integration` (sugar for `{:integration true}`) and `^{:tags [:integration :slow]}` work.
- `run-tests` partitions discovered tests through the selector module and emits a `:skipped` event per filtered test, carrying `:test-name`, `:ns`, `:reason`, `:tags`.
- `report` multimethod gains a `:skipped` method; skip counts propagate into the `:summary` event and show in the `default`, `testdox`, and `dot` built-in reporters.
- Back-compat: if no selector flag is given, behaviour is identical to before.

### PHP

- `TestCommand` adds `--include`, `--exclude`, `--ns`, and `--filter` options (all repeatable; `--filter` was already present but scalar, now an array). Default arrays stay empty, so existing invocations keep working.
- `TestCommandOptions` carries the four new option lists and renders them into the generated Phel option map. Empty strings are dropped; non-array inputs are ignored.

### Tests

- `tests/phel/test/selectors.phel`: 51 unit tests for the pure selector helpers (each flag in isolation, OR semantics, AND composition, edge cases).
- `tests/phel/test/selectors-runtime.phel`: 22 end-to-end tests that script `run-tests` against a fixture namespace (`tests/phel/test/fixtures/tagged-tests.phel`) and verify filtering, skip events, summary counts, and back-compat.
- `tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php`: extended with 10 new cases covering every selector permutation in the Phel hash-map emitter.
- `tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php`: six new PHPUnit cases asserting the Symfony `InputDefinition` exposes each flag as repeatable.