### PR TITLE
feat(api): add async, cli, match, pprint, router, walk, test/gen to ApiConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - `phel\repl`: `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`
 - `phel\cli`: spec-map wrapper over `symfony/console` with prompts, tables, progress, coercion, hooks, signals, and test helpers. See `docs/cli-guide.md`
 - `phel\match`: `match` macro with literal, vector, map, wildcard, `:as`, `:guard`, `:or`, and rest-binding patterns; matches left-to-right and raises on no-match when no `:else` is given
+- `phel doc` and REPL completion now cover `phel\async`, `phel\cli`, `phel\match`, `phel\pprint`, `phel\router`, `phel\walk`, and `phel\test\gen`
 
 ### Fixed
 

--- a/src/php/Api/ApiConfig.php
+++ b/src/php/Api/ApiConfig.php
@@ -14,15 +14,22 @@ final class ApiConfig extends AbstractConfig
     public static function allNamespaces(): array
     {
         return [
+            'phel\\async',
             'phel\\base64',
+            'phel\\cli',
             'phel\\core',
             'phel\\html',
             'phel\\http',
             'phel\\json',
+            'phel\\match',
             'phel\\mock',
+            'phel\\pprint',
             'phel\\repl',
+            'phel\\router',
             'phel\\string',
             'phel\\test',
+            'phel\\test\\gen',
+            'phel\\walk',
             'phel\\watch',
         ];
     }


### PR DESCRIPTION
## 🤔 Background

`ApiConfig::allNamespaces()` lists the phel stdlib namespaces loaded by `PhelFnLoader` for doc browsing (`./bin/phel doc`), REPL completion, and `ApiFacade::getPhelFunctions()`. Inclusion is not by directory prefix: `loadAllPhelFunctions` builds a synthetic phel file with `(:require <ns>)` per entry and resolves the full dep graph via `getDependenciesForNamespace`. Transitively reachable namespaces are auto-covered; orphans are silently missing.

Previous roots: `base64, core, html, http, json, mock, repl, string, test, watch`.

Transitively reachable (no entry needed): `phel\test\selector` (via `phel\test`), `phel\ai` (via `phel\repl`), `phel\http-client` (via `phel\ai`).

Orphans missing from docs/completion: `phel\async`, `phel\cli`, `phel\match`, `phel\pprint`, `phel\router`, `phel\walk`, `phel\test\gen`.

## 💡 Goal

Expose every bundled phel stdlib module through doc browsing, REPL completion, and the Api facade.

## 🔖 Changes

- `src/php/Api/ApiConfig.php`: add `phel\async`, `phel\cli`, `phel\match`, `phel\pprint`, `phel\router`, `phel\walk`, `phel\test\gen` to `allNamespaces()`
- `CHANGELOG.md`: note the expanded doc/completion coverage under Unreleased > Modules