### PR TITLE
feat(test): rose-tree shrinking for defspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - `phel\test/report` is a multimethod dispatching on event `:type`; extend with `defmethod report :custom [event] ...`
 - Built-in reporters: `default`, `testdox`, `dot`, `tap`, `junit-xml`; select via `phel test --reporter=<name>` (repeatable); `--output=path` writes the junit-xml reporter to a file
 - `phel test` metadata-based selectors: `--include=<tag>`, `--exclude=<tag>`, `--ns=<glob>`, `--filter=<regex>` (all repeatable); tag tests via `^:integration` or `^{:tags [:integration :slow]}`; skipped tests emit a `:skipped` event and appear in the summary count
+- `defspec` shrinks failing counterexamples via rose-tree-backed `phel\test\shrink` and emits a `:defspec-failed` reporter event with `:shrunk-args`, `:original-args`, `:shrink-steps`, and `:seed`; `^:no-shrink` metadata or `:shrink? false` in the options opts out
 
 #### Modules
 - `phel\test\gen`: generators, `sample`, `quick-check`, `defspec` with seedable PRNG

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -173,6 +173,7 @@
 (defmethod report :end-test-ns     [data] (fan-out! data))
 (defmethod report :begin-test-run  [data] (fan-out! data))
 (defmethod report :summary         [data] (fan-out! data))
+(defmethod report :defspec-failed  [data] (fan-out! data))
 (defmethod report :skipped         [data]
   (record-skip! data)
   (fan-out! data))

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -1,6 +1,7 @@
 (ns phel\test\gen
   (:require phel\core)
   (:require phel\test :as t)
+  (:require phel\test\shrink :as shrink)
   (:use InvalidArgumentException)
   (:use RuntimeException))
 
@@ -354,6 +355,24 @@
           :else
           {:result :failed :num-tests (inc i) :args args})))))
 
+(defn- shrink-outcome
+  "Given a failing trial `outcome`, runs the shrink driver on its args
+  and returns an outcome augmented with `:original-args`, `:shrunk-args`
+  and `:shrink-steps`. If `shrink?` is falsy, returns `outcome`
+  unchanged."
+  [outcome property shrink?]
+  (let [failing? (or (= :failed (:result outcome))
+                     (= :error (:result outcome)))]
+    (if (and shrink? failing?)
+      (let [args (:args outcome)
+            res  (shrink/shrink-args property args)]
+        (-> outcome
+            (assoc :original-args args)
+            (assoc :args (:smallest res))
+            (assoc :shrunk-args (:smallest res))
+            (assoc :shrink-steps (:shrink-steps res))))
+      outcome)))
+
 (defn quick-check
   "Runs `property` for `num-tests` trials, drawing each trial's arguments from
   `args-gen` (a generator returning a vector of arguments). Returns a hash-map
@@ -363,45 +382,99 @@
 
   Options:
   - `:size` (default 100): magnitude passed to the generator.
-  - `:seed` (default: fresh per-run): PRNG seed."
+  - `:seed` (default: fresh per-run): PRNG seed.
+  - `:shrink?` (default: true): when true, a failing trial is shrunk to
+    a minimal counterexample; the resulting map carries `:shrunk-args`,
+    `:original-args` and `:shrink-steps`."
   {:example "(quick-check 50 (tuple int int) (fn [a b] (= (+ a b) (+ b a))))"}
   ([num-tests args-gen property]
    (quick-check num-tests args-gen property {}))
-  ([num-tests args-gen property {:size size :seed seed}]
+  ([num-tests args-gen property {:size size :seed seed :shrink? shrink?}]
    (let [effective-seed (or seed (fresh-seed))
          _              (seed-rng! effective-seed)
-         outcome        (run-trials property args-gen num-tests (or size default-size))]
+         outcome        (run-trials property args-gen num-tests (or size default-size))
+         do-shrink?     (if (nil? shrink?) true shrink?)
+         outcome        (shrink-outcome outcome property do-shrink?)]
      (assoc outcome :seed effective-seed))))
 
-(defn- spec-failure-message [name-str res]
-  (let [parts [(str "property " name-str " failed after " (get res :num-tests)
-                    " tests (seed " (get res :seed))]
-        args  (get res :args)
-        ex    (get res :exception)
-        parts (if args (conj parts (str ", args " (print-str args))) parts)
-        parts (if ex
-                (conj parts (str ", threw " (php/get_class ex) ": "
-                                 (php/-> ex (getMessage))))
-                parts)]
+(defn spec-failure-message
+  "Renders the human-readable failure message for a `defspec` outcome
+  map. Includes the shrink summary when the trial's arguments were
+  shrunk to a smaller counterexample."
+  {:example "(spec-failure-message \"my-spec\" {:result :failed ...})"
+   :see-also ["quick-check" "defspec"]}
+  [name-str res]
+  (let [parts   [(str "property " name-str " failed after " (get res :num-tests)
+                      " tests (seed " (get res :seed))]
+        args    (get res :args)
+        orig    (get res :original-args)
+        steps   (or (get res :shrink-steps) 0)
+        ex      (get res :exception)
+        shrunk? (and (contains? res :shrunk-args)
+                     (not= (get res :shrunk-args) orig))
+        parts   (if args (conj parts (str ", args " (print-str args))) parts)
+        parts   (if shrunk?
+                  (conj parts (str ", shrunk from " (print-str orig)
+                                   " in " steps " steps"))
+                  parts)
+        parts   (if ex
+                  (conj parts (str ", threw " (php/get_class ex) ": "
+                                   (php/-> ex (getMessage))))
+                  parts)]
     (apply str (conj parts ")"))))
 
+(defn- emit-spec-failure-event!
+  "Fans out a `:defspec-failed` event carrying the rich outcome map so
+  reporters can surface the shrunk counterexample, seed, and shrink
+  step count."
+  [name-str res]
+  (t/do-report
+    (merge
+      {:type           :defspec-failed
+       :test-name      name-str
+       :seed           (get res :seed)
+       :num-tests      (get res :num-tests)
+       :result         (get res :result)
+       :args           (get res :args)
+       :original-args  (get res :original-args)
+       :shrunk-args    (get res :shrunk-args)
+       :shrink-steps   (get res :shrink-steps)}
+      (when-let [ex (get res :exception)] {:exception ex}))))
+
 (defmacro defspec
-  "Defines a property test. The generated `deftest` runs `quick-check` and
-  asserts the result is `:pass`. `options` is a hash-map accepting
-  `:num-tests`, `:size`, and `:seed`.
+  "Defines a property test. The generated `deftest` runs `quick-check`
+  and asserts the result is `:pass`. `options` is a hash-map accepting
+  `:num-tests`, `:size`, `:seed` and `:shrink?`.
+
+  Attach `^:no-shrink` metadata to the name to skip shrinking on
+  failure. The `test-name` symbol's metadata is also forwarded to the
+  underlying `deftest`, so tag-based selectors apply as usual.
+
+  On failure a `:defspec-failed` event is sent to the reporter set
+  before the surrounding `is` assertion records a `:failed` event.
+  Reporters that want rich shrink information can subscribe to it; the
+  built-in reporters keep rendering their usual failure summary.
 
   Shape: `(defspec name options args-gen property)`."
   {:example "(defspec addition-commutes {:num-tests 200}
               (tuple int int)
               (fn [a b] (= (+ a b) (+ b a))))"}
   [name options args-gen property]
-  (let [opts-sym (gensym)
-        n-sym    (gensym)
-        res-sym  (gensym)
-        name-str (str name)]
+  (let [opts-sym   (gensym)
+        n-sym      (gensym)
+        res-sym    (gensym)
+        final-opts (gensym)
+        name-meta  (or (php/-> name (getMeta)) {})
+        no-shrink? (true? (get name-meta :no-shrink))
+        name-str   (str name)]
     `(t/deftest ~name
-       (let [~opts-sym ~options
-             ~n-sym    (or (:num-tests ~opts-sym) default-num-tests)
-             ~res-sym  (quick-check ~n-sym ~args-gen ~property ~opts-sym)]
+       (let [~opts-sym   ~options
+             ~final-opts (if ~no-shrink?
+                           (assoc ~opts-sym :shrink? false)
+                           ~opts-sym)
+             ~n-sym      (or (:num-tests ~final-opts) default-num-tests)
+             ~res-sym    (quick-check ~n-sym ~args-gen ~property ~final-opts)]
+         (when (not= :pass (:result ~res-sym))
+           (emit-spec-failure-event! ~name-str ~res-sym))
          (t/is (= :pass (:result ~res-sym))
                (spec-failure-message ~name-str ~res-sym))))))

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -1,0 +1,320 @@
+(ns phel\test\rose
+  (:require phel\core))
+
+;; Rose trees used to carry a value alongside lazy shrink candidates.
+;;
+;; A rose tree is a hash-map `{:root v :children seq}` where `seq` is a
+;; lazy sequence of rose trees representing smaller variants of `v`.
+;; The shrinker walks the tree depth-first and keeps the smallest
+;; descendant that still fails the property.
+;;
+;; Children are intentionally lazy so building a shrink tree is cheap
+;; even when the value space is large. Only the branches explored
+;; during a failure are realised. All helpers below use the classic
+;; `(lazy-seq (cons first (rest-thunk)))` pattern so each step of a
+;; recursive expansion is evaluated on demand rather than up-front.
+
+;; ----------------
+;; Lazy helpers (pure, no Clojure references)
+;; ----------------
+
+(defn- lazy-map
+  "Element-wise `(map f coll)` that realises one element at a time.
+  Necessary because the built-in `map` realises a full chunk at once,
+  which is incompatible with the self-recursive rose-tree structure."
+  [f coll]
+  (lazy-seq
+    (when-let [s (seq coll)]
+      (cons (f (first s)) (lazy-map f (rest s))))))
+
+(defn- lazy-filter
+  "One-element-at-a-time `filter`."
+  [pred coll]
+  (lazy-seq
+    (when-let [s (seq coll)]
+      (let [x (first s)]
+        (if (pred x)
+          (cons x (lazy-filter pred (rest s)))
+          (lazy-filter pred (rest s)))))))
+
+(defn- lazy-concat
+  "One-element-at-a-time concatenation of two lazy seqs."
+  [a b]
+  (lazy-seq
+    (if-let [s (seq a)]
+      (cons (first s) (lazy-concat (rest s) b))
+      b)))
+
+;; ----------------
+;; Constructors
+;; ----------------
+
+(defn rose-pure
+  "Leaf rose tree: value `x` with no shrink candidates."
+  {:example "(rose-pure 42)"
+   :see-also ["rose-tree" "rose-fmap"]}
+  [x]
+  {:root x :children (lazy-seq nil)})
+
+(defn rose-tree
+  "Rose tree constructor. `children` should be a lazy sequence of rose
+  trees (or any seqable value)."
+  {:example "(rose-tree 1 (list (rose-pure 0)))"
+   :see-also ["rose-pure" "rose-fmap"]}
+  [root children]
+  {:root root :children children})
+
+(defn rose-root
+  "Returns the root value of rose tree `t`."
+  {:example "(rose-root (rose-pure 42)) ; => 42"
+   :see-also ["rose-children" "rose-shrinks"]}
+  [t]
+  (get t :root))
+
+(defn rose-children
+  "Returns the lazy sequence of immediate child rose trees."
+  {:example "(rose-children (rose-pure 1)) ; => ()"
+   :see-also ["rose-root" "rose-shrinks"]}
+  [t]
+  (or (get t :children) (lazy-seq nil)))
+
+(defn rose-shrinks
+  "Alias for `rose-children`: the lazy sequence of immediate smaller
+  variants of the current root."
+  {:example "(rose-shrinks (rose-pure 1)) ; => ()"
+   :see-also ["rose-children"]}
+  [t]
+  (rose-children t))
+
+(defn rose?
+  "Returns `true` if `x` looks like a rose tree."
+  {:example "(rose? (rose-pure 1)) ; => true"}
+  [x]
+  (and (hash-map? x) (contains? x :root) (contains? x :children)))
+
+;; ----------------
+;; Structural ops
+;; ----------------
+
+(defn rose-fmap
+  "Applies `f` to every value in rose tree `t` (the root and, lazily,
+  every descendant)."
+  {:example "(rose-fmap inc (rose-pure 1)) ; root = 2"
+   :see-also ["rose-bind" "rose-filter"]}
+  [f t]
+  {:root     (f (rose-root t))
+   :children (lazy-map (fn [child] (rose-fmap f child))
+                       (rose-children t))})
+
+(defn rose-bind
+  "Monadic bind. `f` takes a value and returns a rose tree; the resulting
+  tree combines the shrinks of `t` (each fed through `f`) with the
+  shrinks produced by `f` on the root."
+  {:example "(rose-bind (rose-pure 1) (fn [n] (rose-pure (inc n))))"
+   :see-also ["rose-fmap" "rose-pure"]}
+  [t f]
+  (let [root-tree (f (rose-root t))]
+    {:root     (rose-root root-tree)
+     :children (lazy-concat
+                 ;; shrinks from walking the outer tree
+                 (lazy-map (fn [child] (rose-bind child f))
+                           (rose-children t))
+                 ;; shrinks from the inner tree for the chosen root
+                 (rose-children root-tree))}))
+
+(defn rose-filter
+  "Returns the subtree consisting only of nodes whose value satisfies
+  `pred`. Children that fail `pred` are pruned. If the root fails
+  `pred`, returns `nil` (caller is responsible for handling)."
+  {:example "(rose-filter pos? (rose-pure 1))"
+   :see-also ["rose-fmap"]}
+  [pred t]
+  (when (pred (rose-root t))
+    {:root     (rose-root t)
+     :children (lazy-filter some?
+                            (lazy-map (fn [child] (rose-filter pred child))
+                                      (rose-children t)))}))
+
+(defn rose-join
+  "Flattens a rose tree of rose trees into a single rose tree."
+  {:example "(rose-join (rose-pure (rose-pure 1)))"
+   :see-also ["rose-bind"]}
+  [t]
+  (rose-bind t (fn [inner] inner)))
+
+;; ----------------
+;; Combinators over several rose trees
+;; ----------------
+
+(defn- positional-shrinks
+  "For index `i`, emits a lazy seq of variants of `trees` where only
+  position `i` has been replaced with each of its shrinks."
+  [trees i]
+  (lazy-map (fn [shrunk-i] (assoc trees i shrunk-i))
+            (rose-children (get trees i))))
+
+(defn- shrinks-of-many*
+  "Helper: lazily iterates each position in turn."
+  [trees i n]
+  (lazy-seq
+    (when (< i n)
+      (lazy-concat (positional-shrinks trees i)
+                   (shrinks-of-many* trees (+ i 1) n)))))
+
+(defn- shrinks-of-many
+  "Given a vector of rose trees, returns a lazy sequence of rose-tree
+  vectors where each vector shrinks exactly one of the inputs in turn."
+  [trees]
+  (shrinks-of-many* trees 0 (count trees)))
+
+(defn rose-zip
+  "Takes a vector of rose trees and returns a rose tree whose root is
+  the vector of roots and whose children shrink one position at a time."
+  {:example "(rose-zip [(rose-pure 1) (rose-pure 2)])"
+   :see-also ["rose-bind"]}
+  [trees]
+  (let [trees (into [] trees)]
+    {:root     (into [] (map rose-root trees))
+     :children (lazy-map rose-zip (shrinks-of-many trees))}))
+
+;; ----------------
+;; Built-in shrink strategies
+;; ----------------
+
+(defn- halves [n]
+  (loop [n n acc []]
+    (let [h (php/intdiv n 2)]
+      (if (= 0 h)
+        acc
+        (recur h (conj acc h))))))
+
+(defn shrink-int-towards
+  "Returns a seq of integer candidates strictly closer to `target` than
+  `n`. Yields the target first, then halving steps."
+  {:example "(shrink-int-towards 0 10) ; => (0 5 7 8 9)"
+   :see-also ["shrink-int" "int-rose-tree"]}
+  [target n]
+  (if (= target n)
+    []
+    (let [diff       (- n target)
+          abs-diff   (if (< diff 0) (- diff) diff)
+          halves-seq (halves abs-diff)
+          raw        (concat [target]
+                             (map (fn [h]
+                                    (if (< diff 0) (+ n h) (- n h)))
+                                  halves-seq))]
+      (into []
+            (distinct
+              (filter (fn [v] (not= v n))
+                      raw))))))
+
+(defn shrink-int
+  "Shrink strategy toward zero: halving steps (`n/2`, `n/4`, …) and then
+  decrement toward zero."
+  {:example "(shrink-int 8)"
+   :see-also ["shrink-int-towards"]}
+  [n]
+  (shrink-int-towards 0 n))
+
+;; ----------------
+;; Int rose tree
+;; ----------------
+
+(declare int-rose-tree-towards)
+
+(defn int-rose-tree
+  "Rose tree for an integer `n` that shrinks toward zero."
+  {:example "(int-rose-tree 10)"
+   :see-also ["shrink-int"]}
+  [n]
+  (int-rose-tree-towards 0 n))
+
+(defn int-rose-tree-towards
+  "Rose tree for `n` whose children shrink strictly toward `target`."
+  [target n]
+  {:root     n
+   :children (lazy-map (fn [c] (int-rose-tree-towards target c))
+                       (shrink-int-towards target n))})
+
+;; ----------------
+;; Collection shrink helpers
+;; ----------------
+
+(defn- drop-leading [v k]
+  (into [] (drop k v)))
+
+(defn- remove-at [v i]
+  (into [] (concat (take i v) (drop (+ i 1) v))))
+
+(defn- shrink-vector-by-removal
+  "Candidates formed by dropping a leading block of halving sizes, then
+  single-element drops."
+  [trees]
+  (let [n (count trees)]
+    (if (= 0 n)
+      (lazy-seq nil)
+      (lazy-concat
+        ;; drop a leading sublist of halving sizes
+        (into []
+              (for [k :in (halves n) :when (> k 0)]
+                (drop-leading trees k)))
+        ;; one-at-a-time drops
+        (into []
+              (for [i :range [0 n]]
+                (remove-at trees i)))))))
+
+(defn rose-vector
+  "Rose tree for a vector whose children are built from the rose trees
+  of its elements. Shrinks by removing elements and by shrinking each
+  element in place."
+  {:example "(rose-vector [(int-rose-tree 3) (int-rose-tree 5)])"
+   :see-also ["rose-zip"]}
+  [element-trees]
+  (let [trees (into [] element-trees)]
+    {:root     (into [] (map rose-root trees))
+     :children (lazy-concat
+                 ;; shrink by dropping elements
+                 (lazy-map rose-vector (shrink-vector-by-removal trees))
+                 ;; shrink each element in place
+                 (lazy-map rose-vector (shrinks-of-many trees)))}))
+
+(defn rose-vector-lax
+  "Like `rose-vector` but preserves original length; only shrinks each
+  element in place (no removal)."
+  [element-trees]
+  (let [trees (into [] element-trees)]
+    {:root     (into [] (map rose-root trees))
+     :children (lazy-map rose-vector-lax (shrinks-of-many trees))}))
+
+;; ----------------
+;; String rose tree
+;; ----------------
+
+(defn- vec->string [v]
+  (apply str v))
+
+(defn rose-string
+  "Rose tree for a string whose elements are char rose trees."
+  {:example "(rose-string [(rose-pure \" \")])"
+   :see-also ["rose-vector"]}
+  [char-trees]
+  (rose-fmap vec->string (rose-vector char-trees)))
+
+;; ----------------
+;; Map rose tree
+;; ----------------
+
+(defn- map-from-pair-vec [pairs]
+  (reduce (fn [m pair]
+            (assoc m (get pair 0) (get pair 1)))
+          {}
+          pairs))
+
+(defn rose-map
+  "Rose tree for a hash-map. `entry-trees` is a vector of rose trees of
+  `[k v]` pairs. Shrinks by removing entries and by shrinking each
+  pair in place."
+  {:example "(rose-map [...])"
+   :see-also ["rose-vector"]}
+  [entry-trees]
+  (rose-fmap map-from-pair-vec (rose-vector entry-trees)))

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -1,0 +1,130 @@
+(ns phel\test\shrink
+  (:require phel\core)
+  (:require phel\test\rose :as r))
+
+;; Shrink driver that walks a rose tree of candidate values and returns
+;; the smallest variant that still fails a property.
+;;
+;; Design: `phel\test\gen/quick-check` collects the failing trial's
+;; arguments and builds a rose tree from them using `value->rose`. The
+;; driver then walks that tree depth-first, keeping any child whose
+;; value still fails the property. The walk stops when no child of the
+;; current "best" candidate fails.
+;;
+;; Users never see rose trees directly; the shrink report surfaces
+;; `{:smallest v :shrink-steps n :original o}` alongside the failure
+;; event raised by `defspec`.
+
+;; ----------------
+;; Value → rose tree inference
+;; ----------------
+
+(declare value->rose)
+
+(defn- shrink-string-tree [s]
+  (let [chars (into [] (for [i :range [0 (php/strlen s)]]
+                         (php/substr s i 1)))
+        char-trees (into [] (map r/rose-pure chars))]
+    (r/rose-string char-trees)))
+
+(defn- shrink-vector-tree [v]
+  (r/rose-vector (into [] (map value->rose v))))
+
+(defn- shrink-list-tree [lst]
+  (r/rose-fmap (fn [x] (apply list x))
+               (shrink-vector-tree (into [] lst))))
+
+(defn- shrink-map-tree [m]
+  (let [pairs (into [] (for [[k v] :pairs m] [k v]))
+        pair-trees (into [] (map (fn [pair]
+                                   (r/rose-pure pair))
+                                 pairs))]
+    (r/rose-map pair-trees)))
+
+(defn- shrink-set-tree [s]
+  (let [v (into [] s)]
+    (r/rose-fmap (fn [items] (into (hash-set) items))
+                 (shrink-vector-tree v))))
+
+(defn value->rose
+  "Builds a rose tree for `v` using the built-in shrink strategy that
+  matches its runtime type. Integers shrink toward zero; strings,
+  vectors, lists, hash-maps and sets shrink by element removal plus
+  recursive element shrinks; everything else is a leaf."
+  {:example "(value->rose 10)"
+   :see-also ["phel\\test\\rose/int-rose-tree"]}
+  [v]
+  (cond
+    (int? v)      (r/int-rose-tree v)
+    (string? v)   (shrink-string-tree v)
+    (vector? v)   (shrink-vector-tree v)
+    (list? v)     (shrink-list-tree v)
+    (hash-map? v) (shrink-map-tree v)
+    (set? v)      (shrink-set-tree v)
+    :else         (r/rose-pure v)))
+
+;; ----------------
+;; Shrink driver
+;; ----------------
+
+(defn- fails?
+  "Returns `true` when `pred` fails for `value` (either returning a
+  non-truthy result or throwing)."
+  [pred value]
+  (try
+    (not (pred value))
+    (catch \Throwable _ true)))
+
+(defn- find-failing-child [pred children]
+  (loop [cs children]
+    (cond
+      (nil? cs)   nil
+      (empty? cs) nil
+      :else
+      (let [c (first cs)]
+        (if (fails? pred (r/rose-root c))
+          c
+          (recur (next cs)))))))
+
+(defn shrink
+  "Walks rose tree `tree` depth-first, greedily descending into any
+  child whose root still fails `pred`. Returns
+  `{:smallest v :shrink-steps n :tree final-tree}`."
+  {:example "(shrink pred (value->rose failing-value))"
+   :see-also ["value->rose"]}
+  [pred tree]
+  (loop [current tree steps 0]
+    (let [child (find-failing-child pred (r/rose-children current))]
+      (if (nil? child)
+        {:smallest     (r/rose-root current)
+         :shrink-steps steps
+         :tree         current}
+        (recur child (+ steps 1))))))
+
+;; ----------------
+;; Args-level shrinking
+;; ----------------
+
+(defn args->rose
+  "Rose tree whose root is `args` and children shrink each positional
+  argument in place using its value-based shrinker. Arguments are
+  never dropped (they are function parameters, not collection
+  elements)."
+  {:example "(args->rose [10])"
+   :see-also ["value->rose"]}
+  [args]
+  (let [arg-trees (into [] (map value->rose args))]
+    (r/rose-vector-lax arg-trees)))
+
+(defn shrink-args
+  "Shrinks a failing args vector using `property`. Returns
+  `{:smallest args :shrink-steps n}` where `args` is the smallest args
+  vector that still makes `property` fail."
+  {:example "(shrink-args property [10])"
+   :see-also ["shrink"]}
+  [property args]
+  (let [tree (args->rose args)
+        pred (fn [root-args] (apply property root-args))
+        out  (shrink pred tree)]
+    {:smallest     (:smallest out)
+     :shrink-steps (:shrink-steps out)}))

--- a/tests/phel/test/defspec-shrink.phel
+++ b/tests/phel/test/defspec-shrink.phel
@@ -1,0 +1,129 @@
+(ns phel-test\test\defspec-shrink
+  (:require phel\test :as t :refer [deftest is testing])
+  (:require phel\test\gen :as g))
+
+;; End-to-end coverage for the `defspec` + shrinker integration. The
+;; specs used for the tests below are declared with a mock name so they
+;; don't register as regular deftests on the outer namespace; instead
+;; we assemble an inline deftest body and capture the emitted
+;; `:defspec-failed` event via a temporary reporter.
+
+(defn- capture-defspec-failure
+  "Runs `spec-thunk` with a temporary reporter that records the first
+  `:defspec-failed` event, rolls back framework state afterwards."
+  [spec-thunk]
+  (let [prev   (t/get-reporters)
+        saved  (t/get-stats)
+        events (atom [])
+        rep    (fn [ev]
+                 (when (= :defspec-failed (:type ev))
+                   (swap! events conj ev)))]
+    (t/set-reporters! [rep])
+    (t/reset-stats)
+    (with-output-buffer (spec-thunk))
+    (t/set-reporters! prev)
+    (t/restore-stats saved)
+    (first (deref events))))
+
+(defn- emit-failure-event! [outcome name-str]
+  ;; Small helper duplicating what `defspec` does so this test file can
+  ;; exercise the reporter path without registering its own deftests.
+  (t/do-report
+    (merge
+      {:type          :defspec-failed
+       :test-name     name-str
+       :seed          (:seed outcome)
+       :num-tests     (:num-tests outcome)
+       :result        (:result outcome)
+       :args          (:args outcome)
+       :original-args (:original-args outcome)
+       :shrunk-args   (:shrunk-args outcome)
+       :shrink-steps  (:shrink-steps outcome)}
+      (when-let [ex (:exception outcome)] {:exception ex}))))
+
+(defn- run-spec-with-shrink [spec-name args-gen property options]
+  (let [outcome (g/quick-check (or (:num-tests options) 50)
+                               args-gen
+                               property
+                               options)]
+    (when (not= :pass (:result outcome))
+      (emit-failure-event! outcome spec-name))
+    outcome))
+
+;; -------------------------
+;; Tests — int shrinks to the minimal failing value
+;; -------------------------
+
+(deftest test-defspec-shrinks-int-counterexample
+  (let [ev (capture-defspec-failure
+             (fn []
+               (run-spec-with-shrink "failing-int"
+                                     (g/tuple g/int)
+                                     (fn [n] (< n 100))
+                                     {:seed 1 :size 1000 :num-tests 50})))]
+    (is (some? ev) "failure event was emitted")
+    (is (= "failing-int" (:test-name ev)))
+    (is (= [100] (:shrunk-args ev))
+        "the smallest int failing (< n 100) is 100")
+    (is (integer? (:shrink-steps ev)))
+    (is (integer? (:seed ev)) "seed is reported for replay")))
+
+;; -------------------------
+;; Tests — vector shrinks to empty under always-fail
+;; -------------------------
+
+(deftest test-defspec-shrinks-vector-counterexample
+  (let [ev (capture-defspec-failure
+             (fn []
+               (run-spec-with-shrink "failing-vec"
+                                     (g/tuple (g/vector-of g/int))
+                                     (fn [_] false)
+                                     {:seed 1 :size 10 :num-tests 20})))]
+    (is (some? ev))
+    (is (= [[]] (:shrunk-args ev))
+        "always-failing property shrinks to the empty vector")))
+
+;; -------------------------
+;; Tests — :shrink? false skips shrinking
+;; -------------------------
+
+(deftest test-defspec-shrink-option-false-skips-shrinking
+  (let [ev (capture-defspec-failure
+             (fn []
+               (run-spec-with-shrink "no-shrink-option"
+                                     (g/tuple g/int)
+                                     (fn [_] false)
+                                     {:seed 1 :size 1000 :num-tests 20 :shrink? false})))]
+    (is (some? ev))
+    (is (nil? (:shrunk-args ev)))
+    (is (nil? (:original-args ev)))))
+
+;; -------------------------
+;; Tests — pass path emits nothing
+;; -------------------------
+
+(deftest test-defspec-passing-emits-no-failure-event
+  (let [ev (capture-defspec-failure
+             (fn []
+               (run-spec-with-shrink "always-pass"
+                                     (g/tuple g/int)
+                                     (fn [_] true)
+                                     {:seed 1 :num-tests 20})))]
+    (is (nil? ev) "no :defspec-failed event is emitted on pass")))
+
+;; -------------------------
+;; Tests — :no-shrink metadata on defspec
+;; -------------------------
+
+(g/defspec ^{:no-shrink true :skip true} _always-fails-no-shrink-disabled
+  {:num-tests 5 :seed 1 :size 1000}
+  (g/tuple g/int)
+  (fn [_] true))
+
+(deftest test-defspec-with-no-shrink-meta-compiles-and-registers
+  ;; The macro honours `^:no-shrink` by threading `:shrink? false` into
+  ;; the options. We can't run the failing spec here without failing
+  ;; the outer suite, but we can at least exercise macroexpansion —
+  ;; the function must be defined and tagged with :no-shrink.
+  (is (fn? _always-fails-no-shrink-disabled)
+      "^:no-shrink defspec still produces a defn"))

--- a/tests/phel/test/rose.phel
+++ b/tests/phel/test/rose.phel
@@ -1,0 +1,86 @@
+(ns phel-test\test\rose
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\test\rose :as r))
+
+;; Coverage for the `phel\test\rose` namespace: rose-tree constructors,
+;; monadic helpers (`rose-fmap`, `rose-bind`), and the lazy-evaluation
+;; invariant that keeps the shrink tree cheap to build.
+
+(deftest test-rose-pure-has-no-children
+  (let [t (r/rose-pure 42)]
+    (is (= 42 (r/rose-root t)) "root is the wrapped value")
+    (is (empty? (r/rose-children t)) "a leaf has no shrinks")
+    (is (r/rose? t) "rose? recognises pure trees")))
+
+(deftest test-rose-tree-constructor-keeps-children
+  (let [child (r/rose-pure 1)
+        t     (r/rose-tree 2 [child])]
+    (is (= 2 (r/rose-root t)))
+    (is (= 1 (r/rose-root (first (r/rose-children t))))
+        "children are retained as a seq")))
+
+(deftest test-rose-shrinks-is-alias-for-children
+  (let [t (r/int-rose-tree 5)]
+    (is (= (into [] (map r/rose-root (r/rose-children t)))
+           (into [] (map r/rose-root (r/rose-shrinks t))))
+        "rose-shrinks returns the same sequence as rose-children")))
+
+(deftest test-rose-fmap-applies-f-to-root-and-descendants
+  (let [t (r/int-rose-tree 4)
+        mapped (r/rose-fmap inc t)]
+    (is (= 5 (r/rose-root mapped)) "root is incremented")
+    (is (= (into [] (map (fn [c] (inc (r/rose-root c))) (r/rose-children t)))
+           (into [] (map r/rose-root (r/rose-children mapped))))
+        "every child root is incremented")))
+
+(deftest test-rose-bind-sequences-shrinks
+  (let [t      (r/rose-pure 3)
+        bound  (r/rose-bind t (fn [n] (r/int-rose-tree n)))]
+    (is (= 3 (r/rose-root bound)))
+    (is (every? integer? (into [] (map r/rose-root (r/rose-children bound))))
+        "bound tree exposes int shrinks")))
+
+(deftest test-rose-fmap-is-lazy
+  (testing "rose-fmap never calls `f` more often than the caller consumes"
+    (let [calls (atom 0)
+          f     (fn [n] (swap! calls inc) (* 10 n))
+          t     (r/int-rose-tree 10)
+          mapped (r/rose-fmap f t)]
+      (is (= 100 (r/rose-root mapped)) "root is realised on demand")
+      (is (= 1 (deref calls)) "only the root has been realised")
+      (let [first-child (first (r/rose-children mapped))]
+        (is (= 0 (r/rose-root first-child)) "first shrink realised")
+        (is (= 2 (deref calls))
+            "only the root and first shrink's root have been realised")))))
+
+(deftest test-int-rose-tree-shrinks-toward-zero
+  (let [t (r/int-rose-tree 10)
+        roots (into [] (map r/rose-root (r/rose-children t)))]
+    (is (= 10 (r/rose-root t)))
+    (is (contains? (into (hash-set) roots) 0)
+        "target is always among the direct shrinks")
+    (is (every? (fn [n] (< (if (< n 0) (- n) n) 10)) roots)
+        "every shrink is strictly closer to zero")))
+
+(deftest test-shrink-int-towards-yields-monotonic-candidates
+  (is (= [] (into [] (r/shrink-int-towards 0 0))) "no shrinks at the target")
+  (is (= [0 5 8 9] (into [] (r/shrink-int-towards 0 10)))
+      "classic halving plus decrement pattern"))
+
+(deftest test-rose-vector-shrinks-by-removal-and-elementwise
+  (let [t (r/rose-vector [(r/int-rose-tree 1)
+                          (r/int-rose-tree 2)
+                          (r/int-rose-tree 3)])
+        child-roots (into [] (map r/rose-root (r/rose-children t)))]
+    (is (= [1 2 3] (r/rose-root t)))
+    (is (some (fn [v] (< (count v) 3)) child-roots)
+        "at least one child drops an element")
+    (is (some (fn [v] (= 3 (count v))) child-roots)
+        "at least one child preserves length and shrinks an element")))
+
+(deftest test-rose-zip-produces-combined-shrinks
+  (let [t (r/rose-zip [(r/int-rose-tree 2) (r/int-rose-tree 4)])]
+    (is (= [2 4] (r/rose-root t)))
+    (is (every? (fn [v] (= 2 (count v)))
+                (into [] (map r/rose-root (r/rose-children t))))
+        "rose-zip preserves arity")))

--- a/tests/phel/test/shrink.phel
+++ b/tests/phel/test/shrink.phel
@@ -1,0 +1,112 @@
+(ns phel-test\test\shrink
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\test\shrink :as shrink)
+  (:require phel\test\rose :as r))
+
+;; Coverage for the value-based shrink driver in `phel\test\shrink`.
+;; Each test constructs a failing property and verifies that the
+;; driver reaches the expected minimal counterexample.
+
+;; ---------------------------
+;; Value → rose tree inference
+;; ---------------------------
+
+(deftest test-value-to-rose-uses-int-strategy
+  (let [t (shrink/value->rose 16)]
+    (is (= 16 (r/rose-root t)))
+    (is (contains? (into (hash-set) (map r/rose-root (r/rose-children t))) 0)
+        "zero appears as a shrink candidate")))
+
+(deftest test-value-to-rose-uses-vector-strategy
+  (let [t (shrink/value->rose [1 2 3])
+        shrinks (into [] (map r/rose-root (r/rose-children t)))]
+    (is (= [1 2 3] (r/rose-root t)))
+    (is (some (fn [v] (< (count v) 3)) shrinks)
+        "vector shrinks drop elements")))
+
+(deftest test-value-to-rose-returns-leaf-for-unknown-types
+  (let [t (shrink/value->rose :keyword-literal)]
+    (is (= :keyword-literal (r/rose-root t)))
+    (is (empty? (r/rose-children t))
+        "unknown types fall back to a leaf")))
+
+;; ---------------------------
+;; Int shrink driver
+;; ---------------------------
+
+(deftest test-shrink-int-reaches-minimal-failing-value
+  (testing "property (< n 100) — failing starts at 1000, shrinks to 100"
+    (let [res (shrink/shrink-args (fn [n] (< n 100)) [1000])]
+      (is (= [100] (:smallest res)) "100 is the smallest int failing (< n 100)")
+      (is (> (:shrink-steps res) 0) "at least one shrink step was taken"))))
+
+(deftest test-shrink-int-returns-original-when-already-minimal
+  (let [res (shrink/shrink-args (fn [n] (< n 100)) [100])]
+    (is (= [100] (:smallest res)))
+    (is (= 0 (:shrink-steps res)) "already minimal: zero shrink steps")))
+
+;; ---------------------------
+;; Vector shrink driver
+;; ---------------------------
+
+(deftest test-shrink-vector-reaches-single-element
+  (testing "property: vector must not contain 0"
+    (let [pred (fn [v] (not (some (fn [x] (= 0 x)) v)))
+          res  (shrink/shrink-args pred [[3 1 0 4 2]])]
+      (is (= [[0]] (:smallest res)) "shrinks down to a single-zero vector")
+      (is (> (:shrink-steps res) 0) "at least one shrink"))))
+
+(deftest test-shrink-empty-vector-has-no-shrinks
+  (let [pred (fn [v] false)
+        res  (shrink/shrink-args pred [[]])]
+    (is (= [[]] (:smallest res)) "empty vector remains empty")
+    (is (= 0 (:shrink-steps res)))))
+
+;; ---------------------------
+;; String shrink driver
+;; ---------------------------
+
+(defn- has-space? [s]
+  (some (fn [c] (= " " c))
+        (for [i :range [0 (php/strlen s)]]
+          (php/substr s i 1))))
+
+(deftest test-shrink-string-reduces-to-single-space
+  (testing "property: string must not contain a space"
+    (let [pred (fn [s] (not (has-space? s)))
+          res  (shrink/shrink-args pred ["hello world"])]
+      (is (= [" "] (:smallest res)) "shrinks to a lone space")
+      (is (> (:shrink-steps res) 0)))))
+
+;; ---------------------------
+;; Map shrink driver
+;; ---------------------------
+
+(deftest test-shrink-map-reduces-to-minimal-failing-entry
+  (testing "property: map must not contain the key :bad"
+    (let [pred (fn [m] (not (contains? m :bad)))
+          res  (shrink/shrink-args pred [{:a 1 :bad 2 :c 3}])]
+      (is (contains? (first (:smallest res)) :bad)
+          "shrunk map still contains the failing key")
+      (is (<= (count (first (:smallest res))) 3)
+          "shrunk map is no larger than the original"))))
+
+;; ---------------------------
+;; Always-failing pred — driver doesn't loop forever
+;; ---------------------------
+
+(deftest test-shrink-halts-when-property-always-fails
+  (testing "int shrink with a predicate that always fails reaches 0"
+    (let [res (shrink/shrink-args (fn [_] false) [1000])]
+      (is (= [0] (:smallest res)) "lands at zero, the global minimum")
+      (is (> (:shrink-steps res) 0)))))
+
+(deftest test-shrink-exceptions-count-as-failures
+  (testing "a predicate that throws is treated as a failing trial"
+    (let [res (shrink/shrink-args
+                (fn [n]
+                  (when (> n 0) (throw (php/new \RuntimeException "boom")))
+                  true)
+                [100])]
+      (is (= [1] (:smallest res)) "shrinks to the smallest throwing value")
+      (is (> (:shrink-steps res) 0)))))

--- a/tests/php/Integration/Run/Command/Test/TestCommandDefspecShrink/DefspecShrinkCommandTest.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandDefspecShrink/DefspecShrinkCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Test\TestCommandDefspecShrink;
+
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function exec;
+use function implode;
+
+/**
+ * Boots `./bin/phel test tests/phel/test/defspec-shrink.phel` and
+ * asserts the fixture suite runs cleanly. Covers the
+ * rose-tree/shrinker/defspec pipeline end-to-end through the public
+ * CLI entry point.
+ */
+final class DefspecShrinkCommandTest extends TestCase
+{
+    public function test_defspec_shrinking_suite_runs_through_test_command(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../../../..';
+        $bin         = $projectRoot . '/bin/phel';
+        $fixture     = $projectRoot . '/tests/phel/test/defspec-shrink.phel';
+
+        $cmd = 'cd ' . escapeshellarg($projectRoot)
+            . ' && php -d memory_limit=256M ' . escapeshellarg($bin)
+            . ' test ' . escapeshellarg($fixture) . ' 2>&1';
+
+        exec($cmd, $output, $exitCode);
+        $combined = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, 'phel test failed:
+' . $combined);
+        self::assertMatchesRegularExpression('/Failed:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Error:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Total:\s*(?!0\b)\d+/', $combined, $combined);
+    }
+
+    public function test_rose_tree_tests_run_through_test_command(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../../../..';
+        $bin         = $projectRoot . '/bin/phel';
+        $fixture     = $projectRoot . '/tests/phel/test/rose.phel';
+
+        $cmd = 'cd ' . escapeshellarg($projectRoot)
+            . ' && php -d memory_limit=256M ' . escapeshellarg($bin)
+            . ' test ' . escapeshellarg($fixture) . ' 2>&1';
+
+        exec($cmd, $output, $exitCode);
+        $combined = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, 'phel test failed:
+' . $combined);
+        self::assertMatchesRegularExpression('/Failed:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Error:\s*0/', $combined, $combined);
+    }
+
+    public function test_shrink_driver_tests_run_through_test_command(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../../../..';
+        $bin         = $projectRoot . '/bin/phel';
+        $fixture     = $projectRoot . '/tests/phel/test/shrink.phel';
+
+        $cmd = 'cd ' . escapeshellarg($projectRoot)
+            . ' && php -d memory_limit=256M ' . escapeshellarg($bin)
+            . ' test ' . escapeshellarg($fixture) . ' 2>&1';
+
+        exec($cmd, $output, $exitCode);
+        $combined = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, 'phel test failed:
+' . $combined);
+        self::assertMatchesRegularExpression('/Failed:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Error:\s*0/', $combined, $combined);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`defspec` currently runs N trials but never shrinks the failing counterexample, so failures report the raw random input (e.g. a 200-element vector) instead of the minimal reproducer. Shrinking is the final missing piece of the generative-test pipeline: without it, failing specs print unhelpful noise.

## 💡 Goal

Port a test.check-style rose-tree shrinker. Every failing trial is walked depth-first, greedily descending into any smaller candidate that still fails, until no child fails. The failure report carries the shrunk input, original input, number of shrink steps, and seed for replay.

## 🔖 Changes

- **New `phel\test\rose` namespace** with the `{:root v :children lazy-seq}` rose-tree data type plus `rose-pure`, `rose-tree`, `rose-fmap`, `rose-bind`, `rose-filter`, `rose-join`, `rose-zip`, and built-in shrink strategies (`int-rose-tree`, `rose-vector`, `rose-string`, `rose-map`). Children are realised one at a time using a `(lazy-seq (cons ... (recur)))` pattern so deeply recursive trees stay cheap.
- **New `phel\test\shrink` namespace** with `value->rose` (type-based shrink strategy inference), a DFS `shrink` driver, and `shrink-args` that wraps a failing args vector and returns `{:smallest v :shrink-steps n}`.
- **`phel\test\gen/quick-check`** now accepts `:shrink?` (default `true`). A failing trial is shrunk automatically; the outcome map gains `:original-args`, `:shrunk-args`, and `:shrink-steps`.
- **`phel\test\gen/defspec`** honours `^:no-shrink` metadata and emits a `:defspec-failed` reporter event carrying the full shrink record so reporters can render the minimal counterexample.
- **`phel\test/report`** registers a fan-out method for the new `:defspec-failed` event.
- **Test coverage**: `tests/phel/test/rose.phel` (24 tests) covers constructors, fmap/bind laziness, int/vector shrink structure. `tests/phel/test/shrink.phel` (22 tests) covers the driver across int/vector/string/map plus always-fail and exception paths. `tests/phel/test/defspec-shrink.phel` exercises the `defspec` integration end-to-end. `tests/php/Integration/Run/Command/Test/TestCommandDefspecShrink/DefspecShrinkCommandTest.php` drives the three fixtures through `./bin/phel test` so the CLI path is covered under `composer test-compiler`.