### PR TITLE
feat(schema): data-driven schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - `phel\repl`: `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`
 - `phel\cli`: spec-map wrapper over `symfony/console` with prompts, tables, progress, coercion, hooks, signals, and test helpers. See `docs/cli-guide.md`
 - `phel\match`: `match` macro with literal, vector, map, wildcard, `:as`, `:guard`, `:or`, and rest-binding patterns; matches left-to-right and raises on no-match when no `:else` is given
+- `phel\schema`: data-driven schemas with `validate`, `explain`, `conform`, `coerce`, `generate`, `instrument!`; supports scalar kinds, `:vector`, `:set`, `:map`, `:map-of`, `:tuple`, `:enum`, `:and`, `:or`, `:maybe`, `:re`, `:fn`, `:ref`, and `[:=> args ret]` function schemas with named-schema registry
 - `phel doc` and REPL completion now cover `phel\async`, `phel\cli`, `phel\match`, `phel\pprint`, `phel\router`, `phel\walk`, and `phel\test\gen`
 
 ### Fixed

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -1,0 +1,212 @@
+(ns phel\schema
+  (:require phel\core)
+  (:require phel\schema\registry :as reg)
+  (:require phel\schema\validator :as v)
+  (:require phel\schema\explainer :as e)
+  (:require phel\schema\coercer :as c)
+  (:require phel\schema\generator :as gen)
+  (:require phel\schema\instrument :as i))
+
+;; Data-driven schemas for Phel.
+;;
+;; Schemas are plain Phel values (keywords or vectors) that describe the
+;; shape of data. This namespace re-exports the primary operations so
+;; callers can use a single import:
+;;
+;;   (validate schema value)             ; boolean
+;;   (explain schema value)              ; nil on success, map on failure
+;;   (conform schema value)              ; coerced value or :phel.schema/invalid
+;;   (coerce schema value)               ; type-coerce input to schema-required type
+;;   (generate schema)                   ; random value conforming to schema
+;;   (instrument! name f schema)         ; validating fn wrapper
+;;   (register! name schema)             ; global named-schema registry
+;;
+;; All supported schema forms are documented in the repository README
+;; and exercised in `tests/phel/test/schema/*.phel`.
+
+;; ------
+;; Predicates
+;; ------
+
+(defn schema?
+  "Returns `true` if `x` has the shape of a schema value."
+  {:example "(schema? :int) ; => true"}
+  [x]
+  (i/schema? x))
+
+(defn schema-head
+  "Returns the dispatch head (kind keyword) of `schema`."
+  {:example "(schema-head [:vector :int]) ; => :vector"}
+  [schema]
+  (v/schema-head schema))
+
+(defn schema-args
+  "Returns the positional arguments of `schema` (children past the head
+  and optional options map)."
+  {:example "(schema-args [:vector :int]) ; => [:int]"}
+  [schema]
+  (v/schema-args schema))
+
+(defn schema-options
+  "Returns the options map of `schema` or `{}`."
+  {:example "(schema-options [:map {:closed true} [:k :int]]) ; => {:closed true}"}
+  [schema]
+  (v/schema-options schema))
+
+;; ------
+;; Core operations
+;; ------
+
+(defn validate
+  "Returns `true` if `value` conforms to `schema`, otherwise `false`."
+  {:example "(validate :int 1) ; => true"
+   :see-also ["explain" "conform"]}
+  [schema value]
+  (v/valid? schema value))
+
+(defn explain
+  "Returns `nil` when `value` conforms to `schema`. On mismatch returns
+  `{:schema schema :value value :errors [...]}` with one error per
+  violation, each carrying `:path`, `:in`, `:schema`, `:value`, `:type`."
+  {:example "(explain :int :oops)"
+   :see-also ["validate" "human-readable-explain"]}
+  [schema value]
+  (e/explain schema value))
+
+(defn human-readable-explain
+  "Renders an `explain` result as a multi-line human string. Returns
+  `nil` for a `nil` input."
+  {:example "(human-readable-explain (explain :int :oops))"
+   :see-also ["explain"]}
+  [result]
+  (e/human-readable-explain result))
+
+(defn coerce
+  "Walks `schema` and coerces string-shaped input into schema-required
+  types. Idempotent for already-typed values."
+  {:example "(coerce :int \"42\") ; => 42"
+   :see-also ["conform" "validate"]}
+  [schema value]
+  (c/coerce schema value))
+
+(defn conform
+  "Coerces `value` against `schema`. Returns the coerced value on
+  success, otherwise `:phel.schema/invalid`."
+  {:example "(conform :int \"42\") ; => 42"
+   :see-also ["coerce" "validate"]}
+  [schema value]
+  (c/conform schema value))
+
+(def invalid-marker
+  "Sentinel returned by `conform` when a value cannot be made to fit a
+  schema."
+  c/invalid-marker)
+
+(defn generate
+  "Generates a single value conforming to `schema`. Accepts `:size` and
+  `:seed` options."
+  {:example "(generate :int)"
+   :see-also ["schema->gen"]}
+  ([schema] (gen/generate schema))
+  ([schema opts] (gen/generate schema opts)))
+
+(defn schema->gen
+  "Returns the `phel\\test\\gen` generator associated with `schema`."
+  {:example "(schema->gen :int)"
+   :see-also ["generate"]}
+  [schema]
+  (gen/schema->gen schema))
+
+;; ------
+;; Registry
+;; ------
+
+(defn register!
+  "Registers `schema` under `name` in the global schema registry."
+  {:example "(register! :email [:and :string [:re \"/@/\"]])"
+   :see-also ["deref-ref" "registered?"]}
+  [name schema]
+  (reg/register! name schema))
+
+(defn unregister!
+  "Removes the schema bound to `name`. Returns `nil`."
+  {:example "(unregister! :email)"
+   :see-also ["register!"]}
+  [name]
+  (reg/unregister! name))
+
+(defn deref-ref
+  "Returns the schema registered under `name`, or `nil`."
+  {:example "(deref-ref :email)"}
+  [name]
+  (reg/deref-ref name))
+
+(defn registered?
+  "Returns `true` if a schema is registered under `name`."
+  {:example "(registered? :email)"}
+  [name]
+  (reg/registered? name))
+
+;; ------
+;; Instrumentation
+;; ------
+
+(defn schema-check?
+  "Returns `true` when runtime validation performed by the instrument
+  helpers is currently enabled."
+  {:example "(schema-check?) ; => true"
+   :see-also ["set-schema-check!" "with-schema-check"]}
+  []
+  (i/schema-check?))
+
+(defn set-schema-check!
+  "Enables (`true`) or disables (`false`) runtime validation. Returns
+  the new value."
+  {:example "(set-schema-check! false)"
+   :see-also ["schema-check?"]}
+  [enabled?]
+  (i/set-schema-check! enabled?))
+
+(defn with-schema-check
+  "Invokes zero-arg thunk `f` with runtime validation forced to
+  `enabled?`. The previous value is restored on return or exception."
+  {:example "(with-schema-check false (fn [] (risky-fn)))"
+   :see-also ["schema-check?"]}
+  [enabled? f]
+  (i/with-schema-check enabled? f))
+
+(defn wrap-with-schema
+  "Wraps `f` so calls validate arguments and return values against the
+  supplied schemas."
+  {:example "(wrap-with-schema add [:int :int] :int)"
+   :see-also ["instrument!"]}
+  [f arg-schema return-schema]
+  (i/wrap-with-schema f arg-schema return-schema))
+
+(defn wrap-with-function-schema
+  "Wraps `f` with the `[:=> args ret]` function schema."
+  {:example "(wrap-with-function-schema add [:=> [:int :int] :int])"
+   :see-also ["wrap-with-schema"]}
+  [f schema]
+  (i/wrap-with-function-schema f schema))
+
+(defn instrument!
+  "Registers `f` wrapped with `schema` under `name`. Returns the wrapped
+  function. The original is preserved so `unstrument!` can restore it."
+  {:example "(instrument! :add add [:=> [:int :int] :int])"
+   :see-also ["unstrument!"]}
+  [name f schema]
+  (i/instrument! name f schema))
+
+(defn unstrument!
+  "Removes the instrumentation registered under `name` and returns the
+  original, unwrapped function (or `nil` if no entry)."
+  {:example "(unstrument! :add)"}
+  [name]
+  (i/unstrument! name))
+
+(defn instrumented?
+  "Returns `true` if `name` is currently instrumented."
+  {:example "(instrumented? :add)"}
+  [name]
+  (i/instrumented? name))

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -1,0 +1,224 @@
+(ns phel\schema\coercer
+  (:require phel\core)
+  (:require phel\schema\registry :as reg)
+  (:require phel\schema\validator :as v))
+
+;; Type coercion driven by schemas.
+;;
+;; `coerce` walks a schema and turns string-shaped input (typically from
+;; HTTP query strings, JSON bodies with numeric strings, form data) into
+;; the underlying Phel type. Idempotent: a value already of the target
+;; type passes through unchanged. Unknown input is returned unchanged so
+;; validation downstream can flag the real failure.
+
+(declare coerce)
+
+(def invalid-marker :phel.schema/invalid)
+
+(defn- coerce-int [value]
+  (cond
+    (int? value) value
+    (and (string? value) (php/=== 1 (php/preg_match "/^-?\\d+$/" value)))
+    (php/intval value)
+    (and (float? value) (= value (php/floatval (php/intval value))))
+    (php/intval value)
+    (true? value) 1
+    (false? value) 0
+    :else value))
+
+(defn- coerce-float [value]
+  (cond
+    (float? value) value
+    (int? value) (php/floatval value)
+    (and (string? value)
+         (php/=== 1 (php/preg_match "/^-?\\d+(?:\\.\\d+)?$/" value)))
+    (php/floatval value)
+    :else value))
+
+(defn- coerce-boolean [value]
+  (cond
+    (boolean? value) value
+    (string? value)
+    (case (php/strtolower value)
+      "true"  true
+      "false" false
+      "1"     true
+      "0"     false
+      "yes"   true
+      "no"    false
+      "on"    true
+      "off"   false
+      value)
+    (= value 1) true
+    (= value 0) false
+    :else value))
+
+(defn- coerce-keyword [value]
+  (cond
+    (keyword? value) value
+    (string? value) (keyword value)
+    (symbol? value) (keyword (name value))
+    :else value))
+
+(defn- coerce-symbol [value]
+  (cond
+    (symbol? value) value
+    (string? value) (symbol value)
+    (keyword? value) (symbol (name value))
+    :else value))
+
+(defn- coerce-uuid [value]
+  (cond
+    (uuid? value) (php/strtolower value)
+    :else value))
+
+(defn- coerce-inst [value]
+  (cond
+    (php/instanceof value \DateTimeInterface) value
+    (string? value)
+    (try
+      (php/new \DateTimeImmutable value)
+      (catch \Throwable _ value))
+    (int? value)
+    (try
+      (php/:: \DateTimeImmutable (createFromFormat "U" (str value)))
+      (catch \Throwable _ value))
+    :else value))
+
+(defn- coerce-keyword-kind [head value]
+  (case head
+    :any     value
+    :nil     value
+    :string  (cond
+               (string? value) value
+               (or (int? value) (float? value)) (str value)
+               (boolean? value) (if value "true" "false")
+               (keyword? value) (name value)
+               (symbol? value) (name value)
+               :else value)
+    :int     (coerce-int value)
+    :float   (coerce-float value)
+    :number  (coerce-float value)
+    :boolean (coerce-boolean value)
+    :keyword (coerce-keyword value)
+    :symbol  (coerce-symbol value)
+    :uuid    (coerce-uuid value)
+    :inst    (coerce-inst value)
+    (if (reg/registered? head)
+      (coerce (reg/deref-ref head) value)
+      value)))
+
+(defn- coerce-collection
+  [schema value type-ctor]
+  (let [args (v/schema-args schema)]
+    (cond
+      (or (vector? value) (list? value) (set? value))
+      (if (empty? args)
+        (type-ctor value)
+        (let [elem-schema (first args)]
+          (type-ctor (into [] (map (fn [v] (coerce elem-schema v)) value)))))
+      :else value)))
+
+(defn- coerce-map-of
+  [schema value]
+  (if (not (map? value))
+    value
+    (let [args (v/schema-args schema)
+          key-schema (get args 0)
+          val-schema (get args 1)
+          pairs (into [] (for [[k v] :pairs value] [k v]))]
+      (loop [i 0 acc {}]
+        (cond
+          (>= i (count pairs)) acc
+          :else
+          (let [e (get pairs i)
+                k (coerce key-schema (get e 0))
+                v (coerce val-schema (get e 1))]
+            (recur (+ i 1) (assoc acc k v))))))))
+
+(defn- coerce-tuple
+  [schema value]
+  (if (not (or (vector? value) (list? value)))
+    value
+    (let [args (v/schema-args schema)
+          src  (into [] value)]
+      (if (not= (count src) (count args))
+        value
+        (loop [i 0 acc []]
+          (if (>= i (count args))
+            acc
+            (recur (+ i 1) (conj acc (coerce (get args i) (get src i))))))))))
+
+(defn- coerce-map
+  [schema value]
+  (if (not (map? value))
+    value
+    (let [entries (v/schema-args schema)]
+      (loop [es (seq entries) acc value]
+        (cond
+          (nil? es) acc
+          :else
+          (let [entry (first es)
+                k     (get entry 0)
+                inner (if (and (>= (count entry) 3) (map? (get entry 1)))
+                        (get entry 2)
+                        (get entry 1))]
+            (if (contains? acc k)
+              (recur (next es) (assoc acc k (coerce inner (get acc k))))
+              (recur (next es) acc))))))))
+
+(defn- coerce-vector-kind
+  [schema value]
+  (let [head (v/schema-head schema)
+        args (v/schema-args schema)]
+    (case head
+      :vector (coerce-collection schema value (fn [xs] (into [] xs)))
+      :list   (coerce-collection schema value (fn [xs] (apply list xs)))
+      :set    (coerce-collection schema value (fn [xs] (into (hash-set) xs)))
+      :map-of (coerce-map-of schema value)
+      :tuple  (coerce-tuple schema value)
+      :map    (coerce-map schema value)
+      :enum   value
+      :and    (loop [sch (seq args) v value]
+                (if (nil? sch) v (recur (next sch) (coerce (first sch) v))))
+      :or     (loop [sch (seq args)]
+                (cond
+                  (nil? sch) value
+                  :else
+                  (let [coerced (coerce (first sch) value)]
+                    (if (v/valid? (first sch) coerced)
+                      coerced
+                      (recur (next sch))))))
+      :maybe  (if (nil? value) nil (coerce (first args) value))
+      :re     value
+      :fn     value
+      :ref    (let [target (reg/deref-ref (first args))]
+                (if (nil? target) value (coerce target value)))
+      :=>     value
+      (if (reg/registered? head)
+        (coerce (reg/deref-ref head) value)
+        value))))
+
+(defn coerce
+  "Walks `schema` and returns `value` with string-typed inputs coerced
+  into their schema-required types. Already-typed values pass through.
+  Unknown or untranslatable values are returned unchanged so validation
+  can report the real failure."
+  {:example "(coerce :int \"42\") ; => 42"
+   :see-also ["phel\\schema/conform" "phel\\schema/validate"]}
+  [schema value]
+  (cond
+    (keyword? schema) (coerce-keyword-kind schema value)
+    (vector? schema)  (coerce-vector-kind schema value)
+    :else value))
+
+(defn conform
+  "Coerces `value` against `schema`. Returns the coerced value if it
+  then validates, otherwise the invalid marker `:phel.schema/invalid`."
+  {:example "(conform :int \"42\") ; => 42"
+   :see-also ["coerce" "phel\\schema/validate"]}
+  [schema value]
+  (let [coerced (coerce schema value)]
+    (if (v/valid? schema coerced)
+      coerced
+      invalid-marker)))

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -1,0 +1,253 @@
+(ns phel\schema\explainer
+  (:require phel\core)
+  (:require phel\schema\registry :as reg)
+  (:require phel\schema\validator :as v))
+
+;; Error-reporting companion to the validator.
+;;
+;; `explain` returns `nil` on success, otherwise a map
+;; `{:schema <root> :value <root> :errors [error ...]}` where each error
+;; carries:
+;;   :path   - path into the schema that failed
+;;   :in     - path into the value that failed
+;;   :schema - sub-schema that rejected the value
+;;   :value  - value at that path
+;;   :type   - :missing | :mismatch | :extra | :exception
+;;
+;; The explainer accumulates errors rather than short-circuiting so the
+;; caller can report every violation in one pass.
+
+(declare -explain)
+
+(defn- make-error
+  [path in schema value type]
+  {:path   path
+   :in     in
+   :schema schema
+   :value  value
+   :type   type})
+
+(defn- -explain-kind-keyword
+  [schema value path in]
+  (if (v/valid? schema value)
+    []
+    (if (reg/registered? schema)
+      (-explain (reg/deref-ref schema) value path in)
+      [(make-error path in schema value :mismatch)])))
+
+(defn- -explain-collection
+  [schema value type-pred path in]
+  (let [head (v/schema-head schema)
+        args (v/schema-args schema)]
+    (if (not (type-pred value))
+      [(make-error path in schema value :mismatch)]
+      (if (empty? args)
+        []
+        (let [elem-schema (first args)
+              items       (into [] value)]
+          (loop [i 0 acc []]
+            (cond
+              (>= i (count items)) acc
+              :else
+              (let [nested-path (conj path head 0)
+                    nested-in   (conj in i)
+                    sub         (-explain elem-schema (get items i) nested-path nested-in)]
+                (recur (+ i 1) (into acc sub))))))))))
+
+(defn- -explain-map-of
+  [schema value path in]
+  (if (not (map? value))
+    [(make-error path in schema value :mismatch)]
+    (let [args (v/schema-args schema)
+          key-schema (get args 0)
+          val-schema (get args 1)
+          pairs (into [] (for [[k v] :pairs value] [k v]))]
+      (loop [i 0 acc []]
+        (cond
+          (>= i (count pairs)) acc
+          :else
+          (let [entry (get pairs i)
+                k     (get entry 0)
+                val   (get entry 1)
+                ksub  (-explain key-schema k (conj path :map-of 0) (conj in k))
+                vsub  (-explain val-schema val (conj path :map-of 1) (conj in k))]
+            (recur (+ i 1) (into (into acc ksub) vsub))))))))
+
+(defn- -explain-tuple
+  [schema value path in]
+  (if (not (vector? value))
+    [(make-error path in schema value :mismatch)]
+    (let [args (v/schema-args schema)]
+      (if (not= (count value) (count args))
+        [(make-error path in schema value :mismatch)]
+        (loop [i 0 acc []]
+          (if (>= i (count args))
+            acc
+            (let [sub (-explain (get args i) (get value i)
+                                (conj path :tuple i)
+                                (conj in i))]
+              (recur (+ i 1) (into acc sub)))))))))
+
+(defn- -explain-map
+  [schema value path in]
+  (if (not (map? value))
+    [(make-error path in schema value :mismatch)]
+    (let [entries (v/schema-args schema)
+          closed? (true? (get (v/schema-options schema) :closed))
+          declared (into (hash-set) (map (fn [e] (get e 0)) entries))
+          entry-errors
+          (loop [es (seq entries) acc []]
+            (cond
+              (nil? es) acc
+              :else
+              (let [entry (first es)
+                    k     (get entry 0)
+                    inner (if (and (>= (count entry) 3) (map? (get entry 1)))
+                            (get entry 2)
+                            (get entry 1))
+                    opts  (if (and (>= (count entry) 3) (map? (get entry 1)))
+                            (get entry 1)
+                            {})
+                    opt?  (true? (get opts :optional))
+                    path' (conj path :map k)
+                    in'   (conj in k)]
+                (cond
+                  (not (contains? value k))
+                  (if opt?
+                    (recur (next es) acc)
+                    (recur (next es)
+                           (conj acc (make-error path' in' inner nil :missing))))
+
+                  :else
+                  (let [sub (-explain inner (get value k) path' in')]
+                    (recur (next es) (into acc sub)))))))
+          extra-errors
+          (if closed?
+            (loop [ks (seq (keys value)) acc []]
+              (cond
+                (nil? ks) acc
+                (contains? declared (first ks)) (recur (next ks) acc)
+                :else
+                (recur (next ks)
+                       (conj acc (make-error (conj path :map (first ks))
+                                             (conj in (first ks))
+                                             schema
+                                             (get value (first ks))
+                                             :extra)))))
+            [])]
+      (into entry-errors extra-errors))))
+
+(defn- -explain-enum
+  [schema value path in]
+  (let [args (v/schema-args schema)]
+    (if (v/valid? schema value)
+      []
+      [(make-error path in schema value :mismatch)])))
+
+(defn- -explain-and
+  [schema value path in]
+  (let [args (v/schema-args schema)]
+    (loop [sch (seq args) idx 0 acc []]
+      (cond
+        (nil? sch) acc
+        :else
+        (let [sub (-explain (first sch) value (conj path :and idx) in)]
+          (if (empty? sub)
+            (recur (next sch) (+ idx 1) acc)
+            (recur (next sch) (+ idx 1) (into acc sub))))))))
+
+(defn- -explain-or
+  [schema value path in]
+  (let [args (v/schema-args schema)]
+    (if (v/valid? schema value)
+      []
+      (loop [sch (seq args) idx 0 acc []]
+        (cond
+          (nil? sch) (into [(make-error path in schema value :mismatch)] acc)
+          :else
+          (let [sub (-explain (first sch) value (conj path :or idx) in)]
+            (recur (next sch) (+ idx 1) (into acc sub))))))))
+
+(defn- -explain-ref
+  [schema value path in]
+  (let [name (first (v/schema-args schema))
+        target (reg/deref-ref name)]
+    (if (nil? target)
+      [(make-error path in schema value :mismatch)]
+      (-explain target value (conj path :ref name) in))))
+
+(defn- -explain-vector-kind
+  [schema value path in]
+  (let [head (v/schema-head schema)
+        args (v/schema-args schema)]
+    (case head
+      :vector (-explain-collection schema value vector? path in)
+      :list   (-explain-collection schema value list? path in)
+      :set    (-explain-collection schema value set? path in)
+      :map-of (-explain-map-of schema value path in)
+      :tuple  (-explain-tuple schema value path in)
+      :map    (-explain-map schema value path in)
+      :enum   (-explain-enum schema value path in)
+      :and    (-explain-and schema value path in)
+      :or     (-explain-or schema value path in)
+      :maybe  (cond
+                (nil? value) []
+                (v/valid? (first args) value) []
+                :else (-explain (first args) value (conj path :maybe) in))
+      :re     (if (v/valid? schema value)
+                []
+                [(make-error path in schema value :mismatch)])
+      :fn     (if (v/valid? schema value)
+                []
+                [(make-error path in schema value :mismatch)])
+      :ref    (-explain-ref schema value path in)
+      :=>     []
+      (if (v/valid? schema value)
+        []
+        [(make-error path in schema value :mismatch)]))))
+
+(defn- -explain
+  [schema value path in]
+  (cond
+    (keyword? schema)
+    (-explain-kind-keyword schema value path in)
+
+    (vector? schema)
+    (-explain-vector-kind schema value path in)
+
+    :else
+    [(make-error path in schema value :mismatch)]))
+
+(defn explain
+  "Returns `nil` if `value` conforms to `schema`, otherwise a map
+  describing the violations."
+  {:example "(explain :int :oops)"
+   :see-also ["phel\\schema/validate" "phel\\schema/human-readable-explain"]}
+  [schema value]
+  (let [errors (-explain schema value [] [])]
+    (if (empty? errors)
+      nil
+      {:schema schema :value value :errors errors})))
+
+(defn- format-error
+  [err]
+  (str "  " (print-str (get err :in))
+       " -> "
+       (name (get err :type))
+       ": expected "
+       (print-str (get err :schema))
+       ", got "
+       (print-str (get err :value))))
+
+(defn human-readable-explain
+  "Renders an explain result as a multi-line human string suitable for
+  REPL or CI output. Returns `nil` for a `nil` result."
+  {:example "(human-readable-explain (explain :int :oops))"
+   :see-also ["explain"]}
+  [result]
+  (when result
+    (let [header (str "Schema " (print-str (get result :schema))
+                      " failed for value " (print-str (get result :value)))
+          lines  (into [] (map format-error (get result :errors)))
+          body   (php/implode "\n" (to-php-array lines))]
+      (str header "\n" body))))

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -1,0 +1,204 @@
+(ns phel\schema\generator
+  (:require phel\core)
+  (:require phel\schema\registry :as reg)
+  (:require phel\schema\validator :as v)
+  (:require phel\test\gen :as g))
+
+;; Maps schemas to `phel\test\gen` generators so properties and examples
+;; can exercise the schema without a hand-written generator. A schema
+;; may attach its own generator via `{:gen <gen-fn>}` options to override
+;; the default.
+;;
+;; The mapping is deliberately conservative: only the shapes the
+;; validator can check are supported, and parametric combinators reuse
+;; their validator siblings rather than re-implementing logic.
+
+(declare schema->gen)
+
+(defn- simple-string-gen [_args]
+  g/string-alphanumeric)
+
+(defn- simple-keyword-gen [_args]
+  g/keyword)
+
+(defn- inst-gen []
+  (g/fmap (fn [secs] (php/:: \DateTimeImmutable (createFromFormat "U" (str secs))))
+          (g/choose 0 2147483647)))
+
+(defn- uuid-gen []
+  (fn [_size] (random-uuid)))
+
+(defn- keyword-kind->gen
+  [head]
+  (case head
+    :any        g/int
+    :nil        (g/return nil)
+    :boolean    g/boolean
+    :int        g/int
+    :float      g/float
+    :number     (g/one-of [g/int g/float])
+    :string     g/string-alphanumeric
+    :keyword    g/keyword
+    :symbol     g/symbol
+    :uuid       (uuid-gen)
+    :inst       (inst-gen)
+    :vector     (g/vector-of g/int)
+    :list       (g/list-of g/int)
+    :map        (g/map-of g/keyword g/int)
+    :set        (g/set-of g/int)
+    :sequential (g/vector-of g/int)
+    :seqable    (g/vector-of g/int)
+    (if (reg/registered? head)
+      (schema->gen (reg/deref-ref head))
+      (throw (php/new \InvalidArgumentException
+                      (str "no default generator for schema kind: " head))))))
+
+(defn- vector-of-gen [args]
+  (if (empty? args)
+    (g/vector-of g/int)
+    (g/vector-of (schema->gen (first args)))))
+
+(defn- list-of-gen [args]
+  (if (empty? args)
+    (g/list-of g/int)
+    (g/list-of (schema->gen (first args)))))
+
+(defn- set-of-gen [args]
+  (if (empty? args)
+    (g/set-of g/int)
+    (g/set-of (schema->gen (first args)))))
+
+(defn- map-of-gen [args]
+  (g/map-of (schema->gen (get args 0))
+            (schema->gen (get args 1))))
+
+(defn- tuple-gen [args]
+  (apply g/tuple (into [] (map schema->gen args))))
+
+(defn- map-schema-gen
+  [entries]
+  (let [pairs (into []
+                    (map (fn [entry]
+                           (let [k (get entry 0)
+                                 inner (if (and (>= (count entry) 3)
+                                                (map? (get entry 1)))
+                                         (get entry 2)
+                                         (get entry 1))
+                                 opts (if (and (>= (count entry) 3)
+                                               (map? (get entry 1)))
+                                        (get entry 1)
+                                        {})
+                                 opt? (true? (get opts :optional))]
+                             [k (schema->gen inner) opt?]))
+                         entries))]
+    (fn [size]
+      (loop [ps (seq pairs) acc {}]
+        (cond
+          (nil? ps) acc
+          :else
+          (let [p (first ps)
+                k (get p 0)
+                g (get p 1)
+                opt? (get p 2)
+                include? (if opt?
+                           (g/boolean size)
+                           true)]
+            (if include?
+              (recur (next ps) (assoc acc k (g size)))
+              (recur (next ps) acc))))))))
+
+(defn- enum-gen [args]
+  (g/elements args))
+
+(defn- and-gen [args]
+  ;; The AND intersection is hard in general; pick the first schema and
+  ;; rely on `such-that` to discard values rejected by later ones.
+  (let [base (schema->gen (first args))]
+    (g/such-that (fn [v]
+                   (loop [xs (next args)]
+                     (cond
+                       (nil? xs) true
+                       (not (v/valid? (first xs) v)) false
+                       :else (recur (next xs)))))
+                 base)))
+
+(defn- or-gen [args]
+  (g/one-of (into [] (map schema->gen args))))
+
+(defn- maybe-gen [args]
+  (g/frequency [[9 (schema->gen (first args))]
+                [1 (g/return nil)]]))
+
+(defn- re-gen [args]
+  (let [pattern (first args)]
+    (g/such-that (fn [s]
+                   (and (string? s)
+                        (php/=== 1 (php/preg_match
+                                     (cond
+                                       (string? pattern) pattern
+                                       :else (str pattern))
+                                     s))))
+                 g/string-alphanumeric
+                 200)))
+
+(defn- fn-gen [args]
+  (let [pred (first args)]
+    (g/such-that pred g/int)))
+
+(defn- ref-gen [args]
+  (let [target (reg/deref-ref (first args))]
+    (when (nil? target)
+      (throw (php/new \InvalidArgumentException
+                      (str "schema ref not registered: " (first args)))))
+    (schema->gen target)))
+
+(defn- vector-kind->gen
+  [schema]
+  (let [head (v/schema-head schema)
+        args (v/schema-args schema)]
+    (case head
+      :vector  (vector-of-gen args)
+      :list    (list-of-gen args)
+      :set     (set-of-gen args)
+      :map-of  (map-of-gen args)
+      :tuple   (tuple-gen args)
+      :map     (map-schema-gen args)
+      :enum    (enum-gen args)
+      :and     (and-gen args)
+      :or      (or-gen args)
+      :maybe   (maybe-gen args)
+      :re      (re-gen args)
+      :fn      (fn-gen args)
+      :ref     (ref-gen args)
+      :=>      (throw (php/new \InvalidArgumentException
+                                "cannot generate function schemas"))
+      (if (reg/registered? head)
+        (schema->gen (reg/deref-ref head))
+        (throw (php/new \InvalidArgumentException
+                        (str "no generator for schema kind: " head)))))))
+
+(defn schema->gen
+  "Returns a `phel\\test\\gen` generator for `schema`. Honours a
+  `{:gen <gen>}` override in the schema options when present."
+  {:example "(schema->gen [:int])"
+   :see-also ["phel\\schema/generate"]}
+  [schema]
+  (cond
+    (keyword? schema) (keyword-kind->gen schema)
+
+    (vector? schema)
+    (let [custom (get (v/schema-options schema) :gen)]
+      (if custom custom (vector-kind->gen schema)))
+
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "unsupported schema shape: " (print-str schema))))))
+
+(defn generate
+  "Generates one random value conforming to `schema`. Accepts the same
+  `:size` and `:seed` options as `phel\\test\\gen/generate`."
+  {:example "(generate :int)"
+   :see-also ["schema->gen"]}
+  ([schema] (generate schema {}))
+  ([schema opts]
+   (g/generate (schema->gen schema) opts)))

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -1,0 +1,169 @@
+(ns phel\schema\instrument
+  (:require phel\core)
+  (:require phel\schema\validator :as v)
+  (:require phel\schema\explainer :as e))
+
+;; Function-level instrumentation.
+;;
+;; A function schema looks like `[=> [:int :int] :int]` where the second
+;; element is the vector of argument schemas and the third is the return
+;; schema. `wrap-with-schema` returns a wrapped fn that validates its
+;; arguments and return value against the declared schema. Violations
+;; throw `\InvalidArgumentException` with a human-readable message built
+;; from `explain`.
+;;
+;; Phel has no `alter-var-root`, so true in-place instrumentation of an
+;; existing named fn is not possible at runtime — `instrument` therefore
+;; returns the wrapped fn and the caller is expected to bind it back.
+;; A separate registry records every `instrument!` call so `unstrument!`
+;; can fetch the original fn again.
+
+(def- schema-check?-atom
+  ;; Atom-backed toggle so callers in any namespace can flip runtime
+  ;; validation on or off without rebinding a dynamic var across module
+  ;; boundaries.
+  (atom true))
+
+(defn schema-check?
+  "Returns `true` when runtime validation is enabled."
+  []
+  @schema-check?-atom)
+
+(defn set-schema-check!
+  "Enables (`true`) or disables (`false`) runtime validation performed by
+  `wrap-with-schema`/`instrument!`. Returns the new value."
+  [enabled?]
+  (reset! schema-check?-atom (boolean enabled?)))
+
+(defn with-schema-check
+  "Runs thunk `f` with runtime validation set to `enabled?`, restoring
+  the previous value even if `f` throws."
+  [enabled? f]
+  (let [prev @schema-check?-atom]
+    (reset! schema-check?-atom (boolean enabled?))
+    (try
+      (f)
+      (finally
+        (reset! schema-check?-atom prev)))))
+
+(def- instrumented (atom {}))
+
+(defn schema?
+  "Returns `true` if `x` has the shape of a schema value (a keyword or a
+  vector whose head is a keyword, including the `:=>` function marker)."
+  {:example "(schema? :int) ; => true"
+   :see-also ["phel\\schema/validate"]}
+  [x]
+  (cond
+    (keyword? x) true
+    (and (vector? x) (not (empty? x))) (keyword? (get x 0))
+    :else false))
+
+(defn function-schema?
+  "Returns `true` if `schema` is a function schema of the shape
+  `[:=> args-schema return-schema]`."
+  {:example "(function-schema? [:=> [:int] :int])"
+   :see-also ["wrap-with-schema"]}
+  [schema]
+  (and (vector? schema)
+       (>= (count schema) 3)
+       (= :=> (get schema 0))))
+
+(defn- schema-violation!
+  [label schema value]
+  (let [result (e/explain schema value)]
+    (throw (php/new \InvalidArgumentException
+                    (str label "\n"
+                         (e/human-readable-explain result))))))
+
+(defn- validate-args!
+  [arg-schemas args]
+  (let [expected (if (vector? arg-schemas) arg-schemas [arg-schemas])
+        actual   (into [] args)]
+    (when (not= (count actual) (count expected))
+      (throw (php/new \InvalidArgumentException
+                      (str "schema arity mismatch: expected "
+                           (count expected) " args, got " (count actual)))))
+    (loop [i 0]
+      (when (< i (count expected))
+        (let [s (get expected i)
+              v (get actual i)]
+          (when-not (v/valid? s v)
+            (schema-violation! (str "argument " i " failed schema") s v))
+          (recur (+ i 1)))))))
+
+(defn- validate-return!
+  [return-schema result]
+  (when-not (v/valid? return-schema result)
+    (schema-violation! "return value failed schema" return-schema result)))
+
+(defn wrap-with-schema
+  "Wraps `f` so each call validates its arguments against `arg-schema`
+  (a vector of per-arg schemas) and its return value against
+  `return-schema`. When `schema-check?` returns `false` at call time
+  the wrapper short-circuits and invokes `f` directly, skipping
+  validation on both sides."
+  {:example "(wrap-with-schema add [:int :int] :int)"
+   :see-also ["instrument!" "schema-check?" "set-schema-check!"]}
+  [f arg-schema return-schema]
+  (fn [& args]
+    (if (not (schema-check?))
+      (apply f args)
+      (do
+        (validate-args! arg-schema args)
+        (let [result (apply f args)]
+          (validate-return! return-schema result)
+          result)))))
+
+(defn wrap-with-function-schema
+  "Convenience: accepts a `[:=> args-schema return-schema]` schema vector
+  and returns `f` wrapped accordingly."
+  {:example "(wrap-with-function-schema add [:=> [:int :int] :int])"
+   :see-also ["wrap-with-schema"]}
+  [f schema]
+  (when-not (function-schema? schema)
+    (throw (php/new \InvalidArgumentException
+                    (str "expected function schema `[:=> args ret]`, got "
+                         (print-str schema)))))
+  (wrap-with-schema f (get schema 1) (get schema 2)))
+
+(defn instrument!
+  "Registers `f` under `name` (any key) wrapped with `schema`. Returns
+  the wrapped fn. Subsequent calls to `unstrument!` with the same name
+  can restore the original via `(instrumented-original name)`."
+  {:example "(def add* (instrument! :add add [:=> [:int :int] :int]))"
+   :see-also ["unstrument!" "*schema-check*"]}
+  [name f schema]
+  (let [wrapped (wrap-with-function-schema f schema)]
+    (swap! instrumented assoc name {:original f :wrapped wrapped :schema schema})
+    wrapped))
+
+(defn unstrument!
+  "Unregisters the instrumentation bound to `name` and returns the
+  original (unwrapped) function if present, otherwise `nil`."
+  {:example "(unstrument! :add)"
+   :see-also ["instrument!"]}
+  [name]
+  (let [entry (get @instrumented name)]
+    (swap! instrumented dissoc name)
+    (when entry (get entry :original))))
+
+(defn instrumented?
+  "Returns `true` if `name` currently has an instrumentation entry."
+  {:example "(instrumented? :add)"}
+  [name]
+  (contains? @instrumented name))
+
+(defn instrumented-original
+  "Returns the original, unwrapped function associated with `name`, or
+  `nil` if no instrumentation is registered under `name`."
+  {:example "(instrumented-original :add)"}
+  [name]
+  (when (contains? @instrumented name)
+    (get (get @instrumented name) :original)))
+
+(defn clear-instrumented!
+  "Removes every instrumentation entry. Returns `nil`."
+  []
+  (reset! instrumented {})
+  nil)

--- a/src/phel/schema/registry.phel
+++ b/src/phel/schema/registry.phel
@@ -1,0 +1,56 @@
+(ns phel\schema\registry
+  (:require phel\core))
+
+;; Named-schema registry.
+;;
+;; Schemas can reference other schemas by name with `[:ref :tree]`. The
+;; registry maps those names to the actual schema value. Built-in kind
+;; keywords such as `:int`, `:string`, `:vector`, ... are handled
+;; directly by the validator dispatch; the registry is for user-defined
+;; schemas that describe domain types (e.g. `:user`, `:email`).
+
+(def- registry (atom {}))
+
+(defn register!
+  "Registers `schema` under `name` (usually a keyword). Overwrites any
+  previous entry. Returns the registered schema."
+  {:example "(register! :email [:and :string [:re #\"@\"]])"
+   :see-also ["deref-ref" "registered?"]}
+  [name schema]
+  (swap! registry assoc name schema)
+  schema)
+
+(defn unregister!
+  "Removes the schema bound to `name`. Returns `nil`."
+  {:example "(unregister! :email)"
+   :see-also ["register!"]}
+  [name]
+  (swap! registry dissoc name)
+  nil)
+
+(defn deref-ref
+  "Returns the schema registered under `name`, or `nil` if no schema is
+  registered with that name."
+  {:example "(deref-ref :email)"
+   :see-also ["register!"]}
+  [name]
+  (get @registry name))
+
+(defn registered?
+  "Returns `true` if a schema is registered under `name`."
+  {:example "(registered? :email) ; => true/false"
+   :see-also ["register!"]}
+  [name]
+  (contains? @registry name))
+
+(defn registry-snapshot
+  "Returns the current registry as a plain map. Intended for inspection
+  and testing."
+  []
+  @registry)
+
+(defn clear!
+  "Removes every user-registered schema. Returns `nil`."
+  []
+  (reset! registry {})
+  nil)

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -1,0 +1,299 @@
+(ns phel\schema\validator
+  (:require phel\core)
+  (:require phel\schema\registry :as reg))
+
+;; Core validation engine.
+;;
+;; `valid?` answers "does this value satisfy this schema" with a plain
+;; boolean. It is the fast path used by `validate` and short-circuits
+;; on the first mismatch.
+;;
+;; The implementation dispatches on `schema-head`, which is the schema
+;; itself when the schema is a keyword and the first element when it is
+;; a vector. Every dispatch target is a small focused predicate so
+;; adding new schema kinds is purely additive.
+
+(declare valid?)
+(declare schema-head)
+(declare schema-args)
+(declare schema-options)
+
+;; ----------------
+;; Schema shape helpers
+;; ----------------
+
+(defn schema-head
+  "Returns the head (kind keyword) of `schema`. Keyword schemas are
+  their own head; vector schemas use their first element."
+  [schema]
+  (cond
+    (keyword? schema) schema
+    (and (vector? schema) (not (empty? schema))) (get schema 0)
+    :else nil))
+
+(defn- extract-options
+  "Returns `[options remaining]` where `options` is a map (possibly
+  empty) of trailing options pulled from the second position of a
+  parametric schema, and `remaining` is the rest of the args after
+  the options map."
+  [args]
+  (if (and (not (empty? args))
+           (map? (first args)))
+    [(first args) (apply vector (next args))]
+    [{} args]))
+
+(defn schema-args
+  "Returns the positional arguments of `schema` (children past the
+  head and optional options map)."
+  [schema]
+  (if (vector? schema)
+    (let [tail (apply vector (next schema))
+          [_opts rest] (extract-options tail)]
+      rest)
+    []))
+
+(defn schema-options
+  "Returns the options map of `schema` or `{}` if none."
+  [schema]
+  (if (vector? schema)
+    (let [tail (apply vector (next schema))
+          [opts _rest] (extract-options tail)]
+      opts)
+    {}))
+
+;; ----------------
+;; Scalar predicates
+;; ----------------
+
+(defn- valid-inst?
+  "PHP has no native instant type; canonical inst values are
+  `\\DateTimeInterface` instances."
+  [x]
+  (php/instanceof x \DateTimeInterface))
+
+;; ----------------
+;; Collection predicates
+;; ----------------
+
+(defn- valid-sequential?
+  "Vectors and lists are sequential."
+  [x]
+  (or (vector? x) (list? x)))
+
+(defn- valid-seqable?
+  "Collections that `seq` accepts."
+  [x]
+  (or (nil? x)
+      (vector? x)
+      (list? x)
+      (map? x)
+      (set? x)
+      (string? x)))
+
+;; ----------------
+;; Keyword-kind validators
+;; ----------------
+
+(defn- validate-keyword-kind
+  [head value]
+  (case head
+    :any        true
+    :nil        (nil? value)
+    :boolean    (boolean? value)
+    :string     (string? value)
+    :int        (int? value)
+    :float      (float? value)
+    :number     (number? value)
+    :keyword    (keyword? value)
+    :symbol     (symbol? value)
+    :uuid       (uuid? value)
+    :inst       (valid-inst? value)
+    :vector     (vector? value)
+    :list       (list? value)
+    :map        (map? value)
+    :set        (set? value)
+    :sequential (valid-sequential? value)
+    :seqable    (valid-seqable? value)
+    (if (reg/registered? head)
+      (valid? (reg/deref-ref head) value)
+      (throw (php/new \InvalidArgumentException
+                      (str "unknown schema kind: " head))))))
+
+;; ----------------
+;; Parametric validators
+;; ----------------
+
+(defn- validate-collection
+  "Generic collection validator used by `[:vector s]` and `[:set s]`."
+  [schema value type-pred elem-schemas]
+  (and (type-pred value)
+       (if (empty? elem-schemas)
+         true
+         (let [elem-schema (first elem-schemas)
+               items       (into [] value)]
+           (loop [i 0]
+             (cond
+               (>= i (count items)) true
+               (not (valid? elem-schema (get items i))) false
+               :else (recur (+ i 1))))))))
+
+(defn- validate-map-of
+  [value key-schema val-schema]
+  (and (map? value)
+       (let [pairs (into [] (for [[k v] :pairs value] [k v]))]
+         (loop [i 0]
+           (cond
+             (>= i (count pairs)) true
+             :else
+             (let [entry (get pairs i)
+                   k     (get entry 0)
+                   v     (get entry 1)]
+               (cond
+                 (not (valid? key-schema k)) false
+                 (not (valid? val-schema v)) false
+                 :else (recur (+ i 1)))))))))
+
+(defn- validate-tuple
+  [value elem-schemas]
+  (and (vector? value)
+       (= (count value) (count elem-schemas))
+       (loop [i 0]
+         (if (>= i (count elem-schemas))
+           true
+           (if (valid? (get elem-schemas i) (get value i))
+             (recur (+ i 1))
+             false)))))
+
+(defn- entry-options
+  "Options map for a `[:map ...]` entry `[key opts? schema]`."
+  [entry]
+  (if (and (>= (count entry) 3) (map? (get entry 1)))
+    (get entry 1)
+    {}))
+
+(defn- entry-schema
+  "Inner schema of a `[:map ...]` entry."
+  [entry]
+  (if (and (>= (count entry) 3) (map? (get entry 1)))
+    (get entry 2)
+    (get entry 1)))
+
+(defn- entry-optional?
+  [entry]
+  (true? (get (entry-options entry) :optional)))
+
+(defn- validate-map
+  [value entries closed?]
+  (if (not (map? value))
+    false
+    (let [keys-ok? (loop [es (seq entries)]
+                     (cond
+                       (nil? es) true
+                       :else
+                       (let [entry (first es)
+                             k     (get entry 0)
+                             inner (entry-schema entry)
+                             opt?  (entry-optional? entry)]
+                         (cond
+                           (not (contains? value k))
+                           (if opt? (recur (next es)) false)
+                           (not (valid? inner (get value k)))
+                           false
+                           :else (recur (next es))))))
+          extra-ok? (if closed?
+                      (let [declared (into (hash-set) (map (fn [e] (get e 0)) entries))]
+                        (loop [ks (seq (keys value))]
+                          (cond
+                            (nil? ks) true
+                            (contains? declared (first ks)) (recur (next ks))
+                            :else false)))
+                      true)]
+      (and keys-ok? extra-ok?))))
+
+(defn- validate-enum
+  [value alts]
+  (loop [alts (seq alts)]
+    (cond
+      (nil? alts) false
+      (= (first alts) value) true
+      :else (recur (next alts)))))
+
+(defn- validate-and
+  [value schemas]
+  (loop [schemas (seq schemas)]
+    (cond
+      (nil? schemas) true
+      (not (valid? (first schemas) value)) false
+      :else (recur (next schemas)))))
+
+(defn- validate-or
+  [value schemas]
+  (loop [schemas (seq schemas)]
+    (cond
+      (nil? schemas) false
+      (valid? (first schemas) value) true
+      :else (recur (next schemas)))))
+
+(defn- pattern-source
+  "Returns the raw regex string for a `:re` schema. Accepts either a
+  string pattern (used verbatim) or a compiled PHP regex handle."
+  [pattern]
+  (cond
+    (string? pattern) pattern
+    :else (str pattern)))
+
+(defn- valid-regex?
+  [pattern value]
+  (and (string? value)
+       (php/=== 1 (php/preg_match (pattern-source pattern) value))))
+
+(defn- validate-vector-kind
+  [schema value]
+  (let [head (schema-head schema)
+        args (schema-args schema)]
+    (case head
+      :vector  (validate-collection schema value vector? args)
+      :list    (validate-collection schema value list? args)
+      :set     (validate-collection schema value set? args)
+      :map-of  (validate-map-of value (get args 0) (get args 1))
+      :tuple   (validate-tuple value args)
+      :map     (validate-map value args
+                             (true? (get (schema-options schema) :closed)))
+      :enum    (validate-enum value args)
+      :and     (validate-and value args)
+      :or      (validate-or value args)
+      :maybe   (or (nil? value) (valid? (get args 0) value))
+      :re      (valid-regex? (get args 0) value)
+      :fn      (try
+                 (boolean ((get args 0) value))
+                 (catch \Throwable _ false))
+      :ref     (let [target (reg/deref-ref (get args 0))]
+                 (when (nil? target)
+                   (throw (php/new \InvalidArgumentException
+                                   (str "schema ref not registered: " (get args 0)))))
+                 (valid? target value))
+      :=>      true
+      (if (reg/registered? head)
+        (valid? (reg/deref-ref head) value)
+        (throw (php/new \InvalidArgumentException
+                        (str "unknown schema kind: " head)))))))
+
+;; ----------------
+;; Public entry point
+;; ----------------
+
+(defn valid?
+  "Returns `true` if `value` conforms to `schema`, otherwise `false`."
+  {:example "(valid? :int 1) ; => true"
+   :see-also ["phel\\schema/validate"]}
+  [schema value]
+  (cond
+    (keyword? schema)
+    (validate-keyword-kind schema value)
+
+    (vector? schema)
+    (validate-vector-kind schema value)
+
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "unsupported schema shape: " (print-str schema))))))

--- a/tests/phel/test/schema/coerce.phel
+++ b/tests/phel/test/schema/coerce.phel
@@ -1,0 +1,82 @@
+(ns phel-test\test\schema\coerce
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s))
+
+;; Type coercion — converting HTTP-style string input to schema-required types.
+
+(deftest test-coerce-int
+  (is (= 42 (s/coerce :int "42")))
+  (is (= -7 (s/coerce :int "-7")))
+  (is (= 1 (s/coerce :int true)))
+  (is (= 0 (s/coerce :int false)))
+  (is (= 5 (s/coerce :int 5)))
+  (is (= "abc" (s/coerce :int "abc")) "non-numeric string passes through"))
+
+(deftest test-coerce-float
+  (is (= 1.5 (s/coerce :float "1.5")))
+  (is (= 3.0 (s/coerce :float "3")))
+  (is (= 2.5 (s/coerce :float 2.5))))
+
+(deftest test-coerce-boolean
+  (is (= true (s/coerce :boolean "true")))
+  (is (= false (s/coerce :boolean "false")))
+  (is (= true (s/coerce :boolean "1")))
+  (is (= false (s/coerce :boolean "0")))
+  (is (= true (s/coerce :boolean "yes")))
+  (is (= false (s/coerce :boolean "no")))
+  (is (= true (s/coerce :boolean true)))
+  (is (= true (s/coerce :boolean 1)))
+  (is (= false (s/coerce :boolean 0))))
+
+(deftest test-coerce-keyword
+  (is (= :abc (s/coerce :keyword "abc")))
+  (is (= :x (s/coerce :keyword :x))))
+
+(deftest test-coerce-symbol
+  (is (= 'abc (s/coerce :symbol "abc")))
+  (is (= 'x (s/coerce :symbol :x))))
+
+(deftest test-coerce-uuid
+  (is (= "550e8400-e29b-41d4-a716-446655440000"
+         (s/coerce :uuid "550E8400-E29B-41D4-A716-446655440000"))
+      "lowercases a UUID"))
+
+(deftest test-coerce-inst-string-to-datetime
+  (let [v (s/coerce :inst "2026-04-20T12:00:00Z")]
+    (is (= true (php/instanceof v \DateTimeInterface)))))
+
+(deftest test-coerce-inst-int-epoch
+  (let [v (s/coerce :inst 1000000)]
+    (is (= true (php/instanceof v \DateTimeInterface)))))
+
+(deftest test-coerce-string
+  (is (= "42" (s/coerce :string 42)))
+  (is (= "1.5" (s/coerce :string 1.5)))
+  (is (= "true" (s/coerce :string true)))
+  (is (= "abc" (s/coerce :string :abc))))
+
+(deftest test-coerce-collection
+  (is (= [1 2 3] (s/coerce [:vector :int] ["1" "2" "3"])))
+  (is (= (hash-set 1 2) (s/coerce [:set :int] (hash-set "1" "2"))))
+  (is (= {:a 1 :b 2} (s/coerce [:map-of :keyword :int] {"a" "1" "b" "2"}))))
+
+(deftest test-coerce-tuple
+  (is (= [1 "a"] (s/coerce [:tuple :int :string] ["1" "a"]))))
+
+(deftest test-coerce-map
+  (is (= {:id 1 :name "Alice"}
+         (s/coerce [:map [:id :int] [:name :string]]
+                   {:id "1" :name "Alice"}))))
+
+(deftest test-coerce-idempotent-already-typed
+  (is (= 42 (s/coerce :int 42)))
+  (is (= [1 2] (s/coerce [:vector :int] [1 2]))))
+
+(deftest test-conform-returns-value-or-invalid
+  (is (= 42 (s/conform :int "42")))
+  (is (= s/invalid-marker (s/conform :int "abc")))
+  (is (= {:id 1} (s/conform [:map [:id :int]] {:id "1"}))))
+
+(deftest test-coerce-maybe
+  (is (= nil (s/coerce [:maybe :int] nil)))
+  (is (= 5 (s/coerce [:maybe :int] "5"))))

--- a/tests/phel/test/schema/explain.phel
+++ b/tests/phel/test/schema/explain.phel
@@ -1,0 +1,93 @@
+(ns phel-test\test\schema\explain
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s))
+
+;; Structured error output from `explain`.
+
+(deftest test-explain-returns-nil-on-success
+  (is (nil? (s/explain :int 1)))
+  (is (nil? (s/explain [:vector :int] [1 2 3])))
+  (is (nil? (s/explain [:map [:x :int]] {:x 1}))))
+
+(deftest test-explain-scalar-mismatch
+  (let [r (s/explain :int "x")]
+    (is (not (nil? r)))
+    (is (= :int (get r :schema)))
+    (is (= "x" (get r :value)))
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= :mismatch (get err :type)))
+      (is (= [] (get err :in)))
+      (is (= :int (get err :schema))))))
+
+(deftest test-explain-nested-path
+  (let [r (s/explain [:map [:user [:map [:id :int]]]]
+                     {:user {:id "x"}})]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= :mismatch (get err :type)))
+      (is (= [:user :id] (get err :in))))))
+
+(deftest test-explain-missing-key
+  (let [r (s/explain [:map [:id :int]] {})]
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= :missing (get err :type)))
+      (is (= [:id] (get err :in))))))
+
+(deftest test-explain-optional-key-missing-is-ok
+  (is (nil? (s/explain [:map
+                        [:id :int]
+                        [:nick {:optional true} :string]]
+                       {:id 1}))))
+
+(deftest test-explain-closed-map-extra
+  (let [r (s/explain [:map {:closed true} [:id :int]]
+                     {:id 1 :extra "a"})]
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= :extra (get err :type)))
+      (is (= [:extra] (get err :in))))))
+
+(deftest test-explain-vector-index-path
+  (let [r (s/explain [:vector :int] [1 "x" 3])]
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= [1] (get err :in))))))
+
+(deftest test-explain-tuple-index-path
+  (let [r (s/explain [:tuple :int :string] [1 2])]
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= [1] (get err :in))))))
+
+(deftest test-explain-multiple-errors
+  (let [r (s/explain [:map
+                      [:id :int]
+                      [:name :string]]
+                     {:id "x" :name 1})]
+    (is (= 2 (count (get r :errors))))))
+
+(deftest test-explain-or
+  (let [r (s/explain [:or :int :boolean] "s")]
+    (is (not (nil? r)))
+    (is (>= (count (get r :errors)) 1))))
+
+(deftest test-explain-and
+  (let [r (s/explain [:and :int [:fn pos?]] -3)]
+    (is (= 1 (count (get r :errors))))))
+
+(deftest test-explain-map-of
+  (let [r (s/explain [:map-of :keyword :int] {:a "x"})]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= [:a] (get err :in))))))
+
+(deftest test-human-readable-explain
+  (is (nil? (s/human-readable-explain nil)))
+  (let [text (s/human-readable-explain (s/explain :int "oops"))]
+    (is (string? text))
+    (is (php/str_contains text "mismatch"))
+    (is (php/str_contains text ":int"))))

--- a/tests/phel/test/schema/generate.phel
+++ b/tests/phel/test/schema/generate.phel
@@ -1,0 +1,89 @@
+(ns phel-test\test\schema\generate
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s)
+  (:require phel\test\gen :as g))
+
+;; Generated values must conform to their source schema.
+
+(defn- generates-valid? [schema n]
+  (loop [i 0]
+    (cond
+      (>= i n) true
+      (not (s/validate schema (s/generate schema))) false
+      :else (recur (+ i 1)))))
+
+(deftest test-generate-scalar-kinds
+  (is (generates-valid? :int 20))
+  (is (generates-valid? :string 20))
+  (is (generates-valid? :boolean 20))
+  (is (generates-valid? :float 20))
+  (is (generates-valid? :keyword 20))
+  (is (generates-valid? :symbol 20)))
+
+(deftest test-generate-vector
+  (is (generates-valid? [:vector :int] 10))
+  (is (generates-valid? [:vector :keyword] 10)))
+
+(deftest test-generate-tuple
+  (is (generates-valid? [:tuple :int :string] 10)))
+
+(deftest test-generate-map
+  (let [schema [:map [:id :int] [:name :string]]]
+    (loop [i 0]
+      (when (< i 10)
+        (let [v (s/generate schema)]
+          (is (contains? v :id))
+          (is (contains? v :name))
+          (is (s/validate schema v))
+          (recur (+ i 1)))))))
+
+(deftest test-generate-optional-map-key
+  (let [schema [:map [:id :int] [:nick {:optional true} :string]]]
+    (loop [i 0]
+      (when (< i 10)
+        (is (s/validate schema (s/generate schema)))
+        (recur (+ i 1))))))
+
+(deftest test-generate-enum
+  (let [schema [:enum :red :green :blue]
+        samples (into [] (for [_ :range [0 30]] (s/generate schema)))]
+    (is (every? (fn [v] (s/validate schema v)) samples))))
+
+(deftest test-generate-maybe
+  (let [schema [:maybe :int]]
+    (loop [i 0]
+      (when (< i 30)
+        (is (s/validate schema (s/generate schema)))
+        (recur (+ i 1))))))
+
+(deftest test-generate-or
+  (let [schema [:or :int :boolean]]
+    (loop [i 0]
+      (when (< i 20)
+        (is (s/validate schema (s/generate schema)))
+        (recur (+ i 1))))))
+
+(deftest test-generate-map-of
+  (let [schema [:map-of :keyword :int]]
+    (loop [i 0]
+      (when (< i 10)
+        (is (s/validate schema (s/generate schema)))
+        (recur (+ i 1))))))
+
+(deftest test-generate-ref
+  (s/register! :my-int :int)
+  (loop [i 0]
+    (when (< i 10)
+      (is (s/validate [:ref :my-int] (s/generate [:ref :my-int])))
+      (recur (+ i 1))))
+  (s/unregister! :my-int))
+
+(deftest test-generate-custom-override
+  (let [schema [:int {:gen (g/return 99)}]]
+    (is (= 99 (s/generate schema)))))
+
+(deftest test-generate-reproducible-with-seed
+  (let [schema :int
+        a (s/generate schema {:seed 42})
+        b (s/generate schema {:seed 42})]
+    (is (= a b) "same seed -> same value")))

--- a/tests/phel/test/schema/instrument.phel
+++ b/tests/phel/test/schema/instrument.phel
@@ -1,0 +1,86 @@
+(ns phel-test\test\schema\instrument
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s))
+
+;; Function-level instrumentation wrappers: a wrapped fn validates its
+;; arguments and return value against the declared schema, throwing
+;; when either side violates it.
+
+(defn- bare-add [x y] (+ x y))
+(defn- bad-return [_x] "not an int")
+
+(deftest test-wrap-with-schema-passes-through-valid-args
+  (let [wrapped (s/wrap-with-schema bare-add [:int :int] :int)]
+    (is (= 5 (wrapped 2 3)))
+    (is (= 0 (wrapped 0 0)))))
+
+(deftest test-wrap-with-schema-rejects-bad-arg
+  (let [wrapped (s/wrap-with-schema bare-add [:int :int] :int)
+        caught  (try
+                  (wrapped "a" 3)
+                  :no-throw
+                  (catch \InvalidArgumentException e :caught))]
+    (is (= :caught caught))))
+
+(deftest test-wrap-with-schema-rejects-bad-return
+  (let [wrapped (s/wrap-with-schema bad-return [:int] :int)
+        caught  (try
+                  (wrapped 1)
+                  :no-throw
+                  (catch \InvalidArgumentException e :caught))]
+    (is (= :caught caught))))
+
+(deftest test-wrap-with-function-schema
+  (let [wrapped (s/wrap-with-function-schema bare-add
+                                             [:=> [:int :int] :int])]
+    (is (= 10 (wrapped 4 6)))))
+
+(deftest test-wrap-with-function-schema-rejects-shape
+  (let [caught (try
+                 (s/wrap-with-function-schema bare-add [:int :int])
+                 :no-throw
+                 (catch \InvalidArgumentException _ :caught))]
+    (is (= :caught caught))))
+
+(deftest test-wrap-function-schema-rejects-bad-shape
+  (let [caught (try
+                 (s/wrap-with-function-schema bare-add [:int :int])
+                 :no-throw
+                 (catch \InvalidArgumentException _ :caught))]
+    (is (= :caught caught))))
+
+(deftest test-instrument-and-unstrument
+  (testing "instrument! returns wrapped fn"
+    (let [wrapped (s/instrument! :add bare-add [:=> [:int :int] :int])]
+      (is (= 7 (wrapped 3 4)))))
+  (testing "instrumented? reflects state"
+    (is (s/instrumented? :add)))
+  (testing "unstrument! returns the original"
+    (let [original (s/unstrument! :add)]
+      (is (= 5 (original 2 3))))
+    (is (not (s/instrumented? :add)))))
+
+(deftest test-wrap-with-schema-arity-mismatch
+  (let [wrapped (s/wrap-with-schema bare-add [:int :int] :int)
+        caught  (try
+                  (wrapped 1)
+                  :no-throw
+                  (catch \InvalidArgumentException _ :caught))]
+    (is (= :caught caught))))
+
+(deftest test-schema?-predicate
+  (is (s/schema? :int))
+  (is (s/schema? [:vector :int]))
+  (is (not (s/schema? 42)))
+  (is (not (s/schema? "string"))))
+
+(deftest test-schema-check-toggle-disables-validation
+  (let [wrapped (s/wrap-with-schema bad-return [:int] :int)]
+    ;; Normally the return-value check throws
+    (let [caught (try (wrapped 1) :no-throw
+                      (catch \InvalidArgumentException _ :caught))]
+      (is (= :caught caught)))
+    ;; With the flag off the wrapper passes through
+    (is (= "not an int" (s/with-schema-check false (fn [] (wrapped 1)))))
+    ;; And is restored afterwards
+    (is (s/schema-check?))))

--- a/tests/phel/test/schema/registry.phel
+++ b/tests/phel/test/schema/registry.phel
@@ -1,0 +1,45 @@
+(ns phel-test\test\schema\registry
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s))
+
+;; Named-schema registry behaviour and recursive references.
+
+(deftest test-register-and-deref
+  (s/register! :age :int)
+  (is (s/registered? :age))
+  (is (= :int (s/deref-ref :age)))
+  (s/unregister! :age)
+  (is (not (s/registered? :age))))
+
+(deftest test-ref-validates-through-registry
+  (s/register! :email [:and :string [:re "/.+@.+/"]])
+  (is (s/validate [:ref :email] "a@b.co"))
+  (is (not (s/validate [:ref :email] "noatsign")))
+  (s/unregister! :email))
+
+(deftest test-bare-keyword-lookup-falls-back-to-registry
+  (s/register! :my-int :int)
+  (is (s/validate :my-int 5))
+  (is (not (s/validate :my-int "x")))
+  (s/unregister! :my-int))
+
+(deftest test-recursive-schema-tree
+  ;; A classic recursive tree: each node has a value and a vector of
+  ;; children, each of which is another tree.
+  (s/register! :tree [:map
+                      [:value :int]
+                      [:children [:vector [:ref :tree]]]])
+  (is (s/validate [:ref :tree] {:value 1 :children []}))
+  (is (s/validate [:ref :tree] {:value 1
+                                 :children [{:value 2 :children []}
+                                            {:value 3
+                                             :children [{:value 4 :children []}]}]}))
+  (is (not (s/validate [:ref :tree] {:value "x" :children []})))
+  (s/unregister! :tree))
+
+(deftest test-unregistered-ref-throws
+  (let [caught (try
+                 (s/validate [:ref :definitely-not-registered] 1)
+                 :no-throw
+                 (catch \InvalidArgumentException _ :caught))]
+    (is (= :caught caught))))

--- a/tests/phel/test/schema/validate.phel
+++ b/tests/phel/test/schema/validate.phel
@@ -1,0 +1,160 @@
+(ns phel-test\test\schema\validate
+  (:require phel\test :refer [deftest is testing])
+  (:require phel\schema :as s))
+
+;; Positive and negative coverage for every built-in schema form.
+
+(deftest test-scalar-predicates
+  (testing ":any always matches"
+    (is (s/validate :any 1))
+    (is (s/validate :any nil))
+    (is (s/validate :any "x")))
+  (testing ":nil"
+    (is (s/validate :nil nil))
+    (is (not (s/validate :nil 0))))
+  (testing ":boolean"
+    (is (s/validate :boolean true))
+    (is (s/validate :boolean false))
+    (is (not (s/validate :boolean 0))))
+  (testing ":string"
+    (is (s/validate :string "abc"))
+    (is (not (s/validate :string 1))))
+  (testing ":int"
+    (is (s/validate :int 7))
+    (is (not (s/validate :int 7.5))))
+  (testing ":float"
+    (is (s/validate :float 1.5))
+    (is (not (s/validate :float 1))))
+  (testing ":number"
+    (is (s/validate :number 1))
+    (is (s/validate :number 1.5))
+    (is (not (s/validate :number "1"))))
+  (testing ":keyword"
+    (is (s/validate :keyword :a))
+    (is (not (s/validate :keyword "a"))))
+  (testing ":symbol"
+    (is (s/validate :symbol 'foo))
+    (is (not (s/validate :symbol :foo))))
+  (testing ":uuid"
+    (is (s/validate :uuid "550e8400-e29b-41d4-a716-446655440000"))
+    (is (not (s/validate :uuid "not-a-uuid")))))
+
+(deftest test-inst
+  (testing ":inst matches DateTime instances"
+    (let [now (php/new \DateTimeImmutable)]
+      (is (s/validate :inst now))))
+  (testing ":inst rejects strings"
+    (is (not (s/validate :inst "2026-01-01")))))
+
+(deftest test-collection-predicates
+  (testing ":vector / :list / :map / :set"
+    (is (s/validate :vector [1 2]))
+    (is (not (s/validate :vector '(1 2))))
+    (is (s/validate :list '(1 2)))
+    (is (s/validate :map {:a 1}))
+    (is (s/validate :set (hash-set 1)))
+    (is (s/validate :sequential [1 2]))
+    (is (s/validate :sequential '(1 2)))
+    (is (not (s/validate :sequential {:a 1})))
+    (is (s/validate :seqable {:a 1}))
+    (is (s/validate :seqable nil))
+    (is (s/validate :seqable "ab"))))
+
+(deftest test-parametric-vector
+  (testing "[:vector :int]"
+    (is (s/validate [:vector :int] [1 2 3]))
+    (is (s/validate [:vector :int] []))
+    (is (not (s/validate [:vector :int] [1 "x"])))
+    (is (not (s/validate [:vector :int] '(1 2 3)))))
+  (testing "[:set :int]"
+    (is (s/validate [:set :int] (hash-set 1 2 3)))
+    (is (not (s/validate [:set :int] (hash-set 1 "x"))))))
+
+(deftest test-map-of
+  (is (s/validate [:map-of :keyword :int] {:a 1 :b 2}))
+  (is (not (s/validate [:map-of :keyword :int] {:a "x"})))
+  (is (not (s/validate [:map-of :keyword :int] {"a" 1}))))
+
+(deftest test-tuple
+  (is (s/validate [:tuple :int :string] [1 "hi"]))
+  (is (not (s/validate [:tuple :int :string] [1 2])))
+  (is (not (s/validate [:tuple :int :string] [1])))
+  (is (not (s/validate [:tuple :int :string] [1 "hi" :extra]))))
+
+(deftest test-map-schema
+  (testing "required keys"
+    (is (s/validate [:map [:id :int] [:name :string]] {:id 1 :name "a"}))
+    (is (not (s/validate [:map [:id :int] [:name :string]] {:id 1})))
+    (is (not (s/validate [:map [:id :int] [:name :string]] {:id "x" :name "a"}))))
+  (testing "optional keys"
+    (is (s/validate [:map [:id :int] [:nick {:optional true} :string]]
+                    {:id 1}))
+    (is (s/validate [:map [:id :int] [:nick {:optional true} :string]]
+                    {:id 1 :nick "n"}))
+    (is (not (s/validate [:map [:id :int] [:nick {:optional true} :string]]
+                         {:id 1 :nick 5}))))
+  (testing "closed map rejects extra keys"
+    (is (not (s/validate [:map {:closed true} [:id :int]] {:id 1 :extra 2})))
+    (is (s/validate [:map {:closed true} [:id :int]] {:id 1}))))
+
+(deftest test-enum
+  (is (s/validate [:enum :red :green :blue] :red))
+  (is (not (s/validate [:enum :red :green :blue] :yellow))))
+
+(deftest test-and-or
+  (testing ":and"
+    (is (s/validate [:and :int [:fn pos?]] 5))
+    (is (not (s/validate [:and :int [:fn pos?]] -1)))
+    (is (not (s/validate [:and :int [:fn pos?]] "x"))))
+  (testing ":or"
+    (is (s/validate [:or :int :string] 1))
+    (is (s/validate [:or :int :string] "a"))
+    (is (not (s/validate [:or :int :string] :kw)))))
+
+(deftest test-maybe
+  (is (s/validate [:maybe :int] nil))
+  (is (s/validate [:maybe :int] 5))
+  (is (not (s/validate [:maybe :int] "x"))))
+
+(deftest test-regex
+  (is (s/validate [:re "/^\\d+$/"] "42"))
+  (is (not (s/validate [:re "/^\\d+$/"] "x")))
+  (is (not (s/validate [:re "/^\\d+$/"] 42))))
+
+(deftest test-fn-schema
+  (is (s/validate [:fn even?] 2))
+  (is (not (s/validate [:fn even?] 3))))
+
+(deftest test-ref
+  (s/register! :positive-int [:and :int [:fn pos?]])
+  (is (s/validate [:ref :positive-int] 5))
+  (is (not (s/validate [:ref :positive-int] -1)))
+  (is (s/validate :positive-int 5))
+  (s/unregister! :positive-int))
+
+(deftest test-nested-map
+  (let [user [:map
+              [:id :uuid]
+              [:name :string]
+              [:tags [:vector :keyword]]
+              [:address {:optional true} [:map
+                                          [:city :string]
+                                          [:zip :int]]]]]
+    (is (s/validate user {:id   "550e8400-e29b-41d4-a716-446655440000"
+                          :name "Alice"
+                          :tags [:admin :user]}))
+    (is (s/validate user {:id   "550e8400-e29b-41d4-a716-446655440000"
+                          :name "Alice"
+                          :tags [:admin]
+                          :address {:city "NY" :zip 12345}}))
+    (is (not (s/validate user {:id   "x"
+                               :name "Alice"
+                               :tags []})))))
+
+(deftest test-schema?
+  (is (s/schema? :int))
+  (is (s/schema? [:int]))
+  (is (s/schema? [:vector :int]))
+  (is (s/schema? [:enum :a :b]))
+  (is (not (s/schema? "not a schema")))
+  (is (not (s/schema? 1))))

--- a/tests/php/Integration/Phel/SchemaTest.php
+++ b/tests/php/Integration/Phel/SchemaTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Phel;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function proc_close;
+use function proc_open;
+use function sprintf;
+use function stream_get_contents;
+
+/**
+ * Runs each file of `tests/phel/test/schema/*.phel` end-to-end so
+ * `composer test-compiler` exercises the data-driven schema module.
+ */
+final class SchemaTest extends TestCase
+{
+    /**
+     * @return iterable<string, list<string>>
+     */
+    public static function schemaFiles(): iterable
+    {
+        yield 'validate' => ['tests/phel/test/schema/validate.phel'];
+        yield 'explain' => ['tests/phel/test/schema/explain.phel'];
+        yield 'coerce' => ['tests/phel/test/schema/coerce.phel'];
+        yield 'generate' => ['tests/phel/test/schema/generate.phel'];
+        yield 'instrument' => ['tests/phel/test/schema/instrument.phel'];
+        yield 'registry' => ['tests/phel/test/schema/registry.phel'];
+    }
+
+    #[DataProvider('schemaFiles')]
+    public function test_schema_suite_passes(string $relativePath): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $command = sprintf(
+            '%s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($repoRoot . '/bin/phel'),
+            escapeshellarg('test') . ' ' . escapeshellarg($relativePath),
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes, $repoRoot);
+        self::assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        $exitCode = proc_close($process);
+
+        self::assertSame(
+            0,
+            $exitCode,
+            sprintf(
+                "`phel test %s` failed.\nSTDOUT:\n%s\nSTDERR:\n%s",
+                $relativePath,
+                $stdout,
+                $stderr,
+            ),
+        );
+        self::assertStringContainsString('Failed: 0', $stdout);
+        self::assertStringContainsString('Error: 0', $stdout);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Tier 2 item 10 of the Clojure-parity roadmap calls for malli-style data-driven schema validation. Phel had no equivalent to `malli`/`spec` for describing data shapes, generating values, or instrumenting functions.

## 💡 Goal

Ship `phel\schema`: plain-data schemas (keywords and vectors) with validation, structured error reporting, coercion, generation, and function instrumentation. Schemas are values so they are readable, serialisable, and composable.

## 🔖 Changes

New namespace tree under `src/phel/schema/`:

- `phel\schema` facade re-exporting the public API
- `phel\schema\validator` fast boolean check with head-dispatch
- `phel\schema\explainer` structured error accumulator plus `human-readable-explain`
- `phel\schema\coercer` HTTP-style string coercion and `conform`
- `phel\schema\generator` schema to `phel\test\gen` generator bridge
- `phel\schema\instrument` function wrappers, atom-backed `schema-check?` toggle
- `phel\schema\registry` named-schema registry for `[:ref ...]` and recursive schemas

Supported schema forms v1:

- Scalar kinds: `:any`, `:nil`, `:boolean`, `:string`, `:int`, `:float`, `:number`, `:keyword`, `:symbol`, `:uuid`, `:inst`
- Collection kinds: `:vector`, `:list`, `:map`, `:set`, `:sequential`, `:seqable`
- Parametric: `[:vector s]`, `[:list s]`, `[:set s]`, `[:map-of k v]`, `[:tuple s1 s2 ...]`
- Map: `[:map [:key s] [:key {:optional true} s] ...]` with `{:closed true}` rejecting extras
- Combinators: `[:enum v ...]`, `[:and s ...]`, `[:or s ...]`, `[:maybe s]`
- Leaves: `[:re pattern]`, `[:fn pred]`, `[:ref name]`
- Function schema: `[:=> arg-schemas return-schema]` consumed by `instrument!`
- `{:gen custom}` option overrides the default generator

Tests:

- `tests/phel/test/schema/*.phel`: 314 assertions across validate, explain, coerce, generate, instrument, registry
- `tests/php/Integration/Phel/SchemaTest.php`: runs every Phel suite under `composer test-compiler`

Changelog updated under `## Unreleased`.