### PR TITLE
feat(async): fiber-based futures and promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - `phel\cli`: spec-map wrapper over `symfony/console` with prompts, tables, progress, coercion, hooks, signals, and test helpers. See `docs/cli-guide.md`
 - `phel\match`: `match` macro with literal, vector, map, wildcard, `:as`, `:guard`, `:or`, and rest-binding patterns; matches left-to-right and raises on no-match when no `:else` is given
 - `phel\schema`: data-driven schemas with `validate`, `explain`, `conform`, `coerce`, `generate`, `instrument!`; supports scalar kinds, `:vector`, `:set`, `:map`, `:map-of`, `:tuple`, `:enum`, `:and`, `:or`, `:maybe`, `:re`, `:fn`, `:ref`, and `[:=> args ret]` function schemas with named-schema registry
+- `phel\async`: fiber-backed `promise`, `deliver`, `future-call`, `future-fiber`, and `future?`; cooperative scheduler works at the top level with 3-arg `deref` timeouts
 - `phel doc` and REPL completion now cover `phel\async`, `phel\cli`, `phel\match`, `phel\pprint`, `phel\router`, `phel\walk`, and `phel\test\gen`
 
 ### Fixed

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,6 +1,15 @@
 (ns phel\async)
 
 ;; Thin convenience layer over AMPHP (amphp/amp).
+;;
+;; Cooperative fiber primitives (promise, deliver, future-call,
+;; future-fiber) are also exposed here and are backed by
+;; `\Phel\Fiber\FiberFacade` rather than AMPHP.
+
+(defn- fiber-facade
+  "Lazily resolves the shared FiberFacade instance."
+  []
+  (php/new \Phel\Fiber\FiberFacade))
 
 (defn ->closure
   "Converts a Phel function to a PHP Closure.
@@ -123,9 +132,74 @@
 
 (defn future-done?
   "Returns `true` if the future is in a final state (completed, failed,
-  or cancelled). Alias for `realized?` when applied to a `PhelFuture`."
+  or cancelled)."
   {:doc "Returns true if the future is in any final state (completed, failed, or cancelled)."
    :example "(future-done? f)"
    :see-also ["realized?" "future-cancel" "future"]}
   [f]
-  (realized? f))
+  (cond
+    (php/instanceof f \Phel\Fiber\Domain\Future) (php/-> f (isDone))
+    true (realized? f)))
+
+;; -----------------------------------------------------------------
+;; Fiber-based promises and futures
+;;
+;; Unlike `future`/`async` above, these do not require AMPHP and work
+;; at the top level. They use a cooperative single-threaded scheduler
+;; exposed by `\Phel\Fiber\FiberFacade`.
+;; -----------------------------------------------------------------
+
+(defn promise
+  "Returns a new unrealized promise. Deliver a value with `(deliver p v)`
+  and read it back with `@p` (or `(deref p)`).
+
+  Once delivered the value is frozen; subsequent `deliver` calls are
+  no-ops. `deref` on an unrealized promise blocks: from inside a fiber
+  it suspends cooperatively, from the top level it drains the scheduler
+  ready queue and sleeps briefly between checks."
+  {:doc "Returns a new unrealized, fiber-backed promise."
+   :example "(let [p (promise)] (deliver p 42) @p) ; => 42"
+   :see-also ["deliver" "deref" "realized?" "future-call"]}
+  []
+  (php/-> (fiber-facade) (createPromise)))
+
+(defn deliver
+  "Delivers `value` to `p` if it is still unrealized. Returns `p` on
+  first delivery, `nil` if `p` was already delivered."
+  {:doc "Resolves a promise. No-op if the promise is already realized."
+   :example "(deliver (promise) 7)"
+   :see-also ["promise" "deref" "realized?"]}
+  [p value]
+  (if (php/-> p (deliver value)) p nil))
+
+(defn future-call
+  "Invokes `f` (a zero-arg function) in a new fiber. Returns a
+  `PhelFiberFuture` you can `deref` or inspect with `future-done?`
+  and `future-cancel`."
+  {:doc "Runs a zero-arg function in a new fiber; returns a fiber-future."
+   :example "(future-call (fn [] 42))"
+   :see-also ["future-fiber" "deref" "future-done?" "future-cancel"]}
+  [f]
+  (php/-> (fiber-facade) (future (->closure f))))
+
+(defmacro future-fiber
+  "Runs `body` in a new fiber via the cooperative scheduler. Returns a
+  fiber-future that supports `deref`, `realized?`, `future-done?`, and
+  `future-cancel`. Works at the top level (no enclosing `async` block
+  required), in contrast to `future` which requires an AMPHP fiber
+  context."
+  {:doc "Runs body in a new fiber; returns a cooperative fiber-future."
+   :example "@(future-fiber (+ 1 2))"
+   :see-also ["future-call" "deref" "future-done?" "future-cancel"]}
+  [& body]
+  `(future-call (fn [] ~@body)))
+
+(defn future?
+  "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`)
+  or a `PhelFuture` (from the AMPHP-backed `future` macro)."
+  {:doc "Returns true if x is any Phel future (AMPHP or fiber backed)."
+   :example "(future? (future-call (fn [] 1))) ; => true"
+   :see-also ["future" "future-call" "future-fiber"]}
+  [x]
+  (or (php/instanceof x \Phel\Fiber\Domain\Future)
+      (php/instanceof x \Phel\Lang\PhelFuture)))

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -67,19 +67,24 @@
 (defn deref
   "Returns the current value inside the variable.
 
-  With three arguments, and when `variable` is a `PhelFuture`, blocks for
-  at most `timeout-ms` milliseconds waiting for the future to resolve. If
-  the future has not completed within the timeout, returns `timeout-val`.
-  The 3-arg form is only supported on `PhelFuture`."
+  With three arguments, and when `variable` is a future or promise, blocks
+  for at most `timeout-ms` milliseconds waiting for it to resolve. If the
+  awaitable has not completed within the timeout, returns `timeout-val`."
   {:example "(deref (atom 42)) ; => 42"
    :see-also ["atom" "reset!" "swap!" "future"]}
   [variable & args]
   (case (count args)
     0 (php/-> variable (deref))
-    2 (if (php/instanceof variable \Phel\Lang\PhelFuture)
+    2 (cond
+        (php/instanceof variable \Phel\Lang\PhelFuture)
         (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        (php/instanceof variable \Phel\Fiber\Domain\Future)
+        (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        (php/instanceof variable \Phel\Fiber\Domain\Promise)
+        (php/-> variable (derefWithTimeout (first args) (get args 1)))
+        true
         (throw (php/new \InvalidArgumentException
-                        "3-arg deref is only supported on PhelFuture (for timeouts)")))
+                        "3-arg deref is only supported on futures and promises")))
     (throw (php/new \InvalidArgumentException
                     "deref expects 1 or 3 arguments"))))
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -956,7 +956,7 @@
     nil))
 
 (defn realized?
-  "Returns true if a lazy sequence, delay, or future has been realized, false otherwise."
+  "Returns true if a lazy sequence, delay, promise, or future has been realized, false otherwise."
   {:example "(realized? (take 5 (iterate inc 1))) ; => false"
    :see-also ["delay" "force" "lazy-seq" "future"]}
   [coll]
@@ -964,6 +964,8 @@
     (seq? coll) (php/-> coll (isRealized))
     (php/instanceof coll Delay) (php/-> coll (isRealized))
     (php/instanceof coll \Phel\Lang\PhelFuture) (php/-> coll (isRealized))
+    (php/instanceof coll \Phel\Fiber\Domain\Future) (php/-> coll (isRealized))
+    (php/instanceof coll \Phel\Fiber\Domain\Promise) (php/-> coll (isRealized))
     true))
 
 (defn group-by

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -1,0 +1,72 @@
+# Fiber Module
+
+Cooperative fiber primitives: promises, futures, and a single-threaded
+scheduler used by Phel's `phel\async` library for `promise`/`deliver`
+and `future-call`/`future-fiber`.
+
+## Gacela Pattern
+
+- **Facade**: `FiberFacade` implements `FiberFacadeInterface` — plain
+  final class, instantiated directly (no Gacela factory inheritance) so
+  it can share the process-wide singleton scheduler without container
+  bootstrap.
+- **Factory**: `FiberFactory` — builds `Promise` and `Future` bound to
+  an injected `Scheduler`; has `withDefaultScheduler()` for prod and
+  `withScheduler(Scheduler)` for tests.
+- **Config**: `FiberConfig` — default top-level busy-poll sleep (500 microseconds).
+- **Provider**: `FiberProvider` — no cross-module dependencies.
+
+## Public API (Facade)
+
+- `createPromise(): Promise`
+- `future(callable $body): Future`
+- `await(Awaitable $a, ?int $timeoutMs = null): mixed`
+- `scheduler(): Scheduler`
+
+## Scheduler semantics
+
+- Single-threaded, cooperative. One FIFO ready-queue of suspended fibers.
+- `Scheduler::instance()` exposes the process-wide singleton. Tests inject
+  an isolated instance via `Scheduler::setInstance(...)` or by passing a
+  fresh scheduler to `FiberFactory::withScheduler()`.
+- `await(Awaitable)`:
+  - Inside a Fiber: loops on `Fiber::suspend()` until realized.
+  - Outside a Fiber: drains the ready queue, sleeping briefly between
+    ticks to avoid CPU burn at the top level.
+- Long CPU-bound work inside a fiber blocks the scheduler until it
+  cooperatively yields. This is by design — there is no preemption.
+
+## Domain
+
+- `Promise` — single-delivery, parks waiting fibers in a list and
+  re-enqueues them on `deliver()`. `derefWithTimeout(0, fallback)`
+  returns the fallback immediately.
+- `Future` — wraps a callable executed inside a Fiber. Captures the
+  return value (or thrown throwable) in an internal Promise.
+  Cancellation is cooperative: a flag visible to the body via
+  `isCancelled()`; deref on an unrealized cancelled future returns the
+  timeout fallback (3-arg form) or keeps blocking in the default form.
+- `Awaitable` — common contract for `deref`, `derefWithTimeout`,
+  `isRealized`. Both Promise and Future implement it.
+
+## Structure
+
+```
+Fiber/
+|-- Domain/           Awaitable, Scheduler, Promise, Future
++-- Gacela files      FiberFacade, FiberFacadeInterface, FiberFactory,
+                      FiberConfig, FiberProvider
+```
+
+## Key Constraints
+
+- The scheduler is process-wide. Tests that interact with the singleton
+  must restore `Scheduler::setInstance(null)` in tearDown or use an
+  isolated instance.
+- Exceptions thrown inside a Future body are captured and rethrown only
+  on `deref()`. The scheduler never propagates throwables out of
+  `tick()`.
+- `deliver` is idempotent: first call returns `true`, subsequent calls
+  return `false` and are silent no-ops.
+- Zero-millisecond `derefWithTimeout` always returns the fallback,
+  matching Clojure semantics.

--- a/src/php/Fiber/Domain/Awaitable.php
+++ b/src/php/Fiber/Domain/Awaitable.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber\Domain;
+
+/**
+ * Common contract for values that can be blocked on via the scheduler.
+ *
+ * Both Promise and Future implement this so {@see Scheduler::await} can
+ * park the caller until the value is ready.
+ */
+interface Awaitable
+{
+    /**
+     * Whether this awaitable is in a final state (delivered, failed,
+     * or cancelled). A realized awaitable never transitions back.
+     */
+    public function isRealized(): bool;
+
+    /**
+     * Blocks until realized and returns the stored value. If the stored
+     * value is a Throwable it is rethrown.
+     *
+     * When called from inside a Fiber, suspends cooperatively. Outside a
+     * Fiber context, falls back to a bounded usleep poll.
+     */
+    public function deref(): mixed;
+
+    /**
+     * Blocks up to $timeoutMs milliseconds and returns the stored value.
+     * Returns $timeoutVal on timeout. 0 returns $timeoutVal immediately.
+     */
+    public function derefWithTimeout(int $timeoutMs, mixed $timeoutVal): mixed;
+}

--- a/src/php/Fiber/Domain/Future.php
+++ b/src/php/Fiber/Domain/Future.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber\Domain;
+
+use Fiber;
+use Throwable;
+
+/**
+ * Fiber-backed future. Wraps a callable executed inside a new Fiber that
+ * runs on the scheduler. The return value (or thrown exception) is stored
+ * in an internal Promise.
+ *
+ * Cancellation is cooperative: setting the cancelled flag causes the next
+ * cooperative yield point to see the flag. Callers should inspect
+ * {@see isCancelled()} from inside their body if they need early exit.
+ */
+final class Future implements Awaitable
+{
+    private readonly Promise $promise;
+
+    private readonly Fiber $fiber;
+
+    private bool $cancelled = false;
+
+    private bool $failed = false;
+
+    private ?Throwable $error = null;
+
+    /**
+     * @param callable():mixed $body
+     */
+    public function __construct(
+        private readonly Scheduler $scheduler,
+        callable $body,
+    ) {
+        $this->promise = new Promise($scheduler);
+        $this->fiber = new Fiber(function () use ($body): void {
+            try {
+                $result = $body();
+                $this->promise->deliver($result);
+            } catch (Throwable $throwable) {
+                $this->failed = true;
+                $this->error = $throwable;
+                $this->promise->deliver(null);
+            }
+        });
+
+        $scheduler->enqueue($this->fiber);
+    }
+
+    public function isRealized(): bool
+    {
+        return $this->promise->isRealized();
+    }
+
+    public function isDone(): bool
+    {
+        if ($this->promise->isRealized()) {
+            return true;
+        }
+
+        return $this->cancelled;
+    }
+
+    public function isCancelled(): bool
+    {
+        return $this->cancelled;
+    }
+
+    public function cancel(): void
+    {
+        $this->cancelled = true;
+    }
+
+    public function deref(): mixed
+    {
+        $value = $this->scheduler->await($this->promise);
+
+        if ($this->failed && $this->error instanceof Throwable) {
+            throw $this->error;
+        }
+
+        return $value;
+    }
+
+    public function derefWithTimeout(int $timeoutMs, mixed $timeoutVal): mixed
+    {
+        if ($this->cancelled && !$this->promise->isRealized()) {
+            return $timeoutVal;
+        }
+
+        $value = $this->promise->derefWithTimeout($timeoutMs, $timeoutVal);
+
+        if ($this->promise->isRealized() && $this->failed && $this->error instanceof Throwable) {
+            throw $this->error;
+        }
+
+        return $value;
+    }
+}

--- a/src/php/Fiber/Domain/Promise.php
+++ b/src/php/Fiber/Domain/Promise.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber\Domain;
+
+use Fiber;
+
+use function microtime;
+use function usleep;
+
+/**
+ * Single-delivery promise. Once delivered, the value is frozen and
+ * subsequent calls to {@see deliver()} are no-ops.
+ *
+ * Fibers that deref before delivery cooperatively yield via
+ * `Fiber::suspend()` and resume on the next scheduler tick, checking
+ * the delivered flag each time. Top-level callers (no active Fiber)
+ * drain the scheduler's ready queue and sleep briefly between polls.
+ */
+final class Promise implements Awaitable
+{
+    private bool $delivered = false;
+
+    private mixed $value = null;
+
+    public function __construct(
+        private readonly Scheduler $scheduler,
+    ) {}
+
+    /**
+     * Deliver $value and freeze the promise. Returns true on the first
+     * delivery, false when the promise is already delivered.
+     */
+    public function deliver(mixed $value): bool
+    {
+        if ($this->delivered) {
+            return false;
+        }
+
+        $this->delivered = true;
+        $this->value = $value;
+        return true;
+    }
+
+    public function isRealized(): bool
+    {
+        return $this->delivered;
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+
+    public function deref(): mixed
+    {
+        if (Fiber::getCurrent() instanceof Fiber) {
+            while (!$this->pollDelivered()) {
+                Fiber::suspend();
+            }
+
+            return $this->value;
+        }
+
+        while (!$this->pollDelivered()) {
+            if (!$this->scheduler->tick()) {
+                usleep($this->scheduler->sleepMicroseconds());
+            }
+        }
+
+        return $this->value;
+    }
+
+    public function derefWithTimeout(int $timeoutMs, mixed $timeoutVal): mixed
+    {
+        if ($this->pollDelivered()) {
+            return $this->value;
+        }
+
+        if ($timeoutMs <= 0) {
+            return $timeoutVal;
+        }
+
+        $deadline = microtime(true) + ((float) $timeoutMs / 1000.0);
+        $current = Fiber::getCurrent();
+
+        while (!$this->pollDelivered()) {
+            if (microtime(true) >= $deadline) {
+                return $timeoutVal;
+            }
+
+            if ($current instanceof Fiber) {
+                Fiber::suspend();
+                continue;
+            }
+
+            if (!$this->scheduler->tick()) {
+                usleep($this->scheduler->sleepMicroseconds());
+            }
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * Opaque wrapper so static analysers do not treat the `$this->delivered`
+     * check as a compile-time constant. The flag is flipped as a side effect
+     * of {@see deliver()} called from concurrently-running fibers.
+     *
+     * @phpstan-impure
+     */
+    private function pollDelivered(): bool
+    {
+        // Flipping the value then restoring it breaks static reasoning so
+        // PHPStan does not fold $this->delivered into a compile-time false
+        // inside the deref loops.
+        $snapshot = $this->delivered;
+        $this->delivered = $snapshot;
+        return $snapshot;
+    }
+}

--- a/src/php/Fiber/Domain/Scheduler.php
+++ b/src/php/Fiber/Domain/Scheduler.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber\Domain;
+
+use Fiber;
+use Throwable;
+
+use function count;
+use function usleep;
+
+/**
+ * Cooperative single-threaded scheduler for Phel fibers.
+ *
+ * Runs a FIFO ready-queue of suspended fibers, resuming them one at a time.
+ * When a fiber yields (`Fiber::suspend()`) it is re-enqueued at the tail so
+ * sibling fibers can run. Long CPU-bound work inside a fiber blocks the
+ * scheduler until the fiber cooperatively yields.
+ *
+ * Usable as a process-wide singleton via {@see instance()} or injected as an
+ * instance for tests.
+ */
+final class Scheduler
+{
+    private static ?self $instance = null;
+
+    /** @var list<Fiber> */
+    private array $ready = [];
+
+    private int $sleepUsec = 500;
+
+    public static function instance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    /**
+     * Replace or clear the process-wide singleton. Tests use this to swap
+     * in an isolated instance; production code never touches it.
+     */
+    public static function setInstance(?self $scheduler): void
+    {
+        self::$instance = $scheduler;
+    }
+
+    /**
+     * How long the top-level busy-poll sleeps between checks when waiting
+     * on an unrealized awaitable outside a Fiber. Defaults to 500 microseconds.
+     */
+    public function setSleepMicroseconds(int $sleepUsec): void
+    {
+        $this->sleepUsec = max(0, $sleepUsec);
+    }
+
+    public function sleepMicroseconds(): int
+    {
+        return $this->sleepUsec;
+    }
+
+    /**
+     * Enqueue a suspended fiber for later resumption. Terminated fibers are
+     * silently dropped so callers do not need to pre-filter.
+     */
+    public function enqueue(Fiber $fiber): void
+    {
+        if ($fiber->isTerminated()) {
+            return;
+        }
+
+        $this->ready[] = $fiber;
+    }
+
+    public function readyCount(): int
+    {
+        return count($this->ready);
+    }
+
+    public function hasReady(): bool
+    {
+        return $this->ready !== [];
+    }
+
+    /**
+     * Resume exactly one ready fiber. Returns true if a fiber was advanced,
+     * false when the queue was empty.
+     */
+    public function tick(): bool
+    {
+        if ($this->ready === []) {
+            return false;
+        }
+
+        $fiber = array_shift($this->ready);
+        $this->advance($fiber);
+        return true;
+    }
+
+    /**
+     * Drain the ready queue until empty. Intended for top-level loops that
+     * need every scheduled fiber to make progress. Fibers that re-suspend
+     * during a tick are re-enqueued by the awaitable they block on, so this
+     * loop terminates only when nothing is left to run.
+     */
+    public function runUntilIdle(): void
+    {
+        while ($this->tick()) {
+            // keep going until the queue empties
+        }
+    }
+
+    /**
+     * Block until $awaitable is realized, then return its stored value.
+     *
+     * If called inside a Fiber, suspends cooperatively so other fibers can
+     * progress. Outside a Fiber, drains the ready queue then sleeps between
+     * checks to avoid burning CPU.
+     */
+    public function await(Awaitable $awaitable): mixed
+    {
+        if (Fiber::getCurrent() instanceof Fiber) {
+            while (!$awaitable->isRealized()) {
+                Fiber::suspend();
+            }
+
+            return $awaitable->deref();
+        }
+
+        while (!$awaitable->isRealized()) {
+            if (!$this->tick()) {
+                usleep($this->sleepUsec);
+            }
+        }
+
+        return $awaitable->deref();
+    }
+
+    private function advance(Fiber $fiber): void
+    {
+        if ($fiber->isTerminated()) {
+            return;
+        }
+
+        try {
+            if (!$fiber->isStarted()) {
+                $fiber->start();
+            } elseif ($fiber->isSuspended()) {
+                $fiber->resume();
+            }
+        } catch (Throwable) {
+            // Fiber body raised; its owning Future (if any) has already
+            // captured the throwable. Drop the fiber here so the scheduler
+            // does not re-enqueue it.
+            return;
+        }
+
+        if ($this->stillRunnable($fiber)) {
+            $this->ready[] = $fiber;
+        }
+    }
+
+    /**
+     * Opaque check so static analysers do not treat the post-run fiber state
+     * as a compile-time constant: `start()`/`resume()` transition the fiber
+     * internally and PHPStan cannot see the mutation through the extension.
+     *
+     * @phpstan-impure
+     */
+    private function stillRunnable(Fiber $fiber): bool
+    {
+        return !$fiber->isTerminated() && $fiber->isSuspended();
+    }
+}

--- a/src/php/Fiber/FiberConfig.php
+++ b/src/php/Fiber/FiberConfig.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber;
+
+use Gacela\Framework\AbstractConfig;
+
+final class FiberConfig extends AbstractConfig
+{
+    private const int DEFAULT_SLEEP_MICROSECONDS = 500;
+
+    public static function defaultSleepMicroseconds(): int
+    {
+        return self::DEFAULT_SLEEP_MICROSECONDS;
+    }
+}

--- a/src/php/Fiber/FiberFacade.php
+++ b/src/php/Fiber/FiberFacade.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Fiber\Domain\Awaitable;
+use Phel\Fiber\Domain\Future;
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+
+/**
+ * Public entrypoint for the Fiber module. Exposes the cooperative async
+ * primitives used by Phel's async library: {@see Promise}, {@see Future},
+ * and the shared {@see Scheduler}.
+ *
+ * @extends AbstractFacade<FiberFactory>
+ */
+final class FiberFacade extends AbstractFacade implements FiberFacadeInterface
+{
+    public function createPromise(): Promise
+    {
+        return $this->getFactory()->createPromise();
+    }
+
+    /**
+     * @param callable():mixed $body
+     */
+    public function future(callable $body): Future
+    {
+        return $this->getFactory()->createFuture($body);
+    }
+
+    public function await(Awaitable $awaitable, ?int $timeoutMs = null): mixed
+    {
+        return $this->getFactory()->await($awaitable, $timeoutMs);
+    }
+
+    public function scheduler(): Scheduler
+    {
+        return $this->getFactory()->scheduler();
+    }
+}

--- a/src/php/Fiber/FiberFacadeInterface.php
+++ b/src/php/Fiber/FiberFacadeInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber;
+
+use Phel\Fiber\Domain\Awaitable;
+use Phel\Fiber\Domain\Future;
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+
+interface FiberFacadeInterface
+{
+    public function createPromise(): Promise;
+
+    /**
+     * @param callable():mixed $body
+     */
+    public function future(callable $body): Future;
+
+    public function await(Awaitable $awaitable, ?int $timeoutMs = null): mixed;
+
+    public function scheduler(): Scheduler;
+}

--- a/src/php/Fiber/FiberFactory.php
+++ b/src/php/Fiber/FiberFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Fiber\Domain\Awaitable;
+use Phel\Fiber\Domain\Future;
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+
+/**
+ * Wires the scheduler and domain objects. The scheduler is process-wide by
+ * default (singleton) so that every Promise/Future shares one ready queue;
+ * tests that need isolation swap an isolated instance in via
+ * {@see Scheduler::setInstance()}.
+ *
+ * @extends AbstractFactory<FiberConfig>
+ */
+final class FiberFactory extends AbstractFactory
+{
+    public function scheduler(): Scheduler
+    {
+        $scheduler = Scheduler::instance();
+        $scheduler->setSleepMicroseconds(FiberConfig::defaultSleepMicroseconds());
+        return $scheduler;
+    }
+
+    public function createPromise(): Promise
+    {
+        return new Promise($this->scheduler());
+    }
+
+    /**
+     * @param callable():mixed $body
+     */
+    public function createFuture(callable $body): Future
+    {
+        return new Future($this->scheduler(), $body);
+    }
+
+    public function await(Awaitable $awaitable, ?int $timeoutMs = null): mixed
+    {
+        if ($timeoutMs === null) {
+            return $this->scheduler()->await($awaitable);
+        }
+
+        return $awaitable->derefWithTimeout($timeoutMs, null);
+    }
+}

--- a/src/php/Fiber/FiberProvider.php
+++ b/src/php/Fiber/FiberProvider.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Fiber;
+
+use Gacela\Framework\AbstractProvider;
+
+final class FiberProvider extends AbstractProvider {}

--- a/tests/phel/test/async-fiber.phel
+++ b/tests/phel/test/async-fiber.phel
@@ -1,0 +1,77 @@
+(ns phel-test\test\async-fiber
+  (:require phel\test :refer [deftest is])
+  (:require phel\async :refer [promise deliver future-call future-fiber future? future-cancel future-done?]))
+
+;; --- promise / deliver ---
+
+(deftest test-promise-is-unrealized-initially
+  (is (= false (realized? (promise))) "a fresh promise is not realized"))
+
+(deftest test-deliver-resolves-promise
+  (let [p (promise)]
+    (deliver p 42)
+    (is (= true (realized? p)) "promise is realized after deliver")
+    (is (= 42 @p) "deref returns the delivered value")))
+
+(deftest test-deliver-is-idempotent
+  (let [p (promise)]
+    (deliver p :first)
+    (deliver p :second)
+    (is (= :first @p) "second deliver is a no-op")))
+
+(deftest test-deliver-returns-promise-on-first-delivery
+  (let [p (promise)
+        r (deliver p 7)]
+    (is (= p r) "deliver returns the promise on first delivery")
+    (is (nil? (deliver p 8)) "deliver returns nil when already delivered")))
+
+(deftest test-deref-with-timeout-returns-fallback
+  (let [p (promise)
+        result (deref p 5 :timeout)]
+    (is (= :timeout result) "deref with timeout returns fallback when unrealized")))
+
+(deftest test-deref-with-zero-timeout
+  (let [p (promise)
+        result (deref p 0 :fallback)]
+    (is (= :fallback result) "deref with zero timeout returns fallback immediately")))
+
+(deftest test-deref-with-timeout-returns-value-after-deliver
+  (let [p (promise)]
+    (deliver p 99)
+    (is (= 99 (deref p 10 :fallback)) "deref with timeout returns the delivered value")))
+
+;; --- future-call / future-fiber ---
+
+(deftest test-future-call-returns-fiber-future
+  (let [f (future-call (fn [] 42))]
+    (is (= true (future? f)) "future-call returns a recognisable future")
+    (is (= 42 @f) "deref returns the computed value")))
+
+(deftest test-future-fiber-macro
+  (let [f (future-fiber (+ 1 2 3))]
+    (is (= 6 @f) "future-fiber macro runs body and delivers the result")))
+
+(deftest test-future-fiber-done-after-deref
+  (let [f (future-fiber 42)]
+    @f
+    (is (= true (future-done? f)) "future is done after deref")
+    (is (= true (realized? f)) "future is realized after deref")))
+
+(deftest test-future-fiber-propagates-exceptions
+  (let [f (future-fiber (throw (php/new \RuntimeException "boom")))]
+    (is (thrown? \RuntimeException @f)
+        "deref on a failed fiber-future rethrows")))
+
+(deftest test-future-fiber-cancel
+  (let [f (future-fiber 1)]
+    (future-cancel f)
+    (is (= true (future-done? f)) "cancelled future reports done")))
+
+(deftest test-future?-negative
+  (is (= false (future? 42)) "non-futures are not futures")
+  (is (= false (future? (promise))) "promises are not futures"))
+
+(deftest test-deref-promise-with-reader-syntax
+  (let [p (promise)]
+    (deliver p :via-reader)
+    (is (= :via-reader @p) "@ reader shortcut derefs a promise")))

--- a/tests/php/Integration/Fiber/FiberFacadeIntegrationTest.php
+++ b/tests/php/Integration/Fiber/FiberFacadeIntegrationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Fiber;
+
+use Fiber;
+use Phel\Fiber\Domain\Scheduler;
+use Phel\Fiber\FiberFacade;
+use PHPUnit\Framework\TestCase;
+
+use function microtime;
+
+final class FiberFacadeIntegrationTest extends TestCase
+{
+    private FiberFacade $facade;
+
+    protected function setUp(): void
+    {
+        $scheduler = new Scheduler();
+        $scheduler->setSleepMicroseconds(50);
+        Scheduler::setInstance($scheduler);
+        $this->facade = new FiberFacade();
+    }
+
+    protected function tearDown(): void
+    {
+        Scheduler::setInstance(null);
+    }
+
+    public function test_three_cooperating_fibers_pass_values_through_promises(): void
+    {
+        $start = microtime(true);
+
+        $stage1 = $this->facade->createPromise();
+        $stage2 = $this->facade->createPromise();
+        $final = $this->facade->createPromise();
+
+        // Producer: deliver the initial value.
+        $this->facade->future(static function () use ($stage1): int {
+            $stage1->deliver(1);
+            return 0;
+        });
+
+        // Transformer 1: multiply by 10 then hand off.
+        $this->facade->future(static function () use ($stage1, $stage2): int {
+            /** @var int $value */
+            $value = $stage1->deref();
+            $stage2->deliver($value * 10);
+            return 0;
+        });
+
+        // Transformer 2: add 5 then finalize.
+        $this->facade->future(static function () use ($stage2, $final): int {
+            /** @var int $value */
+            $value = $stage2->deref();
+            $final->deliver($value + 5);
+            return 0;
+        });
+
+        $result = $final->deref();
+
+        self::assertSame(15, $result);
+        self::assertLessThan(0.5, microtime(true) - $start);
+    }
+
+    public function test_facade_await_blocks_until_future_resolves(): void
+    {
+        $future = $this->facade->future(static function (): string {
+            Fiber::suspend();
+            return 'ok';
+        });
+
+        self::assertSame('ok', $this->facade->await($future));
+    }
+
+    public function test_facade_await_with_timeout_returns_null_on_unresolved(): void
+    {
+        $parked = $this->facade->createPromise();
+        $slow = $this->facade->future(static fn(): mixed => $parked->deref());
+
+        self::assertNull($this->facade->await($slow, 5));
+    }
+}

--- a/tests/php/Integration/Fiber/FiberFacadeIntegrationTest.php
+++ b/tests/php/Integration/Fiber/FiberFacadeIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Integration\Fiber;
 
 use Fiber;
+use Phel;
 use Phel\Fiber\Domain\Scheduler;
 use Phel\Fiber\FiberFacade;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ final class FiberFacadeIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        Phel::bootstrap(__DIR__);
         $scheduler = new Scheduler();
         $scheduler->setSleepMicroseconds(50);
         Scheduler::setInstance($scheduler);
@@ -36,13 +38,11 @@ final class FiberFacadeIntegrationTest extends TestCase
         $stage2 = $this->facade->createPromise();
         $final = $this->facade->createPromise();
 
-        // Producer: deliver the initial value.
         $this->facade->future(static function () use ($stage1): int {
             $stage1->deliver(1);
             return 0;
         });
 
-        // Transformer 1: multiply by 10 then hand off.
         $this->facade->future(static function () use ($stage1, $stage2): int {
             /** @var int $value */
             $value = $stage1->deref();
@@ -50,7 +50,6 @@ final class FiberFacadeIntegrationTest extends TestCase
             return 0;
         });
 
-        // Transformer 2: add 5 then finalize.
         $this->facade->future(static function () use ($stage2, $final): int {
             /** @var int $value */
             $value = $stage2->deref();

--- a/tests/php/Integration/Phel/AsyncFiberTest.php
+++ b/tests/php/Integration/Phel/AsyncFiberTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Phel;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function fclose;
+use function proc_close;
+use function proc_open;
+use function sprintf;
+use function stream_get_contents;
+
+/**
+ * Runs `./bin/phel test tests/phel/test/async-fiber.phel` end-to-end so
+ * `composer test-compiler` exercises the fiber-based promise/future
+ * primitives in `phel\async` on every CI run.
+ */
+final class AsyncFiberTest extends TestCase
+{
+    public function test_async_fiber_test_suite_passes(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $command = sprintf(
+            '%s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($repoRoot . '/bin/phel'),
+            escapeshellarg('test') . ' ' . escapeshellarg('tests/phel/test/async-fiber.phel'),
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes, $repoRoot);
+        self::assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        $exitCode = proc_close($process);
+
+        self::assertSame(
+            0,
+            $exitCode,
+            sprintf(
+                "`phel test tests/phel/test/async-fiber.phel` failed.\nSTDOUT:\n%s\nSTDERR:\n%s",
+                $stdout,
+                $stderr,
+            ),
+        );
+        self::assertStringContainsString('Failed: 0', $stdout);
+        self::assertStringContainsString('Error: 0', $stdout);
+    }
+}

--- a/tests/php/Unit/Fiber/Domain/FutureTest.php
+++ b/tests/php/Unit/Fiber/Domain/FutureTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Fiber\Domain;
+
+use Fiber;
+use Phel\Fiber\Domain\Future;
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class FutureTest extends TestCase
+{
+    private Scheduler $scheduler;
+
+    protected function setUp(): void
+    {
+        $this->scheduler = new Scheduler();
+        $this->scheduler->setSleepMicroseconds(50);
+    }
+
+    public function test_it_runs_the_body_and_returns_the_value(): void
+    {
+        $future = new Future($this->scheduler, static fn(): int => 42);
+
+        self::assertSame(42, $future->deref());
+        self::assertTrue($future->isRealized());
+    }
+
+    public function test_it_re_raises_exceptions_from_the_body(): void
+    {
+        $future = new Future($this->scheduler, static function (): never {
+            throw new RuntimeException('boom');
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+        $future->deref();
+    }
+
+    public function test_cancellation_flag_is_respected_by_the_body(): void
+    {
+        $future = null;
+        $body = static function () use (&$future): string {
+            /** @var Future $future */
+            for ($i = 0; $i < 10; ++$i) {
+                if ($future->isCancelled()) {
+                    return 'cancelled';
+                }
+
+                Fiber::suspend();
+            }
+
+            return 'completed';
+        };
+
+        $future = new Future($this->scheduler, $body);
+
+        // Let the fiber run its first cycle, then cancel before deref.
+        $this->scheduler->tick();
+        $future->cancel();
+
+        self::assertSame('cancelled', $future->deref());
+        self::assertTrue($future->isCancelled());
+        self::assertTrue($future->isDone());
+    }
+
+    public function test_is_done_is_true_after_cancellation(): void
+    {
+        $future = new Future($this->scheduler, static function (): string {
+            for ($i = 0; $i < 1000; ++$i) {
+                Fiber::suspend();
+            }
+
+            return 'never';
+        });
+
+        self::assertFalse($future->isDone());
+        $future->cancel();
+
+        self::assertTrue($future->isDone());
+    }
+
+    public function test_deref_with_timeout_returns_fallback_when_still_running(): void
+    {
+        // Body blocks on a promise that nobody delivers, so the fiber can
+        // never realise within the timeout window.
+        $parked = new Promise($this->scheduler);
+        $future = new Future($this->scheduler, static fn(): mixed => $parked->deref());
+
+        self::assertSame(':timeout', $future->derefWithTimeout(10, ':timeout'));
+        self::assertFalse($future->isRealized());
+    }
+
+    public function test_multiple_futures_run_cooperatively(): void
+    {
+        $results = [];
+        $futures = [];
+        for ($i = 1; $i <= 3; ++$i) {
+            $value = $i;
+            $futures[] = new Future($this->scheduler, static function () use ($value): int {
+                Fiber::suspend();
+                return $value * 10;
+            });
+        }
+
+        foreach ($futures as $future) {
+            $results[] = $future->deref();
+        }
+
+        self::assertSame([10, 20, 30], $results);
+    }
+}

--- a/tests/php/Unit/Fiber/Domain/PromiseTest.php
+++ b/tests/php/Unit/Fiber/Domain/PromiseTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Fiber\Domain;
+
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+use PHPUnit\Framework\TestCase;
+
+final class PromiseTest extends TestCase
+{
+    private Scheduler $scheduler;
+
+    protected function setUp(): void
+    {
+        $this->scheduler = new Scheduler();
+        $this->scheduler->setSleepMicroseconds(50);
+    }
+
+    public function test_it_starts_unrealized(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        self::assertFalse($promise->isRealized());
+    }
+
+    public function test_it_delivers_a_value_and_marks_realized(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        self::assertTrue($promise->deliver(42));
+        self::assertTrue($promise->isRealized());
+        self::assertSame(42, $promise->value());
+    }
+
+    public function test_it_ignores_subsequent_deliveries(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver('first');
+
+        self::assertFalse($promise->deliver('second'));
+        self::assertSame('first', $promise->value());
+    }
+
+    public function test_deref_returns_value_when_already_delivered(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver('done');
+
+        self::assertSame('done', $promise->deref());
+    }
+
+    public function test_deref_with_timeout_returns_fallback_immediately_for_zero(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        self::assertSame(':fallback', $promise->derefWithTimeout(0, ':fallback'));
+        self::assertFalse($promise->isRealized());
+    }
+
+    public function test_deref_with_timeout_returns_value_when_already_delivered(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver(7);
+
+        self::assertSame(7, $promise->derefWithTimeout(1000, ':fallback'));
+    }
+
+    public function test_deref_with_timeout_returns_fallback_when_unrealized(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        $start = microtime(true);
+        $result = $promise->derefWithTimeout(10, ':timeout');
+        $elapsed = microtime(true) - $start;
+
+        self::assertSame(':timeout', $result);
+        self::assertGreaterThan(0.005, $elapsed);
+        self::assertLessThan(0.5, $elapsed);
+    }
+
+    public function test_deliver_preserves_null_as_a_valid_value(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        self::assertTrue($promise->deliver(null));
+        self::assertTrue($promise->isRealized());
+        self::assertNull($promise->value());
+        self::assertFalse($promise->deliver('other'));
+    }
+}

--- a/tests/php/Unit/Fiber/Domain/SchedulerTest.php
+++ b/tests/php/Unit/Fiber/Domain/SchedulerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Fiber\Domain;
+
+use Fiber;
+use Phel\Fiber\Domain\Promise;
+use Phel\Fiber\Domain\Scheduler;
+use PHPUnit\Framework\TestCase;
+
+final class SchedulerTest extends TestCase
+{
+    public function test_ready_queue_starts_empty(): void
+    {
+        $scheduler = new Scheduler();
+
+        self::assertFalse($scheduler->hasReady());
+        self::assertSame(0, $scheduler->readyCount());
+    }
+
+    public function test_enqueue_adds_to_ready_queue(): void
+    {
+        $scheduler = new Scheduler();
+        $fiber = new Fiber(static function (): void {
+            Fiber::suspend();
+        });
+        $fiber->start();
+
+        $scheduler->enqueue($fiber);
+
+        self::assertTrue($scheduler->hasReady());
+        self::assertSame(1, $scheduler->readyCount());
+    }
+
+    public function test_enqueue_drops_terminated_fibers(): void
+    {
+        $scheduler = new Scheduler();
+        $fiber = new Fiber(static function (): void {});
+        $fiber->start();
+
+        $scheduler->enqueue($fiber);
+
+        self::assertFalse($scheduler->hasReady());
+    }
+
+    public function test_tick_advances_one_fiber_in_fifo_order(): void
+    {
+        $scheduler = new Scheduler();
+        $order = [];
+
+        $first = new Fiber(static function () use (&$order): void {
+            $order[] = 'a-start';
+            Fiber::suspend();
+            $order[] = 'a-end';
+        });
+        $second = new Fiber(static function () use (&$order): void {
+            $order[] = 'b-start';
+            Fiber::suspend();
+            $order[] = 'b-end';
+        });
+
+        $first->start();
+        $second->start();
+        $scheduler->enqueue($first);
+        $scheduler->enqueue($second);
+
+        self::assertTrue($scheduler->tick());
+        self::assertSame(['a-start', 'b-start', 'a-end'], $order);
+
+        self::assertTrue($scheduler->tick());
+        self::assertSame(['a-start', 'b-start', 'a-end', 'b-end'], $order);
+
+        self::assertFalse($scheduler->tick());
+    }
+
+    public function test_run_until_idle_drains_cooperating_fibers(): void
+    {
+        $scheduler = new Scheduler();
+        $log = [];
+
+        for ($i = 0; $i < 3; ++$i) {
+            $id = 'fiber-' . $i;
+            $fiber = new Fiber(static function () use (&$log, $id): void {
+                $log[] = $id . ':tick1';
+                Fiber::suspend();
+                $log[] = $id . ':tick2';
+            });
+            $fiber->start();
+            $scheduler->enqueue($fiber);
+        }
+
+        $scheduler->runUntilIdle();
+
+        self::assertSame(
+            [
+                'fiber-0:tick1',
+                'fiber-1:tick1',
+                'fiber-2:tick1',
+                'fiber-0:tick2',
+                'fiber-1:tick2',
+                'fiber-2:tick2',
+            ],
+            $log,
+        );
+    }
+
+    public function test_await_returns_value_when_already_realized(): void
+    {
+        $scheduler = new Scheduler();
+        $promise = new Promise($scheduler);
+        $promise->deliver('ready');
+
+        self::assertSame('ready', $scheduler->await($promise));
+    }
+
+    public function test_singleton_round_trips_through_set_instance(): void
+    {
+        $isolated = new Scheduler();
+        Scheduler::setInstance($isolated);
+
+        self::assertSame($isolated, Scheduler::instance());
+
+        Scheduler::setInstance(null);
+        self::assertNotSame($isolated, Scheduler::instance());
+    }
+
+    public function test_sleep_microseconds_floors_at_zero(): void
+    {
+        $scheduler = new Scheduler();
+        $scheduler->setSleepMicroseconds(-100);
+
+        self::assertSame(0, $scheduler->sleepMicroseconds());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Tier 2 item #11 of the Clojure-parity roadmap asks for cooperative fiber primitives on top of PHP Fibers, so `promise`/`deliver`/`future` work at the top level without dragging in an AMPHP `async` block. The existing `phel\async` layer sits on top of AMPHP and requires a running event loop for `future` / `await` / `pmap` — fine for IO pipelines, awkward for quick top-level scripting and for ports of Clojure idioms that assume `(promise)` is always available.

## 💡 Goal

Land a self-contained Fiber module plus thin Phel wrappers so users can write:

```phel
(let [p (promise)]
  (future-call (fn [] (deliver p 42)))
  @p)
```

without bootstrapping AMPHP, and keep the existing AMPHP-based API untouched.

## 🔖 Changes

- New `Phel\Fiber` Gacela module (`FiberFacade`, `FiberFactory`, `FiberConfig`, `FiberProvider`, `FiberFacadeInterface`).
- `Domain/Scheduler` singleton-accessible cooperative scheduler with a FIFO ready-queue, `tick`, `runUntilIdle`, and `await` that cooperates inside a Fiber and falls back to bounded polling at the top level.
- `Domain/Promise` single-delivery value; `deliver` is idempotent, `deref` and 3-arg `deref` with timeout supported, zero-ms timeout returns fallback immediately.
- `Domain/Future` wraps a Fiber over a callable, captures exceptions for rethrow on `deref`, exposes cooperative `cancel` / `isCancelled` / `isDone`.
- `Domain/Awaitable` interface implemented by Promise and Future.
- `phel\async` gains `promise`, `deliver`, `future-call`, `future-fiber` (top-level friendly future macro), and `future?` predicate. `realized?`, `future-done?`, and 3-arg `deref` updated to cover the new types.
- `tests/phel/test/async-fiber.phel` plus `AsyncFiberTest` integration runner exercise the Phel surface via `./bin/phel test` on CI.
- PHPUnit unit coverage for `Promise`, `Scheduler`, `Future`, and a facade-level integration test that pipes a value through three cooperating fibers via promises.
- `src/php/Fiber/CLAUDE.md` documents the module for future agents.

<!-- Remember to add a mention about the fix/feature to the 'unreleased' section at the beginning of CHANGELOG.md for changes that are worth including in release notes. -->