### PR TITLE
feat(reader): extensible tagged literals with #inst and #regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Reader & Compiler
+- `#inst "..."` reads as `\DateTimeImmutable` and `#regex "..."` reads as a delimited PCRE string; user tags via `(register-tag "name" f)` in the new `phel\reader` namespace; `data-readers.phel` at any source root is auto-loaded
 - `#php` reader literal: `#php [1 2 3]` expands to `(php-indexed-array 1 2 3)`; `#php {"a" 1}` to `(php-associative-array "a" 1)` (non-recursive)
 - PHP interop shorthands: `(.method obj args)`, `(.-field obj)`, `(ClassName/method args)`, `\Ns\Class/MEMBER`, `(new ClassName args)`
 - `def` returns a printable var ref (e.g. `#'user/my-var`)

--- a/src/phel/reader.phel
+++ b/src/phel/reader.phel
@@ -1,0 +1,56 @@
+(ns phel\reader
+  (:use Phel)
+  (:use Phel\Lang\TagRegistry))
+
+;; Reader tagged-literal registry.
+;;
+;; When the reader encounters `#foo value`, it looks `foo` up in the
+;; global tag registry. If a handler is found, the handler is called
+;; with the already-read value and its return value replaces the
+;; tagged literal. Built-in tags (`#uuid`, `#inst`, `#regex`) are
+;; registered at compiler boot; user handlers can be added with
+;; `register-tag` at runtime.
+
+(defn- registry
+  "Returns the shared TagRegistry singleton."
+  []
+  (php/:: TagRegistry (getInstance)))
+
+(defn register-tag
+  "Registers a handler for reader tag `tag-name` (a string without the
+  leading `#`). The handler `f` is a 1-arg function receiving the
+  already-read form value and returning the value that should replace
+  the tagged literal.
+
+  Re-registering an existing tag overwrites the previous handler."
+  {:example "(register-tag \"date\" my-ns/parse-date)
+  ; later: #date \"2026-04-20\" => (my-ns/parse-date \"2026-04-20\")"
+   :see-also ["tag-registered?" "unregister-tag" "registered-tags"]}
+  [tag-name f]
+  (php/-> (registry) (register tag-name f))
+  nil)
+
+(defn tag-registered?
+  "Returns true if a handler is registered for reader tag `tag-name`."
+  {:example "(tag-registered? \"inst\") ; => true"
+   :see-also ["register-tag" "unregister-tag" "registered-tags"]}
+  [tag-name]
+  (php/-> (registry) (has tag-name)))
+
+(defn unregister-tag
+  "Removes any handler registered for reader tag `tag-name`. Built-in
+  tags can be unregistered but are re-installed on the next reader
+  bootstrap."
+  {:example "(unregister-tag \"date\")"
+   :see-also ["register-tag" "tag-registered?" "registered-tags"]}
+  [tag-name]
+  (php/-> (registry) (unregister tag-name))
+  nil)
+
+(defn registered-tags
+  "Returns a sorted vector of the currently registered reader tag
+  names."
+  {:example "(registered-tags) ; => [\"inst\" \"regex\" \"uuid\"]"
+   :see-also ["register-tag" "tag-registered?" "unregister-tag"]}
+  []
+  (php/:: Phel (vector (php/-> (registry) (tags)))))

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -27,6 +27,7 @@ use function is_array;
 use function is_bool;
 use function is_float;
 use function is_int;
+use function is_object;
 use function is_string;
 
 final class Analyzer implements AnalyzerInterface
@@ -100,7 +101,7 @@ final class Analyzer implements AnalyzerInterface
      * @throws AnalyzerException
      */
     public function analyzeMacro(
-        TypeInterface|array|string|float|int|bool|null $x,
+        mixed $x,
         NodeEnvironmentInterface $env,
     ): AbstractNode {
         $this->globalEnvironment->addLevelToAllowPrivateAccess();
@@ -114,7 +115,7 @@ final class Analyzer implements AnalyzerInterface
      * @throws AnalyzerException
      */
     public function analyze(
-        TypeInterface|array|string|float|int|bool|null $x,
+        mixed $x,
         NodeEnvironmentInterface $env,
     ): AbstractNode {
         if ($this->isLiteral($x)) {
@@ -146,10 +147,17 @@ final class Analyzer implements AnalyzerInterface
             return $this->mapAnalyzer->analyze($x, $env);
         }
 
+        // Tagged literals may read as arbitrary PHP objects (e.g. `#inst`
+        // yields `DateTimeImmutable`). Any object that is not one of the
+        // persistent types above is treated as an opaque literal value.
+        if (is_object($x) && !$x instanceof TypeInterface) {
+            return (new AnalyzeLiteral())->analyze($x, $env);
+        }
+
         throw new AnalyzerException('Unhandled type: ' . var_export($x, true));
     }
 
-    private function isLiteral(float|array|bool|int|string|TypeInterface|null $x): bool
+    private function isLiteral(mixed $x): bool
     {
         return is_string($x)
             || is_float($x)

--- a/src/php/Compiler/Application/Reader.php
+++ b/src/php/Compiler/Application/Reader.php
@@ -64,7 +64,7 @@ final class Reader implements ReaderInterface
     public function readExpression(
         NodeInterface $node,
         NodeInterface $root,
-    ): Symbol|float|bool|int|string|TypeInterface|MetaInterface|null {
+    ): mixed {
         if ($node instanceof SymbolNode) {
             return $this->readSymbolNode($node);
         }
@@ -85,9 +85,10 @@ final class Reader implements ReaderInterface
             return $this->readMetaNode($node, $root);
         }
 
-        // Built-in tagged literals (e.g. `#uuid`) are dispatched to a dedicated
-        // reader. Unknown tags throw there; unselected `#?` branches are already
-        // discarded by the parser so their tags never reach this point.
+        // Tagged literals (e.g. `#uuid`, `#inst`, `#regex`, user tags) are
+        // dispatched through the TagRegistry. Unknown tags throw there; unselected
+        // `#?` branches are already discarded by the parser so their tags never
+        // reach this point.
         if ($node instanceof TaggedLiteralNode) {
             return $this->readerFactory
                 ->createTaggedLiteralReader($this)

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -44,6 +44,8 @@ use Phel\Compiler\Domain\Reader\ReaderInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Filesystem\FilesystemFacadeInterface;
+use Phel\Lang\TagHandlers\BuiltinTagHandlers;
+use Phel\Lang\TagRegistry;
 use Phel\Printer\Printer;
 
 /**
@@ -96,6 +98,8 @@ final class CompilerFactory extends AbstractFactory
 
     public function createReader(): ReaderInterface
     {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
         return new Reader(
             new ExpressionReaderFactory(),
             new QuasiquoteTransformer($this->getGlobalEnvironment()),

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -8,16 +8,15 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeInterface;
 
 interface AnalyzerInterface
 {
     /**
      * @throws AnalyzerException
      */
-    public function analyze(TypeInterface|array|string|float|int|bool|null $x, NodeEnvironmentInterface $env): AbstractNode;
+    public function analyze(mixed $x, NodeEnvironmentInterface $env): AbstractNode;
 
-    public function analyzeMacro(TypeInterface|array|string|float|int|bool|null $x, NodeEnvironmentInterface $env): AbstractNode;
+    public function analyzeMacro(mixed $x, NodeEnvironmentInterface $env): AbstractNode;
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode;
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/LiteralNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/LiteralNode.php
@@ -6,19 +6,18 @@ namespace Phel\Compiler\Domain\Analyzer\Ast;
 
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\TypeInterface;
 
 final class LiteralNode extends AbstractNode
 {
     public function __construct(
         NodeEnvironmentInterface $env,
-        private readonly TypeInterface|array|string|float|int|bool|null $value,
+        private readonly mixed $value,
         ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
 
-    public function getValue(): TypeInterface|array|string|float|int|bool|null
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/php/Compiler/Domain/Analyzer/Ast/QuoteNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/QuoteNode.php
@@ -6,19 +6,18 @@ namespace Phel\Compiler\Domain\Analyzer\Ast;
 
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\TypeInterface;
 
 final class QuoteNode extends AbstractNode
 {
     public function __construct(
         NodeEnvironmentInterface $env,
-        private readonly TypeInterface|array|string|float|int|bool|null $value,
+        private readonly mixed $value,
         ?SourceLocation $sourceLocation = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
 
-    public function getValue(): TypeInterface|array|string|float|int|bool|null
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzeLiteral.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzeLiteral.php
@@ -10,7 +10,7 @@ use Phel\Lang\TypeInterface;
 
 final class AnalyzeLiteral
 {
-    public function analyze(float|bool|int|string|array|TypeInterface|null $value, NodeEnvironmentInterface $env): LiteralNode
+    public function analyze(mixed $value, NodeEnvironmentInterface $env): LiteralNode
     {
         $sourceLocation = ($value instanceof TypeInterface)
             ? $value->getStartLocation()

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor.php
@@ -13,7 +13,6 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeInterface;
 
 use function count;
 
@@ -37,16 +36,16 @@ final readonly class Deconstructor implements DeconstructorInterface
     /**
      * Destructure a $binding $value pair and add the result to $bindings.
      *
-     * @param array                                    $bindings A reference to already defined bindings
-     * @param bool|float|int|string|TypeInterface|null $binding  The binding form
-     * @param bool|float|int|string|TypeInterface|null $value    The value form
+     * @param array $bindings A reference to already defined bindings
+     * @param mixed $binding  The binding form
+     * @param mixed $value    The value form
      *
      * @throws AnalyzerException
      */
     public function deconstructBindings(
         array &$bindings,
-        float|bool|int|string|TypeInterface|null $binding,
-        float|bool|int|string|TypeInterface|null $value,
+        mixed $binding,
+        mixed $value,
     ): void {
         $this->bindingValidator->assertSupportedBinding($binding);
 
@@ -55,9 +54,9 @@ final readonly class Deconstructor implements DeconstructorInterface
     }
 
     /**
-     * @param bool|float|int|string|TypeInterface|null $binding The binding form
+     * @param mixed $binding The binding form
      */
-    private function createDeconstructorForBinding(float|bool|int|string|TypeInterface|null $binding): BindingDeconstructorInterface
+    private function createDeconstructorForBinding(mixed $binding): BindingDeconstructorInterface
     {
         if ($binding instanceof Symbol) {
             return new SymbolBindingDeconstructor();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -14,7 +14,6 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeInterface;
 use Phel\Printer\PrinterInterface;
 
 use function count;
@@ -188,7 +187,7 @@ final class OutputEmitter implements OutputEmitterInterface
         $this->emitStr('})()', $sl);
     }
 
-    public function emitLiteral(array|bool|float|int|TypeInterface|string|null $value): void
+    public function emitLiteral(mixed $value): void
     {
         (new LiteralEmitter($this, $this->printer))->emitLiteral($value);
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
+use DateTimeImmutable;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
@@ -11,10 +12,10 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeInterface;
 use Phel\Printer\PrinterInterface;
 use RuntimeException;
 
+use function addslashes;
 use function count;
 use function is_array;
 use function is_bool;
@@ -29,7 +30,7 @@ final readonly class LiteralEmitter
         private PrinterInterface $printer,
     ) {}
 
-    public function emitLiteral(TypeInterface|array|string|float|bool|int|null $x): void
+    public function emitLiteral(mixed $x): void
     {
         if (is_float($x)) {
             $this->emitFloat($x);
@@ -53,6 +54,8 @@ final readonly class LiteralEmitter
             $this->emitVector($x);
         } elseif ($x instanceof PersistentListInterface) {
             $this->emitList($x);
+        } elseif ($x instanceof DateTimeImmutable) {
+            $this->emitDateTime($x);
         } elseif (is_array($x)) {
             $this->emitArray($x);
         } else {
@@ -60,6 +63,14 @@ final readonly class LiteralEmitter
 
             throw new RuntimeException('literal not supported: ' . $typeName);
         }
+    }
+
+    private function emitDateTime(DateTimeImmutable $x): void
+    {
+        // Emit an expression that reconstructs the exact instant and timezone.
+        // RFC 3339 with microseconds preserves both.
+        $iso = $x->format('Y-m-d\\TH:i:s.uP');
+        $this->outputEmitter->emitStr('(new \\DateTimeImmutable("' . addslashes($iso) . '"))');
     }
 
     private function emitFloat(float $x): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -10,7 +10,6 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
-use Phel\Lang\TypeInterface;
 
 interface OutputEmitterInterface
 {
@@ -49,7 +48,7 @@ interface OutputEmitterInterface
 
     public function emitFnWrapSuffix(?SourceLocation $sl = null): void;
 
-    public function emitLiteral(array|bool|float|int|TypeInterface|string|null $value): void;
+    public function emitLiteral(mixed $value): void;
 
     public function increaseIndentLevel(): void;
 

--- a/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
+++ b/src/php/Compiler/Domain/Parser/ReadModel/ReaderResult.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Parser\ReadModel;
 
-use Phel\Lang\TypeInterface;
-
 final readonly class ReaderResult
 {
     public function __construct(
-        private float|bool|int|string|TypeInterface|null $ast,
+        private mixed $ast,
         private CodeSnippet $codeSnippet,
     ) {}
 
-    public function getAst(): float|bool|int|string|TypeInterface|null
+    public function getAst(): mixed
     {
         return $this->ast;
     }

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -9,27 +9,32 @@ use Phel\Compiler\Application\Reader;
 use Phel\Compiler\Domain\Lexer\Token;
 use Phel\Compiler\Domain\Parser\ParserNode\ListNode;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
-use Phel\Compiler\Domain\Parser\ParserNode\StringNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TaggedLiteralNode;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
+use Phel\Lang\TagHandlerException;
+use Phel\Lang\TagHandlers\BuiltinTagHandlers;
+use Phel\Lang\TagRegistry;
+use Throwable;
 
-use function preg_match;
+use function array_merge;
+use function implode;
+use function sort;
 use function sprintf;
-use function strtolower;
 
 /**
- * Reads Phel's built-in tagged literals (e.g. `#uuid`, `#php`). Unknown tags
- * are rejected here so they can still be silently discarded when they sit
- * inside an unselected reader-conditional branch (that discard happens
- * earlier, in the parser).
+ * Dispatches tagged literals (e.g. `#uuid`, `#inst`, `#regex`, `#php`).
+ *
+ * `#php` stays hard-wired here because it inspects the token type of the
+ * following form (vector/map) before reading. Every other tag is resolved
+ * via the global `TagRegistry`, which hosts both the built-in handlers
+ * (`#uuid`, `#inst`, `#regex`) and any user-registered handlers added at
+ * runtime through `(register-tag ...)`.
  */
 final readonly class TaggedLiteralReader
 {
-    private const string UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
-
     public function __construct(private Reader $reader) {}
 
     /**
@@ -37,46 +42,47 @@ final readonly class TaggedLiteralReader
      */
     public function read(TaggedLiteralNode $node, NodeInterface $root): mixed
     {
-        return match ($node->getTag()) {
-            'uuid' => $this->readUuid($node, $root),
-            'php' => $this->readPhp($node, $root),
-            default => throw ReaderException::forNode(
-                $node,
-                $root,
-                sprintf(
-                    "Unknown tagged literal '#%s'. Phel has no built-in handler for this tag; it may only appear inside a non-selected reader-conditional branch (e.g. :clj, :jank).",
-                    $node->getTag(),
-                ),
-            ),
-        };
+        $tag = $node->getTag();
+
+        if ($tag === 'php') {
+            return $this->readPhp($node, $root);
+        }
+
+        $registry = TagRegistry::getInstance();
+        $handler = $registry->get($tag);
+
+        if ($handler === null) {
+            throw ReaderException::forNode($node, $root, $this->unknownTagMessage($tag, $registry));
+        }
+
+        $formValue = $this->reader->readExpression($node->getForm(), $root);
+
+        try {
+            return $handler($formValue);
+        } catch (TagHandlerException $e) {
+            throw ReaderException::forNode($node, $root, $e->getMessage());
+        } catch (Throwable $e) {
+            throw ReaderException::forNode($node, $root, sprintf(
+                "Tagged-literal handler for '#%s' threw an error: %s",
+                $tag,
+                $e->getMessage(),
+            ));
+        }
     }
 
-    /**
-     * @throws ReaderException
-     */
-    private function readUuid(TaggedLiteralNode $node, NodeInterface $root): string
+    private function unknownTagMessage(string $tag, TagRegistry $registry): string
     {
-        $form = $node->getForm();
+        $registeredTags = array_merge($registry->tags(), BuiltinTagHandlers::RESERVED);
+        sort($registeredTags);
 
-        if (!$form instanceof StringNode) {
-            throw ReaderException::forNode(
-                $node,
-                $root,
-                '#uuid expects a string literal (e.g. #uuid "00000000-0000-0000-0000-000000000000").',
-            );
-        }
+        $list = '#' . implode(', #', $registeredTags);
 
-        $value = $form->getValue();
-
-        if (preg_match(self::UUID_REGEX, $value) !== 1) {
-            throw ReaderException::forNode(
-                $node,
-                $root,
-                sprintf('#uuid value %s is not a canonical UUID string.', $form->getCode()),
-            );
-        }
-
-        return strtolower($value);
+        return sprintf(
+            "Unknown tagged literal '#%s'. Registered tags: %s. Use `(register-tag \"%s\" f)` to register a handler, or ensure the literal only appears inside a non-selected reader-conditional branch (e.g. :clj, :jank).",
+            $tag,
+            $list,
+            $tag,
+        );
     }
 
     /**

--- a/src/php/Lang/TagHandlerException.php
+++ b/src/php/Lang/TagHandlerException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use RuntimeException;
+
+/**
+ * Thrown by a tagged-literal handler when the input form is invalid.
+ *
+ * The reader catches this exception and rewraps it as a ReaderException
+ * carrying the source location of the offending `#tag` literal.
+ */
+final class TagHandlerException extends RuntimeException {}

--- a/src/php/Lang/TagHandlers/BuiltinTagHandlers.php
+++ b/src/php/Lang/TagHandlers/BuiltinTagHandlers.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\TagHandlers;
+
+use Phel\Lang\TagRegistry;
+
+/**
+ * Registers Phel's built-in tagged-literal handlers with the global
+ * `TagRegistry`. Safe to call multiple times — registration is
+ * idempotent and last registration wins.
+ */
+final class BuiltinTagHandlers
+{
+    /**
+     * The identifiers of tags that resolve to node-structure-aware
+     * handlers implemented directly in the reader instead of a
+     * registry callable (e.g. `#php` which dispatches on the token type
+     * of its following form).
+     *
+     * @var list<string>
+     */
+    public const array RESERVED = ['php'];
+
+    public static function registerAll(TagRegistry $registry): void
+    {
+        $registry->register('inst', new InstTagHandler());
+        $registry->register('regex', new RegexTagHandler());
+        $registry->register('uuid', new UuidTagHandler());
+    }
+}

--- a/src/php/Lang/TagHandlers/InstTagHandler.php
+++ b/src/php/Lang/TagHandlers/InstTagHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\TagHandlers;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+use Phel\Lang\TagHandlerException;
+
+use function is_string;
+use function preg_match;
+use function sprintf;
+
+/**
+ * Built-in handler for the `#inst "..."` tagged literal.
+ *
+ * Accepts an ISO 8601 timestamp string (RFC 3339 subset) and returns a
+ * `\DateTimeImmutable`. Missing timezone offsets are interpreted as UTC.
+ */
+final readonly class InstTagHandler
+{
+    /**
+     * Matches ISO 8601 / RFC 3339 timestamps of the shape
+     * `YYYY-MM-DDThh:mm:ss[.fff][Z|+hh:mm|-hh:mm]`.
+     */
+    private const string REGEX = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/';
+
+    public function __invoke(mixed $form): DateTimeImmutable
+    {
+        if (!is_string($form)) {
+            throw new TagHandlerException(
+                '#inst expects a string literal (e.g. #inst "2026-04-20T12:00:00Z").',
+            );
+        }
+
+        if (preg_match(self::REGEX, $form) !== 1) {
+            throw new TagHandlerException(sprintf(
+                '#inst value "%s" is not a valid ISO 8601 / RFC 3339 timestamp.',
+                $form,
+            ));
+        }
+
+        try {
+            $hasOffset = preg_match('/(?:Z|[+-]\d{2}:?\d{2})$/', $form) === 1;
+            if ($hasOffset) {
+                return new DateTimeImmutable($form);
+            }
+
+            return new DateTimeImmutable($form, new DateTimeZone('UTC'));
+        } catch (Exception $exception) {
+            throw new TagHandlerException(sprintf(
+                '#inst value "%s" is not a valid ISO 8601 / RFC 3339 timestamp: %s',
+                $form,
+                $exception->getMessage(),
+            ), 0, $exception);
+        }
+    }
+}

--- a/src/php/Lang/TagHandlers/RegexTagHandler.php
+++ b/src/php/Lang/TagHandlers/RegexTagHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+
+use function is_string;
+use function preg_replace;
+
+/**
+ * Built-in handler for the `#regex "..."` tagged literal.
+ *
+ * Accepts a PCRE pattern (without delimiters) and returns a delimited
+ * pattern string (`/pattern/`) equivalent to Phel's `#"..."` regex
+ * literal. The value is directly usable with `re-find`, `re-seq`,
+ * `re-matches`, and `re-pattern`.
+ */
+final readonly class RegexTagHandler
+{
+    public function __invoke(mixed $form): string
+    {
+        if (!is_string($form)) {
+            throw new TagHandlerException(
+                '#regex expects a string literal (e.g. #regex "[a-z]+").',
+            );
+        }
+
+        // Match `RegexParser::parse()`: escape unescaped `/` so the
+        // `/delimiter/` is never broken by the user's pattern.
+        $pattern = preg_replace('/(?<!\\\\)\\//', '\\/', $form) ?? $form;
+
+        return '/' . $pattern . '/';
+    }
+}

--- a/src/php/Lang/TagHandlers/UuidTagHandler.php
+++ b/src/php/Lang/TagHandlers/UuidTagHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+
+use function is_string;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Built-in handler for the `#uuid "..."` tagged literal.
+ *
+ * Accepts a canonical UUID string (`8-4-4-4-12` hexadecimal groups) and
+ * returns the lower-cased form. Phel has no dedicated UUID type, so the
+ * reader value is a normalised string.
+ */
+final readonly class UuidTagHandler
+{
+    private const string REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    public function __invoke(mixed $form): string
+    {
+        if (!is_string($form)) {
+            throw new TagHandlerException(
+                '#uuid expects a string literal (e.g. #uuid "00000000-0000-0000-0000-000000000000").',
+            );
+        }
+
+        if (preg_match(self::REGEX, $form) !== 1) {
+            throw new TagHandlerException(sprintf(
+                '#uuid value "%s" is not a canonical UUID string.',
+                $form,
+            ));
+        }
+
+        return strtolower($form);
+    }
+}

--- a/src/php/Lang/TagRegistry.php
+++ b/src/php/Lang/TagRegistry.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use function array_key_exists;
+use function array_keys;
+use function is_callable;
+
+/**
+ * Global registry for reader tagged-literal handlers.
+ *
+ * A handler is a callable `fn(mixed $form): mixed` applied by the reader
+ * when it encounters `#tag <form>`. The value returned by the handler
+ * replaces the tagged literal in the read output.
+ *
+ * Last registration wins: re-registering an existing tag overwrites its
+ * handler.
+ */
+final class TagRegistry
+{
+    /** @var array<string, callable> */
+    private array $handlers = [];
+
+    private static ?self $instance = null;
+
+    private function __construct() {}
+
+    public static function getInstance(): self
+    {
+        if (!self::$instance instanceof self) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function register(string $tag, callable $handler): void
+    {
+        $this->handlers[$tag] = $handler;
+    }
+
+    public function unregister(string $tag): void
+    {
+        unset($this->handlers[$tag]);
+    }
+
+    public function has(string $tag): bool
+    {
+        return array_key_exists($tag, $this->handlers);
+    }
+
+    public function get(string $tag): ?callable
+    {
+        $handler = $this->handlers[$tag] ?? null;
+        return is_callable($handler) ? $handler : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function tags(): array
+    {
+        $tags = array_keys($this->handlers);
+        sort($tags);
+        return $tags;
+    }
+
+    public function clear(): void
+    {
+        $this->handlers = [];
+    }
+}

--- a/src/php/Run/Application/DataReadersLoader.php
+++ b/src/php/Run/Application/DataReadersLoader.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Throwable;
+
+use function array_unique;
+use function file_exists;
+use function is_dir;
+use function realpath;
+
+/**
+ * Auto-loads `data-readers.phel` from each source root.
+ *
+ * The file, if present, is expected to be a Phel namespace that calls
+ * `(register-tag ...)` for each tag it wants to register. Files found in
+ * earlier directories are evaluated first, so entries from later
+ * directories override earlier registrations.
+ *
+ * A `data-readers.phel` file that depends on `phel\reader` relies on the
+ * auto-loader evaluating reader first; callers are responsible for
+ * sequencing the dependency bootstrap before calling `load()`.
+ */
+final readonly class DataReadersLoader
+{
+    public const string FILE_NAME = 'data-readers.phel';
+
+    public function __construct(
+        private BuildFacadeInterface $buildFacade,
+    ) {}
+
+    /**
+     * @param list<string> $srcDirectories
+     */
+    public function load(array $srcDirectories): void
+    {
+        $files = $this->findDataReaderFiles($srcDirectories);
+        if ($files === []) {
+            return;
+        }
+
+        // `data-readers.phel` typically `(:require phel\reader)` so we
+        // bootstrap the reader namespace first; missing reader is treated
+        // as a no-op to keep the loader opt-in.
+        try {
+            $readerInfos = $this->buildFacade->getDependenciesForNamespace(
+                $srcDirectories,
+                ['phel\\reader', 'phel\\core'],
+            );
+        } catch (Throwable) {
+            return;
+        }
+
+        foreach ($readerInfos as $info) {
+            $this->buildFacade->evalFile($info->getFile());
+        }
+
+        foreach ($files as $file) {
+            $this->buildFacade->evalFile($file);
+        }
+    }
+
+    /**
+     * @param list<string> $srcDirectories
+     *
+     * @return list<string>
+     */
+    private function findDataReaderFiles(array $srcDirectories): array
+    {
+        $files = [];
+        foreach ($this->uniqueDirectories($srcDirectories) as $dir) {
+            $file = $dir . '/' . self::FILE_NAME;
+            if (file_exists($file)) {
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function uniqueDirectories(array $directories): array
+    {
+        $normalised = [];
+        foreach ($directories as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            $real = realpath($dir);
+            if ($real === false) {
+                continue;
+            }
+
+            $normalised[] = $real;
+        }
+
+        return array_values(array_unique($normalised));
+    }
+}

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -29,6 +29,11 @@ final readonly class FileRunner
 
         LoadClasspath::publish($directories);
 
+        // `data-readers.phel` must be evaluated before the user namespace
+        // so its `(register-tag ...)` calls are visible to the reader when
+        // the user source is compiled.
+        (new DataReadersLoader($this->buildFacade))->load($directories);
+
         $infos = $this->buildFacade->getDependenciesForNamespace($directories, [$namespace, 'phel\\core']);
         foreach ($infos as $info) {
             $this->buildFacade->evalFile($info->getFile());

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -18,6 +18,8 @@ final class NamespaceLoader
 {
     private static array $loadedFiles = [];
 
+    private static bool $dataReadersLoaded = false;
+
     public function __construct(
         private readonly BuildFacadeInterface $buildFacade,
         private readonly CommandFacadeInterface $commandFacade,
@@ -27,6 +29,7 @@ final class NamespaceLoader
     public static function reset(): void
     {
         self::$loadedFiles = [];
+        self::$dataReadersLoaded = false;
     }
 
     public function loadPhelNamespaces(?string $replStartupFile = null): void
@@ -64,6 +67,8 @@ final class NamespaceLoader
         }
 
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, '*file*', '');
+
+        $this->loadDataReaders($srcDirectories);
     }
 
     /**
@@ -82,5 +87,18 @@ final class NamespaceLoader
         }
 
         return $srcDirectories;
+    }
+
+    /**
+     * @param list<string> $srcDirectories
+     */
+    private function loadDataReaders(array $srcDirectories): void
+    {
+        if (self::$dataReadersLoaded) {
+            return;
+        }
+
+        self::$dataReadersLoaded = true;
+        (new DataReadersLoader($this->buildFacade))->load($srcDirectories);
     }
 }

--- a/src/php/Run/Application/NamespaceRunner.php
+++ b/src/php/Run/Application/NamespaceRunner.php
@@ -27,6 +27,12 @@ final readonly class NamespaceRunner implements NamespaceRunnerInterface
         // (or any of its dependencies) can find their sibling files.
         LoadClasspath::publish($srcDirectories);
 
+        // `data-readers.phel` must be evaluated before the user namespace
+        // so its `(register-tag ...)` calls are visible to the reader when
+        // the user source is compiled.
+        $dataReadersLoader = new DataReadersLoader($this->buildFacade);
+        $dataReadersLoader->load($srcDirectories);
+
         $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
             $srcDirectories,
             [$namespace, 'phel\\core'],

--- a/tests/phel/test/reader.phel
+++ b/tests/phel/test/reader.phel
@@ -1,0 +1,40 @@
+(ns phel-test\test\reader
+  (:require phel\reader :as reader)
+  (:require phel\test :refer [deftest is]))
+
+(defn- datetime? [x]
+  (php/instanceof x \DateTimeImmutable))
+
+(deftest test-inst-returns-datetime
+  (let [dt #inst "2026-04-20T12:00:00Z"]
+    (is (datetime? dt))
+    (is (= "2026-04-20T12:00:00+00:00" (php/-> dt (format "c"))))))
+
+(deftest test-inst-defaults-to-utc
+  (let [dt #inst "2026-04-20T12:00:00"]
+    (is (= "+00:00" (php/-> dt (format "P"))))))
+
+(deftest test-uuid-regression
+  (is (= "550e8400-e29b-41d4-a716-446655440000"
+         #uuid "550E8400-E29B-41D4-A716-446655440000")))
+
+(deftest test-regex-literal-tag
+  (is (= "/[a-z]+/" #regex "[a-z]+")))
+
+(deftest test-tag-registered
+  (is (reader/tag-registered? "inst"))
+  (is (reader/tag-registered? "regex"))
+  (is (reader/tag-registered? "uuid"))
+  (is (not (reader/tag-registered? "does-not-exist"))))
+
+(deftest test-registered-tags-includes-builtins
+  (let [tags (reader/registered-tags)]
+    (is (contains? (set tags) "inst"))
+    (is (contains? (set tags) "regex"))
+    (is (contains? (set tags) "uuid"))))
+
+(deftest test-register-tag-roundtrip
+  (reader/register-tag "shout-test" (fn [s] (php/strtoupper s)))
+  (is (reader/tag-registered? "shout-test"))
+  (reader/unregister-tag "shout-test")
+  (is (not (reader/tag-registered? "shout-test"))))

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -1412,7 +1412,9 @@ final class ReaderTest extends TestCase
 
     public function test_unknown_tag_lists_registered_tags(): void
     {
-        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+        $registry = TagRegistry::getInstance();
+        $registry->clear();
+        BuiltinTagHandlers::registerAll($registry);
 
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage('Registered tags: #inst, #php, #regex, #uuid');

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Integration\Compiler\Reader;
 
+use DateTimeImmutable;
 use Phel;
 use Phel\Compiler\Application\Lexer;
 use Phel\Compiler\CompilerFacade;
@@ -16,11 +17,16 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+use Phel\Lang\TagHandlers\BuiltinTagHandlers;
+use Phel\Lang\TagRegistry;
 use Phel\Lang\TypeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use PHPUnit\Framework\TestCase;
 
+use function get_debug_type;
+use function is_scalar;
 use function sprintf;
+use function strtoupper;
 
 final class ReaderTest extends TestCase
 {
@@ -1359,7 +1365,85 @@ final class ReaderTest extends TestCase
         $this->read('#php 42');
     }
 
+    public function test_inst_tagged_literal_returns_datetime(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        $result = $this->readAny('#inst "2026-04-20T12:00:00Z"');
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2026-04-20T12:00:00+00:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_inst_tagged_literal_defaults_missing_offset_to_utc(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        $result = $this->readAny('#inst "2026-04-20T12:00:00"');
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2026-04-20T12:00:00+00:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_inst_tagged_literal_rejects_invalid_string(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('is not a valid ISO 8601');
+        $this->read('#inst "bad-date"');
+    }
+
+    public function test_regex_tagged_literal_returns_delimited_pattern(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        self::assertSame('/[a-z]+/', $this->read('#regex "[a-z]+"'));
+    }
+
+    public function test_regex_tagged_literal_rejects_non_string(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('#regex expects a string literal');
+        $this->read('#regex 42');
+    }
+
+    public function test_unknown_tag_lists_registered_tags(): void
+    {
+        BuiltinTagHandlers::registerAll(TagRegistry::getInstance());
+
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Registered tags: #inst, #php, #regex, #uuid');
+        $this->read('#xyz "x"');
+    }
+
+    public function test_runtime_registered_tag_applies_handler(): void
+    {
+        $registry = TagRegistry::getInstance();
+        BuiltinTagHandlers::registerAll($registry);
+        $registry->register('shout', static fn(mixed $s): string => strtoupper((string) $s));
+
+        try {
+            self::assertSame('HELLO', $this->read('#shout "hello"'));
+        } finally {
+            $registry->unregister('shout');
+        }
+    }
+
     private function read(string $string, bool $withLocation = true): float|bool|int|string|TypeInterface|null
+    {
+        $ast = $this->readAny($string, $withLocation);
+
+        if ($ast === null || is_scalar($ast) || $ast instanceof TypeInterface) {
+            return $ast;
+        }
+
+        self::fail(sprintf('Unexpected read result of type %s', get_debug_type($ast)));
+    }
+
+    private function readAny(string $string, bool $withLocation = true): mixed
     {
         Symbol::resetGen();
         $tokenStream = $this->compilerFacade->lexString($string, Lexer::DEFAULT_SOURCE, $withLocation);

--- a/tests/php/Integration/Run/DataReaders/DataReadersAutoloadTest.php
+++ b/tests/php/Integration/Run/DataReaders/DataReadersAutoloadTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\DataReaders;
+
+use Phel\Run\Infrastructure\Command\RunCommand;
+use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Input\InputInterface;
+
+use function ob_get_clean;
+use function ob_start;
+
+final class DataReadersAutoloadTest extends AbstractTestCommand
+{
+    public function test_it_registers_tags_from_data_readers_file(): void
+    {
+        $output = $this->captureRunOutput(__DIR__ . '/Fixtures/consumer.phel');
+
+        self::assertStringContainsString('HELLO', $output);
+    }
+
+    private function captureRunOutput(string $path): string
+    {
+        ob_start();
+        (new RunCommand())->run(
+            $this->stubInput($path),
+            $this->stubOutput(),
+        );
+
+        return ob_get_clean() ?: '';
+    }
+
+    private function stubInput(string $path): InputInterface
+    {
+        $input = $this->createStub(InputInterface::class);
+        $input->method('getArgument')->willReturnCallback(
+            static fn(string $name): string|array => match ($name) {
+                'path' => $path,
+                'argv' => [],
+                default => '',
+            },
+        );
+
+        return $input;
+    }
+}

--- a/tests/php/Integration/Run/DataReaders/Fixtures/consumer.phel
+++ b/tests/php/Integration/Run/DataReaders/Fixtures/consumer.phel
@@ -1,0 +1,3 @@
+(ns fixture\consumer)
+
+(php/print #shout "hello")

--- a/tests/php/Integration/Run/DataReaders/Fixtures/data-readers.phel
+++ b/tests/php/Integration/Run/DataReaders/Fixtures/data-readers.phel
@@ -1,0 +1,5 @@
+(ns fixture\data-readers
+  (:require phel\reader :as r))
+
+(r/register-tag "shout"
+  (fn [s] (php/strtoupper s)))

--- a/tests/php/Integration/Run/DataReaders/phel-config.php
+++ b/tests/php/Integration/Run/DataReaders/phel-config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'src-dirs' => [
+        __DIR__ . '/../../../../src/phel/',
+        __DIR__ . '/Fixtures',
+    ],
+    'test-dirs' => [],
+    'vendor-dir' => '',
+
+    'export' => [
+        'directories' => [],
+        'namespace-prefix' => '',
+        'target-directory' => '',
+    ],
+];

--- a/tests/php/Unit/Lang/TagHandlers/InstTagHandlerTest.php
+++ b/tests/php/Unit/Lang/TagHandlers/InstTagHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\TagHandlers;
+
+use DateTimeImmutable;
+use Phel\Lang\TagHandlerException;
+use Phel\Lang\TagHandlers\InstTagHandler;
+use PHPUnit\Framework\TestCase;
+
+final class InstTagHandlerTest extends TestCase
+{
+    private InstTagHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->handler = new InstTagHandler();
+    }
+
+    public function test_it_parses_utc_timestamp(): void
+    {
+        $result = ($this->handler)('2026-04-20T12:00:00Z');
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2026-04-20T12:00:00+00:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_it_parses_timestamp_with_offset(): void
+    {
+        $result = ($this->handler)('2026-04-20T12:00:00+02:00');
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2026-04-20T12:00:00+02:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_it_defaults_missing_offset_to_utc(): void
+    {
+        $result = ($this->handler)('2026-04-20T12:00:00');
+
+        self::assertSame('2026-04-20T12:00:00+00:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_it_accepts_fractional_seconds(): void
+    {
+        $result = ($this->handler)('2026-04-20T12:00:00.123Z');
+
+        self::assertSame('2026-04-20T12:00:00+00:00', $result->format(DATE_ATOM));
+    }
+
+    public function test_it_rejects_non_string(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('#inst expects a string literal');
+
+        ($this->handler)(42);
+    }
+
+    public function test_it_rejects_invalid_format(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('is not a valid ISO 8601');
+
+        ($this->handler)('bad-date');
+    }
+
+    public function test_it_rejects_date_only_value(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('is not a valid ISO 8601');
+
+        ($this->handler)('2026-04-20');
+    }
+}

--- a/tests/php/Unit/Lang/TagHandlers/RegexTagHandlerTest.php
+++ b/tests/php/Unit/Lang/TagHandlers/RegexTagHandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+use Phel\Lang\TagHandlers\RegexTagHandler;
+use PHPUnit\Framework\TestCase;
+
+final class RegexTagHandlerTest extends TestCase
+{
+    private RegexTagHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->handler = new RegexTagHandler();
+    }
+
+    public function test_it_wraps_pattern_in_slashes(): void
+    {
+        self::assertSame('/[a-z]+/', ($this->handler)('[a-z]+'));
+    }
+
+    public function test_it_escapes_unescaped_forward_slash(): void
+    {
+        self::assertSame('/a\\/b/', ($this->handler)('a/b'));
+    }
+
+    public function test_it_leaves_escaped_forward_slash_alone(): void
+    {
+        self::assertSame('/a\\/b/', ($this->handler)('a\\/b'));
+    }
+
+    public function test_it_rejects_non_string(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('#regex expects a string literal');
+
+        ($this->handler)(1);
+    }
+}

--- a/tests/php/Unit/Lang/TagHandlers/UuidTagHandlerTest.php
+++ b/tests/php/Unit/Lang/TagHandlers/UuidTagHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+use Phel\Lang\TagHandlers\UuidTagHandler;
+use PHPUnit\Framework\TestCase;
+
+final class UuidTagHandlerTest extends TestCase
+{
+    private UuidTagHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->handler = new UuidTagHandler();
+    }
+
+    public function test_it_returns_lower_cased_uuid(): void
+    {
+        self::assertSame(
+            '550e8400-e29b-41d4-a716-446655440000',
+            ($this->handler)('550E8400-E29B-41D4-A716-446655440000'),
+        );
+    }
+
+    public function test_it_rejects_invalid_format(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('is not a canonical UUID string');
+
+        ($this->handler)('not-a-uuid');
+    }
+
+    public function test_it_rejects_non_string(): void
+    {
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('#uuid expects a string literal');
+
+        ($this->handler)(42);
+    }
+}

--- a/tests/php/Unit/Lang/TagRegistryTest.php
+++ b/tests/php/Unit/Lang/TagRegistryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Phel\Lang\TagRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class TagRegistryTest extends TestCase
+{
+    private TagRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = TagRegistry::getInstance();
+        $this->registry->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        TagRegistry::getInstance()->clear();
+    }
+
+    public function test_it_returns_the_same_instance(): void
+    {
+        self::assertSame(TagRegistry::getInstance(), TagRegistry::getInstance());
+    }
+
+    public function test_it_starts_empty_after_clear(): void
+    {
+        self::assertSame([], $this->registry->tags());
+        self::assertFalse($this->registry->has('foo'));
+        self::assertNull($this->registry->get('foo'));
+    }
+
+    public function test_it_registers_and_looks_up_a_handler(): void
+    {
+        $handler = static fn(mixed $form): string => 'got:' . $form;
+
+        $this->registry->register('foo', $handler);
+
+        self::assertTrue($this->registry->has('foo'));
+        self::assertSame($handler, $this->registry->get('foo'));
+    }
+
+    public function test_it_last_registration_wins(): void
+    {
+        $first = static fn(mixed $_): int => 1;
+        $second = static fn(mixed $_): int => 2;
+
+        $this->registry->register('foo', $first);
+        $this->registry->register('foo', $second);
+
+        self::assertSame($second, $this->registry->get('foo'));
+    }
+
+    public function test_it_unregisters_a_handler(): void
+    {
+        $this->registry->register('foo', static fn(mixed $_): int => 1);
+        $this->registry->unregister('foo');
+
+        self::assertFalse($this->registry->has('foo'));
+        self::assertNull($this->registry->get('foo'));
+    }
+
+    public function test_it_unregistering_missing_tag_is_a_noop(): void
+    {
+        $this->registry->unregister('does-not-exist');
+
+        self::assertFalse($this->registry->has('does-not-exist'));
+    }
+
+    public function test_it_returns_sorted_tag_list(): void
+    {
+        $noop = static fn(mixed $_): mixed => null;
+        $this->registry->register('zeta', $noop);
+        $this->registry->register('alpha', $noop);
+        $this->registry->register('mike', $noop);
+
+        self::assertSame(['alpha', 'mike', 'zeta'], $this->registry->tags());
+    }
+}

--- a/tests/php/Unit/Run/Application/DataReadersLoaderTest.php
+++ b/tests/php/Unit/Run/Application/DataReadersLoaderTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Application\DataReadersLoader;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function array_merge;
+use function file_put_contents;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class DataReadersLoaderTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+
+        foreach ($this->tempDirs as $dir) {
+            @rmdir($dir);
+        }
+
+        $this->tempFiles = [];
+        $this->tempDirs = [];
+    }
+
+    public function test_it_does_nothing_when_no_data_readers_file_exists(): void
+    {
+        $dir = $this->makeTempDir();
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+
+        $buildFacade->expects(self::never())->method('evalFile');
+        $buildFacade->expects(self::never())->method('getDependenciesForNamespace');
+
+        (new DataReadersLoader($buildFacade))->load([$dir]);
+    }
+
+    public function test_it_loads_reader_dependencies_then_data_readers_file(): void
+    {
+        $dir = $this->makeTempDir();
+        $file = $dir . '/data-readers.phel';
+        $this->writeFile($file, ";; placeholder\n");
+
+        $readerFile = $dir . '/phel-reader.phel';
+        $this->writeFile($readerFile, ";; placeholder\n");
+
+        $readerInfo = new NamespaceInformation(
+            $readerFile,
+            'phel\\reader',
+            [],
+        );
+
+        $calls = [];
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getDependenciesForNamespace')
+            ->willReturnCallback(static function (array $dirs, array $ns) use (&$calls, $readerInfo): array {
+                $calls[] = ['deps', $ns];
+                return [$readerInfo];
+            });
+
+        $buildFacade->method('evalFile')
+            ->willReturnCallback(static function (string $path) use (&$calls): CompiledFile {
+                $calls[] = ['eval', $path];
+                return new CompiledFile($path, $path, 'phel\\reader');
+            });
+
+        (new DataReadersLoader($buildFacade))->load([$dir]);
+
+        self::assertSame('deps', $calls[0][0]);
+        self::assertSame(['phel\\reader', 'phel\\core'], $calls[0][1]);
+        self::assertSame('eval', $calls[1][0]);
+        self::assertSame($readerFile, $calls[1][1]);
+        self::assertSame('eval', $calls[2][0]);
+        self::assertSame(realpath($file), realpath((string) $calls[2][1]));
+    }
+
+    public function test_it_silently_skips_when_reader_dependency_resolution_fails(): void
+    {
+        $dir = $this->makeTempDir();
+        $file = $dir . '/data-readers.phel';
+        $this->writeFile($file, ";; placeholder\n");
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getDependenciesForNamespace')
+            ->willThrowException(new RuntimeException('cannot resolve'));
+
+        $buildFacade->expects(self::never())->method('evalFile');
+
+        (new DataReadersLoader($buildFacade))->load([$dir]);
+    }
+
+    private function makeTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/phel-data-readers-' . uniqid();
+        mkdir($dir);
+        $this->tempDirs[] = $dir;
+        return $dir;
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        file_put_contents($path, $contents);
+        $this->tempFiles = array_merge($this->tempFiles, [$path]);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel already reads `#uuid "..."` as a built-in tagged literal, but `#inst` did not work and any unknown tag aborted the read. Clojure exposes a registry so library authors can extend the reader with domain-specific data literals. This PR closes Tier 2 item #12 of the Clojure-parity roadmap.

## 💡 Goal

Ship an extensible reader tag system that supports built-in `#inst` and `#regex` literals, user-registered tags, and a `data-readers.phel` auto-loader.

## 🔖 Changes

- `TagRegistry` singleton in `Phel\Lang\` stores `tag -> callable` and is populated at compiler boot with `InstTagHandler`, `RegexTagHandler`, `UuidTagHandler`.
- `TaggedLiteralReader` dispatches via `TagRegistry::get`; `#php` stays special-cased because it inspects the following form's token type; unknown tags now throw a descriptive error listing every registered tag.
- `#inst "2026-04-20T12:00:00Z"` yields a `\DateTimeImmutable`, defaults to UTC when no offset is present, and validates the string against an ISO 8601 / RFC 3339 regex.
- `#regex "pattern"` yields a PCRE-delimited string compatible with `re-find`, `re-seq`, `re-matches`, and `re-pattern` (mirrors `#"..."`).
- New `phel\reader` namespace exposes `register-tag`, `tag-registered?`, `unregister-tag`, `registered-tags`.
- `DataReadersLoader` auto-loads `data-readers.phel` from any src/vendor directory before user namespaces run; it bootstraps `phel\reader` first and is a no-op if the reader namespace cannot be resolved.
- The analyzer, emitter, and reader pipelines were broadened to accept arbitrary PHP objects as literal values so a `DateTimeImmutable` survives compile-to-PHP.
- PHPUnit coverage: `TagRegistryTest`, `InstTagHandlerTest`, `RegexTagHandlerTest`, `UuidTagHandlerTest`, `DataReadersLoaderTest`, `DataReadersAutoloadTest`, plus integration cases in `ReaderTest`.
- Phel coverage: `tests/phel/test/reader.phel` exercises `#inst`, `#regex`, `#uuid` regression, `register-tag` round-trip, and `registered-tags`.

cc @me