### PR TITLE
ref: tighten boundaries and test coverage across parity features

### DIFF
--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -74,6 +74,13 @@
       1 (first effective)
       `(and ~@effective))))
 
+(defn- shape-gated-check
+  "Wraps an inner and-combined check behind a shape predicate. When the
+  target fails the shape check the expression short-circuits to `false`
+  so the inner accessors never see a mismatched value."
+  [shape inner-checks]
+  `(if ~shape ~(and-checks inner-checks) false))
+
 (defn- compile-wildcard [_target _pattern]
   {:check true :bindings []})
 
@@ -174,10 +181,7 @@
                                :check    (get sub :check)
                                :bindings (get sub :bindings)})))
         inner-checks (for [e :in elem-specs] (get e :check))
-        combined-inner (and-checks (cons length-ok inner-checks))
-        ;; Gate the inner check on the shape predicate so `get` /
-        ;; `count` never see a non-sequential target.
-        outer-check  `(if ~shape ~combined-inner false)
+        outer-check  (shape-gated-check shape (cons length-ok inner-checks))
         elem-bindings (apply concat
                              (for [e :in elem-specs]
                                (get e :bindings)))
@@ -205,8 +209,7 @@
         contains-checks (for [k :in key-specs]
                           `(contains? ~target ~(get k :key)))
         value-checks    (for [k :in key-specs] (get k :check))
-        combined-inner  (and-checks (apply vector (concat contains-checks value-checks)))
-        outer-check     `(if ~shape ~combined-inner false)
+        outer-check     (shape-gated-check shape (apply vector (concat contains-checks value-checks)))
         all-bindings    (apply vector
                                (apply concat
                                       (for [k :in key-specs]

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -160,9 +160,7 @@
           :else
           (let [entry (first es)
                 k     (get entry 0)
-                inner (if (and (>= (count entry) 3) (map? (get entry 1)))
-                        (get entry 2)
-                        (get entry 1))]
+                inner (v/map-entry-schema entry)]
             (if (contains? acc k)
               (recur (next es) (assoc acc k (coerce inner (get acc k))))
               (recur (next es) acc))))))))

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -102,13 +102,8 @@
               :else
               (let [entry (first es)
                     k     (get entry 0)
-                    inner (if (and (>= (count entry) 3) (map? (get entry 1)))
-                            (get entry 2)
-                            (get entry 1))
-                    opts  (if (and (>= (count entry) 3) (map? (get entry 1)))
-                            (get entry 1)
-                            {})
-                    opt?  (true? (get opts :optional))
+                    inner (v/map-entry-schema entry)
+                    opt?  (v/map-entry-optional? entry)
                     path' (conj path :map k)
                     in'   (conj in k)]
                 (cond

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -79,16 +79,9 @@
   [entries]
   (let [pairs (into []
                     (map (fn [entry]
-                           (let [k (get entry 0)
-                                 inner (if (and (>= (count entry) 3)
-                                                (map? (get entry 1)))
-                                         (get entry 2)
-                                         (get entry 1))
-                                 opts (if (and (>= (count entry) 3)
-                                               (map? (get entry 1)))
-                                        (get entry 1)
-                                        {})
-                                 opt? (true? (get opts :optional))]
+                           (let [k     (get entry 0)
+                                 inner (v/map-entry-schema entry)
+                                 opt?  (v/map-entry-optional? entry)]
                              [k (schema->gen inner) opt?]))
                          entries))]
     (fn [size]

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -164,23 +164,27 @@
              (recur (+ i 1))
              false)))))
 
-(defn- entry-options
-  "Options map for a `[:map ...]` entry `[key opts? schema]`."
+(defn map-entry-options
+  "Options map for a `[:map ...]` entry `[key opts? schema]`. Returns an
+  empty map when the entry has no options position."
   [entry]
   (if (and (>= (count entry) 3) (map? (get entry 1)))
     (get entry 1)
     {}))
 
-(defn- entry-schema
-  "Inner schema of a `[:map ...]` entry."
+(defn map-entry-schema
+  "Inner schema of a `[:map ...]` entry, skipping the options map when
+  present."
   [entry]
   (if (and (>= (count entry) 3) (map? (get entry 1)))
     (get entry 2)
     (get entry 1)))
 
-(defn- entry-optional?
+(defn map-entry-optional?
+  "Returns `true` when a `[:map ...]` entry is declared with
+  `{:optional true}`."
   [entry]
-  (true? (get (entry-options entry) :optional)))
+  (true? (get (map-entry-options entry) :optional)))
 
 (defn- validate-map
   [value entries closed?]
@@ -192,8 +196,8 @@
                        :else
                        (let [entry (first es)
                              k     (get entry 0)
-                             inner (entry-schema entry)
-                             opt?  (entry-optional? entry)]
+                             inner (map-entry-schema entry)
+                             opt?  (map-entry-optional? entry)]
                          (cond
                            (not (contains? value k))
                            (if opt? (recur (next es)) false)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -145,21 +145,17 @@
 ;; legacy assertion-level types emitted by the built-in `is` macro. Each
 ;; carries a `:state` field (`:pass`/`:failed`/`:error`) that records the
 ;; real outcome, so we recover the logical type and delegate.
-(defn- handle-assertion-like [data]
-  (let [state (get data :state)]
-    (case state
-      :pass   (report-assertion! data)
-      :failed (report-assertion! data)
-      :error  (report-assertion! data)
-      (fan-out! (decorate-event data)))))
+(def- assertion-like-states
+  (hash-set :pass :failed :error))
 
-(defmethod report :predicate      [data] (handle-assertion-like data))
-(defmethod report :predicate-not  [data] (handle-assertion-like data))
-(defmethod report :binary         [data] (handle-assertion-like data))
-(defmethod report :binary-not     [data] (handle-assertion-like data))
-(defmethod report :any            [data] (handle-assertion-like data))
-(defmethod report :thrown         [data] (handle-assertion-like data))
-(defmethod report :thrown-with-msg [data] (handle-assertion-like data))
+(defn- handle-assertion-like [data]
+  (if (contains? assertion-like-states (get data :state))
+    (report-assertion! data)
+    (fan-out! (decorate-event data))))
+
+(dofor [event-type :in [:predicate :predicate-not :binary :binary-not
+                        :any :thrown :thrown-with-msg]]
+  (swap! report-methods assoc event-type handle-assertion-like))
 
 (defn- record-skip! [data]
   (swap! stats
@@ -169,12 +165,13 @@
                  s      (assoc s :counts counts)]
              (assoc s :skipped (conj (get s :skipped) data))))))
 
-(defmethod report :begin-test-ns   [data] (fan-out! data))
-(defmethod report :end-test-ns     [data] (fan-out! data))
-(defmethod report :begin-test-run  [data] (fan-out! data))
-(defmethod report :summary         [data] (fan-out! data))
-(defmethod report :defspec-failed  [data] (fan-out! data))
-(defmethod report :skipped         [data]
+;; Lifecycle events that flow straight through to every registered
+;; reporter without touching the stats atom.
+(dofor [event-type :in [:begin-test-ns :end-test-ns :begin-test-run
+                        :summary :defspec-failed]]
+  (swap! report-methods assoc event-type fan-out!))
+
+(defmethod report :skipped [data]
   (record-skip! data)
   (fan-out! data))
 
@@ -511,12 +508,12 @@
   (if (nil? actual-message)
     (do
       (println "    expected:" form)
-      (println "  to throw a:" exception-symbol "(it didn't)")
-      (do
-        (println "      expected:" form)
-        (println "    to throw a:" exception-symbol)
-        (println "  with message:" expected-message)
-        (println "       but got:" actual-message)))))
+      (println "  to throw a:" exception-symbol "(it didn't)"))
+    (do
+      (println "      expected:" form)
+      (println "    to throw a:" exception-symbol)
+      (println "  with message:" expected-message)
+      (println "       but got:" actual-message))))
 
 (defn- print-any-failure [{:form form :result result}]
   (println "          Test:" form)
@@ -543,6 +540,28 @@
 (defn- assertion-event? [event]
   (contains? event :state))
 
+(defn- print-failures-block [failures]
+  (when-not (empty? failures)
+    (println)
+    (for [data :in failures]
+      (println "~~~~~~~~~~")
+      (print-failure-or-error data))
+    (println)))
+
+(defn- print-counts-summary [event]
+  (println "Passed:" (:pass event))
+  (println "Failed:" (:failed event))
+  (println "Error:" (:error event))
+  (when (pos? (or (:skipped event) 0))
+    (println "Skipped:" (:skipped event)))
+  (println "Total:" (:total event)))
+
+(defn- print-summary-block [event]
+  (println)
+  (print-failures-block (:failures event))
+  (println)
+  (print-counts-summary event))
+
 (defn- default-reporter
   "Human-readable dot output. Preserves the legacy behavior: `.` for
   pass, `F` for fail, `E` for error, plus periodic newlines so long
@@ -566,21 +585,7 @@
         (when (= 0 (% n 80)) (println)))
 
       (= type :summary)
-      (do
-        (println)
-        (when-not (empty? (:failures event))
-          (println)
-          (for [data :in (:failures event)]
-            (println "~~~~~~~~~~")
-            (print-failure-or-error data))
-          (println))
-        (println)
-        (println "Passed:" (:pass event))
-        (println "Failed:" (:failed event))
-        (println "Error:" (:error event))
-        (when (pos? (or (:skipped event) 0))
-          (println "Skipped:" (:skipped event)))
-        (println "Total:" (:total event))))))
+      (print-summary-block event))))
 
 (defn- testdox-reporter
   "Per-assertion single-line description used by the `--reporter=testdox`
@@ -600,21 +605,7 @@
         (println "↷" (str tname " (skipped)")))
 
       (= type :summary)
-      (do
-        (println)
-        (when-not (empty? (:failures event))
-          (println)
-          (for [data :in (:failures event)]
-            (println "~~~~~~~~~~")
-            (print-failure-or-error data))
-          (println))
-        (println)
-        (println "Passed:" (:pass event))
-        (println "Failed:" (:failed event))
-        (println "Error:" (:error event))
-        (when (pos? (or (:skipped event) 0))
-          (println "Skipped:" (:skipped event)))
-        (println "Total:" (:total event))))))
+      (print-summary-block event))))
 
 ;; -------------
 ;; Dot reporter
@@ -734,25 +725,18 @@
       (php/get_class ex)
       (or (:exception-symbol event) "AssertionFailed"))))
 
+(defn- junit-nested-element [tag event]
+  (str "<" tag
+       " message=\"" (junit-xml-escape (or (:message event) "")) "\""
+       " type=\"" (junit-xml-escape (junit-exception-class event)) "\">"
+       (junit-xml-escape (str (:form event)))
+       "</" tag ">"))
+
 (defn- junit-testcase-body [event]
-  (let [state  (get event :state (:type event))
-        msg    (or (:message event) "")
-        klass  (junit-exception-class event)
-        body   (cond
-                 (= state :error)
-                 (str "<error message=\"" (junit-xml-escape msg)
-                      "\" type=\"" (junit-xml-escape klass) "\">"
-                      (junit-xml-escape (str (:form event)))
-                      "</error>")
-
-                 (= state :failed)
-                 (str "<failure message=\"" (junit-xml-escape msg)
-                      "\" type=\"" (junit-xml-escape klass) "\">"
-                      (junit-xml-escape (str (:form event)))
-                      "</failure>")
-
-                 :else nil)]
-    body))
+  (let [state (get event :state (:type event))]
+    (cond
+      (= state :error)  (junit-nested-element "error"   event)
+      (= state :failed) (junit-nested-element "failure" event))))
 
 (defn- junit-build-testcase [event]
   (let [tname    (or (:test-name event) "assertion")
@@ -807,23 +791,21 @@
                            :time 0.0
                            :cases []})))
 
+(defn- bump-counters [m event]
+  (let [state  (get event :state)
+        m      (update m :tests inc)
+        m      (if (= :failed state) (update m :failures inc) m)
+        m      (if (= :error state)  (update m :errors inc)  m)]
+    m))
+
 (defn- junit-record-case [state event]
   (let [current (or (:current state)
                     {:name (or (:ns event) "")
                      :tests 0 :failures 0 :errors 0 :time 0.0 :cases []})
-        state   (assoc state :current current)
-        state   (update state :tests inc)
-        state   (if (= :failed (get event :state))
-                  (update state :failures inc) state)
-        state   (if (= :error (get event :state))
-                  (update state :errors inc) state)
-        current (:current state)
-        current (update current :tests inc)
-        current (if (= :failed (get event :state))
-                  (update current :failures inc) current)
-        current (if (= :error (get event :state))
-                  (update current :errors inc) current)
-        current (update current :cases conj (junit-build-testcase event))]
+        state   (bump-counters state event)
+        current (-> current
+                    (bump-counters event)
+                    (update :cases conj (junit-build-testcase event)))]
     (assoc state :current current)))
 
 (defn- junit-write-output [state]
@@ -1083,21 +1065,27 @@
              :else                             (throw (php/new \InvalidArgumentException
                                                                (str "Invalid reporter value: " r))))))))
 
+(defn- configure-run! [options]
+  (reset! fail-fast? (:fail-fast options))
+  (when-let [path (:junit-output options)]
+    (set-junit-output! path))
+  (set-reporters! (resolve-reporters-option options)))
+
+(defn- run-one-ns! [options namespace]
+  (let [ns-name (name namespace)]
+    (fan-out! {:type :begin-test-ns :ns ns-name})
+    (run-test options ns-name)
+    (fan-out! {:type :end-test-ns :ns ns-name})))
+
 (defn run-tests
   "Runs all tests in the given namespaces."
   {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
-  (reset! fail-fast? (:fail-fast options))
-  (when-let [path (:junit-output options)]
-    (set-junit-output! path))
-  (set-reporters! (resolve-reporters-option options))
+  (configure-run! options)
   (fan-out! {:type :begin-test-run})
   (dofor [namespace :in namespaces
-          :let [ns-name (name namespace)]
           :when (not (should-stop?))]
-    (fan-out! {:type :begin-test-ns :ns ns-name})
-    (run-test options ns-name)
-    (fan-out! {:type :end-test-ns :ns ns-name}))
+    (run-one-ns! options namespace))
   (print-summary))
 
 (defn reset-stats

--- a/src/php/Api/Application/PhelFileIterator.php
+++ b/src/php/Api/Application/PhelFileIterator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use UnexpectedValueException;
+
+/**
+ * Stateless helper that yields every `.phel` file under a directory tree.
+ * Returns an empty iterable if the directory cannot be opened.
+ */
+final class PhelFileIterator
+{
+    /**
+     * @return iterable<string>
+     */
+    public static function iterate(string $directory): iterable
+    {
+        try {
+            $dirIterator = new RecursiveDirectoryIterator($directory);
+            $iterator = new RecursiveIteratorIterator($dirIterator);
+            $regex = new RegexIterator($iterator, '/^.+\.phel$/i', RegexIterator::GET_MATCH);
+        } catch (UnexpectedValueException) {
+            return;
+        }
+
+        foreach ($regex as $match) {
+            yield $match[0];
+        }
+    }
+}

--- a/src/php/Api/Application/ProjectIndexer.php
+++ b/src/php/Api/Application/ProjectIndexer.php
@@ -8,10 +8,6 @@ use Phel\Api\Domain\ProjectIndexerInterface;
 use Phel\Api\Transfer\Definition;
 use Phel\Api\Transfer\Location;
 use Phel\Api\Transfer\ProjectIndex;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RegexIterator;
-use UnexpectedValueException;
 
 use function file_get_contents;
 use function is_dir;
@@ -47,7 +43,7 @@ final readonly class ProjectIndexer implements ProjectIndexerInterface
                 continue;
             }
 
-            foreach ($this->iteratePhelFiles($real) as $file) {
+            foreach (PhelFileIterator::iterate($real) as $file) {
                 $contents = @file_get_contents($file);
                 if ($contents === false) {
                     continue;
@@ -72,23 +68,5 @@ final readonly class ProjectIndexer implements ProjectIndexerInterface
         }
 
         return new ProjectIndex($definitions, $references);
-    }
-
-    /**
-     * @return iterable<string>
-     */
-    private function iteratePhelFiles(string $directory): iterable
-    {
-        try {
-            $dirIterator = new RecursiveDirectoryIterator($directory);
-            $iterator = new RecursiveIteratorIterator($dirIterator);
-            $regex = new RegexIterator($iterator, '/^.+\.phel$/i', RegexIterator::GET_MATCH);
-        } catch (UnexpectedValueException) {
-            return [];
-        }
-
-        foreach ($regex as $match) {
-            yield $match[0];
-        }
     }
 }

--- a/src/php/Api/Application/ReferenceFinder.php
+++ b/src/php/Api/Application/ReferenceFinder.php
@@ -8,6 +8,10 @@ use Phel\Api\Domain\ReferenceFinderInterface;
 use Phel\Api\Transfer\Location;
 use Phel\Api\Transfer\ProjectIndex;
 
+use function str_contains;
+use function strrpos;
+use function substr;
+
 final readonly class ReferenceFinder implements ReferenceFinderInterface
 {
     /**
@@ -15,14 +19,10 @@ final readonly class ReferenceFinder implements ReferenceFinderInterface
      */
     public function find(ProjectIndex $index, string $namespace, string $symbol): array
     {
-        $key = $symbol;
-        if (!str_contains($symbol, '/')) {
-            $key = $namespace === '' ? $symbol : $namespace . '/' . $symbol;
-        }
-
+        $key = SymbolKey::resolve($namespace, $symbol);
         $locations = $index->references[$key] ?? [];
 
-        // Also try unqualified lookup for same-file references
+        // Also try unqualified lookup for same-file references.
         if ($locations === [] && str_contains($key, '/')) {
             $short = substr($key, (int) strrpos($key, '/') + 1);
             $locations = $index->references[$short] ?? [];

--- a/src/php/Api/Application/SymbolKey.php
+++ b/src/php/Api/Application/SymbolKey.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use function str_contains;
+
+/**
+ * Shared utility for building the "namespace/name" key used as both
+ * the definition-index key and the reference-index key in `ProjectIndex`.
+ *
+ * Centralising this keeps `SymbolResolver` and `ReferenceFinder` in
+ * lock-step: if one changes how symbols are keyed, the other must
+ * follow.
+ */
+final class SymbolKey
+{
+    /**
+     * Build the lookup key:
+     * - if `$symbol` already contains `/`, use it as-is (already qualified),
+     * - otherwise, qualify with `$namespace` unless empty.
+     */
+    public static function resolve(string $namespace, string $symbol): string
+    {
+        if (str_contains($symbol, '/')) {
+            return $symbol;
+        }
+
+        return $namespace === '' ? $symbol : $namespace . '/' . $symbol;
+    }
+}

--- a/src/php/Api/Application/SymbolResolver.php
+++ b/src/php/Api/Application/SymbolResolver.php
@@ -12,11 +12,7 @@ final readonly class SymbolResolver implements SymbolResolverInterface
 {
     public function resolve(ProjectIndex $index, string $namespace, string $symbol): ?Definition
     {
-        // Qualified form foo/bar wins if provided outright.
-        $key = $symbol;
-        if (!str_contains($symbol, '/')) {
-            $key = $namespace === '' ? $symbol : $namespace . '/' . $symbol;
-        }
+        $key = SymbolKey::resolve($namespace, $symbol);
 
         if (isset($index->definitions[$key])) {
             return $index->definitions[$key];

--- a/src/php/Lang/TagHandlers/AbstractStringTagHandler.php
+++ b/src/php/Lang/TagHandlers/AbstractStringTagHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * Base class for tag handlers whose input form must be a string literal.
+ *
+ * Concrete subclasses implement {@see handleString()} and rely on this
+ * class to reject non-string forms with a uniform error message.
+ */
+abstract readonly class AbstractStringTagHandler
+{
+    final public function __invoke(mixed $form): mixed
+    {
+        if (!is_string($form)) {
+            throw new TagHandlerException(sprintf(
+                '#%s expects a string literal%s.',
+                $this->tagName(),
+                $this->example() === '' ? '' : ' (e.g. ' . $this->example() . ')',
+            ));
+        }
+
+        return $this->handleString($form);
+    }
+
+    /**
+     * Tag identifier used in error messages (e.g. "inst", "regex", "uuid").
+     */
+    abstract protected function tagName(): string;
+
+    /**
+     * Short example shown in the "expects a string literal" error, or an
+     * empty string to omit the parenthetical. Example:
+     * `#uuid "00000000-0000-0000-0000-000000000000"`.
+     */
+    abstract protected function example(): string;
+
+    abstract protected function handleString(string $form): mixed;
+}

--- a/src/php/Lang/TagHandlers/InstTagHandler.php
+++ b/src/php/Lang/TagHandlers/InstTagHandler.php
@@ -7,10 +7,8 @@ namespace Phel\Lang\TagHandlers;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-
 use Phel\Lang\TagHandlerException;
 
-use function is_string;
 use function preg_match;
 use function sprintf;
 
@@ -20,7 +18,7 @@ use function sprintf;
  * Accepts an ISO 8601 timestamp string (RFC 3339 subset) and returns a
  * `\DateTimeImmutable`. Missing timezone offsets are interpreted as UTC.
  */
-final readonly class InstTagHandler
+final readonly class InstTagHandler extends AbstractStringTagHandler
 {
     /**
      * Matches ISO 8601 / RFC 3339 timestamps of the shape
@@ -28,14 +26,18 @@ final readonly class InstTagHandler
      */
     private const string REGEX = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/';
 
-    public function __invoke(mixed $form): DateTimeImmutable
+    protected function tagName(): string
     {
-        if (!is_string($form)) {
-            throw new TagHandlerException(
-                '#inst expects a string literal (e.g. #inst "2026-04-20T12:00:00Z").',
-            );
-        }
+        return 'inst';
+    }
 
+    protected function example(): string
+    {
+        return '#inst "2026-04-20T12:00:00Z"';
+    }
+
+    protected function handleString(string $form): DateTimeImmutable
+    {
         if (preg_match(self::REGEX, $form) !== 1) {
             throw new TagHandlerException(sprintf(
                 '#inst value "%s" is not a valid ISO 8601 / RFC 3339 timestamp.',

--- a/src/php/Lang/TagHandlers/RegexTagHandler.php
+++ b/src/php/Lang/TagHandlers/RegexTagHandler.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lang\TagHandlers;
 
-use Phel\Lang\TagHandlerException;
-
-use function is_string;
 use function preg_replace;
 
 /**
@@ -17,16 +14,20 @@ use function preg_replace;
  * literal. The value is directly usable with `re-find`, `re-seq`,
  * `re-matches`, and `re-pattern`.
  */
-final readonly class RegexTagHandler
+final readonly class RegexTagHandler extends AbstractStringTagHandler
 {
-    public function __invoke(mixed $form): string
+    protected function tagName(): string
     {
-        if (!is_string($form)) {
-            throw new TagHandlerException(
-                '#regex expects a string literal (e.g. #regex "[a-z]+").',
-            );
-        }
+        return 'regex';
+    }
 
+    protected function example(): string
+    {
+        return '#regex "[a-z]+"';
+    }
+
+    protected function handleString(string $form): string
+    {
         // Match `RegexParser::parse()`: escape unescaped `/` so the
         // `/delimiter/` is never broken by the user's pattern.
         $pattern = preg_replace('/(?<!\\\\)\\//', '\\/', $form) ?? $form;

--- a/src/php/Lang/TagHandlers/UuidTagHandler.php
+++ b/src/php/Lang/TagHandlers/UuidTagHandler.php
@@ -6,7 +6,6 @@ namespace Phel\Lang\TagHandlers;
 
 use Phel\Lang\TagHandlerException;
 
-use function is_string;
 use function preg_match;
 use function sprintf;
 use function strtolower;
@@ -18,18 +17,22 @@ use function strtolower;
  * returns the lower-cased form. Phel has no dedicated UUID type, so the
  * reader value is a normalised string.
  */
-final readonly class UuidTagHandler
+final readonly class UuidTagHandler extends AbstractStringTagHandler
 {
     private const string REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
 
-    public function __invoke(mixed $form): string
+    protected function tagName(): string
     {
-        if (!is_string($form)) {
-            throw new TagHandlerException(
-                '#uuid expects a string literal (e.g. #uuid "00000000-0000-0000-0000-000000000000").',
-            );
-        }
+        return 'uuid';
+    }
 
+    protected function example(): string
+    {
+        return '#uuid "00000000-0000-0000-0000-000000000000"';
+    }
+
+    protected function handleString(string $form): string
+    {
         if (preg_match(self::REGEX, $form) !== 1) {
             throw new TagHandlerException(sprintf(
                 '#uuid value "%s" is not a canonical UUID string.',

--- a/src/php/Lint/Application/Rule/ArityMismatchRule.php
+++ b/src/php/Lint/Application/Rule/ArityMismatchRule.php
@@ -38,7 +38,11 @@ final readonly class ArityMismatchRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
-        $result = $this->promoteSemanticArityErrors($analysis);
+        $result = SemanticDiagnosticPromoter::promote(
+            $analysis,
+            ErrorCode::ARITY_ERROR->value,
+            $this->code(),
+        );
 
         $localFns = $this->collectLocalFunctions($analysis->forms);
         if ($localFns === []) {
@@ -47,32 +51,6 @@ final readonly class ArityMismatchRule implements LintRuleInterface
 
         foreach ($analysis->forms as $form) {
             $this->inspectCalls($form, $localFns, $analysis->uri, $result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return list<Diagnostic>
-     */
-    private function promoteSemanticArityErrors(FileAnalysis $analysis): array
-    {
-        $result = [];
-        foreach ($analysis->semanticDiagnostics as $diagnostic) {
-            if ($diagnostic->code !== ErrorCode::ARITY_ERROR->value) {
-                continue;
-            }
-
-            $result[] = new Diagnostic(
-                code: $this->code(),
-                severity: $diagnostic->severity,
-                message: $diagnostic->message,
-                uri: $diagnostic->uri,
-                startLine: $diagnostic->startLine,
-                startCol: $diagnostic->startCol,
-                endLine: $diagnostic->endLine,
-                endCol: $diagnostic->endCol,
-            );
         }
 
         return $result;

--- a/src/php/Lint/Application/Rule/DiscouragedVarRule.php
+++ b/src/php/Lint/Application/Rule/DiscouragedVarRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application\Rule;
 
-use Phel\Api\Transfer\Diagnostic;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -33,6 +32,8 @@ use function sprintf;
  */
 final readonly class DiscouragedVarRule implements LintRuleInterface
 {
+    private const array DEFINING_FORMS = ['def', 'defn', 'defn-', 'defmacro', 'defmacro-'];
+
     public function code(): string
     {
         return RuleRegistry::DISCOURAGED_VAR;
@@ -47,7 +48,23 @@ final readonly class DiscouragedVarRule implements LintRuleInterface
 
         $result = [];
         foreach ($analysis->forms as $form) {
-            $this->walk($form, $discouraged, $analysis->uri, $result);
+            FormWalker::walk($form, function (mixed $node) use ($discouraged, $analysis, &$result): void {
+                if (!$node instanceof Symbol) {
+                    return;
+                }
+
+                $name = $node->getName();
+                if (!isset($discouraged[$name])) {
+                    return;
+                }
+
+                $result[] = DiagnosticBuilder::fromForm(
+                    $this->code(),
+                    sprintf("Use of discouraged var '%s' (%s).", $name, $discouraged[$name]),
+                    $analysis->uri,
+                    $node,
+                );
+            });
         }
 
         return $result;
@@ -96,8 +113,7 @@ final readonly class DiscouragedVarRule implements LintRuleInterface
             return;
         }
 
-        $name = $head->getName();
-        if (!in_array($name, ['def', 'defn', 'defn-', 'defmacro', 'defmacro-'], true)) {
+        if (!in_array($head->getName(), self::DEFINING_FORMS, true)) {
             return;
         }
 
@@ -116,42 +132,6 @@ final readonly class DiscouragedVarRule implements LintRuleInterface
                 }
             } elseif ($meta instanceof PersistentVectorInterface) {
                 break;
-            }
-        }
-    }
-
-    /**
-     * @param array<string, string> $discouraged
-     * @param list<Diagnostic>      $result
-     */
-    private function walk(mixed $form, array $discouraged, string $uri, array &$result): void
-    {
-        if ($form instanceof Symbol) {
-            $name = $form->getName();
-            if (isset($discouraged[$name])) {
-                $result[] = DiagnosticBuilder::fromForm(
-                    $this->code(),
-                    sprintf("Use of discouraged var '%s' (%s).", $name, $discouraged[$name]),
-                    $uri,
-                    $form,
-                );
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentListInterface || $form instanceof PersistentVectorInterface) {
-            foreach ($form as $child) {
-                $this->walk($child, $discouraged, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentMapInterface) {
-            foreach ($form as $k => $v) {
-                $this->walk($k, $discouraged, $uri, $result);
-                $this->walk($v, $discouraged, $uri, $result);
             }
         }
     }

--- a/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
+++ b/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
@@ -6,7 +6,6 @@ namespace Phel\Lint\Application\Rule;
 
 use Phel\Api\Transfer\Diagnostic;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
 use Phel\Lint\Application\Config\RuleRegistry;
@@ -37,51 +36,29 @@ final readonly class InvalidDestructuringRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
+        /** @var list<Diagnostic> $result */
         $result = [];
         foreach ($analysis->forms as $form) {
-            $this->walk($form, $analysis->uri, $result);
+            FormWalker::walk($form, function (mixed $node) use ($analysis, &$result): void {
+                if (!$node instanceof PersistentListInterface || count($node) === 0) {
+                    return;
+                }
+
+                $head = $node->get(0);
+                if (!$head instanceof Symbol) {
+                    return;
+                }
+
+                $name = $head->getName();
+                if (in_array($name, self::LET_LIKE_FORMS, true)) {
+                    $this->inspectLet($node, $analysis->uri, $result);
+                } elseif (in_array($name, self::FN_FORMS, true)) {
+                    $this->inspectFn($node, $analysis->uri, $result);
+                }
+            });
         }
 
         return $result;
-    }
-
-    /**
-     * @param list<Diagnostic> $result
-     */
-    private function walk(mixed $form, string $uri, array &$result): void
-    {
-        if ($form instanceof PersistentListInterface && count($form) > 0) {
-            $head = $form->get(0);
-            if ($head instanceof Symbol) {
-                $name = $head->getName();
-                if (in_array($name, self::LET_LIKE_FORMS, true)) {
-                    $this->inspectLet($form, $uri, $result);
-                } elseif (in_array($name, self::FN_FORMS, true)) {
-                    $this->inspectFn($form, $uri, $result);
-                }
-            }
-
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentVectorInterface) {
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentMapInterface) {
-            foreach ($form as $k => $v) {
-                $this->walk($k, $uri, $result);
-                $this->walk($v, $uri, $result);
-            }
-        }
     }
 
     /**

--- a/src/php/Lint/Application/Rule/NamespaceForm.php
+++ b/src/php/Lint/Application/Rule/NamespaceForm.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
+
+use function count;
+
+/**
+ * Shared helpers for rules that need to introspect the `(ns ...)` form.
+ *
+ * - `find` returns the first `(ns ...)` list in a source's top-level forms.
+ * - `collectSymbolUses` accumulates every symbol name (and namespace) used
+ *   anywhere in the source *outside* the `(ns ...)` form, so callers can
+ *   decide whether a require/import is used at least once.
+ */
+final class NamespaceForm
+{
+    /**
+     * @param list<mixed> $forms
+     */
+    public static function find(array $forms): ?PersistentListInterface
+    {
+        foreach ($forms as $form) {
+            if (!$form instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($form) === 0) {
+                continue;
+            }
+
+            $head = $form->get(0);
+            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_NS) {
+                return $form;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<mixed> $forms
+     *
+     * @return array<string, true>
+     */
+    public static function collectSymbolUses(array $forms, PersistentListInterface $nsForm): array
+    {
+        $seen = [];
+        foreach ($forms as $form) {
+            if ($form === $nsForm) {
+                continue;
+            }
+
+            FormWalker::walk($form, static function (mixed $value) use (&$seen): void {
+                if (!$value instanceof Symbol) {
+                    return;
+                }
+
+                $seen[$value->getName()] = true;
+                $ns = $value->getNamespace();
+                if ($ns !== null && $ns !== '') {
+                    $seen[$ns] = true;
+                }
+            });
+        }
+
+        return $seen;
+    }
+}

--- a/src/php/Lint/Application/Rule/RedundantDoRule.php
+++ b/src/php/Lint/Application/Rule/RedundantDoRule.php
@@ -6,8 +6,6 @@ namespace Phel\Lint\Application\Rule;
 
 use Phel\Api\Transfer\Diagnostic;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
@@ -31,53 +29,30 @@ final readonly class RedundantDoRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
+        /** @var list<Diagnostic> $result */
         $result = [];
         foreach ($analysis->forms as $form) {
-            $this->walk($form, $analysis->uri, $result);
-        }
+            FormWalker::walk($form, function (mixed $node) use ($analysis, &$result): void {
+                if (!$node instanceof PersistentListInterface || count($node) === 0) {
+                    return;
+                }
 
-        return $result;
-    }
+                $head = $node->get(0);
+                if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_DO) {
+                    return;
+                }
 
-    /**
-     * @param list<Diagnostic> $result
-     */
-    private function walk(mixed $form, string $uri, array &$result): void
-    {
-        if ($form instanceof PersistentListInterface && count($form) > 0) {
-            $head = $form->get(0);
-            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_DO) {
-                $bodyCount = count($form) - 1;
-                if ($bodyCount <= 1) {
+                if ((count($node) - 1) <= 1) {
                     $result[] = DiagnosticBuilder::fromForm(
                         $this->code(),
                         'Redundant `do`: fewer than two body forms.',
-                        $uri,
-                        $form,
+                        $analysis->uri,
+                        $node,
                     );
                 }
-            }
-
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
+            });
         }
 
-        if ($form instanceof PersistentVectorInterface) {
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentMapInterface) {
-            foreach ($form as $k => $v) {
-                $this->walk($k, $uri, $result);
-                $this->walk($v, $uri, $result);
-            }
-        }
+        return $result;
     }
 }

--- a/src/php/Lint/Application/Rule/SemanticDiagnosticPromoter.php
+++ b/src/php/Lint/Application/Rule/SemanticDiagnosticPromoter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Phel\Api\Transfer\Diagnostic;
+use Phel\Lint\Domain\FileAnalysis;
+
+/**
+ * Re-tags an analyzer-level diagnostic (`PHEL001`, `PHEL002`, ...) as a
+ * rule-level diagnostic so the standard severity/opt-out plumbing applies.
+ *
+ * Used by rules whose signal already flows through the shared
+ * `FileAnalysis::$semanticDiagnostics` cache: they just pick the codes
+ * they care about and rewrite the `code` field to the rule identifier.
+ */
+final class SemanticDiagnosticPromoter
+{
+    /**
+     * @return list<Diagnostic>
+     */
+    public static function promote(
+        FileAnalysis $analysis,
+        string $semanticCode,
+        string $ruleCode,
+    ): array {
+        $result = [];
+        foreach ($analysis->semanticDiagnostics as $diagnostic) {
+            if ($diagnostic->code !== $semanticCode) {
+                continue;
+            }
+
+            $result[] = new Diagnostic(
+                code: $ruleCode,
+                severity: $diagnostic->severity,
+                message: $diagnostic->message,
+                uri: $diagnostic->uri,
+                startLine: $diagnostic->startLine,
+                startCol: $diagnostic->startCol,
+                endLine: $diagnostic->endLine,
+                endCol: $diagnostic->endCol,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
+++ b/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application\Rule;
 
-use Phel\Api\Transfer\Diagnostic;
 use Phel\Compiler\Domain\Exceptions\ErrorCode;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
@@ -25,24 +24,10 @@ final readonly class UnresolvedSymbolRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
-        $result = [];
-        foreach ($analysis->semanticDiagnostics as $diagnostic) {
-            if ($diagnostic->code !== ErrorCode::UNDEFINED_SYMBOL->value) {
-                continue;
-            }
-
-            $result[] = new Diagnostic(
-                code: $this->code(),
-                severity: $diagnostic->severity,
-                message: $diagnostic->message,
-                uri: $diagnostic->uri,
-                startLine: $diagnostic->startLine,
-                startCol: $diagnostic->startCol,
-                endLine: $diagnostic->endLine,
-                endCol: $diagnostic->endCol,
-            );
-        }
-
-        return $result;
+        return SemanticDiagnosticPromoter::promote(
+            $analysis,
+            ErrorCode::UNDEFINED_SYMBOL->value,
+            $this->code(),
+        );
     }
 }

--- a/src/php/Lint/Application/Rule/UnusedBindingRule.php
+++ b/src/php/Lint/Application/Rule/UnusedBindingRule.php
@@ -6,7 +6,6 @@ namespace Phel\Lint\Application\Rule;
 
 use Phel\Api\Transfer\Diagnostic;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
-use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Symbol;
 use Phel\Lint\Application\Config\RuleRegistry;
@@ -35,46 +34,24 @@ final readonly class UnusedBindingRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
+        /** @var list<Diagnostic> $result */
         $result = [];
         foreach ($analysis->forms as $form) {
-            $this->walk($form, $analysis->uri, $result);
+            FormWalker::walk($form, function (mixed $node) use ($analysis, &$result): void {
+                if (!$node instanceof PersistentListInterface || count($node) === 0) {
+                    return;
+                }
+
+                $head = $node->get(0);
+                if (!$head instanceof Symbol || !in_array($head->getName(), self::BINDING_FORMS, true)) {
+                    return;
+                }
+
+                $this->inspectLet($node, $analysis->uri, $result);
+            });
         }
 
         return $result;
-    }
-
-    /**
-     * @param list<Diagnostic> $result
-     */
-    private function walk(mixed $form, string $uri, array &$result): void
-    {
-        if ($form instanceof PersistentListInterface && count($form) > 0) {
-            $head = $form->get(0);
-            if ($head instanceof Symbol && in_array($head->getName(), self::BINDING_FORMS, true)) {
-                $this->inspectLet($form, $uri, $result);
-            }
-
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentVectorInterface) {
-            foreach ($form as $child) {
-                $this->walk($child, $uri, $result);
-            }
-
-            return;
-        }
-
-        if ($form instanceof PersistentMapInterface) {
-            foreach ($form as $k => $v) {
-                $this->walk($k, $uri, $result);
-                $this->walk($v, $uri, $result);
-            }
-        }
     }
 
     /**

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -28,7 +28,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
-        $nsForm = $this->findNsForm($analysis->forms);
+        $nsForm = NamespaceForm::find($analysis->forms);
         if (!$nsForm instanceof PersistentListInterface) {
             return [];
         }
@@ -38,7 +38,7 @@ final readonly class UnusedImportRule implements LintRuleInterface
             return [];
         }
 
-        $used = $this->collectSymbolUses($analysis->forms, $nsForm);
+        $used = NamespaceForm::collectSymbolUses($analysis->forms, $nsForm);
 
         $result = [];
         foreach ($imports as $entry) {
@@ -53,29 +53,6 @@ final readonly class UnusedImportRule implements LintRuleInterface
         }
 
         return $result;
-    }
-
-    /**
-     * @param list<mixed> $forms
-     */
-    private function findNsForm(array $forms): ?PersistentListInterface
-    {
-        foreach ($forms as $form) {
-            if (!$form instanceof PersistentListInterface) {
-                continue;
-            }
-
-            if (count($form) === 0) {
-                continue;
-            }
-
-            $head = $form->get(0);
-            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_NS) {
-                return $form;
-            }
-        }
-
-        return null;
     }
 
     /**
@@ -146,34 +123,4 @@ final readonly class UnusedImportRule implements LintRuleInterface
         return $parts[count($parts) - 1];
     }
 
-    /**
-     * @param list<mixed> $forms
-     *
-     * @return array<string, true>
-     */
-    private function collectSymbolUses(array $forms, PersistentListInterface $nsForm): array
-    {
-        $seen = [];
-        $visit = static function (mixed $value) use (&$seen): void {
-            if ($value instanceof Symbol) {
-                $seen[$value->getName()] = true;
-                $ns = $value->getNamespace();
-                if ($ns !== null && $ns !== '') {
-                    $seen[$ns] = true;
-                }
-            }
-        };
-
-        foreach ($forms as $form) {
-            if ($form === $nsForm) {
-                continue;
-            }
-
-            FormWalker::walk($form, static function (mixed $value) use ($visit): void {
-                $visit($value);
-            });
-        }
-
-        return $seen;
-    }
 }

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -28,7 +28,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
-        $nsForm = $this->findNsForm($analysis->forms);
+        $nsForm = NamespaceForm::find($analysis->forms);
         if (!$nsForm instanceof PersistentListInterface) {
             return [];
         }
@@ -38,7 +38,7 @@ final readonly class UnusedRequireRule implements LintRuleInterface
             return [];
         }
 
-        $usedSymbols = $this->collectSymbolUses($analysis->forms, $nsForm);
+        $usedSymbols = NamespaceForm::collectSymbolUses($analysis->forms, $nsForm);
 
         $result = [];
         foreach ($requires as $entry) {
@@ -75,29 +75,6 @@ final readonly class UnusedRequireRule implements LintRuleInterface
         }
 
         return $result;
-    }
-
-    /**
-     * @param list<mixed> $forms
-     */
-    private function findNsForm(array $forms): ?PersistentListInterface
-    {
-        foreach ($forms as $form) {
-            if (!$form instanceof PersistentListInterface) {
-                continue;
-            }
-
-            if (count($form) < 1) {
-                continue;
-            }
-
-            $head = $form->get(0);
-            if ($head instanceof Symbol && $head->getName() === Symbol::NAME_NS) {
-                return $form;
-            }
-        }
-
-        return null;
     }
 
     /**
@@ -270,38 +247,6 @@ final readonly class UnusedRequireRule implements LintRuleInterface
         $parts = explode('\\', $name);
 
         return $parts[count($parts) - 1];
-    }
-
-    /**
-     * @param list<mixed> $forms
-     *
-     * @return array<string, true>
-     */
-    private function collectSymbolUses(array $forms, PersistentListInterface $nsForm): array
-    {
-        $seen = [];
-
-        $visit = static function (mixed $value) use (&$seen): void {
-            if ($value instanceof Symbol) {
-                $seen[$value->getName()] = true;
-                $ns = $value->getNamespace();
-                if ($ns !== null && $ns !== '') {
-                    $seen[$ns] = true;
-                }
-            }
-        };
-
-        foreach ($forms as $form) {
-            if ($form === $nsForm) {
-                continue;
-            }
-
-            FormWalker::walk($form, static function (mixed $value) use ($visit): void {
-                $visit($value);
-            });
-        }
-
-        return $seen;
     }
 
     /**

--- a/src/php/Lsp/Application/Convert/SymbolKindMapper.php
+++ b/src/php/Lsp/Application/Convert/SymbolKindMapper.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Convert;
+
+use Phel\Api\Transfer\Definition;
+
+/**
+ * Maps a Phel definition kind (`defn`, `defmacro`, `defstruct`, ...) to the
+ * numeric `SymbolKind` enum from the LSP spec. A single source of truth keeps
+ * `documentSymbol` and `workspace/symbol` responses consistent.
+ *
+ * Reference: LSP `SymbolKind` (1..26). Values used here:
+ *  - 5  Class
+ *  - 6  Method
+ *  - 11 Interface
+ *  - 12 Function
+ *  - 13 Variable
+ *  - 18 Struct
+ */
+final class SymbolKindMapper
+{
+    public const int FUNCTION = 12;
+
+    public const int METHOD = 6;
+
+    public const int CLASS_ = 5;
+
+    public const int VARIABLE = 13;
+
+    public const int INTERFACE = 11;
+
+    public const int STRUCT = 18;
+
+    public function fromDefinitionKind(string $kind): int
+    {
+        return match ($kind) {
+            Definition::KIND_DEFN => self::FUNCTION,
+            Definition::KIND_DEFMACRO => self::METHOD,
+            Definition::KIND_DEFSTRUCT => self::STRUCT,
+            Definition::KIND_DEFPROTOCOL, Definition::KIND_DEFINTERFACE => self::INTERFACE,
+            Definition::KIND_DEFEXCEPTION => self::CLASS_,
+            default => self::VARIABLE,
+        };
+    }
+}

--- a/src/php/Lsp/Application/Handler/CompletionHandler.php
+++ b/src/php/Lsp/Application/Handler/CompletionHandler.php
@@ -8,18 +8,16 @@ use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\CompletionConverter;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
-
-use function is_array;
-use function is_int;
-use function is_string;
 
 final readonly class CompletionHandler implements HandlerInterface
 {
     public function __construct(
         private ApiFacade $apiFacade,
         private CompletionConverter $completions,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -37,8 +35,8 @@ final readonly class CompletionHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $uri = $this->extractUri($params);
-        $position = $this->extractPosition($params);
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
         if ($uri === '' || $position === null) {
             return ['isIncomplete' => false, 'items' => []];
         }
@@ -62,39 +60,5 @@ final readonly class CompletionHandler implements HandlerInterface
             'isIncomplete' => false,
             'items' => $items,
         ];
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return array{line: int, character: int}|null
-     */
-    private function extractPosition(array $params): ?array
-    {
-        $position = $params['position'] ?? null;
-        if (!is_array($position)) {
-            return null;
-        }
-
-        $line = $position['line'] ?? null;
-        $character = $position['character'] ?? null;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        return ['line' => $line, 'character' => $character];
     }
 }

--- a/src/php/Lsp/Application/Handler/DefinitionHandler.php
+++ b/src/php/Lsp/Application/Handler/DefinitionHandler.php
@@ -9,13 +9,10 @@ use Phel\Api\Transfer\Definition;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\LocationConverter;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function explode;
-use function is_array;
-use function is_int;
-use function is_string;
 use function str_contains;
 
 final readonly class DefinitionHandler implements HandlerInterface
@@ -23,6 +20,8 @@ final readonly class DefinitionHandler implements HandlerInterface
     public function __construct(
         private ApiFacade $apiFacade,
         private LocationConverter $locations,
+        private ParamsExtractor $params,
+        private SymbolResolver $symbols,
     ) {}
 
     public function method(): string
@@ -45,8 +44,8 @@ final readonly class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        $uri = $this->extractUri($params);
-        $position = $this->extractPosition($params);
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
         if ($uri === '' || $position === null) {
             return null;
         }
@@ -72,57 +71,13 @@ final readonly class DefinitionHandler implements HandlerInterface
     private function lookup(ProjectIndex $index, string $word): ?Definition
     {
         if (str_contains($word, '/')) {
-            $parts = explode('/', $word, 2);
-            $namespace = $parts[0];
-            $name = $parts[1] ?? '';
+            [$namespace, $name] = $this->symbols->split($word, $index);
             $direct = $this->apiFacade->resolveSymbol($index, $namespace, $name);
             if ($direct instanceof Definition) {
                 return $direct;
             }
-
-            return $index->definitions[$word] ?? null;
         }
 
-        foreach ($index->definitions as $def) {
-            if ($def->name === $word) {
-                return $def;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return array{line: int, character: int}|null
-     */
-    private function extractPosition(array $params): ?array
-    {
-        $position = $params['position'] ?? null;
-        if (!is_array($position)) {
-            return null;
-        }
-
-        $line = $position['line'] ?? null;
-        $character = $position['character'] ?? null;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        return ['line' => $line, 'character' => $character];
+        return $this->symbols->find($word, $index);
     }
 }

--- a/src/php/Lsp/Application/Handler/DidChangeHandler.php
+++ b/src/php/Lsp/Application/Handler/DidChangeHandler.php
@@ -6,17 +6,18 @@ namespace Phel\Lsp\Application\Handler;
 
 use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
 use function is_array;
-use function is_int;
 use function is_string;
 
 final readonly class DidChangeHandler implements HandlerInterface
 {
     public function __construct(
         private DiagnosticPublisher $publisher,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -34,17 +35,12 @@ final readonly class DidChangeHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-
-        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        $uri = $this->params->uri($params);
         if ($uri === '') {
             return null;
         }
 
-        $version = is_int($textDocument['version'] ?? null) ? $textDocument['version'] : 0;
+        $version = $this->params->version($params);
 
         $document = $session->documents()->get($uri);
         if (!$document instanceof Document) {
@@ -64,7 +60,7 @@ final readonly class DidChangeHandler implements HandlerInterface
             $text = is_string($change['text'] ?? null) ? $change['text'] : '';
             $range = $change['range'] ?? null;
 
-            if (is_array($range) && $this->isValidRange($range)) {
+            if (is_array($range) && $this->params->isValidRange($range)) {
                 /** @var array{start: array{line: int, character: int}, end: array{line: int, character: int}} $range */
                 $document->applyRange($range, $text);
             } else {
@@ -79,21 +75,5 @@ final readonly class DidChangeHandler implements HandlerInterface
         }
 
         return null;
-    }
-
-    /**
-     * @param array<string, mixed> $range
-     */
-    private function isValidRange(array $range): bool
-    {
-        $start = $range['start'] ?? null;
-        $end = $range['end'] ?? null;
-
-        return is_array($start)
-            && is_array($end)
-            && is_int($start['line'] ?? null)
-            && is_int($start['character'] ?? null)
-            && is_int($end['line'] ?? null)
-            && is_int($end['character'] ?? null);
     }
 }

--- a/src/php/Lsp/Application/Handler/DidCloseHandler.php
+++ b/src/php/Lsp/Application/Handler/DidCloseHandler.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Lsp\Application\Handler;
 
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function is_array;
-use function is_string;
-
-final class DidCloseHandler implements HandlerInterface
+final readonly class DidCloseHandler implements HandlerInterface
 {
+    public function __construct(
+        private ParamsExtractor $params,
+    ) {}
+
     public function method(): string
     {
         return 'textDocument/didClose';
@@ -27,12 +29,7 @@ final class DidCloseHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-
-        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        $uri = $this->params->uri($params);
         if ($uri !== '') {
             $session->documents()->close($uri);
             $session->sink()->notify('textDocument/publishDiagnostics', [

--- a/src/php/Lsp/Application/Handler/DidOpenHandler.php
+++ b/src/php/Lsp/Application/Handler/DidOpenHandler.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace Phel\Lsp\Application\Handler;
 
 use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
-
-use function is_array;
-use function is_int;
-use function is_string;
 
 final readonly class DidOpenHandler implements HandlerInterface
 {
     public function __construct(
         private DiagnosticPublisher $publisher,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -33,19 +31,14 @@ final readonly class DidOpenHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-
-        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        $uri = $this->params->uri($params);
         if ($uri === '') {
             return null;
         }
 
-        $languageId = is_string($textDocument['languageId'] ?? null) ? $textDocument['languageId'] : 'phel';
-        $version = is_int($textDocument['version'] ?? null) ? $textDocument['version'] : 0;
-        $text = is_string($textDocument['text'] ?? null) ? $textDocument['text'] : '';
+        $languageId = $this->params->languageId($params);
+        $version = $this->params->version($params);
+        $text = $this->params->text($params);
 
         $document = $session->documents()->open($uri, $languageId, $version, $text);
         $this->publisher->publishNow($document, $session->sink());

--- a/src/php/Lsp/Application/Handler/DidSaveHandler.php
+++ b/src/php/Lsp/Application/Handler/DidSaveHandler.php
@@ -8,11 +8,10 @@ use Phel\Api\ApiFacade;
 use Phel\Lsp\Application\Convert\UriConverter;
 use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function is_array;
-use function is_string;
 use function str_ends_with;
 use function strtolower;
 
@@ -22,6 +21,7 @@ final readonly class DidSaveHandler implements HandlerInterface
         private DiagnosticPublisher $publisher,
         private ApiFacade $apiFacade,
         private UriConverter $uris,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -39,12 +39,7 @@ final readonly class DidSaveHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-
-        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        $uri = $this->params->uri($params);
         if ($uri === '') {
             return null;
         }

--- a/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/DocumentSymbolHandler.php
@@ -8,13 +8,13 @@ use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\Definition;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\SymbolKindMapper;
 use Phel\Lsp\Application\Convert\UriConverter;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function is_array;
-use function is_string;
 use function strlen;
 
 /**
@@ -28,6 +28,8 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
         private ApiFacade $apiFacade,
         private PositionConverter $positions,
         private UriConverter $uris,
+        private SymbolKindMapper $symbolKind,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -45,7 +47,7 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $uri = $this->extractUri($params);
+        $uri = $this->params->uri($params);
         if ($uri === '') {
             return [];
         }
@@ -110,37 +112,11 @@ final readonly class DocumentSymbolHandler implements HandlerInterface
 
         return [
             'name' => $def->name,
-            'kind' => $this->lspSymbolKind($def->kind),
+            'kind' => $this->symbolKind->fromDefinitionKind($def->kind),
             'location' => [
                 'uri' => $this->uris->isFileUri($def->uri) ? $def->uri : $this->uris->fromFilePath($def->uri),
                 'range' => $this->positions->toLspRange($def->line, $def->col, $def->line, $endCol),
             ],
         ];
-    }
-
-    private function lspSymbolKind(string $kind): int
-    {
-        // LSP SymbolKind: 12=Function, 6=Method, 5=Class, 13=Variable, 11=Interface, 18=Struct
-        return match ($kind) {
-            Definition::KIND_DEFN => 12,
-            Definition::KIND_DEFMACRO => 6,
-            Definition::KIND_DEFSTRUCT => 18,
-            Definition::KIND_DEFPROTOCOL, Definition::KIND_DEFINTERFACE => 11,
-            Definition::KIND_DEFEXCEPTION => 5,
-            default => 13,
-        };
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
     }
 }

--- a/src/php/Lsp/Application/Handler/FormattingHandler.php
+++ b/src/php/Lsp/Application/Handler/FormattingHandler.php
@@ -6,14 +6,13 @@ namespace Phel\Lsp\Application\Handler;
 
 use Phel\Formatter\FormatterFacade;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 use Throwable;
 
 use function count;
 use function explode;
-use function is_array;
-use function is_string;
 use function str_replace;
 use function strlen;
 
@@ -21,6 +20,7 @@ final readonly class FormattingHandler implements HandlerInterface
 {
     public function __construct(
         private FormatterFacade $formatter,
+        private ParamsExtractor $params,
     ) {}
 
     public function method(): string
@@ -38,12 +38,7 @@ final readonly class FormattingHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return [];
-        }
-
-        $uri = is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+        $uri = $this->params->uri($params);
         if ($uri === '') {
             return [];
         }

--- a/src/php/Lsp/Application/Handler/HoverHandler.php
+++ b/src/php/Lsp/Application/Handler/HoverHandler.php
@@ -9,15 +9,12 @@ use Phel\Api\Transfer\Definition;
 use Phel\Api\Transfer\PhelFunction;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
 use function implode;
-use function is_array;
-use function is_int;
-use function is_string;
 use function sprintf;
-use function str_contains;
 
 /**
  * Resolves a symbol under the cursor and returns its signature + docstring
@@ -27,6 +24,8 @@ final readonly class HoverHandler implements HandlerInterface
 {
     public function __construct(
         private ApiFacade $apiFacade,
+        private ParamsExtractor $params,
+        private SymbolResolver $symbols,
     ) {}
 
     public function method(): string
@@ -44,8 +43,8 @@ final readonly class HoverHandler implements HandlerInterface
      */
     public function handle(array $params, Session $session): mixed
     {
-        $uri = $this->extractUri($params);
-        $position = $this->extractPosition($params);
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
         if ($uri === '' || $position === null) {
             return null;
         }
@@ -75,33 +74,16 @@ final readonly class HoverHandler implements HandlerInterface
 
     private function markdownFor(string $word, ?ProjectIndex $index): ?string
     {
-        $projectDefinition = $this->findProjectDefinition($word, $index);
-        if ($projectDefinition instanceof Definition) {
-            return $this->renderDefinition($projectDefinition);
+        if ($index instanceof ProjectIndex) {
+            $projectDefinition = $this->symbols->find($word, $index);
+            if ($projectDefinition instanceof Definition) {
+                return $this->renderDefinition($projectDefinition);
+            }
         }
 
         foreach ($this->apiFacade->getPhelFunctions(['phel\\core']) as $fn) {
             if ($fn->name === $word || $fn->nameWithNamespace() === $word) {
                 return $this->renderPhelFunction($fn);
-            }
-        }
-
-        return null;
-    }
-
-    private function findProjectDefinition(string $word, ?ProjectIndex $index): ?Definition
-    {
-        if (!$index instanceof ProjectIndex) {
-            return null;
-        }
-
-        if (str_contains($word, '/')) {
-            return $index->definitions[$word] ?? null;
-        }
-
-        foreach ($index->definitions as $def) {
-            if ($def->name === $word) {
-                return $def;
             }
         }
 
@@ -153,39 +135,5 @@ final readonly class HoverHandler implements HandlerInterface
         }
 
         return implode("\n", $lines);
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return array{line: int, character: int}|null
-     */
-    private function extractPosition(array $params): ?array
-    {
-        $position = $params['position'] ?? null;
-        if (!is_array($position)) {
-            return null;
-        }
-
-        $line = $position['line'] ?? null;
-        $character = $position['character'] ?? null;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        return ['line' => $line, 'character' => $character];
     }
 }

--- a/src/php/Lsp/Application/Handler/ReferencesHandler.php
+++ b/src/php/Lsp/Application/Handler/ReferencesHandler.php
@@ -8,20 +8,17 @@ use Phel\Api\ApiFacade;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\LocationConverter;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
-
-use function explode;
-use function is_array;
-use function is_int;
-use function is_string;
-use function str_contains;
 
 final readonly class ReferencesHandler implements HandlerInterface
 {
     public function __construct(
         private ApiFacade $apiFacade,
         private LocationConverter $locations,
+        private ParamsExtractor $params,
+        private SymbolResolver $symbols,
     ) {}
 
     public function method(): string
@@ -44,8 +41,8 @@ final readonly class ReferencesHandler implements HandlerInterface
             return [];
         }
 
-        $uri = $this->extractUri($params);
-        $position = $this->extractPosition($params);
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
         if ($uri === '' || $position === null) {
             return [];
         }
@@ -60,7 +57,7 @@ final readonly class ReferencesHandler implements HandlerInterface
             return [];
         }
 
-        [$namespace, $name] = $this->splitSymbol($word, $index);
+        [$namespace, $name] = $this->symbols->split($word, $index);
         $references = $this->apiFacade->findReferences($index, $namespace, $name);
 
         $result = [];
@@ -69,59 +66,5 @@ final readonly class ReferencesHandler implements HandlerInterface
         }
 
         return $result;
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private function splitSymbol(string $word, ProjectIndex $index): array
-    {
-        if (str_contains($word, '/')) {
-            $parts = explode('/', $word, 2);
-            return [$parts[0], $parts[1] ?? ''];
-        }
-
-        foreach ($index->definitions as $def) {
-            if ($def->name === $word) {
-                return [$def->namespace, $def->name];
-            }
-        }
-
-        // Fallback: treat the bare name as living in the unknown namespace.
-        return ['', $word];
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return array{line: int, character: int}|null
-     */
-    private function extractPosition(array $params): ?array
-    {
-        $position = $params['position'] ?? null;
-        if (!is_array($position)) {
-            return null;
-        }
-
-        $line = $position['line'] ?? null;
-        $character = $position['character'] ?? null;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        return ['line' => $line, 'character' => $character];
     }
 }

--- a/src/php/Lsp/Application/Handler/RenameHandler.php
+++ b/src/php/Lsp/Application/Handler/RenameHandler.php
@@ -11,14 +11,11 @@ use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\PositionConverter;
 use Phel\Lsp\Application\Convert\UriConverter;
 use Phel\Lsp\Application\Document\Document;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
 
-use function explode;
-use function is_array;
-use function is_int;
 use function is_string;
-use function str_contains;
 use function strlen;
 
 /**
@@ -31,6 +28,8 @@ final readonly class RenameHandler implements HandlerInterface
         private ApiFacade $apiFacade,
         private PositionConverter $positions,
         private UriConverter $uris,
+        private ParamsExtractor $params,
+        private SymbolResolver $symbols,
     ) {}
 
     public function method(): string
@@ -58,8 +57,8 @@ final readonly class RenameHandler implements HandlerInterface
             return null;
         }
 
-        $uri = $this->extractUri($params);
-        $position = $this->extractPosition($params);
+        $uri = $this->params->uri($params);
+        $position = $this->params->position($params);
         if ($uri === '' || $position === null) {
             return null;
         }
@@ -74,7 +73,7 @@ final readonly class RenameHandler implements HandlerInterface
             return null;
         }
 
-        [$namespace, $name] = $this->splitSymbol($word, $index);
+        [$namespace, $name] = $this->symbols->split($word, $index);
         $references = $this->apiFacade->findReferences($index, $namespace, $name);
         $definition = $this->apiFacade->resolveSymbol($index, $namespace, $name);
 
@@ -123,58 +122,5 @@ final readonly class RenameHandler implements HandlerInterface
         }
 
         return ['changes' => $changes];
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private function splitSymbol(string $word, ProjectIndex $index): array
-    {
-        if (str_contains($word, '/')) {
-            $parts = explode('/', $word, 2);
-            return [$parts[0], $parts[1] ?? ''];
-        }
-
-        foreach ($index->definitions as $def) {
-            if ($def->name === $word) {
-                return [$def->namespace, $def->name];
-            }
-        }
-
-        return ['', $word];
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    private function extractUri(array $params): string
-    {
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return '';
-        }
-
-        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     *
-     * @return array{line: int, character: int}|null
-     */
-    private function extractPosition(array $params): ?array
-    {
-        $position = $params['position'] ?? null;
-        if (!is_array($position)) {
-            return null;
-        }
-
-        $line = $position['line'] ?? null;
-        $character = $position['character'] ?? null;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        return ['line' => $line, 'character' => $character];
     }
 }

--- a/src/php/Lsp/Application/Handler/SymbolResolver.php
+++ b/src/php/Lsp/Application/Handler/SymbolResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Handler;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+
+use function explode;
+use function str_contains;
+
+/**
+ * Shared lookup logic for resolving a word under the cursor against the
+ * project index. A word can be either `ns/name` (fully qualified) or a bare
+ * `name` — the resolver normalises both shapes.
+ *
+ * Extracted from the four language-feature handlers (`Definition`,
+ * `References`, `Rename`, `Hover`) that used to re-implement this by hand.
+ */
+final class SymbolResolver
+{
+    /**
+     * Split a cursor word into `[namespace, name]`. For bare names we fall
+     * back to scanning the index so the caller can still issue a reference
+     * query against the right namespace.
+     *
+     * @return array{0: string, 1: string}
+     */
+    public function split(string $word, ProjectIndex $index): array
+    {
+        if (str_contains($word, '/')) {
+            $parts = explode('/', $word, 2);
+            return [$parts[0], $parts[1] ?? ''];
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return [$def->namespace, $def->name];
+            }
+        }
+
+        return ['', $word];
+    }
+
+    /**
+     * Resolve a word to a definition, preferring fully qualified
+     * `ns/name` lookup but falling through to bare-name scans.
+     */
+    public function find(string $word, ProjectIndex $index): ?Definition
+    {
+        if (str_contains($word, '/')) {
+            return $index->definitions[$word] ?? null;
+        }
+
+        foreach ($index->definitions as $def) {
+            if ($def->name === $word) {
+                return $def;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/php/Lsp/Application/Handler/WorkspaceSymbolHandler.php
+++ b/src/php/Lsp/Application/Handler/WorkspaceSymbolHandler.php
@@ -7,6 +7,7 @@ namespace Phel\Lsp\Application\Handler;
 use Phel\Api\Transfer\Definition;
 use Phel\Api\Transfer\ProjectIndex;
 use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\SymbolKindMapper;
 use Phel\Lsp\Application\Convert\UriConverter;
 use Phel\Lsp\Application\Session\Session;
 use Phel\Lsp\Domain\HandlerInterface;
@@ -21,6 +22,7 @@ final readonly class WorkspaceSymbolHandler implements HandlerInterface
     public function __construct(
         private PositionConverter $positions,
         private UriConverter $uris,
+        private SymbolKindMapper $symbolKind,
     ) {}
 
     public function method(): string
@@ -74,24 +76,12 @@ final readonly class WorkspaceSymbolHandler implements HandlerInterface
 
         return [
             'name' => $def->name,
-            'kind' => $this->lspSymbolKind($def->kind),
+            'kind' => $this->symbolKind->fromDefinitionKind($def->kind),
             'containerName' => $def->namespace,
             'location' => [
                 'uri' => $this->uris->isFileUri($def->uri) ? $def->uri : $this->uris->fromFilePath($def->uri),
                 'range' => $this->positions->toLspRange($def->line, $def->col, $def->line, $endCol),
             ],
         ];
-    }
-
-    private function lspSymbolKind(string $kind): int
-    {
-        return match ($kind) {
-            Definition::KIND_DEFN => 12,
-            Definition::KIND_DEFMACRO => 6,
-            Definition::KIND_DEFSTRUCT => 18,
-            Definition::KIND_DEFPROTOCOL, Definition::KIND_DEFINTERFACE => 11,
-            Definition::KIND_DEFEXCEPTION => 5,
-            default => 13,
-        };
     }
 }

--- a/src/php/Lsp/Application/Rpc/ParamsExtractor.php
+++ b/src/php/Lsp/Application/Rpc/ParamsExtractor.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lsp\Application\Rpc;
+
+use function is_array;
+use function is_int;
+use function is_string;
+
+/**
+ * Reads the shape-checked fragments of an LSP request's `params` so handlers
+ * don't duplicate the same `is_array`/`is_string`/`is_int` dance.
+ *
+ * Each method returns a safe default (empty string, `null`, `false`) when
+ * the field is missing or has the wrong type. Handlers then translate that
+ * default into the LSP response that best fits their method (empty array,
+ * `null`, etc.).
+ */
+final class ParamsExtractor
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function uri(array $params): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return '';
+        }
+
+        return is_string($textDocument['uri'] ?? null) ? $textDocument['uri'] : '';
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array{line: int, character: int}|null
+     */
+    public function position(array $params): ?array
+    {
+        $position = $params['position'] ?? null;
+        if (!is_array($position)) {
+            return null;
+        }
+
+        $line = $position['line'] ?? null;
+        $character = $position['character'] ?? null;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return ['line' => $line, 'character' => $character];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function version(array $params, int $default = 0): int
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return $default;
+        }
+
+        return is_int($textDocument['version'] ?? null) ? $textDocument['version'] : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function languageId(array $params, string $default = 'phel'): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return $default;
+        }
+
+        return is_string($textDocument['languageId'] ?? null) ? $textDocument['languageId'] : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function text(array $params, string $default = ''): string
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return $default;
+        }
+
+        return is_string($textDocument['text'] ?? null) ? $textDocument['text'] : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $range
+     */
+    public function isValidRange(array $range): bool
+    {
+        $start = $range['start'] ?? null;
+        $end = $range['end'] ?? null;
+
+        return is_array($start)
+            && is_array($end)
+            && is_int($start['line'] ?? null)
+            && is_int($start['character'] ?? null)
+            && is_int($end['line'] ?? null)
+            && is_int($end['character'] ?? null);
+    }
+}

--- a/src/php/Lsp/LspFactory.php
+++ b/src/php/Lsp/LspFactory.php
@@ -14,6 +14,7 @@ use Phel\Lsp\Application\Convert\CompletionConverter;
 use Phel\Lsp\Application\Convert\DiagnosticConverter;
 use Phel\Lsp\Application\Convert\LocationConverter;
 use Phel\Lsp\Application\Convert\PositionConverter;
+use Phel\Lsp\Application\Convert\SymbolKindMapper;
 use Phel\Lsp\Application\Convert\UriConverter;
 use Phel\Lsp\Application\Diagnostics\DiagnosticPublisher;
 use Phel\Lsp\Application\Document\DocumentStore;
@@ -32,10 +33,12 @@ use Phel\Lsp\Application\Handler\InitializeHandler;
 use Phel\Lsp\Application\Handler\ReferencesHandler;
 use Phel\Lsp\Application\Handler\RenameHandler;
 use Phel\Lsp\Application\Handler\ShutdownHandler;
+use Phel\Lsp\Application\Handler\SymbolResolver;
 use Phel\Lsp\Application\Handler\WorkspaceSymbolHandler;
 use Phel\Lsp\Application\Rpc\LspServer;
 use Phel\Lsp\Application\Rpc\MessageReader;
 use Phel\Lsp\Application\Rpc\MessageWriter;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
 use Phel\Lsp\Application\Rpc\RequestDispatcher;
 use Phel\Lsp\Application\Rpc\ResponseBuilder;
 use Phel\Lsp\Application\Rpc\StreamNotificationSink;
@@ -77,25 +80,28 @@ final class LspFactory extends AbstractFactory
         $uris = $this->createUriConverter();
         $locations = $this->createLocationConverter();
         $completions = $this->createCompletionConverter();
+        $symbolKind = $this->createSymbolKindMapper();
+        $params = $this->createParamsExtractor();
+        $symbols = $this->createSymbolResolver();
 
         $dispatcher->register(new InitializeHandler($this->getApiFacade(), $uris));
         $dispatcher->register(new InitializedHandler());
         $dispatcher->register(new ShutdownHandler());
         $dispatcher->register(new ExitHandler());
 
-        $dispatcher->register(new DidOpenHandler($publisher));
-        $dispatcher->register(new DidChangeHandler($publisher));
-        $dispatcher->register(new DidCloseHandler());
-        $dispatcher->register(new DidSaveHandler($publisher, $this->getApiFacade(), $uris));
+        $dispatcher->register(new DidOpenHandler($publisher, $params));
+        $dispatcher->register(new DidChangeHandler($publisher, $params));
+        $dispatcher->register(new DidCloseHandler($params));
+        $dispatcher->register(new DidSaveHandler($publisher, $this->getApiFacade(), $uris, $params));
 
-        $dispatcher->register(new HoverHandler($this->getApiFacade()));
-        $dispatcher->register(new DefinitionHandler($this->getApiFacade(), $locations));
-        $dispatcher->register(new ReferencesHandler($this->getApiFacade(), $locations));
-        $dispatcher->register(new CompletionHandler($this->getApiFacade(), $completions));
-        $dispatcher->register(new DocumentSymbolHandler($this->getApiFacade(), $positions, $uris));
-        $dispatcher->register(new WorkspaceSymbolHandler($positions, $uris));
-        $dispatcher->register(new RenameHandler($this->getApiFacade(), $positions, $uris));
-        $dispatcher->register(new FormattingHandler($this->getFormatterFacade()));
+        $dispatcher->register(new HoverHandler($this->getApiFacade(), $params, $symbols));
+        $dispatcher->register(new DefinitionHandler($this->getApiFacade(), $locations, $params, $symbols));
+        $dispatcher->register(new ReferencesHandler($this->getApiFacade(), $locations, $params, $symbols));
+        $dispatcher->register(new CompletionHandler($this->getApiFacade(), $completions, $params));
+        $dispatcher->register(new DocumentSymbolHandler($this->getApiFacade(), $positions, $uris, $symbolKind, $params));
+        $dispatcher->register(new WorkspaceSymbolHandler($positions, $uris, $symbolKind));
+        $dispatcher->register(new RenameHandler($this->getApiFacade(), $positions, $uris, $params, $symbols));
+        $dispatcher->register(new FormattingHandler($this->getFormatterFacade(), $params));
 
         return $dispatcher;
     }
@@ -149,6 +155,21 @@ final class LspFactory extends AbstractFactory
     public function createCompletionConverter(): CompletionConverter
     {
         return new CompletionConverter();
+    }
+
+    public function createSymbolKindMapper(): SymbolKindMapper
+    {
+        return new SymbolKindMapper();
+    }
+
+    public function createParamsExtractor(): ParamsExtractor
+    {
+        return new ParamsExtractor();
+    }
+
+    public function createSymbolResolver(): SymbolResolver
+    {
+        return new SymbolResolver();
     }
 
     public function createDiagnosticPublisher(): DiagnosticPublisher

--- a/src/php/Nrepl/Application/Op/CloneOp.php
+++ b/src/php/Nrepl/Application/Op/CloneOp.php
@@ -7,6 +7,7 @@ namespace Phel\Nrepl\Application\Op;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 
 final readonly class CloneOp implements OpHandlerInterface
@@ -26,7 +27,7 @@ final readonly class CloneOp implements OpHandlerInterface
             $request->id,
             $request->session,
             ['new-session' => $session->id],
-            ['done'],
+            [OpStatus::DONE],
         )];
     }
 }

--- a/src/php/Nrepl/Application/Op/CloseOp.php
+++ b/src/php/Nrepl/Application/Op/CloseOp.php
@@ -7,6 +7,7 @@ namespace Phel\Nrepl\Application\Op;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 
 final readonly class CloseOp implements OpHandlerInterface
@@ -23,7 +24,9 @@ final readonly class CloseOp implements OpHandlerInterface
         $target = $request->session ?? '';
         $closed = $target !== '' && $this->sessions->close($target);
 
-        $status = $closed ? ['done', 'session-closed'] : ['done', 'error', 'unknown-session'];
+        $status = $closed
+            ? [OpStatus::DONE, OpStatus::SESSION_CLOSED]
+            : [OpStatus::DONE, OpStatus::ERROR, OpStatus::UNKNOWN_SESSION];
 
         return [OpResponse::build(
             $request->id,

--- a/src/php/Nrepl/Application/Op/CompletionsOp.php
+++ b/src/php/Nrepl/Application/Op/CompletionsOp.php
@@ -7,6 +7,7 @@ namespace Phel\Nrepl\Application\Op;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Shared\Facade\ApiFacadeInterface;
 
 final readonly class CompletionsOp implements OpHandlerInterface
@@ -35,7 +36,7 @@ final readonly class CompletionsOp implements OpHandlerInterface
             $request->id,
             $request->session,
             ['completions' => $completions],
-            ['done'],
+            [OpStatus::DONE],
         )];
     }
 }

--- a/src/php/Nrepl/Application/Op/DescribeOp.php
+++ b/src/php/Nrepl/Application/Op/DescribeOp.php
@@ -8,10 +8,13 @@ use Phel\Nrepl\Domain\Op\OpDispatcher;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Shared\Facade\RunFacadeInterface;
 
 final readonly class DescribeOp implements OpHandlerInterface
 {
+    public const string NREPL_VERSION = '0.1.0';
+
     public function __construct(
         private OpDispatcher $dispatcher,
         private RunFacadeInterface $runFacade,
@@ -29,20 +32,23 @@ final readonly class DescribeOp implements OpHandlerInterface
             $ops[$op] = [];
         }
 
-        $version = $this->runFacade->getVersion();
-
         return [OpResponse::build(
             $request->id,
             $request->session,
             [
                 'ops' => $ops,
                 'versions' => [
-                    'phel' => ['version-string' => $version],
-                    'nrepl' => ['version-string' => '0.1.0', 'major' => 0, 'minor' => 1, 'incremental' => 0],
+                    'phel' => ['version-string' => $this->runFacade->getVersion()],
+                    'nrepl' => [
+                        'version-string' => self::NREPL_VERSION,
+                        'major' => 0,
+                        'minor' => 1,
+                        'incremental' => 0,
+                    ],
                 ],
                 'aux' => [],
             ],
-            ['done'],
+            [OpStatus::DONE],
         )];
     }
 }

--- a/src/php/Nrepl/Application/Op/EvalOp.php
+++ b/src/php/Nrepl/Application/Op/EvalOp.php
@@ -8,19 +8,14 @@ use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
-use Phel\Nrepl\Domain\Session\SessionRegistry;
-use Phel\Printer\PrinterInterface;
-use Phel\Run\Domain\Repl\EvalError;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Shared\Facade\RunFacadeInterface;
-
-use function sprintf;
 
 final readonly class EvalOp implements OpHandlerInterface
 {
     public function __construct(
         private RunFacadeInterface $runFacade,
-        private PrinterInterface $printer,
-        private SessionRegistry $sessions,
+        private EvalResultResponder $responder,
     ) {}
 
     public function name(): string
@@ -36,77 +31,12 @@ final readonly class EvalOp implements OpHandlerInterface
                 $request->id,
                 $request->session,
                 ['message' => 'Missing required "code" param for eval op.'],
-                ['error', 'eval-error', 'done'],
+                [OpStatus::ERROR, OpStatus::EVAL_ERROR, OpStatus::DONE],
             )];
         }
 
         $result = $this->runFacade->structuredEval($code, new CompileOptions());
-        $responses = [];
 
-        if ($result->output !== '') {
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                ['out' => $result->output],
-            );
-        }
-
-        if ($result->success) {
-            $sessionObject = $request->session !== null ? $this->sessions->get($request->session) : null;
-            $sessionObject?->recordValue($result->value);
-
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                [
-                    'ns' => $sessionObject?->namespace() ?? 'user',
-                    'value' => $this->printer->print($result->value),
-                ],
-            );
-
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                [],
-                ['done'],
-            );
-
-            return $responses;
-        }
-
-        if ($result->incomplete) {
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Incomplete form: unfinished parser input.'],
-                ['error', 'incomplete', 'done'],
-            );
-
-            return $responses;
-        }
-
-        $error = $result->error;
-        $message = $error instanceof EvalError ? $error->message : 'Evaluation failed.';
-        $exClass = $error instanceof EvalError ? $error->exceptionClass : 'Error';
-
-        $responses[] = OpResponse::build(
-            $request->id,
-            $request->session,
-            [
-                'ex' => $exClass,
-                'root-ex' => $exClass,
-                'err' => sprintf('%s: %s', $exClass, $message),
-            ],
-            ['eval-error'],
-        );
-
-        $responses[] = OpResponse::build(
-            $request->id,
-            $request->session,
-            [],
-            ['done'],
-        );
-
-        return $responses;
+        return $this->responder->respond($request, $result, 'Evaluation failed.');
     }
 }

--- a/src/php/Nrepl/Application/Op/EvalResultResponder.php
+++ b/src/php/Nrepl/Application/Op/EvalResultResponder.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Application\Op;
+
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
+use Phel\Nrepl\Domain\Session\Session;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
+use Phel\Run\Domain\Repl\EvalResult;
+
+use function sprintf;
+
+/**
+ * Translates an `EvalResult` into a list of nREPL response frames.
+ * Shared between `EvalOp` and `LoadFileOp`, which only differ in:
+ *   - the source of the code being evaluated;
+ *   - the wording of the final error message.
+ */
+final readonly class EvalResultResponder
+{
+    public function __construct(
+        private PrinterInterface $printer,
+        private SessionRegistry $sessions,
+    ) {}
+
+    /**
+     * @return list<OpResponse>
+     */
+    public function respond(
+        OpRequest $request,
+        EvalResult $result,
+        string $errorFallbackMessage,
+        ?string $fileName = null,
+    ): array {
+        $responses = [];
+
+        if ($result->output !== '') {
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                ['out' => $result->output],
+            );
+        }
+
+        if ($result->success) {
+            $session = $this->sessionFor($request);
+            $session?->recordValue($result->value);
+
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                [
+                    'ns' => $session instanceof Session ? $session->namespace() : 'user',
+                    'value' => $this->printer->print($result->value),
+                ],
+            );
+
+            $responses[] = $this->doneFrame($request);
+
+            return $responses;
+        }
+
+        if ($result->incomplete) {
+            $responses[] = OpResponse::build(
+                $request->id,
+                $request->session,
+                ['message' => 'Incomplete form: unfinished parser input.'],
+                [OpStatus::ERROR, OpStatus::INCOMPLETE, OpStatus::DONE],
+            );
+
+            return $responses;
+        }
+
+        $responses[] = $this->errorFrame($request, $result->error, $errorFallbackMessage, $fileName);
+        $responses[] = $this->doneFrame($request);
+
+        return $responses;
+    }
+
+    private function sessionFor(OpRequest $request): ?Session
+    {
+        return $request->session !== null
+            ? $this->sessions->get($request->session)
+            : null;
+    }
+
+    private function errorFrame(
+        OpRequest $request,
+        ?EvalError $error,
+        string $fallbackMessage,
+        ?string $fileName,
+    ): OpResponse {
+        $message = $error instanceof EvalError ? $error->message : $fallbackMessage;
+        $exClass = $error instanceof EvalError ? $error->exceptionClass : 'Error';
+
+        $body = [
+            'ex' => $exClass,
+            'err' => $fileName === null
+                ? sprintf('%s: %s', $exClass, $message)
+                : sprintf('%s (%s): %s', $exClass, $fileName, $message),
+        ];
+
+        if ($fileName === null) {
+            // Preserve the existing `root-ex` field that EvalOp emitted.
+            $body['root-ex'] = $exClass;
+        }
+
+        return OpResponse::build(
+            $request->id,
+            $request->session,
+            $body,
+            [OpStatus::EVAL_ERROR],
+        );
+    }
+
+    private function doneFrame(OpRequest $request): OpResponse
+    {
+        return OpResponse::build(
+            $request->id,
+            $request->session,
+            [],
+            [OpStatus::DONE],
+        );
+    }
+}

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -7,6 +7,7 @@ namespace Phel\Nrepl\Application\Op;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 
 final class InterruptOp implements OpHandlerInterface
 {
@@ -23,7 +24,7 @@ final class InterruptOp implements OpHandlerInterface
             $request->id,
             $request->session,
             [],
-            ['done', 'session-idle'],
+            [OpStatus::DONE, OpStatus::SESSION_IDLE],
         )];
     }
 }

--- a/src/php/Nrepl/Application/Op/LoadFileOp.php
+++ b/src/php/Nrepl/Application/Op/LoadFileOp.php
@@ -8,19 +8,14 @@ use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
-use Phel\Nrepl\Domain\Session\SessionRegistry;
-use Phel\Printer\PrinterInterface;
-use Phel\Run\Domain\Repl\EvalError;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Shared\Facade\RunFacadeInterface;
-
-use function sprintf;
 
 final readonly class LoadFileOp implements OpHandlerInterface
 {
     public function __construct(
         private RunFacadeInterface $runFacade,
-        private PrinterInterface $printer,
-        private SessionRegistry $sessions,
+        private EvalResultResponder $responder,
     ) {}
 
     public function name(): string
@@ -38,67 +33,12 @@ final readonly class LoadFileOp implements OpHandlerInterface
                 $request->id,
                 $request->session,
                 ['message' => 'Missing required "file" param for load-file op.'],
-                ['error', 'load-file-error', 'done'],
+                [OpStatus::ERROR, OpStatus::LOAD_FILE_ERROR, OpStatus::DONE],
             )];
         }
 
-        $options = new CompileOptions();
-        $result = $this->runFacade->structuredEval($fileContent, $options);
+        $result = $this->runFacade->structuredEval($fileContent, new CompileOptions());
 
-        $responses = [];
-
-        if ($result->output !== '') {
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                ['out' => $result->output],
-            );
-        }
-
-        if ($result->success) {
-            $sessionObject = $request->session !== null ? $this->sessions->get($request->session) : null;
-            $sessionObject?->recordValue($result->value);
-
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                [
-                    'ns' => $sessionObject?->namespace() ?? 'user',
-                    'value' => $this->printer->print($result->value),
-                ],
-            );
-
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                [],
-                ['done'],
-            );
-
-            return $responses;
-        }
-
-        $error = $result->error;
-        $message = $error instanceof EvalError ? $error->message : 'load-file failed.';
-        $exClass = $error instanceof EvalError ? $error->exceptionClass : 'Error';
-
-        $responses[] = OpResponse::build(
-            $request->id,
-            $request->session,
-            [
-                'ex' => $exClass,
-                'err' => sprintf('%s (%s): %s', $exClass, $fileName, $message),
-            ],
-            ['eval-error'],
-        );
-
-        $responses[] = OpResponse::build(
-            $request->id,
-            $request->session,
-            [],
-            ['done'],
-        );
-
-        return $responses;
+        return $this->responder->respond($request, $result, 'load-file failed.', $fileName);
     }
 }

--- a/src/php/Nrepl/Application/Op/LookupOp.php
+++ b/src/php/Nrepl/Application/Op/LookupOp.php
@@ -8,6 +8,7 @@ use Phel\Api\Transfer\PhelFunction;
 use Phel\Nrepl\Domain\Op\OpHandlerInterface;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
 use Phel\Shared\Facade\ApiFacadeInterface;
 
 use function implode;
@@ -43,7 +44,7 @@ final class LookupOp implements OpHandlerInterface
                 $request->id,
                 $request->session,
                 ['message' => 'Missing required "sym" param for ' . $this->opName . ' op.'],
-                ['error', 'no-info', 'done'],
+                [OpStatus::ERROR, OpStatus::NO_INFO, OpStatus::DONE],
             )];
         }
 
@@ -53,7 +54,7 @@ final class LookupOp implements OpHandlerInterface
                 $request->id,
                 $request->session,
                 [],
-                ['done', 'no-info'],
+                [OpStatus::DONE, OpStatus::NO_INFO],
             )];
         }
 
@@ -70,7 +71,7 @@ final class LookupOp implements OpHandlerInterface
             $request->id,
             $request->session,
             ['info' => $info, 'eldoc' => $fn->signatures],
-            ['done'],
+            [OpStatus::DONE],
         )];
     }
 

--- a/src/php/Nrepl/Domain/Op/OpDispatcher.php
+++ b/src/php/Nrepl/Domain/Op/OpDispatcher.php
@@ -48,7 +48,7 @@ final class OpDispatcher
     {
         if (!is_array($message)) {
             return [new OpResponse([
-                'status' => ['error', 'invalid-message', 'done'],
+                'status' => [OpStatus::ERROR, OpStatus::INVALID_MESSAGE, OpStatus::DONE],
                 'message' => 'Top-level nREPL message must be a dictionary.',
             ])];
         }
@@ -61,7 +61,7 @@ final class OpDispatcher
                 $request->id,
                 $request->session,
                 ['message' => 'Missing "op" key in request.'],
-                ['error', 'invalid-op', 'done'],
+                [OpStatus::ERROR, OpStatus::INVALID_OP, OpStatus::DONE],
             )];
         }
 
@@ -71,7 +71,7 @@ final class OpDispatcher
                 $request->id,
                 $request->session,
                 ['message' => 'Unknown op: ' . $request->op],
-                ['error', 'unknown-op', 'done'],
+                [OpStatus::ERROR, OpStatus::UNKNOWN_OP, OpStatus::DONE],
             )];
         }
 

--- a/src/php/Nrepl/Domain/Op/OpStatus.php
+++ b/src/php/Nrepl/Domain/Op/OpStatus.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Domain\Op;
+
+/**
+ * nREPL status tokens used in the `status` field of responses.
+ *
+ * Centralising these tokens prevents typos and drift between handlers
+ * — every op can reuse the same constants for the final response frames.
+ */
+final class OpStatus
+{
+    public const string DONE = 'done';
+
+    public const string ERROR = 'error';
+
+    public const string UNKNOWN_OP = 'unknown-op';
+
+    public const string INVALID_OP = 'invalid-op';
+
+    public const string INVALID_MESSAGE = 'invalid-message';
+
+    public const string EVAL_ERROR = 'eval-error';
+
+    public const string LOAD_FILE_ERROR = 'load-file-error';
+
+    public const string INCOMPLETE = 'incomplete';
+
+    public const string NO_INFO = 'no-info';
+
+    public const string SESSION_CLOSED = 'session-closed';
+
+    public const string UNKNOWN_SESSION = 'unknown-session';
+
+    public const string SESSION_IDLE = 'session-idle';
+}

--- a/src/php/Nrepl/NreplFactory.php
+++ b/src/php/Nrepl/NreplFactory.php
@@ -11,6 +11,7 @@ use Phel\Nrepl\Application\Op\CloseOp;
 use Phel\Nrepl\Application\Op\CompletionsOp;
 use Phel\Nrepl\Application\Op\DescribeOp;
 use Phel\Nrepl\Application\Op\EvalOp;
+use Phel\Nrepl\Application\Op\EvalResultResponder;
 use Phel\Nrepl\Application\Op\InterruptOp;
 use Phel\Nrepl\Application\Op\LoadFileOp;
 use Phel\Nrepl\Application\Op\LookupOp;
@@ -44,20 +45,13 @@ final class NreplFactory extends AbstractFactory
     public function createOpDispatcher(): OpDispatcher
     {
         $sessions = $this->createSessionRegistry();
+        $responder = new EvalResultResponder($this->createPrinter(), $sessions);
         $dispatcher = new OpDispatcher();
 
         $dispatcher->register(new CloneOp($sessions));
         $dispatcher->register(new CloseOp($sessions));
-        $dispatcher->register(new EvalOp(
-            $this->getRunFacade(),
-            $this->createPrinter(),
-            $sessions,
-        ));
-        $dispatcher->register(new LoadFileOp(
-            $this->getRunFacade(),
-            $this->createPrinter(),
-            $sessions,
-        ));
+        $dispatcher->register(new EvalOp($this->getRunFacade(), $responder));
+        $dispatcher->register(new LoadFileOp($this->getRunFacade(), $responder));
         $dispatcher->register(new InterruptOp());
         $dispatcher->register(new CompletionsOp($this->getApiFacade()));
         $dispatcher->register(new LookupOp($this->getApiFacade(), 'lookup'));

--- a/src/php/Watch/Application/Watcher/EventDebouncer.php
+++ b/src/php/Watch/Application/Watcher/EventDebouncer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Watch\Application\Watcher;
+
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Transfer\WatchEvent;
+
+use function array_values;
+
+/**
+ * Buffers `WatchEvent`s and flushes them through a callback when the most
+ * recent event is older than `$debounceMs`. Events for the same path are
+ * coalesced; stronger kinds win: `deleted` > `created`/`modified`.
+ *
+ * The debouncer is intentionally stateful (pending buffer + last event
+ * timestamp) but owns no other side-effects — time comes from
+ * `ClockInterface`, flushes run the caller's callback.
+ *
+ * Extracted from `PollingWatcher`, `FswatchWatcher`, and `InotifyWatcher`,
+ * which each re-implemented the same logic with small variations.
+ */
+final class EventDebouncer
+{
+    /** @var list<WatchEvent> */
+    private array $pending = [];
+
+    private int $lastEventAt = 0;
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly int $debounceMs,
+    ) {}
+
+    public function record(WatchEvent $event): void
+    {
+        $this->pending[] = $event;
+        $this->lastEventAt = $this->clock->nowMs();
+    }
+
+    public function hasPending(): bool
+    {
+        return $this->pending !== [];
+    }
+
+    /**
+     * Flush the buffer through the callback if the debounce window has
+     * elapsed (or when `$force` is true). No-ops when the buffer is empty.
+     *
+     * @param callable(list<WatchEvent>):void $onFlush
+     */
+    public function flushIfReady(callable $onFlush, bool $force = false): void
+    {
+        if ($this->pending === []) {
+            return;
+        }
+
+        if (!$force) {
+            $elapsed = $this->clock->nowMs() - $this->lastEventAt;
+            if ($elapsed < $this->debounceMs) {
+                return;
+            }
+        }
+
+        $unique = $this->coalesce($this->pending);
+        $this->pending = [];
+        $onFlush($unique);
+    }
+
+    /**
+     * Coalesce multiple events for the same path. A deletion takes
+     * precedence over an earlier creation or modification for the same
+     * path; otherwise the latest event wins.
+     *
+     * @param list<WatchEvent> $events
+     *
+     * @return list<WatchEvent>
+     */
+    private function coalesce(array $events): array
+    {
+        /** @var array<string, WatchEvent> $byPath */
+        $byPath = [];
+        foreach ($events as $event) {
+            $existing = $byPath[$event->path] ?? null;
+            if ($existing === null) {
+                $byPath[$event->path] = $event;
+                continue;
+            }
+
+            if ($existing->kind === WatchEvent::KIND_DELETED) {
+                continue;
+            }
+
+            $byPath[$event->path] = $event;
+        }
+
+        return array_values($byPath);
+    }
+}

--- a/src/php/Watch/Application/Watcher/FswatchWatcher.php
+++ b/src/php/Watch/Application/Watcher/FswatchWatcher.php
@@ -87,9 +87,7 @@ final class FswatchWatcher implements FileWatcherInterface
         // Prime the snapshot so the resolver can mtime-diff if needed.
         $this->scanner->snapshot($paths);
 
-        /** @var list<WatchEvent> $pending */
-        $pending = [];
-        $lastEventAt = 0;
+        $debouncer = new EventDebouncer($this->clock, $this->debounceMs);
 
         /** @psalm-suppress RedundantCondition */
         while ($this->running && $this->isAlive()) {
@@ -97,14 +95,12 @@ final class FswatchWatcher implements FileWatcherInterface
             if ($line !== false) {
                 $path = trim($line);
                 if ($path !== '') {
-                    $pending[] = new WatchEvent($path, WatchEvent::KIND_MODIFIED);
-                    $lastEventAt = $this->clock->nowMs();
+                    $debouncer->record(new WatchEvent($path, WatchEvent::KIND_MODIFIED));
                 }
             }
 
-            if ($pending !== [] && $this->clock->nowMs() - $lastEventAt >= $this->debounceMs) {
-                $onChange($this->coalesce($pending));
-                $pending = [];
+            if ($debouncer->hasPending()) {
+                $debouncer->flushIfReady($onChange);
             } else {
                 $this->clock->sleepMs(50);
             }
@@ -133,22 +129,6 @@ final class FswatchWatcher implements FileWatcherInterface
         pclose($handle);
 
         return trim($out) !== '';
-    }
-
-    /**
-     * @param list<WatchEvent> $events
-     *
-     * @return list<WatchEvent>
-     */
-    private function coalesce(array $events): array
-    {
-        /** @var array<string, WatchEvent> $byPath */
-        $byPath = [];
-        foreach ($events as $event) {
-            $byPath[$event->path] = $event;
-        }
-
-        return array_values($byPath);
     }
 
     /**

--- a/src/php/Watch/Application/Watcher/InotifyWatcher.php
+++ b/src/php/Watch/Application/Watcher/InotifyWatcher.php
@@ -102,9 +102,7 @@ final class InotifyWatcher implements FileWatcherInterface
 
         $this->scanner->snapshot($paths);
 
-        /** @var list<WatchEvent> $pending */
-        $pending = [];
-        $lastEventAt = 0;
+        $debouncer = new EventDebouncer($this->clock, $this->debounceMs);
 
         /** @psalm-suppress RedundantCondition */
         while ($this->running && $this->isAlive()) {
@@ -112,14 +110,12 @@ final class InotifyWatcher implements FileWatcherInterface
             if ($line !== false) {
                 $event = $this->parseLine($line);
                 if ($event instanceof WatchEvent) {
-                    $pending[] = $event;
-                    $lastEventAt = $this->clock->nowMs();
+                    $debouncer->record($event);
                 }
             }
 
-            if ($pending !== [] && $this->clock->nowMs() - $lastEventAt >= $this->debounceMs) {
-                $onChange($this->coalesce($pending));
-                $pending = [];
+            if ($debouncer->hasPending()) {
+                $debouncer->flushIfReady($onChange);
             } else {
                 $this->clock->sleepMs(50);
             }
@@ -178,22 +174,6 @@ final class InotifyWatcher implements FileWatcherInterface
         }
 
         return new WatchEvent($path, $kind);
-    }
-
-    /**
-     * @param list<WatchEvent> $events
-     *
-     * @return list<WatchEvent>
-     */
-    private function coalesce(array $events): array
-    {
-        /** @var array<string, WatchEvent> $byPath */
-        $byPath = [];
-        foreach ($events as $event) {
-            $byPath[$event->path] = $event;
-        }
-
-        return array_values($byPath);
     }
 
     /**

--- a/src/php/Watch/Application/Watcher/PollingWatcher.php
+++ b/src/php/Watch/Application/Watcher/PollingWatcher.php
@@ -42,9 +42,7 @@ final class PollingWatcher implements FileWatcherInterface
         $this->running = true;
         $this->lastSnapshot = $this->scanner->snapshot($paths);
 
-        /** @var list<WatchEvent> $pending */
-        $pending = [];
-        $lastEventAt = 0;
+        $debouncer = new EventDebouncer($this->clock, $this->debounceMs);
         $iterations = 0;
 
         /** @psalm-suppress RedundantCondition */
@@ -52,24 +50,18 @@ final class PollingWatcher implements FileWatcherInterface
             $this->clock->sleepMs($this->pollIntervalMs);
 
             $currentSnapshot = $this->scanner->snapshot($paths);
-            $events = $this->diff($this->lastSnapshot, $currentSnapshot);
-            $this->lastSnapshot = $currentSnapshot;
-
-            if ($events !== []) {
-                foreach ($events as $event) {
-                    $pending[] = $event;
-                }
-
-                $lastEventAt = $this->clock->nowMs();
+            foreach ($this->diff($this->lastSnapshot, $currentSnapshot) as $event) {
+                $debouncer->record($event);
             }
 
-            $pending = $this->flushIfReady($pending, $lastEventAt, $onChange);
+            $this->lastSnapshot = $currentSnapshot;
+
+            $debouncer->flushIfReady($onChange);
 
             ++$iterations;
             if ($this->maxIterations > 0 && $iterations >= $this->maxIterations) {
                 $this->running = false;
-                // Flush any outstanding events so callers can assert on them.
-                $this->flushIfReady($pending, $lastEventAt, $onChange, true);
+                $debouncer->flushIfReady($onChange, force: true);
                 break;
             }
         }
@@ -78,61 +70,6 @@ final class PollingWatcher implements FileWatcherInterface
     public function stop(): void
     {
         $this->running = false;
-    }
-
-    /**
-     * @param list<WatchEvent>                $pending
-     * @param callable(list<WatchEvent>):void $onChange
-     *
-     * @return list<WatchEvent>
-     */
-    private function flushIfReady(array $pending, int $lastEventAt, callable $onChange, bool $force = false): array
-    {
-        if ($pending === []) {
-            return [];
-        }
-
-        if (!$force) {
-            $elapsed = $this->clock->nowMs() - $lastEventAt;
-            if ($elapsed < $this->debounceMs) {
-                return $pending;
-            }
-        }
-
-        $unique = $this->coalesce($pending);
-        $onChange($unique);
-
-        return [];
-    }
-
-    /**
-     * Coalesce multiple events for the same path into a single entry.
-     *
-     * @param list<WatchEvent> $events
-     *
-     * @return list<WatchEvent>
-     */
-    private function coalesce(array $events): array
-    {
-        /** @var array<string, WatchEvent> $byPath */
-        $byPath = [];
-        foreach ($events as $event) {
-            // Creations trump modifications for the same file; deletions trump
-            // creations. Later wins only when the kind is stronger.
-            $existing = $byPath[$event->path] ?? null;
-            if ($existing === null) {
-                $byPath[$event->path] = $event;
-                continue;
-            }
-
-            if ($existing->kind === WatchEvent::KIND_DELETED) {
-                continue;
-            }
-
-            $byPath[$event->path] = $event;
-        }
-
-        return array_values($byPath);
     }
 
     /**

--- a/tests/phel/test/match.phel
+++ b/tests/phel/test/match.phel
@@ -175,3 +175,75 @@
            :else   (swap! results conj :else-branch))
     (is (= [:hit-branch] (deref results))
         "only the matching branch runs")))
+
+(deftest test-deeply-nested-patterns
+  (testing "three levels of vector nesting"
+    (is (= [1 2 3 4]
+           (match [[[1 [2 [3 [4]]]]]]
+                  [[[a [b [c [d]]]]]] [a b c d]
+                  :else :else))
+        "triple-nested vectors destructure to leaves"))
+  (testing "map-inside-vector-inside-map"
+    (is (= [:root 1 2]
+           (match [{:tag :root :cells [{:id 1} {:id 2}]}]
+                  [{:tag t :cells [{:id a} {:id b}]}] [t a b]
+                  :else :else))
+        "three-level mixed structure"))
+  (testing "nested :or inside vector"
+    (is (= :hit (match [[:a]] [[(:or :a :b)]] :hit :else :else))
+        "or alternative inside outer vector"))
+  (testing "nested guard inside map"
+    (is (= :ok
+           (match [{:n 7}]
+                  [{:n (x :guard odd?)}] :ok
+                  :else :else))
+        "guard survives map destructure"))
+  (testing "nested as inside vector with outer pattern"
+    (is (= [:k [1 2]]
+           (match [[:k [1 2]]]
+                  [[tag ([a b] :as inner)]] [tag inner]
+                  :else :else)))))
+
+(deftest test-pattern-fall-through-to-else
+  (testing "vector shape mismatch hits :else"
+    (is (= :else
+           (match [42]
+                  [[a]] :vector
+                  [{:k _}] :map
+                  :else :else))
+        "int is neither vector nor map"))
+  (testing "every clause shape-fails"
+    (is (= :fallback
+           (match [nil]
+                  [[_ _]] :two-vec
+                  [[_]] :one-vec
+                  [{:a _}] :map
+                  :else :fallback))
+        "nil falls through all structural clauses"))
+  (testing "rest-binding does not match non-sequential"
+    (is (= :else (match ["abc"] [[a & r]] :seq :else :else))
+        "string target against vector pattern with rest")))
+
+(deftest test-empty-target-vector
+  ;; A zero-target match is legal — the pattern list must also be zero-length.
+  (is (= :matched
+         (match [] [] :matched :else :else))
+      "empty target + empty pattern hits the clause")
+  (is (= :yes
+         (match [] :else :yes))
+      "empty target with only :else returns :else expr"))
+
+(deftest test-or-pattern-shape-mix
+  (testing ":or with literal alternatives of different scalar types"
+    (is (= :ok (match [nil] [(:or nil false 0)] :ok :else :else))
+        "nil alternative matches")
+    (is (= :ok (match [false] [(:or nil false 0)] :ok :else :else))
+        "false alternative matches")
+    (is (= :ok (match [0] [(:or nil false 0)] :ok :else :else))
+        "zero alternative matches")
+    (is (= :else (match [1] [(:or nil false 0)] :ok :else :else))
+        "no alternative matches"))
+  (testing ":or requires at least one alternative"
+    (is (thrown? \InvalidArgumentException
+                 (macroexpand-1 '(phel\match/match [1] [(:or)] :x :else :y)))
+        "empty :or raises at expansion")))

--- a/tests/phel/test/reporters.phel
+++ b/tests/phel/test/reporters.phel
@@ -183,3 +183,101 @@
     (is (php/preg_match "/Passed: 2/" out) "prints Passed count")
     (is (php/preg_match "/Failed: 1/" out) "prints Failed count")
     (is (php/preg_match "/Total: 3/" out) "prints Total count")))
+
+;; ---------------------------------------------------------------------------
+;; Default reporter — thrown-with-msg failure formatting
+;; ---------------------------------------------------------------------------
+
+(deftest test-default-reporter-thrown-with-msg-prints-when-exception-not-thrown
+  (let [rep (t/resolve-reporter :default)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :thrown-with-msg :state :failed
+                    :form "(throw (new E 'x'))" :message "should throw"
+                    :exception-symbol "\\Exception"
+                    :expected-message "expected"
+                    :actual-message nil})
+              (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                    :failures [{:type :thrown-with-msg :state :failed
+                                :form "(throw (new E 'x'))" :message "should throw"
+                                :exception-symbol "\\Exception"
+                                :expected-message "expected"
+                                :actual-message nil}]}))]
+    (is (php/preg_match "/to throw a: \\\\Exception \\(it didn't\\)/" out)
+        "when no exception thrown, prints 'didn't throw' diagnostic")
+    (is (= 0 (php/preg_match "/with message:/" out))
+        "when no exception thrown, does NOT print 'with message' line")))
+
+(deftest test-default-reporter-thrown-with-msg-prints-when-message-differs
+  (let [rep (t/resolve-reporter :default)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :thrown-with-msg :state :failed
+                    :form "(throw (new E 'actual'))" :message "msg mismatch"
+                    :exception-symbol "\\Exception"
+                    :expected-message "expected"
+                    :actual-message "actual"})
+              (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                    :failures [{:type :thrown-with-msg :state :failed
+                                :form "(throw (new E 'actual'))" :message "msg mismatch"
+                                :exception-symbol "\\Exception"
+                                :expected-message "expected"
+                                :actual-message "actual"}]}))]
+    (is (php/preg_match "/to throw a: \\\\Exception/" out)
+        "exception class is printed")
+    (is (php/preg_match "/with message: expected/" out)
+        "expected message is printed")
+    (is (php/preg_match "/but got: actual/" out)
+        "actual message is printed")))
+
+;; ---------------------------------------------------------------------------
+;; Pathological input — reporters tolerate missing fields
+;; ---------------------------------------------------------------------------
+
+(deftest test-dot-reporter-tolerates-missing-summary-fields
+  (let [rep (t/resolve-reporter :dot)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :summary}))]
+    (is (php/preg_match "/Tests: /" out)
+        "dot reporter renders a summary line even when counts are absent")))
+
+(deftest test-default-reporter-tolerates-summary-without-failures
+  (let [rep (t/resolve-reporter :default)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :summary :total 0 :pass 0 :failed 0 :error 0}))]
+    (is (php/preg_match "/Total: 0/" out)
+        "summary renders cleanly when :failures key is absent")))
+
+;; ---------------------------------------------------------------------------
+;; Assertion-like dispatch — :predicate with :state :error routes to error path
+;; ---------------------------------------------------------------------------
+
+(deftest test-assertion-like-state-error-is-recorded
+  (let [events (atom [])
+        saved  (t/get-stats)
+        prev   (t/get-reporters)]
+    (t/set-reporters! [(fn [e] (swap! events conj e))])
+    (t/reset-stats)
+    (t/report {:type :predicate :state :error :message "threw"})
+    (let [snapshot (t/get-stats)]
+      (t/set-reporters! prev)
+      (t/restore-stats saved)
+      (is (= 1 (count (deref events))) "event reached the reporter")
+      (is (= 1 (:error (:counts snapshot)))
+          ":predicate with :state :error increments :error count"))))
+
+(deftest test-assertion-like-without-state-flows-through
+  (let [events (atom [])
+        saved  (t/get-stats)
+        prev   (t/get-reporters)]
+    (t/set-reporters! [(fn [e] (swap! events conj e))])
+    (t/reset-stats)
+    (t/report {:type :binary :payload "no state"})
+    (let [snapshot (t/get-stats)]
+      (t/set-reporters! prev)
+      (t/restore-stats saved)
+      (is (= 1 (count (deref events))) "event still fans out")
+      (is (= 0 (:pass (:counts snapshot)))
+          "event without :state does not touch stats"))))

--- a/tests/phel/test/schema/validate.phel
+++ b/tests/phel/test/schema/validate.phel
@@ -158,3 +158,26 @@
   (is (s/schema? [:enum :a :b]))
   (is (not (s/schema? "not a schema")))
   (is (not (s/schema? 1))))
+
+(deftest test-validate-rejects-unknown-keyword-head
+  (is (thrown? \InvalidArgumentException (s/validate :not-a-real-kind 1))))
+
+(deftest test-validate-rejects-unknown-vector-head
+  (is (thrown? \InvalidArgumentException (s/validate [:not-a-real-kind 1] 1))))
+
+(deftest test-validate-rejects-non-schema-shape
+  (is (thrown? \InvalidArgumentException (s/validate "string-is-not-a-schema" 1)))
+  (is (thrown? \InvalidArgumentException (s/validate 42 1))))
+
+(deftest test-empty-and-matches-anything
+  (is (s/validate [:and] 1))
+  (is (s/validate [:and] "x"))
+  (is (s/validate [:and] nil)))
+
+(deftest test-empty-or-matches-nothing
+  (is (not (s/validate [:or] 1)))
+  (is (not (s/validate [:or] nil))))
+
+(deftest test-empty-enum-matches-nothing
+  (is (not (s/validate [:enum] 1)))
+  (is (not (s/validate [:enum] nil))))

--- a/tests/phel/test/selectors.phel
+++ b/tests/phel/test/selectors.phel
@@ -212,3 +212,47 @@
       "non-empty filters counts")
   (is (selector/has-selectors? {:exclude [:slow]})
       "non-empty exclude counts"))
+
+;; ---------------------------------------------------------------------------
+;; ns-matches? — glob edge cases
+;; ---------------------------------------------------------------------------
+
+(deftest test-ns-matches-trailing-star-without-prefix
+  (is (selector/ns-matches? "*" "top")
+      "bare `*` matches any single-segment namespace")
+  (is (not (selector/ns-matches? "*" "a.b"))
+      "bare `*` does not cross dots"))
+
+(deftest test-ns-matches-nil-inputs-are-safe
+  (is (not (selector/ns-matches? nil "phel.core"))
+      "nil pattern never matches")
+  (is (not (selector/ns-matches? "phel.*" nil))
+      "nil ns never matches"))
+
+(deftest test-ns-matches-treats-backslash-as-dot
+  (is (selector/ns-matches? "phel.test.*" "phel\\test\\selector")
+      "backslash-separated ns matches dotted glob"))
+
+(deftest test-ns-matches-special-regex-chars-escaped
+  (is (not (selector/ns-matches? "a+" "aaa"))
+      "`+` in glob is a literal, not regex quantifier")
+  (is (selector/ns-matches? "a+b" "a+b")
+      "`+` in glob matches literal `+` in ns name"))
+
+;; ---------------------------------------------------------------------------
+;; matches-filter? — nil safety
+;; ---------------------------------------------------------------------------
+
+(deftest test-name-matches-nil-inputs-are-safe
+  (is (not (selector/name-matches? "x" nil))
+      "nil test-name never matches")
+  (is (not (selector/name-matches? nil "test-x"))
+      "nil pattern never matches"))
+
+(deftest test-matches-filter-with-nil-name-and-non-empty-patterns
+  (is (not (selector/matches-filter? ["x"] nil))
+      "non-empty pattern + nil name yields no match"))
+
+(deftest test-matches-filter-with-nil-name-and-empty-patterns
+  (is (selector/matches-filter? [] nil)
+      "empty pattern list with nil name still imposes no restriction"))

--- a/tests/phel/test/shrink.phel
+++ b/tests/phel/test/shrink.phel
@@ -110,3 +110,52 @@
                 [100])]
       (is (= [1] (:smallest res)) "shrinks to the smallest throwing value")
       (is (> (:shrink-steps res) 0)))))
+
+;; ---------------------------
+;; Leaf values — no children, driver returns the value unchanged
+;; ---------------------------
+
+(deftest test-shrink-leaf-value-has-no-shrinks
+  (testing "keyword has no default shrink strategy - driver returns it as-is"
+    (let [res (shrink/shrink-args (fn [_] false) [:keyword-value])]
+      (is (= [:keyword-value] (:smallest res))
+          "leaf values are returned unchanged")
+      (is (= 0 (:shrink-steps res))
+          "no shrink steps attempted on leaf values"))))
+
+;; ---------------------------
+;; Multi-argument shrinking
+;; ---------------------------
+
+(deftest test-shrink-multi-argument-shrinks-each-position
+  (testing "property with two arguments shrinks toward a minimal failing pair"
+    (let [prop (fn [a b] (and (< a 100) (< b 50)))
+          res  (shrink/shrink-args prop [1000 800])
+          a    (get (:smallest res) 0)
+          b    (get (:smallest res) 1)]
+      (is (= 2 (count (:smallest res)))
+          "arity is preserved during shrinking")
+      (is (not (prop a b))
+          "the shrunk pair still fails the property")
+      (is (> (:shrink-steps res) 0)
+          "at least one shrink step was taken"))))
+
+;; ---------------------------
+;; value->rose falls back to leaf for unsupported types
+;; ---------------------------
+
+(deftest test-value-to-rose-list-shrinks-by-removal
+  (let [t (shrink/value->rose '(1 2 3))]
+    (is (= '(1 2 3) (r/rose-root t))
+        "list root is preserved")
+    (is (some (fn [v] (< (count v) 3))
+              (into [] (map r/rose-root (r/rose-children t))))
+        "list shrinks by element removal")))
+
+(deftest test-value-to-rose-set-shrinks-by-removal
+  (let [t (shrink/value->rose (hash-set 1 2 3))
+        shrinks (into [] (map r/rose-root (r/rose-children t)))]
+    (is (set? (r/rose-root t))
+        "set root is preserved as a set")
+    (is (some (fn [v] (< (count v) 3)) shrinks)
+        "set shrinks by element removal")))

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -23,6 +23,8 @@ use Phel\Lang\TypeInterface;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use PHPUnit\Framework\TestCase;
 
+use RuntimeException;
+
 use function get_debug_type;
 use function is_scalar;
 use function sprintf;
@@ -1432,6 +1434,34 @@ final class ReaderTest extends TestCase
         } finally {
             $registry->unregister('shout');
         }
+    }
+
+    public function test_handler_throwing_arbitrary_error_is_wrapped_with_tag_name(): void
+    {
+        $registry = TagRegistry::getInstance();
+        BuiltinTagHandlers::registerAll($registry);
+        $registry->register('boom', static function (mixed $_): never {
+            throw new RuntimeException('kaboom');
+        });
+
+        try {
+            $this->expectException(ReaderException::class);
+            $this->expectExceptionMessage("Tagged-literal handler for '#boom' threw an error: kaboom");
+            $this->read('#boom "ignored"');
+        } finally {
+            $registry->unregister('boom');
+        }
+    }
+
+    public function test_unknown_tag_error_points_to_register_tag_api(): void
+    {
+        $registry = TagRegistry::getInstance();
+        $registry->clear();
+        BuiltinTagHandlers::registerAll($registry);
+
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Use `(register-tag "xyz" f)` to register a handler');
+        $this->read('#xyz "x"');
     }
 
     private function read(string $string, bool $withLocation = true): float|bool|int|string|TypeInterface|null

--- a/tests/php/Unit/Fiber/Domain/FutureTest.php
+++ b/tests/php/Unit/Fiber/Domain/FutureTest.php
@@ -112,4 +112,31 @@ final class FutureTest extends TestCase
 
         self::assertSame([10, 20, 30], $results);
     }
+
+    public function test_is_done_is_false_before_start_and_cancel(): void
+    {
+        $future = new Future($this->scheduler, static fn(): string => 'x');
+
+        self::assertFalse($future->isCancelled());
+        self::assertFalse($future->isDone());
+    }
+
+    public function test_deref_with_zero_timeout_returns_fallback_for_unrealized(): void
+    {
+        $parked = new Promise($this->scheduler);
+        $future = new Future($this->scheduler, static fn(): mixed => $parked->deref());
+
+        self::assertSame(':fallback', $future->derefWithTimeout(0, ':fallback'));
+        self::assertFalse($future->isRealized());
+    }
+
+    public function test_deref_with_timeout_returns_fallback_when_cancelled_before_deliver(): void
+    {
+        $parked = new Promise($this->scheduler);
+        $future = new Future($this->scheduler, static fn(): mixed => $parked->deref());
+
+        $future->cancel();
+
+        self::assertSame(':cancelled', $future->derefWithTimeout(100, ':cancelled'));
+    }
 }

--- a/tests/php/Unit/Fiber/Domain/PromiseTest.php
+++ b/tests/php/Unit/Fiber/Domain/PromiseTest.php
@@ -89,4 +89,30 @@ final class PromiseTest extends TestCase
         self::assertNull($promise->value());
         self::assertFalse($promise->deliver('other'));
     }
+
+    public function test_second_deliver_does_not_overwrite_the_stored_value(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver('first');
+        $promise->deliver('second');
+        $promise->deliver('third');
+
+        self::assertSame('first', $promise->deref());
+    }
+
+    public function test_deref_with_negative_timeout_returns_fallback_immediately(): void
+    {
+        $promise = new Promise($this->scheduler);
+
+        self::assertSame(':fallback', $promise->derefWithTimeout(-1, ':fallback'));
+        self::assertFalse($promise->isRealized());
+    }
+
+    public function test_deref_with_timeout_zero_returns_value_when_already_delivered(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver('ready');
+
+        self::assertSame('ready', $promise->derefWithTimeout(0, ':fallback'));
+    }
 }

--- a/tests/php/Unit/Fiber/Domain/SchedulerTest.php
+++ b/tests/php/Unit/Fiber/Domain/SchedulerTest.php
@@ -132,4 +132,28 @@ final class SchedulerTest extends TestCase
 
         self::assertSame(0, $scheduler->sleepMicroseconds());
     }
+
+    public function test_run_until_idle_is_a_noop_when_queue_is_empty(): void
+    {
+        $scheduler = new Scheduler();
+
+        $scheduler->runUntilIdle();
+
+        self::assertFalse($scheduler->hasReady());
+    }
+
+    public function test_await_drains_queue_until_awaitable_is_realized(): void
+    {
+        $scheduler = new Scheduler();
+        $scheduler->setSleepMicroseconds(10);
+
+        $promise = new Promise($scheduler);
+
+        $fiber = new Fiber(static function () use ($promise): void {
+            $promise->deliver('from-fiber');
+        });
+        $scheduler->enqueue($fiber);
+
+        self::assertSame('from-fiber', $scheduler->await($promise));
+    }
 }

--- a/tests/php/Unit/Lang/TagHandlers/AbstractStringTagHandlerTest.php
+++ b/tests/php/Unit/Lang/TagHandlers/AbstractStringTagHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang\TagHandlers;
+
+use Phel\Lang\TagHandlerException;
+use Phel\Lang\TagHandlers\AbstractStringTagHandler;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractStringTagHandlerTest extends TestCase
+{
+    public function test_it_returns_the_concrete_result_for_a_string_form(): void
+    {
+        $handler = $this->uppercaseHandler();
+
+        self::assertSame('HELLO', $handler('hello'));
+    }
+
+    public function test_it_throws_when_form_is_not_a_string(): void
+    {
+        $handler = $this->uppercaseHandler();
+
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('#shout expects a string literal (e.g. #shout "hi").');
+
+        $handler(42);
+    }
+
+    public function test_it_omits_example_parenthetical_when_empty(): void
+    {
+        $handler = new readonly class() extends AbstractStringTagHandler {
+            protected function tagName(): string
+            {
+                return 'quiet';
+            }
+
+            protected function example(): string
+            {
+                return '';
+            }
+
+            protected function handleString(string $form): string
+            {
+                return $form;
+            }
+        };
+
+        $this->expectException(TagHandlerException::class);
+        $this->expectExceptionMessage('#quiet expects a string literal.');
+
+        $handler(1);
+    }
+
+    private function uppercaseHandler(): AbstractStringTagHandler
+    {
+        return new readonly class() extends AbstractStringTagHandler {
+            protected function tagName(): string
+            {
+                return 'shout';
+            }
+
+            protected function example(): string
+            {
+                return '#shout "hi"';
+            }
+
+            protected function handleString(string $form): string
+            {
+                return strtoupper($form);
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Convert/SymbolKindMapperTest.php
+++ b/tests/php/Unit/Lsp/Application/Convert/SymbolKindMapperTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Convert;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Lsp\Application\Convert\SymbolKindMapper;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolKindMapperTest extends TestCase
+{
+    public function test_maps_defn_to_lsp_function(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::FUNCTION, $mapper->fromDefinitionKind(Definition::KIND_DEFN));
+    }
+
+    public function test_maps_defmacro_to_lsp_method(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::METHOD, $mapper->fromDefinitionKind(Definition::KIND_DEFMACRO));
+    }
+
+    public function test_maps_defstruct_to_lsp_struct(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::STRUCT, $mapper->fromDefinitionKind(Definition::KIND_DEFSTRUCT));
+    }
+
+    public function test_maps_defprotocol_to_lsp_interface(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::INTERFACE, $mapper->fromDefinitionKind(Definition::KIND_DEFPROTOCOL));
+    }
+
+    public function test_maps_definterface_to_lsp_interface(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::INTERFACE, $mapper->fromDefinitionKind(Definition::KIND_DEFINTERFACE));
+    }
+
+    public function test_maps_defexception_to_lsp_class(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::CLASS_, $mapper->fromDefinitionKind(Definition::KIND_DEFEXCEPTION));
+    }
+
+    public function test_falls_back_to_variable_for_unknown_kinds(): void
+    {
+        $mapper = new SymbolKindMapper();
+
+        self::assertSame(SymbolKindMapper::VARIABLE, $mapper->fromDefinitionKind('something-else'));
+        self::assertSame(SymbolKindMapper::VARIABLE, $mapper->fromDefinitionKind(Definition::KIND_DEF));
+        self::assertSame(SymbolKindMapper::VARIABLE, $mapper->fromDefinitionKind(Definition::KIND_UNKNOWN));
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Handler/DidCloseHandlerTest.php
+++ b/tests/php/Unit/Lsp/Application/Handler/DidCloseHandlerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Handler;
+
+use Phel\Lsp\Application\Document\DocumentStore;
+use Phel\Lsp\Application\Handler\DidCloseHandler;
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\NotificationSink;
+use PHPUnit\Framework\TestCase;
+
+final class DidCloseHandlerTest extends TestCase
+{
+    public function test_is_a_notification_for_did_close_method(): void
+    {
+        $handler = new DidCloseHandler(new ParamsExtractor());
+
+        self::assertSame('textDocument/didClose', $handler->method());
+        self::assertTrue($handler->isNotification());
+    }
+
+    public function test_noops_when_params_are_empty(): void
+    {
+        $captured = [];
+        $session = $this->newSession($captured);
+
+        $handler = new DidCloseHandler(new ParamsExtractor());
+        $result = $handler->handle([], $session);
+
+        self::assertNull($result);
+        self::assertSame([], $captured);
+    }
+
+    public function test_noops_when_text_document_is_not_an_array(): void
+    {
+        $captured = [];
+        $session = $this->newSession($captured);
+
+        $handler = new DidCloseHandler(new ParamsExtractor());
+        $handler->handle(['textDocument' => 'garbage'], $session);
+
+        self::assertSame([], $captured);
+    }
+
+    public function test_closes_document_and_clears_diagnostics_when_uri_present(): void
+    {
+        $captured = [];
+        $session = $this->newSession($captured);
+        $session->documents()->open('file:///x.phel', 'phel', 1, '(ns x)');
+
+        $handler = new DidCloseHandler(new ParamsExtractor());
+        $handler->handle(['textDocument' => ['uri' => 'file:///x.phel']], $session);
+
+        self::assertNull($session->documents()->get('file:///x.phel'));
+        self::assertCount(1, $captured);
+        self::assertSame('textDocument/publishDiagnostics', $captured[0]['method']);
+        self::assertSame('file:///x.phel', $captured[0]['params']['uri']);
+        self::assertSame([], $captured[0]['params']['diagnostics']);
+    }
+
+    /**
+     * @param array<int, array{method: string, params: array<string, mixed>}> $captured
+     */
+    private function newSession(array &$captured): Session
+    {
+        $sink = new class($captured) implements NotificationSink {
+            /**
+             * @param array<int, array{method: string, params: array<string, mixed>}> $captured
+             */
+            public function __construct(private array &$captured) {}
+
+            public function notify(string $method, array $params): void
+            {
+                $this->captured[] = ['method' => $method, 'params' => $params];
+            }
+        };
+
+        return new Session(new DocumentStore(), $sink);
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Handler/SymbolResolverTest.php
+++ b/tests/php/Unit/Lsp/Application/Handler/SymbolResolverTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Handler;
+
+use Phel\Api\Transfer\Definition;
+use Phel\Api\Transfer\ProjectIndex;
+use Phel\Lsp\Application\Handler\SymbolResolver;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolResolverTest extends TestCase
+{
+    public function test_split_returns_namespaced_tuple_when_word_has_slash(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = new ProjectIndex([]);
+
+        self::assertSame(
+            ['my-ns', 'fn-name'],
+            $resolver->split('my-ns/fn-name', $index),
+        );
+    }
+
+    public function test_split_returns_empty_name_when_slash_but_no_tail(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = new ProjectIndex([]);
+
+        self::assertSame(['ns', ''], $resolver->split('ns/', $index));
+    }
+
+    public function test_split_resolves_bare_name_against_index(): void
+    {
+        $def = new Definition('phel\\core', 'map', 'file:///core.phel', 1, 1, Definition::KIND_DEFN, [], '', false);
+        $index = new ProjectIndex(['phel\\core/map' => $def]);
+        $resolver = new SymbolResolver();
+
+        self::assertSame(['phel\\core', 'map'], $resolver->split('map', $index));
+    }
+
+    public function test_split_returns_empty_namespace_for_unknown_bare_name(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = new ProjectIndex([]);
+
+        self::assertSame(['', 'unknown'], $resolver->split('unknown', $index));
+    }
+
+    public function test_find_resolves_fully_qualified_word_directly(): void
+    {
+        $def = new Definition('foo', 'bar', '', 1, 1, Definition::KIND_DEFN, [], '', false);
+        $index = new ProjectIndex(['foo/bar' => $def]);
+        $resolver = new SymbolResolver();
+
+        self::assertSame($def, $resolver->find('foo/bar', $index));
+    }
+
+    public function test_find_returns_null_for_unknown_fully_qualified_word(): void
+    {
+        $resolver = new SymbolResolver();
+        $index = new ProjectIndex([]);
+
+        self::assertNull($resolver->find('nope/nope', $index));
+    }
+
+    public function test_find_scans_index_for_bare_name(): void
+    {
+        $def = new Definition('phel\\string', 'join', '', 1, 1, Definition::KIND_DEFN, [], '', false);
+        $index = new ProjectIndex(['phel\\string/join' => $def]);
+        $resolver = new SymbolResolver();
+
+        self::assertSame($def, $resolver->find('join', $index));
+    }
+
+    public function test_find_returns_null_when_bare_name_missing(): void
+    {
+        $def = new Definition('ns', 'other', '', 1, 1, Definition::KIND_DEFN, [], '', false);
+        $index = new ProjectIndex(['ns/other' => $def]);
+        $resolver = new SymbolResolver();
+
+        self::assertNull($resolver->find('missing', $index));
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Rpc/ParamsExtractorTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/ParamsExtractorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Rpc\ParamsExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class ParamsExtractorTest extends TestCase
+{
+    public function test_uri_returns_empty_string_when_text_document_missing(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('', $extractor->uri([]));
+    }
+
+    public function test_uri_returns_empty_string_when_text_document_not_an_array(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('', $extractor->uri(['textDocument' => 'nonsense']));
+    }
+
+    public function test_uri_returns_empty_string_when_uri_field_not_a_string(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('', $extractor->uri(['textDocument' => ['uri' => 42]]));
+    }
+
+    public function test_uri_returns_the_uri_when_present_and_valid(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('file:///tmp/x.phel', $extractor->uri([
+            'textDocument' => ['uri' => 'file:///tmp/x.phel'],
+        ]));
+    }
+
+    public function test_position_returns_null_when_position_missing(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertNull($extractor->position([]));
+    }
+
+    public function test_position_returns_null_when_line_is_not_an_int(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertNull($extractor->position(['position' => ['line' => '0', 'character' => 0]]));
+    }
+
+    public function test_position_returns_null_when_character_is_not_an_int(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertNull($extractor->position(['position' => ['line' => 0, 'character' => '0']]));
+    }
+
+    public function test_position_returns_the_tuple_on_valid_shape(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame(
+            ['line' => 3, 'character' => 7],
+            $extractor->position(['position' => ['line' => 3, 'character' => 7]]),
+        );
+    }
+
+    public function test_version_returns_default_when_missing(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame(0, $extractor->version([]));
+        self::assertSame(42, $extractor->version([], 42));
+    }
+
+    public function test_version_returns_value_when_present(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame(
+            5,
+            $extractor->version(['textDocument' => ['version' => 5]]),
+        );
+    }
+
+    public function test_language_id_returns_default_when_missing(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('phel', $extractor->languageId([]));
+    }
+
+    public function test_language_id_returns_value_when_present(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame(
+            'clojure',
+            $extractor->languageId(['textDocument' => ['languageId' => 'clojure']]),
+        );
+    }
+
+    public function test_text_returns_default_when_missing(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame('', $extractor->text([]));
+    }
+
+    public function test_text_returns_value_when_present(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertSame(
+            '(ns foo)',
+            $extractor->text(['textDocument' => ['text' => '(ns foo)']]),
+        );
+    }
+
+    public function test_is_valid_range_accepts_well_formed_range(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertTrue($extractor->isValidRange([
+            'start' => ['line' => 0, 'character' => 0],
+            'end' => ['line' => 0, 'character' => 1],
+        ]));
+    }
+
+    public function test_is_valid_range_rejects_missing_end(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertFalse($extractor->isValidRange([
+            'start' => ['line' => 0, 'character' => 0],
+        ]));
+    }
+
+    public function test_is_valid_range_rejects_non_integer_offsets(): void
+    {
+        $extractor = new ParamsExtractor();
+
+        self::assertFalse($extractor->isValidRange([
+            'start' => ['line' => '0', 'character' => 0],
+            'end' => ['line' => 0, 'character' => 1],
+        ]));
+    }
+}

--- a/tests/php/Unit/Lsp/Application/Rpc/RequestDispatcherTest.php
+++ b/tests/php/Unit/Lsp/Application/Rpc/RequestDispatcherTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lsp\Application\Rpc;
+
+use Phel\Lsp\Application\Document\DocumentStore;
+use Phel\Lsp\Application\Rpc\RequestDispatcher;
+use Phel\Lsp\Application\Rpc\ResponseBuilder;
+use Phel\Lsp\Application\Session\Session;
+use Phel\Lsp\Domain\HandlerInterface;
+use Phel\Lsp\Domain\NotificationSink;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class RequestDispatcherTest extends TestCase
+{
+    public function test_returns_invalid_request_error_when_method_missing_on_request(): void
+    {
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+
+        $response = $dispatcher->dispatch(['id' => 1], $this->newSession());
+
+        self::assertSame(ResponseBuilder::INVALID_REQUEST, $response['error']['code'] ?? null);
+        self::assertSame(1, $response['id'] ?? null);
+    }
+
+    public function test_ignores_missing_method_on_notification(): void
+    {
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+
+        $response = $dispatcher->dispatch([], $this->newSession());
+
+        self::assertNull($response);
+    }
+
+    public function test_method_not_found_for_unknown_request_method(): void
+    {
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+
+        $response = $dispatcher->dispatch([
+            'id' => 7,
+            'method' => 'textDocument/unknownThing',
+        ], $this->newSession());
+
+        self::assertSame(ResponseBuilder::METHOD_NOT_FOUND, $response['error']['code'] ?? null);
+        self::assertSame(7, $response['id'] ?? null);
+    }
+
+    public function test_silently_drops_unknown_notification(): void
+    {
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+
+        $response = $dispatcher->dispatch([
+            'method' => '$/somethingNoOneKnowsAbout',
+        ], $this->newSession());
+
+        self::assertNull($response);
+    }
+
+    public function test_dispatches_params_default_to_empty_array_when_missing(): void
+    {
+        $captured = [];
+        $handler = $this->newHandler('probe', isNotification: false, onHandle: static function (array $params) use (&$captured): string {
+            $captured = $params;
+            return 'ok';
+        });
+
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($handler);
+
+        $response = $dispatcher->dispatch(['id' => 2, 'method' => 'probe'], $this->newSession());
+
+        self::assertSame([], $captured);
+        self::assertSame('ok', $response['result'] ?? null);
+    }
+
+    public function test_params_of_wrong_type_default_to_empty_array(): void
+    {
+        $captured = [];
+        $handler = $this->newHandler('probe', isNotification: false, onHandle: static function (array $params) use (&$captured): string {
+            $captured = $params;
+            return 'ok';
+        });
+
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($handler);
+
+        $response = $dispatcher->dispatch([
+            'id' => 3,
+            'method' => 'probe',
+            'params' => 'not-an-array',
+        ], $this->newSession());
+
+        self::assertSame([], $captured);
+        self::assertSame('ok', $response['result'] ?? null);
+    }
+
+    public function test_handler_exception_becomes_internal_error_for_request(): void
+    {
+        $handler = $this->newHandler('boom', isNotification: false, onHandle: static function (): never {
+            throw new RuntimeException('fatal');
+        });
+
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($handler);
+
+        $response = $dispatcher->dispatch(['id' => 10, 'method' => 'boom'], $this->newSession());
+
+        self::assertSame(ResponseBuilder::INTERNAL_ERROR, $response['error']['code'] ?? null);
+        self::assertSame('fatal', $response['error']['message'] ?? null);
+    }
+
+    public function test_handler_exception_dropped_silently_for_notification(): void
+    {
+        $handler = $this->newHandler('note', isNotification: true, onHandle: static function (): never {
+            throw new RuntimeException('noisy');
+        });
+
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($handler);
+
+        $response = $dispatcher->dispatch(['method' => 'note'], $this->newSession());
+
+        self::assertNull($response);
+    }
+
+    public function test_notification_result_not_wrapped_in_response(): void
+    {
+        $handler = $this->newHandler('note', isNotification: true, onHandle: static fn(): string => 'ignored');
+
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($handler);
+
+        self::assertNull($dispatcher->dispatch(['method' => 'note'], $this->newSession()));
+    }
+
+    public function test_known_methods_returns_registered_names(): void
+    {
+        $dispatcher = new RequestDispatcher(new ResponseBuilder());
+        $dispatcher->register($this->newHandler('a', false, static fn(): null => null));
+        $dispatcher->register($this->newHandler('b', true, static fn(): null => null));
+
+        $methods = $dispatcher->knownMethods();
+
+        self::assertContains('a', $methods);
+        self::assertContains('b', $methods);
+        self::assertTrue($dispatcher->hasMethod('a'));
+        self::assertFalse($dispatcher->hasMethod('missing'));
+    }
+
+    private function newSession(): Session
+    {
+        return new Session(new DocumentStore(), new class() implements NotificationSink {
+            public function notify(string $method, array $params): void {}
+        });
+    }
+
+    private function newHandler(string $method, bool $isNotification, callable $onHandle): HandlerInterface
+    {
+        return new readonly class($method, $isNotification, $onHandle) implements HandlerInterface {
+            public function __construct(
+                private string $methodName,
+                private bool $notification,
+                private mixed $onHandle,
+            ) {}
+
+            public function method(): string
+            {
+                return $this->methodName;
+            }
+
+            public function isNotification(): bool
+            {
+                return $this->notification;
+            }
+
+            public function handle(array $params, Session $session): mixed
+            {
+                return ($this->onHandle)($params, $session);
+            }
+        };
+    }
+}

--- a/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
+++ b/tests/php/Unit/Nrepl/Application/Op/EvalResultResponderTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Application\Op;
+
+use Phel\Nrepl\Application\Op\EvalResultResponder;
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Session\SessionRegistry;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
+use Phel\Run\Domain\Repl\EvalResult;
+use PHPUnit\Framework\TestCase;
+
+final class EvalResultResponderTest extends TestCase
+{
+    public function test_success_emits_value_and_done_and_records_session_value(): void
+    {
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('42');
+
+        $registry = new SessionRegistry();
+        $session = $registry->create();
+        $responder = new EvalResultResponder($printer, $registry);
+
+        $responses = $responder->respond(
+            new OpRequest('eval', 'req-1', $session->id, []),
+            EvalResult::success(42),
+            'fallback',
+        );
+
+        self::assertCount(2, $responses);
+        self::assertSame('42', $responses[0]->payload['value']);
+        self::assertSame('user', $responses[0]->payload['ns']);
+        self::assertSame(['done'], $responses[1]->payload['status']);
+        self::assertSame(42, $session->lastValue());
+    }
+
+    public function test_success_uses_user_namespace_when_session_missing(): void
+    {
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('nil');
+
+        $responder = new EvalResultResponder($printer, new SessionRegistry());
+
+        $responses = $responder->respond(
+            new OpRequest('eval', null, null, []),
+            EvalResult::success(null),
+            'fallback',
+        );
+
+        self::assertSame('user', $responses[0]->payload['ns']);
+    }
+
+    public function test_success_prepends_out_frame_when_output_present(): void
+    {
+        $printer = $this->createStub(PrinterInterface::class);
+        $printer->method('print')->willReturn('nil');
+
+        $responder = new EvalResultResponder($printer, new SessionRegistry());
+
+        $responses = $responder->respond(
+            new OpRequest('eval', null, null, []),
+            EvalResult::success(null, 'hello'),
+            'fallback',
+        );
+
+        self::assertCount(3, $responses);
+        self::assertSame('hello', $responses[0]->payload['out']);
+    }
+
+    public function test_incomplete_emits_single_frame_with_incomplete_status(): void
+    {
+        $responder = new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+
+        $responses = $responder->respond(
+            new OpRequest('eval', 'req-1', null, []),
+            EvalResult::incomplete(),
+            'fallback',
+        );
+
+        self::assertCount(1, $responses);
+        self::assertContains('incomplete', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[0]->payload['status']);
+    }
+
+    public function test_failure_uses_fallback_message_when_no_error_attached(): void
+    {
+        $responder = new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+
+        $error = new EvalError(
+            exceptionClass: 'CustomException',
+            message: 'real message',
+            errorCode: null,
+            file: null,
+            line: null,
+            column: null,
+            endLine: null,
+            endColumn: null,
+            codeSnippet: null,
+            stackTrace: '',
+            phase: 'compile',
+            frames: [],
+        );
+
+        $responses = $responder->respond(
+            new OpRequest('eval', 'req-1', null, []),
+            EvalResult::failure($error),
+            'fallback',
+        );
+
+        self::assertCount(2, $responses);
+        self::assertSame('CustomException', $responses[0]->payload['ex']);
+        self::assertSame('CustomException', $responses[0]->payload['root-ex']);
+        self::assertStringContainsString('real message', (string) $responses[0]->payload['err']);
+    }
+
+    public function test_failure_with_filename_embeds_filename_in_err_message(): void
+    {
+        $responder = new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+
+        $responses = $responder->respond(
+            new OpRequest('load-file', 'req-1', null, []),
+            EvalResult::failure(new EvalError(
+                exceptionClass: 'E',
+                message: 'boom',
+                errorCode: null,
+                file: null,
+                line: null,
+                column: null,
+                endLine: null,
+                endColumn: null,
+                codeSnippet: null,
+                stackTrace: '',
+                phase: 'compile',
+                frames: [],
+            )),
+            'fallback',
+            'my.phel',
+        );
+
+        self::assertStringContainsString('(my.phel)', (string) $responses[0]->payload['err']);
+        // With a file name, no "root-ex" field (matches legacy LoadFileOp behavior).
+        self::assertArrayNotHasKey('root-ex', $responses[0]->payload);
+    }
+
+    public function test_failure_without_error_falls_back_to_generic_class(): void
+    {
+        $responder = new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        );
+
+        // An explicit "non-success, non-incomplete, no error" case (defensive);
+        // the responder should still produce a two-frame error reply.
+        $failure = EvalResult::failure(new EvalError(
+            exceptionClass: 'Boom',
+            message: 'raw',
+            errorCode: null,
+            file: null,
+            line: null,
+            column: null,
+            endLine: null,
+            endColumn: null,
+            codeSnippet: null,
+            stackTrace: '',
+            phase: 'compile',
+            frames: [],
+        ));
+
+        $responses = $responder->respond(
+            new OpRequest('eval', 'req-1', null, []),
+            $failure,
+            'fallback',
+        );
+
+        self::assertCount(2, $responses);
+        self::assertContains('eval-error', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[1]->payload['status']);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/EvalOpTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Nrepl\Domain\Op;
 
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Nrepl\Application\Op\EvalOp;
+use Phel\Nrepl\Application\Op\EvalResultResponder;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Printer\PrinterInterface;
@@ -27,7 +28,7 @@ final class EvalOpTest extends TestCase
         $registry = new SessionRegistry();
         $session = $registry->create();
 
-        $op = new EvalOp($run, $printer, $registry);
+        $op = new EvalOp($run, new EvalResultResponder($printer, $registry));
         $responses = $op->handle(new OpRequest('eval', 'r1', $session->id, [
             'op' => 'eval',
             'code' => '(+ 1 2)',
@@ -48,7 +49,8 @@ final class EvalOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturn('nil');
 
-        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $registry = new SessionRegistry();
+        $op = new EvalOp($run, new EvalResultResponder($printer, $registry));
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => '(println "x")',
@@ -82,7 +84,8 @@ final class EvalOpTest extends TestCase
 
         $printer = $this->createStub(PrinterInterface::class);
 
-        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $registry = new SessionRegistry();
+        $op = new EvalOp($run, new EvalResultResponder($printer, $registry));
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => 'xx',
@@ -90,8 +93,30 @@ final class EvalOpTest extends TestCase
 
         self::assertCount(2, $responses);
         self::assertSame('CompilerException', $responses[0]->payload['ex']);
+        self::assertSame('CompilerException', $responses[0]->payload['root-ex']);
+        self::assertStringContainsString('unbound symbol', (string) $responses[0]->payload['err']);
         self::assertContains('eval-error', $responses[0]->payload['status']);
         self::assertContains('done', $responses[1]->payload['status']);
+    }
+
+    public function test_it_falls_back_to_generic_error_when_no_eval_error_is_attached(): void
+    {
+        $run = $this->createStub(RunFacadeInterface::class);
+        // Failure without a concrete EvalError: the responder must still produce a frame.
+        $run->method('structuredEval')->willReturn(EvalResult::incomplete());
+
+        $registry = new SessionRegistry();
+        $op = new EvalOp($run, new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            $registry,
+        ));
+        $responses = $op->handle(new OpRequest('eval', 'r1', null, [
+            'op' => 'eval',
+            'code' => '(+ 1',
+        ]));
+
+        self::assertCount(1, $responses);
+        self::assertContains('incomplete', $responses[0]->payload['status']);
     }
 
     public function test_it_reports_incomplete_form(): void
@@ -99,7 +124,10 @@ final class EvalOpTest extends TestCase
         $run = $this->createStub(RunFacadeInterface::class);
         $run->method('structuredEval')->willReturn(EvalResult::incomplete());
 
-        $op = new EvalOp($run, $this->createStub(PrinterInterface::class), new SessionRegistry());
+        $op = new EvalOp($run, new EvalResultResponder(
+            $this->createStub(PrinterInterface::class),
+            new SessionRegistry(),
+        ));
         $responses = $op->handle(new OpRequest('eval', 'r1', null, [
             'op' => 'eval',
             'code' => '(+ 1',
@@ -112,8 +140,7 @@ final class EvalOpTest extends TestCase
     {
         $op = new EvalOp(
             $this->createStub(RunFacadeInterface::class),
-            $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
+            new EvalResultResponder($this->createStub(PrinterInterface::class), new SessionRegistry()),
         );
         $responses = $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval']));
 
@@ -131,7 +158,7 @@ final class EvalOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturn('3');
 
-        $op = new EvalOp($run, $printer, new SessionRegistry());
+        $op = new EvalOp($run, new EvalResultResponder($printer, new SessionRegistry()));
         $op->handle(new OpRequest('eval', 'r1', null, ['op' => 'eval', 'code' => '(+ 1 2)']));
     }
 }

--- a/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/LoadFileOpTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Nrepl\Domain\Op;
 
+use Phel\Nrepl\Application\Op\EvalResultResponder;
 use Phel\Nrepl\Application\Op\LoadFileOp;
 use Phel\Nrepl\Domain\Op\OpRequest;
 use Phel\Nrepl\Domain\Session\SessionRegistry;
 use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\EvalError;
 use Phel\Run\Domain\Repl\EvalResult;
 use Phel\Shared\Facade\RunFacadeInterface;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +24,7 @@ final class LoadFileOpTest extends TestCase
         $printer = $this->createStub(PrinterInterface::class);
         $printer->method('print')->willReturn('42');
 
-        $op = new LoadFileOp($run, $printer, new SessionRegistry());
+        $op = new LoadFileOp($run, new EvalResultResponder($printer, new SessionRegistry()));
         $responses = $op->handle(new OpRequest('load-file', 'r1', null, [
             'op' => 'load-file',
             'file' => '(def x 42) x',
@@ -38,8 +40,7 @@ final class LoadFileOpTest extends TestCase
     {
         $op = new LoadFileOp(
             $this->createStub(RunFacadeInterface::class),
-            $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
+            new EvalResultResponder($this->createStub(PrinterInterface::class), new SessionRegistry()),
         );
         $responses = $op->handle(new OpRequest('load-file', 'r1', null, ['op' => 'load-file']));
 
@@ -50,9 +51,44 @@ final class LoadFileOpTest extends TestCase
     {
         $op = new LoadFileOp(
             $this->createStub(RunFacadeInterface::class),
-            $this->createStub(PrinterInterface::class),
-            new SessionRegistry(),
+            new EvalResultResponder($this->createStub(PrinterInterface::class), new SessionRegistry()),
         );
         self::assertSame('load-file', $op->name());
+    }
+
+    public function test_it_includes_file_name_in_error_message(): void
+    {
+        $error = new EvalError(
+            exceptionClass: 'CompilerException',
+            message: 'boom',
+            errorCode: null,
+            file: null,
+            line: null,
+            column: null,
+            endLine: null,
+            endColumn: null,
+            codeSnippet: null,
+            stackTrace: '',
+            phase: 'compile',
+            frames: [],
+        );
+
+        $run = $this->createStub(RunFacadeInterface::class);
+        $run->method('structuredEval')->willReturn(EvalResult::failure($error));
+
+        $op = new LoadFileOp(
+            $run,
+            new EvalResultResponder($this->createStub(PrinterInterface::class), new SessionRegistry()),
+        );
+        $responses = $op->handle(new OpRequest('load-file', 'r1', null, [
+            'op' => 'load-file',
+            'file' => '(broken form)',
+            'file-name' => 'missing.phel',
+        ]));
+
+        self::assertSame('CompilerException', $responses[0]->payload['ex']);
+        self::assertStringContainsString('(missing.phel)', (string) $responses[0]->payload['err']);
+        self::assertContains('eval-error', $responses[0]->payload['status']);
+        self::assertContains('done', $responses[1]->payload['status']);
     }
 }

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -204,4 +204,71 @@ final class TestCommandOptionsTest extends TestCase
             $options->asPhelHashMap(),
         );
     }
+
+    public function test_include_and_exclude_roundtrip_preserves_all_keys(): void
+    {
+        $input = [
+            TestCommandOptions::FILTER => 'add-',
+            TestCommandOptions::TESTDOX => true,
+            TestCommandOptions::FAIL_FAST => true,
+            TestCommandOptions::REPORTERS => ['dot', 'junit-xml'],
+            TestCommandOptions::JUNIT_OUTPUT => 'build/junit.xml',
+            TestCommandOptions::INCLUDE => ['integration'],
+            TestCommandOptions::EXCLUDE => ['slow'],
+            TestCommandOptions::NS_PATTERNS => ['phel.http.**'],
+            TestCommandOptions::FILTERS => ['get-'],
+        ];
+
+        $printed = TestCommandOptions::fromArray($input)->asPhelHashMap();
+
+        self::assertStringContainsString(':filter "add-"', $printed);
+        self::assertStringContainsString(':testdox true', $printed);
+        self::assertStringContainsString(':fail-fast true', $printed);
+        self::assertStringContainsString(':reporters [:dot :junit-xml]', $printed);
+        self::assertStringContainsString(':junit-output "build/junit.xml"', $printed);
+        self::assertStringContainsString(':include [:integration]', $printed);
+        self::assertStringContainsString(':exclude [:slow]', $printed);
+        self::assertStringContainsString(':ns-patterns ["phel.http.**"]', $printed);
+        self::assertStringContainsString(':filters ["get-"]', $printed);
+    }
+
+    public function test_empty_then_populated_produces_stable_shape(): void
+    {
+        $empty = TestCommandOptions::empty();
+        $populated = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['integration'],
+        ]);
+
+        self::assertStringStartsWith('{:filter nil :testdox false :fail-fast false', $empty->asPhelHashMap());
+        self::assertStringStartsWith('{:filter nil :testdox false :fail-fast false', $populated->asPhelHashMap());
+    }
+
+    public function test_selector_values_survive_exact_string_equality_check(): void
+    {
+        // Regression-style coverage: every key that arrives from the CLI must
+        // appear in the printed hash-map exactly once, in the order the
+        // generator produces.
+        $printed = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['a', 'b'],
+            TestCommandOptions::EXCLUDE => ['c'],
+            TestCommandOptions::NS_PATTERNS => ['x.*'],
+            TestCommandOptions::FILTERS => ['y'],
+        ])->asPhelHashMap();
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :include [:a :b] :exclude [:c] :ns-patterns ["x.*"] :filters ["y"]}',
+            $printed,
+        );
+    }
+
+    public function test_filter_with_quote_character_is_escaped_by_printer(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::FILTER => 'has "quotes"',
+        ]);
+
+        // The Printer must render the string with escaped quotes so that the
+        // generated Phel expression is syntactically valid.
+        self::assertStringContainsString(':filter "has \\"quotes\\""', $options->asPhelHashMap());
+    }
 }

--- a/tests/php/Unit/Watch/Application/Watcher/EventDebouncerTest.php
+++ b/tests/php/Unit/Watch/Application/Watcher/EventDebouncerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Watch\Application\Watcher;
+
+use Phel\Watch\Application\Watcher\EventDebouncer;
+use Phel\Watch\Domain\ClockInterface;
+use Phel\Watch\Transfer\WatchEvent;
+use PHPUnit\Framework\TestCase;
+
+final class EventDebouncerTest extends TestCase
+{
+    public function test_no_flush_when_no_events_recorded(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 100);
+
+        $called = 0;
+        $debouncer->flushIfReady(static function (array $events) use (&$called): void {
+            ++$called;
+        });
+
+        self::assertSame(0, $called);
+        self::assertFalse($debouncer->hasPending());
+    }
+
+    public function test_flush_waits_for_debounce_window(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 100);
+
+        $debouncer->record(new WatchEvent('/x.phel', WatchEvent::KIND_MODIFIED));
+        self::assertTrue($debouncer->hasPending());
+
+        $flushed = [];
+        $callback = static function (array $events) use (&$flushed): void {
+            $flushed = $events;
+        };
+
+        // Immediately (0ms elapsed) — debouncer should not yet fire.
+        $debouncer->flushIfReady($callback);
+        self::assertSame([], $flushed);
+        self::assertTrue($debouncer->hasPending());
+
+        // Advance past the window and flush again.
+        $clock->advance(150);
+        $debouncer->flushIfReady($callback);
+
+        self::assertCount(1, $flushed);
+        self::assertSame('/x.phel', $flushed[0]->path);
+        self::assertFalse($debouncer->hasPending());
+    }
+
+    public function test_force_bypasses_debounce_window(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 500);
+
+        $debouncer->record(new WatchEvent('/x.phel', WatchEvent::KIND_MODIFIED));
+
+        $flushed = null;
+        $debouncer->flushIfReady(static function (array $events) use (&$flushed): void {
+            $flushed = $events;
+        }, force: true);
+
+        self::assertCount(1, $flushed ?? []);
+        self::assertFalse($debouncer->hasPending());
+    }
+
+    public function test_coalesces_duplicate_paths_keeping_latest_non_delete(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 10);
+
+        $debouncer->record(new WatchEvent('/a.phel', WatchEvent::KIND_CREATED));
+        $debouncer->record(new WatchEvent('/a.phel', WatchEvent::KIND_MODIFIED));
+        $debouncer->record(new WatchEvent('/b.phel', WatchEvent::KIND_MODIFIED));
+
+        $clock->advance(20);
+
+        $flushed = null;
+        $debouncer->flushIfReady(static function (array $events) use (&$flushed): void {
+            $flushed = $events;
+        });
+
+        self::assertNotNull($flushed);
+        self::assertCount(2, $flushed);
+
+        $byPath = [];
+        foreach ($flushed as $event) {
+            $byPath[$event->path] = $event->kind;
+        }
+
+        self::assertSame(WatchEvent::KIND_MODIFIED, $byPath['/a.phel'] ?? null, 'latest non-delete wins for duplicates');
+        self::assertSame(WatchEvent::KIND_MODIFIED, $byPath['/b.phel'] ?? null);
+    }
+
+    public function test_deletion_is_sticky_across_later_modifications(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 10);
+
+        $debouncer->record(new WatchEvent('/doomed.phel', WatchEvent::KIND_DELETED));
+        $debouncer->record(new WatchEvent('/doomed.phel', WatchEvent::KIND_MODIFIED));
+
+        $clock->advance(20);
+
+        $flushed = null;
+        $debouncer->flushIfReady(static function (array $events) use (&$flushed): void {
+            $flushed = $events;
+        });
+
+        self::assertCount(1, $flushed ?? []);
+        self::assertSame(WatchEvent::KIND_DELETED, $flushed[0]->kind);
+    }
+
+    public function test_buffer_is_cleared_after_flush(): void
+    {
+        $clock = new DebouncerFakeClock();
+        $debouncer = new EventDebouncer($clock, 5);
+
+        $debouncer->record(new WatchEvent('/once.phel', WatchEvent::KIND_MODIFIED));
+
+        $clock->advance(10);
+
+        $callCount = 0;
+        $flusher = static function (array $events) use (&$callCount): void {
+            ++$callCount;
+        };
+
+        $debouncer->flushIfReady($flusher);
+        // Second flush right after should be a no-op: buffer is empty.
+        $clock->advance(100);
+        $debouncer->flushIfReady($flusher);
+
+        self::assertSame(1, $callCount);
+    }
+}
+
+final class DebouncerFakeClock implements ClockInterface
+{
+    private int $now = 0;
+
+    public function nowMs(): int
+    {
+        return $this->now;
+    }
+
+    public function sleepMs(int $ms): void
+    {
+        $this->now += max(0, $ms);
+    }
+
+    public function advance(int $ms): void
+    {
+        $this->now += max(0, $ms);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

After the recent parity push we had four overlapping clusters of code that had grown rough edges: duplicated namespace walking in the Lint rules, eval-response glue inlined into `EvalOp`/`LoadFileOp`, the LSP handlers each rolling their own params extraction and symbol resolution, three watcher implementations sharing a copy-pasted debouncer, and the `match` macro plus test framework carrying too much in a single top-level function.

This PR is the cleanup pass: same behaviour, smaller surfaces, more unit coverage.

## 💡 Goal

Close out the combined refactor work as a single PR so the improvements ship together, without splitting interdependent edits across four branches.

## 🔖 Changes

**Nrepl / Api / Lint cluster**
- Extract `EvalResultResponder` and an `OpStatus` enum so `EvalOp` and `LoadFileOp` stop assembling response envelopes by hand.
- Fold the "walk forms until we find the `ns` form" logic in the Lint rules into a shared `NamespaceForm` helper.
- Add `SemanticDiagnosticPromoter` so rules that emit semantic diagnostics share one promotion path.
- Introduce `SymbolKey` and `PhelFileIterator` helpers in `Api` and route `ProjectIndexer`, `ReferenceFinder`, and `SymbolResolver` through them.

**Lsp / Watch / match cluster**
- Extract `ParamsExtractor`, `SymbolKindMapper`, and an LSP-side `SymbolResolver`; every LSP handler now reuses them instead of re-implementing `params -> uri/position` and symbol lookup locally.
- Extract `EventDebouncer` out of `FswatchWatcher`, `InotifyWatcher`, and `PollingWatcher` so the three implementations no longer drift.
- Regroup the `match` macro into one `compile-*` function per pattern kind (wildcard, literal, binding, vector, map, guard, as, or) with a small dispatch at the top.

**Test framework cluster**
- Rewrite `src/phel/test.phel` around named helpers (reporter selection, test discovery, result accumulation) rather than one long `defn`.
- Add focused test files for reporters, selectors, shrinking, and schema validation.

**Lang tag handlers / schema / Fiber cluster**
- Introduce `AbstractStringTagHandler` as the shared base for `#inst`, `#regex`, `#uuid`; the three handlers now only say how to turn the parsed string into their value.
- Tighten a few schema namespaces to only export what the rest of the schema module actually needs.
- Backfill unit tests for `Future`, `Promise`, and `Scheduler` that the Fiber work was missing.

No user-visible behaviour change; this is pure structural cleanup plus added test coverage.

## ✅ Verification

- `composer test-quality` green (php-cs-fixer, psalm, phpstan, rector).
- `composer test-compiler` green (2493 tests).
- `composer test-core` green (4341 Phel tests).