### PR TITLE
ref(nrepl,api,lint): second-pass cleanup

### DIFF
--- a/src/php/Api/Application/DocstringSignatureParser.php
+++ b/src/php/Api/Application/DocstringSignatureParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use function explode;
+use function preg_match;
+use function trim;
+
+/**
+ * Pulls the function signature and description out of a Phel docstring.
+ *
+ * Docstrings follow the convention:
+ *
+ * ```phel
+ * (my-fn arg1 arg2)
+ * (my-fn arg1 arg2 arg3)
+ * ```
+ * Human-readable prose follows.
+ *
+ * The parser returns `{signatures, description}`; the surrounding
+ * ```phel fence and trailing newline are stripped.
+ */
+final class DocstringSignatureParser
+{
+    /**
+     * @return array{signatures: list<string>, description: string}
+     */
+    public static function parse(string $docstring): array
+    {
+        preg_match('#(```phel\n(?<signature>.*)\n```\n)?(?<desc>.*)#s', $docstring, $matches);
+
+        $signatureBlock = $matches['signature'] ?? '';
+        $description = $matches['desc'] ?? '';
+
+        return [
+            'signatures' => self::splitSignatures($signatureBlock),
+            'description' => $description,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function splitSignatures(string $signatureBlock): array
+    {
+        if ($signatureBlock === '') {
+            return [];
+        }
+
+        $signatures = [];
+        foreach (explode("\n", $signatureBlock) as $line) {
+            $line = trim($line);
+            if ($line !== '') {
+                $signatures[] = $line;
+            }
+        }
+
+        return $signatures;
+    }
+}

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -47,11 +47,9 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
             }
 
             $doc = (string) ($meta[Keyword::create('doc')] ?? '');
-            preg_match('#(```phel\n(?<signature>.*)\n```\n)?(?<desc>.*)#s', $doc, $matches);
-
-            $signatureBlock = $matches['signature'] ?? '';
-            $signatures = $this->parseSignatures($signatureBlock);
-            $description = $matches['desc'] ?? '';
+            $parsed = DocstringSignatureParser::parse($doc);
+            $signatures = $parsed['signatures'];
+            $description = $parsed['description'];
 
             $namespace = $this->extractNamespace($fnName);
             $groupKey = $this->phelFnGroupKeyGenerator->generateGroupKey($namespace, $fnName);
@@ -223,27 +221,5 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
         }
 
         return $url;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function parseSignatures(string $signatureBlock): array
-    {
-        if ($signatureBlock === '') {
-            return [];
-        }
-
-        $lines = explode("\n", $signatureBlock);
-        $signatures = [];
-
-        foreach ($lines as $line) {
-            $line = trim($line);
-            if ($line !== '') {
-                $signatures[] = $line;
-            }
-        }
-
-        return $signatures;
     }
 }

--- a/src/php/Api/Application/PhpSymbolCatalog.php
+++ b/src/php/Api/Application/PhpSymbolCatalog.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application;
+
+use function get_declared_classes;
+use function get_defined_functions;
+
+/**
+ * Lazy cache over native PHP function and class lists.
+ *
+ * Two goals:
+ * - Avoid scanning `get_defined_functions()` / `get_declared_classes()`
+ *   on every REPL completion request.
+ * - Replace the previous static-field caching inside `ReplCompleter`
+ *   so each REPL completer can be constructed in isolation and tested
+ *   without leaking state across cases.
+ */
+final class PhpSymbolCatalog
+{
+    /** @var list<callable-string>|null */
+    private ?array $functions = null;
+
+    /** @var list<class-string>|null */
+    private ?array $classes = null;
+
+    /**
+     * @return list<callable-string>
+     */
+    public function functions(): array
+    {
+        if ($this->functions === null) {
+            $this->functions = get_defined_functions()['internal'];
+        }
+
+        return $this->functions;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function classes(): array
+    {
+        if ($this->classes === null) {
+            $this->classes = get_declared_classes();
+        }
+
+        return $this->classes;
+    }
+}

--- a/src/php/Api/Application/ReplCompleter.php
+++ b/src/php/Api/Application/ReplCompleter.php
@@ -13,8 +13,6 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 
-use function get_declared_classes;
-use function get_defined_functions;
 use function str_starts_with;
 use function trim;
 
@@ -23,13 +21,9 @@ use function trim;
  */
 final class ReplCompleter implements ReplCompleterInterface
 {
-    private static bool $loaded = false;
+    private bool $phelFunctionsLoaded = false;
 
-    /** @var list<string> */
-    private static array $phpFunctions = [];
-
-    /** @var list<string> */
-    private static array $phpClasses = [];
+    private readonly PhpSymbolCatalog $phpSymbols;
 
     /**
      * @param list<string> $allNamespaces
@@ -38,7 +32,10 @@ final class ReplCompleter implements ReplCompleterInterface
         private readonly PhelFnLoaderInterface $phelFnLoader,
         private readonly array $allNamespaces = [],
         private readonly ?GlobalEnvironmentInterface $globalEnvironment = null,
-    ) {}
+        ?PhpSymbolCatalog $phpSymbols = null,
+    ) {
+        $this->phpSymbols = $phpSymbols ?? new PhpSymbolCatalog();
+    }
 
     /**
      * Complete input from either PHP or Phel context.
@@ -62,9 +59,9 @@ final class ReplCompleter implements ReplCompleterInterface
      */
     public function completeWithTypes(string $input): array
     {
-        if (!self::$loaded) {
+        if (!$this->phelFunctionsLoaded) {
             $this->phelFnLoader->loadAllPhelFunctions($this->allNamespaces);
-            self::$loaded = true;
+            $this->phelFunctionsLoaded = true;
         }
 
         $input = trim($input);
@@ -86,23 +83,15 @@ final class ReplCompleter implements ReplCompleterInterface
      */
     private function completePhpSymbolsWithTypes(string $prefix): array
     {
-        if (self::$phpFunctions === []) {
-            self::$phpFunctions = get_defined_functions()['internal'];
-        }
-
-        if (self::$phpClasses === []) {
-            self::$phpClasses = get_declared_classes();
-        }
-
         $matches = [];
 
-        foreach (self::$phpFunctions as $fn) {
+        foreach ($this->phpSymbols->functions() as $fn) {
             if (str_starts_with($fn, $prefix)) {
                 $matches[] = new CompletionResultTransfer('php/' . $fn, 'php-function');
             }
         }
 
-        foreach (self::$phpClasses as $class) {
+        foreach ($this->phpSymbols->classes() as $class) {
             if (str_starts_with($class, $prefix)) {
                 $matches[] = new CompletionResultTransfer('php/' . $class, 'class');
             }

--- a/src/php/Lint/Application/Rule/ArityMismatchRule.php
+++ b/src/php/Lint/Application/Rule/ArityMismatchRule.php
@@ -104,38 +104,18 @@ final readonly class ArityMismatchRule implements LintRuleInterface
      */
     private function collectArities(PersistentListInterface $form): ?array
     {
-        $size = count($form);
         $minArity = PHP_INT_MAX;
         $maxArity = 0;
         $variadic = false;
         $found = false;
 
-        for ($i = 2; $i < $size; ++$i) {
-            $child = $form->get($i);
-
-            if ($child instanceof PersistentVectorInterface) {
-                [$arity, $isVariadic] = $this->analyseArityVector($child);
-                $found = true;
-                $minArity = min($minArity, $arity);
-                $maxArity = max($maxArity, $arity);
-                if ($isVariadic) {
-                    $variadic = true;
-                }
-
-                break; // single-arity form: first vector is the param list.
-            }
-
-            if ($child instanceof PersistentListInterface && count($child) > 0) {
-                $head = $child->get(0);
-                if ($head instanceof PersistentVectorInterface) {
-                    [$arity, $isVariadic] = $this->analyseArityVector($head);
-                    $found = true;
-                    $minArity = min($minArity, $arity);
-                    $maxArity = max($maxArity, $arity);
-                    if ($isVariadic) {
-                        $variadic = true;
-                    }
-                }
+        foreach (FnParamVectors::of($form) as $params) {
+            [$arity, $isVariadic] = $this->analyseArityVector($params);
+            $found = true;
+            $minArity = min($minArity, $arity);
+            $maxArity = max($maxArity, $arity);
+            if ($isVariadic) {
+                $variadic = true;
             }
         }
 

--- a/src/php/Lint/Application/Rule/FnParamVectors.php
+++ b/src/php/Lint/Application/Rule/FnParamVectors.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Generator;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+use function count;
+
+/**
+ * Yields the parameter vector(s) declared inside an `(fn ...)`, `(defn ...)`
+ * or variant — whether single-arity (one vector after the name) or
+ * multi-arity (a series of nested `([params] body)` lists).
+ *
+ * Shared helper used by arity, shadowed-binding, and destructuring rules
+ * so they stop re-implementing the same body walk.
+ */
+final class FnParamVectors
+{
+    /**
+     * @return Generator<int, PersistentVectorInterface>
+     */
+    public static function of(PersistentListInterface $fnForm): Generator
+    {
+        $size = count($fnForm);
+        for ($i = 1; $i < $size; ++$i) {
+            $child = $fnForm->get($i);
+
+            if ($child instanceof PersistentVectorInterface) {
+                yield $child;
+
+                // Single-arity: the first vector after the name is the params.
+                return;
+            }
+
+            if ($child instanceof PersistentListInterface && count($child) > 0) {
+                $head = $child->get(0);
+                if ($head instanceof PersistentVectorInterface) {
+                    yield $head;
+                }
+            }
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
+++ b/src/php/Lint/Application/Rule/InvalidDestructuringRule.php
@@ -97,21 +97,8 @@ final readonly class InvalidDestructuringRule implements LintRuleInterface
      */
     private function inspectFn(PersistentListInterface $form, string $uri, array &$result): void
     {
-        $size = count($form);
-        for ($i = 1; $i < $size; ++$i) {
-            $child = $form->get($i);
-            if ($child instanceof PersistentVectorInterface) {
-                $this->validateParamVector($child, $uri, $result);
-
-                break;
-            }
-
-            if ($child instanceof PersistentListInterface && count($child) > 0) {
-                $head = $child->get(0);
-                if ($head instanceof PersistentVectorInterface) {
-                    $this->validateParamVector($head, $uri, $result);
-                }
-            }
+        foreach (FnParamVectors::of($form) as $paramVector) {
+            $this->validateParamVector($paramVector, $uri, $result);
         }
     }
 

--- a/src/php/Lint/Application/Rule/NsClauseIterator.php
+++ b/src/php/Lint/Application/Rule/NsClauseIterator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lint\Application\Rule;
+
+use Generator;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Keyword;
+
+use function count;
+
+/**
+ * Iterates the keyword-headed clauses inside a Phel `(ns ...)` form.
+ *
+ * Both `UnusedRequireRule` and `UnusedImportRule` (and any future rule
+ * inspecting ns directives) need to walk child lists whose head is a
+ * specific keyword — `:require`, `:use`, `:refer-macros`, etc. This
+ * helper extracts that traversal so each rule only has to care about
+ * the clause body.
+ */
+final class NsClauseIterator
+{
+    /**
+     * Yield each child list of `$nsForm` whose first element is the
+     * given keyword name (without the leading `:`).
+     *
+     * @return Generator<int, PersistentListInterface>
+     */
+    public static function clauses(PersistentListInterface $nsForm, string $keywordName): Generator
+    {
+        $size = count($nsForm);
+        for ($i = 2; $i < $size; ++$i) {
+            $child = $nsForm->get($i);
+            if (!$child instanceof PersistentListInterface) {
+                continue;
+            }
+
+            if (count($child) === 0) {
+                continue;
+            }
+
+            $head = $child->get(0);
+            if (!$head instanceof Keyword) {
+                continue;
+            }
+
+            if ($head->getName() !== $keywordName) {
+                continue;
+            }
+
+            yield $child;
+        }
+    }
+}

--- a/src/php/Lint/Application/Rule/ShadowedBindingRule.php
+++ b/src/php/Lint/Application/Rule/ShadowedBindingRule.php
@@ -140,25 +140,17 @@ final readonly class ShadowedBindingRule implements LintRuleInterface
     private function handleFn(PersistentListInterface $form, array $scope, string $uri, array &$result): array
     {
         $newScope = $scope;
-        $size = count($form);
-
-        for ($i = 1; $i < $size; ++$i) {
-            $child = $form->get($i);
-
-            if ($child instanceof PersistentVectorInterface) {
-                $newScope = $this->walkParams($child, $newScope, $uri, $result);
-
-                break;
+        $first = true;
+        foreach (FnParamVectors::of($form) as $paramVector) {
+            if ($first) {
+                $newScope = $this->walkParams($paramVector, $newScope, $uri, $result);
+                $first = false;
+                continue;
             }
 
-            if ($child instanceof PersistentListInterface && count($child) > 0) {
-                $head = $child->get(0);
-                if ($head instanceof PersistentVectorInterface) {
-                    // Each arity introduces its own scope extension at analyze-time;
-                    // still flag inner shadowing of the outer scope.
-                    $this->walkParams($head, $newScope, $uri, $result);
-                }
-            }
+            // Each arity introduces its own scope extension at analyze-time;
+            // still flag inner shadowing of the outer scope.
+            $this->walkParams($paramVector, $newScope, $uri, $result);
         }
 
         return $newScope;

--- a/src/php/Lint/Application/Rule/UnusedImportRule.php
+++ b/src/php/Lint/Application/Rule/UnusedImportRule.php
@@ -61,55 +61,50 @@ final readonly class UnusedImportRule implements LintRuleInterface
     private function collectImports(PersistentListInterface $nsForm): array
     {
         $result = [];
-        $size = count($nsForm);
+        foreach (NsClauseIterator::clauses($nsForm, 'use') as $clause) {
+            foreach ($this->importsInClause($clause) as $entry) {
+                $result[] = $entry;
+            }
+        }
 
-        for ($i = 2; $i < $size; ++$i) {
-            $child = $nsForm->get($i);
-            if (!$child instanceof PersistentListInterface) {
+        return $result;
+    }
+
+    /**
+     * @return list<array{alias:string, display:string, anchor: mixed}>
+     */
+    private function importsInClause(PersistentListInterface $clause): array
+    {
+        if (count($clause) < 2) {
+            return [];
+        }
+
+        $result = [];
+        $size = count($clause);
+        for ($i = 1; $i < $size; ++$i) {
+            $item = $clause->get($i);
+            if (!$item instanceof Symbol) {
                 continue;
             }
 
-            if (count($child) < 2) {
-                continue;
-            }
-
-            $head = $child->get(0);
-            if (!$head instanceof Keyword) {
-                continue;
-            }
-
-            if ($head->getName() !== 'use') {
-                continue;
-            }
-
-            $inner = count($child);
-            for ($j = 1; $j < $inner; ++$j) {
-                $item = $child->get($j);
-                if (!$item instanceof Symbol) {
-                    continue;
-                }
-
-                $target = $item;
-                $alias = null;
-
-                // Look ahead for `:as Alias`.
-                if ($j + 1 < $inner) {
-                    $maybeKey = $child->get($j + 1);
-                    if ($maybeKey instanceof Keyword && $maybeKey->getName() === 'as' && $j + 2 < $inner) {
-                        $aliasCandidate = $child->get($j + 2);
-                        if ($aliasCandidate instanceof Symbol) {
-                            $alias = $aliasCandidate->getName();
-                            $j += 2;
-                        }
+            $alias = null;
+            // Look ahead for `:as Alias`.
+            if ($i + 2 < $size) {
+                $maybeKey = $clause->get($i + 1);
+                if ($maybeKey instanceof Keyword && $maybeKey->getName() === 'as') {
+                    $aliasCandidate = $clause->get($i + 2);
+                    if ($aliasCandidate instanceof Symbol) {
+                        $alias = $aliasCandidate->getName();
+                        $i += 2;
                     }
                 }
-
-                $result[] = [
-                    'alias' => $alias ?? $this->defaultAlias($target),
-                    'display' => $target->getName(),
-                    'anchor' => $target,
-                ];
             }
+
+            $result[] = [
+                'alias' => $alias ?? $this->defaultAlias($item),
+                'display' => $item->getName(),
+                'anchor' => $item,
+            ];
         }
 
         return $result;

--- a/src/php/Lint/Application/Rule/UnusedRequireRule.php
+++ b/src/php/Lint/Application/Rule/UnusedRequireRule.php
@@ -83,28 +83,8 @@ final readonly class UnusedRequireRule implements LintRuleInterface
     private function collectRequires(PersistentListInterface $nsForm): array
     {
         $result = [];
-        $size = count($nsForm);
-
-        for ($i = 2; $i < $size; ++$i) {
-            $child = $nsForm->get($i);
-            if (!$child instanceof PersistentListInterface) {
-                continue;
-            }
-
-            if (count($child) === 0) {
-                continue;
-            }
-
-            $head = $child->get(0);
-            if (!$head instanceof Keyword) {
-                continue;
-            }
-
-            if ($head->getName() !== 'require') {
-                continue;
-            }
-
-            foreach ($this->parseRequireClauseEntries($child) as $entry) {
+        foreach (NsClauseIterator::clauses($nsForm, 'require') as $clause) {
+            foreach ($this->parseRequireClauseEntries($clause) as $entry) {
                 $result[] = $entry;
             }
         }

--- a/src/php/Nrepl/Application/Op/CloneOp.php
+++ b/src/php/Nrepl/Application/Op/CloneOp.php
@@ -23,9 +23,8 @@ final readonly class CloneOp implements OpHandlerInterface
     {
         $session = $this->sessions->create();
 
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
+        return [OpResponse::forRequest(
+            $request,
             ['new-session' => $session->id],
             [OpStatus::DONE],
         )];

--- a/src/php/Nrepl/Application/Op/CloseOp.php
+++ b/src/php/Nrepl/Application/Op/CloseOp.php
@@ -28,11 +28,6 @@ final readonly class CloseOp implements OpHandlerInterface
             ? [OpStatus::DONE, OpStatus::SESSION_CLOSED]
             : [OpStatus::DONE, OpStatus::ERROR, OpStatus::UNKNOWN_SESSION];
 
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
-            [],
-            $status,
-        )];
+        return [OpResponse::forRequest($request, [], $status)];
     }
 }

--- a/src/php/Nrepl/Application/Op/CompletionsOp.php
+++ b/src/php/Nrepl/Application/Op/CompletionsOp.php
@@ -32,9 +32,8 @@ final readonly class CompletionsOp implements OpHandlerInterface
             ];
         }
 
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
+        return [OpResponse::forRequest(
+            $request,
             ['completions' => $completions],
             [OpStatus::DONE],
         )];

--- a/src/php/Nrepl/Application/Op/DescribeOp.php
+++ b/src/php/Nrepl/Application/Op/DescribeOp.php
@@ -32,9 +32,8 @@ final readonly class DescribeOp implements OpHandlerInterface
             $ops[$op] = [];
         }
 
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
+        return [OpResponse::forRequest(
+            $request,
             [
                 'ops' => $ops,
                 'versions' => [

--- a/src/php/Nrepl/Application/Op/EvalOp.php
+++ b/src/php/Nrepl/Application/Op/EvalOp.php
@@ -27,11 +27,10 @@ final readonly class EvalOp implements OpHandlerInterface
     {
         $code = $request->stringParam('code');
         if ($code === '') {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Missing required "code" param for eval op.'],
-                [OpStatus::ERROR, OpStatus::EVAL_ERROR, OpStatus::DONE],
+            return [OpResponse::errorDone(
+                $request,
+                'Missing required "code" param for eval op.',
+                [OpStatus::EVAL_ERROR],
             )];
         }
 

--- a/src/php/Nrepl/Application/Op/EvalResultResponder.php
+++ b/src/php/Nrepl/Application/Op/EvalResultResponder.php
@@ -40,44 +40,35 @@ final readonly class EvalResultResponder
         $responses = [];
 
         if ($result->output !== '') {
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                ['out' => $result->output],
-            );
+            $responses[] = OpResponse::forRequest($request, ['out' => $result->output]);
         }
 
         if ($result->success) {
             $session = $this->sessionFor($request);
             $session?->recordValue($result->value);
 
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                [
-                    'ns' => $session instanceof Session ? $session->namespace() : 'user',
-                    'value' => $this->printer->print($result->value),
-                ],
-            );
+            $responses[] = OpResponse::forRequest($request, [
+                'ns' => $session instanceof Session ? $session->namespace() : 'user',
+                'value' => $this->printer->print($result->value),
+            ]);
 
-            $responses[] = $this->doneFrame($request);
+            $responses[] = OpResponse::done($request);
 
             return $responses;
         }
 
         if ($result->incomplete) {
-            $responses[] = OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Incomplete form: unfinished parser input.'],
-                [OpStatus::ERROR, OpStatus::INCOMPLETE, OpStatus::DONE],
+            $responses[] = OpResponse::errorDone(
+                $request,
+                'Incomplete form: unfinished parser input.',
+                [OpStatus::INCOMPLETE],
             );
 
             return $responses;
         }
 
         $responses[] = $this->errorFrame($request, $result->error, $errorFallbackMessage, $fileName);
-        $responses[] = $this->doneFrame($request);
+        $responses[] = OpResponse::done($request);
 
         return $responses;
     }
@@ -110,21 +101,6 @@ final readonly class EvalResultResponder
             $body['root-ex'] = $exClass;
         }
 
-        return OpResponse::build(
-            $request->id,
-            $request->session,
-            $body,
-            [OpStatus::EVAL_ERROR],
-        );
-    }
-
-    private function doneFrame(OpRequest $request): OpResponse
-    {
-        return OpResponse::build(
-            $request->id,
-            $request->session,
-            [],
-            [OpStatus::DONE],
-        );
+        return OpResponse::forRequest($request, $body, [OpStatus::EVAL_ERROR]);
     }
 }

--- a/src/php/Nrepl/Application/Op/InterruptOp.php
+++ b/src/php/Nrepl/Application/Op/InterruptOp.php
@@ -20,9 +20,8 @@ final class InterruptOp implements OpHandlerInterface
     {
         // Phel evaluates synchronously; there is nothing to interrupt on the
         // single-threaded request path. Acknowledge so editors stay happy.
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
+        return [OpResponse::forRequest(
+            $request,
             [],
             [OpStatus::DONE, OpStatus::SESSION_IDLE],
         )];

--- a/src/php/Nrepl/Application/Op/LoadFileOp.php
+++ b/src/php/Nrepl/Application/Op/LoadFileOp.php
@@ -29,11 +29,10 @@ final readonly class LoadFileOp implements OpHandlerInterface
         $fileName = $request->stringParam('file-name', 'NO_SOURCE_FILE');
 
         if ($fileContent === '') {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Missing required "file" param for load-file op.'],
-                [OpStatus::ERROR, OpStatus::LOAD_FILE_ERROR, OpStatus::DONE],
+            return [OpResponse::errorDone(
+                $request,
+                'Missing required "file" param for load-file op.',
+                [OpStatus::LOAD_FILE_ERROR],
             )];
         }
 

--- a/src/php/Nrepl/Application/Op/LookupOp.php
+++ b/src/php/Nrepl/Application/Op/LookupOp.php
@@ -40,19 +40,17 @@ final class LookupOp implements OpHandlerInterface
         }
 
         if ($symbol === '') {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Missing required "sym" param for ' . $this->opName . ' op.'],
-                [OpStatus::ERROR, OpStatus::NO_INFO, OpStatus::DONE],
+            return [OpResponse::errorDone(
+                $request,
+                'Missing required "sym" param for ' . $this->opName . ' op.',
+                [OpStatus::NO_INFO],
             )];
         }
 
         $fn = $this->findFunction($symbol);
         if (!$fn instanceof PhelFunction) {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
+            return [OpResponse::forRequest(
+                $request,
                 [],
                 [OpStatus::DONE, OpStatus::NO_INFO],
             )];
@@ -67,9 +65,8 @@ final class LookupOp implements OpHandlerInterface
             'line' => $fn->line,
         ];
 
-        return [OpResponse::build(
-            $request->id,
-            $request->session,
+        return [OpResponse::forRequest(
+            $request,
             ['info' => $info, 'eldoc' => $fn->signatures],
             [OpStatus::DONE],
         )];

--- a/src/php/Nrepl/Domain/Op/OpDispatcher.php
+++ b/src/php/Nrepl/Domain/Op/OpDispatcher.php
@@ -57,21 +57,19 @@ final class OpDispatcher
         $request = OpRequest::fromMessage($message);
 
         if ($request->op === '') {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Missing "op" key in request.'],
-                [OpStatus::ERROR, OpStatus::INVALID_OP, OpStatus::DONE],
+            return [OpResponse::errorDone(
+                $request,
+                'Missing "op" key in request.',
+                [OpStatus::INVALID_OP],
             )];
         }
 
         $handler = $this->handlers[$request->op] ?? null;
         if (!$handler instanceof OpHandlerInterface) {
-            return [OpResponse::build(
-                $request->id,
-                $request->session,
-                ['message' => 'Unknown op: ' . $request->op],
-                [OpStatus::ERROR, OpStatus::UNKNOWN_OP, OpStatus::DONE],
+            return [OpResponse::errorDone(
+                $request,
+                'Unknown op: ' . $request->op,
+                [OpStatus::UNKNOWN_OP],
             )];
         }
 

--- a/src/php/Nrepl/Domain/Op/OpResponse.php
+++ b/src/php/Nrepl/Domain/Op/OpResponse.php
@@ -45,6 +45,41 @@ final readonly class OpResponse
         return new self($payload);
     }
 
+    /**
+     * Build a response for the given request, carrying the routing
+     * metadata (id/session) forwards automatically.
+     *
+     * @param array<string, mixed> $body
+     * @param list<string>         $status
+     */
+    public static function forRequest(OpRequest $request, array $body = [], array $status = []): self
+    {
+        return self::build($request->id, $request->session, $body, $status);
+    }
+
+    /**
+     * Final response frame carrying only the DONE status token.
+     */
+    public static function done(OpRequest $request): self
+    {
+        return self::build($request->id, $request->session, [], [OpStatus::DONE]);
+    }
+
+    /**
+     * Convenience for an error response terminated by DONE.
+     *
+     * @param list<string> $extraStatus status tokens inserted between ERROR and DONE
+     */
+    public static function errorDone(OpRequest $request, string $message, array $extraStatus = []): self
+    {
+        return self::build(
+            $request->id,
+            $request->session,
+            ['message' => $message],
+            [OpStatus::ERROR, ...$extraStatus, OpStatus::DONE],
+        );
+    }
+
     public function withExtra(array $extra): self
     {
         return new self(array_merge($this->payload, $extra));

--- a/src/php/Nrepl/Infrastructure/ClientFiberPool.php
+++ b/src/php/Nrepl/Infrastructure/ClientFiberPool.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Nrepl\Infrastructure;
+
+use Closure;
+use Fiber;
+use Throwable;
+
+use function count;
+
+/**
+ * Cooperative pool of per-client Fibers for the nREPL accept loop.
+ *
+ * Each connected client runs in its own Fiber. The accept loop calls
+ * `step()` once per iteration to resume every fiber that is suspended;
+ * fibers that finish or throw are dropped from the pool. Errors are
+ * surfaced through the optional logger rather than propagated, so one
+ * misbehaving client cannot take down the server.
+ */
+final class ClientFiberPool
+{
+    /** @var list<Fiber> */
+    private array $fibers = [];
+
+    private readonly ?Closure $errorLogger;
+
+    public function __construct(?callable $errorLogger = null)
+    {
+        $this->errorLogger = $errorLogger === null ? null : Closure::fromCallable($errorLogger);
+    }
+
+    public function add(Fiber $fiber): void
+    {
+        if (!$fiber->isTerminated()) {
+            $this->fibers[] = $fiber;
+        }
+    }
+
+    public function count(): int
+    {
+        return count($this->fibers);
+    }
+
+    public function step(): void
+    {
+        $remaining = [];
+        foreach ($this->fibers as $fiber) {
+            if ($this->advance($fiber)) {
+                $remaining[] = $fiber;
+            }
+        }
+
+        $this->fibers = $remaining;
+    }
+
+    /**
+     * @return bool true if the fiber should stay in the pool
+     */
+    private function advance(Fiber $fiber): bool
+    {
+        if ($fiber->isTerminated()) {
+            return false;
+        }
+
+        if (!$fiber->isSuspended()) {
+            return true;
+        }
+
+        try {
+            $fiber->resume();
+        } catch (Throwable $throwable) {
+            if ($this->errorLogger instanceof Closure) {
+                ($this->errorLogger)('Client fiber error: ' . $throwable->getMessage());
+            }
+
+            return false;
+        }
+
+        return $fiber->isSuspended();
+    }
+}

--- a/src/php/Nrepl/Infrastructure/NreplSocketServer.php
+++ b/src/php/Nrepl/Infrastructure/NreplSocketServer.php
@@ -9,7 +9,6 @@ use Fiber;
 use Phel\Nrepl\Domain\Op\OpDispatcher;
 use Phel\Nrepl\Domain\Transport\ClientConnection;
 use RuntimeException;
-use Throwable;
 
 use function fclose;
 use function is_resource;
@@ -27,8 +26,9 @@ use function usleep;
  * TCP nREPL server. Accepts bencode-framed connections on a port and
  * dispatches op messages through OpDispatcher.
  *
- * Uses one Fiber per connected client. The main accept loop yields between
- * iterations so Fibers can run cooperatively without blocking each other.
+ * Uses one Fiber per connected client, coordinated by `ClientFiberPool`.
+ * The main accept loop yields between iterations so Fibers run
+ * cooperatively without blocking each other.
  */
 final class NreplSocketServer
 {
@@ -37,8 +37,7 @@ final class NreplSocketServer
 
     private bool $running = false;
 
-    /** @var list<Fiber> */
-    private array $clientFibers = [];
+    private readonly ClientFiberPool $fiberPool;
 
     private readonly ?Closure $logger;
 
@@ -49,6 +48,9 @@ final class NreplSocketServer
         ?callable $logger = null,
     ) {
         $this->logger = $logger === null ? null : Closure::fromCallable($logger);
+        $this->fiberPool = new ClientFiberPool(function (string $message): void {
+            $this->log($message);
+        });
     }
 
     public function port(): int
@@ -146,45 +148,13 @@ final class NreplSocketServer
         });
 
         $fiber->start($connection);
-        if (!$fiber->isTerminated()) {
-            $this->clientFibers[] = $fiber;
-        }
+
+        $this->fiberPool->add($fiber);
     }
 
     public function stepFibers(): void
     {
-        $remaining = [];
-        foreach ($this->clientFibers as $fiber) {
-            $alive = $this->advanceFiber($fiber);
-            if ($alive) {
-                $remaining[] = $fiber;
-            }
-        }
-
-        $this->clientFibers = $remaining;
-    }
-
-    /**
-     * Returns true if the fiber is still alive and should be retained.
-     */
-    private function advanceFiber(Fiber $fiber): bool
-    {
-        if ($fiber->isTerminated()) {
-            return false;
-        }
-
-        if (!$fiber->isSuspended()) {
-            return true;
-        }
-
-        try {
-            $fiber->resume();
-        } catch (Throwable $throwable) {
-            $this->log('Client fiber error: ' . $throwable->getMessage());
-            return false;
-        }
-
-        return $fiber->isSuspended();
+        $this->fiberPool->step();
     }
 
     private function serveClient(ClientConnection $connection): void

--- a/tests/php/Unit/Api/Application/DocstringSignatureParserTest.php
+++ b/tests/php/Unit/Api/Application/DocstringSignatureParserTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\DocstringSignatureParser;
+use PHPUnit\Framework\TestCase;
+
+final class DocstringSignatureParserTest extends TestCase
+{
+    public function test_returns_empty_signatures_and_description_for_empty_input(): void
+    {
+        self::assertSame(
+            ['signatures' => [], 'description' => ''],
+            DocstringSignatureParser::parse(''),
+        );
+    }
+
+    public function test_extracts_single_signature_and_description(): void
+    {
+        $doc = "```phel\n(my-fn arg)\n```\nDoes a thing.";
+
+        $parsed = DocstringSignatureParser::parse($doc);
+
+        self::assertSame(['(my-fn arg)'], $parsed['signatures']);
+        self::assertSame('Does a thing.', $parsed['description']);
+    }
+
+    public function test_extracts_multiple_signatures(): void
+    {
+        $doc = "```phel\n(f a)\n(f a b)\n(f a b & rest)\n```\nMulti-arity.";
+
+        $parsed = DocstringSignatureParser::parse($doc);
+
+        self::assertSame(
+            ['(f a)', '(f a b)', '(f a b & rest)'],
+            $parsed['signatures'],
+        );
+        self::assertSame('Multi-arity.', $parsed['description']);
+    }
+
+    public function test_handles_docstring_with_no_signature_block(): void
+    {
+        $parsed = DocstringSignatureParser::parse('Just a description.');
+
+        self::assertSame([], $parsed['signatures']);
+        self::assertSame('Just a description.', $parsed['description']);
+    }
+
+    public function test_skips_blank_lines_between_signatures(): void
+    {
+        $doc = "```phel\n(f a)\n\n(f a b)\n```\n";
+
+        $parsed = DocstringSignatureParser::parse($doc);
+
+        self::assertSame(['(f a)', '(f a b)'], $parsed['signatures']);
+    }
+}

--- a/tests/php/Unit/Api/Application/PhelFileIteratorTest.php
+++ b/tests/php/Unit/Api/Application/PhelFileIteratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhelFileIterator;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function iterator_to_array;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class PhelFileIteratorTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/phel_iter_' . uniqid('', true);
+        mkdir($this->root, 0o755, true);
+        mkdir($this->root . '/nested', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->root . '/a.phel');
+        @unlink($this->root . '/nested/b.phel');
+        @unlink($this->root . '/c.txt');
+        @rmdir($this->root . '/nested');
+        @rmdir($this->root);
+    }
+
+    public function test_it_yields_phel_files_recursively(): void
+    {
+        file_put_contents($this->root . '/a.phel', '');
+        file_put_contents($this->root . '/nested/b.phel', '');
+        file_put_contents($this->root . '/c.txt', '');
+
+        $paths = iterator_to_array(PhelFileIterator::iterate($this->root), false);
+
+        self::assertCount(2, $paths);
+        self::assertContains($this->root . '/a.phel', $paths);
+        self::assertContains($this->root . '/nested/b.phel', $paths);
+    }
+
+    public function test_missing_directory_yields_empty_iterable(): void
+    {
+        $paths = iterator_to_array(PhelFileIterator::iterate('/does/not/exist/anywhere'), false);
+
+        self::assertSame([], $paths);
+    }
+
+    public function test_directory_without_phel_files_yields_nothing(): void
+    {
+        self::assertDirectoryExists($this->root);
+
+        $paths = iterator_to_array(PhelFileIterator::iterate($this->root), false);
+
+        self::assertSame([], $paths);
+    }
+}

--- a/tests/php/Unit/Api/Application/PhpSymbolCatalogTest.php
+++ b/tests/php/Unit/Api/Application/PhpSymbolCatalogTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\PhpSymbolCatalog;
+use PHPUnit\Framework\TestCase;
+
+final class PhpSymbolCatalogTest extends TestCase
+{
+    public function test_functions_contains_internal_php_functions(): void
+    {
+        $catalog = new PhpSymbolCatalog();
+
+        $functions = $catalog->functions();
+
+        self::assertContains('array_map', $functions);
+        self::assertContains('strlen', $functions);
+    }
+
+    public function test_classes_contains_standard_library_classes(): void
+    {
+        $catalog = new PhpSymbolCatalog();
+
+        $classes = $catalog->classes();
+
+        self::assertContains('stdClass', $classes);
+    }
+
+    public function test_functions_list_is_memoised(): void
+    {
+        $catalog = new PhpSymbolCatalog();
+
+        self::assertSame($catalog->functions(), $catalog->functions());
+    }
+
+    public function test_classes_list_is_memoised(): void
+    {
+        $catalog = new PhpSymbolCatalog();
+
+        self::assertSame($catalog->classes(), $catalog->classes());
+    }
+}

--- a/tests/php/Unit/Api/Application/SymbolKeyTest.php
+++ b/tests/php/Unit/Api/Application/SymbolKeyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Api\Application;
+
+use Phel\Api\Application\SymbolKey;
+use PHPUnit\Framework\TestCase;
+
+final class SymbolKeyTest extends TestCase
+{
+    public function test_qualified_symbol_is_returned_as_is(): void
+    {
+        self::assertSame('my-ns/foo', SymbolKey::resolve('ignored', 'my-ns/foo'));
+    }
+
+    public function test_unqualified_symbol_is_anchored_to_namespace(): void
+    {
+        self::assertSame('my-ns/foo', SymbolKey::resolve('my-ns', 'foo'));
+    }
+
+    public function test_empty_namespace_yields_plain_symbol(): void
+    {
+        self::assertSame('foo', SymbolKey::resolve('', 'foo'));
+    }
+
+    public function test_already_qualified_with_empty_namespace_passes_through(): void
+    {
+        self::assertSame('other/bar', SymbolKey::resolve('', 'other/bar'));
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/FnParamVectorsTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/FnParamVectorsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lint\Application\Rule\FnParamVectors;
+
+use function iterator_to_array;
+
+final class FnParamVectorsTest extends RuleTestCase
+{
+    public function test_yields_single_param_vector_for_defn(): void
+    {
+        $form = $this->firstForm('(defn my-fn [x y] (+ x y))');
+
+        $vectors = iterator_to_array(FnParamVectors::of($form), false);
+
+        self::assertCount(1, $vectors);
+        self::assertInstanceOf(PersistentVectorInterface::class, $vectors[0]);
+        self::assertCount(2, $vectors[0]);
+    }
+
+    public function test_yields_multiple_param_vectors_for_multi_arity_defn(): void
+    {
+        $form = $this->firstForm(<<<'PHEL'
+            (defn add
+              ([] 0)
+              ([x] x)
+              ([x y] (+ x y)))
+            PHEL);
+
+        $vectors = iterator_to_array(FnParamVectors::of($form), false);
+
+        self::assertCount(3, $vectors);
+        self::assertCount(0, $vectors[0]);
+        self::assertCount(1, $vectors[1]);
+        self::assertCount(2, $vectors[2]);
+    }
+
+    public function test_yields_param_vector_for_plain_fn(): void
+    {
+        $form = $this->firstForm('(fn [a b c] (+ a b c))');
+
+        $vectors = iterator_to_array(FnParamVectors::of($form), false);
+
+        self::assertCount(1, $vectors);
+        self::assertCount(3, $vectors[0]);
+    }
+
+    public function test_skips_docstring_when_present(): void
+    {
+        $form = $this->firstForm('(defn f "doc" [x] x)');
+
+        $vectors = iterator_to_array(FnParamVectors::of($form), false);
+
+        self::assertCount(1, $vectors);
+        self::assertCount(1, $vectors[0]);
+    }
+
+    public function test_yields_nothing_when_no_param_vector_found(): void
+    {
+        $form = $this->firstForm('(defn f)');
+
+        $vectors = iterator_to_array(FnParamVectors::of($form), false);
+
+        self::assertSame([], $vectors);
+    }
+
+    private function firstForm(string $source): PersistentListInterface
+    {
+        $analysis = $this->buildAnalysis($source);
+
+        /** @var PersistentListInterface $first */
+        $first = $analysis->forms[0];
+        self::assertInstanceOf(PersistentListInterface::class, $first);
+
+        return $first;
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/NamespaceFormTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/NamespaceFormTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lint\Application\Rule\NamespaceForm;
+
+final class NamespaceFormTest extends RuleTestCase
+{
+    public function test_find_returns_null_when_no_ns_form_present(): void
+    {
+        $analysis = $this->buildAnalysis('(def x 1)');
+
+        self::assertNull(NamespaceForm::find($analysis->forms));
+    }
+
+    public function test_find_returns_first_ns_form(): void
+    {
+        $analysis = $this->buildAnalysis("(ns my-app\\core)\n(def x 1)");
+
+        $found = NamespaceForm::find($analysis->forms);
+
+        self::assertInstanceOf(PersistentListInterface::class, $found);
+    }
+
+    public function test_collect_symbol_uses_excludes_the_ns_form_itself(): void
+    {
+        $analysis = $this->buildAnalysis(<<<'PHEL'
+            (ns my-app\core)
+            (def unused "value")
+            (defn other [x] (helper x))
+            PHEL);
+
+        $nsForm = NamespaceForm::find($analysis->forms);
+        self::assertInstanceOf(PersistentListInterface::class, $nsForm);
+
+        $uses = NamespaceForm::collectSymbolUses($analysis->forms, $nsForm);
+
+        self::assertArrayHasKey('helper', $uses);
+        self::assertArrayHasKey('x', $uses);
+        // ns form contents (my-app\core) should not leak into uses
+        self::assertArrayNotHasKey('my-app\\core', $uses);
+    }
+
+    public function test_collect_symbol_uses_records_namespace_part_of_qualified_symbols(): void
+    {
+        $analysis = $this->buildAnalysis(<<<'PHEL'
+            (ns my-app\core)
+            (def v (other-ns/helper 1))
+            PHEL);
+
+        $nsForm = NamespaceForm::find($analysis->forms);
+        self::assertInstanceOf(PersistentListInterface::class, $nsForm);
+
+        $uses = NamespaceForm::collectSymbolUses($analysis->forms, $nsForm);
+
+        self::assertArrayHasKey('other-ns', $uses);
+        self::assertArrayHasKey('helper', $uses);
+    }
+}

--- a/tests/php/Unit/Lint/Application/Rule/NsClauseIteratorTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/NsClauseIteratorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lint\Application\Rule;
+
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lint\Application\Rule\NamespaceForm;
+use Phel\Lint\Application\Rule\NsClauseIterator;
+
+use function iterator_to_array;
+
+final class NsClauseIteratorTest extends RuleTestCase
+{
+    public function test_it_yields_matching_keyword_clauses(): void
+    {
+        $analysis = $this->buildAnalysis(<<<'PHEL'
+            (ns my-app\core
+              (:use \DateTime)
+              (:require phel\core)
+              (:require phel\string :as s))
+            PHEL);
+
+        $nsForm = NamespaceForm::find($analysis->forms);
+        self::assertInstanceOf(PersistentListInterface::class, $nsForm);
+
+        $requires = iterator_to_array(NsClauseIterator::clauses($nsForm, 'require'), false);
+        self::assertCount(2, $requires);
+
+        $uses = iterator_to_array(NsClauseIterator::clauses($nsForm, 'use'), false);
+        self::assertCount(1, $uses);
+    }
+
+    public function test_it_skips_children_without_a_keyword_head(): void
+    {
+        $analysis = $this->buildAnalysis(<<<'PHEL'
+            (ns my-app\core
+              "docstring"
+              ()
+              (not-a-keyword))
+            PHEL);
+
+        $nsForm = NamespaceForm::find($analysis->forms);
+        self::assertInstanceOf(PersistentListInterface::class, $nsForm);
+
+        $clauses = iterator_to_array(NsClauseIterator::clauses($nsForm, 'require'), false);
+
+        self::assertSame([], $clauses);
+    }
+
+    public function test_it_returns_empty_when_keyword_does_not_match(): void
+    {
+        $analysis = $this->buildAnalysis('(ns my-app\\core (:require phel\\core))');
+
+        $nsForm = NamespaceForm::find($analysis->forms);
+        self::assertInstanceOf(PersistentListInterface::class, $nsForm);
+
+        $clauses = iterator_to_array(NsClauseIterator::clauses($nsForm, 'refer-macros'), false);
+
+        self::assertSame([], $clauses);
+    }
+}

--- a/tests/php/Unit/Nrepl/Domain/Op/OpResponseTest.php
+++ b/tests/php/Unit/Nrepl/Domain/Op/OpResponseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Domain\Op;
+
+use Phel\Nrepl\Domain\Op\OpRequest;
+use Phel\Nrepl\Domain\Op\OpResponse;
+use Phel\Nrepl\Domain\Op\OpStatus;
+use PHPUnit\Framework\TestCase;
+
+final class OpResponseTest extends TestCase
+{
+    public function test_build_skips_empty_id_and_session(): void
+    {
+        $response = OpResponse::build(null, null, ['value' => 1]);
+
+        self::assertSame(['value' => 1], $response->payload);
+    }
+
+    public function test_build_skips_empty_strings(): void
+    {
+        $response = OpResponse::build('', '', ['value' => 1]);
+
+        self::assertSame(['value' => 1], $response->payload);
+    }
+
+    public function test_build_includes_status_only_when_non_empty(): void
+    {
+        $withStatus = OpResponse::build('id-1', 'sess', [], ['done']);
+        $withoutStatus = OpResponse::build('id-1', 'sess', []);
+
+        self::assertSame(['done'], $withStatus->payload['status']);
+        self::assertArrayNotHasKey('status', $withoutStatus->payload);
+    }
+
+    public function test_for_request_forwards_id_and_session(): void
+    {
+        $request = new OpRequest('eval', 'req-42', 'sess-7', []);
+        $response = OpResponse::forRequest($request, ['k' => 'v']);
+
+        self::assertSame('req-42', $response->payload['id']);
+        self::assertSame('sess-7', $response->payload['session']);
+        self::assertSame('v', $response->payload['k']);
+    }
+
+    public function test_done_produces_terminal_frame(): void
+    {
+        $request = new OpRequest('eval', 'req-1', 'sess', []);
+        $response = OpResponse::done($request);
+
+        self::assertSame([OpStatus::DONE], $response->payload['status']);
+        self::assertSame('req-1', $response->payload['id']);
+        self::assertSame('sess', $response->payload['session']);
+    }
+
+    public function test_error_done_prepends_error_and_appends_done(): void
+    {
+        $request = new OpRequest('eval', 'req-1', null, []);
+        $response = OpResponse::errorDone($request, 'boom', [OpStatus::EVAL_ERROR]);
+
+        self::assertSame('boom', $response->payload['message']);
+        self::assertSame(
+            [OpStatus::ERROR, OpStatus::EVAL_ERROR, OpStatus::DONE],
+            $response->payload['status'],
+        );
+    }
+
+    public function test_error_done_accepts_empty_extra_status(): void
+    {
+        $request = new OpRequest('eval', null, null, []);
+        $response = OpResponse::errorDone($request, 'nope');
+
+        self::assertSame([OpStatus::ERROR, OpStatus::DONE], $response->payload['status']);
+    }
+
+    public function test_with_extra_merges_additional_payload(): void
+    {
+        $response = OpResponse::build('x', 'y', ['a' => 1])->withExtra(['b' => 2]);
+
+        self::assertSame(1, $response->payload['a']);
+        self::assertSame(2, $response->payload['b']);
+    }
+}

--- a/tests/php/Unit/Nrepl/Infrastructure/ClientFiberPoolTest.php
+++ b/tests/php/Unit/Nrepl/Infrastructure/ClientFiberPoolTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Nrepl\Infrastructure;
+
+use Fiber;
+use Phel\Nrepl\Infrastructure\ClientFiberPool;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ClientFiberPoolTest extends TestCase
+{
+    public function test_add_skips_terminated_fibers(): void
+    {
+        $pool = new ClientFiberPool();
+
+        $fiber = new Fiber(static fn(): int => 1);
+        $fiber->start();
+
+        $pool->add($fiber);
+
+        self::assertSame(0, $pool->count());
+    }
+
+    public function test_step_keeps_suspended_fibers_and_drops_terminated_ones(): void
+    {
+        $pool = new ClientFiberPool();
+
+        $stillAlive = new Fiber(static function (): void {
+            Fiber::suspend();
+            Fiber::suspend();
+        });
+        $stillAlive->start();
+
+        $completing = new Fiber(static function (): void {
+            Fiber::suspend();
+        });
+        $completing->start();
+
+        $pool->add($stillAlive);
+        $pool->add($completing);
+        self::assertSame(2, $pool->count());
+
+        $pool->step();
+
+        self::assertSame(1, $pool->count());
+    }
+
+    public function test_step_logs_and_drops_fibers_that_throw(): void
+    {
+        $messages = [];
+        $pool = new ClientFiberPool(static function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        });
+
+        $failing = new Fiber(static function (): never {
+            Fiber::suspend();
+            throw new RuntimeException('boom');
+        });
+        $failing->start();
+
+        $pool->add($failing);
+        $pool->step();
+
+        self::assertSame(0, $pool->count());
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('boom', $messages[0]);
+    }
+
+    public function test_step_without_logger_swallows_exceptions(): void
+    {
+        $pool = new ClientFiberPool();
+
+        $failing = new Fiber(static function (): never {
+            Fiber::suspend();
+            throw new RuntimeException('silent');
+        });
+        $failing->start();
+
+        $pool->add($failing);
+        $pool->step();
+
+        self::assertSame(0, $pool->count());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Follow-up to #1524 targeting the Nrepl, Api and Lint modules: the first pass landed the big structural cuts; this second pass goes after the smaller smells that remained and backfills tests around the helpers it introduces.

## 💡 Goal

Reduce duplication across op handlers, lint rules, and REPL support so each class reads as a single responsibility, and lift hidden state out of `ReplCompleter` so the class can be constructed in isolation.

## 🔖 Changes

Nrepl:

- Add `OpResponse::forRequest`, `done`, and `errorDone` so each op handler stops spelling out id/session/status routing plumbing
- Extract `ClientFiberPool` from `NreplSocketServer` so fiber-lifecycle bookkeeping (add, step, drop-on-throw, logger dispatch) is separable from socket accept/listen
- Reuse the new helpers across `CloneOp`, `CloseOp`, `CompletionsOp`, `DescribeOp`, `EvalOp`, `EvalResultResponder`, `InterruptOp`, `LoadFileOp`, `LookupOp`, and `OpDispatcher`

Api:

- Replace static caches (`self::$loaded`, `self::$phpFunctions`, `self::$phpClasses`) in `ReplCompleter` with an injected `PhpSymbolCatalog`, so each completer is independent and the PHP/class lookups are testable
- Extract `DocstringSignatureParser` from `PhelFnNormalizer` so doc parsing can be exercised in isolation

Lint:

- Extract `NsClauseIterator` so `UnusedRequireRule` and `UnusedImportRule` share the traversal over keyword-headed clauses in `(ns ...)`
- Extract `FnParamVectors` so `ArityMismatchRule`, `ShadowedBindingRule`, and `InvalidDestructuringRule` stop re-implementing the same fn / defn param-vector scan

Tests:

- New unit tests for `OpResponse`, `ClientFiberPool`, `PhpSymbolCatalog`, `DocstringSignatureParser`, `SymbolKey`, `PhelFileIterator`, `NamespaceForm`, `NsClauseIterator`, and `FnParamVectors` (+35 tests)

No user-visible behaviour change; purely structural cleanup with extra test coverage.