### PR TITLE
ref(test): second-pass cleanup of test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 - `(get v nil)` and `(get l nil)` return default on vectors/lists
 - Vector/list with nil index raise `InvalidArgumentException`
 - Stack-trace arg rendering truncates each Phel argument at 200 chars
+- `phel test --reporter=junit-xml` preserves namespace and testcase order in output
 
 ### Changed
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -18,13 +18,16 @@
   "Stack of testing context strings, most recent first."
   [])
 
-(def- stats (atom {:failed []
-                  :skipped []
-                  :counts {:failed 0
-                           :error 0
-                           :pass 0
-                           :skipped 0
-                           :total 0}}))
+(def- initial-stats
+  {:failed []
+   :skipped []
+   :counts {:failed 0
+            :error 0
+            :pass 0
+            :skipped 0
+            :total 0}})
+
+(def- stats (atom initial-stats))
 
 ;; Dynamic registry of active reporter functions. Each reporter is a
 ;; function of a single argument — the event map with a `:type` key — and
@@ -88,20 +91,22 @@
       (assoc data :test-name *current-test-name*)
       data)))
 
+(defn- bump-stat [s path]
+  (update-in s path inc))
+
 (defn- record-stats!
   "Mutates the internal stats atom based on an assertion-result event."
   [data]
-  (let [{:state state} data
-        ok             (= state :pass)]
+  (let [state (get data :state)
+        ok?   (= state :pass)]
     (swap! stats
            (fn [s]
-             (let [counts (get s :counts)
-                   counts (assoc counts :total (inc (get counts :total)))
-                   counts (assoc counts state (inc (get counts state)))
-                   s      (assoc s :counts counts)]
-               (if ok
+             (let [s (-> s
+                         (bump-stat [:counts :total])
+                         (bump-stat [:counts state]))]
+               (if ok?
                  s
-                 (assoc s :failed (conj (get s :failed) data))))))))
+                 (update s :failed conj data)))))))
 
 (defn- fan-out! [event]
   (dofor [reporter :in (deref *reporters*)]
@@ -160,10 +165,9 @@
 (defn- record-skip! [data]
   (swap! stats
          (fn [s]
-           (let [counts (get s :counts)
-                 counts (assoc counts :skipped (inc (get counts :skipped)))
-                 s      (assoc s :counts counts)]
-             (assoc s :skipped (conj (get s :skipped) data))))))
+           (-> s
+               (bump-stat [:counts :skipped])
+               (update :skipped conj data)))))
 
 ;; Lifecycle events that flow straight through to every registered
 ;; reporter without touching the stats atom.
@@ -755,7 +759,7 @@
          "</testcase>")))
 
 (defn- junit-render [state]
-  (let [suites (reverse (get state :testsuites))
+  (let [suites (get state :testsuites)
         parts  (for [{:name ns-name :tests t :failures f :errors e :time tm :cases cases} :in suites]
                  (str "<testsuite "
                       (junit-attr :name ns-name) " "
@@ -763,7 +767,7 @@
                       (junit-attr :failures f) " "
                       (junit-attr :errors e) " "
                       (junit-attr :time tm) ">"
-                      (s/join "" (reverse cases))
+                      (s/join "" cases)
                       "</testsuite>"))]
     (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
          "<testsuites "
@@ -774,6 +778,9 @@
          (s/join "" parts)
          "</testsuites>")))
 
+(def- empty-junit-suite
+  {:tests 0 :failures 0 :errors 0 :time 0.0 :cases []})
+
 (defn- junit-finalize-current [state]
   (let [current (:current state)]
     (if current
@@ -783,30 +790,33 @@
       state)))
 
 (defn- junit-start-ns [state ns-name]
-  (let [state (junit-finalize-current state)]
-    (assoc state :current {:name ns-name
-                           :tests 0
-                           :failures 0
-                           :errors 0
-                           :time 0.0
-                           :cases []})))
+  (-> state
+      (junit-finalize-current)
+      (assoc :current (assoc empty-junit-suite :name ns-name))))
 
-(defn- bump-counters [m event]
-  (let [state  (get event :state)
-        m      (update m :tests inc)
-        m      (if (= :failed state) (update m :failures inc) m)
-        m      (if (= :error state)  (update m :errors inc)  m)]
-    m))
+(defn- bump-junit-counters
+  "Increments `:tests`, plus `:failures`/`:errors` based on the event's
+  `:state`. Used to aggregate both the per-suite and per-run totals."
+  [m event]
+  (let [state (get event :state)]
+    (cond-> (update m :tests inc)
+      (= :failed state) (update :failures inc)
+      (= :error state)  (update :errors inc))))
+
+(defn- junit-ensure-current
+  "Ensures `state` has a `:current` suite; lazily initialised from the
+  event's `:ns` when a testcase arrives outside a `begin-test-ns`."
+  [state event]
+  (or (:current state)
+      (assoc empty-junit-suite :name (or (:ns event) ""))))
 
 (defn- junit-record-case [state event]
-  (let [current (or (:current state)
-                    {:name (or (:ns event) "")
-                     :tests 0 :failures 0 :errors 0 :time 0.0 :cases []})
-        state   (bump-counters state event)
-        current (-> current
-                    (bump-counters event)
+  (let [current (-> (junit-ensure-current state event)
+                    (bump-junit-counters event)
                     (update :cases conj (junit-build-testcase event)))]
-    (assoc state :current current)))
+    (-> state
+        (bump-junit-counters event)
+        (assoc :current current))))
 
 (defn- junit-write-output [state]
   (let [xml  (junit-render state)
@@ -1003,24 +1013,32 @@
    :ns-patterns (:ns-patterns options)
    :filters     (:filters options)})
 
+(defn- skip-reason
+  "Returns the reason the test should be skipped — `:filtered` for the
+  legacy `--filter` gate, `:selector` for any other selector miss, or
+  `nil` when the test should run."
+  [options sel-opts ns-name m]
+  (cond
+    (not (legacy-filter-matches? (:filter options) (:test-name m)))
+    :filtered
+
+    (not (selector/keep-test? sel-opts ns-name m))
+    :selector
+
+    :else
+    nil))
+
 (defn- partition-tests
   "Splits the discovered tests into a `{:keep [...] :skip [...]}` map
   using the selector options. `:keep` preserves original order; each
   `:skip` entry is annotated with its metadata so reporters can surface
   skip events."
   [options ns-name tests]
-  (let [sel-opts  (selector-options options)
-        filter-v  (:filter options)]
+  (let [sel-opts (selector-options options)]
     (reduce
      (fn [acc {:fn f :meta m}]
-       (cond
-         (not (legacy-filter-matches? filter-v (:test-name m)))
-         (update acc :skip conj {:fn f :meta m :reason :filtered})
-
-         (not (selector/keep-test? sel-opts ns-name m))
-         (update acc :skip conj {:fn f :meta m :reason :selector})
-
-         :else
+       (if-let [reason (skip-reason options sel-opts ns-name m)]
+         (update acc :skip conj {:fn f :meta m :reason reason})
          (update acc :keep conj {:fn f :meta m})))
      {:keep [] :skip []}
      tests)))
@@ -1048,22 +1066,37 @@
                  :when (not (should-stop?))]
            (each-wrap f)))))))
 
+(defn- coerce-reporter
+  "Turns a single `:reporters` entry (function, keyword, or string) into
+  a reporter function. Throws on unknown names or invalid values."
+  [r]
+  (cond
+    (fn? r)
+    r
+
+    (or (keyword? r) (string? r))
+    (or (resolve-reporter r)
+        (throw (php/new \InvalidArgumentException
+                        (str "Unknown reporter: " r))))
+
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "Invalid reporter value: " r)))))
+
+(defn- requested-reporters
+  "Returns the user-selected reporter identifiers, honouring the
+  `--testdox` shortcut and defaulting to `[:default]`."
+  [options]
+  (or (:reporters options)
+      (when (:testdox options) [:testdox])
+      [:default]))
+
 (defn- resolve-reporters-option
   "Resolves the `:reporters` option into a vector of reporter functions.
   Accepts a sequence of keywords or strings (built-in names), or a
   sequence of functions, or a mix. Defaults to `[:default]`."
   [options]
-  (let [requested (or (:reporters options)
-                      (when (:testdox options) [:testdox])
-                      [:default])]
-    (vec (for [r :in requested]
-           (cond
-             (fn? r)                           r
-             (or (keyword? r) (string? r))     (or (resolve-reporter r)
-                                                   (throw (php/new \InvalidArgumentException
-                                                                   (str "Unknown reporter: " r))))
-             :else                             (throw (php/new \InvalidArgumentException
-                                                               (str "Invalid reporter value: " r))))))))
+  (vec (map coerce-reporter (requested-reporters options))))
 
 (defn- configure-run! [options]
   (reset! fail-fast? (:fail-fast options))
@@ -1093,13 +1126,7 @@
   Call this before running a new batch of tests to get fresh results."
   {:example "(reset-stats)"}
   []
-  (reset! stats {:failed []
-                 :skipped []
-                 :counts {:failed 0
-                          :error 0
-                          :pass 0
-                          :skipped 0
-                          :total 0}}))
+  (reset! stats initial-stats))
 
 (defn successful?
   "Checks if all tests passed."

--- a/src/phel/test/selector.phel
+++ b/src/phel/test/selector.phel
@@ -28,6 +28,13 @@
 ;; Tag extraction
 ;; ---------------------------------------------------------------------------
 
+(defn- non-empty-vec?
+  "Returns `true` when `xs` is a non-nil, non-empty vector/seq. Used to
+  check whether a selector option was supplied by the caller."
+  [xs]
+  (and (not (nil? xs))
+       (not (empty? xs))))
+
 (defn- tag-key
   "Coerces a selector tag (keyword or string) into the keyword form used
   to look up metadata. Returns `nil` for other inputs."
@@ -63,15 +70,17 @@
 ;; Include / exclude by tag
 ;; ---------------------------------------------------------------------------
 
+(defn- any-tag-matches? [tags meta]
+  (truthy? (some (fn [tag] (has-tag? meta tag)) tags)))
+
 (defn matches-include?
   "Returns `true` when `includes` is empty (no restriction) or when any
   tag in `includes` is truthy on `meta`."
   {:example "(matches-include? [:integration] {:integration true})"
    :see-also ["matches-exclude?" "keep-test?"]}
   [includes meta]
-  (or (nil? includes)
-      (empty? includes)
-      (truthy? (some (fn [tag] (has-tag? meta tag)) includes))))
+  (or (not (non-empty-vec? includes))
+      (any-tag-matches? includes meta)))
 
 (defn matches-exclude?
   "Returns `true` when any tag in `excludes` is truthy on `meta`. An
@@ -80,9 +89,8 @@
   {:example "(matches-exclude? [:slow] {:slow true})"
    :see-also ["matches-include?" "keep-test?"]}
   [excludes meta]
-  (and (not (nil? excludes))
-       (not (empty? excludes))
-       (truthy? (some (fn [tag] (has-tag? meta tag)) excludes))))
+  (and (non-empty-vec? excludes)
+       (any-tag-matches? excludes meta)))
 
 ;; ---------------------------------------------------------------------------
 ;; Namespace glob matching
@@ -151,8 +159,7 @@
   {:example "(matches-ns? [\"phel.http.*\"] \"phel.http.client\")"
    :see-also ["ns-matches?" "keep-test?"]}
   [patterns ns-name]
-  (or (nil? patterns)
-      (empty? patterns)
+  (or (not (non-empty-vec? patterns))
       (truthy? (some (fn [p] (ns-matches? p ns-name)) patterns))))
 
 ;; ---------------------------------------------------------------------------
@@ -187,8 +194,7 @@
   {:example "(matches-filter? [\"add-\"] \"test-add-one\")"
    :see-also ["name-matches?" "keep-test?"]}
   [patterns test-name]
-  (or (nil? patterns)
-      (empty? patterns)
+  (or (not (non-empty-vec? patterns))
       (truthy? (some (fn [p] (name-matches? p test-name)) patterns))))
 
 ;; ---------------------------------------------------------------------------
@@ -214,17 +220,12 @@
          (matches-ns? ns-patterns ns-name)
          (matches-filter? filters tname))))
 
+(def- selector-keys [:include :exclude :ns-patterns :filters])
+
 (defn has-selectors?
   "Returns `true` when `options` contains at least one non-empty
   selector key."
   {:example "(has-selectors? {:include [:integration]})"
    :see-also ["keep-test?"]}
   [options]
-  (or (and (not (nil? (get options :include)))
-           (not (empty? (get options :include))))
-      (and (not (nil? (get options :exclude)))
-           (not (empty? (get options :exclude))))
-      (and (not (nil? (get options :ns-patterns)))
-           (not (empty? (get options :ns-patterns))))
-      (and (not (nil? (get options :filters)))
-           (not (empty? (get options :filters))))))
+  (truthy? (some (fn [k] (non-empty-vec? (get options k))) selector-keys)))

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -81,40 +81,23 @@ final readonly class TestCommandOptions
     {
         $printer = Printer::readable();
 
-        $filter = $this->filter === null
-            ? 'nil'
-            : $printer->print($this->filter);
-
-        $reportersPart = '';
-        if ($this->reporters !== []) {
-            $reporterKeywords = array_map(
-                static fn(string $name): string => ':' . $name,
-                $this->reporters,
-            );
-            $reportersPart = ' :reporters [' . implode(' ', $reporterKeywords) . ']';
-        }
-
-        $junitPart = $this->junitOutput === null
-            ? ''
-            : ' :junit-output ' . $printer->print($this->junitOutput);
-
-        $includesPart = $this->keywordVector(':include', $this->includes);
-        $excludesPart = $this->keywordVector(':exclude', $this->excludes);
-        $nsPart = $this->stringVector(':ns-patterns', $this->nsPatterns);
-        $filtersPart = $this->stringVector(':filters', $this->filters);
-
         return sprintf(
             '{:filter %s :testdox %s :fail-fast %s%s%s%s%s%s%s}',
-            $filter,
+            $this->filter === null ? 'nil' : $printer->print($this->filter),
             $printer->print($this->testdox),
             $printer->print($this->failFast),
-            $reportersPart,
-            $junitPart,
-            $includesPart,
-            $excludesPart,
-            $nsPart,
-            $filtersPart,
+            $this->keywordVector(':reporters', $this->reporters),
+            $this->optionalString(':junit-output', $this->junitOutput, $printer),
+            $this->keywordVector(':include', $this->includes),
+            $this->keywordVector(':exclude', $this->excludes),
+            $this->stringVector(':ns-patterns', $this->nsPatterns),
+            $this->stringVector(':filters', $this->filters),
         );
+    }
+
+    private function optionalString(string $key, ?string $value, Printer $printer): string
+    {
+        return $value === null ? '' : ' ' . $key . ' ' . $printer->print($value);
     }
 
     /**
@@ -141,16 +124,11 @@ final readonly class TestCommandOptions
      */
     private function keywordVector(string $key, array $values): string
     {
-        if ($values === []) {
-            return '';
-        }
-
-        $keywords = array_map(
-            static fn(string $name): string => ':' . $name,
+        return $this->renderVector(
+            $key,
             $values,
+            static fn(string $name): string => ':' . $name,
         );
-
-        return ' ' . $key . ' [' . implode(' ', $keywords) . ']';
     }
 
     /**
@@ -158,16 +136,19 @@ final readonly class TestCommandOptions
      */
     private function stringVector(string $key, array $values): string
     {
+        return $this->renderVector($key, $values, Printer::readable()->print(...));
+    }
+
+    /**
+     * @param list<string>             $values
+     * @param callable(string): string $mapper
+     */
+    private function renderVector(string $key, array $values, callable $mapper): string
+    {
         if ($values === []) {
             return '';
         }
 
-        $printer = Printer::readable();
-        $printed = array_map(
-            $printer->print(...),
-            $values,
-        );
-
-        return ' ' . $key . ' [' . implode(' ', $printed) . ']';
+        return ' ' . $key . ' [' . implode(' ', array_map($mapper, $values)) . ']';
     }
 }

--- a/tests/phel/test/reporters.phel
+++ b/tests/phel/test/reporters.phel
@@ -281,3 +281,216 @@
       (is (= 1 (count (deref events))) "event still fans out")
       (is (= 0 (:pass (:counts snapshot)))
           "event without :state does not touch stats"))))
+
+;; ---------------------------------------------------------------------------
+;; Reporter resolution — edge cases
+;; ---------------------------------------------------------------------------
+
+(deftest test-resolve-reporter-nil-name-returns-nil
+  (is (nil? (t/resolve-reporter nil))
+      "resolve-reporter with nil returns nil instead of throwing"))
+
+(deftest test-register-reporter-rejects-non-name-types
+  (is (thrown-with-msg? \InvalidArgumentException
+                        "register-reporter! name must be a keyword or string"
+                        (t/register-reporter! 42 (fn [_])))
+      "register-reporter! rejects numeric names"))
+
+(deftest test-register-reporter-overrides-built-in
+  (let [built-in (t/resolve-reporter :my-override-target)
+        reporter (fn [_event] nil)]
+    (is (nil? built-in) "baseline: the target name is not yet registered")
+    (t/register-reporter! :my-override-target reporter)
+    (is (identical? reporter (t/resolve-reporter :my-override-target))
+        "user-registered reporter resolves via public API")))
+
+;; ---------------------------------------------------------------------------
+;; TAP reporter — description edge cases
+;; ---------------------------------------------------------------------------
+
+(deftest test-tap-reporter-falls-back-to-assertion-description
+  (let [rep (t/resolve-reporter :tap)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass})
+              (rep {:type :summary :total 1}))]
+    (is (php/preg_match "/^ok 1 - assertion$/m" out)
+        "events without :test-name or :message fall back to 'assertion'")))
+
+(deftest test-tap-reporter-description-uses-message-only-when-name-missing
+  (let [rep (t/resolve-reporter :tap)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :message "only-message"})
+              (rep {:type :summary :total 1}))]
+    (is (php/preg_match "/^ok 1 - only-message$/m" out)
+        "events with :message only use it verbatim")))
+
+(deftest test-tap-reporter-description-uses-test-name-only-when-message-missing
+  (let [rep (t/resolve-reporter :tap)
+        out (with-output-buffer
+              (rep {:type :begin-test-run})
+              (rep {:type :pass :state :pass :test-name "only-test"})
+              (rep {:type :summary :total 1}))]
+    (is (php/preg_match "/^ok 1 - only-test$/m" out)
+        "events with :test-name only use it verbatim")))
+
+;; ---------------------------------------------------------------------------
+;; JUnit reporter — fallback to event :ns when begin-test-ns is missed
+;; ---------------------------------------------------------------------------
+
+(deftest test-junit-reporter-uses-event-ns-when-no-begin-test-ns
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :pass :state :pass :test-name "t1" :ns "orphan.ns"})
+    (rep {:type :summary :total 1 :pass 1 :failed 0 :error 0})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/preg_match "/<testsuite name=\"orphan.ns\"/" xml)
+          "junit reporter falls back to event :ns when no begin-test-ns was seen"))
+    (php/unlink path)))
+
+(deftest test-junit-reporter-failure-without-exception-defaults-class
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "n"})
+    (rep {:type :failed :state :failed :test-name "t" :message "x"
+          :form "(= 1 2)"
+          :location {:file "a.phel" :line 1}})
+    (rep {:type :end-test-ns :ns "n"})
+    (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/preg_match "/type=\"AssertionFailed\"/" xml)
+          "failure without :exception/:exception-symbol falls back to AssertionFailed"))
+    (php/unlink path)))
+
+(deftest test-junit-reporter-summary-totals-reflect-pass-and-failure-counts
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "n"})
+    (rep {:type :pass :state :pass :test-name "t1"})
+    (rep {:type :pass :state :pass :test-name "t2"})
+    (rep {:type :error :state :error :test-name "t3"
+          :exception-symbol "\\RuntimeException"})
+    (rep {:type :end-test-ns :ns "n"})
+    (rep {:type :summary :total 3 :pass 2 :failed 0 :error 1})
+    (t/set-junit-output! nil)
+    (let [xml (php/file_get_contents path)]
+      (is (php/preg_match "/<testsuites tests=\"3\"/" xml)
+          "aggregate test count includes all cases")
+      (is (php/preg_match "/<testsuite[^>]*tests=\"3\"/" xml)
+          "per-suite test count matches")
+      (is (php/preg_match "/<error /" xml)
+          "error cases emit <error> child elements"))
+    (php/unlink path)))
+
+(deftest test-junit-reporter-preserves-suite-order-across-multiple-ns
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "first.ns"})
+    (rep {:type :pass :state :pass :test-name "t-first"})
+    (rep {:type :end-test-ns :ns "first.ns"})
+    (rep {:type :begin-test-ns :ns "second.ns"})
+    (rep {:type :pass :state :pass :test-name "t-second"})
+    (rep {:type :end-test-ns :ns "second.ns"})
+    (rep {:type :summary :total 2 :pass 2 :failed 0 :error 0})
+    (t/set-junit-output! nil)
+    (let [xml       (php/file_get_contents path)
+          first-pos (php/strpos xml "name=\"first.ns\"")
+          second-pos (php/strpos xml "name=\"second.ns\"")]
+      (is (and (not (false? first-pos))
+               (not (false? second-pos)))
+          "both suites present in output")
+      (is (< first-pos second-pos)
+          "suites emitted in the order their namespaces arrived"))
+    (php/unlink path)))
+
+;; ---------------------------------------------------------------------------
+;; Testdox reporter — per-assertion descriptive output
+;; ---------------------------------------------------------------------------
+
+(deftest test-testdox-reporter-uses-marker-per-outcome
+  (let [rep (t/resolve-reporter :testdox)
+        out (with-output-buffer
+              (rep {:type :pass :state :pass :test-name "t1" :message "ok"})
+              (rep {:type :failed :state :failed :test-name "t2" :message "bad"})
+              (rep {:type :error :state :error :test-name "t3" :message "boom"}))]
+    (is (php/preg_match "/^✔ t1: ok$/m" out)
+        "pass marker prints with test name and message")
+    (is (php/preg_match "/^✘ t2: bad$/m" out)
+        "fail marker prints with test name and message")
+    (is (php/preg_match "/^E t3: boom$/m" out)
+        "error marker prints with test name and message")))
+
+(deftest test-testdox-reporter-emits-skipped-marker
+  (let [rep (t/resolve-reporter :testdox)
+        out (with-output-buffer
+              (rep {:type :skipped :test-name "ignored-case"}))]
+    (is (php/preg_match "/↷ ignored-case \\(skipped\\)/" out)
+        "skip marker and parenthesised tag appear for skipped tests")))
+
+(deftest test-testdox-reporter-handles-missing-message-with-default
+  (let [rep (t/resolve-reporter :testdox)
+        out (with-output-buffer
+              (rep {:type :pass :state :pass :test-name "no-msg"}))]
+    (is (php/preg_match "/no test message found/" out)
+        "falls back to descriptive placeholder when :message absent")))
+
+(deftest test-junit-reporter-preserves-testcase-order-within-a-suite
+  (let [path (str "/tmp/phel-junit-" (php/mt_rand) ".xml")
+        rep  (t/resolve-reporter :junit-xml)
+        _    (t/set-junit-output! path)]
+    (rep {:type :begin-test-run})
+    (rep {:type :begin-test-ns :ns "ordered.ns"})
+    (rep {:type :pass :state :pass :test-name "alpha"})
+    (rep {:type :pass :state :pass :test-name "beta"})
+    (rep {:type :pass :state :pass :test-name "gamma"})
+    (rep {:type :end-test-ns :ns "ordered.ns"})
+    (rep {:type :summary :total 3 :pass 3 :failed 0 :error 0})
+    (t/set-junit-output! nil)
+    (let [xml     (php/file_get_contents path)
+          a-pos   (php/strpos xml "name=\"alpha\"")
+          b-pos   (php/strpos xml "name=\"beta\"")
+          g-pos   (php/strpos xml "name=\"gamma\"")]
+      (is (< a-pos b-pos) "alpha appears before beta")
+      (is (< b-pos g-pos) "beta appears before gamma"))
+    (php/unlink path)))
+
+;; ---------------------------------------------------------------------------
+;; resolve-reporters-option — unknown reporter throws
+;; ---------------------------------------------------------------------------
+
+(deftest test-run-tests-throws-on-unknown-reporter-keyword
+  (is (thrown-with-msg? \InvalidArgumentException
+                        "Unknown reporter: :does-not-exist"
+                        (t/run-tests {:reporters [:does-not-exist]}))
+      "run-tests rejects unknown reporter keywords at configure time"))
+
+(deftest test-run-tests-throws-on-invalid-reporter-value
+  (is (thrown-with-msg? \InvalidArgumentException
+                        "Invalid reporter value: 42"
+                        (t/run-tests {:reporters [42]}))
+      "run-tests rejects non-keyword, non-string, non-fn reporter values"))
+
+(deftest test-run-tests-accepts-inline-function-reporter
+  (let [events (atom [])
+        saved  (t/get-stats)
+        prev   (t/get-reporters)]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests {:reporters [(fn [e] (swap! events conj (:type e)))]}))
+    (t/set-reporters! prev)
+    (t/restore-stats saved)
+    (is (contains? (into (hash-set) (deref events)) :begin-test-run)
+        "inline reporter function received :begin-test-run")
+    (is (contains? (into (hash-set) (deref events)) :summary)
+        "inline reporter function received :summary")))

--- a/tests/phel/test/rose.phel
+++ b/tests/phel/test/rose.phel
@@ -84,3 +84,82 @@
     (is (every? (fn [v] (= 2 (count v)))
                 (into [] (map r/rose-root (r/rose-children t))))
         "rose-zip preserves arity")))
+
+;; ---------------------------------------------------------------------------
+;; shrink-int-towards — negative-direction shrinks and same-input short-circuit
+;; ---------------------------------------------------------------------------
+
+(deftest test-shrink-int-towards-negative-shrinks-toward-zero
+  (let [candidates (into [] (r/shrink-int-towards 0 -8))]
+    (is (contains? (into (hash-set) candidates) 0)
+        "target is among the shrinks")
+    (is (every? (fn [v] (< v 0)) (rest candidates))
+        "non-target shrinks are still negative")
+    (is (not (contains? (into (hash-set) candidates) -8))
+        "the input itself is never a shrink of itself")))
+
+(deftest test-shrink-int-towards-uses-non-zero-target
+  (is (= [10 15 18 19] (into [] (r/shrink-int-towards 10 20)))
+      "halving candidates converge on the configured target")
+  (is (= [-5 -8 -9] (into [] (r/shrink-int-towards -5 -10)))
+      "negative target still produces strictly-closer candidates"))
+
+;; ---------------------------------------------------------------------------
+;; rose-filter — keep only matching nodes, children pruned
+;; ---------------------------------------------------------------------------
+
+(deftest test-rose-filter-nil-when-root-fails-predicate
+  (is (nil? (r/rose-filter pos? (r/rose-pure -1)))
+      "when root fails the predicate, filter returns nil"))
+
+(deftest test-rose-filter-keeps-matching-subtree
+  (let [filtered (r/rose-filter (fn [n] (>= n 0)) (r/int-rose-tree 8))]
+    (is (not (nil? filtered)) "root passes pred, subtree is kept")
+    (is (= 8 (r/rose-root filtered)) "root value preserved")
+    (is (every? (fn [n] (>= n 0))
+                (into [] (map r/rose-root (r/rose-children filtered))))
+        "all surviving children satisfy the predicate")))
+
+;; ---------------------------------------------------------------------------
+;; rose-join — flattens nested rose trees
+;; ---------------------------------------------------------------------------
+
+(deftest test-rose-join-flattens-inner-tree
+  (let [inner  (r/rose-pure 42)
+        outer  (r/rose-pure inner)
+        joined (r/rose-join outer)]
+    (is (= 42 (r/rose-root joined))
+        "joined tree root is the inner root")))
+
+;; ---------------------------------------------------------------------------
+;; rose-string — shrinks via the underlying vector strategy
+;; ---------------------------------------------------------------------------
+
+(deftest test-rose-string-builds-string-from-char-leaves
+  (let [chars [(r/rose-pure "a") (r/rose-pure "b") (r/rose-pure "c")]
+        t     (r/rose-string chars)]
+    (is (= "abc" (r/rose-root t)) "root concatenates char leaves")))
+
+;; ---------------------------------------------------------------------------
+;; rose-map — shrinks of a hash-map preserve its associative nature
+;; ---------------------------------------------------------------------------
+
+(deftest test-rose-map-root-is-hash-map
+  (let [entries [(r/rose-pure [:a 1])
+                 (r/rose-pure [:b 2])]
+        t       (r/rose-map entries)]
+    (is (hash-map? (r/rose-root t)) "root is a hash-map")
+    (is (= 1 (get (r/rose-root t) :a)) "value preserved under key :a")
+    (is (= 2 (get (r/rose-root t) :b)) "value preserved under key :b")))
+
+;; ---------------------------------------------------------------------------
+;; rose-vector-lax — shrinks positions but never drops elements
+;; ---------------------------------------------------------------------------
+
+(deftest test-rose-vector-lax-preserves-length-in-children
+  (let [t (r/rose-vector-lax [(r/int-rose-tree 2) (r/int-rose-tree 3)])
+        child-lengths (into [] (map (fn [v] (count v))
+                                    (map r/rose-root (r/rose-children t))))]
+    (is (= [2 3] (r/rose-root t)) "root is the vector of roots")
+    (is (every? (fn [n] (= 2 n)) child-lengths)
+        "every child preserves the original arity")))

--- a/tests/phel/test/selectors.phel
+++ b/tests/phel/test/selectors.phel
@@ -256,3 +256,47 @@
 (deftest test-matches-filter-with-nil-name-and-empty-patterns
   (is (selector/matches-filter? [] nil)
       "empty pattern list with nil name still imposes no restriction"))
+
+;; ---------------------------------------------------------------------------
+;; ns-matches? — more glob edge cases
+;; ---------------------------------------------------------------------------
+
+(deftest test-ns-matches-trailing-star-expands-to-single-segment
+  (is (selector/ns-matches? "phel.*" "phel.core")
+      "trailing `*` matches a single segment")
+  (is (not (selector/ns-matches? "phel.*" "phel.core.sub"))
+      "trailing `*` does not cross dots"))
+
+(deftest test-ns-matches-empty-glob-matches-empty-ns-only
+  (is (selector/ns-matches? "" "")
+      "empty glob matches empty namespace")
+  (is (not (selector/ns-matches? "" "anything"))
+      "empty glob does not match a non-empty namespace"))
+
+(deftest test-ns-matches-double-star-only-matches-anything
+  (is (selector/ns-matches? "**" "a.b.c.d")
+      "standalone `**` matches everything")
+  (is (selector/ns-matches? "**" "")
+      "standalone `**` matches even the empty namespace"))
+
+;; ---------------------------------------------------------------------------
+;; has-selectors? — each key in isolation
+;; ---------------------------------------------------------------------------
+
+(deftest test-has-selectors-detects-each-key-independently
+  (is (selector/has-selectors? {:include ["a"]}) "include alone")
+  (is (selector/has-selectors? {:exclude ["a"]}) "exclude alone")
+  (is (selector/has-selectors? {:ns-patterns ["a.*"]}) "ns-patterns alone")
+  (is (selector/has-selectors? {:filters ["a"]}) "filters alone")
+  (is (not (selector/has-selectors? {:include nil})) "nil include is absent")
+  (is (not (selector/has-selectors? {:exclude []})) "empty exclude is absent"))
+
+;; ---------------------------------------------------------------------------
+;; keep-test? — defensive nil semantics
+;; ---------------------------------------------------------------------------
+
+(deftest test-keep-test-handles-nil-meta-gracefully
+  (is (selector/keep-test? {} "ns" {})
+      "empty meta with empty options keeps test")
+  (is (not (selector/keep-test? {:include [:integration]} "ns" {}))
+      "include gate with no matching meta drops test"))

--- a/tests/phel/test/shrink.phel
+++ b/tests/phel/test/shrink.phel
@@ -159,3 +159,31 @@
         "set root is preserved as a set")
     (is (some (fn [v] (< (count v) 3)) shrinks)
         "set shrinks by element removal")))
+
+;; ---------------------------
+;; Shrink driver terminates on nil children seq
+;; ---------------------------
+
+(deftest test-shrink-returns-original-for-leaf-when-property-fails
+  (testing "leaf value with failing pred returns original with zero steps"
+    (let [res (shrink/shrink-args (fn [_] false) [true])]
+      (is (= [true] (:smallest res))
+          "leaf bool returned unchanged")
+      (is (= 0 (:shrink-steps res))
+          "no shrink attempts on a leaf rose tree"))))
+
+;; ---------------------------
+;; value->rose dispatches on type
+;; ---------------------------
+
+(deftest test-value-to-rose-float-is-leaf
+  (testing "floats are not shrunk by the default strategy"
+    (let [t (shrink/value->rose 3.14)]
+      (is (= 3.14 (r/rose-root t)) "root is the input float")
+      (is (empty? (r/rose-children t)) "no shrinks for floats"))))
+
+(deftest test-value-to-rose-empty-string-is-a-leaf
+  (testing "empty strings have no shrinks"
+    (let [t (shrink/value->rose "")]
+      (is (= "" (r/rose-root t)))
+      (is (empty? (r/rose-children t)) "empty string shrinks to nothing"))))

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -271,4 +271,89 @@ final class TestCommandOptionsTest extends TestCase
         // generated Phel expression is syntactically valid.
         self::assertStringContainsString(':filter "has \\"quotes\\""', $options->asPhelHashMap());
     }
+
+    public function test_non_string_entries_in_string_list_are_dropped(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::INCLUDE => ['ok', 42, null, 'smoke', false],
+            TestCommandOptions::FILTERS => [12, 'keep', true],
+        ]);
+
+        self::assertSame(
+            '{:filter nil :testdox false :fail-fast false :include [:ok :smoke] :filters ["keep"]}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_ns_patterns_preserve_order_and_get_printed_as_strings(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::NS_PATTERNS => ['phel.a.*', 'phel.b.**', 'phel.c'],
+        ]);
+
+        self::assertStringContainsString(
+            ':ns-patterns ["phel.a.*" "phel.b.**" "phel.c"]',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_filter_roundtrips_a_plain_substring_verbatim(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::FILTER => 'add-',
+        ]);
+
+        self::assertSame(
+            '{:filter "add-" :testdox false :fail-fast false}',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_junit_output_with_spaces_quoted_by_printer(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::REPORTERS => ['junit-xml'],
+            TestCommandOptions::JUNIT_OUTPUT => 'build dir/junit.xml',
+        ]);
+
+        self::assertStringContainsString(
+            ':junit-output "build dir/junit.xml"',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_junit_output_rejects_non_string_type(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::JUNIT_OUTPUT => 42,
+        ]);
+
+        self::assertStringNotContainsString(':junit-output', $options->asPhelHashMap());
+    }
+
+    public function test_selector_order_in_output_is_stable_across_inputs(): void
+    {
+        // Regardless of input order, the output always emits selector keys
+        // in the documented order: include, exclude, ns-patterns, filters.
+        $asKeys = static fn(array $keys): array => array_fill_keys($keys, ['a']);
+
+        $first = TestCommandOptions::fromArray(
+            $asKeys([
+                TestCommandOptions::FILTERS,
+                TestCommandOptions::NS_PATTERNS,
+                TestCommandOptions::EXCLUDE,
+                TestCommandOptions::INCLUDE,
+            ]),
+        );
+        $second = TestCommandOptions::fromArray(
+            $asKeys([
+                TestCommandOptions::INCLUDE,
+                TestCommandOptions::EXCLUDE,
+                TestCommandOptions::NS_PATTERNS,
+                TestCommandOptions::FILTERS,
+            ]),
+        );
+
+        self::assertSame($first->asPhelHashMap(), $second->asPhelHashMap());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Second cleanup pass over the `phel\test` framework after #1524. Focus areas: DRY stats bookkeeping, SRP for `run-tests` orchestration, shared helpers for selectors and junit counters, coverage gaps in reporters and rose/shrink modules, and unifying the PHP/Phel `TestCommandOptions` boundary.

## 💡 Goal

Tighten the internals without changing the public API (`run-tests`, `defspec`, `quick-check`, `report`, `deftest`). Shrink duplicated patterns, move magic numbers and shapes into named constants, and fill the missing tests around nil events, glob edge cases, junit state, and reporter resolution.

## 🔖 Changes

### `src/phel/test.phel`
- Extract `initial-stats` constant and `bump-stat` helper. `record-stats!`, `record-skip!`, `reset-stats` now share the same `update-in`-based counter pattern.
- Split `resolve-reporters-option` into `coerce-reporter` and `requested-reporters` for SRP.
- Replace the inline cond-chain in `partition-tests` with `skip-reason`, which returns the reason keyword or nil.
- Add `empty-junit-suite`, `bump-junit-counters`, `junit-ensure-current`. `junit-record-case` and `junit-start-ns` read from the shared shape.
- Fix: `phel test --reporter=junit-xml` preserves namespace and testcase order in the emitted XML. Previously `junit-render` reversed both the suites vector and the cases vector.

### `src/phel/test/selector.phel`
- Extract `non-empty-vec?` and `any-tag-matches?` helpers.
- `matches-include?` / `matches-exclude?` / `matches-ns?` / `matches-filter?` share the same empty-option short-circuit.
- `has-selectors?` iterates over `selector-keys` instead of repeating four `(and (not (nil? ...)) (not (empty? ...)))` clauses.

### `src/php/Run/Domain/Test/TestCommandOptions.php`
- Unify `keywordVector` and `stringVector` behind `renderVector` taking a mapper closure.
- Extract `optionalString` for `:junit-output` rendering.
- Remove the ad-hoc `:reporters` block in `asPhelHashMap`; it now flows through `keywordVector`.

### Tests
Added coverage for:
- `resolve-reporter` with nil, unknown reporter keyword, and non-name `register-reporter!` inputs
- Custom reporter registration via the public API
- `:tap` description fallbacks when `:test-name` or `:message` is absent
- Junit reporter default exception class, fallback to event `:ns` without a `begin-test-ns`, and ordering of suites and cases
- Testdox reporter markers for pass/fail/error/skipped and default-message fallback
- `run-tests` with inline function reporter, unknown reporter keyword, and invalid reporter value
- `ns-matches?` trailing `*`, empty glob, and standalone `**`
- `has-selectors?` detection per key
- `rose-filter`, `rose-join`, `rose-string`, `rose-map`, `rose-vector-lax`
- `shrink-int-towards` with negative target and negative-direction shrinks
- `value->rose` leaf fallback for float, empty string
- `TestCommandOptions`: non-string entries dropped from lists, ns-patterns order, plain-substring filter roundtrip, junit-output with spaces, non-string junit path rejected, stable output order across input permutations