### PR TITLE
ref(schema,fiber,reader): second-pass cleanup

### DIFF
--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -104,9 +104,9 @@
     :symbol  (coerce-symbol value)
     :uuid    (coerce-uuid value)
     :inst    (coerce-inst value)
-    (if (reg/registered? head)
-      (coerce (reg/deref-ref head) value)
-      value)))
+    (v/resolve-or-default head
+                          (fn [target] (coerce target value))
+                          value)))
 
 (defn- coerce-collection
   [schema value type-ctor]
@@ -193,9 +193,9 @@
       :ref    (let [target (reg/deref-ref (first args))]
                 (if (nil? target) value (coerce target value)))
       :=>     value
-      (if (reg/registered? head)
-        (coerce (reg/deref-ref head) value)
-        value))))
+      (v/resolve-or-default head
+                            (fn [target] (coerce target value))
+                            value))))
 
 (defn coerce
   "Walks `schema` and returns `value` with string-typed inputs coerced

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -48,10 +48,8 @@
     :set        (g/set-of g/int)
     :sequential (g/vector-of g/int)
     :seqable    (g/vector-of g/int)
-    (if (reg/registered? head)
-      (schema->gen (reg/deref-ref head))
-      (throw (php/new \InvalidArgumentException
-                      (str "no default generator for schema kind: " head))))))
+    (v/resolve-or-throw "no default generator for schema kind" head
+                        (fn [target] (schema->gen target)))))
 
 (defn- vector-of-gen [args]
   (if (empty? args)
@@ -165,10 +163,8 @@
       :ref     (ref-gen args)
       :=>      (throw (php/new \InvalidArgumentException
                                 "cannot generate function schemas"))
-      (if (reg/registered? head)
-        (schema->gen (reg/deref-ref head))
-        (throw (php/new \InvalidArgumentException
-                        (str "no generator for schema kind: " head)))))))
+      (v/resolve-or-throw "no generator for schema kind" head
+                          (fn [target] (schema->gen target))))))
 
 (defn schema->gen
   "Returns a `phel\\test\\gen` generator for `schema`. Honours a

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -19,6 +19,34 @@
 (declare schema-options)
 
 ;; ----------------
+;; Head-dispatch fallback
+;; ----------------
+
+(defn resolve-or-throw
+  "Resolves an unknown head by looking it up in the registry. When
+  `head` names a registered schema, invokes `f` with the registered
+  schema; otherwise throws an `InvalidArgumentException` mentioning
+  `label` (e.g. `\"unknown schema kind\"` or `\"no generator for schema kind\"`).
+
+  Every head-dispatching caller uses this so the error shape is
+  consistent across validator/explainer/coercer/generator."
+  [label head f]
+  (if (reg/registered? head)
+    (f (reg/deref-ref head))
+    (throw (php/new \InvalidArgumentException
+                    (str label ": " head)))))
+
+(defn resolve-or-default
+  "Like `resolve-or-throw`, but returns `default` when `head` is not
+  registered instead of throwing. Used by `coerce` where unknown heads
+  are intentionally passed through unchanged for downstream validation
+  to flag."
+  [head f default]
+  (if (reg/registered? head)
+    (f (reg/deref-ref head))
+    default))
+
+;; ----------------
 ;; Schema shape helpers
 ;; ----------------
 
@@ -114,10 +142,8 @@
     :set        (set? value)
     :sequential (valid-sequential? value)
     :seqable    (valid-seqable? value)
-    (if (reg/registered? head)
-      (valid? (reg/deref-ref head) value)
-      (throw (php/new \InvalidArgumentException
-                      (str "unknown schema kind: " head))))))
+    (resolve-or-throw "unknown schema kind" head
+                      (fn [target] (valid? target value)))))
 
 ;; ----------------
 ;; Parametric validators
@@ -277,10 +303,8 @@
                                    (str "schema ref not registered: " (get args 0)))))
                  (valid? target value))
       :=>      true
-      (if (reg/registered? head)
-        (valid? (reg/deref-ref head) value)
-        (throw (php/new \InvalidArgumentException
-                        (str "unknown schema kind: " head)))))))
+      (resolve-or-throw "unknown schema kind" head
+                        (fn [target] (valid? target value))))))
 
 ;; ----------------
 ;; Public entry point

--- a/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
+++ b/src/php/Compiler/Domain/Reader/ExpressionReader/TaggedLiteralReader.php
@@ -19,9 +19,7 @@ use Phel\Lang\TagHandlers\BuiltinTagHandlers;
 use Phel\Lang\TagRegistry;
 use Throwable;
 
-use function array_merge;
 use function implode;
-use function sort;
 use function sprintf;
 
 /**
@@ -72,10 +70,7 @@ final readonly class TaggedLiteralReader
 
     private function unknownTagMessage(string $tag, TagRegistry $registry): string
     {
-        $registeredTags = array_merge($registry->tags(), BuiltinTagHandlers::RESERVED);
-        sort($registeredTags);
-
-        $list = '#' . implode(', #', $registeredTags);
+        $list = '#' . implode(', #', $registry->allTags(BuiltinTagHandlers::RESERVED));
 
         return sprintf(
             "Unknown tagged literal '#%s'. Registered tags: %s. Use `(register-tag \"%s\" f)` to register a handler, or ensure the literal only appears inside a non-selected reader-conditional branch (e.g. :clj, :jank).",

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -38,8 +38,9 @@ and `future-call`/`future-fiber`.
 
 ## Domain
 
-- `Promise` — single-delivery, parks waiting fibers in a list and
-  re-enqueues them on `deliver()`. `derefWithTimeout(0, fallback)`
+- `Promise` — single-delivery. Waiting fibers poll via `Fiber::suspend()`
+  and rely on the scheduler to resume them on the next tick; they
+  re-check the delivered flag each wake-up. `derefWithTimeout(0, fallback)`
   returns the fallback immediately.
 - `Future` — wraps a callable executed inside a Fiber. Captures the
   return value (or thrown throwable) in an internal Promise.

--- a/src/php/Fiber/Domain/Promise.php
+++ b/src/php/Fiber/Domain/Promise.php
@@ -104,17 +104,18 @@ final class Promise implements Awaitable
     }
 
     /**
-     * Opaque wrapper so static analysers do not treat the `$this->delivered`
-     * check as a compile-time constant. The flag is flipped as a side effect
-     * of {@see deliver()} called from concurrently-running fibers.
+     * Re-read the delivered flag through a method call so PHPStan cannot
+     * fold it into a compile-time constant inside the deref poll loops.
+     * The flag is flipped as a side effect of {@see deliver()} called from
+     * a concurrently-running fiber, which no static analyser can see.
+     *
+     * The self-assignment below is intentional: writing the property back to
+     * itself marks the method as impure to PHPStan without changing state.
      *
      * @phpstan-impure
      */
     private function pollDelivered(): bool
     {
-        // Flipping the value then restoring it breaks static reasoning so
-        // PHPStan does not fold $this->delivered into a compile-time false
-        // inside the deref loops.
         $snapshot = $this->delivered;
         $this->delivered = $snapshot;
         return $snapshot;

--- a/src/php/Lang/TagRegistry.php
+++ b/src/php/Lang/TagRegistry.php
@@ -6,7 +6,11 @@ namespace Phel\Lang;
 
 use function array_key_exists;
 use function array_keys;
+use function array_merge;
+use function array_unique;
+use function array_values;
 use function is_callable;
+use function sort;
 
 /**
  * Global registry for reader tagged-literal handlers.
@@ -65,6 +69,23 @@ final class TagRegistry
         $tags = array_keys($this->handlers);
         sort($tags);
         return $tags;
+    }
+
+    /**
+     * Returns the sorted union of {@see tags()} and any additional reserved
+     * tags handled elsewhere (e.g. `#php` resolved inside the reader).
+     * Callers building "unknown tag" error messages use this so the
+     * advertised list matches what the reader will actually accept.
+     *
+     * @param list<string> $reserved
+     *
+     * @return list<string>
+     */
+    public function allTags(array $reserved): array
+    {
+        $merged = array_values(array_unique(array_merge($this->tags(), $reserved)));
+        sort($merged);
+        return $merged;
     }
 
     public function clear(): void

--- a/tests/phel/test/schema/coerce.phel
+++ b/tests/phel/test/schema/coerce.phel
@@ -80,3 +80,24 @@
 (deftest test-coerce-maybe
   (is (= nil (s/coerce [:maybe :int] nil)))
   (is (= 5 (s/coerce [:maybe :int] "5"))))
+
+(deftest test-coerce-unknown-head-passes-through-unchanged
+  (is (= "42" (s/coerce :no-such-head "42")))
+  (is (= "42" (s/coerce [:no-such-head] "42"))))
+
+(deftest test-coerce-through-registered-schema
+  (s/register! :price :int)
+  (is (= 7 (s/coerce :price "7")))
+  (is (= 7 (s/coerce [:ref :price] "7")))
+  (s/unregister! :price))
+
+(deftest test-coerce-map-preserves-non-schema-entries
+  (let [result (s/coerce [:map [:id :int]]
+                         {:id "1" :extra "unchanged"})]
+    (is (= 1 (get result :id)))
+    (is (= "unchanged" (get result :extra))))
+  "undeclared keys stay intact so the caller can validate shape separately")
+
+(deftest test-coerce-non-schema-input-is-identity
+  (is (= 42 (s/coerce 99 42)) "numeric schema shape returns value as-is")
+  (is (= "x" (s/coerce "schema-string" "x"))))

--- a/tests/phel/test/schema/explain.phel
+++ b/tests/phel/test/schema/explain.phel
@@ -91,3 +91,37 @@
     (is (string? text))
     (is (php/str_contains text "mismatch"))
     (is (php/str_contains text ":int"))))
+
+(deftest test-explain-empty-or-reports-mismatch
+  (let [r (s/explain [:or] 1)]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))))
+
+(deftest test-explain-empty-and-accepts-any
+  (is (nil? (s/explain [:and] 1)))
+  (is (nil? (s/explain [:and] "x")))
+  (is (nil? (s/explain [:and] nil))))
+
+(deftest test-explain-empty-enum-reports-mismatch
+  (let [r (s/explain [:enum] 1)]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))))
+
+(deftest test-explain-recursive-ref-reports-leaf-path
+  (s/register! :tree [:map
+                      [:value :int]
+                      [:children [:vector [:ref :tree]]]])
+  (let [r (s/explain [:ref :tree]
+                     {:value 1
+                      :children [{:value "oops" :children []}]})]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))
+    (let [err (first (get r :errors))]
+      (is (= :mismatch (get err :type)))
+      (is (= [:children 0 :value] (get err :in)))))
+  (s/unregister! :tree))
+
+(deftest test-explain-unregistered-ref-reports-mismatch
+  (let [r (s/explain [:ref :definitely-not-there] 1)]
+    (is (not (nil? r)))
+    (is (= 1 (count (get r :errors))))))

--- a/tests/phel/test/schema/instrument.phel
+++ b/tests/phel/test/schema/instrument.phel
@@ -84,3 +84,16 @@
     (is (= "not an int" (s/with-schema-check false (fn [] (wrapped 1)))))
     ;; And is restored afterwards
     (is (s/schema-check?))))
+
+(deftest test-with-schema-check-restores-previous-value-on-throw
+  (s/set-schema-check! true)
+  (let [caught (try
+                 (s/with-schema-check false
+                   (fn [] (throw (php/new \RuntimeException "oops"))))
+                 :no-throw
+                 (catch \RuntimeException _ :caught))]
+    (is (= :caught caught))
+    (is (s/schema-check?) "flag is restored to its previous value even when the thunk throws")))
+
+(deftest test-unstrument-returns-nil-for-unknown-name
+  (is (nil? (s/unstrument! :never-instrumented))))

--- a/tests/phel/test/schema/registry.phel
+++ b/tests/phel/test/schema/registry.phel
@@ -43,3 +43,22 @@
                  :no-throw
                  (catch \InvalidArgumentException _ :caught))]
     (is (= :caught caught))))
+
+(deftest test-re-register-overwrites-previous-schema
+  (s/register! :rate :int)
+  (is (s/validate :rate 5))
+  (s/register! :rate :string)
+  (is (not (s/validate :rate 5)))
+  (is (s/validate :rate "fast"))
+  (s/unregister! :rate))
+
+(deftest test-unregister-missing-name-is-noop
+  (is (nil? (s/unregister! :never-registered))))
+
+(deftest test-generate-recursive-tree-schema-uses-registry
+  (s/register! :leaf :int)
+  (s/register! :branch [:map
+                        [:value [:ref :leaf]]])
+  (is (s/validate [:ref :branch] (s/generate [:ref :branch])))
+  (s/unregister! :branch)
+  (s/unregister! :leaf))

--- a/tests/php/Unit/Fiber/Domain/FutureTest.php
+++ b/tests/php/Unit/Fiber/Domain/FutureTest.php
@@ -139,4 +139,38 @@ final class FutureTest extends TestCase
 
         self::assertSame(':cancelled', $future->derefWithTimeout(100, ':cancelled'));
     }
+
+    public function test_deref_with_zero_timeout_returns_value_when_already_realized(): void
+    {
+        $future = new Future($this->scheduler, static fn(): int => 99);
+
+        // Drive the fiber to completion before asking for the value.
+        $this->scheduler->runUntilIdle();
+
+        self::assertSame(99, $future->derefWithTimeout(0, ':fallback'));
+    }
+
+    public function test_deref_with_timeout_still_rethrows_body_exception(): void
+    {
+        $future = new Future($this->scheduler, static function (): never {
+            throw new RuntimeException('late boom');
+        });
+
+        // Let the fiber run so the internal promise is realized with failure.
+        $this->scheduler->runUntilIdle();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('late boom');
+        $future->derefWithTimeout(100, ':never');
+    }
+
+    public function test_cancel_is_idempotent(): void
+    {
+        $future = new Future($this->scheduler, static fn(): string => 'x');
+        $future->cancel();
+        $future->cancel();
+        $future->cancel();
+
+        self::assertTrue($future->isCancelled());
+    }
 }

--- a/tests/php/Unit/Fiber/Domain/PromiseTest.php
+++ b/tests/php/Unit/Fiber/Domain/PromiseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Fiber\Domain;
 
+use Fiber;
 use Phel\Fiber\Domain\Promise;
 use Phel\Fiber\Domain\Scheduler;
 use PHPUnit\Framework\TestCase;
@@ -114,5 +115,36 @@ final class PromiseTest extends TestCase
         $promise->deliver('ready');
 
         self::assertSame('ready', $promise->derefWithTimeout(0, ':fallback'));
+    }
+
+    public function test_deref_from_fiber_unblocks_when_another_fiber_delivers(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $waiter = new Fiber(static function () use ($promise, &$observed): void {
+            $observed = $promise->deref();
+        });
+        $waiter->start();
+
+        $this->scheduler->enqueue($waiter);
+
+        $producer = new Fiber(static function () use ($promise): void {
+            $promise->deliver('handoff');
+        });
+        $this->scheduler->enqueue($producer);
+        $this->scheduler->runUntilIdle();
+
+        self::assertSame('handoff', $observed);
+        self::assertTrue($promise->isRealized());
+    }
+
+    public function test_many_deliveries_leave_first_value_and_return_false_each_time(): void
+    {
+        $promise = new Promise($this->scheduler);
+        $promise->deliver(1);
+
+        self::assertFalse($promise->deliver(2));
+        self::assertFalse($promise->deliver(3));
+        self::assertFalse($promise->deliver(4));
+        self::assertSame(1, $promise->value());
     }
 }

--- a/tests/php/Unit/Fiber/Domain/SchedulerTest.php
+++ b/tests/php/Unit/Fiber/Domain/SchedulerTest.php
@@ -8,6 +8,7 @@ use Fiber;
 use Phel\Fiber\Domain\Promise;
 use Phel\Fiber\Domain\Scheduler;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class SchedulerTest extends TestCase
 {
@@ -155,5 +156,53 @@ final class SchedulerTest extends TestCase
         $scheduler->enqueue($fiber);
 
         self::assertSame('from-fiber', $scheduler->await($promise));
+    }
+
+    public function test_tick_swallows_throwable_and_continues_with_remaining_fibers(): void
+    {
+        $scheduler = new Scheduler();
+        $seen = [];
+
+        $throwing = new Fiber(static function (): never {
+            throw new RuntimeException('boom');
+        });
+        $surviving = new Fiber(static function () use (&$seen): void {
+            $seen[] = 'ran';
+        });
+
+        $scheduler->enqueue($throwing);
+        $scheduler->enqueue($surviving);
+
+        $scheduler->runUntilIdle();
+
+        self::assertSame(['ran'], $seen);
+        self::assertFalse($scheduler->hasReady());
+    }
+
+    public function test_enqueue_preserves_fifo_order_across_many_suspends(): void
+    {
+        $scheduler = new Scheduler();
+        $order = [];
+
+        $makeFiber = static function (string $id) use (&$order): Fiber {
+            return new Fiber(static function () use (&$order, $id): void {
+                $order[] = $id . ':1';
+                Fiber::suspend();
+                $order[] = $id . ':2';
+            });
+        };
+
+        foreach (['a', 'b', 'c', 'd'] as $id) {
+            $fiber = $makeFiber($id);
+            $fiber->start();
+            $scheduler->enqueue($fiber);
+        }
+
+        $scheduler->runUntilIdle();
+
+        self::assertSame(
+            ['a:1', 'b:1', 'c:1', 'd:1', 'a:2', 'b:2', 'c:2', 'd:2'],
+            $order,
+        );
     }
 }

--- a/tests/php/Unit/Lang/TagRegistryTest.php
+++ b/tests/php/Unit/Lang/TagRegistryTest.php
@@ -80,4 +80,35 @@ final class TagRegistryTest extends TestCase
 
         self::assertSame(['alpha', 'mike', 'zeta'], $this->registry->tags());
     }
+
+    public function test_all_tags_merges_reserved_into_sorted_list(): void
+    {
+        $noop = static fn(mixed $_): mixed => null;
+        $this->registry->register('uuid', $noop);
+        $this->registry->register('inst', $noop);
+
+        self::assertSame(['inst', 'php', 'uuid'], $this->registry->allTags(['php']));
+    }
+
+    public function test_all_tags_deduplicates_overlap_between_registered_and_reserved(): void
+    {
+        $noop = static fn(mixed $_): mixed => null;
+        $this->registry->register('php', $noop);
+        $this->registry->register('uuid', $noop);
+
+        self::assertSame(['php', 'uuid'], $this->registry->allTags(['php']));
+    }
+
+    public function test_all_tags_works_with_empty_reserved(): void
+    {
+        $noop = static fn(mixed $_): mixed => null;
+        $this->registry->register('a', $noop);
+
+        self::assertSame(['a'], $this->registry->allTags([]));
+    }
+
+    public function test_all_tags_returns_reserved_only_when_no_handlers(): void
+    {
+        self::assertSame(['php'], $this->registry->allTags(['php']));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Second-pass cleanup of the schema, fiber, and reader subsystems that landed in #1524. The first pass set the public API shape; this pass tightens head-dispatch duplication, moves the reserved-tag union next to its data, clarifies documentation that drifted from code, and fills in missing edge-case tests.

No user-visible behaviour changes; public APIs are stable.

## 💡 Goal

- Remove duplicated head-dispatch fallback across schema consumers (validator, explainer, coercer, generator).
- Stop the reader from owning the combined registered + reserved tag list; let `TagRegistry` expose it.
- Correct Fiber CLAUDE.md Promise description so docs match the polling implementation.
- Close coverage gaps in malformed schema inputs, recursive `:ref`, empty `[:and]`/`[:or]`/`[:enum]` explain paths, Promise deliver-wakeup across fibers, Future cancel + timeout interactions, Scheduler body-throw survival, and `TagRegistry::allTags`.

## 🔖 Changes

### Schema
- New helpers `resolve-or-throw` and `resolve-or-default` on `phel\schema\validator` centralize the "registered schema? recurse, else throw or default" pattern that was duplicated across validator, coercer, and generator.
- Added explainer tests for empty `[:and]`, `[:or]`, `[:enum]`, recursive `:ref` path reporting, and unregistered `:ref`.
- Added coerce tests for unknown head passthrough, registered-schema coercion via `:ref`, undeclared-key preservation, and non-schema shape identity.
- Added registry tests for re-register overwrite, unregister-missing noop, and recursive tree-schema generator roundtrip.
- Added instrument tests for `with-schema-check` restoring the flag when the thunk throws, and `unstrument!` returning nil for unknown names.

### Reader
- `TagRegistry::allTags(list<string> $reserved)` returns the sorted union of registered + reserved tags. `TaggedLiteralReader` delegates to it instead of inlining `array_merge + sort`.
- New `TagRegistryTest` coverage for `allTags` (merge, dedup, empty inputs, reserved-only).

### Fiber
- `Fiber/CLAUDE.md` Promise entry now describes the actual polling + re-check behaviour (the original "parks waiting fibers in a list" text did not match the code).
- `Promise::pollDelivered` comment explains why the self-assignment defeats PHPStan folding.
- `PromiseTest`: fiber-to-fiber deliver handoff; post-delivered idempotence across repeated deliveries.
- `FutureTest`: zero-timeout on a realized future returns the value; `derefWithTimeout` still rethrows when the body failed; `cancel()` is idempotent.
- `SchedulerTest`: fiber body throw does not stop remaining fibers; FIFO order preserved across many suspends.