### PR TITLE
docs: refresh guides and verify examples

### DIFF
--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -2,6 +2,18 @@
 
 `phel\async` exposes two cooperating concurrency layers over PHP fibers. Both live in the same namespace so you can mix them, but each has its own best use.
 
+## Contents
+
+- [Overview](#overview)
+- [When to use which](#when-to-use-which)
+- [AMPHP layer reference](#amphp-layer-reference)
+- [Fiber layer reference](#fiber-layer-reference)
+- [Shared primitives](#shared-primitives)
+- [Error and cancellation model](#error-and-cancellation-model)
+- [Interop](#interop)
+- [Pitfalls](#pitfalls)
+- [Recipes](#recipes)
+
 ## Overview
 
 **AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `delay`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` live here. Use this layer when you already run inside an event loop or when you need timers, IO multiplexing, or fan-out across many Futures.
@@ -250,7 +262,7 @@ Wall time tracks the slowest branch, not the sum.
           fast (future (do (delay 0.05)
                            (throw (php/new \RuntimeException "boom"))))]
       (try
-        (await (php/-> fast (unwrap)))
+        (await fast)
         (catch \RuntimeException e
           (future-cancel slow)
           (str "cancelled after: " (php/-> e (getMessage))))))))
@@ -259,3 +271,8 @@ Wall time tracks the slowest branch, not the sum.
 ```
 
 `future-cancel` is cooperative, so `slow` finishes its current step before observing the cancellation, but any `deref` on it now throws `Amp\CancelledException`.
+
+## See also
+
+- [Example: `docs/examples/11_async-concurrency.phel`](examples/11_async-concurrency.phel)
+- [`phel\http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls that slot into this model

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -30,9 +30,9 @@ Because `symfony/console` is already a runtime dependency of `phel-lang`, using 
 
 Run:
 
-```
-$ phel run my-tool/main greet alice
-[OK] Hello, alice!
+```bash
+./vendor/bin/phel run my-tool/main greet alice
+# [OK] Hello, alice!
 ```
 
 ## Spec reference
@@ -182,8 +182,8 @@ Available `:style` values: `:default`, `:borderless`, `:compact`, `:symfony`, `:
 
 Symfony calls your completion function when the user presses `<TAB>` after installing the shell completion script:
 
-```
-$ my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
+```bash
+my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
 ```
 
 ## Signal handling
@@ -233,6 +233,20 @@ For prompt testing, pipe canned STDIN:
   (cli/run app input output)
   (is (cli/output-contains? output "hi alice")))
 ```
+
+## Running under `phel run`
+
+When you run a CLI script via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. The user-facing arguments come through as the Phel core var `argv`. Pass them to `cli/run` explicitly:
+
+```phel
+;; Bad: reads the wrapper's argv, so "run" looks like your first command.
+(cli/run app)
+
+;; Good: pass only the user-supplied args.
+(cli/run app (cli/argv argv))
+```
+
+This is only needed when the script is invoked via `phel run`. A compiled standalone binary built with `phel build` uses `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
 
 ## Best practices
 

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -2,10 +2,10 @@
 
 This guide covers all functions for manipulating Phel's immutable data structures: vectors, maps, sets, and lists.
 
-## Table of Contents
+## Contents
 
 - [Introduction](#introduction)
-- [String Iteration](#string-iteration-)
+- [String Iteration](#string-iteration)
 - [Adding & Building Collections](#adding--building-collections)
 - [Accessing Elements](#accessing-elements)
 - [Modifying Collections](#modifying-collections)
@@ -13,17 +13,15 @@ This guide covers all functions for manipulating Phel's immutable data structure
 - [Analysis Functions](#analysis-functions)
 - [Working with Nested Structures](#working-with-nested-structures)
 - [Transient Collections](#transient-collections)
-- [Phel-Specific Extensions](#phel-specific-extensions-)
+- [Phel-Specific Extensions](#phel-specific-extensions)
 - [Quick Reference](#quick-reference)
 - [Deprecated Functions](#deprecated-functions)
 
 ## Introduction
 
-Phel's data structures are **immutable** and **persistent**. Operations return new versions of the data structure while efficiently sharing structure with the original. This guide focuses on functions that manipulate these structures.
+Phel's data structures are **immutable** and **persistent**. Operations return new versions of the collection while sharing structure with the original, so reads stay O(1) amortized and updates cost log32(n).
 
-### Clojure Compatibility
-
-Phel aims for strong compatibility with Clojure. Most functions work identically to their Clojure counterparts. Where differences exist, they're noted inline with **"Clojure note:"** annotations.
+The function names follow the same conventions as most Lisps (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). A short [quick reference](#quick-reference) appears at the end of the guide.
 
 ---
 
@@ -148,8 +146,6 @@ The universal function for adding elements to any collection type. Behavior vari
 
 **Signature:** `([] [coll] [coll value] [coll value & more])`
 
-**Clojure note:** Identical behavior to Clojure's `conj`.
-
 ---
 
 ### `assoc` - Associate Key-Value Pairs
@@ -171,8 +167,6 @@ Associates a value with a key in a collection. For maps, adds/updates key-value 
 
 **Signature:** `[ds key value]`
 
-**Clojure note:** Identical behavior to Clojure's `assoc`.
-
 **See also:** For maps with structured data, consider `conj`. For nested updates, use `assoc-in`.
 
 ---
@@ -193,11 +187,15 @@ Returns a collection with all elements from one or more source collections added
 
 (into #{1 2} [2 3 4])
 ;; => #{1 2 3 4}
+
+;; With a transducer (middle argument)
+(into [] (map inc) [1 2 3])
+;; => [2 3 4]
 ```
 
-**Signature:** `[to & from]`
+**Signatures:** `[to from]`, `[to xform from]`
 
-**Clojure note:** Phel's `into` doesn't support transducers yet. Use `(into to from)` only.
+See [Transducers](transducers.md) for building reusable transformations.
 
 ---
 
@@ -224,8 +222,6 @@ Gets the value at a key in a collection. Returns `nil` or an optional default if
 
 **Signature:** `[ds k & [opt]]`
 
-**Clojure note:** Identical behavior to Clojure's `get`.
-
 ---
 
 ### `get-in` - Nested Access
@@ -246,8 +242,6 @@ Accesses a value in a nested data structure via a sequence of keys.
 
 **Signature:** `[ds ks & [opt]]`
 
-**Clojure note:** Identical behavior to Clojure's `get-in`.
-
 ---
 
 ### `keys` - Extract Keys
@@ -261,22 +255,20 @@ Returns a sequence of all keys in a map.
 
 **Signature:** `[coll]`
 
-**Clojure note:** Identical behavior to Clojure's `keys`.
-
 ---
 
-### `values` - Extract Values
+### `vals` - Extract Values
 
 Returns a sequence of all values in a map.
 
 ```phel
-(values {:a 1 :b 2 :c 3})
+(vals {:a 1 :b 2 :c 3})
 ;; => (1 2 3)
 ```
 
 **Signature:** `[coll]`
 
-**Clojure note:** Clojure uses `vals` instead of `values`. This is a naming difference only.
+> `values` is a deprecated alias that still works.
 
 ---
 
@@ -296,8 +288,6 @@ Returns `true` if a key exists in the collection. **Important:** Checks for keys
 ```
 
 **Signature:** `[coll key]`
-
-**Clojure note:** Identical behavior to Clojure's `contains?`.
 
 ---
 
@@ -338,8 +328,6 @@ Updates a value in a data structure by applying a function to the current value.
 
 **Signature:** `[ds k f & args]`
 
-**Clojure note:** Identical behavior to Clojure's `update`.
-
 ---
 
 ### `update-in` - Nested Transform
@@ -355,8 +343,6 @@ Updates a value in a nested data structure by applying a function.
 ```
 
 **Signature:** `[ds [k & ks] f & args]`
-
-**Clojure note:** Identical behavior to Clojure's `update-in`.
 
 ---
 
@@ -374,8 +360,6 @@ Associates a value in a nested data structure. Creates intermediate structures a
 
 **Signature:** `[ds [k & ks] v]`
 
-**Clojure note:** Identical behavior to Clojure's `assoc-in`.
-
 ---
 
 ### `dissoc` - Dissociate Keys
@@ -391,8 +375,6 @@ Removes a key from a data structure.
 ```
 
 **Signature:** `[ds key]`
-
-**Clojure note:** Identical behavior to Clojure's `dissoc`.
 
 ---
 
@@ -427,8 +409,6 @@ Merges multiple maps into one. Later values override earlier ones for duplicate 
 
 **Signature:** `[& maps]`
 
-**Clojure note:** Identical behavior to Clojure's `merge`.
-
 ---
 
 ### `merge-with` - Merge with Function
@@ -444,8 +424,6 @@ Merges maps, using a function to resolve duplicate keys.
 ```
 
 **Signature:** `[f & maps]`
-
-**Clojure note:** Identical behavior to Clojure's `merge-with`.
 
 ---
 
@@ -484,8 +462,6 @@ Returns a new map with only the specified keys.
 
 **Signature:** `[m ks]`
 
-**Clojure note:** Identical behavior to Clojure's `select-keys`.
-
 ---
 
 ### `zipmap` - Create Map from Sequences
@@ -502,8 +478,6 @@ Creates a map by pairing up keys and values from two sequences.
 ```
 
 **Signature:** `[keys vals]`
-
-**Clojure note:** Identical behavior to Clojure's `zipmap`.
 
 ---
 
@@ -555,8 +529,6 @@ Groups elements by the result of applying a function to each element.
 ```
 
 **Signature:** `[f coll]`
-
-**Clojure note:** Identical behavior to Clojure's `group-by`.
 
 ---
 
@@ -731,7 +703,7 @@ The predicate receives two arguments: `%1` (index) and `%2` (item).
 | Get nested | `get-in` | `(get-in {:a {:b 1}} [:a :b])` → `1` |
 | Check key exists | `contains?` | `(contains? {:a 1} :a)` → `true` |
 | Get all keys | `keys` | `(keys {:a 1 :b 2})` → `(:a :b)` |
-| Get all values | `values` | `(values {:a 1 :b 2})` → `(1 2)` |
+| Get all values | `vals` | `(vals {:a 1 :b 2})` → `(1 2)` |
 | **Modifying** |
 | Transform value | `update` | `(update {:a 1} :a inc)` → `{:a 2}` |
 | Transform nested | `update-in` | `(update-in {:a {:b 1}} [:a :b] inc)` → `{:a {:b 2}}` |

--- a/docs/examples/05_data-structures.phel
+++ b/docs/examples/05_data-structures.phel
@@ -54,9 +54,9 @@
 (println "get-in wireless:" (get-in product [:specs :wireless]))
 (println "get-in nested:" (get-in inventory [0 :name]))  ;; First item's name
 
-;; keys and values
+;; keys and vals
 (println "keys:" (keys product))
-(println "values:" (values {:a 1 :b 2 :c 3}))
+(println "vals:" (vals {:a 1 :b 2 :c 3}))
 
 ;; contains? - Check for keys (not values!)
 (println "contains? :name:" (contains? product :name))  ;; => true

--- a/docs/examples/12_cli.phel
+++ b/docs/examples/12_cli.phel
@@ -1,26 +1,28 @@
 ;; Runnable phel\cli demo: a tiny todo-list CLI.
 ;;
-;;   phel run docs/examples/12_cli.phel add "buy milk"
-;;   phel run docs/examples/12_cli.phel list
-;;   phel run docs/examples/12_cli.phel list --format=markdown
-;;   phel run docs/examples/12_cli.phel wipe
+;;   ./bin/phel run docs/examples/12_cli.phel add "buy milk"
+;;   ./bin/phel run docs/examples/12_cli.phel list
+;;   ./bin/phel run docs/examples/12_cli.phel list --format=markdown
+;;   ./bin/phel run docs/examples/12_cli.phel done 1
+;;   ./bin/phel run docs/examples/12_cli.phel wipe
 ;;
-;; Persists to /tmp/phel-todo.edn — not production-grade, just a demo.
+;; Persists to /tmp/phel-todo.json, not production-grade, just a demo.
 
 (ns examples\cli
-  (:require phel\cli :as cli))
+  (:require phel\cli :as cli)
+  (:require phel\json :as json))
 
-(def store-file "/tmp/phel-todo.edn")
+(def store-file "/tmp/phel-todo.json")
 
 ;; ----- persistence helpers ------------------------------------------------
 
 (defn- load-todos []
   (if (php/file_exists store-file)
-    (read-string (php/file_get_contents store-file))
+    (json/decode (php/file_get_contents store-file))
     []))
 
 (defn- save-todos [xs]
-  (php/file_put_contents store-file (print-str xs)))
+  (php/file_put_contents store-file (json/encode xs)))
 
 ;; ----- command handlers ---------------------------------------------------
 
@@ -48,7 +50,7 @@
     (if (or (< idx 0) (>= idx (count items)))
       (do (cli/error ctx (str "No todo at position " (+ idx 1))) 2)
       (do
-        (save-todos (put items idx (put (get items idx) :done? true)))
+        (save-todos (assoc items idx (assoc (get items idx) :done? true)))
         (cli/success ctx (str "Marked #" (+ idx 1) " done"))))))
 
 (defn- wipe-todos [ctx]
@@ -87,4 +89,7 @@
                  :aliases ["clear"]
                  :run     wipe-todos}]}))
 
-(cli/run app)
+;; Pass Phel's `argv` explicitly so Symfony sees the user arguments rather
+;; than `phel run <file> ...`. `cli/argv` wraps a vector of tokens into a
+;; Symfony `ArgvInput`.
+(cli/run app (cli/argv argv))

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,31 +1,32 @@
 # Phel single-file showcase
 
-These standalone scripts demonstrate how Phel scales from a friendly first contact to
-more expressive programs that lean on both functional patterns and the underlying PHP
-runtime. Each file can be executed with the Phel CLI:
+Standalone scripts that walk from primitive literals up to concurrency and a full CLI. Each file runs with:
 
 ```bash
-bin/phel run docs/examples/<file>.phel
+./bin/phel run docs/examples/<file>.phel
 ```
 
 ## Example overview
 
-1. **basic-types.phel** – Explore primitive values, keywords, and common collection literals.
-2. **arithmetic.phel** – Crunch numbers with helper functions for common operations.
-3. **control-flow.phel** – Use `cond` and `case` for branching logic.
-4. **functions-recursion.phel** – Build reusable helpers and recursive algorithms.
-5. **data-structures.phel** – Traverse vectors, maps, and strings with destructuring and iteration patterns.
-6. **data-pipeline.phel** – Compose sequence operations with higher-order helpers and threading.
-7. **macro-playground.phel** – Craft a macro to generate structured launch plans.
-8. **interfaces.phel** – Model behaviour with interfaces and multiple implementations.
-9. **php-integration.phel** – Interoperate with PHP classes, dates, and JSON encoding.
-10. **html-rendering.phel** – Render dynamic HTML with Phel's templating macros.
-11. **async-concurrency.phel** – Run cooperative work with `amphp` fibers.
-12. **cli.phel** – Build a small todo-list CLI on top of `phel\cli`.
+| # | File | Topic |
+|---|------|-------|
+| 01 | `01_basic-types.phel` | Primitive values, keywords, collection literals |
+| 02 | `02_arithmetic.phel` | Numeric operations and helper functions |
+| 03 | `03_control-flow.phel` | `cond` and `case` for branching |
+| 04 | `04_functions-recursion.phel` | Reusable helpers, `loop`/`recur`, recursion |
+| 05 | `05_data-structures.phel` | Vectors, maps, `conj`, `assoc`, nested updates, transients |
+| 06 | `06_data-pipeline.phel` | Threading macros, `filter`/`map`/`reduce`, `group-by` |
+| 07 | `07_macro-playground.phel` | A small DSL built with `defmacro` |
+| 08 | `08_interfaces.phel` | `definterface` + `defstruct` polymorphism |
+| 09 | `09_php-integration.phel` | PHP interop: `DateTimeImmutable`, `DateInterval`, JSON |
+| 10 | `10_html-rendering.phel` | HTML templating with `phel\html` |
+| 11 | `11_async-concurrency.phel` | AMPHP + fiber concurrency (`async`, `await`, `promise`) |
+| 12 | `12_cli.phel` | A todo-list CLI on `phel\cli` with subcommands and tables |
+| — | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
 
-Feel free to copy these files into your own project and experiment.
+Copy any file into your project and tweak it.
 
-## Test all examples
+## Run them all
 
 ```bash
 find docs/examples -name "*.phel" -type f | \
@@ -34,6 +35,8 @@ find docs/examples -name "*.phel" -type f | \
       echo "=== Running: {} ===" && \
       ./bin/phel run {} && \
       echo "" || \
-      (echo "❌ ERROR in {}" && exit 1)
+      (echo "ERROR in {}" && exit 1)
     '
 ```
+
+This is the same command the CI `examples` job runs on every push.

--- a/docs/examples/transducers.phel
+++ b/docs/examples/transducers.phel
@@ -1,4 +1,4 @@
-(ns doc\examples\transducers)
+(ns examples\transducers)
 
 ;; -------------------------------------------------------
 ;; Phel Transducers -- A Practical Guide

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -7,6 +7,7 @@ Practical patterns for writing idiomatic Phel code.
 - [Working with Nil](#working-with-nil)
 - [Collection Transformations](#collection-transformations)
 - [Threading Macros](#threading-macros)
+- [Pattern Matching](#pattern-matching)
 - [Error Handling](#error-handling)
 - [State Management](#state-management)
 - [Recursion and Looping](#recursion-and-looping)
@@ -218,6 +219,50 @@ Threads value as **last** argument:
      (map square)
      (reduce +))
 ```
+
+## Pattern Matching
+
+`phel\match` provides a `match` macro that destructures by shape and binds symbols in one step. Use it when `cond`/`case` would force you to re-query the same value from multiple angles.
+
+```phel
+(ns app\commands
+  (:require phel\match :refer [match]))
+
+(defn handle [event]
+  (match [event]
+    [{:type :add :value v}]            (str "add " v)
+    [{:type :remove :id (_ :guard pos?)}] "remove-valid"
+    [[:cmd (:or :up :down) n]]         (str "move " n)
+    [[head & rest]]                    (str "list of " (count rest) " after " head)
+    :else                              :unknown))
+```
+
+Pattern elements:
+
+| Pattern | Matches |
+|---------|---------|
+| `1`, `"s"`, `:k`, `nil`, `true` | Equality with the literal |
+| `_` | Anything (no binding) |
+| `x` (bare symbol) | Anything, binds to `x` |
+| `[a b c]` | Vector or list of length 3 |
+| `[a & more]` | Vector or list, rest captured |
+| `{:k v}` | Map containing key `:k`, binds value to `v` |
+| `(x :guard pred)` | Value where `(pred x)` is truthy |
+| `(pat :as x)` | Match `pat` and also bind whole value to `x` |
+| `(:or a b c)` | Any of the alternatives |
+
+`match` requires multi-target targets (the outer `[event]` vector) so you can match several values at once:
+
+```phel
+(match [http-status role]
+  [200 :admin]       :dashboard
+  [200 _]            :ok
+  [401 _]            :login
+  [(_ :guard #(>= % 500)) _] :error
+  :else              :unknown)
+```
+
+Without an `:else` clause, `match` throws `RuntimeException` when nothing fits — add `:else` when "none of these" is a valid outcome.
 
 ## Error Handling
 

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -174,7 +174,7 @@ Both `phel\string` and `phel.string` resolve to the same namespace.
 ```phel
 ;; PHP arrays → Phel collections
 (php-array-to-map $php_assoc_array)  ; => {:key value}
-(values $php_indexed_array)          ; => [val1 val2 val3]
+(vals $php_indexed_array)            ; => [val1 val2 val3]
 
 ;; Indexed PHP array → vector
 [1 2 3]                           ; Already works as Phel vector

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -334,10 +334,14 @@ curl http://localhost:8000/users
 
 ### Learn More
 
-- **[Common Patterns](patterns.md)** - Idiomatic Phel code
+- **[Common Patterns](patterns.md)** - Idiomatic Phel code including pattern matching
+- **[Data Structures Guide](data-structures-guide.md)** - Vectors, maps, sets, transients
 - **[PHP Interop](php-interop.md)** - Deep dive into PHP integration
 - **[Reader Shortcuts](reader-shortcuts.md)** - Syntax reference
-- **[Examples](examples/)** - More code samples
+- **[Async Guide](async-guide.md)** - Concurrency with fibers and AMPHP
+- **[CLI Guide](cli-guide.md)** - Build CLIs with `phel\cli`
+- **[Framework Integration](framework-integration.md)** - Laravel, Symfony, framework-less
+- **[Examples](examples/)** - Runnable single-file samples
 
 ### REPL Workflow
 

--- a/docs/reader-shortcuts.md
+++ b/docs/reader-shortcuts.md
@@ -111,6 +111,40 @@ Shorthand for `(deref ...)`:
 @my-atom              ; Same as (deref my-atom)
 ```
 
+## Tagged Literals `#<tag> form`
+
+Tagged literals let the reader convert an arbitrary form into a different value. Phel ships two built-ins:
+
+```phel
+#inst "2026-01-01T00:00:00Z"     ; reads as \DateTimeImmutable
+#regex "\\d+"                     ; reads as a PCRE pattern string
+```
+
+Register your own with `phel\reader/register-tag`:
+
+```phel
+(ns my-app\main
+  (:require phel\reader :refer [register-tag]))
+
+(register-tag "money" (fn [s] {:kind :money :raw s}))
+
+;; Now the reader accepts:
+#money "10.00 EUR"
+;; => {:kind :money :raw "10.00 EUR"}
+```
+
+For project-wide tags, drop a `data-readers.phel` at any source root — it is auto-loaded and should register each tag explicitly:
+
+```phel
+;; src/phel/data-readers.phel
+(ns my-app\data-readers
+  (:require phel\reader :refer [register-tag]))
+
+(register-tag "point" (fn [[x y]] {:x x :y y}))
+```
+
+Related helpers in `phel\reader`: `tag-registered?`, `unregister-tag`, `registered-tags`.
+
 ## Regex Literals `#"..."`
 
 Creates a PCRE pattern string:
@@ -213,6 +247,7 @@ Attaches metadata to the following form:
 | `name#`     | Auto-gensym        | Hygienic generated symbol in syntax-quote      | `` `(let [g# ~x] g#)`` |
 | `#?()`      | Reader conditional | Platform-specific code                         | `#?(:phel 1)`      |
 | `#?@()`     | Conditional splice | Splice by platform                             | `#?@(:phel [1 2])` |
+| `#<tag>`    | Tagged literal     | Call the tag's reader function                 | `#inst "2026-01-01T00:00:00Z"` |
 | `@`         | Deref              | Dereference an atom                            | `@my-atom`         |
 | `#"..."`    | Regex literal      | PCRE pattern                                   | `#"\\d+"`          |
 | `#(...)`    | Lambda             | Anonymous function (`%` args)                  | `#(+ %1 %2)`       |


### PR DESCRIPTION
## 🤔 Background

The `docs/` tree had drifted since the last major surface push. Several example `.phel` files used deprecated calls (`put`, `values`) or relied on `cli/run` grabbing the wrong `argv` under `phel run`, so running them printed `Command "run" is not defined`. Recently landed features (`phel\match`, `phel\schema`, tagged literals, `into` with a transducer) weren't in the docs yet. Some guides also had an editorial Clojure-reference style we're moving away from.

## 💡 Goal

Optimize, simplify, and ensure every example actually works with the current Phel syntax. Target best DX for a first-time reader.

## 🔖 Changes

**Examples (every file now runs end-to-end via `./bin/phel run docs/examples/<file>.phel`):**
- `examples/12_cli.phel`: pass `argv` explicitly via `(cli/argv argv)` so Symfony sees the user args, not `phel run <file>`. Switched persistence from EDN (`print-str` / `read-string`) to JSON since there is no `pr-str`/readable printer. Replaced deprecated `put` with `assoc`.
- `examples/transducers.phel`: ns renamed from `doc\examples\transducers` to `examples\transducers` for consistency.
- `examples/05_data-structures.phel`: `values` to `vals`.
- `examples/README.md`: tabular overview, correct path hints, one-liner run-all block matching CI.

**Guides:**
- `patterns.md`: new Pattern Matching section for `phel\match` (literal, wildcard, binding, vector, map, `:guard`, `:as`, `:or`, rest). Schema subsection for `phel\schema` with validate/explain and the full kind list.
- `reader-shortcuts.md`: new Tagged Literals section covering `#inst`, `#regex`, `register-tag`, and `data-readers.phel` auto-loading.
- `async-guide.md`: added Contents list, See-also section linking back to the example and `phel\http-client`. Dropped the redundant `(php/-> fast (unwrap))` since `await` handles `PhelFuture` directly.
- `cli-guide.md`: new "Running under `phel run`" subsection documenting the `(cli/argv argv)` gotcha. Fenced shell snippets as bash, updated the quickstart command to use `./vendor/bin/phel`.
- `data-structures-guide.md`: removed low-signal "Identical behavior to Clojure's X" footnotes; documented `into` 3-arg transducer form; `vals` is now the primary name with `values` as a deprecated alias; expanded deprecated-names table.
- `php-interop.md`: `vals` over deprecated `values` in the PHP to Phel conversion snippet.
- `quickstart.md`: Next Steps now links async, CLI, framework integration, data-structures guides.

## Test plan

- [x] All 13 `docs/examples/*.phel` files run cleanly: `./bin/phel run docs/examples/<file>.phel` exits 0 for every file
- [x] `composer fix` clean
- [x] `composer test-quality` clean (cs-fixer, psalm, phpstan, rector)
- [x] `composer test-core` green (4341 tests)
- [ ] CI `examples` job stays green (runs the full `docs/examples/*.phel` sweep)
- [ ] CI `tests` job stays green