### PR TITLE
docs: add guide stubs for schema, match, lint, lsp, nrepl, watch

### DIFF
--- a/.agents/index.md
+++ b/.agents/index.md
@@ -15,6 +15,11 @@ Rules + CLI: [`RULES.md`](RULES.md).
 | Debug errors | [`tasks/debug-errors.md`](tasks/debug-errors.md) | `docs/patterns.md` § Error Handling |
 | Common pitfalls | [`tasks/common-gotchas.md`](tasks/common-gotchas.md) | `RULES.md` § Gotchas |
 | Use a PHP library | [`tasks/use-php-libs.md`](tasks/use-php-libs.md) | `docs/php-interop.md` |
+| Validate data | [`tasks/validate-with-schema.md`](tasks/validate-with-schema.md) | `src/phel/schema.phel`, `docs/schema-guide.md` |
+| Pattern match | [`tasks/pattern-match.md`](tasks/pattern-match.md) | `src/phel/match.phel`, `docs/match-guide.md` |
+| Lint code | — | `docs/lint-guide.md` |
+| Editor integration | — | `docs/lsp-guide.md`, `docs/nrepl-guide.md` |
+| Hot-reload | — | `docs/watch-guide.md` |
 | Syntax reference | — | `docs/quickstart.md`, `docs/reader-shortcuts.md` |
 | Idioms | — | `docs/patterns.md`, `docs/examples/` |
 | Call Phel from PHP | — | `docs/framework-integration.md` |

--- a/.agents/tasks/pattern-match.md
+++ b/.agents/tasks/pattern-match.md
@@ -1,0 +1,54 @@
+# Pattern match
+
+`phel\match/match` destructures by shape. It expands to nested `cond` + `let` at compile time.
+
+## Syntax
+
+```phel
+(match [target1 target2 ...]
+  pattern1 expr1
+  pattern2 expr2
+  :else    default)
+```
+
+Each pattern is a vector whose length must equal the target count.
+
+## Basic example
+
+```phel
+(ns my-app\main
+  (:require phel\match :refer [match]))
+
+(defn describe [x]
+  (match [x]
+    [0]               "zero"
+    [(n :guard pos?)] "positive"
+    [[a b]]           (str "pair " a "/" b)
+    [{:type :err :msg m}] (str "error: " m)
+    :else             "other"))
+```
+
+## Pattern kinds
+
+| Pattern | Meaning |
+|---------|---------|
+| `42`, `:k`, `"s"` | literal equality |
+| `_` | wildcard |
+| `sym` | bind target to `sym` |
+| `[a b c]` | vector of exactly 3 |
+| `{:k sym}` | map with `:k`, bind value to `sym` |
+| `(:or a b)` | alternative match |
+| `(sym :as name)` | bind the whole subject |
+| `(sym :guard pred)` | runtime predicate check |
+| `[head & tail]` | rest binding |
+
+## Gotchas
+
+- Pattern vector length must equal target count
+- `:else` must be last
+- Later bindings shadow earlier ones with the same name
+
+## See also
+
+- `validate-with-schema.md` for declaring reusable shapes
+- `docs/match-guide.md` for full reference

--- a/.agents/tasks/validate-with-schema.md
+++ b/.agents/tasks/validate-with-schema.md
@@ -1,0 +1,54 @@
+# Validate with schema
+
+`phel\schema` validates, coerces, and generates values against data-driven schemas.
+
+## Define a schema
+
+```phel
+(ns my-app\main
+  (:require phel\schema :as s))
+
+(def User
+  [:map {:closed? true}
+   [:id    :int]
+   [:email [:re #"^[^@]+@[^@]+$"]]
+   [:age   [:maybe :int]]])
+```
+
+## Common operations
+
+```phel
+(s/validate User {:id 1 :email "a@b.co"})   ; => true
+(s/explain  User {:id "x" :email "a@b"})    ; => {:errors [...]}
+(s/coerce   User {"id" "1" "email" "a@b.co"})
+```
+
+## Instrument a function
+
+```phel
+(defn add [a b] (+ a b))
+(s/instrument! 'add add [:=> [:int :int] :int])
+;; (add "x" 2) ; throws with explain data
+```
+
+## Common kinds
+
+| Kind | Example |
+|------|---------|
+| scalar | `:int`, `:string`, `:bool`, `:any` |
+| collection | `[:vector :int]`, `[:map-of :keyword :int]` |
+| map | `[:map [:k :int]]` |
+| choice | `[:or :int :string]`, `[:enum :a :b]`, `[:maybe :int]` |
+| regex | `[:re #"pattern"]` |
+| predicate | `[:fn pos?]` |
+
+## Gotchas
+
+- `:map` is open by default; add `{:closed? true}` to reject extras
+- `[:re #"..."]` expects a regex literal, not a string
+- `generate` may diverge on tight `[:and ...]` or `[:re ...]`; provide a `:gen` hint
+
+## See also
+
+- `docs/schema-guide.md` for full reference
+- `use-core-lib.md` for combining with `get-in`, `update-in`

--- a/docs/lint-guide.md
+++ b/docs/lint-guide.md
@@ -1,0 +1,69 @@
+# Linter Guide
+
+`phel lint` is a semantic linter that catches common mistakes without running code. It runs on source files or directories and emits diagnostics in human, JSON, or GitHub Actions format.
+
+## Contents
+
+- [Quickstart](#quickstart)
+- [Rules](#rules)
+- [Output formats](#output-formats)
+- [Configuration](#configuration)
+- [Cache](#cache)
+- [Editor integration](#editor-integration)
+
+## Quickstart
+
+```bash
+./vendor/bin/phel lint                    # lint configured source dirs
+./vendor/bin/phel lint src/ tests/        # lint specific paths
+./vendor/bin/phel lint --format=json      # machine-readable
+./vendor/bin/phel lint --format=github    # CI annotations
+```
+
+## Rules
+
+| Rule | Catches |
+|------|---------|
+| `unresolved-symbol` | reference to an unknown binding |
+| `arity-mismatch` | call with wrong number of args |
+| `unused-binding` | `let`/`fn` bindings never referenced |
+| `unused-require` | imported ns never used |
+| `unused-import` | imported PHP class never used |
+| `shadowed-binding` | inner binding hides an outer one |
+| `redundant-do` | `do` with a single child form |
+| `duplicate-key` | map or let has the same key twice |
+| `invalid-destructuring` | malformed destructure pattern |
+| `discouraged-var` | use of deprecated or banned symbols |
+
+## Output formats
+
+- `human` (default): colored terminal output, suitable for local use
+- `json`: array of `{file, line, column, rule, severity, message}` records
+- `github`: `::error file=...` directives for GitHub Actions annotations
+
+## Configuration
+
+Drop a `phel-lint.phel` at your repo root:
+
+```phel
+{:rules
+ {:unused-binding   {:enabled? true  :severity :warning}
+  :shadowed-binding {:enabled? false}
+  :discouraged-var  {:vars     ['println 'prn]}}
+ :ignore-paths ["build/" "vendor/"]}
+```
+
+Pass a custom path with `--config=path/to/lint.phel`.
+
+## Cache
+
+Lint results are cached per file by content hash; subsequent runs only reanalyze changed files. Disable with `--no-cache`.
+
+## Editor integration
+
+Use `--format=json` from an editor plugin, or launch `phel lsp` for real-time diagnostics as you type.
+
+## See also
+
+- [LSP Guide](./lsp-guide.md)
+- [Watch Guide](./watch-guide.md)

--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -1,0 +1,72 @@
+# Language Server Guide
+
+`phel lsp` speaks LSP v3.17 over stdio (JSON-RPC 2.0 with Content-Length framing). It gives editors hover, goto-definition, completion, references, rename, formatting, document/workspace symbols, and live diagnostics.
+
+## Contents
+
+- [Starting the server](#starting-the-server)
+- [Capabilities](#capabilities)
+- [Editor setup](#editor-setup)
+- [Diagnostics](#diagnostics)
+- [Pitfalls](#pitfalls)
+
+## Starting the server
+
+```bash
+./vendor/bin/phel lsp
+```
+
+The server reads LSP messages on stdin and writes responses on stdout. Logs go to stderr.
+
+## Capabilities
+
+| Feature | Method |
+|---------|--------|
+| Hover | `textDocument/hover` |
+| Go to definition | `textDocument/definition` |
+| Find references | `textDocument/references` |
+| Completion | `textDocument/completion` |
+| Rename | `textDocument/rename` |
+| Formatting | `textDocument/formatting` |
+| Document symbols | `textDocument/documentSymbol` |
+| Workspace symbols | `workspace/symbol` |
+| Diagnostics | `textDocument/publishDiagnostics` (debounced) |
+
+## Editor setup
+
+### VS Code
+
+Use any generic LSP client extension (for example, `sumneko.lua-language-server`-style) pointed at `./vendor/bin/phel lsp` with `phel` as the language id and `.phel` as the file extension.
+
+### Neovim (built-in LSP)
+
+```lua
+vim.lsp.start({
+  name     = 'phel',
+  cmd      = { './vendor/bin/phel', 'lsp' },
+  filetypes = { 'phel' },
+  root_dir  = vim.fs.dirname(vim.fs.find({ 'phel-config.php', 'composer.json' }, { upward = true })[1]),
+})
+```
+
+### Emacs (`eglot`)
+
+```elisp
+(add-to-list 'eglot-server-programs
+             '(phel-mode . ("./vendor/bin/phel" "lsp")))
+```
+
+## Diagnostics
+
+Diagnostics include compiler errors, unresolved symbols, arity mismatches, and lint rule violations. Publication is debounced so typing does not thrash.
+
+## Pitfalls
+
+- The server scans files under the project root; keep `phel-config.php` up to date so require resolution works
+- Huge projects benefit from running `phel index` ahead of time to warm the symbol cache
+- LSP runs in the same PHP process; long-running REPL state is not shared with a running `phel nrepl`
+
+## See also
+
+- [Linter Guide](./lint-guide.md)
+- [nREPL Guide](./nrepl-guide.md)

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -1,0 +1,66 @@
+# Pattern Matching Guide
+
+`phel\match` provides a `match` macro that destructures by shape. It expands to nested `cond` + `let` at compile time.
+
+## Contents
+
+- [Quickstart](#quickstart)
+- [Pattern kinds](#pattern-kinds)
+- [Guards](#guards)
+- [Rest binding](#rest-binding)
+- [Pitfalls](#pitfalls)
+
+## Quickstart
+
+```phel
+(ns my-app\main
+  (:require phel\match :refer [match]))
+
+(defn describe [x]
+  (match [x]
+    [0]            "zero"
+    [(_ :guard pos?)] "positive"
+    [[a b]]        (str "pair " a " / " b)
+    [{:type :err :msg m}] (str "error: " m)
+    :else          "other"))
+```
+
+## Pattern kinds
+
+| Pattern | Meaning |
+|---------|---------|
+| `42`, `:key`, `"s"` | literal equality |
+| `_` | wildcard |
+| `sym` | bind target to `sym` |
+| `[a b c]` | vector of exactly 3 elements |
+| `{:k sym}` | map with key `:k`, bind value to `sym` |
+| `(:or a b c)` | any of the alternatives |
+| `(sym :as name)` | bind whole subject to `name` |
+| `(sym :guard pred)` | literal plus runtime predicate |
+
+## Guards
+
+```phel
+(match [n]
+  [(x :guard neg?)] "negative"
+  [(x :guard pos?)] "positive"
+  :else "zero")
+```
+
+## Rest binding
+
+```phel
+(match [xs]
+  [[head & tail]] (str head ":" (count tail)))
+```
+
+## Pitfalls
+
+- Each pattern vector length must equal the target count
+- `:else` must be the final clause
+- Nested patterns bind in left-to-right order; a later binding shadows an earlier one with the same name
+
+## See also
+
+- `phel\schema` for declaring shapes reusable across validation and matching
+- `cond`, `case`, `condp` for simpler dispatch without destructuring

--- a/docs/nrepl-guide.md
+++ b/docs/nrepl-guide.md
@@ -1,0 +1,63 @@
+# nREPL Guide
+
+`phel nrepl` starts a bencode-over-TCP nREPL server for editor tooling and interactive development. Any client that speaks the nREPL protocol (CIDER, Calva, vim-iced, neovim-nrepl clients) can connect.
+
+## Contents
+
+- [Starting the server](#starting-the-server)
+- [Operations](#operations)
+- [Client setup](#client-setup)
+- [Pitfalls](#pitfalls)
+
+## Starting the server
+
+```bash
+./vendor/bin/phel nrepl                    # port 7888, 127.0.0.1
+./vendor/bin/phel nrepl --port=0           # bind a random free port
+./vendor/bin/phel nrepl --host=0.0.0.0 --port=7888
+```
+
+The server prints the actual port to stdout on startup so clients can auto-discover it.
+
+## Operations
+
+| Op | Purpose |
+|----|---------|
+| `eval` | evaluate code, stream stdout/stderr/value |
+| `clone` | fork a session (preserves ns and state) |
+| `close` | close a session |
+| `describe` | capability discovery |
+| `load-file` | slurp-and-eval a file's contents |
+| `interrupt` | stop a running `eval` in a session |
+| `completions` | return candidate completions for a prefix |
+| `lookup` | return symbol metadata (arglists, doc, file:line) |
+| `info` | equivalent to `lookup` under a different name |
+| `eldoc` | inline signature hint for the function under point |
+
+## Client setup
+
+### Emacs (CIDER)
+
+```elisp
+(setq cider-default-cljs-repl nil)
+;; M-x cider-connect-clj RET 127.0.0.1 RET 7888 RET
+```
+
+### VS Code (Calva)
+
+Run `Calva: Connect to a running REPL`, choose `Generic nREPL`, and point at `127.0.0.1:7888`.
+
+### Neovim (vim-iced or Conjure)
+
+Both detect `.nrepl-port` in the repo root; set it after launching the server.
+
+## Pitfalls
+
+- The server is single-user by default; multiple clients sharing a session will see interleaved output
+- Bind to `127.0.0.1` unless you are inside a trusted network; there is no auth
+- `interrupt` only stops the eval in that session, not other sessions or fibers
+
+## See also
+
+- [LSP Guide](./lsp-guide.md)
+- [Quickstart](./quickstart.md) for the basic built-in REPL

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -340,6 +340,12 @@ curl http://localhost:8000/users
 - **[Reader Shortcuts](reader-shortcuts.md)** - Syntax reference
 - **[Async Guide](async-guide.md)** - Concurrency with fibers and AMPHP
 - **[CLI Guide](cli-guide.md)** - Build CLIs with `phel\cli`
+- **[Schema Guide](schema-guide.md)** - Data-driven validation, coercion, generation
+- **[Pattern Matching Guide](match-guide.md)** - `match` macro with guards and destructuring
+- **[Linter Guide](lint-guide.md)** - `phel lint` rules and configuration
+- **[Language Server Guide](lsp-guide.md)** - `phel lsp` editor integration
+- **[nREPL Guide](nrepl-guide.md)** - `phel nrepl` for editor tooling
+- **[Watch Guide](watch-guide.md)** - `phel watch` hot-reload
 - **[Framework Integration](framework-integration.md)** - Laravel, Symfony, framework-less
 - **[Examples](examples/)** - Runnable single-file samples
 

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -1,0 +1,79 @@
+# Schema Guide
+
+`phel\schema` provides data-driven schemas for validating, coercing, and generating values. Schemas are plain Phel data (keywords or vectors); there is no DSL to parse.
+
+## Contents
+
+- [Quickstart](#quickstart)
+- [Schema kinds](#schema-kinds)
+- [Core operations](#core-operations)
+- [Named-schema registry](#named-schema-registry)
+- [Function instrumentation](#function-instrumentation)
+- [Pitfalls](#pitfalls)
+
+## Quickstart
+
+```phel
+(ns my-app\main
+  (:require phel\schema :as s))
+
+(def User
+  [:map {:closed? true}
+   [:id    :int]
+   [:email [:re #"^[^@]+@[^@]+$"]]
+   [:age   [:maybe :int]]])
+
+(s/validate User {:id 1 :email "a@b.co"})   ; => true
+(s/explain  User {:id "x" :email "a@b"})    ; => {:errors [...]}
+(s/coerce   User {"id" "1" "email" "a@b.co"})
+```
+
+## Schema kinds
+
+| Kind | Example |
+|------|---------|
+| scalar | `:int`, `:string`, `:bool`, `:keyword`, `:any` |
+| collection | `[:vector :int]`, `[:set :string]`, `[:map-of :keyword :int]` |
+| map | `[:map [:k :int] [:k2 :string]]` |
+| tuple | `[:tuple :int :string]` |
+| choice | `[:enum :a :b]`, `[:or :int :string]`, `[:and :int pos-int?]`, `[:maybe :int]` |
+| regex | `[:re #"pattern"]` |
+| predicate | `[:fn even?]` |
+| reference | `[:ref :my/User]` |
+| function | `[[:=> [:int :int] :int]]` |
+
+## Core operations
+
+| Fn | Purpose |
+|----|---------|
+| `(validate schema value)` | boolean |
+| `(explain schema value)` | `nil` on success, map on failure |
+| `(conform schema value)` | coerced value or `:phel.schema/invalid` |
+| `(coerce schema value)` | type-coerce to required shape |
+| `(generate schema)` | random value conforming to schema |
+
+## Named-schema registry
+
+```phel
+(s/register! :my/User User)
+(s/validate [:ref :my/User] {:id 1 :email "a@b.co"})
+```
+
+## Function instrumentation
+
+```phel
+(defn add [a b] (+ a b))
+(s/instrument! 'add add [:=> [:int :int] :int])
+;; (add "x" 2)  ; throws with schema failure
+```
+
+## Pitfalls
+
+- `:map` is open by default; add `{:closed? true}` to reject extra keys
+- `[:re ...]` expects a `#"regex"` literal, not a string
+- `generate` may fail for over-constrained `[:and ...]` or `[:re ...]` schemas; add a `[:gen ...]` hint if needed
+
+## See also
+
+- `phel\match` for destructuring matched shapes
+- `phel\test\gen` for property-based testing driven by schemas

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -1,0 +1,50 @@
+# Watch Guide
+
+`phel watch` recompiles and reloads changed namespaces in dependency order so you can iterate without restarting the REPL or a long-running process. Backends: `inotify` (Linux), `fswatch` (macOS), `polling` (everywhere).
+
+## Contents
+
+- [Quickstart](#quickstart)
+- [Options](#options)
+- [Programmatic API](#programmatic-api)
+- [Pitfalls](#pitfalls)
+
+## Quickstart
+
+```bash
+./vendor/bin/phel watch                         # watch configured source dirs
+./vendor/bin/phel watch src/ tests/             # watch specific paths
+./vendor/bin/phel watch -b polling --poll=250   # force polling, 250ms interval
+```
+
+On each change, `phel watch` reloads the changed namespace plus any downstream namespaces that depend on it, in topological order.
+
+## Options
+
+| Flag | Purpose |
+|------|---------|
+| `-b, --backend=auto\|inotify\|fswatch\|polling` | override auto-detection |
+| `--poll=MS` | polling backend interval in ms (default 500) |
+| `--debounce=MS` | collapse rapid events within this window (default 100) |
+
+## Programmatic API
+
+```phel
+(ns dev\watcher
+  (:require phel\watch :refer [watch!]))
+
+(watch! ["src/" "tests/"])
+```
+
+Returns a handle you can stop with `(stop-watch! h)`.
+
+## Pitfalls
+
+- The polling backend has the highest CPU cost; prefer `inotify` or `fswatch` when available
+- Reload order follows the dependency graph; cyclic requires will break live reload
+- Editors that write files atomically (rename) emit two events; `--debounce` handles this by default
+
+## See also
+
+- [Linter Guide](./lint-guide.md)
+- [LSP Guide](./lsp-guide.md)


### PR DESCRIPTION
## 🤔 Background

Six modules landed in the unreleased window (`phel\schema`, `phel\match`, `phel lint`, `phel lsp`, `phel nrepl`, `phel watch`) without dedicated user-facing docs. Before release, users discover them only via `phel --help` or brief CHANGELOG lines. `docs/patterns.md` got schema + match subsections in #1530, but the other four have no top-level entry point at all.

## 💡 Goal

Ship a terse guide per module so the release notes link somewhere, `Next Steps` in `quickstart.md` covers every shipped feature, and AI agents have focused task recipes for the two most common workflows (validate with schema, pattern match).

## 🔖 Changes

### `docs/`
- `schema-guide.md`: kinds table, core operations, registry, function instrumentation
- `match-guide.md`: pattern kinds, guards, rest binding
- `lint-guide.md`: rules table, output formats (human/json/github), `phel-lint.phel` config, cache
- `lsp-guide.md`: capability table, VS Code/Neovim/Emacs setup snippets
- `nrepl-guide.md`: ops table, CIDER/Calva/Conjure/vim-iced setup
- `watch-guide.md`: backends (inotify/fswatch/polling), options, `(watch!)` API
- `quickstart.md`: link the six new guides from **Next Steps**

### `.agents/`
- `tasks/validate-with-schema.md`: agent recipe for `phel\schema`
- `tasks/pattern-match.md`: agent recipe for `phel\match`
- `index.md`: intent-map entries for validate / match / lint / lsp / hot-reload

Each guide matches the existing async/cli voice: one-line purpose, quickstart, option/flag table, gotchas, see-also.

## ✅ Test plan

- [x] `composer test-agents` still passes (examples untouched)
- [x] Every new doc links exist (cross-refs resolve)
- [x] No em dashes in new content outside existing intent-map style