### PR TITLE
docs: address #1531 review feedback on schema and lsp guides

### DIFF
--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -36,7 +36,7 @@ The server reads LSP messages on stdin and writes responses on stdout. Logs go t
 
 ### VS Code
 
-Use any generic LSP client extension (for example, `sumneko.lua-language-server`-style) pointed at `./vendor/bin/phel lsp` with `phel` as the language id and `.phel` as the file extension.
+Install a generic LSP client extension and point it at `./vendor/bin/phel lsp` with `phel` as the language id and `.phel` as the file extension.
 
 ### Neovim (built-in LSP)
 

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -40,7 +40,7 @@
 | regex | `[:re #"pattern"]` |
 | predicate | `[:fn even?]` |
 | reference | `[:ref :my/User]` |
-| function | `[[:=> [:int :int] :int]]` |
+| function | `[:=> [:int :int] :int]` |
 
 ## Core operations
 


### PR DESCRIPTION
## 🤔 Background

Post-merge review on #1531 (https://github.com/phel-lang/phel-lang/pull/1531#pullrequestreview-4142945143) flagged two doc-accuracy issues.

## 💡 Goal

Fix both before the next release so the new guides are correct.

## 🔖 Changes

- `docs/schema-guide.md`: drop stray outer vector from the function-schema example in the *Schema kinds* table. Now matches the `instrument!` example and the rest of the file: `[:=> [:int :int] :int]`.
- `docs/lsp-guide.md`: remove the `sumneko.lua-language-server` placeholder. That is a Lua-specific server, not a generic LSP client. Kept the "install a generic LSP client and point it at `./vendor/bin/phel lsp`" instruction.

## ✅ Test plan

- [x] Review diff: two single-line edits
- [x] No link changes; cross-refs still resolve