### PR TITLE
fix(build): skip unparseable .phel files during directory scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tests/**/out/
 .env
 .php-cs-fixer.php
 .phel-repl-history
+*.phel-repl-history
 phel-debug.log
 phel-error.log
 local.phel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - **BREAKING**: Minimum PHP version bumped from 8.3 to 8.4. PHP 8.3 is no longer supported.
 
+### Fixed
+
+#### Build
+- Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources
+
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 
 ### Added

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Application;
 use Phel\Build\Domain\Cache\NamespaceCacheEntry;
 use Phel\Build\Domain\Cache\NamespaceCacheInterface;
 use Phel\Build\Domain\Extractor\ExcludedScanPaths;
+use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
@@ -59,7 +60,15 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
     {
         $allInfos = [];
         foreach ($this->findAllPhelFiles($directories) as $file) {
-            $allInfos[] = $this->getNamespaceFromFile($file);
+            try {
+                $allInfos[] = $this->getNamespaceFromFile($file);
+            } catch (ExtractorException) {
+                // Skip files that cannot be parsed/lexed so one malformed
+                // .phel file in a scanned directory does not abort the
+                // whole scan (e.g. REPL starting in a cwd that contains
+                // unrelated broken Phel files).
+                continue;
+            }
         }
 
         return $this->grouper->groupAndSort($allInfos);

--- a/src/php/Build/Application/NamespaceExtractor.php
+++ b/src/php/Build/Application/NamespaceExtractor.php
@@ -44,7 +44,6 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
 
     /**
      * @throws ExtractorException
-     * @throws LexerValueException
      */
     public function getNamespaceFromFile(string $path): NamespaceInformation
     {
@@ -91,7 +90,7 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
             }
 
             throw ExtractorException::cannotExtractNamespaceFromPath($path);
-        } catch (AbstractParserException|ReaderException) {
+        } catch (AbstractParserException|ReaderException|LexerValueException) {
             throw ExtractorException::cannotParseFile($path);
         }
     }
@@ -140,7 +139,15 @@ final readonly class NamespaceExtractor implements NamespaceExtractorInterface
                     continue;
                 }
 
-                $result[] = $this->getNamespaceFromFile($file[0]);
+                try {
+                    $result[] = $this->getNamespaceFromFile($file[0]);
+                } catch (ExtractorException) {
+                    // Skip files that cannot be parsed/lexed so one malformed
+                    // .phel file in a scanned directory does not abort the
+                    // whole scan (e.g. REPL starting in a cwd that contains
+                    // unrelated broken Phel files).
+                    continue;
+                }
             }
         } catch (UnexpectedValueException) {
             // Skip directories that cannot be read (e.g., permission denied)

--- a/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Build\Application;
 
 use Phel\Build\Application\CachedNamespaceExtractor;
+use Phel\Build\Domain\Extractor\ExtractorException;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Domain\Extractor\TopologicalNamespaceSorter;
@@ -77,6 +78,39 @@ final class CachedNamespaceExtractorTest extends TestCase
         self::assertStringEndsWith('/main.phel', $picked[0]->getFile());
         self::assertFalse($picked[1]->isPrimaryDefinition());
         self::assertStringEndsWith('/split/part.phel', $picked[1]->getFile());
+    }
+
+    public function test_directory_scan_skips_files_that_fail_to_extract(): void
+    {
+        $goodPath = $this->dir . '/good.phel';
+        $badPath = $this->dir . '/split/bad.phel';
+
+        file_put_contents($goodPath, '(ns good\\ns)');
+        file_put_contents($badPath, '(ns bad\\ns)');
+
+        $goodInfo = new NamespaceInformation($goodPath, 'good\\ns', [], isPrimaryDefinition: true);
+
+        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner->method('getNamespaceFromFile')->willReturnCallback(
+            static function (string $path) use ($goodInfo): NamespaceInformation {
+                if (str_ends_with($path, 'good.phel')) {
+                    return $goodInfo;
+                }
+
+                throw ExtractorException::cannotParseFile($path);
+            },
+        );
+
+        $extractor = new CachedNamespaceExtractor(
+            $inner,
+            new NullNamespaceCache(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $infos = $extractor->getNamespacesFromDirectories([$this->dir]);
+
+        self::assertCount(1, $infos, 'Malformed file must be skipped, good file still returned.');
+        self::assertSame('good\\ns', $infos[0]->getNamespace());
     }
 
     private function removeDir(string $dir): void

--- a/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Domain/Extractor/NamespaceExtractorTest.php
@@ -69,6 +69,40 @@ final class NamespaceExtractorTest extends TestCase
         $this->extractNamespace($fileContent);
     }
 
+    public function test_get_namespace_from_file_unlexable_content_throws(): void
+    {
+        $this->expectException(ExtractorException::class);
+        $fileContent = '## markdown-style comments are not valid phel';
+        $this->extractNamespace($fileContent);
+    }
+
+    public function test_scan_skips_unparseable_files(): void
+    {
+        $dir = sys_get_temp_dir() . '/phel-extractor-test-' . uniqid();
+        mkdir($dir, 0777, true);
+
+        $goodPath = $dir . '/good.phel';
+        $badPath = $dir . '/bad.phel';
+
+        file_put_contents($goodPath, '(ns good\\ns)');
+        file_put_contents($badPath, '## not valid phel, lexer will throw');
+
+        $nsExtractor = new NamespaceExtractor(
+            new CompilerFacade(),
+            new TopologicalNamespaceSorter(),
+            new SystemFileIo(),
+        );
+
+        $infos = $nsExtractor->getNamespacesFromDirectories([$dir]);
+
+        self::assertCount(1, $infos, 'Malformed file must be skipped, good file still returned.');
+        self::assertSame('good\\ns', $infos[0]->getNamespace());
+
+        unlink($goodPath);
+        unlink($badPath);
+        rmdir($dir);
+    }
+
     public function test_primary_ns_file_comes_before_its_in_ns_siblings(): void
     {
         $dir = sys_get_temp_dir() . '/phel-extractor-test-' . uniqid();


### PR DESCRIPTION
## 🤔 Background

When the REPL starts, `NamespaceLoader::buildSrcDirectories` adds `getcwd()` to the source roots (src/php/Run/Application/NamespaceLoader.php:86). The Build module then recursively scans every `.phel` / `.cljc` file under that tree to resolve namespaces and dependencies.

If a single file anywhere in that tree fails to lex, the whole scan aborts. Reproduced with v0.34.1 PHAR:

```
$ cd ~/Downloads   # tree contains .phel files from unrelated projects
$ php phel.phar repl
Welcome to the Phel Repl (v0.34.1)
Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException: Cannot lex string after at column 0 in string:1
... #5 NamespaceExtractor.php(54): CompilerFacade->lexString('## Phel Error H...')
```

The offending file used `#` as a comment prefix (Markdown-style) which is invalid Phel syntax.

## 💡 Goal

Make REPL/build robust to malformed `.phel` files found in cwd tree: skip them during recursive scans while still surfacing parse errors when a user explicitly targets a single file (e.g. `phel run bad.phel`).

## 🔖 Changes

- `NamespaceExtractor::getNamespaceFromFile` now wraps `LexerValueException` into `ExtractorException::cannotParseFile` alongside existing parser/reader errors. Single-file callers still see a clear error.
- `NamespaceExtractor::findAllNs` and `CachedNamespaceExtractor::getNamespacesFromDirectories` catch `ExtractorException` per-file and continue the scan.
- Added regression tests:
  - `NamespaceExtractorTest::test_get_namespace_from_file_unlexable_content_throws`
  - `NamespaceExtractorTest::test_scan_skips_unparseable_files`
  - `CachedNamespaceExtractorTest::test_directory_scan_skips_files_that_fail_to_extract`
- `.gitignore`: also ignore `*.phel-repl-history` (catches stray history files created when `getAppRootDir()` concatenation yields e.g. `bin.phel-repl-history`).
- CHANGELOG: entry under Unreleased > Fixed > Build.