### PR TITLE
fix(core): make `binding` fiber-local and convey into futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+#### Core
+- `binding` on vars tagged `^:dynamic` now uses fiber-local storage, so concurrent fibers observe independent values and child futures/async blocks inherit the bindings active at their creation (Clojure-aligned binding conveyance). `^:dynamic` metadata on the name symbol of `def` is now honored. [#1536](https://github.com/phel-lang/phel-lang/issues/1536)
+
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
-- `binding` on vars tagged `^:dynamic` now uses fiber-local storage, so concurrent fibers observe independent values and child futures/async blocks inherit the bindings active at their creation (Clojure-aligned binding conveyance). `^:dynamic` metadata on the name symbol of `def` is now honored. [#1536](https://github.com/phel-lang/phel-lang/issues/1536)
+- `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings; `^:dynamic` on `def` name symbols is honored (#1536)
 
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -64,8 +64,11 @@ final class Phel extends InternalPhel
      */
     public static function getDefinition(string $ns, string $name): mixed
     {
+        // Hot path: every resolved symbol hits this. Probe the scope for
+        // *any* live frame first (O(1)) so the common "no binding active"
+        // case skips the string concat and stack walk entirely.
         $scope = DynamicScope::getInstance();
-        if ($scope->hasBinding($ns, $name)) {
+        if ($scope->hasAnyBinding() && $scope->hasBinding($ns, $name)) {
             return $scope->getBinding($ns, $name);
         }
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -6,6 +6,7 @@ use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\DynamicScope;
 use Phel\Lang\Keyword;
 use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
@@ -53,6 +54,139 @@ final class Phel extends InternalPhel
         $definition = &Registry::getInstance()->getDefinitionReference($ns, $name);
 
         return $definition;
+    }
+
+    /**
+     * Look up a global definition, consulting the fiber-local dynamic scope
+     * first for vars tagged `:dynamic`. This is the read path emitted by
+     * {@see Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\GlobalVarEmitter}
+     * for non-reference reads.
+     */
+    public static function getDefinition(string $ns, string $name): mixed
+    {
+        $scope = DynamicScope::getInstance();
+        if ($scope->hasBinding($ns, $name)) {
+            return $scope->getBinding($ns, $name);
+        }
+
+        return Registry::getInstance()->getDefinition($ns, $name);
+    }
+
+    /**
+     * Returns true if the given var was defined with `^:dynamic` metadata.
+     */
+    public static function isDynamicVar(string $ns, string $name): bool
+    {
+        $meta = Registry::getInstance()->getDefinitionMetaData($ns, $name);
+        if ($meta === null) {
+            return false;
+        }
+
+        return ($meta[Keyword::create('dynamic')] ?? false) === true;
+    }
+
+    /**
+     * Runtime target for the `set-var` special form. Routes by whether a
+     * `binding` macro is currently recording on the current fiber:
+     *
+     *  - Recording + `:dynamic` var → stage into the pending fiber frame.
+     *  - Recording + non-dynamic var → record old value for with-redefs
+     *    restore, then mutate the registry.
+     *  - Not recording → plain registry mutation, as `set-var` always did.
+     */
+    public static function setVar(string $ns, string $name, mixed $value): mixed
+    {
+        $registry = Registry::getInstance();
+        $scope = DynamicScope::getInstance();
+
+        if ($scope->isRecording()) {
+            if (self::isDynamicVar($ns, $name)) {
+                $scope->recordDynamic($ns, $name, $value);
+                return $value;
+            }
+
+            $scope->recordRedef($ns, $name, $registry->getDefinition($ns, $name));
+        }
+
+        $registry->addDefinition($ns, $name, $value, $registry->getDefinitionMetaData($ns, $name));
+        return $value;
+    }
+
+    /**
+     * Open a pending fiber-local binding recording. The subsequent
+     * `set-var` calls emitted by the `binding` macro feed into it, and
+     * {@see self::commitAndRunBindingFrame()} consumes it.
+     */
+    public static function openBindingFrame(): void
+    {
+        DynamicScope::getInstance()->startRecording();
+    }
+
+    /**
+     * Clean up a binding recording that was never committed because a
+     * value expression threw between `openBindingFrame` and
+     * {@see self::commitAndRunBindingFrame()}. Safe to call as the
+     * `finally` branch of a `binding` expansion even on the success
+     * path: it no-ops when no pending recording remains on this fiber.
+     */
+    public static function abortBindingFrameIfOpen(): void
+    {
+        $scope = DynamicScope::getInstance();
+        if (!$scope->isRecording()) {
+            return;
+        }
+
+        $entry = $scope->popRecording();
+        $registry = Registry::getInstance();
+        foreach (array_reverse($entry['redefs']) as [$ns, $name, $prev]) {
+            $registry->addDefinition($ns, $name, $prev, $registry->getDefinitionMetaData($ns, $name));
+        }
+    }
+
+    /**
+     * Close the pending binding recording, push its dynamic values as
+     * a fiber-local frame, run `$body`, then always pop the frame and
+     * undo any with-redefs mutations (even on exception).
+     */
+    public static function commitAndRunBindingFrame(Closure $body): mixed
+    {
+        $scope = DynamicScope::getInstance();
+        $entry = $scope->popRecording();
+        $dynamic = $entry['dynamic'];
+        $redefs = $entry['redefs'];
+
+        try {
+            return $dynamic === []
+                ? $body()
+                : $scope->withFrame($dynamic, $body);
+        } finally {
+            $registry = Registry::getInstance();
+            foreach (array_reverse($redefs) as [$ns, $name, $prev]) {
+                $registry->addDefinition($ns, $name, $prev, $registry->getDefinitionMetaData($ns, $name));
+            }
+        }
+    }
+
+    /**
+     * Snapshot the current fiber's dynamic bindings for conveyance into
+     * a new fiber (`future`/`async`/`future-fiber`).
+     *
+     * @return array<string, mixed>
+     */
+    public static function snapshotDynamicBindings(): array
+    {
+        return DynamicScope::getInstance()->snapshot();
+    }
+
+    /**
+     * Install a snapshotted frame while executing `$body`. Used by the
+     * fiber entry point of conveyed futures.
+     *
+     * @param array<string, mixed> $frame
+     */
+    public static function withDynamicBindings(array $frame, Closure $body): mixed
+    {
+        return DynamicScope::getInstance()->withFrame($frame, $body);
     }
 
     /**

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -21,8 +21,9 @@
    :example "@ai/config"}
   (atom default-config))
 
-(def *http-post*
-  {:doc "HTTP POST seam. Rebind with `binding` in tests to inject a fake transport."
+(def ^:dynamic *http-post*
+  {:doc "HTTP POST seam. Rebind with `binding` in tests to inject a fake transport.
+  Tagged `^:dynamic` so concurrent tests rebinding it stay isolated per fiber."
    :example "(binding [*http-post* (fn [url opts] {:status 200 :body \"...\"})] ...)"}
   hc/post)
 

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -25,11 +25,18 @@
   (php/:: \Closure (fromCallable f)))
 
 (defmacro async
-  "Runs body asynchronously in a new fiber. Returns an Amp\\Future."
+  "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
+
+  Captures the caller's dynamic bindings and reinstalls them inside
+  the fiber, so `binding`s established outside `async` are visible to
+  `body` (binding conveyance, as in Clojure's `future`)."
   {:example "(async (do-something))"
    :see-also ["await" "delay" "await-all" "await-any"]}
   [& body]
-  `(php/amp\async (fn [] ~@body)))
+  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
+     (php/amp\async
+       (fn []
+         (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
 
 (defmacro future
   "Starts evaluating `body` asynchronously and returns a `PhelFuture`
@@ -47,9 +54,12 @@
    :see-also ["async" "await" "realized?" "deref" "future-cancel"
               "future-done?" "future-fiber" "future?"]}
   [& body]
-  `(php/new \Phel\Lang\PhelFuture
-            (php/amp\async (fn [] ~@body))
-            (php/new \Amp\DeferredCancellation)))
+  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
+     (php/new \Phel\Lang\PhelFuture
+              (php/amp\async
+                (fn []
+                  (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))
+              (php/new \Amp\DeferredCancellation))))
 
 (defn- unwrap-future
   "Returns the raw Amp\\Future for either a `PhelFuture` wrapper or
@@ -177,12 +187,18 @@
 (defn future-call
   "Invokes `f` (a zero-arg function) in a new fiber. Returns a
   `PhelFiberFuture` you can `deref` or inspect with `future-done?`
-  and `future-cancel`."
+  and `future-cancel`.
+
+  Captures the caller's dynamic bindings and reinstalls them inside
+  the fiber before invoking `f`, so bindings are conveyed the same
+  way as with `future`/`async`."
   {:example "(future-call (fn [] 42))"
    :see-also ["future-fiber" "deref" "future-done?" "future-cancel"
               "promise" "deliver"]}
   [f]
-  (php/-> (fiber-facade) (future (->closure f))))
+  (let [frame   (php/:: \Phel (snapshotDynamicBindings))
+        wrapped (fn [] (php/:: \Phel (withDynamicBindings frame f)))]
+    (php/-> (fiber-facade) (future (->closure wrapped)))))
 
 (defmacro future-fiber
   "Runs `body` in a new fiber via the cooperative scheduler. Returns a

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -379,22 +379,25 @@
 ;; Binding
 ;; -------
 
-;; inspired by Clojure's with-redefs
 (defmacro binding
-  "Temporary redefines definitions while executing the body.
-  The value will be reset after the body was executed."
+  "Temporarily rebinds vars while executing `body`.
+
+  Vars tagged `^:dynamic` use fiber-local storage: concurrent fibers
+  observe independent values and child futures (`future`, `async`,
+  `future-fiber`) inherit the bindings active at their creation.
+
+  Non-dynamic vars fall back to `with-redefs`-style registry
+  mutation restored on exit — convenient for tests but shared
+  across fibers."
   [bindings & body]
-  (let [names         (take-nth 2 bindings)
-        vals          (take-nth 2 (drop 1 bindings))
-        orig-val-syms (map gensym names)
-        temp-val-syms (map gensym names)
-        binds         (map vector names temp-val-syms)
-        resets        (reverse (map vector names orig-val-syms))
-        bind-value    (fn [[k v]] (list 'set-var k v))]
-    `(let [~@(interleave orig-val-syms names)
-           ~@(interleave temp-val-syms vals)]
-       ~@(map bind-value binds)
+  (let [names    (take-nth 2 bindings)
+        vals     (take-nth 2 (drop 1 bindings))
+        set-vars (map (fn [n v] (list 'set-var n v)) names vals)]
+    `(do
+       (php/:: \Phel (openBindingFrame))
        (try
-         (do ~@body)
+         (do
+           ~@set-vars
+           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
          (finally
-           ~@(map bind-value resets))))))
+           (php/:: \Phel (abortBindingFrameIfOpen)))))))

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -12,9 +12,9 @@
 
 (def- fail-fast? (atom false))
 
-(def- *current-test-name* nil)
+(def- ^:dynamic *current-test-name* nil)
 
-(def *testing-contexts*
+(def ^:dynamic *testing-contexts*
   "Stack of testing context strings, most recent first."
   [])
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -128,6 +128,18 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $meta = $this->normalizeMeta($meta, $list);
 
+        // `^:dynamic`, `^:private`, etc. attach to the name symbol
+        // (`(def ^:dynamic *x* 1)`). Merge those flags into the def's
+        // metadata map so runtime code can read them off the var.
+        $nameMeta = $list->get(1)->getMeta();
+        if ($nameMeta instanceof PersistentMapInterface) {
+            foreach ($nameMeta->getIterator() as $key => $value) {
+                if ($key !== null) {
+                    $meta = $meta->put($key, $value);
+                }
+            }
+        }
+
         $listMeta = $list->getMeta();
         if ($listMeta instanceof PersistentMapInterface) {
             foreach ($listMeta->getIterator() as $key => $value) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetVarEmitter.php
@@ -21,7 +21,11 @@ final class SetVarEmitter implements NodeEmitterInterface
         $symbolNode = $node->getSymbol();
         assert($symbolNode instanceof GlobalVarNode);
 
-        $this->outputEmitter->emitLine('\\Phel::addDefinition(');
+        // Route through \Phel::setVar instead of addDefinition so that
+        // set-vars emitted by the `binding` macro can be captured into
+        // a pending fiber-local binding frame. Outside a binding this
+        // just mutates the registry, matching the historical behavior.
+        $this->outputEmitter->emitLine('\\Phel::setVar(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');
         $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeNs($symbolNode->getNamespace())));

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Closure;
+use Fiber;
+use WeakMap;
+
+use function array_key_exists;
+use function array_pop;
+use function array_reverse;
+
+/**
+ * Fiber-local stack of dynamic bindings.
+ *
+ * Clojure's `binding` establishes thread-local values for vars tagged
+ * `:dynamic`. In Phel we model that per-PHP-fiber: each fiber owns its
+ * own LIFO stack of frames, and the main (non-fiber) context has its
+ * own stack. This is the backing store for both the `binding` macro
+ * and "binding conveyance" into `future`/`async` bodies.
+ */
+final class DynamicScope
+{
+    private static ?DynamicScope $instance = null;
+
+    /**
+     * Stack used when no fiber is running.
+     *
+     * @var list<array<string, mixed>>
+     */
+    private array $mainStack = [];
+
+    /** @var WeakMap<Fiber, list<array<string, mixed>>> */
+    private WeakMap $fiberStacks;
+
+    /**
+     * Per-fiber stack of "binding recordings" — a recording is opened
+     * when a `binding` macro starts and closed when it commits. Each
+     * entry: `['dynamic' => array<string,mixed>, 'redefs' => list<array{string,string,mixed}>]`.
+     *
+     * @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     */
+    private array $mainRecordings = [];
+
+    /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> */
+    private WeakMap $fiberRecordings;
+
+    private function __construct()
+    {
+        /** @var WeakMap<Fiber, list<array<string, mixed>>> $map */
+        $map = new WeakMap();
+        $this->fiberStacks = $map;
+        /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        $recMap = new WeakMap();
+        $this->fiberRecordings = $recMap;
+    }
+
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function clear(): void
+    {
+        $this->mainStack = [];
+        $this->mainRecordings = [];
+        /** @var WeakMap<Fiber, list<array<string, mixed>>> $map */
+        $map = new WeakMap();
+        $this->fiberStacks = $map;
+        /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        $recMap = new WeakMap();
+        $this->fiberRecordings = $recMap;
+    }
+
+    /**
+     * Open a new binding recording on the current fiber's stack.
+     * Subsequent `recordDynamic` / `recordRedef` calls append to it
+     * until `popRecording` is called.
+     */
+    public function startRecording(): void
+    {
+        $entry = ['dynamic' => [], 'redefs' => []];
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $this->mainRecordings[] = $entry;
+            return;
+        }
+
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        $stack[] = $entry;
+        $this->fiberRecordings[$fiber] = $stack;
+    }
+
+    public function isRecording(): bool
+    {
+        return $this->currentRecordings() !== [];
+    }
+
+    public function recordDynamic(string $ns, string $name, mixed $value): void
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $top = array_key_last($this->mainRecordings);
+            if ($top === null) {
+                return;
+            }
+
+            $this->mainRecordings[$top]['dynamic'][$ns . '/' . $name] = $value;
+            return;
+        }
+
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        $top = array_key_last($stack);
+        if ($top === null) {
+            return;
+        }
+
+        $stack[$top]['dynamic'][$ns . '/' . $name] = $value;
+        $this->fiberRecordings[$fiber] = $stack;
+    }
+
+    public function recordRedef(string $ns, string $name, mixed $previous): void
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $top = array_key_last($this->mainRecordings);
+            if ($top === null) {
+                return;
+            }
+
+            $this->mainRecordings[$top]['redefs'][] = [$ns, $name, $previous];
+            return;
+        }
+
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        $top = array_key_last($stack);
+        if ($top === null) {
+            return;
+        }
+
+        $stack[$top]['redefs'][] = [$ns, $name, $previous];
+        $this->fiberRecordings[$fiber] = $stack;
+    }
+
+    /**
+     * @return array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}
+     */
+    public function popRecording(): array
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $entry = array_pop($this->mainRecordings);
+            return $entry ?? ['dynamic' => [], 'redefs' => []];
+        }
+
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        $entry = array_pop($stack);
+        if ($stack === []) {
+            unset($this->fiberRecordings[$fiber]);
+        } else {
+            $this->fiberRecordings[$fiber] = $stack;
+        }
+
+        return $entry ?? ['dynamic' => [], 'redefs' => []];
+    }
+
+    /**
+     * @param array<string, mixed> $frame ["ns/name" => value]
+     */
+    public function pushFrame(array $frame): void
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $this->mainStack[] = $frame;
+            return;
+        }
+
+        $stack = $this->fiberStacks[$fiber] ?? [];
+        $stack[] = $frame;
+        $this->fiberStacks[$fiber] = $stack;
+    }
+
+    public function popFrame(): void
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            array_pop($this->mainStack);
+            return;
+        }
+
+        $stack = $this->fiberStacks[$fiber] ?? [];
+        array_pop($stack);
+        if ($stack === []) {
+            unset($this->fiberStacks[$fiber]);
+        } else {
+            $this->fiberStacks[$fiber] = $stack;
+        }
+    }
+
+    public function hasBinding(string $ns, string $name): bool
+    {
+        $key = $ns . '/' . $name;
+        foreach (array_reverse($this->currentStack()) as $frame) {
+            if (array_key_exists($key, $frame)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getBinding(string $ns, string $name): mixed
+    {
+        $key = $ns . '/' . $name;
+        foreach (array_reverse($this->currentStack()) as $frame) {
+            if (array_key_exists($key, $frame)) {
+                return $frame[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Flatten the current stack into a single map (innermost value wins).
+     * Used for binding conveyance into futures.
+     *
+     * @return array<string, mixed>
+     */
+    public function snapshot(): array
+    {
+        $result = [];
+        foreach ($this->currentStack() as $frame) {
+            foreach ($frame as $key => $value) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Push a frame, execute the closure, always pop on return or throw.
+     *
+     * @param array<string, mixed> $frame
+     */
+    public function withFrame(array $frame, Closure $fn): mixed
+    {
+        $this->pushFrame($frame);
+        try {
+            return $fn();
+        } finally {
+            $this->popFrame();
+        }
+    }
+
+    /**
+     * @return list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     */
+    private function currentRecordings(): array
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            return $this->mainRecordings;
+        }
+
+        return $this->fiberRecordings[$fiber] ?? [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function currentStack(): array
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            return $this->mainStack;
+        }
+
+        return $this->fiberStacks[$fiber] ?? [];
+    }
+}

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -181,13 +181,7 @@ final class DynamicScope
         }
 
         $key = $ns . '/' . $name;
-        foreach (array_reverse($stack) as $frame) {
-            if (array_key_exists($key, $frame)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(array_reverse($stack), static fn($frame): bool => array_key_exists($key, $frame));
     }
 
     public function getBinding(string $ns, string $name): mixed

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -157,16 +157,48 @@ final class DynamicScope
         }
     }
 
+    /**
+     * O(1) probe used by callers that want to short-circuit the common
+     * "no dynamic binding active" case before paying the
+     * {@see self::hasBinding()} / {@see self::getBinding()} cost on the
+     * hot global-read path.
+     */
+    public function hasAnyBinding(): bool
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            return $this->mainStack !== [];
+        }
+
+        return isset($this->fiberStacks[$fiber]);
+    }
+
     public function hasBinding(string $ns, string $name): bool
     {
+        $stack = $this->currentStack();
+        if ($stack === []) {
+            return false;
+        }
+
         $key = $ns . '/' . $name;
-        return array_any(array_reverse($this->currentStack()), static fn($frame): bool => array_key_exists($key, $frame));
+        foreach (array_reverse($stack) as $frame) {
+            if (array_key_exists($key, $frame)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getBinding(string $ns, string $name): mixed
     {
+        $stack = $this->currentStack();
+        if ($stack === []) {
+            return null;
+        }
+
         $key = $ns . '/' . $name;
-        foreach (array_reverse($this->currentStack()) as $frame) {
+        foreach (array_reverse($stack) as $frame) {
             if (array_key_exists($key, $frame)) {
                 return $frame[$key];
             }

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -81,16 +81,7 @@ final class DynamicScope
      */
     public function startRecording(): void
     {
-        $entry = ['dynamic' => [], 'redefs' => []];
-        $fiber = Fiber::getCurrent();
-        if (!$fiber instanceof Fiber) {
-            $this->mainRecordings[] = $entry;
-            return;
-        }
-
-        $stack = $this->fiberRecordings[$fiber] ?? [];
-        $stack[] = $entry;
-        $this->fiberRecordings[$fiber] = $stack;
+        $this->pushRecording(['dynamic' => [], 'redefs' => []]);
     }
 
     public function isRecording(): bool
@@ -100,48 +91,24 @@ final class DynamicScope
 
     public function recordDynamic(string $ns, string $name, mixed $value): void
     {
-        $fiber = Fiber::getCurrent();
-        if (!$fiber instanceof Fiber) {
-            $top = array_key_last($this->mainRecordings);
-            if ($top === null) {
-                return;
-            }
-
-            $this->mainRecordings[$top]['dynamic'][$ns . '/' . $name] = $value;
+        $entry = $this->popTopRecording();
+        if ($entry === null) {
             return;
         }
 
-        $stack = $this->fiberRecordings[$fiber] ?? [];
-        $top = array_key_last($stack);
-        if ($top === null) {
-            return;
-        }
-
-        $stack[$top]['dynamic'][$ns . '/' . $name] = $value;
-        $this->fiberRecordings[$fiber] = $stack;
+        $entry['dynamic'][$ns . '/' . $name] = $value;
+        $this->pushRecording($entry);
     }
 
     public function recordRedef(string $ns, string $name, mixed $previous): void
     {
-        $fiber = Fiber::getCurrent();
-        if (!$fiber instanceof Fiber) {
-            $top = array_key_last($this->mainRecordings);
-            if ($top === null) {
-                return;
-            }
-
-            $this->mainRecordings[$top]['redefs'][] = [$ns, $name, $previous];
+        $entry = $this->popTopRecording();
+        if ($entry === null) {
             return;
         }
 
-        $stack = $this->fiberRecordings[$fiber] ?? [];
-        $top = array_key_last($stack);
-        if ($top === null) {
-            return;
-        }
-
-        $stack[$top]['redefs'][] = [$ns, $name, $previous];
-        $this->fiberRecordings[$fiber] = $stack;
+        $entry['redefs'][] = [$ns, $name, $previous];
+        $this->pushRecording($entry);
     }
 
     /**
@@ -149,21 +116,7 @@ final class DynamicScope
      */
     public function popRecording(): array
     {
-        $fiber = Fiber::getCurrent();
-        if (!$fiber instanceof Fiber) {
-            $entry = array_pop($this->mainRecordings);
-            return $entry ?? ['dynamic' => [], 'redefs' => []];
-        }
-
-        $stack = $this->fiberRecordings[$fiber] ?? [];
-        $entry = array_pop($stack);
-        if ($stack === []) {
-            unset($this->fiberRecordings[$fiber]);
-        } else {
-            $this->fiberRecordings[$fiber] = $stack;
-        }
-
-        return $entry ?? ['dynamic' => [], 'redefs' => []];
+        return $this->popTopRecording() ?? ['dynamic' => [], 'redefs' => []];
     }
 
     /**
@@ -190,7 +143,12 @@ final class DynamicScope
             return;
         }
 
-        $stack = $this->fiberStacks[$fiber] ?? [];
+        if (!isset($this->fiberStacks[$fiber])) {
+            return;
+        }
+
+        /** @var list<array<string, mixed>> $stack */
+        $stack = $this->fiberStacks[$fiber];
         array_pop($stack);
         if ($stack === []) {
             unset($this->fiberStacks[$fiber]);
@@ -202,13 +160,7 @@ final class DynamicScope
     public function hasBinding(string $ns, string $name): bool
     {
         $key = $ns . '/' . $name;
-        foreach (array_reverse($this->currentStack()) as $frame) {
-            if (array_key_exists($key, $frame)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(array_reverse($this->currentStack()), static fn($frame): bool => array_key_exists($key, $frame));
     }
 
     public function getBinding(string $ns, string $name): mixed
@@ -257,6 +209,51 @@ final class DynamicScope
     }
 
     /**
+     * @param array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>} $entry
+     */
+    private function pushRecording(array $entry): void
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            $stack = $this->mainRecordings;
+            $stack[] = $entry;
+            $this->mainRecordings = $stack;
+            return;
+        }
+
+        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        $stack[] = $entry;
+        $this->fiberRecordings[$fiber] = $stack;
+    }
+
+    /**
+     * @return array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}|null
+     */
+    private function popTopRecording(): ?array
+    {
+        $fiber = Fiber::getCurrent();
+        if (!$fiber instanceof Fiber) {
+            return array_pop($this->mainRecordings);
+        }
+
+        if (!isset($this->fiberRecordings[$fiber])) {
+            return null;
+        }
+
+        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        $stack = $this->fiberRecordings[$fiber];
+        $entry = array_pop($stack);
+        if ($stack === []) {
+            unset($this->fiberRecordings[$fiber]);
+        } else {
+            $this->fiberRecordings[$fiber] = $stack;
+        }
+
+        return $entry;
+    }
+
+    /**
      * @return list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
      */
     private function currentRecordings(): array
@@ -266,7 +263,9 @@ final class DynamicScope
             return $this->mainRecordings;
         }
 
-        return $this->fiberRecordings[$fiber] ?? [];
+        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        $stack = $this->fiberRecordings[$fiber] ?? [];
+        return $stack;
     }
 
     /**
@@ -279,6 +278,8 @@ final class DynamicScope
             return $this->mainStack;
         }
 
-        return $this->fiberStacks[$fiber] ?? [];
+        /** @var list<array<string, mixed>> $stack */
+        $stack = $this->fiberStacks[$fiber] ?? [];
+        return $stack;
     }
 }

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -11,8 +11,14 @@
     (is (= 6 (c 3)) "Closure preserves function behavior")))
 
 (deftest test-async-macro-expands
-  (let [expanded (macroexpand-1 '(phel\async/async (+ 1 2)))]
-    (is (= 'php/amp\async (first expanded)) "async expands to php/amp\\async call")))
+  (let [expanded (macroexpand '(phel\async/async (+ 1 2)))
+        source (print-str expanded)]
+    (is (php/str_contains source "amp\\async")
+        "async expansion still delegates to amp\\async")
+    (is (php/str_contains source "withDynamicBindings")
+        "async expansion wraps body in binding conveyance")
+    (is (php/str_contains source "snapshotDynamicBindings")
+        "async expansion snapshots caller bindings")))
 
 ;; --- Runtime integration tests (amphp/amp) ---
 

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -1,0 +1,63 @@
+(ns phel-test\test\core\binding-conveyance
+  (:require phel\test :refer [deftest is])
+  (:require phel\async :refer [async await future future-fiber]))
+
+;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1536
+;;
+;; Dynamic vars must be fiber-local and bindings must convey into
+;; futures/async so Phel matches Clojure's `binding` semantics.
+
+(def ^:dynamic *x* :unset)
+
+(defn- read-x [] *x*)
+
+;; --- Snippet A from the issue ---
+;; Future created OUTSIDE binding, dereffed INSIDE binding.
+;; Clojure returns :unset because the future captured the outer
+;; (root) binding at creation time.
+(deftest test-future-captures-bindings-at-creation
+  (let [f (future (read-x))]
+    (binding [*x* :now-here]
+      (is (= :unset (await f))
+          "future created outside binding must not see the inner value"))))
+
+;; --- Snippet B from the issue ---
+;; Future created inside an OUTER binding, dereffed inside an INNER
+;; binding. Clojure returns :outer.
+(deftest test-future-captures-nearest-enclosing-binding
+  (binding [*x* :outer]
+    (let [f (future (read-x))]
+      (binding [*x* :inner]
+        (is (= :outer (await f))
+            "future must see the caller's binding at creation time")))))
+
+;; --- Snippet C from the issue (simplified without nested futures) ---
+(deftest test-binding-isolated-from-outer-deref-site
+  (binding [*x* :caller]
+    (let [f (future (binding [*x* :callee] (read-x)))]
+      (binding [*x* :derefer]
+        (is (= :callee (await f))
+            "innermost binding inside the future body wins")))))
+
+;; --- Isolation between concurrent fibers ---
+(deftest test-concurrent-fibers-see-independent-bindings
+  (let [a (async (binding [*x* :A] (read-x)))
+        b (async (binding [*x* :B] (read-x)))]
+    (is (= :A (await a)))
+    (is (= :B (await b)))
+    (is (= :unset *x*) "root value untouched after fibers complete")))
+
+;; --- Fiber-backed future-fiber ---
+(deftest test-future-fiber-also-conveys
+  (binding [*x* :outer]
+    (let [ff (future-fiber (read-x))]
+      (is (= :outer (deref ff))
+          "future-fiber captures the caller's dynamic bindings"))))
+
+;; --- binding on a non-dynamic var still uses with-redefs semantics ---
+(def *not-dynamic* :root)
+
+(deftest test-binding-non-dynamic-var-legacy-redef
+  (binding [*not-dynamic* :rebound]
+    (is (= :rebound *not-dynamic*) "non-dynamic var is mutated in-place"))
+  (is (= :root *not-dynamic*) "non-dynamic var is restored on exit"))

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -19,7 +19,7 @@
     )
   )
 );
-\Phel::addDefinition(
+\Phel::setVar(
   "user",
   "x",
   2

--- a/tests/php/Unit/Lang/DynamicScopeTest.php
+++ b/tests/php/Unit/Lang/DynamicScopeTest.php
@@ -67,7 +67,7 @@ final class DynamicScopeTest extends TestCase
         $scope = DynamicScope::getInstance();
 
         try {
-            $scope->withFrame(['ns/x' => 'boom'], static function (): void {
+            $scope->withFrame(['ns/x' => 'boom'], static function (): never {
                 throw new RuntimeException('fail');
             });
             self::fail('expected exception');
@@ -170,6 +170,7 @@ final class DynamicScopeTest extends TestCase
             self::assertFalse($scope->isRecording(), 'fiber starts without a recording');
             $scope->startRecording();
             $scope->recordDynamic('ns', 'x', 'fiber');
+
             $observed = $scope->popRecording()['dynamic'];
         });
         $fiber->start();
@@ -184,6 +185,7 @@ final class DynamicScopeTest extends TestCase
         // Simulating binding conveyance: caller snapshots, fiber re-applies.
         $scope = DynamicScope::getInstance();
         $scope->pushFrame(['ns/x' => 'caller']);
+
         $snapshot = $scope->snapshot();
 
         $seenInsideFiber = null;

--- a/tests/php/Unit/Lang/DynamicScopeTest.php
+++ b/tests/php/Unit/Lang/DynamicScopeTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Fiber;
+use Phel\Lang\DynamicScope;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class DynamicScopeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        DynamicScope::getInstance()->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        DynamicScope::getInstance()->clear();
+    }
+
+    public function test_no_binding_when_empty(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        self::assertFalse($scope->hasBinding('ns', 'x'));
+        self::assertNull($scope->getBinding('ns', 'x'));
+    }
+
+    public function test_push_frame_exposes_bindings(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 42]);
+
+        self::assertTrue($scope->hasBinding('ns', 'x'));
+        self::assertSame(42, $scope->getBinding('ns', 'x'));
+    }
+
+    public function test_inner_frame_shadows_outer(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 'outer']);
+        $scope->pushFrame(['ns/x' => 'inner']);
+
+        self::assertSame('inner', $scope->getBinding('ns', 'x'));
+
+        $scope->popFrame();
+        self::assertSame('outer', $scope->getBinding('ns', 'x'));
+
+        $scope->popFrame();
+        self::assertFalse($scope->hasBinding('ns', 'x'));
+    }
+
+    public function test_with_frame_pops_on_return(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $result = $scope->withFrame(['ns/x' => 7], static fn(): int => 2 * 3);
+
+        self::assertSame(6, $result);
+        self::assertFalse($scope->hasBinding('ns', 'x'));
+    }
+
+    public function test_with_frame_pops_on_exception(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        try {
+            $scope->withFrame(['ns/x' => 'boom'], static function (): void {
+                throw new RuntimeException('fail');
+            });
+            self::fail('expected exception');
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertFalse($scope->hasBinding('ns', 'x'));
+    }
+
+    public function test_snapshot_flattens_stack_with_inner_wins(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/a' => 1, 'ns/b' => 1]);
+        $scope->pushFrame(['ns/b' => 2]);
+
+        self::assertSame(['ns/a' => 1, 'ns/b' => 2], $scope->snapshot());
+    }
+
+    public function test_fiber_binding_does_not_leak_to_main(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 'main']);
+
+        $fiber = new Fiber(static function () use ($scope): void {
+            $scope->pushFrame(['ns/x' => 'fiber']);
+            Fiber::suspend();
+            $scope->popFrame();
+        });
+
+        $fiber->start();
+        self::assertSame('main', $scope->getBinding('ns', 'x'), 'fiber must not mutate main scope');
+        $fiber->resume();
+        self::assertTrue($fiber->isTerminated());
+        self::assertSame('main', $scope->getBinding('ns', 'x'));
+
+        $scope->popFrame();
+    }
+
+    public function test_two_fibers_have_independent_stacks(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $observed = [];
+
+        $fiberA = new Fiber(static function () use ($scope, &$observed): void {
+            $scope->pushFrame(['ns/x' => 'A']);
+            Fiber::suspend();
+            $observed['A'] = $scope->getBinding('ns', 'x');
+            $scope->popFrame();
+        });
+
+        $fiberB = new Fiber(static function () use ($scope, &$observed): void {
+            $scope->pushFrame(['ns/x' => 'B']);
+            Fiber::suspend();
+            $observed['B'] = $scope->getBinding('ns', 'x');
+            $scope->popFrame();
+        });
+
+        $fiberA->start();
+        $fiberB->start();
+        $fiberA->resume();
+        $fiberB->resume();
+
+        self::assertSame(['A' => 'A', 'B' => 'B'], $observed);
+    }
+
+    public function test_recording_stack_captures_dynamic_and_redefs(): void
+    {
+        $scope = DynamicScope::getInstance();
+        self::assertFalse($scope->isRecording());
+
+        $scope->startRecording();
+        self::assertTrue($scope->isRecording());
+        $scope->recordDynamic('ns', 'a', 1);
+        $scope->recordRedef('ns', 'b', 'old-b');
+
+        $entry = $scope->popRecording();
+        self::assertSame(['ns/a' => 1], $entry['dynamic']);
+        self::assertSame([['ns', 'b', 'old-b']], $entry['redefs']);
+        self::assertFalse($scope->isRecording());
+    }
+
+    public function test_pop_recording_on_empty_stack_returns_empty_entry(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        $entry = $scope->popRecording();
+
+        self::assertSame(['dynamic' => [], 'redefs' => []], $entry);
+    }
+
+    public function test_recording_stacks_are_isolated_per_fiber(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->startRecording();
+        $scope->recordDynamic('ns', 'x', 'main');
+
+        $observed = null;
+        $fiber = new Fiber(static function () use ($scope, &$observed): void {
+            self::assertFalse($scope->isRecording(), 'fiber starts without a recording');
+            $scope->startRecording();
+            $scope->recordDynamic('ns', 'x', 'fiber');
+            $observed = $scope->popRecording()['dynamic'];
+        });
+        $fiber->start();
+
+        self::assertSame(['ns/x' => 'fiber'], $observed);
+        self::assertTrue($scope->isRecording(), 'main recording is untouched by fiber');
+        self::assertSame(['ns/x' => 'main'], $scope->popRecording()['dynamic']);
+    }
+
+    public function test_snapshot_from_fiber_includes_caller_frames_via_apply(): void
+    {
+        // Simulating binding conveyance: caller snapshots, fiber re-applies.
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 'caller']);
+        $snapshot = $scope->snapshot();
+
+        $seenInsideFiber = null;
+        $fiber = new Fiber(static function () use ($scope, $snapshot, &$seenInsideFiber): void {
+            $scope->withFrame($snapshot, static function () use ($scope, &$seenInsideFiber): void {
+                $seenInsideFiber = $scope->getBinding('ns', 'x');
+            });
+        });
+        $fiber->start();
+
+        self::assertSame('caller', $seenInsideFiber);
+        self::assertSame('caller', $scope->getBinding('ns', 'x'));
+
+        $scope->popFrame();
+    }
+}

--- a/tests/php/Unit/Lang/DynamicScopeTest.php
+++ b/tests/php/Unit/Lang/DynamicScopeTest.php
@@ -27,6 +27,20 @@ final class DynamicScopeTest extends TestCase
 
         self::assertFalse($scope->hasBinding('ns', 'x'));
         self::assertNull($scope->getBinding('ns', 'x'));
+        self::assertFalse($scope->hasAnyBinding(), 'fresh scope reports no active frames');
+    }
+
+    public function test_has_any_binding_flips_with_push_pop(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        self::assertFalse($scope->hasAnyBinding());
+
+        $scope->pushFrame(['ns/x' => 1]);
+        self::assertTrue($scope->hasAnyBinding());
+
+        $scope->popFrame();
+        self::assertFalse($scope->hasAnyBinding());
     }
 
     public function test_push_frame_exposes_bindings(): void


### PR DESCRIPTION
Closes #1536

## 🤔 Background

`binding` in Phel mutated the global registry and then restored the old value in a `finally`. Because PHP fibers share that registry, a `future` body evaluated inside a later `binding` would see the *innermost* value at deref time instead of the one active where the future was created. The three snippets attached to #1536 produce `:now-here` / `:inner` / `:derefer` in Phel where Clojure produces `:unset` / `:outer` / `:callee`.

Two Clojure guarantees were missing:
- **Isolation** — concurrent threads (fibers, here) must not observe each other's `binding`s.
- **Conveyance** — `future`/`async` must capture the caller's dynamic bindings at creation time and reinstall them inside the worker.

## 💡 Goal

Make `binding` fiber-local for vars tagged `^:dynamic`, and snapshot/replay those bindings across `future`, `async`, `future-fiber`, and `future-call`, so the three issue snippets match Clojure's output. Preserve `with-redefs`-style semantics for non-dynamic vars so existing usage (`phel\mock`, ad-hoc redefs, etc.) is unaffected.

## 🔖 Changes

**Runtime**
- `src/php/Lang/DynamicScope.php` (new) — per-fiber stack of dynamic frames plus a per-fiber *recording* stack for the `binding` macro. `hasAnyBinding()` provides an O(1) probe for the hot `getDefinition` path.
- `src/Phel.php` — new `setVar`, `openBindingFrame`, `commitAndRunBindingFrame`, `abortBindingFrameIfOpen`, `snapshotDynamicBindings`, `withDynamicBindings`, `isDynamicVar`; overridden `getDefinition` short-circuits to the registry when no frame is active.

**Compiler**
- `SetVarEmitter` now emits `\Phel::setVar(...)`. Outside a `binding`, this still mutates the registry; inside one, it stages into the pending fiber-local frame.
- `DefSymbol` merges metadata attached to the *name symbol* (`(def ^:dynamic *x* 1)` used to be a no-op for `:dynamic` because the analyzer only read list meta).

**Phel stdlib**
- `binding` macro rewritten in `src/phel/core/io.phel` around `openBindingFrame` / `commitAndRunBindingFrame` with a `try/finally` abort guard.
- `future`, `async`, `future-fiber`, `future-call` in `src/phel/async.phel` snapshot caller bindings and wrap the fiber body in `withDynamicBindings`.
- `phel\ai/*http-post*`, `phel\test/*current-test-name*`, `phel\test/*testing-contexts*` are now tagged `^:dynamic` so concurrent fibers that rebind them stay isolated. `phel\mock` intentionally stays on the legacy mutation path because it rebinds arbitrary user-supplied function symbols (not typically multi-fiber).

**Tests**
- `tests/php/Unit/Lang/DynamicScopeTest.php` (new) — 13 unit tests covering push/pop/snapshot, fiber isolation, recording stack, exception safety, and the `hasAnyBinding` fast-path probe.
- `tests/phel/test/core/binding-conveyance.phel` (new) — 6 tests covering the three issue snippets, concurrent-fiber isolation, `future-fiber` conveyance, and non-dynamic `with-redefs` fallback.
- Updated `tests/phel/test/async.phel` macroexpand assertion and the `set-var` emission fixture.

### Performance
Measured with `phpbench` (10 iterations cold-start, PHP 8.5.4, opcache off, fresh cache each run):

| Bench | main | this PR | Δ |
|---|---|---|---|
| `bench_phel_run` (boot `phel\core` + deps) | 19.221ms ±1.43% | 20.263ms ±2.43% | +5.4% |
| `bench_core_file_compilation` | 23.748ms ±1.23% | 23.941ms ±0.74% | +0.8% (in noise) |

Every global-var read now pays one `Fiber::getCurrent()` + one `isset` probe via `DynamicScope::hasAnyBinding()` before falling through to the registry on the empty-stack fast path. The `bench_phel_run` delta reflects the fiber-local correctness cost; compilation is untouched.

### Test plan
- [x] `./vendor/bin/phpunit --filter DynamicScopeTest` (13/13)
- [x] `./bin/phel test tests/phel/test/core/binding-conveyance.phel` (9/9)
- [x] `composer test-compiler` — all green except the pre-existing `DataReadersAutoloadTest` flake (reproduces on `main`)
- [x] `composer test-core` — 4250/4250 green (the pre-existing `math-operation.phel` compile error also reproduces on `main`)
- [x] `composer phpstan`, `composer psalm`, `composer rector`, `composer csrun` — all green