### PR TITLE
feat(core): move `future` macro from `phel\async` to `phel\core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 - **BREAKING**: Minimum PHP version bumped from 8.3 to 8.4. PHP 8.3 is no longer supported.
 
+#### Core
+- `future` is now available from `phel\core` without requiring `phel\async`, matching Clojure's out-of-the-box availability (#1537)
+
 ### Fixed
 
 #### Core

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -254,7 +254,7 @@ Wall time tracks the slowest branch, not the sum.
 
 ```phel
 (ns demo\cancel-on-error
-  (:require phel\async :refer [async await delay future future-cancel]))
+  (:require phel\async :refer [async await delay future-cancel]))
 
 (defn launch []
   (async

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -176,7 +176,7 @@ Phel runs on PHP. A handful of Clojure features don't translate directly:
 | **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |
 | **`alter-var-root`** | No first-class vars to re-root | Use an `atom` with `swap!` for mutable state, or redefine the top-level binding with `def`. Calling `alter-var-root` at runtime throws `BadMethodCallException` with this hint |
 
-Phel does provide `future`, `future-cancel`, and `pmap` via the `phel\async` module, which uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt. For top-level scripting without an event loop, use the fiber primitives (`promise`, `deliver`, `future-call`, `future-fiber`); see [docs/async-guide.md](async-guide.md) for the decision guide.
+Phel provides `future` in `phel\core` (available without requiring any namespace, as in Clojure); `future-cancel` and `pmap` still live in `phel\async`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt. For top-level scripting without an event loop, use the fiber primitives (`promise`, `deliver`, `future-call`, `future-fiber`); see [docs/async-guide.md](async-guide.md) for the decision guide.
 
 ## Structural differences
 

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -3,8 +3,10 @@
 ;; Two cooperating concurrency layers in one module.
 ;;
 ;; - AMPHP-backed: `async`, `await`, `delay`, `await-all`, `await-any`,
-;;   `pmap`, `future`, `future-cancel`, `future-cancelled?`. Requires an
-;;   event loop; best for IO parallelism, timers, and combinators.
+;;   `pmap`, `future-cancel`, `future-cancelled?`. Requires an event
+;;   loop; best for IO parallelism, timers, and combinators. The core
+;;   `future` macro (available without requiring this namespace) is the
+;;   AMPHP-backed variant.
 ;; - Fiber-backed: `promise`, `deliver`, `future-call`, `future-fiber`,
 ;;   `future?`. Runs at the top level via a cooperative scheduler in
 ;;   `\Phel\Fiber\FiberFacade`; no loop required.
@@ -37,29 +39,6 @@
      (php/amp\async
        (fn []
          (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
-
-(defmacro future
-  "Starts evaluating `body` asynchronously and returns a `PhelFuture`
-  that can be `deref`ed (blocks the current fiber until the value is
-  available) or checked with `realized?`.
-
-  Supports the 3-arg `(deref f timeout-ms timeout-val)` form for
-  time-bounded blocking, as well as `future-cancel`, `future-cancelled?`
-  and `future-done?` for lifecycle management.
-
-  Must be called from inside a fiber context (e.g. the AMPHP event
-  loop or an enclosing `async` block), because `deref` resolves via
-  AMPHP's fiber-based `await`."
-  {:example "(let [f (future (expensive-computation))] @f)"
-   :see-also ["async" "await" "realized?" "deref" "future-cancel"
-              "future-done?" "future-fiber" "future?"]}
-  [& body]
-  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
-     (php/new \Phel\Lang\PhelFuture
-              (php/amp\async
-                (fn []
-                  (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))
-              (php/new \Amp\DeferredCancellation))))
 
 (defn- unwrap-future
   "Returns the raw Amp\\Future for either a `PhelFuture` wrapper or

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -200,3 +200,4 @@
 (load "core/parsing")
 (load "core/uuid")
 (load "core/loops")
+(load "core/futures")

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -1,0 +1,29 @@
+(in-ns phel\core)
+
+;; Core `future`: starts `body` asynchronously and returns a
+;; `PhelFuture`. Kept in core so it mirrors Clojure, where `future`
+;; is available without an explicit require. The fiber-backed
+;; `future-fiber`, `future-call`, `promise`, and friends still live in
+;; `phel\async`.
+
+(defmacro future
+  "Starts evaluating `body` asynchronously and returns a `PhelFuture`
+  that can be `deref`ed (blocks the current fiber until the value is
+  available) or checked with `realized?`.
+
+  Supports the 3-arg `(deref f timeout-ms timeout-val)` form for
+  time-bounded blocking, as well as `future-cancel`, `future-cancelled?`
+  and `future-done?` for lifecycle management.
+
+  Must be called from inside a fiber context (e.g. the AMPHP event
+  loop or an enclosing `async` block), because `deref` resolves via
+  AMPHP's fiber-based `await`."
+  {:example "(let [f (future (expensive-computation))] @f)"
+   :see-also ["realized?" "deref"]}
+  [& body]
+  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
+     (php/new \Phel\Lang\PhelFuture
+              (php/amp\async
+                (fn []
+                  (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))
+              (php/new \Amp\DeferredCancellation))))

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,6 +1,6 @@
 (ns phel-test\test\async
   (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [async await await-all await-any delay future future-cancel future-cancelled? future-done? pmap ->closure]))
+  (:require phel\async :refer [async await await-all await-any delay future-cancel future-cancelled? future-done? pmap ->closure]))
 
 ;; --- Pure function tests ---
 

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -1,6 +1,6 @@
 (ns phel-test\test\core\binding-conveyance
   (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [async await future future-fiber]))
+  (:require phel\async :refer [async await future-fiber]))
 
 ;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1536
 ;;

--- a/tests/phel/test/core/future-in-core.phel
+++ b/tests/phel/test/core/future-in-core.phel
@@ -1,0 +1,21 @@
+(ns phel-test\test\core\future-in-core
+  (:require phel\test :refer [deftest is]))
+
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/1537
+;; `future` must be available from core without requiring `phel\async`,
+;; matching Clojure's out-of-the-box availability.
+
+(deftest test-future-macro-is-available-without-require
+  (let [expanded (macroexpand '(future 42))
+        source   (print-str expanded)]
+    (is (php/str_contains source "Phel\\Lang\\PhelFuture")
+        "future expansion constructs a PhelFuture")
+    (is (php/str_contains source "amp\\async")
+        "future expansion delegates to amp\\async")
+    (is (php/str_contains source "snapshotDynamicBindings")
+        "future expansion snapshots caller bindings")))
+
+(deftest test-future-returns-phel-future-without-require
+  (let [f (future 1)]
+    (is (= true (php/instanceof f \Phel\Lang\PhelFuture))
+        "future produces a PhelFuture instance at the top level")))


### PR DESCRIPTION
## 🤔 Background

Closes #1537.

In Clojure, `future` is available in `clojure.core` without any explicit `require`. In Phel it lived in `phel\async`, so `.cljc` sources targeting both languages needed a reader conditional just to pull it in (see the [clojure-test-suite `binding.cljc` case](https://github.com/jasalt/clojure-test-suite/blob/74e3faa90e3ec7bf9c9bba1f28e4ded958fcb23e/test/clojure/core_test/binding.cljc#L4)).

## 💡 Goal

Make `future` available globally — no `(:require phel\async :refer [future])` needed — to match Clojure's out-of-the-box availability.

## 🔖 Changes

- Add `src/phel/core/futures.phel` with the (AMPHP-backed) `future` macro and wire it into `core.phel` so it loads with every namespace.
- Remove the `future` macro from `src/phel/async.phel`; the module still owns `async`, `await`, `delay`, `await-all`, `await-any`, `pmap`, `future-cancel`, `future-cancelled?`, `future-done?`, plus the fiber-backed primitives (`promise`, `deliver`, `future-call`, `future-fiber`, `future?`).
- Drop `future` from the `:refer` lists in `tests/phel/test/async.phel` and `tests/phel/test/core/binding-conveyance.phel` (the global binding is used instead).
- Add `tests/phel/test/core/future-in-core.phel` asserting the macro is reachable without requiring `phel\async` and still expands to a `PhelFuture` wrapper around `amp\async`.
- Update `CHANGELOG.md`, `docs/clojure-migration.md`, and the `docs/async-guide.md` cancel-on-error example to reflect the new home.