### PR TITLE
feat(core): hierarchy-arity for isa?, derive, underive, parents, ancestors, descendants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+#### Core
+- Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
+
 ### Changed
 
 - **BREAKING**: Minimum PHP version bumped from 8.3 to 8.4. PHP 8.3 is no longer supported.

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -85,76 +85,142 @@
          false
          direct)))))
 
+(defn- compute-ancestors-map
+  "Builds the full {tag #{ancestors}} map from a parents map."
+  [parents-map]
+  (reduce
+   (fn [acc tag]
+     (let [anc (compute-ancestors parents-map tag)]
+       (if (empty? anc) acc (assoc acc tag anc))))
+   {}
+   (keys parents-map)))
+
+(defn- compute-descendants-map
+  "Builds the full {tag #{descendants}} map from a parents map."
+  [parents-map]
+  (reduce
+   (fn [acc child]
+     (reduce
+      (fn [inner ancestor]
+        (let [existing (get inner ancestor (hash-set))]
+          (assoc inner ancestor (union existing (hash-set child)))))
+      acc
+      (compute-ancestors parents-map child)))
+   {}
+   (keys parents-map)))
+
+(defn- rebuild-hierarchy
+  "Rebuilds :ancestors and :descendants maps from the :parents map in h."
+  [h]
+  (let [pm (get h :parents)]
+    (assoc h
+           :ancestors   (compute-ancestors-map pm)
+           :descendants (compute-descendants-map pm))))
+
 (defn isa?
-  "Returns true if child equals parent, or child is a descendant of parent
-  in the global hierarchy."
+  "Returns true if child equals parent, or child is a descendant of parent.
+  When a hierarchy is provided, the check is performed against it; otherwise
+  the global hierarchy is used."
   {:example "(do (derive :square :shape) (isa? :square :shape)) ; => true"
    :see-also ["derive" "parents" "ancestors" "descendants"]}
-  [child parent]
-  (or (= child parent)
-      (isa-in? (get @*hierarchy* :parents) child parent)))
+  ([child parent]
+   (isa? @*hierarchy* child parent))
+  ([h child parent]
+   (or (= child parent)
+       (isa-in? (get h :parents) child parent))))
 
 (defn derive
-  "Establishes a parent/child relationship between child and parent keywords
-  in the global hierarchy. Throws on cyclic derivation."
+  "Establishes a parent/child relationship between child and parent keywords.
+  With two arguments, mutates the global hierarchy and returns nil.
+  With a hierarchy `h`, returns a new hierarchy with the relationship added;
+  the original hierarchy is not modified. Throws on cyclic derivation."
   {:example "(derive :square :shape)"
    :see-also ["underive" "isa?" "parents" "ancestors" "descendants"]}
-  [child parent]
-  (when (isa? parent child)
-    (throw (php/new \InvalidArgumentException
-                    (str "Cyclic derivation: " parent " already isa " child))))
-  (swap! *hierarchy*
-         (fn [h]
-           (let [parents-map (get h :parents)
-                 old-parents (get parents-map child (hash-set))
-                 new-parents (union old-parents (hash-set parent))]
-             (assoc h :parents (assoc parents-map child new-parents)))))
-  nil)
+  ([child parent]
+   (when (isa? parent child)
+     (throw (php/new \InvalidArgumentException
+                     (str "Cyclic derivation: " parent " already isa " child))))
+   (swap! *hierarchy*
+          (fn [h]
+            (let [parents-map (get h :parents)
+                  old-parents (get parents-map child (hash-set))
+                  new-parents (union old-parents (hash-set parent))]
+              (assoc h :parents (assoc parents-map child new-parents)))))
+   nil)
+  ([h child parent]
+   (when (isa? h parent child)
+     (throw (php/new \InvalidArgumentException
+                     (str "Cyclic derivation: " parent " already isa " child))))
+   (let [parents-map (get h :parents)
+         old-parents (get parents-map child (hash-set))
+         new-parents (union old-parents (hash-set parent))
+         new-pm      (assoc parents-map child new-parents)]
+     (rebuild-hierarchy (assoc h :parents new-pm)))))
 
 (defn underive
-  "Removes a parent/child relationship from the global hierarchy."
+  "Removes a parent/child relationship.
+  With two arguments, mutates the global hierarchy and returns nil.
+  With a hierarchy `h`, returns a new hierarchy without the relationship;
+  the original is unchanged."
   {:example "(underive :square :shape)"
    :see-also ["derive" "isa?" "parents" "ancestors" "descendants"]}
-  [child parent]
-  (swap! *hierarchy*
-         (fn [h]
-           (let [parents-map (get h :parents)
-                 old-parents (get parents-map child (hash-set))
-                 new-parents (difference old-parents (hash-set parent))
-                 new-map     (if (empty? new-parents)
-                               (dissoc parents-map child)
-                               (assoc parents-map child new-parents))]
-             (assoc h :parents new-map))))
-  nil)
+  ([child parent]
+   (swap! *hierarchy*
+          (fn [h]
+            (let [parents-map (get h :parents)
+                  old-parents (get parents-map child (hash-set))
+                  new-parents (difference old-parents (hash-set parent))
+                  new-map     (if (empty? new-parents)
+                                (dissoc parents-map child)
+                                (assoc parents-map child new-parents))]
+              (assoc h :parents new-map))))
+   nil)
+  ([h child parent]
+   (let [parents-map (get h :parents)
+         old-parents (get parents-map child (hash-set))
+         new-parents (difference old-parents (hash-set parent))
+         new-pm      (if (empty? new-parents)
+                       (dissoc parents-map child)
+                       (assoc parents-map child new-parents))]
+     (rebuild-hierarchy (assoc h :parents new-pm)))))
 
 (defn parents
-  "Returns the set of immediate parents of tag in the global hierarchy, or nil."
+  "Returns the set of immediate parents of tag, or nil.
+  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
   {:see-also ["ancestors" "descendants" "derive" "isa?"]}
-  [tag]
-  (let [p (get (get @*hierarchy* :parents) tag)]
-    (when (and p (not (empty? p))) p)))
+  ([tag]
+   (parents @*hierarchy* tag))
+  ([h tag]
+   (let [p (get (get h :parents) tag)]
+     (when (and p (not (empty? p))) p))))
 
 (defn ancestors
-  "Returns the set of all transitive ancestors of tag, or nil."
+  "Returns the set of all transitive ancestors of tag, or nil.
+  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
   {:see-also ["parents" "descendants" "derive" "isa?"]}
-  [tag]
-  (let [a (compute-ancestors (get @*hierarchy* :parents) tag)]
-    (when (not (empty? a)) a)))
+  ([tag]
+   (ancestors @*hierarchy* tag))
+  ([h tag]
+   (let [a (compute-ancestors (get h :parents) tag)]
+     (when (not (empty? a)) a))))
 
 (defn descendants
-  "Returns the set of all descendants of tag, or nil."
+  "Returns the set of all descendants of tag, or nil.
+  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
   {:see-also ["parents" "ancestors" "derive" "isa?"]}
-  [tag]
-  (let [parents-map  (get @*hierarchy* :parents)
-        all-children (keys parents-map)
-        result       (reduce
-                      (fn [acc child]
-                        (if (contains? (compute-ancestors parents-map child) tag)
-                          (union acc (hash-set child))
-                          acc))
-                      (hash-set)
-                      all-children)]
-    (when (not (empty? result)) result)))
+  ([tag]
+   (descendants @*hierarchy* tag))
+  ([h tag]
+   (let [parents-map  (get h :parents)
+         all-children (keys parents-map)
+         result       (reduce
+                       (fn [acc child]
+                         (if (contains? (compute-ancestors parents-map child) tag)
+                           (union acc (hash-set child))
+                           acc))
+                       (hash-set)
+                       all-children)]
+     (when (not (empty? result)) result))))
 
 (defn find-hierarchy-method
   "Finds the best matching method for dispatch-val using the global hierarchy.

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -91,6 +91,89 @@
     (is (= {} (get h :descendants)) "fresh hierarchy has no descendants")
     (is (= {} (get h :ancestors)) "fresh hierarchy has no ancestors")))
 
+;; --- hierarchy-arity variants ---
+
+(deftest test-derive-hierarchy-returns-new-hierarchy
+  (let [h  (make-hierarchy)
+        h' (derive h :hd-child :hd-parent)]
+    (is (= {} (get h :parents)) "original hierarchy left untouched")
+    (is (contains? (get (get h' :parents) :hd-child) :hd-parent)
+        "new hierarchy carries the parent link")
+    (is (contains? (get (get h' :ancestors) :hd-child) :hd-parent)
+        "new hierarchy populates :ancestors")
+    (is (contains? (get (get h' :descendants) :hd-parent) :hd-child)
+        "new hierarchy populates :descendants")))
+
+(deftest test-derive-hierarchy-transitive-ancestors
+  (let [h (-> (make-hierarchy)
+              (derive :hd2-c :hd2-b)
+              (derive :hd2-b :hd2-a))]
+    (is (contains? (get (get h :ancestors) :hd2-c) :hd2-a)
+        "ancestors map captures transitive parent")
+    (is (contains? (get (get h :descendants) :hd2-a) :hd2-c)
+        "descendants map captures transitive child")))
+
+(deftest test-derive-hierarchy-cyclic-throws
+  (let [h (derive (make-hierarchy) :hd3-a :hd3-b)]
+    (is (thrown? \InvalidArgumentException (derive h :hd3-b :hd3-a))
+        "pure derive rejects cycles")))
+
+(deftest test-derive-hierarchy-does-not-touch-global
+  (let [_ (derive (make-hierarchy) :hd4-child :hd4-parent)]
+    (is (false? (isa? :hd4-child :hd4-parent))
+        "pure derive must not leak into the global hierarchy")))
+
+(deftest test-underive-hierarchy-returns-new-hierarchy
+  (let [h  (derive (make-hierarchy) :hu-child :hu-parent)
+        h' (underive h :hu-child :hu-parent)]
+    (is (contains? (get (get h :parents) :hu-child) :hu-parent)
+        "original hierarchy preserved")
+    (is (nil? (get (get h' :parents) :hu-child))
+        "parent link removed in new hierarchy")))
+
+(deftest test-underive-hierarchy-preserves-other-parents
+  (let [h  (-> (make-hierarchy)
+               (derive :hu2-child :hu2-p1)
+               (derive :hu2-child :hu2-p2))
+        h' (underive h :hu2-child :hu2-p1)]
+    (is (false? (contains? (get (get h' :parents) :hu2-child) :hu2-p1))
+        "removed parent gone")
+    (is (contains? (get (get h' :parents) :hu2-child) :hu2-p2)
+        "other parent preserved")))
+
+(deftest test-isa-hierarchy
+  (let [h (-> (make-hierarchy)
+              (derive :hi-c :hi-b)
+              (derive :hi-b :hi-a))]
+    (is (true? (isa? h :hi-c :hi-a)) "transitive isa? in hierarchy")
+    (is (true? (isa? h :hi-c :hi-c)) "identity in hierarchy")
+    (is (false? (isa? h :hi-a :hi-c)) "no reverse in hierarchy")))
+
+(deftest test-parents-hierarchy
+  (let [h (derive (make-hierarchy) :hp-child :hp-parent)]
+    (is (contains? (parents h :hp-child) :hp-parent)
+        "parents in hierarchy")
+    (is (nil? (parents h :hp-unknown))
+        "nil for unknown tag in hierarchy")))
+
+(deftest test-ancestors-hierarchy
+  (let [h (-> (make-hierarchy)
+              (derive :ha-c :ha-b)
+              (derive :ha-b :ha-a))]
+    (let [anc (ancestors h :ha-c)]
+      (is (contains? anc :ha-b) "direct ancestor in hierarchy")
+      (is (contains? anc :ha-a) "transitive ancestor in hierarchy"))
+    (is (nil? (ancestors h :ha-unknown)) "nil for unknown tag")))
+
+(deftest test-descendants-hierarchy
+  (let [h (-> (make-hierarchy)
+              (derive :hdc-child :hdc-root)
+              (derive :hdc-grandchild :hdc-child))]
+    (let [desc (descendants h :hdc-root)]
+      (is (contains? desc :hdc-child) "direct descendant in hierarchy")
+      (is (contains? desc :hdc-grandchild) "transitive descendant in hierarchy"))
+    (is (nil? (descendants h :hdc-leaf)) "nil for leaf/unknown tag")))
+
 ;; --- multimethod with hierarchy dispatch ---
 
 ;; Multimethods must be top-level (defmulti expands to def)


### PR DESCRIPTION
## 🤔 Background

Closes #1543.

Currently `derive` and its sibling hierarchy functions in Phel only operate on the global hierarchy, while `clojure.core` exposes a companion arity that takes (or returns) an explicit hierarchy value produced by `make-hierarchy`. This prevented porting Clojure tests/libraries that build up isolated hierarchies (and was visible in the clojure-test-suite gap).

## 💡 Goal

Reach full Clojure-parity on the hierarchy API so `.cljc` code relying on `(derive h tag parent)`, `(isa? h child parent)`, `(parents h tag)`, etc. can run on Phel unchanged.

## 🔖 Changes

### Core
- `isa?`, `parents`, `ancestors`, `descendants` — added `[h tag ...]` arity that consults the given hierarchy instead of the global one.
- `derive`, `underive` — added `[h child parent]` arity that is **pure**: returns a new hierarchy with `:parents`, `:ancestors`, and `:descendants` all populated (matching Clojure's map shape). The two-argument forms continue to mutate the global hierarchy and return `nil`.
- Cyclic-derivation check now honours the passed hierarchy on the pure arity.
- Internal helpers `compute-ancestors-map` / `compute-descendants-map` / `rebuild-hierarchy` added.

### Tests
- New tests in `tests/phel/test/core/hierarchy.phel` covering pure `derive`/`underive` (shape, immutability of original, cyclic throw, no global leakage) and hierarchy-arity queries.

### Changelog
- Entry under `## Unreleased → Added → Core`.