### PR TITLE
fix(core): symmetric = between lists and sequential collections (#1546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings; `^:dynamic` on `def` name symbols is honored (#1536)
+- `=` between a list and any other sequential collection (vector, lazy seq) now returns the same result regardless of argument order (#1546)
 
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources

--- a/src/php/Lang/Collections/LinkedList/EmptyList.php
+++ b/src/php/Lang/Collections/LinkedList/EmptyList.php
@@ -11,6 +11,7 @@ use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Phel\Lang\SeqInterface;
 use RuntimeException;
 use Traversable;
 
@@ -69,7 +70,22 @@ final class EmptyList extends AbstractType implements PersistentListInterface
 
     public function equals(mixed $other): bool
     {
-        return $other instanceof self;
+        if ($other instanceof self) {
+            return true;
+        }
+
+        // Any empty sequential collection (vector, lazy seq, …) compares equal
+        // to the empty list. Maps and sets don't implement SeqInterface so
+        // they're excluded even when empty.
+        if (!$other instanceof SeqInterface || !$other instanceof Traversable) {
+            return false;
+        }
+
+        foreach ($other as $ignored) {
+            return false;
+        }
+
+        return true;
     }
 
     public function hash(): int

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -145,7 +145,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
         $node = $this;
         $visited = 0;
         foreach ($other as $rightValue) {
-            if ($visited >= $this->count) {
+            if (!$node instanceof PersistentListInterface) {
                 return false;
             }
 

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -11,6 +11,7 @@ use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\EqualizerInterface;
 use Phel\Lang\HasherInterface;
+use Phel\Lang\SeqInterface;
 
 use Traversable;
 
@@ -130,25 +131,33 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
     public function equals(mixed $other): bool
     {
-        if (!$other instanceof self) {
+        if ($this === $other) {
+            return true;
+        }
+
+        // Sequential collections compare equal when they yield the same elements
+        // in order, regardless of concrete type (list vs vector vs lazy seq).
+        // Maps and sets do not implement SeqInterface, so they are excluded.
+        if (!$other instanceof SeqInterface || !$other instanceof Traversable) {
             return false;
         }
 
-        if ($this->count !== $other->count()) {
-            return false;
-        }
-
-        $s = $this;
-        $ms = $other;
-        for ($s = $this; $s !== null; $s = $s->cdr(), $ms = $ms->cdr()) {
-            /** @var PersistentList $s */
-            /** @var ?PersistentList $ms */
-            if (!$ms instanceof self || !$this->equalizer->equals($s->first(), $ms->first())) {
+        $node = $this;
+        $visited = 0;
+        foreach ($other as $rightValue) {
+            if ($visited >= $this->count) {
                 return false;
             }
+
+            if (!$this->equalizer->equals($node->first(), $rightValue)) {
+                return false;
+            }
+
+            $node = $node->cdr();
+            ++$visited;
         }
 
-        return true;
+        return $visited === $this->count;
     }
 
     public function hash(): int

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -55,6 +55,23 @@
   (is (false? (= [:a ["1"]] [:a [1]])) "nested vectors with different types are not equal")
   (is (false? (= [1] [1 2])) "vectors with different size are not equals"))
 
+; Regression tests for https://github.com/phel-lang/phel-lang/issues/1546.
+; Sequential collections with the same elements must compare equal regardless
+; of argument order or concrete type (list/vector/lazy-seq).
+(deftest test-=-list-vector
+  (is (true? (= '(1 2) [1 2])) "list = vector")
+  (is (true? (= [1 2] '(1 2))) "vector = list")
+  (is (true? (= '() [])) "empty list = empty vector")
+  (is (true? (= [] '())) "empty vector = empty list")
+  (is (true? (= '(0 1 2 3) (take 4 (range)))) "list = finite prefix of infinite range")
+  (is (true? (= (take 4 (range)) '(0 1 2 3))) "finite prefix of infinite range = list")
+  (is (false? (= '(1 2 3) [1 2])) "lists and vectors of different lengths are not equal")
+  (is (false? (= '(1 2) {1 2})) "list is not equal to a map")
+  (is (false? (= '(1 2) (hash-set 1 2))) "list is not equal to a set")
+  (let [a '(1 2) b [1 2]]
+    (is (true? (= a b)) "def a = def b (list vs vector)")
+    (is (true? (= b a)) "def b = def a (vector vs list)")))
+
 (deftest test-=-set
   (is (true? (= (hash-set) (hash-set))) "two empty sets are equal")
   (is (true? (= (hash-set "hello") (hash-set "hello"))) "two sets with the same values")

--- a/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/EmptyListTest.php
@@ -6,9 +6,11 @@ namespace PhelTest\Unit\Lang\Collections\LinkedList;
 
 use Phel;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
+use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVector;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -57,6 +59,30 @@ final class EmptyListTest extends TestCase
     {
         $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
         $this->assertTrue($list->equals(new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null)));
+    }
+
+    public function test_equals_empty_vector(): void
+    {
+        $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
+        $vector = PersistentVector::empty(new ModuloHasher(), new SimpleEqualizer());
+
+        $this->assertTrue($list->equals($vector));
+    }
+
+    public function test_equals_non_empty_vector(): void
+    {
+        $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1]);
+
+        $this->assertFalse($list->equals($vector));
+    }
+
+    public function test_equals_empty_lazy_seq(): void
+    {
+        $list = new EmptyList(new ModuloHasher(), new SimpleEqualizer(), null);
+        $empty = new LazySeq(new ModuloHasher(), new SimpleEqualizer(), static fn(): null => null);
+
+        $this->assertTrue($list->equals($empty));
     }
 
     public function test_hash(): void

--- a/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
+++ b/tests/php/Unit/Lang/Collections/LinkedList/PersistentListTest.php
@@ -7,10 +7,13 @@ namespace PhelTest\Unit\Lang\Collections\LinkedList;
 use InvalidArgumentException;
 use Phel;
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
+use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LinkedList\EmptyList;
 use Phel\Lang\Collections\LinkedList\PersistentList;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentArrayMap;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVector;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
 use PHPUnit\Framework\TestCase;
@@ -138,6 +141,46 @@ final class PersistentListTest extends TestCase
 
         $this->assertTrue($a->equals($b));
         $this->assertTrue($b->equals($a));
+    }
+
+    public function test_equals_vector_with_same_values(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+
+        $this->assertTrue($list->equals($vector));
+    }
+
+    public function test_equals_vector_with_different_values(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 4]);
+
+        $this->assertFalse($list->equals($vector));
+    }
+
+    public function test_equals_vector_with_different_length(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+        $vector = PersistentVector::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
+
+        $this->assertFalse($list->equals($vector));
+    }
+
+    public function test_equals_lazy_seq_with_same_values(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+        $lazy = LazySeq::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2, 3]);
+
+        $this->assertTrue($list->equals($lazy));
+    }
+
+    public function test_equals_map_returns_false(): void
+    {
+        $list = PersistentList::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
+        $map = PersistentArrayMap::fromArray(new ModuloHasher(), new SimpleEqualizer(), [1, 2]);
+
+        $this->assertFalse($list->equals($map));
     }
 
     public function test_hash(): void


### PR DESCRIPTION
## 🤔 Background

`=` was asymmetric for lists vs other sequential collections:

```clojure
(= '(1 2) [1 2])  ;=> false  ❌
(= [1 2] '(1 2))  ;=> true
```

`PersistentList::equals` only accepted other `PersistentList` instances, so a list on the left-hand side short-circuited to `false` before comparing elements. On the right-hand side, `AbstractPersistentVector::equals` walked the list via its `toArray()` fallback, so the reverse order worked.

The same bug caused `(= '(0 1 2 3) (take 4 (range)))` to return `false`, which is the remaining `clojure-test-suite` failure reported alongside #1536.

Closes #1546.

## 💡 Goal

Make `=` commutative across sequential collections (list, vector, lazy-seq, chunked-seq) while keeping maps and sets correctly excluded.

## 🔖 Changes

- `PersistentList::equals` walks pairwise against any `SeqInterface + Traversable`, yielding the same result as `AbstractPersistentVector::equals` and `LazySeq::equals`. Maps and sets don't implement `SeqInterface`, so they remain unequal to lists.
- `EmptyList::equals` likewise accepts any empty `SeqInterface` (empty vector, empty lazy-seq).
- Adds PHP unit tests in `PersistentListTest` / `EmptyListTest` covering list vs vector, list vs lazy-seq, and list vs map/set.
- Adds `test-=-list-vector` phel regression test in `tests/phel/test/core/boolean-operation.phel` covering both argument orders, empties, finite lazy-seq prefixes, and the `def a / def b` scenario from the issue.
- Adds CHANGELOG entry under `Fixed → Core` referencing #1546.

## Test plan
- [x] `./vendor/bin/phpunit tests/php/Unit/Lang/Collections/LinkedList/` — 52 tests pass
- [x] `composer test-compiler` — no new regressions (only the pre-existing `DataReadersAutoloadTest` failure that is unrelated to this change)
- [x] `./bin/phel test tests/phel/test/core/boolean-operation.phel` — 229 tests pass, including the new `test-=-list-vector`
- [x] Manual Phel-level repro (`(= '(1 2) [1 2])`, `(= '(0 1 2 3) (take 4 (range)))`, etc.) all now return `true`