### PR TITLE
fix(compiler): descriptive error for php/new with non-class value (#1538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources
 
+#### Compiler
+- `php/new` with a non-string, non-object class expression now throws a descriptive `InvalidArgumentException` including the offending value instead of PHP's cryptic `Class name must be a valid object or a string` (#1538)
+
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 
 ### Added

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
 use function assert;
+use function is_string;
 
 final class PhpNewEmitter implements NodeEmitterInterface
 {
@@ -43,13 +45,33 @@ final class PhpNewEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitNode($classExpr);
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
 
-            $this->outputEmitter->emitStr('return new $' . $targetSym->getName() . '(', $node->getStartSourceLocation());
+            $targetVar = '$' . $targetSym->getName();
+            if (!$this->isKnownValidClassExpr($classExpr)) {
+                $this->outputEmitter->emitStr(
+                    'if (!is_string(' . $targetVar . ') && !is_object(' . $targetVar . ')) {',
+                    $node->getStartSourceLocation(),
+                );
+                $this->outputEmitter->emitLine();
+                $this->outputEmitter->emitStr(
+                    'throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type(' . $targetVar . '), var_export(' . $targetVar . ', true)));',
+                    $node->getStartSourceLocation(),
+                );
+                $this->outputEmitter->emitLine();
+                $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+            }
+
+            $this->outputEmitter->emitStr('return new ' . $targetVar . '(', $node->getStartSourceLocation());
         }
     }
 
     private function emitPhpNewArgs(PhpNewNode $node): void
     {
         $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+    }
+
+    private function isKnownValidClassExpr(AbstractNode $classExpr): bool
+    {
+        return $classExpr instanceof LiteralNode && is_string($classExpr->getValue());
     }
 
     private function emitPhpNewEnd(PhpNewNode $node): void

--- a/tests/php/Integration/Compiler/PhpNewRuntimeTest.php
+++ b/tests/php/Integration/Compiler/PhpNewRuntimeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class PhpNewRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_dynamic_new_with_integer_literal_throws_descriptive_error(): void
+    {
+        $this->expectException(EvaluatedCodeException::class);
+        $this->expectExceptionMessage('php/new expects a class name or object, int given (1)');
+
+        $this->compilerFacade->eval(
+            '(php/new 1)',
+            new CompileOptions(),
+        );
+    }
+
+    public function test_dynamic_new_with_bound_integer_throws_descriptive_error(): void
+    {
+        $this->expectException(EvaluatedCodeException::class);
+        $this->expectExceptionMessage('php/new expects a class name or object, int given (42)');
+
+        $this->compilerFacade->eval(
+            '(let [x 42] (php/new x))',
+            new CompileOptions(),
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Issue #1538 reported that a local binding named `new` appears "shadowed" by the `new` special form. Per the discussion, this matches Clojure's semantics — `new` in call position is always a special form — so the shadowing itself is not a bug.

The agreed-upon improvement is the error message produced by the example `(let [new +] (new 1 1))`. Today PHP raises its opaque `Class name must be a valid object or a string` at runtime. Clojure, by contrast, tells you which value it could not resolve: `Unable to resolve classname: 1`.

## 💡 Goal

Surface a Phel-friendly `InvalidArgumentException` when `php/new` (or the `new` special form) receives a class expression that resolves to a non-string, non-object value at runtime. The exception message includes both the PHP type and the offending value.

## 🔖 Changes

- `PhpNewEmitter` now emits a guard before the dynamic `new $target(...)` path:
  ```php
  if (!is_string($target_1) && !is_object($target_1)) {
      throw new \InvalidArgumentException(sprintf(
          "php/new expects a class name or object, %s given (%s)",
          get_debug_type($target_1),
          var_export($target_1, true),
      ));
  }
  ```
- The guard is **skipped** when the class expression is a known string literal (e.g. the `(php/new "Ns\\Struct" ...)` forms produced by `defstruct`), so generated struct constructors remain byte-identical.
- Added `PhpNewRuntimeTest` exercising both a literal integer class (`(php/new 1)`) and a local-variable integer class (`(let [x 42] (php/new x))`).
- Updated `CHANGELOG.md` Unreleased > Fixed > Compiler.