### PR TITLE
fix(api): pre-load phel\core so `phel analyze` resolves core macros (#1539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources
 
+#### API
+- `phel analyze` now pre-loads `phel\core` so core macros like `when-not`, `defn`, and `let` resolve instead of being reported as unresolved symbols (#1539)
+
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 
 ### Added

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -29,6 +29,7 @@ use Phel\Api\Infrastructure\Daemon\ApiDaemon;
 use Phel\Api\Infrastructure\PhelFnLoader;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Shared\Facade\CompilerFacadeInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
 
 /**
  * @extends AbstractFactory<ApiConfig>
@@ -100,10 +101,18 @@ final class ApiFactory extends AbstractFactory
         );
     }
 
+    public function getRunFacade(): RunFacadeInterface
+    {
+        /** @var RunFacadeInterface $facade */
+        $facade = $this->getProvidedDependency(ApiProvider::FACADE_RUN);
+
+        return $facade;
+    }
+
     private function createPhelFnLoader(): PhelFnLoaderInterface
     {
         return new PhelFnLoader(
-            $this->getProvidedDependency(ApiProvider::FACADE_RUN),
+            $this->getRunFacade(),
         );
     }
 

--- a/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
+++ b/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Api\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Api\ApiFacade;
+use Phel\Api\ApiFactory;
 use Phel\Api\Transfer\Diagnostic;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +23,7 @@ use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 
 #[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
+#[ServiceMap(method: 'getFactory', className: ApiFactory::class)]
 final class AnalyzeCommand extends Command
 {
     use ServiceResolverAwareTrait;
@@ -47,6 +49,10 @@ final class AnalyzeCommand extends Command
             $output->writeln(sprintf('<error>Unable to read file: %s</error>', $file));
             return self::FAILURE;
         }
+
+        // Load phel core so analyzeSource() resolves core symbols like `when-not`, `defn`, `let`, etc.
+        // Without this the analyzer flags every core macro as "Cannot resolve symbol ...".
+        $this->getFactory()->getRunFacade()->loadPhelNamespaces();
 
         $diagnostics = $this->getFacade()->analyzeSource($source, $file);
         $payload = array_map(static fn(Diagnostic $d): array => $d->toArray(), $diagnostics);

--- a/tests/php/Integration/Api/AnalyzeCommandTest.php
+++ b/tests/php/Integration/Api/AnalyzeCommandTest.php
@@ -37,6 +37,24 @@ final class AnalyzeCommandTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_analyze_command_resolves_core_macros(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new AnalyzeCommand());
+        $exit = $tester->execute(['file' => __DIR__ . '/Fixtures/uses_core_macro.phel']);
+        self::assertSame(0, $exit);
+
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        self::assertSame(
+            [],
+            $decoded,
+            'Expected no diagnostics when the analyzed file only references phel\\core macros',
+        );
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_analyze_command_fails_when_file_missing(): void
     {
         $this->bootstrap();

--- a/tests/php/Integration/Api/Fixtures/uses_core_macro.phel
+++ b/tests/php/Integration/Api/Fixtures/uses_core_macro.phel
@@ -1,0 +1,3 @@
+(ns fixtures\uses-core)
+
+(when-not false :yes)


### PR DESCRIPTION
## 🤔 Background

Issue #1539: `vendor/bin/phel analyze <file>` reports core stdlib macros like `when-not`, `defn`, `let` as `Cannot resolve symbol ...`. The analyzer runs against a global environment that has never had `phel\core` loaded, so every form that uses a core macro is flagged as unresolved.

`phel lint` already works around this by calling `RunFacade::loadPhelNamespaces()` before invoking `ApiFacade::analyzeSource()` ([LintCommand.php:119](https://github.com/phel-lang/phel-lang/blob/main/src/php/Lint/Infrastructure/Command/LintCommand.php#L119)). `phel analyze` had no equivalent.

## 💡 Goal

Make `phel analyze` resolve core macros out of the box, matching the behaviour of `phel lint` and the compile/run paths.

## 🔖 Changes

- `AnalyzeCommand::execute()` now calls `$this->getFactory()->getRunFacade()->loadPhelNamespaces()` before `ApiFacade::analyzeSource()`.
- `ApiFactory` exposes `getRunFacade(): RunFacadeInterface` for commands in the module that need it (the `FACADE_RUN` dependency was already provided).
- Added integration test `test_analyze_command_resolves_core_macros` covering a file that uses `when-not`; it fails on `main` with a `PHEL001` diagnostic and passes with this patch.
- Updated `CHANGELOG.md` Unreleased > Fixed > API.