### PR TITLE
fix(lint): suppress false unresolved-symbol for (:require :as) aliases (#1540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project will be documented in this file.
 #### Compiler
 - `php/new` with a non-string, non-object class expression now throws a descriptive `InvalidArgumentException` including the offending value instead of PHP's cryptic `Class name must be a valid object or a string` (#1538)
 
+#### Lint
+- `phel lint` no longer reports `phel/unresolved-symbol` for alias-qualified calls (`alias/name`) when `alias` is declared via `(:require ... :as alias)` in the file's ns form; the linter cannot load other namespaces, so valid cross-namespace calls are now suppressed (#1540)
+
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 
 ### Added

--- a/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
+++ b/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
@@ -4,16 +4,30 @@ declare(strict_types=1);
 
 namespace Phel\Lint\Application\Rule;
 
+use Phel\Api\Transfer\Diagnostic;
 use Phel\Compiler\Domain\Exceptions\ErrorCode;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
+
+use function count;
+use function explode;
+use function preg_match;
 
 /**
  * Promotes the analyzer's native `PHEL001` undefined-symbol diagnostic
  * into a lint-rule diagnostic so the standard severity/opt-out plumbing
  * applies. Reads from the shared `FileAnalysis::$semanticDiagnostics`
  * cache so the Parser + Analyzer only runs once per file.
+ *
+ * Alias-qualified symbols (`alias/name`) whose `alias` part is declared
+ * via `(:require ... :as alias)` in the file's ns form are suppressed:
+ * the linter never evaluates other namespaces, so the analyzer cannot
+ * see their definitions even though the call is syntactically valid.
  */
 final readonly class UnresolvedSymbolRule implements LintRuleInterface
 {
@@ -24,10 +38,144 @@ final readonly class UnresolvedSymbolRule implements LintRuleInterface
 
     public function apply(FileAnalysis $analysis): array
     {
-        return SemanticDiagnosticPromoter::promote(
+        $promoted = SemanticDiagnosticPromoter::promote(
             $analysis,
             ErrorCode::UNDEFINED_SYMBOL->value,
             $this->code(),
         );
+
+        if ($promoted === []) {
+            return $promoted;
+        }
+
+        $aliases = $this->collectRequireAliases($analysis->forms);
+        if ($aliases === []) {
+            return $promoted;
+        }
+
+        $filtered = [];
+        foreach ($promoted as $diagnostic) {
+            if ($this->isAliasQualified($diagnostic, $aliases)) {
+                continue;
+            }
+
+            $filtered[] = $diagnostic;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param array<string, true> $aliases
+     */
+    private function isAliasQualified(Diagnostic $diagnostic, array $aliases): bool
+    {
+        if (preg_match("/^Cannot resolve symbol '([^']+)'/", $diagnostic->message, $matches) !== 1) {
+            return false;
+        }
+
+        $parts = explode('/', $matches[1], 2);
+        if (count($parts) !== 2 || $parts[0] === '') {
+            return false;
+        }
+
+        return isset($aliases[$parts[0]]);
+    }
+
+    /**
+     * @param list<bool|float|int|\Phel\Lang\TypeInterface|string|null> $forms
+     *
+     * @return array<string, true>
+     */
+    private function collectRequireAliases(array $forms): array
+    {
+        $nsForm = NamespaceForm::find($forms);
+        if (!$nsForm instanceof PersistentListInterface) {
+            return [];
+        }
+
+        $aliases = [];
+        foreach (NsClauseIterator::clauses($nsForm, 'require') as $clause) {
+            foreach ($this->extractAliasesFromClause($clause) as $alias) {
+                $aliases[$alias] = true;
+            }
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractAliasesFromClause(PersistentListInterface $clause): array
+    {
+        $aliases = [];
+        $size = count($clause);
+
+        for ($i = 1; $i < $size; ++$i) {
+            $item = $clause->get($i);
+
+            if ($item instanceof PersistentVectorInterface) {
+                $alias = $this->aliasFromVector($item);
+                if ($alias !== null) {
+                    $aliases[] = $alias;
+                }
+
+                continue;
+            }
+
+            if ($item instanceof Symbol) {
+                $alias = $this->aliasFromFlatClause($clause, $i);
+                if ($alias !== null) {
+                    $aliases[] = $alias;
+                }
+            }
+        }
+
+        return $aliases;
+    }
+
+    private function aliasFromVector(PersistentVectorInterface $vector): ?string
+    {
+        $size = count($vector);
+        for ($i = 1; $i < $size - 1; ++$i) {
+            $item = $vector->get($i);
+            if (!$item instanceof Keyword || $item->getName() !== 'as') {
+                continue;
+            }
+
+            $next = $vector->get($i + 1);
+            if ($next instanceof Symbol) {
+                return $next->getName();
+            }
+        }
+
+        return null;
+    }
+
+    private function aliasFromFlatClause(PersistentListInterface $clause, int $startIndex): ?string
+    {
+        $size = count($clause);
+        for ($i = $startIndex + 1; $i < $size - 1; ++$i) {
+            $item = $clause->get($i);
+            if ($item instanceof Symbol || $item instanceof PersistentVectorInterface) {
+                return null;
+            }
+
+            if (!$item instanceof Keyword) {
+                continue;
+            }
+
+            if ($item->getName() !== 'as') {
+                continue;
+            }
+
+            $next = $clause->get($i + 1);
+            if ($next instanceof Symbol) {
+                return $next->getName();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
+++ b/src/php/Lint/Application/Rule/UnresolvedSymbolRule.php
@@ -10,6 +10,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
 use Phel\Lint\Application\Config\RuleRegistry;
 use Phel\Lint\Domain\FileAnalysis;
 use Phel\Lint\Domain\LintRuleInterface;
@@ -83,7 +84,7 @@ final readonly class UnresolvedSymbolRule implements LintRuleInterface
     }
 
     /**
-     * @param list<bool|float|int|\Phel\Lang\TypeInterface|string|null> $forms
+     * @param list<bool|float|int|string|TypeInterface|null> $forms
      *
      * @return array<string, true>
      */
@@ -140,7 +141,11 @@ final readonly class UnresolvedSymbolRule implements LintRuleInterface
         $size = count($vector);
         for ($i = 1; $i < $size - 1; ++$i) {
             $item = $vector->get($i);
-            if (!$item instanceof Keyword || $item->getName() !== 'as') {
+            if (!$item instanceof Keyword) {
+                continue;
+            }
+
+            if ($item->getName() !== 'as') {
                 continue;
             }
 

--- a/tests/php/Integration/Lint/Fixtures/require_alias.phel
+++ b/tests/php/Integration/Lint/Fixtures/require_alias.phel
@@ -1,0 +1,4 @@
+(ns phel-snake\main
+  (:require [phel-snake\game :as game]))
+
+(game/run)

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -85,6 +85,31 @@ final class LintCommandTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_it_suppresses_unresolved_symbol_for_known_require_alias(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new LintCommand());
+        $exit = $tester->execute([
+            'paths' => [__DIR__ . '/Fixtures/require_alias.phel'],
+            '--format' => 'json',
+            '--no-cache' => true,
+        ]);
+
+        $payload = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($payload);
+
+        $codes = array_map(static fn(array $d): string => $d['code'], $payload);
+        self::assertNotContains(
+            'phel/unresolved-symbol',
+            $codes,
+            'Alias-qualified call via (:require :as) must not be flagged as unresolved',
+        );
+        self::assertSame(0, $exit);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_github_format_emits_annotation_commands(): void
     {
         $this->bootstrap();


### PR DESCRIPTION
## 🤔 Background

Issue #1540: `phel lint` reports alias-qualified calls (`alias/name`) as `phel/unresolved-symbol` when the `alias` is declared via `(:require ... :as alias)`. The linter cannot load other namespaces, so the analyzer never sees their definitions — but the call itself is syntactically valid and will resolve at compile/run time.

Example:

```phel
(ns phel-snake\main
  (:require [phel-snake\game :as game]))

(game/run)
```

```
src/main.phel:4:1 [error] phel/unresolved-symbol Cannot resolve symbol 'game/run'. Did you mean 'run!', 'put', or 'dorun'?
```

## 💡 Goal

Stop emitting `phel/unresolved-symbol` for alias-qualified symbols whose alias is a known `(:require ... :as alias)` target in the file's own ns form. Bare symbols and other qualified symbols are still flagged.

## 🔖 Changes

- `UnresolvedSymbolRule` now reads the require-alias names from the current file's ns form (using the same `NamespaceForm`/`NsClauseIterator` helpers other ns-aware rules use) and drops `PHEL001` diagnostics whose symbol is prefixed with any declared alias.
- Added `test_it_suppresses_unresolved_symbol_for_known_require_alias` integration test (+ `Fixtures/require_alias.phel`). Verified it fails on `main` with the expected `phel/unresolved-symbol` for `game/run` and passes with this patch.
- Updated `CHANGELOG.md` Unreleased > Fixed > Lint.