### PR TITLE
fix(parser): tolerate trailing trivia before `)` in `#?` reader conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - `php/new` with a non-string, non-object class expression now throws a descriptive `InvalidArgumentException` including the offending value instead of PHP's cryptic `Class name must be a valid object or a string` (#1538)
+- `#?` and `#?@` reader conditionals no longer fail with `Unterminated list (BRACKETS)` when the closing paren sits on its own line; trailing whitespace, newlines, or comments before `)` are now tolerated (#1547)
 
 #### Lint
 - `phel lint` no longer reports `phel/unresolved-symbol` for alias-qualified calls (`alias/name`) when `alias` is declared via `(:require ... :as alias)` in the file's ns form; the linter cannot load other namespaces, so valid cross-namespace calls are now suppressed (#1540)

--- a/src/php/Compiler/Application/Parser.php
+++ b/src/php/Compiler/Application/Parser.php
@@ -337,25 +337,42 @@ final readonly class Parser implements ParserInterface
             ->parse($tokenStream, $token->getType());
     }
 
+    /**
+     * Reads the next non-trivia expression inside a reader conditional.
+     * Returns null when only trivia remains before the closing paren (or EOF),
+     * letting the caller exit the branch loop cleanly.
+     */
+    private function readNonTriviaExpression(TokenStream $tokenStream): ?NodeInterface
+    {
+        while ($tokenStream->valid()) {
+            if ($tokenStream->current()->getType() === Token::T_CLOSE_PARENTHESIS) {
+                return null;
+            }
+
+            $node = $this->readExpression($tokenStream);
+            if (!$node instanceof TriviaNodeInterface) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
     private function parseReaderCondNode(TokenStream $tokenStream, Token $openToken): NodeInterface
     {
         $phelNode = null;
         $defaultNode = null;
 
-        while ($tokenStream->valid() && $tokenStream->current()->getType() !== Token::T_CLOSE_PARENTHESIS) {
-            // Read keyword (skip trivia)
-            do {
-                $keywordNode = $this->readExpression($tokenStream);
-            } while ($keywordNode instanceof TriviaNodeInterface);
-
-            if ($tokenStream->valid() && $tokenStream->current()->getType() === Token::T_CLOSE_PARENTHESIS) {
+        while ($tokenStream->valid()) {
+            $keywordNode = $this->readNonTriviaExpression($tokenStream);
+            if (!$keywordNode instanceof NodeInterface) {
                 break;
             }
 
-            // Read form (skip trivia)
-            do {
-                $formNode = $this->readExpression($tokenStream);
-            } while ($formNode instanceof TriviaNodeInterface);
+            $formNode = $this->readNonTriviaExpression($tokenStream);
+            if (!$formNode instanceof NodeInterface) {
+                break;
+            }
 
             // Check keyword
             if ($keywordNode instanceof KeywordNode) {
@@ -389,20 +406,16 @@ final readonly class Parser implements ParserInterface
         $phelNode = null;
         $defaultNode = null;
 
-        while ($tokenStream->valid() && $tokenStream->current()->getType() !== Token::T_CLOSE_PARENTHESIS) {
-            // Read keyword (skip trivia)
-            do {
-                $keywordNode = $this->readExpression($tokenStream);
-            } while ($keywordNode instanceof TriviaNodeInterface);
-
-            if ($tokenStream->valid() && $tokenStream->current()->getType() === Token::T_CLOSE_PARENTHESIS) {
+        while ($tokenStream->valid()) {
+            $keywordNode = $this->readNonTriviaExpression($tokenStream);
+            if (!$keywordNode instanceof NodeInterface) {
                 break;
             }
 
-            // Read form (skip trivia)
-            do {
-                $formNode = $this->readExpression($tokenStream);
-            } while ($formNode instanceof TriviaNodeInterface);
+            $formNode = $this->readNonTriviaExpression($tokenStream);
+            if (!$formNode instanceof NodeInterface) {
+                break;
+            }
 
             // Check keyword
             if ($keywordNode instanceof KeywordNode) {

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -631,6 +631,41 @@ final class ParserTest extends TestCase
         );
     }
 
+    public function test_reader_conditional_trailing_newline_before_close_paren(): void
+    {
+        // Closing paren on its own line should not fail — issue #1547.
+        $node = $this->parse("#?(:phel nil\n          :default identity\n         )");
+        self::assertInstanceOf(NilNode::class, $node);
+    }
+
+    public function test_reader_conditional_trailing_whitespace_before_close_paren(): void
+    {
+        self::assertEquals(
+            new NumberNode('42', $this->loc(1, 9), $this->loc(1, 11), 42),
+            $this->parse('#?(:phel 42 :default 0   )'),
+        );
+    }
+
+    public function test_reader_conditional_splicing_trailing_newline_before_close_paren(): void
+    {
+        // [1 #?@(:phel [2 3]\n      ) 4] → [1 2 3 4]
+        $tokenStream = $this->compilerFacade->lexString("[1 #?@(:phel [2 3]\n      ) 4]");
+        $node = $this->compilerFacade->parseNext($tokenStream);
+
+        self::assertInstanceOf(ListNode::class, $node);
+
+        $nonTrivia = array_values(array_filter(
+            $node->getChildren(),
+            static fn(NodeInterface $n): bool => !$n instanceof WhitespaceNode && !$n instanceof NewlineNode,
+        ));
+
+        self::assertCount(4, $nonTrivia);
+        self::assertSame(1, $nonTrivia[0]->getValue());
+        self::assertSame(2, $nonTrivia[1]->getValue());
+        self::assertSame(3, $nonTrivia[2]->getValue());
+        self::assertSame(4, $nonTrivia[3]->getValue());
+    }
+
     public function test_reader_conditional_nested(): void
     {
         self::assertEquals(


### PR DESCRIPTION
## 🤔 Background

Fixes #1547. The reader-conditional parser for `#?(...)` and `#?@(...)` required the closing paren to come immediately after the last form. If a newline, trailing whitespace, or comment separated the last form from `)`, parsing blew up with:

```
Unterminated list (BRACKETS)
```

Repro from the issue:

```phel
{:demo #?(:phel nil
          :default identity
         )}
```

The working/failing split was puzzling to users because Clojure and Janet both accept this formatting, and the multi-line variant with `)` on the same line as the last form already parsed fine.

## 💡 Goal

Treat trailing whitespace/newlines/comments between the last form and the closing `)` of a reader conditional as trivia — same as any other list-like form in Phel.

## 🔖 Changes

- `Parser::parseReaderCondNode` / `parseReaderCondSplicingNode`: loop on `readNonTriviaExpression`, a new helper that skips trivia tokens and returns `null` when it hits the closing paren. The outer loop breaks cleanly instead of trying to read a keyword from the `)` token.
- Added three integration tests in `ParserTest`:
  - `test_reader_conditional_trailing_newline_before_close_paren` (exact issue repro)
  - `test_reader_conditional_trailing_whitespace_before_close_paren`
  - `test_reader_conditional_splicing_trailing_newline_before_close_paren`
- Updated `CHANGELOG.md` under `## Unreleased` → `Fixed` → `Compiler`.

Related to #1547