### PR TITLE
fix(analyzer): treat `()` as a self-quoting empty list literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings; `^:dynamic` on `def` name symbols is honored (#1536)
 - `=` between a list and any other sequential collection (vector, lazy seq) now returns the same result regardless of argument order (#1546)
+- `()` is now a self-quoting empty list literal instead of raising `Value nil of type null is not callable`; forms like `(into () coll)`, `(conj () 1)`, `(cons 1 ())`, `(= () (list))`, and `(if () :a :b)` now work as in Clojure (#1549)
 
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -8,6 +8,7 @@ use Phel;
 use Phel\Compiler\Application\Munge;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ApplySymbol;
@@ -74,6 +75,13 @@ final class AnalyzePersistentList
      */
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
     {
+        if (count($list) === 0) {
+            // `()` is a self-quoting empty list literal — not an invocation
+            // of a missing head. Matches Clojure/Janet and keeps forms like
+            // `(into () ...)` or `(= () (list))` usable.
+            return new QuoteNode($env, $list, $list->getStartLocation());
+        }
+
         $list = $this->expandConstructorShorthand($list);
         $list = $this->expandMemberAccessShorthand($list);
 

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -4,6 +4,16 @@
 (deftest create-list
   (is (= '(1 2 3) (list '1 '2 '3)) "construct list"))
 
+# Issue #1549: `()` is a self-quoting empty list literal, not an invocation
+(deftest empty-list-literal
+  (is (= () (list)) "() equals empty list constructor")
+  (is (= '() ()) "() equals quoted empty list")
+  (is (empty? ()) "() is empty")
+  (is (= '(1) (conj () 1)) "conj onto () works")
+  (is (= '(1) (cons 1 ())) "cons onto () works")
+  (is (= :truthy (if () :truthy :falsy)) "() is truthy in if")
+  (let [x ()] (is (= () x) "() usable in let binding")))
+
 (deftest create-vector
   (is (= '[1 2 3] (vector '1 '2 '3)) "construct vector"))
 

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzePersistentListTest.php
@@ -45,6 +45,18 @@ final class AnalyzePersistentListTest extends TestCase
         );
     }
 
+    public function test_empty_list_analyzes_as_self_quoting_literal(): void
+    {
+        // `()` should be treated as the empty list literal, not as an
+        // invocation of a missing head (issue #1549).
+        $list = Phel::list([]);
+
+        $node = $this->listAnalyzer->analyze($list, NodeEnvironment::empty());
+
+        self::assertInstanceOf(QuoteNode::class, $node);
+        self::assertSame($list, $node->getValue());
+    }
+
     public function test_symbol_with_name_def(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

Fixes #1549. In Phel `0.34.1`, the empty list `()` was analyzed as a function call with no head. The analyzer saw `list->first() === null`, emitted a `LiteralNode(null)`, and `rejectNonCallableLiteral` then threw:

```
[PHEL011] Value nil of type null is not callable.
```

This made all of the following fail, even though they work in Clojure/Janet:

```phel
(into () (range 1 10))
(= () (list))
(conj () 1)
(cons 1 ())
(if () :a :b)
```

The contributor comment on the issue [confirms the right fix layer is the analyzer](https://github.com/phel-lang/phel-lang/issues/1549#issuecomment-4304420228): "when the analyzer encounters a `ListNode` with no children, it should return an empty `PersistentList` value instead of attempting to evaluate it as a function call."

## 💡 Goal

Make `()` a self-quoting empty list literal. The change should be transparent anywhere an empty list shows up as a value: collection seeds (`into`/`conj`/`cons`), equality checks, truthy guards, `let` bindings, etc.

## 🔖 Changes

- `AnalyzePersistentList::analyze` now short-circuits when `count($list) === 0` and returns `new QuoteNode($env, $list, …)` — the same shape the reader produces for `'()`. Empty-list expansion happens before any shorthand/symbol-name logic, so no downstream analyzer sees an empty list.
- Added `test_empty_list_analyzes_as_self_quoting_literal` in `AnalyzePersistentListTest` (unit-level guard that the analyzer returns a `QuoteNode` wrapping the same empty list).
- Added `empty-list-literal` deftest in `tests/phel/test/core/basic-constructors.phel` covering the end-to-end cases from the issue: `()` equals `(list)` and `'()`, `empty?`, `conj`, `cons`, truthiness in `if`, and `let` binding.
- Updated `CHANGELOG.md` under `## Unreleased → Fixed → Core`.

### Verification

- `./bin/phel run` on the issue examples now produces expected values (`(into () (range 1 10)) → (1 2 3 4 5 6 7 8 9)`, `(= () (list)) → true`, `(conj () 1) → (1)`, `(cons 1 ()) → (1)`, `(if () :a :b) → :a`).
- `composer test-core`: 4295 tests pass.
- `composer test-quality`: clean.
- `composer test-compiler`: only pre-existing failures on `main` remain (DataReadersAutoloadTest + 3 PhelTest integration errors that also fail on `main`).

Related to #1549