### PR TITLE
feat(core): add `into-array` for .cljc interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
+- `into-array` function for `.cljc` interop: `(into-array aseq)` and `(into-array type aseq)` both return a PHP array containing the elements of `aseq`. The `type` argument is accepted for Clojure source compatibility but is ignored in Phel — PHP has no typed arrays. Use `int-array`/`float-array`/etc. when element coercion is needed (#1550)
 
 ### Changed
 

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -68,6 +68,19 @@
     (php/array)
     (to-php-array coll)))
 
+(defn into-array
+  "Returns a PHP array containing the elements of `aseq`. Accepts any
+  collection (vector, list, set, map, PHP array) or `nil`, which yields
+  an empty PHP array. The optional `type` argument is accepted for
+  `.cljc` interop but has no runtime effect — PHP has no typed arrays,
+  so the result is always a plain PHP array. Use the dedicated coercion
+  helpers (`int-array`, `long-array`, `float-array`, `double-array`,
+  `short-array`) when element coercion is actually required."
+  {:example "(into-array [1 2 3]) ; => a PHP array [1, 2, 3]\n(into-array :Object [:a :b]) ; => a PHP array [:a, :b]"
+   :see-also ["to-array" "object-array" "int-array"]}
+  ([aseq] (to-array aseq))
+  ([_type aseq] (to-array aseq)))
+
 (defn- ensure-php-array
   "Returns `arr` when it is a PHP array, otherwise throws an
   `InvalidArgumentException` naming the calling operation."

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -121,6 +121,44 @@
   (is (thrown? \InvalidArgumentException (object-array -1))
       "object-array raises InvalidArgumentException on negative size"))
 
+(deftest test-into-array-from-vector
+  (let [arr (into-array [1 2 3])]
+    (is (php/is_array arr) "into-array from vector returns a PHP array")
+    (is (= 3 (php/count arr)) "into-array preserves vector length")
+    (is (= 1 (php/aget arr 0)) "into-array element 0")
+    (is (= 3 (php/aget arr 2)) "into-array last element")))
+
+(deftest test-into-array-from-list
+  (let [arr (into-array '(:a :b :c))]
+    (is (php/is_array arr) "into-array from list returns a PHP array")
+    (is (= 3 (php/count arr)) "into-array preserves list length")
+    (is (= :a (php/aget arr 0)) "into-array element 0")
+    (is (= :c (php/aget arr 2)) "into-array last element")))
+
+(deftest test-into-array-from-empty
+  (let [arr (into-array [])]
+    (is (php/is_array arr) "into-array from empty vector is a PHP array")
+    (is (= 0 (php/count arr)) "into-array from empty vector is empty")))
+
+(deftest test-into-array-from-nil
+  (let [arr (into-array nil)]
+    (is (php/is_array arr) "into-array nil is a PHP array")
+    (is (= 0 (php/count arr)) "into-array nil is empty")))
+
+(deftest test-into-array-with-type-hint-ignored
+  ;; The type argument is accepted for .cljc interop but PHP has no
+  ;; typed arrays, so it is ignored — the result matches the 1-arity call.
+  (let [arr (into-array :Object [1 2 3])]
+    (is (php/is_array arr) "into-array with type hint returns a PHP array")
+    (is (= 3 (php/count arr)) "into-array with type hint preserves length")
+    (is (= 1 (php/aget arr 0)) "into-array with type hint element 0")))
+
+(deftest test-into-array-with-nil-type
+  (let [arr (into-array nil '(10 20))]
+    (is (php/is_array arr) "into-array nil-type returns a PHP array")
+    (is (= 10 (php/aget arr 0)) "into-array nil-type element 0")
+    (is (= 20 (php/aget arr 1)) "into-array nil-type element 1")))
+
 (deftest test-to-array-from-vector
   (let [arr (to-array [1 2 3])]
     (is (php/is_array arr) "to-array from vector returns a PHP array")


### PR DESCRIPTION
## 🤔 Background

Closes #1550. `into-array` is part of `clojure.core` and shows up in [`clojure-test-suite/reduce.cljc`](https://github.com/jasalt/clojure-test-suite/blob/4af10ad3ada1e8cd352a372ffe838c73fcf53f15/test/clojure/core_test/reduce.cljc#L80) alongside platform-specific class references (e.g. `(into-array (:Integer interop) ...)`). Without it, any `.cljc` file that uses `into-array` fails to compile under Phel.

Phel already has the matching family of interop helpers — `to-array`, `object-array`, `int-array`, `long-array`, `float-array`, `double-array`, `short-array` — all documented as "PHP has no typed arrays, so these all return plain PHP arrays". `into-array` slots into the same family.

## 💡 Goal

Provide a Clojure-compatible `into-array` whose surface signature matches `clojure.core/into-array` so `.cljc` sources keep compiling, and whose runtime behaviour is consistent with the rest of the Phel array-interop family (plain PHP array, no typed coercion, `nil` → empty).

## 🔖 Changes

- `src/phel/core/arrays.phel`: new `into-array` defn with two arities:
  - `[aseq]` → `(to-array aseq)`
  - `[_type aseq]` → same; `type` is accepted for `.cljc` portability but has no runtime effect, consistent with `to-array`/`object-array`. If element coercion is actually required, users reach for `int-array`, `float-array`, etc.
- `tests/phel/test/core/basic-constructors.phel`: 6 new `deftest` cases covering vector, list, empty, `nil`, type-hint ignored, and nil-type input.
- `CHANGELOG.md`: entry under `## Unreleased → Added → Core`.

### Verification

- `composer test-core`: 4313 tests pass (up from 4307).
- `composer test-quality`: clean.

Related to #1550