### PR TITLE
fix(lint): scope default paths to project src (#1541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 
 #### Lint
 - `phel lint` no longer reports `phel/unresolved-symbol` for alias-qualified calls (`alias/name`) when `alias` is declared via `(:require ... :as alias)` in the file's ns form; the linter cannot load other namespaces, so valid cross-namespace calls are now suppressed (#1540)
+- `phel lint` with no arguments no longer aborts with `Symbol walk is already bound in namespace phel\walk` when run in a project that depends on phel via Composer; default paths now resolve to the project's own configured source dirs and skip phel's bundled stdlib (#1541)
 
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 

--- a/src/php/Command/Application/DirectoryFinder.php
+++ b/src/php/Command/Application/DirectoryFinder.php
@@ -27,6 +27,14 @@ final readonly class DirectoryFinder implements DirectoryFinderInterface
     /**
      * @return list<string>
      */
+    public function getProjectSourceDirectories(): array
+    {
+        return $this->toAbsoluteDirectories($this->codeDirectories->getProjectSourceDirs());
+    }
+
+    /**
+     * @return list<string>
+     */
     public function getTestDirectories(): array
     {
         return $this->toAbsoluteDirectories($this->codeDirectories->getTestDirs());

--- a/src/php/Command/CLAUDE.md
+++ b/src/php/Command/CLAUDE.md
@@ -18,6 +18,7 @@ Foundational infrastructure: error reporting, exception formatting, and project 
 - `getExceptionPrinter(): ExceptionPrinterInterface`
 - `getAllPhelDirectories(): array` — all source + test + vendor directories
 - `getSourceDirectories(): array` / `getTestDirectories(): array` / `getVendorSourceDirectories(): array`
+- `getProjectSourceDirectories(): array` — user-configured src dirs only (excludes phel's own bundled stdlib dir)
 - `getOutputDirectory(): string`
 - `readPhelConfig(string): array`
 

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -43,7 +43,8 @@ final class CommandConfig extends AbstractConfig
         $phelInternalSrcDir = dirname(__DIR__, 2);
 
         return new CodeDirectories(
-            [$phelInternalSrcDir, ...(array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS)],
+            $phelInternalSrcDir,
+            (array) $this->get(PhelConfig::SRC_DIRS, self::DEFAULT_SRC_DIRS),
             (array) $this->get(PhelConfig::TEST_DIRS, self::DEFAULT_TEST_DIRS),
             (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR),
         );

--- a/src/php/Command/CommandFacade.php
+++ b/src/php/Command/CommandFacade.php
@@ -74,6 +74,14 @@ final class CommandFacade extends AbstractFacade implements CommandFacadeInterfa
     }
 
     #[Cacheable]
+    public function getProjectSourceDirectories(): array
+    {
+        return $this->cached(fn(): array => $this->getFactory()
+            ->createDirectoryFinder()
+            ->getProjectSourceDirectories());
+    }
+
+    #[Cacheable]
     public function getTestDirectories(): array
     {
         return $this->cached(fn(): array => $this->getFactory()

--- a/src/php/Command/Domain/CodeDirectories.php
+++ b/src/php/Command/Domain/CodeDirectories.php
@@ -11,15 +11,29 @@ final readonly class CodeDirectories
      * @param list<string> $testDirs
      */
     public function __construct(
+        private string $phelInternalSrcDir,
         private array $srcDirs,
         private array $testDirs,
         private string $outputDir,
     ) {}
 
+    public function getPhelInternalSrcDir(): string
+    {
+        return $this->phelInternalSrcDir;
+    }
+
     /**
      * @return list<string>
      */
     public function getSourceDirs(): array
+    {
+        return [$this->phelInternalSrcDir, ...$this->srcDirs];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getProjectSourceDirs(): array
     {
         return $this->srcDirs;
     }

--- a/src/php/Command/Domain/Finder/DirectoryFinderInterface.php
+++ b/src/php/Command/Domain/Finder/DirectoryFinderInterface.php
@@ -12,6 +12,15 @@ interface DirectoryFinderInterface
     public function getSourceDirectories(): array;
 
     /**
+     * Source directories configured by the user — excludes phel's own
+     * bundled stdlib directory that is prepended for runtime namespace
+     * resolution.
+     *
+     * @return list<string>
+     */
+    public function getProjectSourceDirectories(): array;
+
+    /**
      * @return list<string>
      */
     public function getTestDirectories(): array;

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -142,7 +142,7 @@ final class LintCommand extends Command
     {
         $cmd = $this->getFactory()->getCommandFacade();
 
-        return $cmd->getSourceDirectories();
+        return $cmd->getProjectSourceDirectories();
     }
 
     /**

--- a/src/php/Shared/Facade/CommandFacadeInterface.php
+++ b/src/php/Shared/Facade/CommandFacadeInterface.php
@@ -36,6 +36,15 @@ interface CommandFacadeInterface
     public function getSourceDirectories(): array;
 
     /**
+     * Source directories configured by the user — excludes phel's own
+     * bundled stdlib directory that is prepended for runtime namespace
+     * resolution.
+     *
+     * @return list<string>
+     */
+    public function getProjectSourceDirectories(): array;
+
+    /**
      * @return list<string>
      */
     public function getTestDirectories(): array;

--- a/tests/php/Integration/Lint/LintCommandTest.php
+++ b/tests/php/Integration/Lint/LintCommandTest.php
@@ -126,6 +126,69 @@ final class LintCommandTest extends TestCase
         self::assertMatchesRegularExpression('/^::(error|warning|notice) /m', $out);
     }
 
+    /**
+     * Regression test for https://github.com/phel-lang/phel-lang/issues/1541:
+     * running `phel lint` with no paths must not re-analyze phel's own bundled
+     * stdlib files (reachable because `CommandConfig` prepends phel's internal
+     * src dir for runtime namespace resolution). Re-analyzing them caused a
+     * `DuplicateDefinitionException` for symbols like `phel\walk/walk`.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_default_paths_exclude_phel_internal_stdlib(): void
+    {
+        $originalCwd = getcwd();
+        $projectRoot = sys_get_temp_dir() . '/phel-lint-1541-' . uniqid('', true);
+        mkdir($projectRoot . '/src', 0o777, true);
+        file_put_contents($projectRoot . '/src/clean.phel', "(ns consumer\\clean)\n(defn f [] :ok)\n");
+
+        try {
+            chdir($projectRoot);
+            Phel::bootstrap($projectRoot);
+            Phel::clear();
+            Symbol::resetGen();
+            GlobalEnvironmentSingleton::initializeNew();
+
+            $tester = new CommandTester(new LintCommand());
+            $exit = $tester->execute([
+                '--format' => 'json',
+                '--no-cache' => true,
+            ]);
+
+            self::assertNotSame(
+                LintCommand::EXIT_INVOCATION_ERROR,
+                $exit,
+                'Lint with no paths must not abort from re-binding bundled stdlib symbols. '
+                . 'Output: ' . $tester->getDisplay(),
+            );
+            self::assertStringNotContainsString('already bound', $tester->getDisplay());
+        } finally {
+            if ($originalCwd !== false) {
+                chdir($originalCwd);
+            }
+
+            @unlink($projectRoot . '/src/clean.phel');
+            if (is_dir($projectRoot . '/src')) {
+                $leftovers = scandir($projectRoot . '/src') ?: [];
+                foreach ($leftovers as $entry) {
+                    if ($entry === '.') {
+                        continue;
+                    }
+
+                    if ($entry === '..') {
+                        continue;
+                    }
+
+                    @unlink($projectRoot . '/src/' . $entry);
+                }
+
+                @rmdir($projectRoot . '/src');
+            }
+
+            @rmdir($projectRoot);
+        }
+    }
+
     private function bootstrap(): void
     {
         Phel::bootstrap(__DIR__);

--- a/tests/php/Unit/Command/Application/DirectoryFinderTest.php
+++ b/tests/php/Unit/Command/Application/DirectoryFinderTest.php
@@ -16,9 +16,32 @@ final class DirectoryFinderTest extends TestCase
         $vendorFinder = $this->createStub(VendorDirectoriesFinderInterface::class);
         $vendorFinder->method('findPhelSourceDirectories')->willReturn([]);
 
-        $codeDirs = new CodeDirectories(['phar://phel.phar/src'], [], 'out');
+        $codeDirs = new CodeDirectories('phar://phel.phar/src', ['phar://phel.phar/src'], [], 'out');
         $finder = new DirectoryFinder('/project', $codeDirs, $vendorFinder);
 
         self::assertSame(['phar://phel.phar/src'], $finder->getSourceDirectories());
+    }
+
+    public function test_project_source_directories_exclude_phel_internal_dir(): void
+    {
+        $vendorFinder = $this->createStub(VendorDirectoriesFinderInterface::class);
+        $vendorFinder->method('findPhelSourceDirectories')->willReturn([]);
+
+        $codeDirs = new CodeDirectories(
+            'phar://phel.phar/phel-internal',
+            ['phar://phel.phar/src'],
+            [],
+            'out',
+        );
+        $finder = new DirectoryFinder('/project', $codeDirs, $vendorFinder);
+
+        self::assertSame(
+            ['phar://phel.phar/phel-internal', 'phar://phel.phar/src'],
+            $finder->getSourceDirectories(),
+        );
+        self::assertSame(
+            ['phar://phel.phar/src'],
+            $finder->getProjectSourceDirectories(),
+        );
     }
 }


### PR DESCRIPTION
## 🤔 Background

`vendor/bin/phel lint` with no arguments aborted in every consumer project with:

```
Lint failed: Symbol walk is already bound in namespace phel\walk in
/.../vendor/phel-lang/phel-lang/src/phel/walk.phel:4
```

`CommandConfig::getCodeDirs()` prepends phel's own bundled stdlib dir to the user's configured `src-dirs` so runtime namespace resolution can find `phel\core` et al. `LintCommand::defaultPaths()` consumed that combined list, so the linter walked into the vendored stdlib and tried to re-analyze `phel/walk.phel` after `loadPhelNamespaces()` had already registered its symbols, blowing up on `DuplicateDefinitionException`.

Closes #1541.

## 💡 Goal

`phel lint` with no arguments should only analyze the project's own source paths (as configured in `phel-config.php`) and must not re-evaluate or re-bind files in `vendor/`.

## 🔖 Changes

- `CodeDirectories` now holds the phel-internal src dir and user-configured src dirs as separate fields; adds `getProjectSourceDirs()` alongside the combined `getSourceDirs()`
- `DirectoryFinder::getProjectSourceDirectories()` + `CommandFacade::getProjectSourceDirectories()` expose user-only src dirs
- `LintCommand::defaultPaths()` switches to `getProjectSourceDirectories()` so vendored stdlib is no longer walked by default. Other callers keep `getSourceDirectories()` so runtime namespace resolution is unaffected
- Regression integration test `test_default_paths_exclude_phel_internal_stdlib` bootstraps a tmp project, invokes `LintCommand` with no paths, and asserts the run does not abort with a duplicate-binding error
- Unit test on `DirectoryFinder` pinning the two accessors' split semantics