### PR TITLE
feat(compiler): resolve bare dot-separated class FQNs (#1553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+#### Compiler
+- Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
+
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
 - `into-array` function for `.cljc` interop: `(into-array aseq)` and `(into-array type aseq)` both return a PHP array containing the elements of `aseq`. The `type` argument is accepted for Clojure source compatibility but is ignored in Phel — PHP has no typed arrays. Use `int-array`/`float-array`/etc. when element coercion is needed (#1550)

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -44,6 +44,13 @@ final readonly class SymbolResolver
             return new PhpClassNameNode($env, $name, $name->getStartLocation());
         }
 
+        if ($name->getNamespace() === null && $this->looksLikeDotSeparatedClassFqn($strName)) {
+            $fqn = Symbol::create('\\' . str_replace('.', '\\', $strName));
+            $fqn->copyLocationFrom($name);
+
+            return new PhpClassNameNode($env, $fqn, $name->getStartLocation());
+        }
+
         $useAliasNode = $this->resolveFromUseAlias($name, $env);
         if ($useAliasNode instanceof AbstractNode) {
             return $useAliasNode;
@@ -85,6 +92,17 @@ final readonly class SymbolResolver
         $ns = $this->globalEnv->resolveAlias($normalizedAlias) ?? $normalizedAlias;
 
         return $this->resolveInterfaceOrDefinition($finalName, $env, $ns);
+    }
+
+    /**
+     * Accept `Foo.Bar.Baz` as an alias for the PHP class FQN `\Foo\Bar\Baz`,
+     * matching Clojure's class-reference syntax in `.cljc` code. Only applies
+     * to names that look like class FQNs (contain a dot, start uppercase) so
+     * plain Phel symbols are left to the normal resolution path.
+     */
+    private function looksLikeDotSeparatedClassFqn(string $name): bool
+    {
+        return preg_match('/^[A-Z]\w*(\.[A-Za-z_]\w*)+$/', $name) === 1;
     }
 
     private function remapClojureAlias(string $alias): string

--- a/tests/php/Integration/Fixtures/Try/try-catch-dot-fqn.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-dot-fqn.test
@@ -1,0 +1,8 @@
+--PHEL--
+(try (php/+ 1 1) (catch Phel.Lang.ExInfoException e (throw e)))
+--PHP--
+try {
+  (1 + 1);
+} catch (\Phel\Lang\ExInfoException $e) {
+  throw $e;
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -308,6 +308,36 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
+    public function test_resolve_bare_dot_fqn_as_php_class(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\' . Symbol::class)),
+            $this->resolver->resolve(Symbol::create('Phel.Lang.Symbol'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_bare_dot_fqn_falls_through_when_lowercase(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertNotInstanceOf(
+            PhpClassNameNode::class,
+            $this->resolver->resolve(Symbol::create('phel.foo'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_bare_name_without_dot_is_not_class_fqn(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertNotInstanceOf(
+            PhpClassNameNode::class,
+            $this->resolver->resolve(Symbol::create('Foo'), $nodeEnv),
+        );
+    }
+
     public function test_resolve_clojure_fqn_uses_munged_registry_lookup(): void
     {
         Registry::getInstance()->addDefinition('phel\\my_lib', '__ns_marker', true);


### PR DESCRIPTION
## 🤔 Background

In `.cljc` code shared across Clojure / ClojureScript / Basilisp / ClojureCLR, bare dot-separated class names like `Phel.Lang.ExInfoException` are idiomatic and resolve to the host platform's class. Phel only accepted the backslash form `\Phel\Lang\ExInfoException` and raised `[PHEL001] Cannot resolve symbol 'Phel.Lang.ExInfoException'` for the dotted form, blocking cross-dialect source sharing (see [clojure-test-suite / add_watch.cljc](https://github.com/jasalt/clojure-test-suite/blob/3e24692606d529e6faf18e9a9dfe39e82d0dfa35/test/clojure/core_test/add_watch.cljc#L5)).

Closes #1553.

Related prior work: #1251 (dot separator inside qualified names), #1207 (clojure.* namespace aliasing).

## 💡 Goal

Accept bare `Foo.Bar.Baz` as a class FQN alias for `\Foo\Bar\Baz` in symbol-position use, matching Clojure's class-reference syntax. Do not change resolution of any other shape of symbol.

## 🔖 Changes

- `SymbolResolver::resolve()` now detects bare symbols matching `^[A-Z]\w*(\.[A-Za-z_]\w*)+$` — start uppercase, at least one dot, word characters otherwise — and wraps them in a `PhpClassNameNode` with the dots replaced by backslashes and a leading `\` prepended
- Symbols with a `/` namespace/name separator, a lowercase first character, or no dot are left to the existing resolution paths unchanged — no regression for Phel's own naming
- Unit tests: `test_resolve_bare_dot_fqn_as_php_class`, `test_resolve_bare_dot_fqn_falls_through_when_lowercase`, `test_resolve_bare_name_without_dot_is_not_class_fqn`
- Integration fixture: `tests/php/Integration/Fixtures/Try/try-catch-dot-fqn.test` exercises the dot form end-to-end in a `try/catch`