### PR TITLE
feat(compiler): opt-in deprecation for backslash namespace separator (#1567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
+- Opt-in deprecation warning for backslash (`\`) as namespace separator in call sites and class FQNs; set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
 
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -1,0 +1,59 @@
+# Migration: backslash namespace separator → dot
+
+Phel historically uses the PHP-style backslash (`\`) as the namespace
+separator in every position: `ns` forms, `:require`/`:use` clauses,
+fully-qualified call sites, and class FQNs. Clojure — and therefore
+`.cljc` code shared with sibling dialects — uses the dot (`.`). For
+long-term Clojure compatibility, the backslash form is being
+**deprecated** and will be removed in a future release.
+
+See tracking issue:
+[phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
+
+## Opt-in to deprecation warnings
+
+Set `PHEL_WARN_DEPRECATIONS=1` before running `phel`:
+
+```bash
+PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel run src/app.phel
+PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
+```
+
+When enabled, the compiler emits one `E_USER_DEPRECATED` per unique
+`(file, symbol)` pair so large projects do not drown in duplicates.
+
+## What the current (Phase 1a) PR detects
+
+Only symbols flowing through the analyzer's `SymbolResolver` emit
+warnings — that covers:
+
+- **Fully-qualified call sites**: `(phel\core/map inc xs)` → use
+  `(phel.core/map inc xs)`
+- **Leading-backslash class FQNs**: `\Phel\Lang\ExInfoException` →
+  use `Phel.Lang.ExInfoException` (the dot alias landed in
+  [#1553](https://github.com/phel-lang/phel-lang/issues/1553))
+
+## What is NOT yet detected (Phase 1b+)
+
+Tracked as follow-up sub-tasks in #1567:
+
+- `ns` declarations: `(ns phel\foo)` → `(ns phel.foo)`
+- `:require` / `:use` / `:refer` / `:as` clauses
+- `load` forms
+- Reader-macro / quoting forms that carry namespace strings
+
+Until those phases ship, running with `PHEL_WARN_DEPRECATIONS=1` only
+surfaces the call-site uses. It is safe to migrate the non-detected
+positions by hand now — the new dot forms already work.
+
+## Suppression
+
+Warnings are suppressed automatically for files under phel's bundled
+stdlib (`.../src/phel/...`). The stdlib itself is written in backslash
+form today and will be rewritten to dot form before the backslash form
+is removed.
+
+## Removal target
+
+TBD — tracked in #1567. At minimum one full minor-release cycle after
+the warning flag flips on by default.

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+
+use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function strtr;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Emits `E_USER_DEPRECATED` warnings when user code uses `\` as the
+ * namespace separator (e.g. `phel\core/map`, `\Phel\Lang\Foo`) so the
+ * codebase can migrate to Clojure-compatible dot syntax ahead of the
+ * backslash form being removed.
+ *
+ * Scope of detection is intentionally narrow: only symbols that pass
+ * through `SymbolResolver::resolve()` — call sites and qualified refs.
+ * `ns`, `:require`, `:use`, and related forms are tracked as follow-ups
+ * in https://github.com/phel-lang/phel-lang/issues/1567.
+ */
+final class BackslashSeparatorDeprecator
+{
+    /** @var array<string, true> */
+    private array $seen = [];
+
+    /** @var callable(string): void */
+    private $emitter;
+
+    public function __construct(
+        private readonly bool $enabled,
+        ?callable $emitter = null,
+    ) {
+        $this->emitter = $emitter ?? static function (string $msg): void {
+            @trigger_error($msg, E_USER_DEPRECATED);
+        };
+    }
+
+    public function maybeWarn(Symbol $symbol): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $location = $symbol->getStartLocation();
+        if (!$location instanceof SourceLocation) {
+            return;
+        }
+
+        $file = $location->getFile();
+        if ($file === '' || $this->isPhelStdlibSource($file)) {
+            return;
+        }
+
+        $original = $symbol->getFullName();
+        if (!$this->containsBackslashSeparator($original)) {
+            return;
+        }
+
+        $key = $file . '|' . $original;
+        if (isset($this->seen[$key])) {
+            return;
+        }
+
+        $this->seen[$key] = true;
+        ($this->emitter)($this->buildMessage($original, $file, $location->getLine()));
+    }
+
+    private function containsBackslashSeparator(string $fullName): bool
+    {
+        return str_contains($fullName, '\\');
+    }
+
+    private function isPhelStdlibSource(string $file): bool
+    {
+        // Normalize separators so the check works on any OS and for both
+        // the dev-repo layout and Composer-vendored installs.
+        $normalized = strtr($file, '\\', '/');
+
+        return str_contains($normalized, '/src/phel/')
+            || str_ends_with($normalized, '/src/phel');
+    }
+
+    private function buildMessage(string $original, string $file, int $line): string
+    {
+        return sprintf(
+            "Backslash ('\\') namespace separator in symbol '%s' at %s:%d is deprecated; "
+            . "use dot ('.') instead — e.g. '%s'. "
+            . 'The backslash form will be removed in a future release.',
+            $original,
+            $file,
+            $line,
+            $this->suggestion($original),
+        );
+    }
+
+    private function suggestion(string $original): string
+    {
+        // Drop the leading backslash from class FQNs and convert all
+        // remaining `\` separators to `.` to match Clojure syntax.
+        $trimmed = str_starts_with($original, '\\') ? substr($original, 1) : $original;
+
+        return str_replace('\\', '.', $trimmed);
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -16,6 +16,7 @@ use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
 
 use function array_key_exists;
+use function in_array;
 
 final class GlobalEnvironment implements GlobalEnvironmentInterface
 {
@@ -42,7 +43,11 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function __construct()
     {
-        $this->symbolResolver = new SymbolResolver($this, new MagicConstantResolver());
+        $this->symbolResolver = new SymbolResolver(
+            $this,
+            new MagicConstantResolver(),
+            new BackslashSeparatorDeprecator($this->backslashDeprecationsEnabled()),
+        );
         $this->addInternalBuildModeDefinition();
     }
 
@@ -249,6 +254,13 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         return array_keys($symbols);
+    }
+
+    private function backslashDeprecationsEnabled(): bool
+    {
+        $flag = getenv('PHEL_WARN_DEPRECATIONS');
+
+        return !in_array($flag, [false, '', '0'], true);
     }
 
     private function initializeNamespace(string $namespace): void

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -20,10 +20,12 @@ final readonly class SymbolResolver
     public function __construct(
         private GlobalEnvironment $globalEnv,
         private MagicConstantResolver $magicConstantResolver,
+        private ?BackslashSeparatorDeprecator $backslashDeprecator = null,
     ) {}
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
     {
+        $this->backslashDeprecator?->maybeWarn($name);
         $strName = $name->getName();
 
         if ($strName === '__DIR__') {

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\Environment;
+
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class BackslashSeparatorDeprecatorTest extends TestCase
+{
+    /** @var list<string> */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->captured = [];
+    }
+
+    public function test_emits_for_backslash_namespace_symbol(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/user.phel'));
+
+        self::assertCount(1, $this->captured);
+        self::assertStringContainsString("'phel\\core/map'", $this->captured[0]);
+        self::assertStringContainsString("'phel.core/map'", $this->captured[0]);
+        self::assertStringContainsString('/app/user.phel', $this->captured[0]);
+    }
+
+    public function test_emits_for_leading_backslash_class_fqn(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol(null, '\\Phel\\Lang\\Foo', '/app/user.phel'));
+
+        self::assertCount(1, $this->captured);
+        self::assertStringContainsString("'\\Phel\\Lang\\Foo'", $this->captured[0]);
+        self::assertStringContainsString("'Phel.Lang.Foo'", $this->captured[0]);
+    }
+
+    public function test_stays_silent_when_disabled(): void
+    {
+        $deprecator = $this->deprecator(enabled: false);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/user.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    public function test_no_warning_for_dot_separated_symbol(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel.core', 'map', '/app/user.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    public function test_dedupes_same_file_and_pattern(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/user.phel'));
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/user.phel'));
+
+        self::assertCount(1, $this->captured);
+    }
+
+    public function test_emits_again_for_different_file(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/a.phel'));
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/app/b.phel'));
+
+        self::assertCount(2, $this->captured);
+    }
+
+    public function test_suppresses_warnings_from_phel_stdlib_sources(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/vendor/phel-lang/phel-lang/src/phel/walk.phel'));
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/home/x/phel-lang/src/phel/core.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    public function test_suppresses_when_location_is_missing(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn(Symbol::createForNamespace('phel\\core', 'map'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    private function deprecator(bool $enabled): BackslashSeparatorDeprecator
+    {
+        return new BackslashSeparatorDeprecator(
+            $enabled,
+            function (string $msg): void {
+                $this->captured[] = $msg;
+            },
+        );
+    }
+
+    private function locatedSymbol(?string $ns, string $name, string $file): Symbol
+    {
+        $symbol = $ns === null ? Symbol::create($name) : Symbol::createForNamespace($ns, $name);
+        $symbol->setStartLocation(new SourceLocation($file, 1, 1));
+
+        return $symbol;
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
@@ -336,6 +337,26 @@ final class SymbolResolverTest extends TestCase
             PhpClassNameNode::class,
             $this->resolver->resolve(Symbol::create('Foo'), $nodeEnv),
         );
+    }
+
+    public function test_resolve_fires_backslash_deprecation_when_wired(): void
+    {
+        $captured = [];
+        $deprecator = new BackslashSeparatorDeprecator(
+            enabled: true,
+            emitter: static function (string $msg) use (&$captured): void {
+                $captured[] = $msg;
+            },
+        );
+        $resolver = new SymbolResolver($this->globalEnv, new MagicConstantResolver(), $deprecator);
+
+        $sym = Symbol::createForNamespace('phel\\core', 'map');
+        $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
+
+        $resolver->resolve($sym, NodeEnvironment::empty());
+
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'phel\\core/map'", $captured[0]);
     }
 
     public function test_resolve_clojure_fqn_uses_munged_registry_lookup(): void


### PR DESCRIPTION
## 🤔 Background

Phel historically uses PHP-style backslash (`\`) as the namespace separator in every position. Clojure — and therefore shared `.cljc` code — uses dot (`.`). Prior work landed dot-syntax support in multiple positions (#1177, #1251, #1207, #1553), but the two styles now coexist. For long-term Clojure compatibility and one unambiguous canonical style, the backslash form needs to be deprecated and eventually removed.

Closes the Phase 1a scope of #1567. Follow-up sub-tasks (ns / require / use / refer / load / stdlib rewrite / default-on flip) are tracked in that same issue.

> **Stacked PR:** based on `feat/1553-dot-separator-class-fqn` (#1566). Merge #1566 first; GitHub will retarget this PR to `main` automatically.

## 💡 Goal

Surface exactly the places where user code still uses `\` as a namespace separator so projects can migrate to `.` at their own pace. Keep the warning **off by default** — flipping it on is a one-env-var decision, not a silent behavior change.

## 🔖 Changes

- New service `BackslashSeparatorDeprecator` at `src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php`: single responsibility, emits one `E_USER_DEPRECATED` per `(file, symbol)` pair, accepts a custom emitter for testability
- Wired into `SymbolResolver::resolve()` as an optional constructor dependency — existing tests keep passing unchanged
- `GlobalEnvironment` reads `PHEL_WARN_DEPRECATIONS` env var once at construction and passes the flag through
- Stdlib suppression via source-path match (`/src/phel/`) so Phel's own `phel\core`, `phel\walk`, etc. do not spam warnings during every compiler boot
- Unit coverage (`BackslashSeparatorDeprecatorTest`): positive cases, disabled state, dedup, per-file separation, stdlib suppression, missing-location handling
- Wiring test in `SymbolResolverTest` pins the resolve-to-deprecator integration
- Migration guide at `docs/migration/backslash-to-dot.md` documenting what Phase 1a detects, what still needs manual migration, and the removal target

## What is explicitly **not** in this PR

Tracked as sub-tasks in #1567:

- `ns`, `:require`, `:use`, `:refer`, `:as` detection (different analyzer path)
- `load` forms
- Rewriting the Phel stdlib itself to dot form
- Default-on flip
- CLI `--warn-deprecations` flag wiring across every command

## Validation

- `./vendor/bin/phpunit tests/php/Unit/Compiler/Analyzer/Environment/` — 81 tests, 120 assertions, all green
- `composer test-compiler` — only the pre-existing `DataReadersAutoloadTest` flake (also fails on main)
- `composer test-core` — 4313 tests, 0 failures
- PHPStan / rector / cs-fixer — clean

## Follow-ups

Once this lands and baseline deprecations are surfaced, the Phase 1b PRs can be opened against #1567: `ns`-form detection first (single chokepoint in the ns-analyzer), then `:require`/`:use`, then the stdlib rewrite.