### PR TITLE
feat(compiler): deprecate backslash in ns form and :require targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
-- Opt-in deprecation warning for backslash (`\`) as namespace separator in call sites and class FQNs; set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
+- Opt-in deprecation warning for backslash (`\`) as namespace separator. Covers call sites, class FQNs, `ns` declarations, and `:require` targets (flat + vector forms). Set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
 
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -22,29 +22,34 @@ PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
 When enabled, the compiler emits one `E_USER_DEPRECATED` per unique
 `(file, symbol)` pair so large projects do not drown in duplicates.
 
-## What the current (Phase 1a) PR detects
+## What is detected today
 
-Only symbols flowing through the analyzer's `SymbolResolver` emit
-warnings — that covers:
+Symbols flowing through the analyzer's `SymbolResolver` **or** the
+`ns`-form analyzer emit warnings:
 
-- **Fully-qualified call sites**: `(phel\core/map inc xs)` → use
-  `(phel.core/map inc xs)`
-- **Leading-backslash class FQNs**: `\Phel\Lang\ExInfoException` →
-  use `Phel.Lang.ExInfoException` (the dot alias landed in
-  [#1553](https://github.com/phel-lang/phel-lang/issues/1553))
+- **Namespace declarations** (Phase 1b): `(ns phel\foo)` → use
+  `(ns phel.foo)`
+- **`:require` targets** (Phase 1b, flat and `[ns :as alias]` vector
+  forms): `(:require phel\walk)` → `(:require phel.walk)`
+- **Fully-qualified call sites** (Phase 1a): `(phel\core/map inc xs)`
+  → `(phel.core/map inc xs)`
+- **Leading-backslash class FQNs** (Phase 1a):
+  `\Phel\Lang\ExInfoException` → `Phel.Lang.ExInfoException` (the dot
+  alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553))
 
-## What is NOT yet detected (Phase 1b+)
+## What is NOT yet detected
 
 Tracked as follow-up sub-tasks in #1567:
 
-- `ns` declarations: `(ns phel\foo)` → `(ns phel.foo)`
-- `:require` / `:use` / `:refer` / `:as` clauses
+- `:use` clauses — deliberately excluded for now because `\` is
+  legitimate PHP-interop syntax there; a separate discussion will
+  decide whether `:use Foo.Bar` should be the canonical form
+- `:refer` targets inside a require
 - `load` forms
-- Reader-macro / quoting forms that carry namespace strings
+- Reader-macro / quoting forms that carry namespace strings as data
 
-Until those phases ship, running with `PHEL_WARN_DEPRECATIONS=1` only
-surfaces the call-site uses. It is safe to migrate the non-detected
-positions by hand now — the new dot forms already work.
+It is safe to migrate the non-detected positions by hand now — the
+new dot forms already work at the language level.
 
 ## Suppression
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -7,10 +7,12 @@ namespace Phel\Compiler\Domain\Analyzer\Environment;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
+use function in_array;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strtr;
+
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
@@ -28,6 +30,8 @@ use const E_USER_DEPRECATED;
  */
 final class BackslashSeparatorDeprecator
 {
+    private static ?self $instance = null;
+
     /** @var array<string, true> */
     private array $seen = [];
 
@@ -41,6 +45,34 @@ final class BackslashSeparatorDeprecator
         $this->emitter = $emitter ?? static function (string $msg): void {
             @trigger_error($msg, E_USER_DEPRECATED);
         };
+    }
+
+    /**
+     * Returns the process-wide deprecator, creating it lazily from the
+     * `PHEL_WARN_DEPRECATIONS` env var so every detection site shares
+     * the same dedup state across a compile run.
+     */
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self(self::readEnvFlag());
+    }
+
+    /**
+     * Replace the singleton with a preconfigured instance — used by tests
+     * that need to assert on captured messages or flip the enabled flag.
+     */
+    public static function useInstance(self $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    /**
+     * Drop the cached singleton so the next `getInstance()` call re-reads
+     * the environment. Intended for test `tearDown()` hooks.
+     */
+    public static function resetInstance(): void
+    {
+        self::$instance = null;
     }
 
     public function maybeWarn(Symbol $symbol): void
@@ -71,6 +103,13 @@ final class BackslashSeparatorDeprecator
 
         $this->seen[$key] = true;
         ($this->emitter)($this->buildMessage($original, $file, $location->getLine()));
+    }
+
+    private static function readEnvFlag(): bool
+    {
+        $flag = getenv('PHEL_WARN_DEPRECATIONS');
+
+        return !in_array($flag, [false, '', '0'], true);
     }
 
     private function containsBackslashSeparator(string $fullName): bool

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -16,7 +16,6 @@ use Phel\Shared\CompilerConstants;
 use Phel\Shared\ReplConstants;
 
 use function array_key_exists;
-use function in_array;
 
 final class GlobalEnvironment implements GlobalEnvironmentInterface
 {
@@ -46,7 +45,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->symbolResolver = new SymbolResolver(
             $this,
             new MagicConstantResolver(),
-            new BackslashSeparatorDeprecator($this->backslashDeprecationsEnabled()),
+            BackslashSeparatorDeprecator::getInstance(),
         );
         $this->addInternalBuildModeDefinition();
     }
@@ -254,13 +253,6 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         return array_keys($symbols);
-    }
-
-    private function backslashDeprecationsEnabled(): bool
-    {
-        $flag = getenv('PHEL_WARN_DEPRECATIONS');
-
-        return !in_array($flag, [false, '', '0'], true);
     }
 
     private function initializeNamespace(string $namespace): void

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -47,6 +48,8 @@ TXT;
         if (!($nsSymbol instanceof Symbol)) {
             throw AnalyzerException::wrongArgumentType("First argument of 'ns", 'Symbol', $nsSymbol, $list);
         }
+
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn($nsSymbol);
 
         $ns = $this->normalizeNamespaceSeparators($nsSymbol->getName());
         $parts = explode('\\', $ns);
@@ -178,6 +181,7 @@ TXT;
 
         /** @var Symbol $requireSymbol */
         $requireSymbol = $elements[$index];
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn($requireSymbol);
         $requireSymbol = $this->normalizeSymbolSeparators($requireSymbol);
 
         ++$index;
@@ -250,6 +254,7 @@ TXT;
             );
         }
 
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn($requireSymbol);
         $requireSymbol = $this->normalizeSymbolSeparators($requireSymbol);
 
         $index = 1;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
-use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
-use Phel\Lang\SourceLocation;
 use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\NsNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\NsSymbol;
 use Phel\Lang\Keyword;
 use Phel\Lang\Registry;
+use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
 
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Lang\SourceLocation;
 use Phel;
 use Phel\Compiler\Application\Analyzer;
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
@@ -34,6 +36,11 @@ final class NsSymbolTest extends TestCase
 
         // Seed the Registry so clojure\* → phel\* remapping finds the target namespace
         Phel::addDefinition('phel\\test', '__ns_marker', true, Phel::map());
+    }
+
+    protected function tearDown(): void
+    {
+        BackslashSeparatorDeprecator::resetInstance();
     }
 
     public function test_first_argument_must_be_symbol(): void
@@ -1112,5 +1119,90 @@ final class NsSymbolTest extends TestCase
         $globalVarNode = $this->globalEnv->resolve(Symbol::create('foo'), NodeEnvironment::empty());
         self::assertInstanceOf(GlobalVarNode::class, $globalVarNode);
         self::assertSame('vendor\\package', $globalVarNode->getNamespace());
+    }
+
+    public function test_backslash_ns_form_emits_deprecation(): void
+    {
+        $captured = [];
+        $this->installCapturingDeprecator($captured);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            $this->locatedSymbol('my\\project', '/app/user.phel'),
+        ]);
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertCount(1, $captured);
+        self::assertStringContainsString("'my\\project'", $captured[0]);
+        self::assertStringContainsString("'my.project'", $captured[0]);
+
+        BackslashSeparatorDeprecator::resetInstance();
+    }
+
+    public function test_backslash_require_emits_deprecation(): void
+    {
+        $captured = [];
+        $this->installCapturingDeprecator($captured);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            $this->locatedSymbol('my\\project', '/app/user.phel'),
+            Phel::list([
+                Keyword::create('require'),
+                $this->locatedSymbol('phel\\walk', '/app/user.phel'),
+            ]),
+        ]);
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        $requireWarnings = array_values(array_filter(
+            $captured,
+            static fn(string $m): bool => str_contains($m, "'phel\\walk'"),
+        ));
+
+        self::assertCount(1, $requireWarnings, 'exactly one warning for the backslash require symbol');
+        self::assertStringContainsString("'phel.walk'", $requireWarnings[0]);
+
+        BackslashSeparatorDeprecator::resetInstance();
+    }
+
+    public function test_dot_ns_form_emits_no_deprecation(): void
+    {
+        $captured = [];
+        $this->installCapturingDeprecator($captured);
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            $this->locatedSymbol('my.project', '/app/user.phel'),
+            Phel::list([
+                Keyword::create('require'),
+                $this->locatedSymbol('phel.walk', '/app/user.phel'),
+            ]),
+        ]);
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertSame([], $captured);
+
+        BackslashSeparatorDeprecator::resetInstance();
+    }
+
+    /**
+     * @param list<string> $captured
+     */
+    private function installCapturingDeprecator(array &$captured): void
+    {
+        BackslashSeparatorDeprecator::useInstance(new BackslashSeparatorDeprecator(
+            enabled: true,
+            emitter: static function (string $msg) use (&$captured): void {
+                $captured[] = $msg;
+            },
+        ));
+    }
+
+    private function locatedSymbol(string $name, string $file): Symbol
+    {
+        $symbol = Symbol::create($name);
+        $symbol->setStartLocation(new SourceLocation($file, 1, 1));
+
+        return $symbol;
     }
 }


### PR DESCRIPTION
## 🤔 Background

Phase 1b of [#1567](https://github.com/phel-lang/phel-lang/issues/1567). Builds on Phase 1a ([#1568](https://github.com/phel-lang/phel-lang/pull/1568)). Merge order: #1566 → #1568 → this PR. GitHub will retarget the base automatically as each parent lands.

Phase 1a detected `\` usage at symbol-resolution time (call sites and class FQNs). That left `ns` / `:require` declarations unseen because they never pass through `SymbolResolver`. Phase 1b closes that gap.

## 💡 Goal

Surface `\`-separated namespace names in the three most common declaration-time positions so projects can migrate their `ns` and `:require` forms at the same time as their call sites.

## 🔖 Changes

- `BackslashSeparatorDeprecator` is now a process-wide singleton via `getInstance()` / `useInstance()` / `resetInstance()` so every detection site shares one dedup set. Direct constructor injection still supported for unit tests
- `GlobalEnvironment` uses the singleton when wiring `SymbolResolver` — same env-var gate, no behavior change for Phase 1a
- `NsSymbol::analyze()` warns on the namespace symbol (e.g. `(ns phel\foo)`)
- `NsSymbol::analyzeRequireFlatEntry()` and `analyzeRequireVectorEntry()` warn on each require target before normalization (e.g. `(:require phel\walk)` and `(:require [phel\walk :as w])`)
- Three new `NsSymbolTest` cases cover positive (ns + require) and negative (dot form stays silent) paths, using the singleton-swap helper
- Migration guide updated to describe the expanded scope

## Deliberate omissions

`:use` clauses are **not** deprecated. `\` is legitimate PHP-interop syntax there (`(:use \Symfony\Component\Console\Command\Command)`) and a separate design question about whether we want `Symfony.Component.Console.Command.Command` as canonical. Leaving for a follow-up discussion.

`:refer` targets, `load` forms, and reader-macro data forms are still out of scope — tracked in #1567.

## Validation

- `./vendor/bin/phpunit tests/php/Unit/Compiler/Analyzer/` — 436 tests, 813 assertions, all green
- `composer test-compiler` — only the pre-existing `DataReadersAutoloadTest` flake (fails on main)
- PHPStan / rector / cs-fixer — clean