### PR TITLE
feat(stdlib): rewrite ns/require forms to Clojure-compatible dot syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 #### Compiler
 - Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
 - Opt-in deprecation warning for backslash (`\`) as namespace separator. Covers call sites, class FQNs, `ns` declarations, and `:require` targets (flat + vector forms). Set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
+- Phel stdlib sources (`src/phel/**/*.phel`) rewritten to use Clojure-compatible dot syntax in `ns`, `in-ns`, and `:require` forms; the stdlib-source suppression in the backslash deprecator was dropped as it is no longer needed (#1567)
 
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -1,6 +1,6 @@
-(ns phel\ai
-  (:require phel\http-client :as hc)
-  (:require phel\json)
+(ns phel.ai
+  (:require phel.http-client :as hc)
+  (:require phel.json)
   (:use RuntimeException))
 
 ;; -----------

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,4 +1,4 @@
-(ns phel\async)
+(ns phel.async)
 
 ;; Two cooperating concurrency layers in one module.
 ;;

--- a/src/phel/base64.phel
+++ b/src/phel/base64.phel
@@ -1,5 +1,5 @@
-(ns phel\base64
-  (:require phel\string :as s))
+(ns phel.base64
+  (:require phel.string :as s))
 
 (defn encode
   "Encodes a string to Base64."

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -1,4 +1,4 @@
-(ns phel\cli
+(ns phel.cli
   (:use InvalidArgumentException)
   (:use Symfony\Component\Console\Application)
   (:use Symfony\Component\Console\Command\Command)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1,4 +1,4 @@
-(ns phel\core
+(ns phel.core
   (:use InvalidArgumentException)
   (:use Phel)
   (:use Phel\Lang\CdrInterface)

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)

--- a/src/phel/core/collections.phel
+++ b/src/phel/core/collections.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 

--- a/src/phel/core/control.phel
+++ b/src/phel/core/control.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel\Compiler\Application\Munge)
 (use Phel\Lang\Collections\LinkedList\PersistentListInterface)

--- a/src/phel/core/exceptions.phel
+++ b/src/phel/core/exceptions.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 (use Phel\Lang\ExInfoException)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 ;; Two loosely-related groups, kept together because both build higher-level
 ;; abstractions over the seq/set primitives in core.phel:

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -1,10 +1,10 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 ;; Core `future`: starts `body` asynchronously and returns a
 ;; `PhelFuture`. Kept in core so it mirrors Clojure, where `future`
 ;; is available without an explicit require. The fiber-backed
 ;; `future-fiber`, `future-call`, `promise`, and friends still live in
-;; `phel\async`.
+;; `phel.async`.
 
 (defmacro future
   "Starts evaluating `body` asynchronously and returns a `PhelFuture`

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/lazy.phel
+++ b/src/phel/core/lazy.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 (use Phel\Lang\Delay)

--- a/src/phel/core/loops.phel
+++ b/src/phel/core/loops.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 ;; Side-effecting iteration that returns `nil`. Currently just `run!`;
 ;; `doseq` itself lives in the macro layer, but related helpers collect here.

--- a/src/phel/core/macroexpand.phel
+++ b/src/phel/core/macroexpand.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 (use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/meta.phel
+++ b/src/phel/core/meta.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 (use Phel\Lang\MetaInterface)

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 ;; Safe string → primitive parsers: `parse-long`, `parse-double`,
 ;; `parse-boolean`. Each returns `nil` on invalid input instead of

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Countable)
 (use Phel)

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Countable)
 (use InvalidArgumentException)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use OutOfBoundsException)

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel\Lang\Symbol)
 

--- a/src/phel/core/tap.phel
+++ b/src/phel/core/tap.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 ;; -------------
 ;; Tap registry

--- a/src/phel/core/transducers.phel
+++ b/src/phel/core/transducers.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel)

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use InvalidArgumentException)
 (use Phel\Lang\Collections\HashSet\TransientHashSetInterface)

--- a/src/phel/core/uuid.phel
+++ b/src/phel/core/uuid.phel
@@ -1,4 +1,4 @@
-(in-ns phel\core)
+(in-ns phel.core)
 
 (use Phel)
 

--- a/src/phel/html.phel
+++ b/src/phel/html.phel
@@ -1,4 +1,4 @@
-(ns phel\html
+(ns phel.html
   (:use \InvalidArgumentException))
 
 (defstruct raw-string [s])

--- a/src/phel/http-client.phel
+++ b/src/phel/http-client.phel
@@ -1,6 +1,6 @@
-(ns phel\http-client
-  (:require phel\http :as http)
-  (:require phel\json))
+(ns phel.http-client
+  (:require phel.http :as http)
+  (:require phel.json))
 
 ;; -----------
 ;; Key helpers

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -1,4 +1,4 @@
-(ns phel\http
+(ns phel.http
   (:use InvalidArgumentException)
   (:use Stringable))
 

--- a/src/phel/json.phel
+++ b/src/phel/json.phel
@@ -1,4 +1,4 @@
-(ns phel\json
+(ns phel.json
   (:use \JsonException))
 
 (defn valid-key?

--- a/src/phel/match.phel
+++ b/src/phel/match.phel
@@ -1,5 +1,5 @@
-(ns phel\match
-  (:require phel\core))
+(ns phel.match
+  (:require phel.core))
 
 ;; Pattern matching macro that expands to nested `cond` + `let` bindings.
 ;;

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -1,4 +1,4 @@
-(ns phel\mock)
+(ns phel.mock)
 
 ;; -----------
 ;; Mock State Registry

--- a/src/phel/pprint.phel
+++ b/src/phel/pprint.phel
@@ -1,5 +1,5 @@
-(ns phel\pprint
-  (:require phel\core)
+(ns phel.pprint
+  (:require phel.core)
   (:use Phel\Printer\Printer))
 
 (def- *default-width* 72)

--- a/src/phel/reader.phel
+++ b/src/phel/reader.phel
@@ -1,4 +1,4 @@
-(ns phel\reader
+(ns phel.reader
   (:use Phel)
   (:use Phel\Lang\TagRegistry))
 

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -283,7 +283,7 @@
 (defn apropos
   "Returns a vector of symbols whose name contains the given search string.
   Searches across all loaded namespaces."
-  {:example "(apropos \"map\") ; => [phel.\core/flat-map phel\\core/map ...]"}
+  {:example "(apropos \"map\") ; => [phel\\core/flat-map phel\\core/map ...]"}
   [search]
   (let [munge   (php/new Munge)
         results (transient [])]

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -1,4 +1,4 @@
-(ns phel\repl
+(ns phel.repl
   (:use Phel)
   (:use Phel\Lang\Symbol)
   (:use Phel\Lang\Registry)
@@ -11,8 +11,8 @@
   (:use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment)
   (:use Phel\Lang\FnInterface)
   (:use Phel\Printer\Printer)
-  (:require phel\ai :as ai)
-  (:require phel\test :as t))
+  (:require phel.ai :as ai)
+  (:require phel.test :as t))
 
 (def build-facade (php/new BuildFacade))
 
@@ -283,7 +283,7 @@
 (defn apropos
   "Returns a vector of symbols whose name contains the given search string.
   Searches across all loaded namespaces."
-  {:example "(apropos \"map\") ; => [phel\\core/flat-map phel\\core/map ...]"}
+  {:example "(apropos \"map\") ; => [phel.\core/flat-map phel\\core/map ...]"}
   [search]
   (let [munge   (php/new Munge)
         results (transient [])]

--- a/src/phel/router.phel
+++ b/src/phel/router.phel
@@ -1,5 +1,5 @@
-(ns phel\router
-  (:require phel\http :as h)
+(ns phel.router
+  (:require phel.http :as h)
   (:use \Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper)
   (:use \Symfony\Component\Routing\Generator\UrlGenerator)
   (:use \Symfony\Component\Routing\Generator\CompiledUrlGenerator)

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -1,11 +1,11 @@
 (ns phel.schema
   (:require phel.core)
-  (:require phel.schema\registry :as reg)
-  (:require phel.schema\validator :as v)
-  (:require phel.schema\explainer :as e)
-  (:require phel.schema\coercer :as c)
-  (:require phel.schema\generator :as gen)
-  (:require phel.schema\instrument :as i))
+  (:require phel.schema.registry :as reg)
+  (:require phel.schema.validator :as v)
+  (:require phel.schema.explainer :as e)
+  (:require phel.schema.coercer :as c)
+  (:require phel.schema.generator :as gen)
+  (:require phel.schema.instrument :as i))
 
 ;; Data-driven schemas for Phel.
 ;;

--- a/src/phel/schema.phel
+++ b/src/phel/schema.phel
@@ -1,11 +1,11 @@
-(ns phel\schema
-  (:require phel\core)
-  (:require phel\schema\registry :as reg)
-  (:require phel\schema\validator :as v)
-  (:require phel\schema\explainer :as e)
-  (:require phel\schema\coercer :as c)
-  (:require phel\schema\generator :as gen)
-  (:require phel\schema\instrument :as i))
+(ns phel.schema
+  (:require phel.core)
+  (:require phel.schema\registry :as reg)
+  (:require phel.schema\validator :as v)
+  (:require phel.schema\explainer :as e)
+  (:require phel.schema\coercer :as c)
+  (:require phel.schema\generator :as gen)
+  (:require phel.schema\instrument :as i))
 
 ;; Data-driven schemas for Phel.
 ;;

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -1,7 +1,7 @@
-(ns phel.schema\coercer
+(ns phel.schema.coercer
   (:require phel.core)
-  (:require phel.schema\registry :as reg)
-  (:require phel.schema\validator :as v))
+  (:require phel.schema.registry :as reg)
+  (:require phel.schema.validator :as v))
 
 ;; Type coercion driven by schemas.
 ;;

--- a/src/phel/schema/coercer.phel
+++ b/src/phel/schema/coercer.phel
@@ -1,7 +1,7 @@
-(ns phel\schema\coercer
-  (:require phel\core)
-  (:require phel\schema\registry :as reg)
-  (:require phel\schema\validator :as v))
+(ns phel.schema\coercer
+  (:require phel.core)
+  (:require phel.schema\registry :as reg)
+  (:require phel.schema\validator :as v))
 
 ;; Type coercion driven by schemas.
 ;;

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -1,7 +1,7 @@
-(ns phel\schema\explainer
-  (:require phel\core)
-  (:require phel\schema\registry :as reg)
-  (:require phel\schema\validator :as v))
+(ns phel.schema\explainer
+  (:require phel.core)
+  (:require phel.schema\registry :as reg)
+  (:require phel.schema\validator :as v))
 
 ;; Error-reporting companion to the validator.
 ;;

--- a/src/phel/schema/explainer.phel
+++ b/src/phel/schema/explainer.phel
@@ -1,7 +1,7 @@
-(ns phel.schema\explainer
+(ns phel.schema.explainer
   (:require phel.core)
-  (:require phel.schema\registry :as reg)
-  (:require phel.schema\validator :as v))
+  (:require phel.schema.registry :as reg)
+  (:require phel.schema.validator :as v))
 
 ;; Error-reporting companion to the validator.
 ;;

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -1,8 +1,8 @@
-(ns phel.schema\generator
+(ns phel.schema.generator
   (:require phel.core)
-  (:require phel.schema\registry :as reg)
-  (:require phel.schema\validator :as v)
-  (:require phel.test\gen :as g))
+  (:require phel.schema.registry :as reg)
+  (:require phel.schema.validator :as v)
+  (:require phel.test.gen :as g))
 
 ;; Maps schemas to `phel.test.gen` generators so properties and examples
 ;; can exercise the schema without a hand-written generator. A schema

--- a/src/phel/schema/generator.phel
+++ b/src/phel/schema/generator.phel
@@ -1,10 +1,10 @@
-(ns phel\schema\generator
-  (:require phel\core)
-  (:require phel\schema\registry :as reg)
-  (:require phel\schema\validator :as v)
-  (:require phel\test\gen :as g))
+(ns phel.schema\generator
+  (:require phel.core)
+  (:require phel.schema\registry :as reg)
+  (:require phel.schema\validator :as v)
+  (:require phel.test\gen :as g))
 
-;; Maps schemas to `phel\test\gen` generators so properties and examples
+;; Maps schemas to `phel.test.gen` generators so properties and examples
 ;; can exercise the schema without a hand-written generator. A schema
 ;; may attach its own generator via `{:gen <gen-fn>}` options to override
 ;; the default.

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -1,7 +1,7 @@
-(ns phel.schema\instrument
+(ns phel.schema.instrument
   (:require phel.core)
-  (:require phel.schema\validator :as v)
-  (:require phel.schema\explainer :as e))
+  (:require phel.schema.validator :as v)
+  (:require phel.schema.explainer :as e))
 
 ;; Function-level instrumentation.
 ;;

--- a/src/phel/schema/instrument.phel
+++ b/src/phel/schema/instrument.phel
@@ -1,7 +1,7 @@
-(ns phel\schema\instrument
-  (:require phel\core)
-  (:require phel\schema\validator :as v)
-  (:require phel\schema\explainer :as e))
+(ns phel.schema\instrument
+  (:require phel.core)
+  (:require phel.schema\validator :as v)
+  (:require phel.schema\explainer :as e))
 
 ;; Function-level instrumentation.
 ;;

--- a/src/phel/schema/registry.phel
+++ b/src/phel/schema/registry.phel
@@ -1,5 +1,5 @@
-(ns phel\schema\registry
-  (:require phel\core))
+(ns phel.schema\registry
+  (:require phel.core))
 
 ;; Named-schema registry.
 ;;

--- a/src/phel/schema/registry.phel
+++ b/src/phel/schema/registry.phel
@@ -1,4 +1,4 @@
-(ns phel.schema\registry
+(ns phel.schema.registry
   (:require phel.core))
 
 ;; Named-schema registry.

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -1,6 +1,6 @@
-(ns phel\schema\validator
-  (:require phel\core)
-  (:require phel\schema\registry :as reg))
+(ns phel.schema\validator
+  (:require phel.core)
+  (:require phel.schema\registry :as reg))
 
 ;; Core validation engine.
 ;;

--- a/src/phel/schema/validator.phel
+++ b/src/phel/schema/validator.phel
@@ -1,6 +1,6 @@
-(ns phel.schema\validator
+(ns phel.schema.validator
   (:require phel.core)
-  (:require phel.schema\registry :as reg))
+  (:require phel.schema.registry :as reg))
 
 ;; Core validation engine.
 ;;

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -1,5 +1,5 @@
-(ns phel\string
-  (:require phel\core)
+(ns phel.string
+  (:require phel.core)
   (:use InvalidArgumentException))
 
 (defn split

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1,10 +1,10 @@
-(ns phel\test
+(ns phel.test
   (:use Phel)
   (:use Phel\Lang\SourceLocationInterface)
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Command\CommandFacade)
-  (:require phel\string :as s)
-  (:require phel\test\selector :as selector))
+  (:require phel.string :as s)
+  (:require phel.test\selector :as selector))
 
 ;; ------
 ;; Report
@@ -320,7 +320,7 @@
 ;; Public extension point for the `is` macro: an open multimethod
 ;; dispatched on the first symbol of the asserted form (or `:default` for
 ;; non-list forms or lists not starting with a symbol). Extend with
-;; `(defmethod phel\test/assert-expr 'my-form [form message] ...)`,
+;; `(defmethod phel.test/assert-expr 'my-form [form message] ...)`,
 ;; returning a quoted form to be evaluated by `is`. Methods must be
 ;; loaded before any `is` form using their dispatch value is expanded.
 (defmulti assert-expr

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -4,7 +4,7 @@
   (:use Phel\Compiler\Application\Munge)
   (:use Phel\Command\CommandFacade)
   (:require phel.string :as s)
-  (:require phel.test\selector :as selector))
+  (:require phel.test.selector :as selector))
 
 ;; ------
 ;; Report

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -1,7 +1,7 @@
-(ns phel\test\gen
-  (:require phel\core)
-  (:require phel\test :as t)
-  (:require phel\test\shrink :as shrink)
+(ns phel.test\gen
+  (:require phel.core)
+  (:require phel.test :as t)
+  (:require phel.test\shrink :as shrink)
   (:use InvalidArgumentException)
   (:use RuntimeException))
 

--- a/src/phel/test/gen.phel
+++ b/src/phel/test/gen.phel
@@ -1,7 +1,7 @@
-(ns phel.test\gen
+(ns phel.test.gen
   (:require phel.core)
   (:require phel.test :as t)
-  (:require phel.test\shrink :as shrink)
+  (:require phel.test.shrink :as shrink)
   (:use InvalidArgumentException)
   (:use RuntimeException))
 

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -1,5 +1,5 @@
-(ns phel\test\rose
-  (:require phel\core))
+(ns phel.test\rose
+  (:require phel.core))
 
 ;; Rose trees used to carry a value alongside lazy shrink candidates.
 ;;

--- a/src/phel/test/rose.phel
+++ b/src/phel/test/rose.phel
@@ -1,4 +1,4 @@
-(ns phel.test\rose
+(ns phel.test.rose
   (:require phel.core))
 
 ;; Rose trees used to carry a value alongside lazy shrink candidates.

--- a/src/phel/test/selector.phel
+++ b/src/phel/test/selector.phel
@@ -1,6 +1,6 @@
-(ns phel\test\selector)
+(ns phel.test\selector)
 
-;; Pure test-selection helpers used by `phel\test/run-tests` to filter the
+;; Pure test-selection helpers used by `phel.test/run-tests` to filter the
 ;; set of test vars that will actually be invoked for a run. All functions
 ;; are side-effect-free: they accept a normalized option map and a
 ;; metadata map for a single test, and return booleans. Composition is

--- a/src/phel/test/selector.phel
+++ b/src/phel/test/selector.phel
@@ -1,4 +1,4 @@
-(ns phel.test\selector)
+(ns phel.test.selector)
 
 ;; Pure test-selection helpers used by `phel.test/run-tests` to filter the
 ;; set of test vars that will actually be invoked for a run. All functions

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -1,6 +1,6 @@
-(ns phel.test\shrink
+(ns phel.test.shrink
   (:require phel.core)
-  (:require phel.test\rose :as r))
+  (:require phel.test.rose :as r))
 
 ;; Shrink driver that walks a rose tree of candidate values and returns
 ;; the smallest variant that still fails a property.

--- a/src/phel/test/shrink.phel
+++ b/src/phel/test/shrink.phel
@@ -1,11 +1,11 @@
-(ns phel\test\shrink
-  (:require phel\core)
-  (:require phel\test\rose :as r))
+(ns phel.test\shrink
+  (:require phel.core)
+  (:require phel.test\rose :as r))
 
 ;; Shrink driver that walks a rose tree of candidate values and returns
 ;; the smallest variant that still fails a property.
 ;;
-;; Design: `phel\test\gen/quick-check` collects the failing trial's
+;; Design: `phel.test.gen/quick-check` collects the failing trial's
 ;; arguments and builds a rose tree from them using `value->rose`. The
 ;; driver then walks that tree depth-first, keeping any child whose
 ;; value still fails the property. The walk stops when no child of the

--- a/src/phel/walk.phel
+++ b/src/phel/walk.phel
@@ -1,5 +1,5 @@
-(ns phel\walk
-  (:require phel\core))
+(ns phel.walk
+  (:require phel.core))
 
 (defn walk
   "Traverses `form`, an arbitrary data structure. Applies `inner` to each

--- a/src/phel/watch.phel
+++ b/src/phel/watch.phel
@@ -1,4 +1,4 @@
-(ns phel\watch
+(ns phel.watch
   (:use Phel)
   (:use Phel\Watch\WatchFacade))
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -11,8 +11,6 @@ use function in_array;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
-use function strtr;
-
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
@@ -87,7 +85,7 @@ final class BackslashSeparatorDeprecator
         }
 
         $file = $location->getFile();
-        if ($file === '' || $this->isPhelStdlibSource($file)) {
+        if ($file === '') {
             return;
         }
 
@@ -115,16 +113,6 @@ final class BackslashSeparatorDeprecator
     private function containsBackslashSeparator(string $fullName): bool
     {
         return str_contains($fullName, '\\');
-    }
-
-    private function isPhelStdlibSource(string $file): bool
-    {
-        // Normalize separators so the check works on any OS and for both
-        // the dev-repo layout and Composer-vendored installs.
-        $normalized = strtr($file, '\\', '/');
-
-        return str_contains($normalized, '/src/phel/')
-            || str_ends_with($normalized, '/src/phel');
     }
 
     private function buildMessage(string $original, string $file, int $line): string

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -74,15 +74,6 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertCount(2, $this->captured);
     }
 
-    public function test_suppresses_warnings_from_phel_stdlib_sources(): void
-    {
-        $deprecator = $this->deprecator(enabled: true);
-        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/vendor/phel-lang/phel-lang/src/phel/walk.phel'));
-        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/home/x/phel-lang/src/phel/core.phel'));
-
-        self::assertSame([], $this->captured);
-    }
-
     public function test_suppresses_when_location_is_missing(): void
     {
         $deprecator = $this->deprecator(enabled: true);


### PR DESCRIPTION
## 🤔 Background

The backslash-deprecation work in Phase 1a / Phase 1b ([#1568](https://github.com/phel-lang/phel-lang/pull/1568), [#1569](https://github.com/phel-lang/phel-lang/pull/1569)) points users at the dot form, but the Phel stdlib itself was still written in backslash form. That left new users confused: "you tell me to write `phel.core`, but your own source says `phel\core`?". This PR converts the stdlib so the same syntax is idiomatic everywhere.

Closes the stdlib-rewrite sub-task of [#1567](https://github.com/phel-lang/phel-lang/issues/1567).

## 💡 Goal

Every `ns`, `in-ns`, and `:require` form under `src/phel/**/*.phel` uses dot syntax; PHP-interop forms (`:use \Phel\Lang\Foo`) stay untouched because `\` is the native PHP FQN separator there.

## 🔖 Changes

- **57 `.phel` files** under `src/phel/` updated — `(ns phel\foo)` → `(ns phel.foo)`, `(:require phel\walk ...)` → `(:require phel.walk ...)`, `[phel\walk :as w]` → `[phel.walk :as w]`, and a handful of comments/docstrings referencing `phel\test/assert-expr` style call sites.
- `BackslashSeparatorDeprecator::isPhelStdlibSource()` removed and the corresponding call site stripped. With the stdlib clean, the path-based suppression is no longer needed and would have been a false negative for any user project whose own sources happened to live under a path ending in `/src/phel/`.
- Matching unit test `test_suppresses_warnings_from_phel_stdlib_sources` removed.

## What is NOT changed

- `(:use \Phel\Lang\SourceLocationInterface)` and similar PHP class imports — the backslash syntax is legitimate PHP FQN there, and changing it would couple the decision to `:use` form redesign (out of scope; tracked in #1567).
- String literals that contain `phel\cli:`, `phel\n`, or `.phel` — those are data/messages, not namespace references.

## Validation

- `composer test-compiler` — 2707 tests pass; only the pre-existing `DataReadersAutoloadTest` flake (also fails on main)
- `composer test-core` — 4313/4313 pass
- `PHEL_WARN_DEPRECATIONS=1 ./bin/phel run <probe>` emits zero deprecations during stdlib boot — proof the stdlib is truly clean without needing a suppression allowlist
- PHPStan, rector, cs-fixer (risky) — clean

## Merge order

Independent of #1569. If #1569 merges first there will be a trivial conflict on `BackslashSeparatorDeprecator.php` (singleton constructors vs. suppression removal) which should auto-resolve.