### PR TITLE
feat(core): add == numeric equality function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
 - `into-array` function for `.cljc` interop: `(into-array aseq)` and `(into-array type aseq)` both return a PHP array containing the elements of `aseq`. The `type` argument is accepted for Clojure source compatibility but is ignored in Phel — PHP has no typed arrays. Use `int-array`/`float-array`/etc. when element coercion is needed (#1550)
+- `==` numeric equality function matching Clojure's `clojure.core/==`: type-independent so `(== 1 1.0)` is true, unlike `=` which is type-strict. Throws `\InvalidArgumentException` on non-numeric arguments (#1561)
 
 ### Changed
 

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -108,6 +108,33 @@
       (recur (first more) (next more))
       false)))
 
+(defn- num? [x]
+  (or (php/is_int x) (php/is_float x)))
+
+(defn- num-equals1 [a b]
+  (when-not (num? a)
+    (throw (php/new \InvalidArgumentException
+                    (str "Argument must be a number, got: " a))))
+  (when-not (num? b)
+    (throw (php/new \InvalidArgumentException
+                    (str "Argument must be a number, got: " b))))
+  (php/== a b))
+
+(defn ==
+  "Numeric equality comparison. Returns true if all arguments have the same
+  numeric value regardless of type (e.g. int vs float); throws on non-numeric
+  arguments. Unlike `=`, which is value-and-type-strict, `==` treats `1` and
+  `1.0` as equal, matching Clojure's `clojure.core/==`."
+  {:see-also ["=" "not=" "<" ">"]
+   :example "(== 1 1.0) ; => true"}
+  [a & more]
+  (case (count more)
+    0 (do (num-equals1 a a) true)
+    1 (num-equals1 a (first more))
+    (if (num-equals1 a (first more))
+      (recur (first more) (next more))
+      false)))
+
 (defn not
   "Returns true if value is falsy (nil or false), false otherwise."
   {:example "(not nil) ; => true"}

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -304,6 +304,18 @@
   (is (true? (contains-value? {:a [1 2] :b 3} [1 2])))
   (is (true? (contains-value? {:a nil :b 2} nil))))
 
+(deftest test-numeric-equals
+  (is (true? (== 42)) "(== 42) is true for single arg")
+  (is (true? (== 1 1)) "(== 1 1)")
+  (is (false? (== 1 2)) "(== 1 2)")
+  (is (true? (== 1 1.0)) "(== 1 1.0) — type-independent numeric equality, unlike =")
+  (is (false? (= 1 1.0)) "(= 1 1.0) stays type-strict for contrast")
+  (is (true? (== 1 1 1)) "(== 1 1 1)")
+  (is (true? (== 1.0 1 1.0 1)) "(== 1.0 1 1.0 1)")
+  (is (false? (== 1 1 2)) "(== 1 1 2)")
+  (is (false? (== 1 2 1)) "(== 1 2 1) — short-circuits on first inequality")
+  (is (thrown? \InvalidArgumentException (== 1 "1")) "(== 1 \"1\") rejects non-numeric operand"))
+
 (deftest test-compare
   (is (= -1 (compare 1 2)) "(compare 1 2)")
   (is (= 1 (compare 2 1)) "(compare 2 1)")


### PR DESCRIPTION
## 🤔 Background

Clojure's `clojure.core/==` compares numbers by value regardless of type, so `(== 1 1.0)` is true whereas `(= 1 1.0)` stays false (type-strict). Phel lacked this primitive, which blocks `.cljc` sources that rely on it — encountered in the [clojure-test-suite `reduce.cljc`](https://github.com/jasalt/clojure-test-suite/blob/dd1b4e37b569b687747879becafcf43ec76bbd07/test/clojure/core_test/reduce.cljc#L88) ([failing CI run](https://github.com/jasalt/clojure-test-suite/actions/runs/24872969940/job/72823216086#step:7:11)).

Closes #1561.

## 💡 Goal

Ship `==` in `phel\core` with Clojure-aligned semantics so cross-dialect sources port cleanly.

## 🔖 Changes

- `src/phel/core/booleans.phel` — new `==` function plus a private `num?`/`num-equals1` pair for type validation. Private helpers avoid depending on `predicates.phel`'s `number?`, which loads later in the core boot order
- `tests/phel/test/core/boolean-operation.phel` — new `test-numeric-equals` covering single-arg, type-independent pairwise equality, short-circuiting on first inequality, and the non-numeric rejection

## Design notes

- No `:inline` optimization: the runtime type check is the contract here, and inlining would bypass it for the common 2-arg path. Performance of a brand-new numeric primitive is not the bottleneck worth optimizing ahead of correctness.
- Arity 1 is `true` (following the `=` precedent) but still runs the type check so `(== "1")` throws. Clojure returns true unconditionally for single args; this is a deliberate slight deviation to prevent silent acceptance of non-numeric inputs, consistent with the throw contract for ≥ 2 args.

## Validation

- `composer test-core` — 4323/4323 (10 new assertions)
- `composer test-compiler` — 2707 pass (only pre-existing `DataReadersAutoloadTest` flake that also fails on main)
- PHPStan, rector, cs-fixer (risky) — clean