### PR TITLE
feat(core): add two-arg arity to int-array and sibling typed-array builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
+- `int-array`, `long-array`, `float-array`, `double-array`, and `short-array` gain a second arity `[size init-val-or-seq]` matching Clojure: when `init-val-or-seq` is a number every slot is filled with it (coerced); when a sequence, its elements fill the prefix (truncated to `size`) and remaining slots are zero-padded. Closes #1562
 - `into-array` function for `.cljc` interop: `(into-array aseq)` and `(into-array type aseq)` both return a PHP array containing the elements of `aseq`. The `type` argument is accepted for Clojure source compatibility but is ignored in Phel — PHP has no typed arrays. Use `int-array`/`float-array`/etc. when element coercion is needed (#1550)
 
 ### Changed

--- a/src/phel/core/arrays.phel
+++ b/src/phel/core/arrays.phel
@@ -110,65 +110,93 @@
   [arr]
   (php/count (ensure-php-array "alength" arr)))
 
+(defn- typed-array-coerce-seq
+  [coerce-fn size seq-src]
+  (let [src (to-php-array seq-src)
+        n   (php/count src)
+        len (if (php/=== nil size)
+              n
+              (if (php/< n size) n size))
+        res (php/array)]
+    (loop [i 0]
+      (if (php/< i len)
+        (do
+          (php/aset res i (coerce-fn (php/aget src i)))
+          (recur (php/+ i 1)))
+        nil))
+    res))
+
+(defn- typed-array-with-size
+  [coerce-fn default size init]
+  (if (php/< size 0)
+    (throw (php/new InvalidArgumentException "Array size must be non-negative"))
+    (if (php/=== 0 size)
+      (php/array)
+      (if (php/=== nil init)
+        (php/array_fill 0 size default)
+        (if (if (php/is_int init) true (php/is_float init))
+          (php/array_fill 0 size (coerce-fn init))
+          (let [prefix (typed-array-coerce-seq coerce-fn size init)
+                pad    (php/- size (php/count prefix))]
+            (if (php/> pad 0)
+              (php/array_merge prefix (php/array_fill 0 pad default))
+              prefix)))))))
+
 (defn- typed-array
-  [coerce-fn default size-or-seq]
-  (if (php/is_int size-or-seq)
-    (if (php/< size-or-seq 0)
-      (throw (php/new InvalidArgumentException "Array size must be non-negative"))
-      (if (php/=== 0 size-or-seq)
-        (php/array)
-        (php/array_fill 0 size-or-seq default)))
-    (let [arr    (to-php-array size-or-seq)
-          len    (php/count arr)
-          result (php/array)]
-      (loop [i 0]
-        (if (php/< i len)
-          (do
-            (php/aset result i (coerce-fn (php/aget arr i)))
-            (recur (php/+ i 1)))
-          nil))
-      result)))
+  ([coerce-fn default size-or-seq]
+   (if (php/is_int size-or-seq)
+     (typed-array-with-size coerce-fn default size-or-seq nil)
+     (typed-array-coerce-seq coerce-fn nil size-or-seq)))
+  ([coerce-fn default size init-val-or-seq]
+   (typed-array-with-size coerce-fn default size init-val-or-seq)))
 
 (defn int-array
-  "Creates a PHP array of integers. Given a size, fills with `0`.
-   Given a sequence, coerces each element to int via `intval`.
-   PHP has no typed arrays, so the result is a plain PHP array."
-  {:example "(int-array 3) ; => PHP array [0, 0, 0]\n(int-array [1.5 2.7]) ; => PHP array [1, 2]"
+  "Creates a PHP array of integers, matching Clojure's `clojure.core/int-array`.
+
+  - `(int-array size-or-seq)` — given a non-negative integer, fills with `0`;
+    given a sequence, coerces each element to int via `intval`.
+  - `(int-array size init-val-or-seq)` — when `init-val-or-seq` is a number, every
+    slot is filled with it (coerced to int). When it is a sequence, its elements
+    fill the prefix of the array (truncated to `size` if longer) and the remaining
+    slots are zero-padded.
+
+  PHP has no typed arrays, so the result is a plain PHP array."
+  {:example "(int-array 3) ; => PHP array [0, 0, 0]\n(int-array [1.5 2.7]) ; => PHP array [1, 2]\n(int-array 4 7) ; => PHP array [7, 7, 7, 7]\n(int-array 5 [10 20]) ; => PHP array [10, 20, 0, 0, 0]"
    :see-also ["long-array" "float-array" "double-array" "short-array" "object-array"]}
-  [size-or-seq]
-  (typed-array php/intval 0 size-or-seq))
+  ([size-or-seq] (typed-array php/intval 0 size-or-seq))
+  ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn long-array
-  "Creates a PHP array of longs (same as int-array in PHP).
-   Given a size, fills with `0`. Given a sequence, coerces each element to int."
-  {:example "(long-array 3) ; => PHP array [0, 0, 0]\n(long-array [1.5 2.7]) ; => PHP array [1, 2]"
+  "Creates a PHP array of longs (same as int-array in PHP). Accepts the same
+  arities and semantics as `int-array`."
+  {:example "(long-array 3) ; => PHP array [0, 0, 0]\n(long-array 4 7) ; => PHP array [7, 7, 7, 7]"
    :see-also ["int-array" "float-array" "double-array" "short-array"]}
-  [size-or-seq]
-  (typed-array php/intval 0 size-or-seq))
+  ([size-or-seq] (typed-array php/intval 0 size-or-seq))
+  ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn float-array
-  "Creates a PHP array of floats. Given a size, fills with `0.0`.
-   Given a sequence, coerces each element to float via `floatval`."
-  {:example "(float-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(float-array [1 2]) ; => PHP array [1.0, 2.0]"
+  "Creates a PHP array of floats. Accepts the same arities as `int-array`;
+  coerces elements to float via `floatval` and zero-pads with `0.0`."
+  {:example "(float-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(float-array 4 1.5) ; => PHP array [1.5, 1.5, 1.5, 1.5]"
    :see-also ["double-array" "int-array" "long-array" "short-array"]}
-  [size-or-seq]
-  (typed-array php/floatval 0.0 size-or-seq))
+  ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
+  ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
 
 (defn double-array
-  "Creates a PHP array of doubles (same as float-array in PHP).
-   Given a size, fills with `0.0`. Given a sequence, coerces each element to float."
-  {:example "(double-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(double-array [1 2]) ; => PHP array [1.0, 2.0]"
+  "Creates a PHP array of doubles (same as float-array in PHP). Accepts the same
+  arities and semantics as `float-array`."
+  {:example "(double-array 3) ; => PHP array [0.0, 0.0, 0.0]\n(double-array 4 1.5) ; => PHP array [1.5, 1.5, 1.5, 1.5]"
    :see-also ["float-array" "int-array" "long-array" "short-array"]}
-  [size-or-seq]
-  (typed-array php/floatval 0.0 size-or-seq))
+  ([size-or-seq] (typed-array php/floatval 0.0 size-or-seq))
+  ([size init-val-or-seq] (typed-array php/floatval 0.0 size init-val-or-seq)))
 
 (defn short-array
-  "Creates a PHP array of shorts (16-bit integers). Given a size, fills with `0`.
-   Given a sequence, coerces each element to int via `intval`."
-  {:example "(short-array 3) ; => PHP array [0, 0, 0]\n(short-array [1.5 2.7]) ; => PHP array [1, 2]"
+  "Creates a PHP array of shorts (16-bit integers). Accepts the same arities
+  and semantics as `int-array`."
+  {:example "(short-array 3) ; => PHP array [0, 0, 0]\n(short-array 4 7) ; => PHP array [7, 7, 7, 7]"
    :see-also ["int-array" "long-array" "float-array" "double-array"]}
-  [size-or-seq]
-  (typed-array php/intval 0 size-or-seq))
+  ([size-or-seq] (typed-array php/intval 0 size-or-seq))
+  ([size init-val-or-seq] (typed-array php/intval 0 size init-val-or-seq)))
 
 (defn aget
   "Returns the value at `index` in a PHP array. With multiple indices,

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -266,6 +266,33 @@
     (is (= 2 (php/aget arr 1)) "int-array truncates float")
     (is (= 3 (php/aget arr 2)) "int-array truncates float")))
 
+(deftest test-int-array-size-with-init-value
+  (let [arr (int-array 4 7)]
+    (is (= 4 (php/count arr)) "int-array size with init has correct length")
+    (is (= 7 (php/aget arr 0)) "all slots filled with init value")
+    (is (= 7 (php/aget arr 1)))
+    (is (= 7 (php/aget arr 2)))
+    (is (= 7 (php/aget arr 3))))
+  (let [arr (int-array 3 1.9)]
+    (is (= 1 (php/aget arr 0)) "init value coerced to int")))
+
+(deftest test-int-array-size-with-seq-copies-and-pads
+  (let [arr (int-array 5 [10 20])]
+    (is (= 5 (php/count arr)) "int-array size takes precedence over shorter seq")
+    (is (= 10 (php/aget arr 0)) "seq element copied at 0")
+    (is (= 20 (php/aget arr 1)) "seq element copied at 1")
+    (is (= 0 (php/aget arr 2)) "remaining slots default-padded with 0")
+    (is (= 0 (php/aget arr 3)))
+    (is (= 0 (php/aget arr 4))))
+  (let [arr (int-array 2 [10 20 30 40 50])]
+    (is (= 2 (php/count arr)) "seq longer than size is truncated to size")
+    (is (= 10 (php/aget arr 0)))
+    (is (= 20 (php/aget arr 1)))))
+
+(deftest test-int-array-rejects-negative-size
+  (is (thrown? \InvalidArgumentException (int-array -1)))
+  (is (thrown? \InvalidArgumentException (int-array -1 7))))
+
 (deftest test-long-array-from-size
   (let [arr (long-array 2)]
     (is (php/is_array arr) "long-array returns a PHP array")


### PR DESCRIPTION
## 🤔 Background

Clojure's `clojure.core/int-array` ships two arities: `([size-or-seq] [size init-val-or-seq])`. Phel had only the single-arg form, so shared `.cljc` sources that use the two-arg call fail — specifically [clojure-test-suite `reduce.cljc`](https://github.com/jasalt/clojure-test-suite/blob/dd1b4e37b569b687747879becafcf43ec76bbd07/test/clojure/core_test/reduce.cljc#L96).

Closes #1562.

## 💡 Goal

Match Clojure's arity and semantics across all five typed-array builders so `.cljc` sources port cleanly.

## 🔖 Changes

- `src/phel/core/arrays.phel` — the shared `typed-array` helper now dispatches to two private workers:
  - `typed-array-coerce-seq` for the seq-only path
  - `typed-array-with-size` for the size-with-optional-init path
- `int-array`, `long-array`, `float-array`, `double-array`, `short-array` each gain the second arity. Semantics:
  - `(int-array 4 7)` → `[7 7 7 7]` — scalar init, all slots filled (coerced)
  - `(int-array 5 [10 20])` → `[10 20 0 0 0]` — seq prefix + zero-pad
  - `(int-array 2 [10 20 30 40 50])` → `[10 20]` — seq truncated to size
- `tests/phel/test/core/basic-constructors.phel` — new test cases cover scalar init, seq-pad, seq-truncation, and negative size rejection across both arities

## Design notes

- The helpers deliberately use only `if` / `let` / `loop` / `do`. `when`, `cond`, and `or` aren't available yet at `arrays.phel` load time — they come from namespaces that depend on `arrays.phel`.

## Validation

- `composer test-core` — 4330/4330 (17 new assertions)
- `composer test-compiler` — unchanged baseline (only the pre-existing `DataReadersAutoloadTest` flake)
- PHPStan, rector, cs-fixer (risky) — clean