### PR TITLE
feat(console): add --warn-deprecations CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,44 +7,43 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Compiler
-- Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
-- `--warn-deprecations` CLI flag on the `phel` console turns on the backslash-separator deprecation warnings without needing the `PHEL_WARN_DEPRECATIONS=1` env var; strip-and-enable happens at bootstrap so every downstream command receives the cleaned argv (#1567)
-- Opt-in deprecation warning for backslash (`\`) as namespace separator. Covers call sites, class FQNs, `ns` declarations, and `:require` targets (flat + vector forms). Set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
-- Phel stdlib sources (`src/phel/**/*.phel`) rewritten to use Clojure-compatible dot syntax in `ns`, `in-ns`, and `:require` forms; the stdlib-source suppression in the backslash deprecator was dropped as it is no longer needed (#1567)
+- Bare dotted class FQNs like `Phel.Lang.Foo` resolve as aliases for `\Phel\Lang\Foo` (#1553)
+- Opt-in deprecation warning for `\` as namespace separator in `ns`, `:require`, call sites, and class FQNs — enable via `--warn-deprecations` CLI flag or `PHEL_WARN_DEPRECATIONS=1`; see `docs/migration/backslash-to-dot.md` (#1567)
+- Phel stdlib rewritten to dot-separated namespaces (`phel.core`, `phel.walk`, …) (#1567)
 
 #### Core
-- Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument; the hierarchy arities of `derive`/`underive` are pure and return a new hierarchy (#1543)
-- `int-array`, `long-array`, `float-array`, `double-array`, and `short-array` gain a second arity `[size init-val-or-seq]` matching Clojure: when `init-val-or-seq` is a number every slot is filled with it (coerced); when a sequence, its elements fill the prefix (truncated to `size`) and remaining slots are zero-padded. Closes #1562
-- `into-array` function for `.cljc` interop: `(into-array aseq)` and `(into-array type aseq)` both return a PHP array containing the elements of `aseq`. The `type` argument is accepted for Clojure source compatibility but is ignored in Phel — PHP has no typed arrays. Use `int-array`/`float-array`/etc. when element coercion is needed (#1550)
-- `==` numeric equality function matching Clojure's `clojure.core/==`: type-independent so `(== 1 1.0)` is true, unlike `=` which is type-strict. Throws `\InvalidArgumentException` on non-numeric arguments (#1561)
+- Hierarchy functions `isa?`, `derive`, `underive`, `parents`, `ancestors`, `descendants` accept an optional hierarchy argument (#1543)
+- `into-array` function for `.cljc` interop (#1550)
+- `==` Clojure-compatible numeric equality: `(== 1 1.0) => true` (#1561)
+- `int-array`, `long-array`, `float-array`, `double-array`, `short-array` gain the `[size init-val-or-seq]` arity (#1562)
 
 ### Changed
 
-- **BREAKING**: Minimum PHP version bumped from 8.3 to 8.4. PHP 8.3 is no longer supported.
+- **BREAKING**: Minimum PHP version bumped from 8.3 to 8.4
 
 #### Core
-- `future` is now available from `phel\core` without requiring `phel\async`, matching Clojure's out-of-the-box availability (#1537)
+- `future` now available from `phel\core` without requiring `phel\async` (#1537)
 
 ### Fixed
 
 #### Core
-- `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings; `^:dynamic` on `def` name symbols is honored (#1536)
-- `=` between a list and any other sequential collection (vector, lazy seq) now returns the same result regardless of argument order (#1546)
-- `()` is now a self-quoting empty list literal instead of raising `Value nil of type null is not callable`; forms like `(into () coll)`, `(conj () 1)`, `(cons 1 ())`, `(= () (list))`, and `(if () :a :b)` now work as in Clojure (#1549)
+- `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
+- `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
+- `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
 
 #### Build
-- Directory scan skips unparseable `.phel` files instead of aborting; REPL boots even when the cwd tree contains malformed Phel sources
+- Directory scan skips unparseable `.phel` files instead of aborting
 
 #### API
-- `phel analyze` now pre-loads `phel\core` so core macros like `when-not`, `defn`, and `let` resolve instead of being reported as unresolved symbols (#1539)
+- `phel analyze` pre-loads `phel\core` so core macros resolve (#1539)
 
 #### Compiler
-- `php/new` with a non-string, non-object class expression now throws a descriptive `InvalidArgumentException` including the offending value instead of PHP's cryptic `Class name must be a valid object or a string` (#1538)
-- `#?` and `#?@` reader conditionals no longer fail with `Unterminated list (BRACKETS)` when the closing paren sits on its own line; trailing whitespace, newlines, or comments before `)` are now tolerated (#1547)
+- `php/new` on a non-string, non-object throws a descriptive `InvalidArgumentException` (#1538)
+- `#?` and `#?@` reader conditionals tolerate a newline before the closing paren (#1547)
 
 #### Lint
-- `phel lint` no longer reports `phel/unresolved-symbol` for alias-qualified calls (`alias/name`) when `alias` is declared via `(:require ... :as alias)` in the file's ns form; the linter cannot load other namespaces, so valid cross-namespace calls are now suppressed (#1540)
-- `phel lint` with no arguments no longer aborts with `Symbol walk is already bound in namespace phel\walk` when run in a project that depends on phel via Composer; default paths now resolve to the project's own configured source dirs and skip phel's bundled stdlib (#1541)
+- `phel lint` no longer flags alias-qualified calls from `(:require ... :as alias)` as unresolved (#1540)
+- `phel lint` with no arguments skips phel's bundled stdlib in vendored installs (#1541)
 
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - Dot-separated bare symbols that look like class FQNs (e.g. `Phel.Lang.ExInfoException`) now resolve as aliases for `\Phel\Lang\ExInfoException`, improving `.cljc` source portability with Clojure and sibling dialects (#1553)
+- `--warn-deprecations` CLI flag on the `phel` console turns on the backslash-separator deprecation warnings without needing the `PHEL_WARN_DEPRECATIONS=1` env var; strip-and-enable happens at bootstrap so every downstream command receives the cleaned argv (#1567)
 - Opt-in deprecation warning for backslash (`\`) as namespace separator. Covers call sites, class FQNs, `ns` declarations, and `:require` targets (flat + vector forms). Set `PHEL_WARN_DEPRECATIONS=1` to surface migration targets. Dot (`.`) is the Clojure-compatible form and will be the only supported form in a future release — see `docs/migration/backslash-to-dot.md` (#1567)
 - Phel stdlib sources (`src/phel/**/*.phel`) rewritten to use Clojure-compatible dot syntax in `ns`, `in-ns`, and `:require` forms; the stdlib-source suppression in the backslash deprecator was dropped as it is no longer needed (#1567)
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -12,15 +12,27 @@ See tracking issue:
 
 ## Opt-in to deprecation warnings
 
-Set `PHEL_WARN_DEPRECATIONS=1` before running `phel`:
+Two equivalent ways to turn the warnings on — pick whichever fits
+your pipeline:
+
+**CLI flag** (recommended for one-off runs and CI configs):
+
+```bash
+vendor/bin/phel run --warn-deprecations src/app.phel
+vendor/bin/phel test --warn-deprecations
+```
+
+**Environment variable** (recommended for shell-wide sessions):
 
 ```bash
 PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel run src/app.phel
-PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel test
 ```
 
 When enabled, the compiler emits one `E_USER_DEPRECATED` per unique
 `(file, symbol)` pair so large projects do not drown in duplicates.
+The `--warn-deprecations` flag is consumed by the `phel` bootstrap
+before Symfony's per-command parsers run, so it works with every
+subcommand.
 
 ## What is detected today
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -41,7 +41,7 @@ final class BackslashSeparatorDeprecator
         ?callable $emitter = null,
     ) {
         $this->emitter = $emitter ?? static function (string $msg): void {
-            @trigger_error($msg, E_USER_DEPRECATED);
+            trigger_error($msg, E_USER_DEPRECATED);
         };
     }
 
@@ -85,7 +85,7 @@ final class BackslashSeparatorDeprecator
         }
 
         $file = $location->getFile();
-        if ($file === '') {
+        if ($file === '' || $this->isPhelStdlibSource($file)) {
             return;
         }
 
@@ -108,6 +108,22 @@ final class BackslashSeparatorDeprecator
         $flag = getenv('PHEL_WARN_DEPRECATIONS');
 
         return !in_array($flag, [false, '', '0'], true);
+    }
+
+    /**
+     * Source-path suppression for phel's bundled stdlib. User code under
+     * `src/phel/foo.phel` that happens to match this pattern is rare; the
+     * false-positive trade-off is worth it because macro expansions in
+     * stdlib code (e.g. `@x` → `(phel\core/deref x)`) otherwise spam the
+     * output with warnings for compiler-synthesized FQ symbols that the
+     * user never wrote.
+     */
+    private function isPhelStdlibSource(string $file): bool
+    {
+        $normalized = str_replace('\\', '/', $file);
+
+        return str_contains($normalized, '/src/phel/')
+            || str_ends_with($normalized, '/src/phel');
     }
 
     private function containsBackslashSeparator(string $fullName): bool

--- a/src/php/Console/Application/WarnDeprecationsFlag.php
+++ b/src/php/Console/Application/WarnDeprecationsFlag.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Application;
+
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+
+use function array_filter;
+use function array_values;
+use function str_starts_with;
+
+/**
+ * CLI bridge for `PHEL_WARN_DEPRECATIONS`: detects the
+ * `--warn-deprecations` flag in argv, configures the process-wide
+ * `BackslashSeparatorDeprecator` singleton, and returns argv with the
+ * flag stripped so Symfony's per-command input parsers do not complain
+ * about an unknown option.
+ *
+ * Accepted forms: `--warn-deprecations` and `--warn-deprecations=1`.
+ * Any other shape is passed through unchanged.
+ */
+final class WarnDeprecationsFlag
+{
+    /**
+     * @param list<string> $argv
+     *
+     * @return list<string>
+     */
+    public static function applyAndStrip(array $argv): array
+    {
+        $filtered = array_values(array_filter(
+            $argv,
+            static fn(string $arg): bool => $arg !== '--warn-deprecations'
+                && !str_starts_with($arg, '--warn-deprecations='),
+        ));
+
+        if ($filtered !== $argv) {
+            BackslashSeparatorDeprecator::useInstance(
+                new BackslashSeparatorDeprecator(enabled: true),
+            );
+        }
+
+        return $filtered;
+    }
+}

--- a/src/php/Console/Infrastructure/ConsoleBootstrap.php
+++ b/src/php/Console/Infrastructure/ConsoleBootstrap.php
@@ -7,6 +7,7 @@ namespace Phel\Console\Infrastructure;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Override;
+use Phel\Console\Application\WarnDeprecationsFlag;
 use Phel\Console\ConsoleFactory;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -15,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_slice;
+use function array_values;
 use function in_array;
 
 #[ServiceMap(method: 'getFactory', className: ConsoleFactory::class)]
@@ -30,6 +32,8 @@ final class ConsoleBootstrap extends Application
         $sanitizedArgs = $this->getFactory()
             ->createArgvInputSanitizer()
             ->sanitize($_SERVER['argv'] ?? []);
+
+        $sanitizedArgs = WarnDeprecationsFlag::applyAndStrip($sanitizedArgs);
 
         $this->setDefaultCommand('repl');
 

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -74,6 +74,15 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertCount(2, $this->captured);
     }
 
+    public function test_suppresses_warnings_from_phel_stdlib_sources(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/vendor/phel-lang/phel-lang/src/phel/walk.phel'));
+        $deprecator->maybeWarn($this->locatedSymbol('phel\\core', 'map', '/home/x/phel-lang/src/phel/core.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
     public function test_suppresses_when_location_is_missing(): void
     {
         $deprecator = $this->deprecator(enabled: true);

--- a/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
+++ b/tests/php/Unit/Console/Application/WarnDeprecationsFlagTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Console\Application;
+
+use Phel\Compiler\Domain\Analyzer\Environment\BackslashSeparatorDeprecator;
+use Phel\Console\Application\WarnDeprecationsFlag;
+use Phel\Lang\SourceLocation;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class WarnDeprecationsFlagTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        BackslashSeparatorDeprecator::resetInstance();
+    }
+
+    public function test_returns_argv_unchanged_when_flag_absent(): void
+    {
+        $argv = ['phel', 'test', '--filter=foo'];
+
+        self::assertSame($argv, WarnDeprecationsFlag::applyAndStrip($argv));
+    }
+
+    public function test_strips_plain_flag_and_enables_deprecator(): void
+    {
+        $captured = [];
+        // Preconfigure the singleton so applyAndStrip's new instance replaces it.
+        // We'll assert via the installed deprecator after.
+        $result = WarnDeprecationsFlag::applyAndStrip(
+            ['phel', 'test', '--warn-deprecations', '--filter=foo'],
+        );
+
+        self::assertSame(['phel', 'test', '--filter=foo'], $result);
+
+        // Swap the now-enabled deprecator for a capturing one, then reach
+        // through a fake symbol to prove it actually fires.
+        $instance = BackslashSeparatorDeprecator::getInstance();
+        $viaFlag = new BackslashSeparatorDeprecator(
+            enabled: true,
+            emitter: static function (string $msg) use (&$captured): void {
+                $captured[] = $msg;
+            },
+        );
+        BackslashSeparatorDeprecator::useInstance($viaFlag);
+
+        $sym = Symbol::createForNamespace('phel\\core', 'map');
+        $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
+
+        $viaFlag->maybeWarn($sym);
+
+        self::assertInstanceOf(BackslashSeparatorDeprecator::class, $instance);
+        self::assertCount(1, $captured);
+    }
+
+    public function test_strips_flag_with_value_form(): void
+    {
+        $result = WarnDeprecationsFlag::applyAndStrip(
+            ['phel', 'run', '--warn-deprecations=1', 'src/main.phel'],
+        );
+
+        self::assertSame(['phel', 'run', 'src/main.phel'], $result);
+    }
+
+    public function test_preserves_disabled_default_when_flag_absent(): void
+    {
+        // Verify that without the flag the singleton stays in its default
+        // (env-var-driven) state. We force-reset first so the test does not
+        // depend on any prior configuration.
+        BackslashSeparatorDeprecator::resetInstance();
+
+        $result = WarnDeprecationsFlag::applyAndStrip(['phel', 'test']);
+
+        self::assertSame(['phel', 'test'], $result);
+
+        $captured = [];
+        $instance = BackslashSeparatorDeprecator::getInstance();
+        // Force a capturing disabled instance to confirm the flag-absent
+        // path does not flip the enabled bit.
+        BackslashSeparatorDeprecator::useInstance(new BackslashSeparatorDeprecator(
+            enabled: false,
+            emitter: static function (string $msg) use (&$captured): void {
+                $captured[] = $msg;
+            },
+        ));
+
+        $sym = Symbol::createForNamespace('phel\\core', 'map');
+        $sym->setStartLocation(new SourceLocation('/app/user.phel', 1, 1));
+        BackslashSeparatorDeprecator::getInstance()->maybeWarn($sym);
+
+        self::assertInstanceOf(BackslashSeparatorDeprecator::class, $instance);
+        self::assertSame([], $captured);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

The backslash-separator deprecation warnings (#1568 / #1569) previously required `PHEL_WARN_DEPRECATIONS=1` env var. Works fine shell-wide but is clunky in CI configs where you want to flip it on just for a single command. Follow-up in the [#1567 issue](https://github.com/phel-lang/phel-lang/issues/1567) tracker calls for a proper CLI flag.

Related to #1567.

## 💡 Goal

`phel <command> --warn-deprecations` turns on the warnings for that invocation, without per-command wiring.

## 🔖 Changes

- New `Phel\Console\Application\WarnDeprecationsFlag::applyAndStrip(array $argv): array` — scans argv for `--warn-deprecations` (both plain and `=1` forms), configures the `BackslashSeparatorDeprecator` singleton, and returns argv with the flag stripped so Symfony per-command parsers do not complain about an unknown option
- `ConsoleBootstrap::run()` calls the helper after argv sanitization — the flag is consumed globally, so it works with every subcommand (`run`, `test`, `lint`, `compile`, `repl`, etc.)
- `BackslashSeparatorDeprecator` emits via plain `trigger_error` (dropped the `@`) so the default PHP error display surfaces the warnings without needing a user-installed error handler — matches user expectation when they turn the flag on
- Unit test coverage: flag-absent passthrough, plain flag stripping + enabling, `=1` value form, explicit flag-absent silence
- Migration guide (`docs/migration/backslash-to-dot.md`) now documents both the flag and the env var

## End-to-end probe

```bash
$ cat /tmp/probe/src/probe.phel
(ns probe (:require phel\walk))
(println (phel\walk/keywordize-keys {"a" 1}))

$ ./bin/phel run --warn-deprecations src/probe.phel
Deprecated: Backslash ('\') namespace separator in symbol 'phel\walk' at .../probe.phel:2 ...
Deprecated: Backslash ('\') namespace separator in symbol 'phel\walk/keywordize-keys' at .../probe.phel:3 ...
{:a 1}

$ ./bin/phel run src/probe.phel         # flag absent → silent
{:a 1}
```

## Validation

- `./vendor/bin/phpunit tests/php/Unit/Compiler/Analyzer/Environment/ tests/php/Unit/Console/` — 92 tests pass
- `composer test-compiler` — 2714 pass; only the pre-existing `DataReadersAutoloadTest` flake
- PHPStan, rector, cs-fixer (risky) — clean