### PR TITLE
feat(compiler): resolve bare uppercase symbols as root-namespace class FQN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Compiler
-- Bare dotted class FQNs like `Phel.Lang.Foo` resolve as aliases for `\Phel\Lang\Foo` (#1553)
+- Bare dotted class FQNs like `Phel.Lang.Foo` resolve as aliases for `\Phel\Lang\Foo`; bare uppercase names like `Exception` resolve as root-namespace aliases for `\Exception` (#1553)
 - Opt-in deprecation warning for `\` as namespace separator in `ns`, `:require`, `:use`, call sites, and class FQNs — enable via `--warn-deprecations` CLI flag or `PHEL_WARN_DEPRECATIONS=1`; see `docs/migration/backslash-to-dot.md` (#1567)
 - Phel stdlib rewritten to dot-separated namespaces (`phel.core`, `phel.walk`, …) (#1567)
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -58,9 +58,26 @@ final readonly class SymbolResolver
             return $useAliasNode;
         }
 
-        return ($name->getNamespace() !== null)
+        $resolved = ($name->getNamespace() !== null)
             ? $this->resolveWithAlias($name, $env)
             : $this->resolveWithoutAlias($name, $env);
+
+        if ($resolved instanceof AbstractNode) {
+            return $resolved;
+        }
+
+        // Fallback: a bare uppercase identifier with no other resolution is
+        // treated as a PHP root-namespace class FQN, so `Exception` resolves
+        // the same as `\Exception`. Kicks in *after* the normal resolution
+        // paths so user-defined definitions (`(def Foo …)`) still win.
+        if ($name->getNamespace() === null && $this->looksLikeBareClassName($strName)) {
+            $fqn = Symbol::create('\\' . $strName);
+            $fqn->copyLocationFrom($name);
+
+            return new PhpClassNameNode($env, $fqn, $name->getStartLocation());
+        }
+
+        return null;
     }
 
     private function resolveFromUseAlias(Symbol $name, NodeEnvironmentInterface $env): ?PhpClassNameNode
@@ -105,6 +122,17 @@ final readonly class SymbolResolver
     private function looksLikeDotSeparatedClassFqn(string $name): bool
     {
         return preg_match('/^[A-Z]\w*(\.[A-Za-z_]\w*)+$/', $name) === 1;
+    }
+
+    /**
+     * Accept bare uppercase identifiers as root-namespace PHP class FQN
+     * aliases, so `Exception` resolves the same as `\Exception`. Matches
+     * Clojure's convention where bare `Exception` resolves via
+     * `java.lang` autoimport.
+     */
+    private function looksLikeBareClassName(string $name): bool
+    {
+        return preg_match('/^[A-Z]\w*$/', $name) === 1;
     }
 
     private function remapClojureAlias(string $alias): string

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -329,12 +329,37 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
-    public function test_resolve_bare_name_without_dot_is_not_class_fqn(): void
+    public function test_resolve_bare_top_level_class(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\Exception')),
+            $this->resolver->resolve(Symbol::create('Exception'), $nodeEnv),
+        );
+    }
+
+    public function test_bare_lowercase_name_does_not_become_class_fqn(): void
     {
         $nodeEnv = NodeEnvironment::empty();
 
         self::assertNotInstanceOf(
             PhpClassNameNode::class,
+            $this->resolver->resolve(Symbol::create('foo-undefined'), $nodeEnv),
+        );
+    }
+
+    public function test_user_defined_def_wins_over_bare_class_fallback(): void
+    {
+        // When a user defines `(def Foo 42)` in the current ns, the bare `Foo`
+        // must resolve to that GlobalVar, not to a PHP class FQN `\Foo`.
+        $this->globalEnv->setNs('user');
+        $this->globalEnv->addDefinition('user', Symbol::create('Foo'));
+
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new GlobalVarNode($nodeEnv, 'user', Symbol::create('Foo'), Phel::map()),
             $this->resolver->resolve(Symbol::create('Foo'), $nodeEnv),
         );
     }


### PR DESCRIPTION
## 🤔 Background

Follow-up to #1566 ([reopen comment](https://github.com/phel-lang/phel-lang/issues/1553#issuecomment-4313406575) from @jasalt). The dot-FQN regex in #1566 required at least one dot, so bare top-level classes like `Exception` still raised `[PHEL001] Cannot resolve symbol 'Exception'` while the dotted form worked.

```clojure
(new Exception)
;; [PHEL001] Cannot resolve symbol 'Exception'

(new Phel.Lang.ExInfoException)
;; ArgumentCountError (resolved as expected)
```

Closes #1553.

## 💡 Goal

Bare uppercase identifiers with no other resolution resolve as PHP root-namespace class FQN aliases, matching Clojure's bare `Exception` convention (where `java.lang` is auto-imported).

## 🔖 Changes

- `SymbolResolver::resolve()` grows a fallback branch *after* the existing resolution paths (use-alias → resolve-with-alias / resolve-without-alias). If those return `null` and the symbol is a bare uppercase identifier matching `^[A-Z]\w*$`, wrap it in a `PhpClassNameNode` with a `\<name>` FQN
- Placement guarantees precedence: user-defined `(def Foo 42)` still resolves to the GlobalVar, never to `\Foo`. The fallback only catches genuinely-undefined uppercase symbols
- New helper `looksLikeBareClassName` alongside the existing `looksLikeDotSeparatedClassFqn`
- Three unit tests:
  - `test_resolve_bare_top_level_class` — `Exception` → `PhpClassNameNode('\Exception')`
  - `test_bare_lowercase_name_does_not_become_class_fqn` — `foo-undefined` still returns null
  - `test_user_defined_def_wins_over_bare_class_fallback` — `(def Foo …)` precedence preserved

## End-to-end probe

```clojure
(ns probe)
(try (throw (php/new Exception "bare-class works"))
     (catch Exception e (println "caught:" (php/-> e (getMessage)))))
;; caught: bare-class works
```

## Validation

- `composer test-compiler` — 2718 pass (only pre-existing `DataReadersAutoloadTest` flake)
- `composer test-core` — 4340/4340 pass
- PHPStan, rector, cs-fixer (risky) — clean