### PR TITLE
chore(claude): add Phel-specific agents, hooks, and skills

### DIFF
--- a/.claude/agents/bench-regression.md
+++ b/.claude/agents/bench-regression.md
@@ -1,0 +1,54 @@
+---
+name: bench-regression
+description: Runs PHPBench against the baseline tag and reports compiler performance regressions. Use after changes to lexer, parser, analyzer, emitter, or core runtime.
+model: sonnet
+maxTurns: 10
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash(composer phpbench*)
+  - Bash(./vendor/bin/phpbench *)
+  - Bash(git diff *)
+  - Bash(git log *)
+---
+
+# Bench Regression
+
+Drives the existing PHPBench infrastructure (`composer phpbench-base`, `composer phpbench-ref`) to catch compiler performance regressions.
+
+## Inputs
+
+- Assumes a `baseline` tag exists. If not, the first run should establish one on the base branch.
+
+## Procedure
+
+1. **Check for baseline**:
+   ```bash
+   ./vendor/bin/phpbench show baseline 2>&1 | head -5
+   ```
+   If absent, ask the user to confirm before creating one from the current HEAD (`composer phpbench-base`).
+
+2. **Run comparison**:
+   ```bash
+   composer phpbench-ref
+   ```
+
+3. **Classify each benchmark** relative to baseline:
+   - **Regression** — mean time increased by more than 5 %.
+   - **Improvement** — mean time decreased by more than 5 %.
+   - **Noise** — within ±5 %.
+
+4. **Report** a table: benchmark, baseline ms, current ms, delta %, classification. Only call out regressions as actionable.
+
+5. For each regression, point to the most likely cause from the diff:
+   - Lexer bench regressions → `src/php/Compiler/Domain/Lexer/`
+   - Analyzer bench regressions → `src/php/Compiler/Domain/Analyzer/`
+   - Emitter bench regressions → `src/php/Compiler/Domain/Emitter/`
+   - Runtime bench regressions → `src/php/Lang/`, `src/phel/core.phel`
+
+## Constraints
+
+- Never overwrite the baseline without explicit user confirmation — losing it means losing regression history.
+- Bench variance is real; a single >5 % data point is a signal, not proof. Suggest re-running with `--iterations=20` before filing a regression.
+- Do not edit source to "fix" a regression — this agent reports, it does not patch.

--- a/.claude/agents/fixture-reviewer.md
+++ b/.claude/agents/fixture-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: fixture-reviewer
+description: Audits .test integration fixtures under tests/php/Integration/Fixtures for drift against the current compiler output. Use after lexer, parser, analyzer, or emitter changes.
+model: sonnet
+maxTurns: 15
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash(./vendor/bin/phpunit *)
+  - Bash(git diff *)
+  - Bash(git log *)
+---
+
+# Fixture Reviewer
+
+Specialized reviewer for `.test` fixtures in `tests/php/Integration/Fixtures/`. Detects when fixture expected output has drifted from what the compiler actually emits now — usually after a compiler-phase change.
+
+## Inputs
+
+- The change set under review (commit, branch diff, or explicit list of files).
+- Always re-read `.claude/rules/integration-tests.md` first — the two-section `--PHEL--`/`--PHP--` format is load-bearing, including embedded source locations.
+
+## Procedure
+
+1. **Scope the impact**:
+   - If the diff touches `src/php/Compiler/Domain/Lexer/` → fixtures most at risk: tokenizer edge cases (numeric literals, strings, keywords).
+   - If it touches `Domain/Parser/` → AST-shape fixtures (`Apply`, `Call`, nested forms).
+   - If it touches `Domain/Analyzer/SpecialForm/*` → the fixture category matching that form (e.g. `Try`, `Let`, `Fn`, `Def`).
+   - If it touches `Domain/Emitter/` → broadly every fixture; focus on node types the diff changed.
+
+2. **Run the integration suite** filtered to the most impacted categories:
+   ```bash
+   ./vendor/bin/phpunit --testsuite=integration --filter=<Category>
+   ```
+
+3. **For every failing fixture**, classify:
+   - **Expected drift** — compiler behavior intentionally changed. Regenerate the `--PHP--` section.
+   - **Regression** — compiler output changed unintentionally. Revert or fix the compiler.
+   - **Metadata-only** — only line/column offsets shifted. Still needs updating but flag separately.
+
+4. **Report** one section per fixture with: path, classification, minimal diff, recommended action. Never silently rewrite fixtures.
+
+## Constraints
+
+- Never hand-edit expected PHP to "match" a failure — the point of fixtures is to catch unintended emitter changes.
+- Do not run `composer fix` or format fixture files.
+- Source locations (line/column) are part of the contract — report them explicitly when they shift.

--- a/.claude/hooks/test-phel.sh
+++ b/.claude/hooks/test-phel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PostToolUse hook: run Phel core tests after edits to src/phel/**.phel
+# Mirrors format-php.sh but for Phel sources.
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE" != *.phel ]]; then
+    exit 0
+fi
+
+# Only trigger for library sources, not for test fixtures
+case "$FILE" in
+    */src/phel/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+# Derive matching test file: src/phel/<ns>/<name>.phel -> tests/phel/<ns>/<name>-test.phel
+REL="${FILE#$CLAUDE_PROJECT_DIR/}"
+REL="${REL#src/phel/}"
+BASE="${REL%.phel}"
+TEST_FILE="tests/phel/${BASE}-test.phel"
+
+if [[ -f "$TEST_FILE" ]]; then
+    timeout 60 php -d memory_limit=256M ./bin/phel test "$TEST_FILE" 2>&1 | tail -n 20
+else
+    # Fall back to running the full suite quietly — keeps the signal loop intact
+    echo "no matching test for $REL, skipping (expected at $TEST_FILE)"
+fi
+
+exit 0

--- a/.claude/skills/integration-fixture/SKILL.md
+++ b/.claude/skills/integration-fixture/SKILL.md
@@ -1,0 +1,50 @@
+---
+description: Create or validate a `.test` integration fixture under tests/php/Integration/Fixtures
+argument-hint: "[category] [name]"
+disable-model-invocation: true
+allowed-tools: "Read, Write, Edit, Glob, Bash(ls *), Bash(./vendor/bin/phpunit *)"
+---
+
+# Integration Fixture
+
+Scaffolds a new `.test` fixture in the two-section `--PHEL--` / `--PHP--` format defined in `.claude/rules/integration-tests.md`.
+
+## Context
+
+!`ls tests/php/Integration/Fixtures/`
+
+## Instructions
+
+1. **Parse `$ARGUMENTS`** as `<category> <name>`.
+   - Category must match an existing dir under `tests/php/Integration/Fixtures/` (e.g. `Def`, `Fn`, `Let`, `Try`, `Call`, `If`, `Apply`, `Foreach`, `Keyword`, `Do`, `Inline`).
+   - If no match, list available categories and ask before creating a new one.
+   - `name` is the file stem (kebab or descriptive): `fn-variadic`, `try-one-catch`.
+
+2. **Ask the user for the Phel input** (one form or a small block).
+
+3. **Compile it locally to capture the expected PHP output**:
+   ```bash
+   ./vendor/bin/phpunit --testsuite=integration --filter=<related>
+   ```
+   Or use the compiler Facade directly via a throwaway script if needed — do NOT hand-write PHP output; it must match byte-for-byte including source locations.
+
+4. **Write the fixture** as `tests/php/Integration/Fixtures/<Category>/<name>.test`:
+   ```
+   --PHEL--
+   <phel source>
+   --PHP--
+   <exact compiled output>
+   ```
+
+5. **Run the integration suite filtered to the new file** to confirm it passes:
+   ```bash
+   ./vendor/bin/phpunit --testsuite=integration --filter=<Category>
+   ```
+
+6. If the fixture fails, do NOT edit the expected PHP to match. Instead, report the diff — a failing fixture usually means a compiler regression or the input is not idiomatic.
+
+## Constraints
+
+- One fixture per behavior — never bundle unrelated cases.
+- Source locations in the PHP output embed line/column metadata — any edit to the Phel input means regenerating the PHP section.
+- PHP output uses `\Phel::` static helpers (`addDefinition`, `map`, `keyword`, `vector`, etc.). Never `use` statements inside fixtures.

--- a/.claude/skills/module-new/SKILL.md
+++ b/.claude/skills/module-new/SKILL.md
@@ -1,0 +1,77 @@
+---
+description: Scaffold a new Gacela module under src/php/ with Facade, DependencyProvider, and CLAUDE.md
+argument-hint: "<ModuleName>"
+disable-model-invocation: true
+allowed-tools: "Read, Write, Edit, Glob, Bash(ls *), Bash(composer *)"
+---
+
+# New Gacela Module
+
+Scaffolds a new module under `src/php/<ModuleName>/` following the project Gacela pattern.
+
+## Context
+
+!`ls src/php/`
+
+## Instructions
+
+1. **Validate `$ARGUMENTS`**: must be PascalCase, not clash with an existing dir. If missing, ask.
+
+2. **Read a reference module** (pick a small one, e.g. `src/php/Printer/` or `src/php/Formatter/`) to mirror its layout. Record:
+   - Facade method shape
+   - DependencyProvider constant names
+   - CLAUDE.md section order
+
+3. **Create the following files** under `src/php/<ModuleName>/`:
+   ```
+   <ModuleName>Facade.php          # final class extending \Gacela\Framework\AbstractFacade
+   <ModuleName>Factory.php         # final class extending AbstractFactory (only if module needs internal wiring)
+   <ModuleName>DependencyProvider.php  # only if the module depends on another module's Facade
+   Domain/                         # pure business logic (no framework deps)
+   Infrastructure/                 # adapters, CLI commands, IO
+   CLAUDE.md                       # one-line purpose, Gacela pattern, public API, deps, structure, constraints
+   ```
+
+4. **Facade contract**: every public call must return from the Factory; never instantiate dependencies inline in the Facade.
+
+5. **CLAUDE.md template** (keep scannable — no prose):
+   ```markdown
+   # <ModuleName>
+
+   <one-line purpose>
+
+   ## Gacela pattern
+
+   Facade → Factory → Domain
+
+   ## Public API
+
+   - `<ModuleName>Facade::method()` — <one line>
+
+   ## Dependencies
+
+   - <OtherModule>Facade (via DependencyProvider)
+
+   ## Structure
+
+   <ModuleName>/
+     Domain/
+     Infrastructure/
+
+   ## Constraints
+
+   - <key invariant or rule>
+   ```
+
+6. **Do not** register the module anywhere — Gacela auto-discovers via PSR-4.
+
+7. **Run static analysis** on the new files only:
+   ```bash
+   composer test-quality
+   ```
+
+## Constraints
+
+- No classes instantiated across module boundaries — always go through another module's Facade.
+- Mark classes `final` unless inheritance is explicitly justified.
+- Use `readonly` properties where possible (per `.claude/rules/php.md`).


### PR DESCRIPTION
## 🤔 Background

The `.claude/` directory already carries project rules and the `format-php.sh` PostToolUse hook. This PR extends it with Phel-specific agent definitions, a Phel-side formatter-equivalent test hook, and a couple of scaffolding skills that match conventions already documented in `.claude/rules/`.

## 💡 Goal

Give any contributor using Claude Code on this repo the same local automation surface — regression checks, fixture review, post-edit Phel tests, fixture/module scaffolding — without adding anything user-specific.

## 🔖 Changes

### Agents (`.claude/agents/`)

- `bench-regression.md` — runs PHPBench against the baseline tag and reports compiler performance regressions. Triggered after lexer/parser/analyzer/emitter or core runtime changes.
- `fixture-reviewer.md` — audits `.test` integration fixtures under `tests/php/Integration/Fixtures` for drift against current compiler output. Triggered after any compiler-phase change.

### Hooks (`.claude/hooks/`)

- `test-phel.sh` — PostToolUse hook that re-runs matching Phel core tests after edits to `src/phel/**.phel`. Mirrors the existing `format-php.sh` structure and respects `$CLAUDE_PROJECT_DIR`.

### Skills (`.claude/skills/`)

- `integration-fixture/SKILL.md` — scaffolds a `.test` fixture in the two-section `--PHEL--` / `--PHP--` format from `.claude/rules/integration-tests.md`.
- `module-new/SKILL.md` — scaffolds a new Gacela module under `src/php/<ModuleName>/` with `Facade`, `DependencyProvider`, and `CLAUDE.md` stubs per `.claude/rules/modules.md`.