### PR TITLE
fix(compiler): resolve lowercase PHP classes in new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - `php/new` on a non-string, non-object throws a descriptive `InvalidArgumentException` (#1538)
+- `(new stdClass)` and `(php/new stdClass)` resolve lowercase-leading root PHP class names in class position (#1567)
 - `#?` and `#?@` reader conditionals tolerate a newline before the closing paren (#1547)
 
 #### Lint

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -65,6 +65,7 @@ To keep calls short, capture the function reference with `def`:
 (def now (php/new DateTime))
 (def now (new DateTime))
 (def now (DateTime.))
+(def data (new stdClass))         ; PHP class names keep their PHP casing
 
 ;; Call methods
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/PhpNewSymbol.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Symbol;
 
 use function count;
+use function preg_match;
 
 /**
  * (php/new ClassName args...).
@@ -28,15 +32,13 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
             throw AnalyzerException::withLocation("At least one arguments is required for 'php/new", $list);
         }
 
-        $classExpr = $this->analyzer->analyze(
-            $list->get(1),
-            $env->withExpressionContext()->withDisallowRecurFrame(),
-        );
+        $classEnv = $env->withExpressionContext()->withDisallowRecurFrame();
+        $classExpr = $this->analyzeClassExpr($list->get(1), $classEnv);
         $args = [];
         for ($forms = $list->rest()->cdr(); $forms !== null; $forms = $forms->cdr()) {
             $args[] = $this->analyzer->analyze(
                 $forms->first(),
-                $env->withExpressionContext()->withDisallowRecurFrame(),
+                $classEnv,
             );
         }
 
@@ -46,5 +48,31 @@ final class PhpNewSymbol implements SpecialFormAnalyzerInterface
             $args,
             $list->getStartLocation(),
         );
+    }
+
+    private function analyzeClassExpr(mixed $classExpr, NodeEnvironmentInterface $env): AbstractNode
+    {
+        if (!$classExpr instanceof Symbol || $env->hasLocal($classExpr)) {
+            return $this->analyzer->analyze($classExpr, $env);
+        }
+
+        $resolvedClassExpr = $this->analyzer->resolve($classExpr, $env);
+        if ($resolvedClassExpr instanceof AbstractNode) {
+            return $resolvedClassExpr;
+        }
+
+        if ($classExpr->getNamespace() !== null || !$this->looksLikeRootPhpClassName($classExpr->getName())) {
+            return $this->analyzer->analyze($classExpr, $env);
+        }
+
+        $fqn = Symbol::create('\\' . $classExpr->getName());
+        $fqn->copyLocationFrom($classExpr);
+
+        return new PhpClassNameNode($env, $fqn, $classExpr->getStartLocation());
+    }
+
+    private function looksLikeRootPhpClassName(string $name): bool
+    {
+        return preg_match('/^[A-Za-z_]\w*$/', $name) === 1;
     }
 }

--- a/tests/php/Integration/Fixtures/New/new-lowercase-leading-class.test
+++ b/tests/php/Integration/Fixtures/New/new-lowercase-leading-class.test
@@ -1,0 +1,4 @@
+--PHEL--
+(new stdClass)
+--PHP--
+(new \stdClass());

--- a/tests/php/Integration/Fixtures/New/new-lowercase-leading-class.test
+++ b/tests/php/Integration/Fixtures/New/new-lowercase-leading-class.test
@@ -1,4 +1,15 @@
 --PHEL--
 (new stdClass)
+(php/new stdClass)
+(stdClass.)
+(new StdClass)
+(php/new StdClass)
+(StdClass.)
+(new \stdClass)
+(php/new \stdClass)
+(\stdClass.)
+(new \StdClass)
+(php/new \StdClass)
+(\StdClass.)
 --PHP--
-(new \stdClass());
+(new \stdClass());(new \stdClass());(new \stdClass());(new \StdClass());(new \StdClass());(new \StdClass());(new \stdClass());(new \stdClass());(new \stdClass());(new \StdClass());(new \StdClass());(new \StdClass());


### PR DESCRIPTION
## 🤔 Background

PHP class names are case-insensitive, but bare lowercase-leading class names such as `stdClass` failed to resolve in Phel `new` forms.

## 💡 Goal

Allow class-position PHP identifiers in `new`/`php/new` to preserve PHP casing without requiring a leading backslash or capitalization workaround.

## 🔖 Changes

- Resolve unresolved root PHP class identifiers in `php/new` class position.
- Add an integration fixture for `(new stdClass)`.
- Document PHP class casing in interop docs.

Refs #1567