### PR TITLE
fix: eval accepts closures and arbitrary PHP objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
 - `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
 - `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
+- `eval` returns closures and other already-evaluated PHP objects unchanged instead of throwing a `TypeError` (#1563)
 
 #### Build
 - Directory scan skips unparseable `.phel` files instead of aborting

--- a/src/php/Compiler/Application/EvalCompiler.php
+++ b/src/php/Compiler/Application/EvalCompiler.php
@@ -26,6 +26,8 @@ use Phel\Compiler\Domain\Reader\ReaderInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Lang\TypeInterface;
 
+use function is_object;
+
 final readonly class EvalCompiler implements EvalCompilerInterface
 {
     public function __construct(
@@ -72,8 +74,14 @@ final readonly class EvalCompiler implements EvalCompilerInterface
         }
     }
 
-    public function evalForm(float|bool|int|string|TypeInterface|null $form, CompileOptions $compileOptions): mixed
+    public function evalForm(mixed $form, CompileOptions $compileOptions): mixed
     {
+        // Non-Phel objects (e.g. closures) are already evaluated values; return
+        // them as-is to match Clojure's self-evaluating semantics.
+        if (is_object($form) && !$form instanceof TypeInterface) {
+            return $form;
+        }
+
         $node = $this->analyzer->analyze($form, NodeEnvironment::empty()->withReturnContext());
         return $this->evalNode($node, $compileOptions);
     }

--- a/src/php/Compiler/CompilerFacade.php
+++ b/src/php/Compiler/CompilerFacade.php
@@ -58,7 +58,7 @@ final class CompilerFacade extends AbstractFacade implements CompilerFacadeInter
     }
 
     public function evalForm(
-        TypeInterface|string|float|int|bool|null $form,
+        mixed $form,
         CompileOptions $compileOptions = new CompileOptions(),
     ): mixed {
         return $this->getFactory()

--- a/src/php/Compiler/Domain/Compiler/EvalCompilerInterface.php
+++ b/src/php/Compiler/Domain/Compiler/EvalCompilerInterface.php
@@ -7,7 +7,6 @@ namespace Phel\Compiler\Domain\Compiler;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Domain\Parser\Exceptions\UnfinishedParserException;
 use Phel\Compiler\Infrastructure\CompileOptions;
-use Phel\Lang\TypeInterface;
 
 interface EvalCompilerInterface
 {
@@ -23,11 +22,14 @@ interface EvalCompilerInterface
     /**
      * Evaluates a provided Phel form.
      *
-     * @param bool|float|int|string|TypeInterface|null $form The phel form to evaluate
+     * Phel forms (literals, symbols, lists, vectors, etc.) are compiled and
+     * executed. Any other PHP value (e.g. a Closure or arbitrary object) is
+     * already evaluated and is returned as-is, matching Clojure's
+     * self-evaluating semantics.
      *
      * @throws CompilerException|UnfinishedParserException
      *
      * @return mixed The result of the executed code
      */
-    public function evalForm(float|bool|int|string|TypeInterface|null $form, CompileOptions $compileOptions): mixed;
+    public function evalForm(mixed $form, CompileOptions $compileOptions): mixed;
 }

--- a/src/php/Shared/Facade/CompilerFacadeInterface.php
+++ b/src/php/Shared/Facade/CompilerFacadeInterface.php
@@ -44,14 +44,17 @@ interface CompilerFacadeInterface
     public function eval(string $phelCode, CompileOptions $compileOptions): mixed;
 
     /**
-     * @param bool|float|int|string|TypeInterface|null $form           The phel form to evaluate
-     * @param CompileOptions                           $compileOptions The compile options
+     * Evaluates a Phel form. Non-Phel objects (e.g. closures) are returned
+     * as-is, matching Clojure's self-evaluating semantics.
+     *
+     * @param mixed          $form           The phel form to evaluate
+     * @param CompileOptions $compileOptions The compile options
      *
      * @throws CompilerException
      *
      * @return mixed The evaluated result
      */
-    public function evalForm(TypeInterface|string|float|int|bool|null $form, CompileOptions $compileOptions): mixed;
+    public function evalForm(mixed $form, CompileOptions $compileOptions): mixed;
 
     /**
      * Compiles the given phel code to PHP code.

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -201,7 +201,11 @@
   (is (= nil (read-string "")) "read empty string"))
 
 (deftest test-eval-form
-  (is (= 2 (eval '(+ 1 1))) "eval simple expression"))
+  (is (= 2 (eval '(+ 1 1))) "eval simple expression")
+  (is (function? (eval (fn [x] x))) "eval returns a closure passed in unchanged")
+  (let [identity-fn (fn [x] x)]
+    (is (= identity-fn (eval identity-fn)) "eval of a closure returns the same closure"))
+  (is (= 42 ((eval (fn [x] x)) 42)) "closure returned by eval is callable"))
 
 (deftest test-compile-form
   (is (= "(\\Phel::getDefinition(\"phel\\\\core\", \"assert-non-nil\"))(1, 1);\n(1 + 1);"


### PR DESCRIPTION
## 🤔 Background

`(eval (fn [x] x))` in Phel throws a `TypeError` because `CompilerFacade::evalForm()` only accepts `TypeInterface|string|float|int|bool|null`. Passing a `Closure` (or any other PHP object) is rejected at the parameter type level.

Clojure returns the closure unchanged in the same scenario — functions are self-evaluating. The bug was reported when running the [clojure-test-suite](https://github.com/jasalt/clojure-test-suite/blob/bac398dfd9c74e630f181856e6de79b1bddde0fe/test/clojure/core_test/eval.cljc#L32) `eval.cljc` against Phel.

Closes #1563.

## 💡 Goal

Make `eval` return closures (and other already-evaluated PHP objects) unchanged, aligning with Clojure's self-evaluating semantics.

## 🔖 Changes

- `EvalCompiler::evalForm` and the `EvalCompilerInterface` / `CompilerFacadeInterface` contracts now accept `mixed`.
- `evalForm` short-circuits when the form is a non-`TypeInterface` object and returns it as-is, matching Clojure's behaviour for self-evaluating values. Phel forms (literals, symbols, lists, vectors, …) still go through analyze + emit + evaluate.
- New regression coverage in `tests/phel/test/core/utility-functions.phel` asserting that `(eval (fn [x] x))` returns the same closure and that the closure stays callable.
- Changelog entry under `## Unreleased` → `Fixed` → `Core`.