### PR TITLE
feat(core): move clojure-parity async surface into phel.core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `future` now available from `phel\core` without requiring `phel\async` (#1537)
+- **BREAKING**: `phel\async`'s Clojure-parity surface moved to `phel\core` so `.cljc` portable code mirrors `clojure.core`'s defaults (#1548). The following are now reachable without a require: `async`, `await`, `await-all`, `await-any`, `pmap`, `promise`, `deliver`, `future-call`, `future-fiber`, `future?`, `future-cancel`, `future-cancelled?`, `future-done?`, `->closure`. Update existing `(:require phel\async :refer [...])` clauses to drop these symbols. `delay` deliberately stays in `phel\async` because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy-thunk wrapper. `pmap`'s docstring now calls out that it is single-threaded (overlaps IO, does not parallelize CPU), matching Basilisp/ClojureScript
 
 ### Fixed
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -1,6 +1,6 @@
 # Async Module Guide
 
-`phel\async` exposes two cooperating concurrency layers over PHP fibers. Both live in the same namespace so you can mix them, but each has its own best use.
+Phel ships two cooperating concurrency layers over PHP fibers, both available **from `phel.core` without an explicit require** so `.cljc` portable code mirrors `clojure.core`'s defaults. The single exception is `delay`, which stays in `phel.async` because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy-thunk wrapper — keeping the names separated avoids silently hijacking Clojure semantics.
 
 ## Contents
 
@@ -16,9 +16,9 @@
 
 ## Overview
 
-**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `delay`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` live here. Use this layer when you already run inside an event loop or when you need timers, IO multiplexing, or fan-out across many Futures.
+**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` are in `phel.core`; `delay` is in `phel.async`. Use this layer when you already run inside an event loop or when you need timers, IO multiplexing, or fan-out across many Futures.
 
-**Fiber-backed layer.** Uses a cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade` with no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, and `future?` live here. Safe to call from the top level of a script or REPL and convenient for CPU coordination, producer/consumer handoffs, and lightweight deref-with-timeout.
+**Fiber-backed layer.** Uses a cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade` with no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, and `future?` are in `phel.core`. Safe to call from the top level of a script or REPL and convenient for CPU coordination, producer/consumer handoffs, and lightweight deref-with-timeout.
 
 ## When to use which
 
@@ -54,15 +54,19 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Futur
 
 Blocks the current fiber until the Future resolves, then returns its value. Accepts either a raw `Amp\Future` or a `PhelFuture` wrapper. Gotcha: must be called from inside a fiber.
 
-### `delay`
+### `delay` (in `phel.async`)
 
 ```phel
 (delay seconds)
 ```
 
-Suspends the current fiber for `seconds` (float). Uses `Amp\delay`. Gotcha: this is a fiber-aware sleep; plain `php/sleep` blocks the whole event loop.
+Suspends execution for `seconds` (float). At the top level it behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* (not the whole process) and the delay becomes cancellable via `future-cancel`. Uses `Amp\delay` under the hood.
+
+> **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) precisely so this difference stays visible to `.cljc` portable code.
 
 ```phel
+(:require phel\async :refer [delay])
+
 (async (delay 0.1) :done)
 ```
 
@@ -92,7 +96,7 @@ Returns the value of the first Future to resolve. Gotcha: losing Futures are not
 (pmap f coll) (pmap f coll1 coll2 ...)
 ```
 
-Parallel `map` via fibers. Results are returned in input order. Gotcha: cooperative on a single thread, so CPU-bound work gains nothing. Great for HTTP, DB, or file IO.
+Concurrent `map` via fibers. Results are returned in input order. Gotcha: PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU-bound computations across cores — unlike `clojure.core/pmap`, which uses a thread pool. ClojureScript and Basilisp follow the same single-threaded model.
 
 ### `future`
 
@@ -208,8 +212,7 @@ Phel's `deref` is overloaded and dispatches to the right layer at runtime.
 ### Producer/consumer via `promise`
 
 ```phel
-(ns demo\producer
-  (:require phel\async :refer [promise deliver future-call]))
+(ns demo\producer)
 
 (let [inbox (promise)]
   (future-call (fn []
@@ -223,7 +226,7 @@ Run with `./bin/phel run demo/producer.phel`.
 
 ```phel
 (ns demo\fanout
-  (:require phel\async :refer [async await-all delay]))
+  (:require phel\async :refer [delay]))
 
 (defn fetch [label ms]
   (async
@@ -241,8 +244,7 @@ Wall time tracks the slowest branch, not the sum.
 ### Timeout race with 3-arg `deref`
 
 ```phel
-(ns demo\timeout
-  (:require phel\async :refer [promise deref]))
+(ns demo\timeout)
 
 (let [p (promise)]
   ;; No producer wired up: the deref expires and returns the fallback.
@@ -254,7 +256,7 @@ Wall time tracks the slowest branch, not the sum.
 
 ```phel
 (ns demo\cancel-on-error
-  (:require phel\async :refer [async await delay future-cancel]))
+  (:require phel\async :refer [delay]))
 
 (defn launch []
   (async

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -169,14 +169,14 @@ Phel runs on PHP. A handful of Clojure features don't translate directly:
 |-----------------|----------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
-| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs | Use `phel\async` (AMPHP for IO, fiber layer for top-level handoffs); see [docs/async-guide.md](async-guide.md) |
+| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs — all in `phel\core`, no require needed | See [docs/async-guide.md](async-guide.md) |
 | **BigInt / BigDecimal / Ratio** | PHP number model | Suffix literals (`1N`, `1.5M`) and ratio literals (`1/2`) are accepted; ratios evaluate to `num / den` as a float. Use `bcmath` / `gmp` via `php/` interop for real arbitrary precision |
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
 | **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |
 | **`alter-var-root`** | No first-class vars to re-root | Use an `atom` with `swap!` for mutable state, or redefine the top-level binding with `def`. Calling `alter-var-root` at runtime throws `BadMethodCallException` with this hint |
 
-Phel provides `future` in `phel\core` (available without requiring any namespace, as in Clojure); `future-cancel` and `pmap` still live in `phel\async`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt. For top-level scripting without an event loop, use the fiber primitives (`promise`, `deliver`, `future-call`, `future-fiber`); see [docs/async-guide.md](async-guide.md) for the decision guide.
+The Clojure-parity async surface lives in `phel\core` and is reachable without any require: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus the Phel fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). The one async symbol that still needs `(:require phel\async)` is `delay`, deliberately kept out of core because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md) for the decision guide.
 
 ## Structural differences
 
@@ -263,5 +263,5 @@ Run tests with `./bin/phel test`.
 2. Update namespace separators: `my.app.core` → `my\app\core` (or keep `.`, both work)
 3. Replace Java interop with PHP interop (`(.method obj)` → `(php/-> obj (method))`)
 4. Rewrite `(:import [java.util Date])` clauses as `(:use DateTime)` in the `ns` form
-5. Check for concurrency primitives (refs, agents, core.async) and replace with `atom` or `phel\async` / AMPHP alternatives
+5. Check for concurrency primitives (refs, agents, core.async) and replace with `atom` or the AMPHP-backed primitives in `phel\core` (`future`, `pmap`, `promise`, `deliver`, …); add `(:require phel\async :refer [delay])` only when you need the sleep primitive
 6. Run `./bin/phel test` to verify

--- a/docs/examples/11_async-concurrency.phel
+++ b/docs/examples/11_async-concurrency.phel
@@ -1,6 +1,5 @@
 (ns examples\async-concurrency
-  (:require phel\async :refer [async await await-all delay
-                               promise deliver future-call future-fiber]))
+  (:require phel\async :refer [delay]))
 
 ;; Async concurrency with Phel and AMPHP (amphp/amp).
 ;; Run: ./bin/phel run docs/examples/11_async-concurrency.phel
@@ -38,7 +37,7 @@
 (println)
 (println "--- Race: first to respond wins ---")
 
-(let [winner (phel\async/await-any
+(let [winner (await-any
                [(fetch-data "server-eu" 70)
                 (fetch-data "server-us" 30)
                 (fetch-data "server-asia" 50)])]

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,200 +1,38 @@
 (ns phel.async)
 
-;; Two cooperating concurrency layers in one module.
+;; Historical home of Phel's async surface. As of #1548 the
+;; Clojure-parity primitives (`async`, `await`, `await-all`, `await-any`,
+;; `pmap`, `promise`, `deliver`, `future-call`, `future-fiber`, `future?`,
+;; `future-cancel`, `future-cancelled?`, `future-done?`, `->closure`)
+;; have moved to `phel.core` so `.cljc` portable code can use them
+;; without an explicit require, mirroring `clojure.core`.
 ;;
-;; - AMPHP-backed: `async`, `await`, `delay`, `await-all`, `await-any`,
-;;   `pmap`, `future-cancel`, `future-cancelled?`. Requires an event
-;;   loop; best for IO parallelism, timers, and combinators. The core
-;;   `future` macro (available without requiring this namespace) is the
-;;   AMPHP-backed variant.
-;; - Fiber-backed: `promise`, `deliver`, `future-call`, `future-fiber`,
-;;   `future?`. Runs at the top level via a cooperative scheduler in
-;;   `\Phel\Fiber\FiberFacade`; no loop required.
+;; This namespace stays alive because `delay` is intentionally divergent
+;; from `clojure.core/delay` (lazy thunk in Clojure, suspending sleep
+;; here) — keeping it behind `phel.async` makes the divergence explicit
+;; for `.cljc` portability work and avoids silently hijacking the
+;; Clojure name in core.
 ;;
-;; See `docs/async-guide.md` for a decision guide, pitfalls, and recipes.
-
-(defn- fiber-facade
-  "Lazily resolves the shared FiberFacade instance."
-  []
-  (php/new \Phel\Fiber\FiberFacade))
-
-(defn ->closure
-  "Converts a Phel function to a PHP Closure.
-  Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject
-  Phel's `AbstractFn` even though it is callable. This bridges the gap."
-  {:example "(->closure (fn [x] (* x 2)))"}
-  [f]
-  (php/:: \Closure (fromCallable f)))
-
-(defmacro async
-  "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
-
-  Captures the caller's dynamic bindings and reinstalls them inside
-  the fiber, so `binding`s established outside `async` are visible to
-  `body` (binding conveyance, as in Clojure's `future`)."
-  {:example "(async (do-something))"
-   :see-also ["await" "delay" "await-all" "await-any"]}
-  [& body]
-  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
-     (php/amp\async
-       (fn []
-         (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
-
-(defn- unwrap-future
-  "Returns the raw Amp\\Future for either a `PhelFuture` wrapper or
-  a bare `Amp\\Future`."
-  [future]
-  (if (php/instanceof future \Phel\Lang\PhelFuture)
-    (php/-> future (unwrap))
-    future))
-
-(defn await
-  "Blocks the current fiber until the Future resolves and returns its value.
-  Accepts either a raw `Amp\\Future` or a `PhelFuture` wrapper."
-  {:example "(await (async (+ 1 2)))"
-   :see-also ["async" "await-all" "await-any" "delay"]}
-  [future]
-  (php/-> (unwrap-future future) (await)))
+;; See `docs/async-guide.md` for the full decision guide and examples.
 
 (defn delay
-  "Suspends the current fiber for the given number of seconds (float)."
-  {:example "(delay 0.5)"
-   :see-also ["async" "await"]}
+  "Suspends execution for `seconds` (a float; supports sub-second
+  precision such as `0.05`).
+
+  At the top level this behaves like `php/sleep` / `php/usleep`: it
+  blocks the script for the given duration. Inside an `async`/`future`
+  body — or any AMPHP fiber context — it suspends the *fiber* (not the
+  whole process), so other concurrent fibers keep running and the
+  delay is cancellable via `future-cancel`.
+
+  `phel.async/delay` is **not** the Clojure `clojure.core/delay`. The
+  Clojure form returns a lazy thunk that caches the result of evaluating
+  `body` on first `deref`; Phel's version is a sleep primitive. They are
+  unrelated. Reach for `phel.async/delay` when you want to throttle, time
+  out, or compose with `future` / `pmap`; reach for `php/sleep` when you
+  just want a blocking pause and don't care about fiber semantics."
+  {:example "(delay 0.5) ; suspends current fiber for 500ms
+  (async (delay 1.0) :done) ; => future that resolves after 1s"
+   :see-also ["async" "await" "future" "future-cancel"]}
   [seconds]
   (php/amp\delay seconds))
-
-(defn await-all
-  "Awaits all Futures in the given collection. Returns a vector of results.
-  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
-  {:example "(await-all [(async 1) (async 2)])"
-   :see-also ["await" "await-any" "pmap"]}
-  [futures]
-  (let [php-futures (to-php-array (map unwrap-future futures))]
-    (for [v :in (php/amp\future\await php-futures)]
-      v)))
-
-(defn await-any
-  "Awaits the first Future to resolve. Returns its value.
-  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
-  {:example "(await-any [(async 1) (async 2)])"
-   :see-also ["await" "await-all"]}
-  [futures]
-  (let [php-futures (to-php-array (map unwrap-future futures))]
-    (php/amp\future\awaitfirst php-futures)))
-
-(defn pmap
-  "Like `map`, but applies `f` to elements in parallel via fibers.
-
-  Returns a vector of results in the original order. With multiple
-  collections, applies `f` to corresponding elements from each collection,
-  stopping when the shortest collection is exhausted.
-
-  Best for IO-bound work (HTTP, DB, file IO). Because PHP fibers are
-  cooperative on a single thread, `pmap` does not speed up CPU-bound
-  computations."
-  {:example "(pmap inc [1 2 3]) ; => [2 3 4]"
-   :see-also ["map" "async" "await-all"]}
-  [f & colls]
-  (case (count colls)
-    0 (throw (php/new \InvalidArgumentException "pmap expects at least one collection"))
-    1 (await-all (map #(async (f %)) (first colls)))
-    (await-all (apply map (fn [& args] (async (apply f args))) colls))))
-
-(defn future-cancel
-  "Signals the future's internal cancellation token, causing any pending
-  or subsequent `deref` call to raise `CancelledException` (or return the
-  timeout value for the 3-arg form). Due to AMPHP's cooperative fibers,
-  the body keeps running until its next cancellation checkpoint; from
-  the caller's perspective the future behaves as cancelled after this
-  returns."
-  {:example "(future-cancel (future (expensive-call)))"
-   :see-also ["future" "future-cancelled?" "future-done?" "deref"]}
-  [f]
-  (php/-> f (cancel)))
-
-(defn future-cancelled?
-  "Returns `true` if `future-cancel` was called on `f`, `false` otherwise."
-  {:example "(future-cancelled? f)"
-   :see-also ["future-cancel" "future-done?" "future"]}
-  [f]
-  (php/-> f (isCancelled)))
-
-(defn future-done?
-  "Returns `true` if the future is in a final state (completed, failed,
-  or cancelled).
-
-  Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed)
-  it calls `isDone`; for any other value it falls back to `realized?`.
-  This lets the same predicate serve both the AMPHP `PhelFuture` wrapper
-  and the cooperative fiber future."
-  {:example "(future-done? f)"
-   :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
-  [f]
-  (cond
-    (php/instanceof f \Phel\Fiber\Domain\Future) (php/-> f (isDone))
-    true                                         (realized? f)))
-
-;; -----------------------------------------------------------------
-;; Fiber-based promises and futures
-;;
-;; Unlike `future`/`async` above, these do not require AMPHP and work
-;; at the top level. They use a cooperative single-threaded scheduler
-;; exposed by `\Phel\Fiber\FiberFacade`.
-;; -----------------------------------------------------------------
-
-(defn promise
-  "Returns a new unrealized promise. Deliver a value with `(deliver p v)`
-  and read it back with `@p` (or `(deref p)`).
-
-  Once delivered the value is frozen; subsequent `deliver` calls are
-  no-ops. `deref` on an unrealized promise blocks: from inside a fiber
-  it suspends cooperatively, from the top level it drains the scheduler
-  ready queue and sleeps briefly between checks."
-  {:example "(let [p (promise)] (deliver p 42) @p) ; => 42"
-   :see-also ["deliver" "deref" "realized?" "future-call" "future-fiber"]}
-  []
-  (php/-> (fiber-facade) (createPromise)))
-
-(defn deliver
-  "Delivers `value` to `p` if it is still unrealized. Returns `p` on
-  first delivery, `nil` if `p` was already delivered."
-  {:example "(deliver (promise) 7)"
-   :see-also ["promise" "deref" "realized?"]}
-  [p value]
-  (if (php/-> p (deliver value)) p nil))
-
-(defn future-call
-  "Invokes `f` (a zero-arg function) in a new fiber. Returns a
-  `PhelFiberFuture` you can `deref` or inspect with `future-done?`
-  and `future-cancel`.
-
-  Captures the caller's dynamic bindings and reinstalls them inside
-  the fiber before invoking `f`, so bindings are conveyed the same
-  way as with `future`/`async`."
-  {:example "(future-call (fn [] 42))"
-   :see-also ["future-fiber" "deref" "future-done?" "future-cancel"
-              "promise" "deliver"]}
-  [f]
-  (let [frame   (php/:: \Phel (snapshotDynamicBindings))
-        wrapped (fn [] (php/:: \Phel (withDynamicBindings frame f)))]
-    (php/-> (fiber-facade) (future (->closure wrapped)))))
-
-(defmacro future-fiber
-  "Runs `body` in a new fiber via the cooperative scheduler. Returns a
-  fiber-future that supports `deref`, `realized?`, `future-done?`, and
-  `future-cancel`. Works at the top level (no enclosing `async` block
-  required), in contrast to `future` which requires an AMPHP fiber
-  context."
-  {:example "@(future-fiber (+ 1 2))"
-   :see-also ["future-call" "deref" "future-done?" "future-cancel"]}
-  [& body]
-  `(future-call (fn [] ~@body)))
-
-(defn future?
-  "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`)
-  or a `PhelFuture` (from the AMPHP-backed `future` macro)."
-  {:example "(future? (future-call (fn [] 1))) ; => true"
-   :see-also ["future" "future-call" "future-fiber"]}
-  [x]
-  (or (php/instanceof x \Phel\Fiber\Domain\Future)
-      (php/instanceof x \Phel\Lang\PhelFuture)))

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -201,3 +201,4 @@
 (load "core/uuid")
 (load "core/loops")
 (load "core/futures")
+(load "core/async")

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -1,0 +1,193 @@
+(in-ns phel.core)
+
+;; AMPHP-backed and fiber-backed async primitives, kept in core so that
+;; `.cljc` portable code mirrors `clojure.core`'s default availability
+;; (see #1537 for the analogous `future` move). The classes referenced
+;; below (`\Phel\Fiber\FiberFacade`, `\Phel\Lang\PhelFuture`, `Amp\\…`)
+;; are autoloaded only when these functions are actually called, so
+;; namespaces that don't use them pay no runtime cost.
+;;
+;; `delay` deliberately stays in `phel.async` because `clojure.core/delay`
+;; is a lazy-computation wrapper, not a sleep. See `docs/async-guide.md`
+;; for the broader decision guide.
+
+(defn- fiber-facade
+  "Lazily resolves the shared FiberFacade instance."
+  []
+  (php/new \Phel\Fiber\FiberFacade))
+
+(defn ->closure
+  "Converts a Phel function to a PHP Closure.
+  Many PHP libraries (AMPHP, ReactPHP) type-hint `\\Closure` and reject
+  Phel's `AbstractFn` even though it is callable. This bridges the gap."
+  {:example "(->closure (fn [x] (* x 2)))"}
+  [f]
+  (php/:: \Closure (fromCallable f)))
+
+(defmacro async
+  "Runs body asynchronously in a new fiber. Returns an Amp\\Future.
+
+  Captures the caller's dynamic bindings and reinstalls them inside
+  the fiber, so `binding`s established outside `async` are visible to
+  `body` (binding conveyance, as in Clojure's `future`)."
+  {:example "(async (do-something))"
+   :see-also ["await" "await-all" "await-any" "future"]}
+  [& body]
+  `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
+     (php/amp\async
+       (fn []
+         (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
+
+(defn- unwrap-future
+  "Returns the raw Amp\\Future for either a `PhelFuture` wrapper or
+  a bare `Amp\\Future`."
+  [future]
+  (if (php/instanceof future \Phel\Lang\PhelFuture)
+    (php/-> future (unwrap))
+    future))
+
+(defn await
+  "Blocks the current fiber until the Future resolves and returns its value.
+  Accepts either a raw `Amp\\Future` or a `PhelFuture` wrapper."
+  {:example "(await (async (+ 1 2)))"
+   :see-also ["async" "await-all" "await-any"]}
+  [future]
+  (php/-> (unwrap-future future) (await)))
+
+(defn await-all
+  "Awaits all Futures in the given collection. Returns a vector of results.
+  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
+  {:example "(await-all [(async 1) (async 2)])"
+   :see-also ["await" "await-any" "pmap"]}
+  [futures]
+  (let [php-futures (to-php-array (map unwrap-future futures))]
+    (for [v :in (php/amp\future\await php-futures)]
+      v)))
+
+(defn await-any
+  "Awaits the first Future to resolve. Returns its value.
+  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
+  {:example "(await-any [(async 1) (async 2)])"
+   :see-also ["await" "await-all"]}
+  [futures]
+  (let [php-futures (to-php-array (map unwrap-future futures))]
+    (php/amp\future\awaitfirst php-futures)))
+
+(defn pmap
+  "Like `map`, but applies `f` to elements concurrently via fibers.
+
+  Returns a vector of results in the original order. With multiple
+  collections, applies `f` to corresponding elements from each collection,
+  stopping when the shortest collection is exhausted.
+
+  PHP fibers are cooperative on a single thread, so `pmap` overlaps
+  IO-bound work (HTTP, DB, file IO) but does not parallelize CPU-bound
+  computations across cores — unlike `clojure.core/pmap`, which uses a
+  thread pool. ClojureScript and Basilisp follow the same single-threaded
+  model."
+  {:example "(pmap inc [1 2 3]) ; => [2 3 4]"
+   :see-also ["map" "async" "await-all"]}
+  [f & colls]
+  (case (count colls)
+    0 (throw (php/new \InvalidArgumentException "pmap expects at least one collection"))
+    1 (await-all (map #(async (f %)) (first colls)))
+    (await-all (apply map (fn [& args] (async (apply f args))) colls))))
+
+(defn future-cancel
+  "Signals the future's internal cancellation token, causing any pending
+  or subsequent `deref` call to raise `CancelledException` (or return the
+  timeout value for the 3-arg form). Due to AMPHP's cooperative fibers,
+  the body keeps running until its next cancellation checkpoint; from
+  the caller's perspective the future behaves as cancelled after this
+  returns."
+  {:example "(future-cancel (future (expensive-call)))"
+   :see-also ["future" "future-cancelled?" "future-done?" "deref"]}
+  [f]
+  (php/-> f (cancel)))
+
+(defn future-cancelled?
+  "Returns `true` if `future-cancel` was called on `f`, `false` otherwise."
+  {:example "(future-cancelled? f)"
+   :see-also ["future-cancel" "future-done?" "future"]}
+  [f]
+  (php/-> f (isCancelled)))
+
+(defn future-done?
+  "Returns `true` if the future is in a final state (completed, failed,
+  or cancelled).
+
+  Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed)
+  it calls `isDone`; for any other value it falls back to `realized?`.
+  This lets the same predicate serve both the AMPHP `PhelFuture` wrapper
+  and the cooperative fiber future."
+  {:example "(future-done? f)"
+   :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
+  [f]
+  (cond
+    (php/instanceof f \Phel\Fiber\Domain\Future) (php/-> f (isDone))
+    true                                         (realized? f)))
+
+;; -----------------------------------------------------------------
+;; Fiber-based promises and futures
+;;
+;; Unlike `future`/`async` above, these do not require AMPHP and work
+;; at the top level. They use a cooperative single-threaded scheduler
+;; exposed by `\Phel\Fiber\FiberFacade`.
+;; -----------------------------------------------------------------
+
+(defn promise
+  "Returns a new unrealized promise. Deliver a value with `(deliver p v)`
+  and read it back with `@p` (or `(deref p)`).
+
+  Once delivered the value is frozen; subsequent `deliver` calls are
+  no-ops. `deref` on an unrealized promise blocks: from inside a fiber
+  it suspends cooperatively, from the top level it drains the scheduler
+  ready queue and sleeps briefly between checks."
+  {:example "(let [p (promise)] (deliver p 42) @p) ; => 42"
+   :see-also ["deliver" "deref" "realized?" "future-call" "future-fiber"]}
+  []
+  (php/-> (fiber-facade) (createPromise)))
+
+(defn deliver
+  "Delivers `value` to `p` if it is still unrealized. Returns `p` on
+  first delivery, `nil` if `p` was already delivered."
+  {:example "(deliver (promise) 7)"
+   :see-also ["promise" "deref" "realized?"]}
+  [p value]
+  (if (php/-> p (deliver value)) p nil))
+
+(defn future-call
+  "Invokes `f` (a zero-arg function) in a new fiber. Returns a
+  `PhelFiberFuture` you can `deref` or inspect with `future-done?`
+  and `future-cancel`.
+
+  Captures the caller's dynamic bindings and reinstalls them inside
+  the fiber before invoking `f`, so bindings are conveyed the same
+  way as with `future`/`async`."
+  {:example "(future-call (fn [] 42))"
+   :see-also ["future-fiber" "deref" "future-done?" "future-cancel"
+              "promise" "deliver"]}
+  [f]
+  (let [frame   (php/:: \Phel (snapshotDynamicBindings))
+        wrapped (fn [] (php/:: \Phel (withDynamicBindings frame f)))]
+    (php/-> (fiber-facade) (future (->closure wrapped)))))
+
+(defmacro future-fiber
+  "Runs `body` in a new fiber via the cooperative scheduler. Returns a
+  fiber-future that supports `deref`, `realized?`, `future-done?`, and
+  `future-cancel`. Works at the top level (no enclosing `async` block
+  required), in contrast to `future` which requires an AMPHP fiber
+  context."
+  {:example "@(future-fiber (+ 1 2))"
+   :see-also ["future-call" "deref" "future-done?" "future-cancel"]}
+  [& body]
+  `(future-call (fn [] ~@body)))
+
+(defn future?
+  "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`)
+  or a `PhelFuture` (from the AMPHP-backed `future` macro)."
+  {:example "(future? (future-call (fn [] 1))) ; => true"
+   :see-also ["future" "future-call" "future-fiber"]}
+  [x]
+  (or (php/instanceof x \Phel\Fiber\Domain\Future)
+      (php/instanceof x \Phel\Lang\PhelFuture)))

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -3,8 +3,8 @@
 ;; Core `future`: starts `body` asynchronously and returns a
 ;; `PhelFuture`. Kept in core so it mirrors Clojure, where `future`
 ;; is available without an explicit require. The fiber-backed
-;; `future-fiber`, `future-call`, `promise`, and friends still live in
-;; `phel.async`.
+;; `future-fiber`, `future-call`, `promise`, and the rest of the
+;; Clojure-parity async surface live alongside in `core/async.phel`.
 
 (defmacro future
   "Starts evaluating `body` asynchronously and returns a `PhelFuture`

--- a/src/php/Fiber/CLAUDE.md
+++ b/src/php/Fiber/CLAUDE.md
@@ -1,8 +1,8 @@
 # Fiber Module
 
 Cooperative fiber primitives: promises, futures, and a single-threaded
-scheduler used by Phel's `phel\async` library for `promise`/`deliver`
-and `future-call`/`future-fiber`.
+scheduler used by `phel\core` for `promise`/`deliver` and
+`future-call`/`future-fiber`.
 
 ## Gacela Pattern
 

--- a/tests/phel/test/async-fiber.phel
+++ b/tests/phel/test/async-fiber.phel
@@ -1,6 +1,5 @@
 (ns phel-test\test\async-fiber
-  (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [promise deliver future-call future-fiber future? future-cancel future-done?]))
+  (:require phel\test :refer [deftest is]))
 
 ;; --- promise / deliver ---
 

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,6 +1,6 @@
 (ns phel-test\test\async
   (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [async await await-all await-any delay future-cancel future-cancelled? future-done? pmap ->closure]))
+  (:require phel\async :refer [delay]))
 
 ;; --- Pure function tests ---
 
@@ -10,15 +10,11 @@
     (is (= true (php/instanceof c \Closure)) "->closure returns a PHP Closure")
     (is (= 6 (c 3)) "Closure preserves function behavior")))
 
-(deftest test-async-macro-expands
-  (let [expanded (macroexpand '(phel\async/async (+ 1 2)))
-        source (print-str expanded)]
-    (is (php/str_contains source "amp\\async")
-        "async expansion still delegates to amp\\async")
-    (is (php/str_contains source "withDynamicBindings")
-        "async expansion wraps body in binding conveyance")
-    (is (php/str_contains source "snapshotDynamicBindings")
-        "async expansion snapshots caller bindings")))
+(deftest test-delay-suspends-execution
+  (let [start   (php/microtime true)
+        _       (delay 0.05)
+        elapsed (- (php/microtime true) start)]
+    (is (>= elapsed 0.04) "delay suspends for at least the requested duration")))
 
 ;; --- Runtime integration tests (amphp/amp) ---
 

--- a/tests/phel/test/core/async-in-core.phel
+++ b/tests/phel/test/core/async-in-core.phel
@@ -1,0 +1,52 @@
+(ns phel-test\test\core\async-in-core
+  (:require phel\test :refer [deftest is]))
+
+;; Regression test for https://github.com/phel-lang/phel-lang/issues/1548
+;; The Clojure-parity async surface (and Phel's fiber combinators that
+;; pair with `future`) must be available from `phel.core` without
+;; requiring `phel.async`, mirroring `clojure.core` and the prior
+;; `future`-in-core change (#1537).
+
+(deftest test-closure-bridge-is-available-without-require
+  (let [c (->closure (fn [x] (* x 2)))]
+    (is (= true (php/instanceof c \Closure)) "->closure is in core")
+    (is (= 6 (c 3)) "the produced Closure is callable")))
+
+(deftest test-async-await-are-available-without-require
+  (is (= 3 (await (async (+ 1 2))))
+      "async/await round-trip a value without requiring phel.async"))
+
+(deftest test-await-all-is-available-without-require
+  (is (= [1 2 3] (await-all [(async 1) (async 2) (async 3)]))
+      "await-all is in core"))
+
+(deftest test-await-any-is-available-without-require
+  (is (= 42 (await-any [(async 42)])) "await-any is in core"))
+
+(deftest test-pmap-is-available-without-require
+  (is (= [2 3 4] (pmap inc [1 2 3])) "pmap is in core"))
+
+(deftest test-promise-deliver-deref-are-available-without-require
+  (let [p (promise)]
+    (is (= p (deliver p 7)) "deliver returns the promise on first delivery")
+    (is (= 7 @p) "deref reads the delivered value")))
+
+(deftest test-future-call-and-future-fiber-are-available-without-require
+  (let [f1 @(future-call (fn [] 41))
+        f2 @(future-fiber (+ 20 22))]
+    (is (= 41 f1) "future-call works in core")
+    (is (= 42 f2) "future-fiber works in core")))
+
+(deftest test-future-predicate-is-available-without-require
+  (let [f (future-call (fn [] 1))]
+    (is (= true (future? f)) "future? recognizes a fiber-future")
+    (is (= false (future? 1)) "future? returns false for non-futures")))
+
+(deftest test-future-lifecycle-helpers-are-available-without-require
+  (let [result (await (async
+                        (let [f (future (do (php/amp\delay 0.5) 42))]
+                          (future-cancel f)
+                          {:cancelled (future-cancelled? f)
+                           :done      (future-done? f)})))]
+    (is (= true (get result :cancelled)) "future-cancelled? in core")
+    (is (= true (get result :done)) "future-done? in core")))

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -1,6 +1,5 @@
 (ns phel-test\test\core\binding-conveyance
-  (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [async await future-fiber]))
+  (:require phel\test :refer [deftest is]))
 
 ;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1536
 ;;


### PR DESCRIPTION
## 🤔 Background

Follow-up from #1548 (and the [PR #1545 review thread](https://github.com/phel-lang/phel-lang/pull/1545#discussion_r3128343501)). Now that `future` already lives in `phel\core` (#1537), the rest of the Clojure-parity async surface — primitives that are in `clojure.core` on the Clojure side — still required `(:require phel\async :refer [...])` to use, which created the same `.cljc` portability friction the earlier move was meant to remove.

The issue's discussion converged on **option (b)**: collapse the Clojure-parity (and pairing fiber-combinator) symbols into core, leaving `phel\async` as the home of the one symbol whose semantics intentionally diverge from Clojure (`delay`).

## 💡 Goal

Make portable Phel code work without remembering which primitive lives where, while keeping the one knowingly-divergent symbol explicit.

## 🔖 Changes

- New `src/phel/core/async.phel` (loaded after `core/futures.phel` from `src/phel/core.phel`) hosts the moved surface:
  - AMPHP layer: `async`, `await`, `await-all`, `await-any`, `pmap`, `future-cancel`, `future-cancelled?`, `future-done?`
  - Fiber layer: `promise`, `deliver`, `future-call`, `future-fiber`, `future?`
  - Bridge: `->closure`
- `phel\async` slimmed to a single export, `delay`. **No rename to `sleep`** — applied @jasalt's feedback that it would clash with `php/sleep`. Docstring expanded to clarify (a) top-level vs fiber behaviour, (b) that this is *not* `clojure.core/delay`, and (c) when to reach for `php/sleep` instead.
- `pmap` docstring now explicitly states it is single-threaded (overlaps IO-bound work, does not parallelize CPU), matching Basilisp/ClojureScript and avoiding the implicit promise of `clojure.core/pmap`'s thread-pool semantics.
- `tests/phel/test/core/async-in-core.phel` added — one assertion per moved capability, mirroring the `future-in-core.phel` style from #1537. Existing `tests/phel/test/async.phel`, `tests/phel/test/async-fiber.phel`, and `tests/phel/test/core/binding-conveyance.phel` updated to drop the now-unnecessary `:refer` lists.
- Docs: `docs/async-guide.md`, `docs/clojure-migration.md`, `docs/examples/11_async-concurrency.phel`, and the Fiber module's `CLAUDE.md` updated for the new home.
- CHANGELOG entry under `## Unreleased` → `Changed` → `Core` flagged **BREAKING** for users currently `:refer`ing the moved symbols from `phel\async` (the fix is just to drop them from the require list).

## ✅ Acceptance criteria mapping

1. **Decision recorded** — option (b) with `delay` consciously kept in `phel\async`.
2. **`delay` resolved** — kept in `phel\async`, no rename, docstring expanded per @jasalt's review.
3. **`docs/async-guide.md`** — AMPHP-vs-fiber decision guide preserved; namespace location notes updated.
4. **CHANGELOG + migration note** — both updated.
5. **Tests** — moved-symbol `:refer`s dropped, `async-in-core.phel` regression file added (per-feature, like `future-in-core.phel`).
6. **Load-order safety** — `core/async.phel` loaded after `core/futures.phel`; `\Phel\Fiber\FiberFacade` is autoloaded only on first call, so namespaces that don't use these primitives still pay nothing at runtime.

## 🧪 Verification

- `composer test-core`: 4352/4352 ✅ (+9 new vs main)
- `composer test-compiler`: only the pre-existing `DataReadersAutoloadTest` flake (also fails on `main`)
- `composer csrun`, `composer phpstan`, `composer rector`: ✅
- `./bin/phel run docs/examples/11_async-concurrency.phel`: ✅ runs end-to-end

## ⚠️ Breaking change

Code currently doing `(:require phel\async :refer [async await pmap …])` will need to drop those symbols from the `:refer` list (they're available unqualified). The only symbol that still needs `(:require phel\async :refer [delay])` is `delay`. Documented in CHANGELOG and `docs/clojure-migration.md`.

Closes #1548.