### PR TITLE
fix: resolve lowercase bare PHP classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - `phel analyze` pre-loads `phel\core` so core macros resolve (#1539)
 
 #### Compiler
+- Bare lowercase PHP class names like `stdClass` resolve consistently with uppercase aliases like `StdClass` (#1567)
 - `php/new` on a non-string, non-object throws a descriptive `InvalidArgumentException` (#1538)
 - `(new stdClass)` and `(php/new stdClass)` resolve lowercase-leading root PHP class names in class position (#1567)
 - `#?` and `#?@` reader conditionals tolerate a newline before the closing paren (#1547)

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -15,6 +15,10 @@ use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use RuntimeException;
 
+use function class_exists;
+use function interface_exists;
+use function trait_exists;
+
 final readonly class SymbolResolver
 {
     public function __construct(
@@ -66,10 +70,11 @@ final readonly class SymbolResolver
             return $resolved;
         }
 
-        // Fallback: a bare uppercase identifier with no other resolution is
-        // treated as a PHP root-namespace class FQN, so `Exception` resolves
-        // the same as `\Exception`. Kicks in *after* the normal resolution
-        // paths so user-defined definitions (`(def Foo …)`) still win.
+        // Fallback: a bare class identifier with no other resolution is
+        // treated as a PHP root-namespace class FQN. Uppercase names keep
+        // Clojure-style behavior for unloaded classes, while lowercase PHP
+        // built-ins like `stdClass` resolve when PHP already knows them.
+        // Kicks in *after* normal resolution so `(def Foo ...)` still wins.
         if ($name->getNamespace() === null && $this->looksLikeBareClassName($strName)) {
             $fqn = Symbol::create('\\' . $strName);
             $fqn->copyLocationFrom($name);
@@ -126,13 +131,22 @@ final readonly class SymbolResolver
 
     /**
      * Accept bare uppercase identifiers as root-namespace PHP class FQN
-     * aliases, so `Exception` resolves the same as `\Exception`. Matches
-     * Clojure's convention where bare `Exception` resolves via
-     * `java.lang` autoimport.
+     * aliases, so `Exception` resolves the same as `\Exception`. Also
+     * accepts known PHP class/interface/trait names regardless of leading
+     * case, so `stdClass` matches PHP's case-insensitive class lookup.
      */
     private function looksLikeBareClassName(string $name): bool
     {
-        return preg_match('/^[A-Z]\w*$/', $name) === 1;
+        if (preg_match('/^[A-Z]\w*$/', $name) === 1) {
+            return true;
+        }
+
+        return preg_match('/^[A-Za-z_]\w*$/', $name) === 1
+            && (
+                class_exists($name, false)
+                || interface_exists($name, false)
+                || trait_exists($name, false)
+            );
     }
 
     private function remapClojureAlias(string $alias): string

--- a/tests/php/Integration/Api/ApiFacadeTest.php
+++ b/tests/php/Integration/Api/ApiFacadeTest.php
@@ -14,7 +14,12 @@ use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
+use function array_unique;
+use function array_values;
 use function count;
+use function implode;
+use function sprintf;
 
 final class ApiFacadeTest extends TestCase
 {
@@ -40,15 +45,31 @@ final class ApiFacadeTest extends TestCase
      */
     private function assertAllNamespacesAreLoaded(array $functions): void
     {
-        $loadedNamespaces = array_unique(array_column($functions, 'namespace'));
+        $loadedNamespaces = array_values(array_unique(array_map(
+            static fn(PhelFunction $fn): string => $fn->namespace,
+            $functions,
+        )));
         $expectedNamespaces = array_map(
             static fn(string $ns): string => str_replace('phel\\', '', $ns),
             ApiConfig::allNamespaces(),
         );
 
         foreach ($expectedNamespaces as $expectedNamespace) {
-            self::assertContains($expectedNamespace, $loadedNamespaces);
+            self::assertContains(
+                $expectedNamespace,
+                $loadedNamespaces,
+                sprintf(
+                    "Expected namespace '%s' to be loaded. Loaded namespaces: %s",
+                    $expectedNamespace,
+                    implode(', ', $loadedNamespaces),
+                ),
+            );
         }
+
+        self::assertNotNull(
+            $this->findFunction($functions, 'async', 'delay'),
+            'Expected phel.async/delay to be loaded as the public phel.async function.',
+        );
     }
 
     /**
@@ -61,5 +82,19 @@ final class ApiFacadeTest extends TestCase
             self::assertNotEmpty($fn->namespace);
             self::assertNotEmpty($fn->name);
         }
+    }
+
+    /**
+     * @param list<PhelFunction> $functions
+     */
+    private function findFunction(array $functions, string $namespace, string $name): ?PhelFunction
+    {
+        foreach ($functions as $fn) {
+            if ($fn->namespace === $namespace && $fn->name === $name) {
+                return $fn;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -339,6 +339,16 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
+    public function test_resolve_bare_lowercase_php_class(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\stdClass')),
+            $this->resolver->resolve(Symbol::create('stdClass'), $nodeEnv),
+        );
+    }
+
     public function test_bare_lowercase_name_does_not_become_class_fqn(): void
     {
         $nodeEnv = NodeEnvironment::empty();


### PR DESCRIPTION
## 🤔 Background

A follow-up comment on #1567 showed that bare `StdClass` and `stdClass` behaved differently in the REPL. `StdClass` resolved as a PHP class reference, while `stdClass` failed with `[PHEL001] Cannot resolve symbol`.

## 💡 Goal

Make known lowercase PHP class names resolve consistently with uppercase aliases, without making arbitrary lowercase Phel symbols look like classes.

Closes #1567

## 🔖 Changes

- Resolve loaded bare PHP classes/interfaces/traits regardless of leading case, so `stdClass` follows PHP class lookup.
- Keep the existing uppercase fallback for Clojure-style class aliases.
- Add resolver coverage for `stdClass` and keep unknown lowercase symbols unresolved.
- Add a changelog entry.

Validation:

- `composer test-compiler -- --filter SymbolResolverTest`
- Exact issue-comment eval cases: `StdClass`, `stdClass`, `(new StdClass)`, `(new stdClass)`
- Commit hook full gate with `COMPOSER_PROCESS_TIMEOUT=0`: static analysis, compiler tests, and core tests.