### PR TITLE
fix: make apply resolve as core function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
 - `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
 - `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
+- Bare `apply` resolves as a first-class `phel\core` function while `(apply ...)` keeps its special-form behavior (#1564)
 - `eval` returns closures and other already-evaluated PHP objects unchanged instead of throwing a `TypeError` (#1563)
 
 #### Build

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -83,6 +83,17 @@
 ;; Function operation
 ;; ------------------
 
+(defn apply
+  "Applies function `f` to the argument list formed by prepending any
+  intervening arguments to the final collection argument."
+  {:example "(apply + [1 2 3]) ; => 6\n((identity apply) + 1 [2 3]) ; => 6"
+   :see-also ["partial" "comp"]}
+  ([f args] (apply f args))
+  ([f x args] (apply f (cons x args)))
+  ([f x y args] (apply f (cons x (cons y args))))
+  ([f x y z args] (apply f (cons x (cons y (cons z args)))))
+  ([f a b c d & args] (apply f (concat [a b c d] (butlast args) (last args)))))
+
 (defn constantly
   "Returns a function that always returns `x` and ignores any passed arguments."
   [x]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -326,6 +326,13 @@
   (is (= {} (apply dissoc {} [])) "apply dissoc with no keys does not raise")
   (is (= {:b 2} (apply dissoc {:a 1 :b 2 :c 3} [:a :c])) "apply dissoc variadic through seq"))
 
+(deftest test-apply
+  (is (fn? apply) "bare apply resolves to a function")
+  (is (= 6 ((identity apply) + [1 2 3])) "apply can be invoked as a value")
+  (is (= 6 ((identity apply) + 1 [2 3])) "apply prepends one argument")
+  (is (= 10 ((identity apply) + 1 2 3 [4])) "apply prepends multiple arguments")
+  (is (= 21 ((identity apply) + 1 2 3 4 5 [6])) "apply handles variadic intervening arguments"))
+
 (deftest test-next
   (is (nil? (next [])) "next of empty vector")
   (is (nil? (next [1])) "next of one element vector")

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -189,6 +189,12 @@
     (is (= "phel\\core" (namespace sym)) "resolve lives in phel\\core")
     (is (= "resolve" (name sym)) "resolve has correct name")))
 
+(deftest test-resolve-apply
+  (let [sym (resolve 'apply)]
+    (is (not (nil? sym)) "resolve returns non-nil for apply")
+    (is (= "phel\\core" (namespace sym)) "apply resolves to phel\\core")
+    (is (= "apply" (name sym)) "apply has correct name")))
+
 (deftest test-time
   (is (= 2 (+ 1 1)) "time returns expr value")
   (let [output-print (with-output-buffer (time (+ 1 1)))]


### PR DESCRIPTION
## 🤔 Background

The API reference documents `apply` as part of `phel\core` with the signature `(apply f expr*)`: https://phel-lang.org/documentation/reference/api/#apply

Before this change, `apply` only worked because the compiler recognized `(apply ...)` in call position as a special form. That handled calls like `(apply + [1 2 3])`, but there was no actual `phel\core/apply` var for normal symbol resolution. As a result, evaluating bare `apply`, resolving `'apply`, or passing `apply` as a first-class function failed with `Cannot resolve symbol 'apply'` even though the documented API listed it as a core function.

Closes #1564

## 💡 Goal

Make `apply` resolve like the documented core function while preserving the existing compiler special-form behavior for `(apply ...)` call sites.

## 🔖 Changes

- Adds a first-class `phel\core/apply` function that delegates to the existing `apply` special form.
- Covers bare symbol resolution and first-class invocation through focused Phel core tests.
- Adds a regression for `(resolve 'apply)` returning the `phel\core` symbol.