### PR TITLE
fix: emit PHP class references as values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - Bare lowercase PHP class names like `stdClass` resolve consistently with uppercase aliases like `StdClass` (#1567)
+- PHP class references imported with `use` can be bound and passed as class strings, while PHP constants imported with `use` still resolve as constants (#1560)
 - `php/new` on a non-string, non-object throws a descriptive `InvalidArgumentException` (#1538)
 - `(new stdClass)` and `(php/new stdClass)` resolve lowercase-leading root PHP class names in class position (#1567)
 - `#?` and `#?@` reader conditionals tolerate a newline before the closing paren (#1547)

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Registry;
@@ -17,6 +18,7 @@ use RuntimeException;
 
 use function class_exists;
 use function interface_exists;
+use function ltrim;
 use function trait_exists;
 
 final readonly class SymbolResolver
@@ -70,10 +72,16 @@ final readonly class SymbolResolver
             return $resolved;
         }
 
+        if ($name->getNamespace() === null && $this->looksLikePhpConstantName($strName)) {
+            return new PhpVarNode($env, $strName, $name->getStartLocation());
+        }
+
         // Fallback: a bare class identifier with no other resolution is
-        // treated as a PHP root-namespace class FQN. Uppercase names keep
-        // Clojure-style behavior for unloaded classes, while lowercase PHP
-        // built-ins like `stdClass` resolve when PHP already knows them.
+        // treated as a PHP root-namespace class FQN. Class-shaped uppercase
+        // names keep Clojure-style behavior for unloaded classes, while
+        // constant-shaped names like JSON_HEX_AMP stay PHP constants.
+        // Lowercase PHP built-ins like `stdClass` resolve when PHP already
+        // knows them.
         // Kicks in *after* normal resolution so `(def Foo ...)` still wins.
         if ($name->getNamespace() === null && $this->looksLikeBareClassName($strName)) {
             $fqn = Symbol::create('\\' . $strName);
@@ -85,7 +93,7 @@ final readonly class SymbolResolver
         return null;
     }
 
-    private function resolveFromUseAlias(Symbol $name, NodeEnvironmentInterface $env): ?PhpClassNameNode
+    private function resolveFromUseAlias(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
     {
         $currentNs = $this->globalEnv->getNs();
         $useAliases = $this->globalEnv->getUseAliases($currentNs);
@@ -97,6 +105,10 @@ final readonly class SymbolResolver
 
         $alias = $useAliases[$strName];
         $alias->copyLocationFrom($name);
+
+        if ($alias->getNamespace() === null && $this->looksLikePhpConstantName(ltrim($alias->getName(), '\\'))) {
+            return new PhpVarNode($env, $alias->getName(), $name->getStartLocation());
+        }
 
         return new PhpClassNameNode($env, $alias, $name->getStartLocation());
     }
@@ -137,7 +149,7 @@ final readonly class SymbolResolver
      */
     private function looksLikeBareClassName(string $name): bool
     {
-        if (preg_match('/^[A-Z]\w*$/', $name) === 1) {
+        if (preg_match('/^[A-Z]\w*$/', $name) === 1 && preg_match('/[a-z]/', $name) === 1) {
             return true;
         }
 
@@ -147,6 +159,11 @@ final readonly class SymbolResolver
                 || interface_exists($name, false)
                 || trait_exists($name, false)
             );
+    }
+
+    private function looksLikePhpConstantName(string $name): bool
+    {
+        return preg_match('/^[A-Z_][A-Z0-9_]*$/', $name) === 1;
     }
 
     private function remapClojureAlias(string $alias): string

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -6,8 +6,10 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Lang\Symbol;
 
 use function assert;
 use function count;
@@ -28,7 +30,11 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         if ($fnNode instanceof PhpVarNode && $fnNode->isInfix()) {
-            $this->emitPhpVarNodeInfix($node, $fnNode);
+            if ($fnNode->getName() === 'instanceof' && count($node->getArguments()) === 2) {
+                $this->emitInstanceof($node);
+            } else {
+                $this->emitPhpVarNodeInfix($node, $fnNode);
+            }
         } else {
             $this->emitPhpVarNode($node, $fnNode);
         }
@@ -55,12 +61,66 @@ final class CallEmitter implements NodeEmitterInterface
     private function emitPhpVarNodeInfix(CallNode $node, PhpVarNode $fnNode): void
     {
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
-        $this->outputEmitter->emitArgList(
-            $node->getArguments(),
-            $node->getStartSourceLocation(),
-            ' ' . $fnNode->getName() . ' ',
-        );
+        $arguments = $node->getArguments();
+        $argumentCount = count($arguments);
+        foreach ($arguments as $i => $argument) {
+            $this->emitInfixArgument($fnNode, $argument, $i);
+
+            if ($i < $argumentCount - 1) {
+                $this->outputEmitter->emitStr(' ' . $fnNode->getName() . ' ', $node->getStartSourceLocation());
+            }
+        }
+
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+    }
+
+    private function emitInstanceof(CallNode $node): void
+    {
+        $arguments = $node->getArguments();
+        assert(count($arguments) === 2);
+        [$value, $class] = $arguments;
+
+        if ($class instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($value);
+            $this->outputEmitter->emitStr(' instanceof ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr($class->getAbsolutePhpName(), $class->getName()->getStartLocation());
+            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+            return;
+        }
+
+        $valueSym = Symbol::gen('instanceof_value_');
+        $classSym = Symbol::gen('instanceof_class_');
+
+        $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitPhpVariable($valueSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($value);
+        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitPhpVariable($classSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($class);
+        $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitStr('return ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitPhpVariable($valueSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' instanceof ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitPhpVariable($classSym, $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
+
+        $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
+    }
+
+    private function emitInfixArgument(PhpVarNode $fnNode, AbstractNode $argument, int $index): void
+    {
+        if ($fnNode->getName() === 'instanceof' && $index === 1 && $argument instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr($argument->getAbsolutePhpName(), $argument->getName()->getStartLocation());
+            return;
+        }
+
+        $this->outputEmitter->emitNode($argument);
     }
 
     private function emitPhpVarNode(CallNode $node, AbstractNode $fnNode): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CatchEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CatchEmitter.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
@@ -19,7 +20,13 @@ final class CatchEmitter implements NodeEmitterInterface
         assert($node instanceof CatchNode);
 
         $this->outputEmitter->emitStr(' catch (', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($node->getType());
+        $type = $node->getType();
+        if ($type instanceof PhpClassNameNode) {
+            $this->outputEmitter->emitStr($type->getAbsolutePhpName(), $type->getName()->getStartLocation());
+        } else {
+            $this->outputEmitter->emitNode($type);
+        }
+
         $this->outputEmitter->emitStr(
             ' $' . $this->outputEmitter->mungeEncode($node->getName()->getName()),
             $node->getName()->getStartLocation(),

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefExceptionEmitter.php
@@ -82,7 +82,8 @@ final readonly class DefExceptionEmitter implements NodeEmitterInterface
             'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends ',
             $node->getStartSourceLocation(),
         );
-        $this->outputEmitter->emitNode($node->getParent());
+        $parent = $node->getParent();
+        $this->outputEmitter->emitStr($parent->getAbsolutePhpName(), $parent->getName()->getStartLocation());
         $this->outputEmitter->emitLine(' {');
         $this->outputEmitter->increaseIndentLevel();
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpClassNameEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpClassNameEmitter.php
@@ -19,7 +19,7 @@ final class PhpClassNameEmitter implements NodeEmitterInterface
         assert($node instanceof PhpClassNameNode);
 
         $this->outputEmitter->emitStr(
-            $node->getAbsolutePhpName(),
+            $node->getAbsolutePhpName() . '::class',
             $node->getName()->getStartLocation(),
         );
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpNewEmitter.php
@@ -34,7 +34,7 @@ final class PhpNewEmitter implements NodeEmitterInterface
 
         if ($classExpr instanceof PhpClassNameNode) {
             $this->outputEmitter->emitStr('(new ', $node->getStartSourceLocation());
-            $this->outputEmitter->emitNode($classExpr);
+            $this->outputEmitter->emitStr($classExpr->getAbsolutePhpName(), $classExpr->getName()->getStartLocation());
             $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         } else {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/PhpObjectCallEmitter.php
@@ -37,7 +37,7 @@ final class PhpObjectCallEmitter implements NodeEmitterInterface
 
         if ($node->isStatic() && $targetExpr instanceof PhpClassNameNode) {
             $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
-            $this->outputEmitter->emitNode($targetExpr);
+            $this->outputEmitter->emitStr($targetExpr->getAbsolutePhpName(), $targetExpr->getName()->getStartLocation());
             $this->outputEmitter->emitStr($fnCode, $node->getStartSourceLocation());
         } else {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());

--- a/tests/php/Integration/Fixtures/Call/php-instanceof-bound-class-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-instanceof-bound-class-reference.test
@@ -1,0 +1,17 @@
+--PHEL--
+(use RecursiveArrayIterator)
+(let [PHPChildT RecursiveArrayIterator]
+  (php/instanceof (php/new PHPChildT (php/array)) PHPChildT))
+--PHP--
+$PHPChildT_1 = \RecursiveArrayIterator::class;
+(function() use($PHPChildT_1) {
+  $instanceof_value_2 = (function() use($PHPChildT_1) {
+    $target_4 = $PHPChildT_1;
+    if (!is_string($target_4) && !is_object($target_4)) {
+    throw new \InvalidArgumentException(sprintf("php/new expects a class name or object, %s given (%s)", get_debug_type($target_4), var_export($target_4, true)));
+    }
+    return new $target_4(array());
+  })();
+  $instanceof_class_3 = $PHPChildT_1;
+  return $instanceof_value_2 instanceof $instanceof_class_3;
+})();

--- a/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
@@ -1,0 +1,23 @@
+--PHEL--
+(use RecursiveArrayIterator)
+(def PHPChildT RecursiveArrayIterator)
+PHPChildT
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "PHPChildT",
+  \RecursiveArrayIterator::class,
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-php-class-reference.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/def-php-class-reference.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 38
+    )
+  )
+);
+\Phel::getDefinition("user", "PHPChildT");

--- a/tests/php/Integration/Fixtures/Def/use-php-constant-reference.test
+++ b/tests/php/Integration/Fixtures/Def/use-php-constant-reference.test
@@ -1,0 +1,5 @@
+--PHEL--
+(use \JSON_HEX_AMP)
+JSON_HEX_AMP
+--PHP--
+\JSON_HEX_AMP;

--- a/tests/php/Integration/Fixtures/Let/let-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-class-reference.test
@@ -1,0 +1,7 @@
+--PHEL--
+(use RecursiveArrayIterator)
+(let [PHPChildT RecursiveArrayIterator]
+  PHPChildT)
+--PHP--
+$PHPChildT_1 = \RecursiveArrayIterator::class;
+$PHPChildT_1;


### PR DESCRIPTION
## 🤔 Background

Issue #1560 points out that imported PHP class symbols resolve during analysis but fail in value position, for example `(def PHPChildT RecursiveArrayIterator)` emits a bare PHP class token and PHP treats it as an undefined constant.

PHP class references used as values should be emitted as class strings, while class-position interop forms still need raw class names.

## 💡 Goal

Allow PHP class references imported with `use` to be bound and passed around as class strings without regressing PHP class-position forms or PHP constants imported with `use`.

## 🔖 Changes

- Emit `PhpClassNameNode` as `::class` in normal value position.
- Keep raw class-name emission for `php/new`, `php/::`, `catch`, and `defexception` class positions.
- Add `php/instanceof` handling for direct class symbols and dynamic class-string expressions.
- Preserve PHP constant-shaped symbols and `use` aliases like `\JSON_HEX_AMP` as constants, not class strings.
- Add integration fixtures for `def`, `let`, dynamic `php/instanceof`, and PHP constants imported with `use`.