### PR TITLE
feat: support PHP class hierarchy tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
 - `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
 - `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
+- `isa?`, `parents`, and `ancestors` include PHP parent classes and implemented interfaces for class-string tags (#1560)
 - Bare `apply` resolves as a first-class `phel\core` function while `(apply ...)` keeps its special-form behavior (#1564)
 - `eval` returns closures and other already-evaluated PHP objects unchanged instead of throwing a `TypeError` (#1563)
 

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -58,11 +58,36 @@
   []
   {:parents {} :descendants {} :ancestors {}})
 
+(defn- php-class-tag?
+  "Returns true when tag is a PHP class/interface/trait name string."
+  [tag]
+  (and (string? tag)
+       (or (php/class_exists tag)
+           (php/interface_exists tag)
+           (php/trait_exists tag))))
+
+(defn- php-class-relations
+  "Returns PHP parent classes and implemented interfaces for a class tag."
+  [tag]
+  (if (php-class-tag? tag)
+    (let [parents    (php/class_parents tag)
+          interfaces (php/class_implements tag)]
+      (union
+       (if (php/=== parents false) (hash-set) (apply hash-set (vals parents)))
+       (if (php/=== interfaces false) (hash-set) (apply hash-set (vals interfaces)))))
+    (hash-set)))
+
+(defn- direct-parents
+  "Returns manually-derived parents plus PHP type parents for tag."
+  [parents-map tag]
+  (union (get parents-map tag (hash-set))
+         (php-class-relations tag)))
+
 (defn- compute-ancestors
   "Computes all transitive ancestors of tag from a parents map."
   [parents-map tag]
-  (let [direct (get parents-map tag)]
-    (if (nil? direct)
+  (let [direct (direct-parents parents-map tag)]
+    (if (empty? direct)
       (hash-set)
       (reduce
        (fn [acc p]
@@ -74,8 +99,8 @@
   "Checks if child is (transitively) a descendant of parent in parents-map.
   Walks up the parent chain without building the full ancestor set."
   [parents-map child parent]
-  (let [direct (get parents-map child)]
-    (if (nil? direct)
+  (let [direct (direct-parents parents-map child)]
+    (if (empty? direct)
       false
       (if (contains? direct parent)
         true
@@ -191,7 +216,7 @@
   ([tag]
    (parents @*hierarchy* tag))
   ([h tag]
-   (let [p (get (get h :parents) tag)]
+   (let [p (direct-parents (get h :parents) tag)]
      (when (and p (not (empty? p))) p))))
 
 (defn ancestors

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -1,5 +1,9 @@
 (ns phel-test\test\core\hierarchy
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is])
+  (:use RecursiveArrayIterator)
+  (:use ArrayIterator)
+  (:use RecursiveIterator)
+  (:use Traversable))
 
 ;; Each test uses unique keyword prefixes to avoid state leaking between tests.
 
@@ -52,6 +56,30 @@
 
 (deftest test-ancestors-nil-for-root
   (is (nil? (ancestors :a2-nonexistent)) "no ancestors returns nil"))
+
+;; --- PHP class hierarchy ---
+
+(def PHPChildT RecursiveArrayIterator)
+(def PHPAncestorT ArrayIterator)
+(def PHPInterfaceT RecursiveIterator)
+(def PHPTransitiveInterfaceT Traversable)
+
+(deftest test-php-class-parents
+  (let [p (parents PHPChildT)]
+    (is (contains? p PHPAncestorT) "parents contains PHP parent class")
+    (is (contains? p PHPInterfaceT) "parents contains implemented PHP interface")))
+
+(deftest test-php-class-ancestors
+  (let [anc (ancestors PHPChildT)]
+    (is (contains? anc PHPAncestorT) "ancestors contains PHP parent class")
+    (is (contains? anc PHPInterfaceT) "ancestors contains implemented PHP interface")
+    (is (contains? anc PHPTransitiveInterfaceT) "ancestors contains transitive PHP interface")))
+
+(deftest test-php-class-isa
+  (is (true? (isa? PHPChildT PHPAncestorT)) "PHP class isa parent class")
+  (is (true? (isa? PHPChildT PHPInterfaceT)) "PHP class isa implemented interface")
+  (is (true? (isa? PHPChildT PHPTransitiveInterfaceT)) "PHP class isa transitive interface")
+  (is (false? (isa? PHPAncestorT PHPChildT)) "PHP parent is not child"))
 
 ;; --- descendants ---
 


### PR DESCRIPTION
## 🤔 Background

PR #1586 made imported PHP class references usable as class-string values. Issue #1560 also called out that Clojure hierarchy functions can understand native class inheritance when class tags are used.

Phel's hierarchy functions currently only consult manually-derived hierarchy data, so class-string tags do not report PHP parent classes or implemented interfaces.

## 💡 Goal

Teach hierarchy lookups to include PHP type relationships for class-string tags, while keeping manual hierarchy behavior unchanged.

## 🔖 Changes

- Add internal helpers for detecting PHP class/interface/trait class-string tags.
- Include PHP parent classes and implemented interfaces in `parents`, `ancestors`, and `isa?` lookups.
- Keep `descendants` based on known/manual hierarchy data; PHP cannot reliably enumerate arbitrary loaded descendants.
- Add core tests for PHP parent classes, implemented interfaces, transitive interfaces, and reverse `isa?` checks.
- Clean up the data-readers integration cache before and after its test to prevent stale generated cache from affecting local runs.
- Update `CHANGELOG.md` under `Unreleased`.
