### PR TITLE
test: clean data readers generated cache

### DIFF
--- a/tests/php/Integration/Run/DataReaders/DataReadersAutoloadTest.php
+++ b/tests/php/Integration/Run/DataReaders/DataReadersAutoloadTest.php
@@ -6,13 +6,31 @@ namespace PhelTest\Integration\Run\DataReaders;
 
 use Phel\Run\Infrastructure\Command\RunCommand;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use PhelTest\Integration\Util\DirectoryUtil;
 use Symfony\Component\Console\Input\InputInterface;
 
 use function ob_get_clean;
 use function ob_start;
+use function register_shutdown_function;
 
 final class DataReadersAutoloadTest extends AbstractTestCommand
 {
+    private const string CACHE_DIR = __DIR__ . '/cache';
+
+    protected function setUp(): void
+    {
+        $this->removeGeneratedCache();
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetContainer();
+        $this->removeGeneratedCache();
+        $this->removeGeneratedCacheOnShutdown();
+        parent::tearDown();
+    }
+
     public function test_it_registers_tags_from_data_readers_file(): void
     {
         $output = $this->captureRunOutput(__DIR__ . '/Fixtures/consumer.phel');
@@ -29,6 +47,18 @@ final class DataReadersAutoloadTest extends AbstractTestCommand
         );
 
         return ob_get_clean() ?: '';
+    }
+
+    private function removeGeneratedCache(): void
+    {
+        DirectoryUtil::removeDir(self::CACHE_DIR);
+    }
+
+    private function removeGeneratedCacheOnShutdown(): void
+    {
+        register_shutdown_function(static function (): void {
+            DirectoryUtil::removeDir(self::CACHE_DIR);
+        });
     }
 
     private function stubInput(string $path): InputInterface


### PR DESCRIPTION
## 🤔 Background

The data-readers integration test writes generated cache files under its fixture directory. Those files are ignored, so stale local cache state can survive between repeated test runs and affect later local runs.

## 💡 Goal

Keep the data-readers integration test isolated by cleaning its generated cache before and after the test runs.

## 🔖 Changes

- Clean the data-readers fixture cache before bootstrapping the test.
- Reset the Gacela container and clean the fixture cache during teardown.
- Register a shutdown cleanup so namespace-cache writes flushed at PHP shutdown do not leave stale ignored files behind.
