### PR TITLE
fix: make repl dir accept bare namespace symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this project will be documented in this file.
 #### API
 - `phel analyze` pre-loads `phel\core` so core macros resolve (#1539)
 
+#### REPL
+- `dir` accepts bare namespace symbols like `(dir phel\string)` while keeping string namespace support (#1588)
+
 #### Compiler
 - Bare lowercase PHP class names like `stdClass` resolve consistently with uppercase aliases like `StdClass` (#1567)
 - PHP class references imported with `use` can be bound and passed as class strings, while PHP constants imported with `use` still resolve as constants (#1560)

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -263,13 +263,13 @@
     (when resolved-sym
       `(get-symbol-info ~(namespace resolved-sym) ~(name resolved-sym)))))
 
-(defn dir
-  "Prints all public definitions in the given namespace string.
+(defn- dir-fn
+  "Prints all public definitions in the given namespace symbol or string.
 
   Returns nil. Prints one name per line, sorted alphabetically."
-  {:example "(dir \"phel\\core\")"}
-  [ns-str]
-  (let [encoded (munge-ns ns-str)
+  [ns]
+  (let [ns-str  (name ns)
+        encoded (munge-ns ns-str)
         defs    (php/:: Phel (getDefinitionInNamespace encoded))
         munge   (php/new Munge)
         names   (for [fn-name :keys defs
@@ -279,6 +279,16 @@
     (foreach [n (sort names)]
       (println n))
     nil))
+
+(defmacro dir
+  "Prints all public definitions in the given namespace symbol or string.
+
+  Returns nil. Prints one name per line, sorted alphabetically."
+  {:example "(dir phel\\core)"}
+  [ns]
+  (if (string? ns)
+    `(dir-fn ~ns)
+    `(dir-fn '~ns)))
 
 (defn apropos
   "Returns a vector of symbols whose name contains the given search string.

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -27,6 +27,16 @@
     (is (s/contains? out "reduce") "dir lists 'reduce'")
     (is (s/contains? out "filter") "dir lists 'filter'")))
 
+(deftest test-dir-accepts-bare-namespace-symbol
+  (let [out (with-output-buffer (dir phel\string))]
+    (is (s/contains? out "split") "dir lists phel\\string definitions")
+    (is (s/contains? out "trim") "dir lists phel\\string definitions")))
+
+(deftest test-dir-keeps-string-namespace-form
+  (let [out (with-output-buffer (dir "phel\\string"))]
+    (is (s/contains? out "split") "dir keeps string namespace support")
+    (is (s/contains? out "trim") "dir keeps string namespace support")))
+
 ;; --------
 ;; find-doc
 ;; --------


### PR DESCRIPTION
## 🤔 Background

`dir` was implemented as a function that expected an evaluated namespace string. That meant `(dir phel\string)` tried to resolve `phel\string` as a var before `dir` could inspect it.

## 💡 Goal

Support Clojure-style REPL usage where `(dir phel\string)` treats the bare namespace as data, while keeping the existing string form working.

Fixes #1588

## 🔖 Changes

- Move the implementation into a private `dir-fn` helper that accepts a namespace symbol or string.
- Make public `dir` a macro that quotes namespace symbols and forwards string literals unchanged.
- Add Phel REPL tests for bare namespace symbols and the existing string form.
- Add an Unreleased changelog entry.

## Testing

- `./bin/phel test tests/phel/test/repl.phel --filter='test-dir' --fail-fast`
- `./bin/phel test tests/phel/test/repl.phel`
- `composer test-core`