### PR TITLE
docs: remove irrelevant mentions of Janet

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Phel Language
 
-Functional programming language compiling to PHP. Lisp dialect inspired by Clojure and Janet.
+Functional programming language compiling to PHP. Lisp dialect inspired by Clojure.
 
 ## Architecture
 

--- a/.claude/hooks/compact-context.sh
+++ b/.claude/hooks/compact-context.sh
@@ -3,7 +3,7 @@
 cat <<'EOF'
 ## Context Reminder (post-compaction)
 
-**Phel** is a Lisp that compiles to PHP (Clojure/Janet-inspired).
+**Phel** is a Lisp that compiles to PHP (Clojure-inspired).
 
 - Conventional commits (`feat:`, `fix:`, `ref:`, `chore:`). NEVER mention AI tooling.
 - Test: `composer test` (all), `test-compiler` (PHP), `test-core` (Phel)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-Phel is a Lisp that compiles to PHP, inspired by Clojure and Janet. The codebase has two source trees:
+Phel is a Lisp that compiles to PHP, inspired by Clojure. The codebase has two source trees:
 
 - **`src/php/`** — PHP runtime and compiler (PSR-4: `Phel\`). Key modules: `Lang` (persistent data types), `Compiler` (lex/parse/analyze/emit pipeline), `Run` (namespace execution and REPL), `Console` (Symfony CLI), `Command` (shared command helpers), `Build` (build orchestration), `Config` (configuration), and `Shared` (constants and facades).
 - **`src/phel/`** — Core library written in Phel itself: `core`, `str`, `html`, `http`, `json`, `test`, `repl`, `walk`, `pprint`, `debug`, `mock`.

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -62,7 +62,7 @@ Replace dependencies with controlled stand-ins for testing.
 ;; Automatically reset here
 ```
 
-For wrapped mocks (PHP/Janet interop):
+For wrapped mocks (PHP interop):
 ```phel
 (with-mock-wrapper [symfony-service mock-http
                     (fn [args] (mock-http (adapt args)))]

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -77,7 +77,7 @@ final class AnalyzePersistentList
     {
         if (count($list) === 0) {
             // `()` is a self-quoting empty list literal — not an invocation
-            // of a missing head. Matches Clojure/Janet and keeps forms like
+            // of a missing head. Matches Clojure and keeps forms like
             // `(into () ...)` or `(= () (list))` usable.
             return new QuoteNode($env, $list, $list->getStartLocation());
         }

--- a/tests/phel/test/mock.phel
+++ b/tests/phel/test/mock.phel
@@ -327,7 +327,7 @@
 ;; -----------
 
 (defn call-external-service [http-fn endpoint]
-  "Simulates calling an external service (could be PHP, Janet, or any foreign function)"
+  "Simulates calling an external service (could be PHP, Clojure, or any foreign function)"
   (http-fn endpoint))
 
 (deftest test-mock-external-interop-function


### PR DESCRIPTION
closes: https://github.com/phel-lang/phel-lang/issues/1593

Erases mentions of Janet in LLM docs and docstrings.