### PR TITLE
fix: handle nil collections in contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
+- `contains?` returns `false` for `nil` collections instead of throwing (#1592)
 - `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
 - `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
 - `isa?`, `parents`, and `ancestors` include PHP parent classes and implemented interfaces for class-string tags (#1560)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -304,6 +304,7 @@
   {:example "(contains? [10 20 30] 1) ; => true"}
   [coll key]
   (cond
+    (nil? coll) false
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
     (php/is_array coll) (php/array_key_exists key coll)
     (php/is_string coll) (and (php/is_int key) (php/>= key 0) (php/< key (php/mb_strlen coll)))

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -229,6 +229,10 @@
     (is (true? (contains? full-name :street)))
     (is (false? (contains? full-name :unknown)))))
 
+(deftest test-contains?-nil
+  (is (false? (contains? nil nil)))
+  (is (false? (contains? nil :anything))))
+
 (deftest test-contains?-list
   (is (false? (contains? '() 0)))
   (is (true? (contains? '(1) 0)))


### PR DESCRIPTION
## 🤔 Background

`(contains? nil nil)` currently throws because the fallback error path calls `get_class` on `nil`. Clojure returns `false` for this case.

Closes #1592

## 💡 Goal

Make `contains?` return `false` for nil collections while preserving existing behavior for supported collection types and unsupported non-nil values.

## 🔖 Changes

- Return `false` early when `contains?` receives a nil collection.
- Add regression coverage for `(contains? nil nil)` and another nil collection key.