### PR TITLE
fix: include generated type ancestors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `binding` on `^:dynamic` vars is fiber-local; `future`/`async` convey caller bindings (#1536)
 - `contains?` returns `false` for `nil` collections instead of throwing (#1592)
+- `ancestors` includes inline protocols and PHP parents for `defrecord` and `deftype` constructor functions (#1591)
 - `=` between a list and any sequential collection (vector, lazy seq) is symmetric (#1546)
 - `()` is a self-quoting empty list literal — `(conj () 1)`, `(cons 1 ())`, `(if () :a :b)` all work (#1549)
 - `isa?`, `parents`, and `ancestors` include PHP parent classes and implemented interfaces for class-string tags (#1560)

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -106,6 +106,7 @@
     `(do
        (defstruct* ~name ~keys ~@implementations)
        (defn ~name ~(php/. "Creates a new " name " struct.") ~keys (php/new ~class-name-str ~@keys))
+       (swap! *type-tag-registry* assoc ~name ~class-name-str)
        (defn ~is-name ~(php/. "Checks if `x` is an instance of the " name " struct.") [x] (php/is_a x ~class-name-str)))))
 
 (defmacro defexception

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -77,11 +77,21 @@
        (if (php/=== interfaces false) (hash-set) (apply hash-set (vals interfaces)))))
     (hash-set)))
 
+(def ^:private *type-tag-registry*
+  "Maps generated struct constructor functions to their PHP class tag."
+  (atom {}))
+
+(defn- hierarchy-tag
+  "Resolves public type constructor functions to their generated PHP class tag."
+  [tag]
+  (get @*type-tag-registry* tag tag))
+
 (defn- direct-parents
   "Returns manually-derived parents plus PHP type parents for tag."
   [parents-map tag]
-  (union (get parents-map tag (hash-set))
-         (php-class-relations tag)))
+  (let [resolved-tag (hierarchy-tag tag)]
+    (union (get parents-map resolved-tag (hash-set))
+           (php-class-relations resolved-tag))))
 
 (defn- compute-ancestors
   "Computes all transitive ancestors of tag from a parents map."
@@ -393,7 +403,11 @@
                   (fn [acc group]
                     (let [proto-name (first group)
                           methods    (second group)
-                          proto-str  (php/-> proto-name (getName))]
+                          proto-str  (php/-> proto-name (getName))
+                          proto-ns   (php/-> proto-name (getNamespace))
+                          proto-tag  (if proto-ns
+                                       (php/-> proto-name (getFullName))
+                                       (php/. *ns* "\\" proto-str))]
                       (reduce
                        (fn [inner method]
                          (let [mname-str (php/-> (first method) (getName))
@@ -402,7 +416,7 @@
                                dsym      (php/:: Symbol
                                                  (create (php/. proto-str "--" mname-str "--dispatch")))]
                            (conj inner `(swap! ~dsym assoc ~type-key (fn ~margs ~@body)))))
-                       acc
+                       (conj acc `(derive ~type-key ~proto-tag))
                        methods)))
                   []
                   groups)]

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -81,6 +81,32 @@
   (is (true? (isa? PHPChildT PHPTransitiveInterfaceT)) "PHP class isa transitive interface")
   (is (false? (isa? PHPAncestorT PHPChildT)) "PHP parent is not child"))
 
+;; --- generated type hierarchy ---
+
+(defprotocol AncestorRecordProtocol)
+(defrecord AncestorRecord [] AncestorRecordProtocol)
+
+(defprotocol AncestorTypeProtocol)
+(deftype AncestorType [] AncestorTypeProtocol)
+
+(deftest test-defrecord-ancestors-include-protocol-and-php-parents
+  (let [anc (ancestors AncestorRecord)]
+    (is (contains? anc "phel-test\\test\\core\\hierarchy\\AncestorRecordProtocol")
+        "defrecord ancestors include inline protocol")
+    (is (contains? anc "Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct")
+        "defrecord ancestors include generated PHP parent class")
+    (is (contains? anc "Phel\\Lang\\Collections\\Map\\PersistentMapInterface")
+        "defrecord ancestors include inherited PHP interface")))
+
+(deftest test-deftype-ancestors-include-protocol-and-php-parents
+  (let [anc (ancestors AncestorType)]
+    (is (contains? anc "phel-test\\test\\core\\hierarchy\\AncestorTypeProtocol")
+        "deftype ancestors include inline protocol")
+    (is (contains? anc "Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct")
+        "deftype ancestors include generated PHP parent class")
+    (is (contains? anc "Phel\\Lang\\Collections\\Map\\PersistentMapInterface")
+        "deftype ancestors include inherited PHP interface")))
+
 ;; --- descendants ---
 
 (deftest test-descendants

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -84,6 +84,7 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
   )
 );
 
+(\Phel::getDefinition("phel\\core", "swap!"))(\Phel::getDefinition("phel\\core", "*type-tag-registry*"), \Phel::getDefinition("phel\\core", "assoc"), \Phel::getDefinition("hello_world", "abc"), "hello_world\\abc");
 \Phel::addDefinition(
   "hello_world",
   "abc?",


### PR DESCRIPTION
## 🤔 Background

`ancestors` handles PHP class tags, but generated `defrecord` and `deftype` constructor functions currently do not resolve to their generated PHP class tags. That means `(ancestors MyType)` misses PHP parents and inline protocol ancestry.

Closes #1591

## 💡 Goal

Make `ancestors` report the expected hierarchy for `defrecord` and `deftype` constructor functions, including inline protocol implementations and generated PHP parent/interface relations.

## 🔖 Changes

- Register generated struct constructor functions with their PHP class tags.
- Resolve hierarchy lookups through that type-tag registry.
- Register inline protocol implementations as hierarchy derivations from generated type tags to protocol tags.
- Add regression coverage for `defrecord` and `deftype` ancestry.
- Update the Unreleased changelog.