### PR TITLE
fix: handle invalid hierarchy arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
+- `parents`, `ancestors`, and `descendants` return `nil` for invalid hierarchy arguments (#1597)
 - `ancestors` includes inline protocols and PHP parents for records and types (#1591)
 - Sequential equality is symmetric across lists, vectors, and lazy seqs (#1546)
 - `()` works as a self-quoting empty list literal (#1549)

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -152,7 +152,7 @@
            :ancestors   (compute-ancestors-map pm)
            :descendants (compute-descendants-map pm))))
 
-(defn- hierarchy-parents-map
+(defn- valid-hierarchy-parents
   "Returns h's parents map when h has the expected hierarchy shape."
   [h]
   (when (map? h)
@@ -232,7 +232,7 @@
   ([tag]
    (parents @*hierarchy* tag))
   ([h tag]
-   (let [parents-map (hierarchy-parents-map h)]
+   (let [parents-map (valid-hierarchy-parents h)]
      (when parents-map
        (let [p (direct-parents parents-map tag)]
          (when (and p (not (empty? p))) p))))))
@@ -244,7 +244,7 @@
   ([tag]
    (ancestors @*hierarchy* tag))
   ([h tag]
-   (let [parents-map (hierarchy-parents-map h)]
+   (let [parents-map (valid-hierarchy-parents h)]
      (when parents-map
        (let [a (compute-ancestors parents-map tag)]
          (when (not (empty? a)) a))))))
@@ -256,7 +256,7 @@
   ([tag]
    (descendants @*hierarchy* tag))
   ([h tag]
-   (let [parents-map (hierarchy-parents-map h)]
+   (let [parents-map (valid-hierarchy-parents h)]
      (when parents-map
        (let [all-children (keys parents-map)
              result       (reduce

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -152,6 +152,12 @@
            :ancestors   (compute-ancestors-map pm)
            :descendants (compute-descendants-map pm))))
 
+(defn- hierarchy-parents-map
+  "Returns h's parents map when h has the expected hierarchy shape."
+  [h]
+  (when (map? h)
+    (get h :parents)))
+
 (defn isa?
   "Returns true if child equals parent, or child is a descendant of parent.
   When a hierarchy is provided, the check is performed against it; otherwise
@@ -226,8 +232,10 @@
   ([tag]
    (parents @*hierarchy* tag))
   ([h tag]
-   (let [p (direct-parents (get h :parents) tag)]
-     (when (and p (not (empty? p))) p))))
+   (let [parents-map (hierarchy-parents-map h)]
+     (when parents-map
+       (let [p (direct-parents parents-map tag)]
+         (when (and p (not (empty? p))) p))))))
 
 (defn ancestors
   "Returns the set of all transitive ancestors of tag, or nil.
@@ -236,8 +244,10 @@
   ([tag]
    (ancestors @*hierarchy* tag))
   ([h tag]
-   (let [a (compute-ancestors (get h :parents) tag)]
-     (when (not (empty? a)) a))))
+   (let [parents-map (hierarchy-parents-map h)]
+     (when parents-map
+       (let [a (compute-ancestors parents-map tag)]
+         (when (not (empty? a)) a))))))
 
 (defn descendants
   "Returns the set of all descendants of tag, or nil.
@@ -246,16 +256,17 @@
   ([tag]
    (descendants @*hierarchy* tag))
   ([h tag]
-   (let [parents-map  (get h :parents)
-         all-children (keys parents-map)
-         result       (reduce
-                       (fn [acc child]
-                         (if (contains? (compute-ancestors parents-map child) tag)
-                           (union acc (hash-set child))
-                           acc))
-                       (hash-set)
-                       all-children)]
-     (when (not (empty? result)) result))))
+   (let [parents-map (hierarchy-parents-map h)]
+     (when parents-map
+       (let [all-children (keys parents-map)
+             result       (reduce
+                           (fn [acc child]
+                             (if (contains? (compute-ancestors parents-map child) tag)
+                               (union acc (hash-set child))
+                               acc))
+                           (hash-set)
+                           all-children)]
+         (when (not (empty? result)) result))))))
 
 (defn find-hierarchy-method
   "Finds the best matching method for dispatch-val using the global hierarchy.

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -210,6 +210,10 @@
     (is (nil? (parents h :hp-unknown))
         "nil for unknown tag in hierarchy")))
 
+(deftest test-parents-nil-for-invalid-hierarchy
+  (is (nil? (parents "anything" "anything"))
+      "invalid hierarchy returns nil"))
+
 (deftest test-ancestors-hierarchy
   (let [h (-> (make-hierarchy)
               (derive :ha-c :ha-b)
@@ -219,6 +223,10 @@
       (is (contains? anc :ha-a) "transitive ancestor in hierarchy"))
     (is (nil? (ancestors h :ha-unknown)) "nil for unknown tag")))
 
+(deftest test-ancestors-nil-for-invalid-hierarchy
+  (is (nil? (ancestors "anything" "anything"))
+      "invalid hierarchy returns nil"))
+
 (deftest test-descendants-hierarchy
   (let [h (-> (make-hierarchy)
               (derive :hdc-child :hdc-root)
@@ -227,6 +235,10 @@
       (is (contains? desc :hdc-child) "direct descendant in hierarchy")
       (is (contains? desc :hdc-grandchild) "transitive descendant in hierarchy"))
     (is (nil? (descendants h :hdc-leaf)) "nil for leaf/unknown tag")))
+
+(deftest test-descendants-nil-for-invalid-hierarchy
+  (is (nil? (descendants "anything" "anything"))
+      "invalid hierarchy returns nil"))
 
 ;; --- multimethod with hierarchy dispatch ---
 

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -210,10 +210,6 @@
     (is (nil? (parents h :hp-unknown))
         "nil for unknown tag in hierarchy")))
 
-(deftest test-parents-nil-for-invalid-hierarchy
-  (is (nil? (parents "anything" "anything"))
-      "invalid hierarchy returns nil"))
-
 (deftest test-ancestors-hierarchy
   (let [h (-> (make-hierarchy)
               (derive :ha-c :ha-b)
@@ -222,10 +218,6 @@
       (is (contains? anc :ha-b) "direct ancestor in hierarchy")
       (is (contains? anc :ha-a) "transitive ancestor in hierarchy"))
     (is (nil? (ancestors h :ha-unknown)) "nil for unknown tag")))
-
-(deftest test-ancestors-nil-for-invalid-hierarchy
-  (is (nil? (ancestors "anything" "anything"))
-      "invalid hierarchy returns nil"))
 
 (deftest test-descendants-hierarchy
   (let [h (-> (make-hierarchy)
@@ -236,9 +228,13 @@
       (is (contains? desc :hdc-grandchild) "transitive descendant in hierarchy"))
     (is (nil? (descendants h :hdc-leaf)) "nil for leaf/unknown tag")))
 
-(deftest test-descendants-nil-for-invalid-hierarchy
+(deftest test-hierarchy-queries-return-nil-for-invalid-hierarchy
+  (is (nil? (parents "anything" "anything"))
+      "parents returns nil")
+  (is (nil? (ancestors "anything" "anything"))
+      "ancestors returns nil")
   (is (nil? (descendants "anything" "anything"))
-      "invalid hierarchy returns nil"))
+      "descendants returns nil"))
 
 ;; --- multimethod with hierarchy dispatch ---
 


### PR DESCRIPTION
## 🤔 Background

Issue #1597 reports that `(ancestors "anything" "anything")`, `(parents "anything" "anything")`, and `(descendants "anything" "anything")` throw when the first argument is not a hierarchy map. Clojure returns nil for these cases.

## 💡 Goal

Return nil for invalid hierarchy arguments in the read-only hierarchy query functions.

Closes #1597

## 🔖 Changes

- Guard hierarchy map access before reading `:parents`.
- Add regression coverage for `parents`, `ancestors`, and `descendants` with string hierarchy arguments.