### PR TITLE
chore: add codex skills

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -9,6 +9,14 @@ This directory contains Codex-native repo-maintenance configuration for Phel.
 | `hooks/` | Codex hook scripts. These use Codex hook JSON, not Claude hook JSON. |
 | `rules/` | Codex exec-policy rules for approval and forbidden command prefixes. |
 | `agents/` | Codex custom subagents in TOML format. |
+| `skills/` | Codex skills shared by contributors working in this repository. |
 
 Shared repository policy belongs in `AGENTS.md`. Claude Code-specific material belongs in `.claude/`. Downstream Phel
 user assets belong in `resources/agents/`.
+
+To install the shared project skills into a local Codex profile when repo-local skills are not auto-loaded:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R .codex/skills/* ~/.codex/skills/
+```

--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: benchmark
+description: Run and interpret Phel performance benchmarks. Use when Codex is asked to run phpbench, create benchmark baselines, compare benchmark results, filter benchmark classes or methods, or investigate performance regressions.
+---
+
+# Benchmark Runner
+
+## Workflow
+
+1. Inspect the current branch and latest commit when benchmark context matters:
+   ```bash
+   git branch --show-current
+   git log --oneline -1
+   ```
+
+2. Choose the benchmark command from the user's request:
+   - default or `run`: `composer phpbench`
+   - `baseline`: `composer phpbench-base`
+   - `compare`: `composer phpbench-ref`
+   - class or method filter: `./vendor/bin/phpbench run --filter="<filter>" --report=aggregate --ansi`
+
+3. For comparisons, highlight:
+   - regressions more than 5% slower
+   - improvements more than 5% faster
+   - affected benchmark classes or methods
+   - mean execution time and memory changes
+
+4. If results look noisy, say so and recommend a rerun before treating the change as significant.

--- a/.codex/skills/benchmark/agents/openai.yaml
+++ b/.codex/skills/benchmark/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Benchmark Runner"
+  short_description: "Run and compare Phel benchmarks."
+  default_prompt: "Use $benchmark to compare this branch against the benchmark baseline."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/changelog/SKILL.md
+++ b/.codex/skills/changelog/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: changelog
+description: Update CHANGELOG.md under Unreleased. Use when Codex is asked to add a changelog entry, derive changelog text from recent commits, or verify whether a user-facing change needs release notes.
+---
+
+# Changelog
+
+## Workflow
+
+1. Read `CHANGELOG.md` and preserve its existing structure.
+2. If the user provides entry text, place it under the appropriate `## Unreleased` category.
+3. If no entry text is provided, inspect commits since the latest tag:
+   ```bash
+   git log $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~20)..HEAD --oneline
+   ```
+4. Draft entries from user-facing commits:
+   - `feat:` -> `### Added`
+   - `ref:` or `perf:` -> `### Changed`
+   - `fix:` -> `### Fixed`
+   - removals -> `### Removed`
+5. Skip non-user-facing commits such as chores, CI-only changes, and internal refactors.
+6. Use imperative mood, keep entries under 100 characters when practical, wrap code identifiers in backticks, and prefix breaking changes with `**BREAKING**`.
+7. When generating entries from commits, present the draft before editing if the mapping is ambiguous.

--- a/.codex/skills/changelog/agents/openai.yaml
+++ b/.codex/skills/changelog/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Changelog"
+  short_description: "Update Unreleased changelog entries."
+  default_prompt: "Use $changelog to update CHANGELOG.md for the current branch."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: commit
+description: Prepare and create a conventional commit for Phel changes. Use when Codex is asked to auto-fix, lint, test, stage specific files, draft a commit message, or commit current repository changes.
+---
+
+# Commit
+
+## Workflow
+
+1. Inspect current changes:
+   ```bash
+   git diff --stat
+   git diff --cached --stat
+   git status --short
+   ```
+
+2. Run auto-fixers when appropriate:
+   ```bash
+   composer fix
+   ```
+   Review any fixer changes before staging them.
+
+3. Run quality gates in order, fixing failures before continuing:
+   ```bash
+   composer test-quality
+   composer test-compiler
+   ```
+
+4. If staged or changed `.phel` files exist, run:
+   ```bash
+   composer test-core
+   ```
+
+5. Stage files by explicit path. Avoid `git add -A` unless every changed file is understood and intended.
+
+6. Draft a conventional commit message:
+   - use the user's message when provided
+   - otherwise derive it from the staged diff
+   - valid prefixes include `feat:`, `fix:`, `ref:`, `chore:`, `docs:`, `test:`, `perf:`
+   - add a scope when changes clearly belong to one module
+   - do not mention AI tooling in the commit message
+
+7. For `feat:` or `fix:` commits, verify `CHANGELOG.md` has an `## Unreleased` entry when the change is user-facing.
+
+8. Commit and report the hash, message, and included files:
+   ```bash
+   git commit -m "<message>"
+   ```

--- a/.codex/skills/commit/agents/openai.yaml
+++ b/.codex/skills/commit/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Commit"
+  short_description: "Fix, test, stage, and commit changes."
+  default_prompt: "Use $commit to prepare and commit the current changes."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/compiler-guide/SKILL.md
+++ b/.codex/skills/compiler-guide/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: compiler-guide
+description: Phel compiler internals reference. Use when Codex works on lexer, parser, analyzer, emitter, compiler AST nodes, special forms, compiler tests, or compiler integration fixtures.
+---
+
+# Compiler Pipeline
+
+## Phases
+
+```text
+Source -> Lexer -> Token[] -> Parser -> AST (PhelArray of Nodes)
+       -> Analyzer -> AnalyzedNode tree -> Emitter -> PHP code string
+```
+
+| Phase | Location | Input | Output |
+|-------|----------|-------|--------|
+| Lexer | `Compiler/Lexer/` | Phel source string | `Token[]` |
+| Parser | `Compiler/Parser/` | `Token[]` | AST (`PhelArray` of nodes) |
+| Analyzer | `Compiler/Analyzer/` | AST nodes | `AnalyzedNode` tree |
+| Emitter | `Compiler/Emitter/` | `AnalyzedNode` tree | PHP code string |
+
+## Special Forms
+
+Special forms are handled in `Compiler/Analyzer/SpecialForm/`. To add a new form:
+
+1. Create the analyzer class in `SpecialForm/`.
+2. Register it in the special form registry.
+3. Create a corresponding emitter node when needed.
+4. Add emitter handling.
+5. Cover behavior with unit tests and an integration fixture when the emitted PHP changes.
+
+## Node Types
+
+Analyzed nodes live in `Compiler/Analyzer/Ast/`. Each emitted node type should have corresponding handling in `Compiler/Emitter/`.
+
+## Environment And Scope
+
+`NodeEnvironment` tracks local bindings, shadowing, expression or statement context, return context, and whether a result is used.
+
+## Testing
+
+- Unit tests live in `tests/php/Unit/Compiler/`.
+- Integration tests live in `tests/php/Integration/`.
+- Test method names use `test_it_<describes_behavior>()`.
+- Use `CompilerTestHelper` for quick compile-and-evaluate integration scenarios.

--- a/.codex/skills/compiler-guide/agents/openai.yaml
+++ b/.codex/skills/compiler-guide/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Compiler Guide"
+  short_description: "Reference Phel compiler internals."
+  default_prompt: "Use $compiler-guide while changing compiler behavior."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/fix/SKILL.md
+++ b/.codex/skills/fix/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: fix
+description: Auto-fix and verify Phel code quality. Use when Codex is asked to run Rector, PHP-CS-Fixer, PHPStan, compiler tests, or clean up style/static-analysis failures.
+---
+
+# Fix Code Quality
+
+## Workflow
+
+1. Run project auto-fixers:
+   ```bash
+   composer fix
+   ```
+
+2. For a single PHP file when a narrow fix is requested:
+   ```bash
+   ./vendor/bin/php-cs-fixer fix "<file>"
+   ```
+
+3. Run static analysis:
+   ```bash
+   composer phpstan
+   ```
+
+4. Run compiler tests to verify behavior:
+   ```bash
+   composer test-compiler
+   ```
+
+5. Summarize what changed and any remaining failures. Include exact failing commands if something cannot be fixed immediately.

--- a/.codex/skills/fix/agents/openai.yaml
+++ b/.codex/skills/fix/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Fix Quality"
+  short_description: "Run fixers and quality checks."
+  default_prompt: "Use $fix to clean up quality issues in the current changes."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/gh-issue/SKILL.md
+++ b/.codex/skills/gh-issue/SKILL.md
@@ -46,7 +46,7 @@ Use repository instructions as the authority for local practice. In the Phel rep
    - implement the minimum correct behavior
    - keep tests green as scope expands
 7. Commit by context as work lands. Use precise staged files, not blanket `git add .`, unless the status is fully understood.
-8. After the issue plan is complete, perform one explicit refactor pass over only the branch changes. Commit that pass separately, even if small. If no refactor is justified, create a commit that documents the reviewed no-op only when the repository accepts empty commits; otherwise state why no refactor commit was made.
+8. After the issue plan is complete, perform one explicit refactor pass over only the branch changes. Commit that pass separately when it produces a real diff. If no refactor is justified, mention that in the PR body or final summary instead of creating a ceremonial commit.
 9. Run the repository quality gate. For Phel, prefer `composer test`; use narrower tests first while iterating.
 10. Update changelog only for user-facing changes, following repository policy.
 11. Open a PR with `gh pr create`, following the repository PR template exactly when present.

--- a/.codex/skills/gh-issue/SKILL.md
+++ b/.codex/skills/gh-issue/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: gh-issue
+description: End-to-end GitHub issue execution workflow. Use when Codex is given a GitHub issue number, #number, issue URL, or asked to fetch an issue, create a branch, implement it with TDD, commit grouped changes, open a PR, watch/fix CI, merge, update main, or continue processing available issues.
+---
+
+# GitHub Issue Workflow
+
+## Quick Start
+
+Run the helper from the repository root:
+
+```bash
+.codex/skills/gh-issue/scripts/prepare-gh-issue.sh <issue-number-or-url> --setup
+```
+
+If this skill is installed in the user Codex skill directory, the same helper is available at:
+
+```bash
+~/.codex/skills/gh-issue/scripts/prepare-gh-issue.sh <issue-number-or-url> --setup
+```
+
+The script fetches the issue title, body, author, labels, assignees, state, and all comments into `.git/codex-gh-issues/issue-<number>.md`. With `--setup`, it also attempts to assign the issue author and creates a branch from fresh `main`.
+
+If the script fails because the worktree is dirty, inspect `git status --short`. Do not stash, reset, or discard changes without explicit user approval unless every change is known to be yours.
+
+## Execution Contract
+
+Treat the issue body and every comment as requirements context. Prefer later maintainer comments over older ambiguous text when they conflict. If requirements are contradictory, unsafe, or require product judgment that cannot be inferred from project policy, stop and ask the user before editing.
+
+Use repository instructions as the authority for local practice. In the Phel repository, read `AGENTS.md` and any touched `src/php/<Module>/CLAUDE.md` before editing that module.
+
+## Workflow
+
+1. Parse and fetch the issue with `prepare-gh-issue.sh`.
+2. Read the generated context file completely.
+3. Confirm the issue is open. If it is closed, ask before continuing.
+4. Create an initial plan:
+   - issue goal in one sentence
+   - affected areas and files to inspect
+   - TDD test plan
+   - implementation order
+   - long-term design consideration, including why the approach fits project direction
+5. Execute the plan without waiting for approval unless there is a real blocker or non-logical human decision.
+6. Follow TDD:
+   - write or update failing focused tests first
+   - implement the minimum correct behavior
+   - keep tests green as scope expands
+7. Commit by context as work lands. Use precise staged files, not blanket `git add .`, unless the status is fully understood.
+8. After the issue plan is complete, perform one explicit refactor pass over only the branch changes. Commit that pass separately, even if small. If no refactor is justified, create a commit that documents the reviewed no-op only when the repository accepts empty commits; otherwise state why no refactor commit was made.
+9. Run the repository quality gate. For Phel, prefer `composer test`; use narrower tests first while iterating.
+10. Update changelog only for user-facing changes, following repository policy.
+11. Open a PR with `gh pr create`, following the repository PR template exactly when present.
+12. Watch CI with `gh pr checks --watch`. Fix failures until all required checks are green.
+13. Merge the PR when CI is green and policy allows it. Update local `main` with `git switch main && git pull --ff-only --prune`.
+
+## Branch and Commit Rules
+
+Branch from fresh `main`. Use the prefix inferred from labels:
+
+- `bug` -> `fix/`
+- `enhancement` or `feature` -> `feat/`
+- `documentation` or `docs` -> `docs/`
+- `performance` or `perf` -> `perf/`
+- `refactor` -> `ref/`
+- `test` or `tests` -> `test/`
+- otherwise -> `feat/`
+
+Branch format: `<prefix><issue-number>-<slug>`.
+
+Use conventional commit prefixes already present in the repository. Include `Related to #<issue-number>` or `Closes #<issue-number>` as appropriate. Use `Closes` only when the PR fully resolves the issue.
+
+## Multiple Issues and Watching
+
+A Codex skill only runs when a Codex session is active; it is not a persistent daemon by itself. To continue through available issues in one active session:
+
+```bash
+gh issue list --state open --limit 20 --json number,title,labels,assignees,author
+```
+
+Pick the next actionable unblocked issue and repeat the workflow. For a true 15-minute background poller, use an external scheduler such as `launchd`, cron, GitHub Actions, or a small local supervisor that invokes the Codex CLI with this skill prompt.
+
+This skill includes an optional local supervisor:
+
+```bash
+.codex/skills/gh-issue/scripts/watch-gh-issues.sh --repo /path/to/repo --interval 900 --execute
+```
+
+Without `--execute`, the watcher only prints the issue it would process. Use `--once` to process or print a single candidate and exit.
+
+## Human Escalation
+
+Ask before continuing when:
+
+- GitHub authentication, assignment, branch setup, CI, or merge permissions fail.
+- The worktree contains changes that may belong to the user.
+- The issue requires a product/API decision not derivable from code, comments, or repo policy.
+- The requested behavior conflicts with long-term maintainability, security, or compatibility.
+- CI is failing for reasons unrelated to the branch and the next action would affect shared state.

--- a/.codex/skills/gh-issue/agents/openai.yaml
+++ b/.codex/skills/gh-issue/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "GitHub Issue Worker"
+  short_description: "Work GitHub issues end to end."
+  default_prompt: "Use $gh-issue for #123."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/gh-issue/scripts/prepare-gh-issue.sh
+++ b/.codex/skills/gh-issue/scripts/prepare-gh-issue.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: prepare-gh-issue.sh <issue-number|#number|issue-url> [--setup]
+
+Fetch full GitHub issue context, including comments, into:
+  .git/codex-gh-issues/issue-<number>.md
+
+Options:
+  --setup    also assign the issue author and create a branch from fresh main
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+issue_arg="${1:-}"
+setup=false
+
+if [[ -z "$issue_arg" || "$issue_arg" == "-h" || "$issue_arg" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --setup) setup=true ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+require_cmd gh
+require_cmd git
+
+issue="$issue_arg"
+issue="${issue##*/}"
+issue="${issue#\#}"
+[[ "$issue" =~ ^[0-9]+$ ]] || die "could not parse issue number from: $issue_arg"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
+cd "$repo_root"
+
+context_dir="$(git rev-parse --git-path codex-gh-issues)"
+mkdir -p "$context_dir"
+json_file="$context_dir/issue-$issue.json"
+context_file="$context_dir/issue-$issue.md"
+
+gh issue view "$issue" \
+  --json number,title,body,author,comments,labels,assignees,state,url \
+  >"$json_file"
+
+python3 - "$json_file" "$context_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+json_path = Path(sys.argv[1])
+context_path = Path(sys.argv[2])
+data = json.loads(json_path.read_text())
+
+def login(value):
+    if isinstance(value, dict):
+        return value.get("login") or value.get("name") or ""
+    return ""
+
+labels = ", ".join(label.get("name", "") for label in data.get("labels", []) if label.get("name")) or "(none)"
+assignees = ", ".join(login(user) for user in data.get("assignees", []) if login(user)) or "(none)"
+author = login(data.get("author", {})) or "(unknown)"
+
+lines = [
+    f"# Issue #{data.get('number')}: {data.get('title', '')}",
+    "",
+    f"- URL: {data.get('url', '')}",
+    f"- State: {data.get('state', '')}",
+    f"- Author: {author}",
+    f"- Labels: {labels}",
+    f"- Assignees: {assignees}",
+    "",
+    "## Body",
+    "",
+    data.get("body") or "(empty)",
+    "",
+    "## Comments",
+]
+
+comments = data.get("comments") or []
+if not comments:
+    lines.extend(["", "(none)"])
+else:
+    for idx, comment in enumerate(comments, 1):
+        commenter = login(comment.get("author", {})) or "(unknown)"
+        created = comment.get("createdAt", "")
+        lines.extend([
+            "",
+            f"### Comment {idx} by {commenter} at {created}",
+            "",
+            comment.get("body") or "(empty)",
+        ])
+
+context_path.write_text("\n".join(lines).rstrip() + "\n")
+print(context_path)
+PY
+
+title="$(gh issue view "$issue" --json title --jq .title)"
+author="$(gh issue view "$issue" --json author --jq .author.login)"
+state="$(gh issue view "$issue" --json state --jq .state)"
+labels="$(gh issue view "$issue" --json labels --jq '[.labels[].name] | join(" ")')"
+
+prefix="feat"
+case " $labels " in
+  *" bug "*) prefix="fix" ;;
+  *" enhancement "*|*" feature "*) prefix="feat" ;;
+  *" documentation "*|*" docs "*) prefix="docs" ;;
+  *" performance "*|*" perf "*) prefix="perf" ;;
+  *" refactor "*) prefix="ref" ;;
+  *" test "*|*" tests "*) prefix="test" ;;
+esac
+
+slug="$(printf '%s' "$title" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+  | cut -c 1-60 \
+  | sed -E 's/-+$//')"
+[[ -n "$slug" ]] || slug="issue"
+branch="$prefix/$issue-$slug"
+
+printf 'Issue context: %s\n' "$context_file"
+printf 'Issue state: %s\n' "$state"
+printf 'Suggested branch: %s\n' "$branch"
+
+if [[ "$setup" != true ]]; then
+  exit 0
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  die "worktree is dirty; inspect changes before creating a fresh issue branch"
+fi
+
+if [[ "$state" != "OPEN" ]]; then
+  die "issue is not open: $state"
+fi
+
+if [[ -n "$author" && "$author" != "null" ]]; then
+  if ! gh issue edit "$issue" --add-assignee "$author" >/dev/null; then
+    printf 'warning: could not assign issue author "%s"; continuing without changing assignee\n' "$author" >&2
+  fi
+fi
+
+git switch main
+git pull --ff-only --prune
+git switch -c "$branch"
+printf 'Created branch: %s\n' "$branch"

--- a/.codex/skills/gh-issue/scripts/prepare-gh-issue.sh
+++ b/.codex/skills/gh-issue/scripts/prepare-gh-issue.sh
@@ -41,10 +41,30 @@ done
 
 require_cmd gh
 require_cmd git
+require_cmd python3
 
-issue="$issue_arg"
-issue="${issue##*/}"
-issue="${issue#\#}"
+parse_issue_number() {
+  local value="$1"
+
+  if [[ "$value" =~ ^#?([0-9]+)$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  if [[ "$value" =~ /issues/([0-9]+)($|[/?#]) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  value="${value%/}"
+  value="${value##*/}"
+  value="${value%%\?*}"
+  value="${value%%#*}"
+  [[ "$value" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$value"
+}
+
+issue="$(parse_issue_number "$issue_arg")" || die "could not parse issue number from: $issue_arg"
 [[ "$issue" =~ ^[0-9]+$ ]] || die "could not parse issue number from: $issue_arg"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
@@ -54,18 +74,21 @@ context_dir="$(git rev-parse --git-path codex-gh-issues)"
 mkdir -p "$context_dir"
 json_file="$context_dir/issue-$issue.json"
 context_file="$context_dir/issue-$issue.md"
+metadata_file="$context_dir/issue-$issue.env"
 
 gh issue view "$issue" \
   --json number,title,body,author,comments,labels,assignees,state,url \
   >"$json_file"
 
-python3 - "$json_file" "$context_file" <<'PY'
+python3 - "$json_file" "$context_file" "$metadata_file" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 
 json_path = Path(sys.argv[1])
 context_path = Path(sys.argv[2])
+metadata_path = Path(sys.argv[3])
 data = json.loads(json_path.read_text())
 
 def login(value):
@@ -73,9 +96,36 @@ def login(value):
         return value.get("login") or value.get("name") or ""
     return ""
 
-labels = ", ".join(label.get("name", "") for label in data.get("labels", []) if label.get("name")) or "(none)"
+def shell_quote(value):
+    return "'" + str(value).replace("'", "'\"'\"'") + "'"
+
+def branch_prefix(label_names):
+    labels = set(label_names)
+    if "bug" in labels:
+        return "fix"
+    if labels.intersection({"enhancement", "feature"}):
+        return "feat"
+    if labels.intersection({"documentation", "docs"}):
+        return "docs"
+    if labels.intersection({"performance", "perf"}):
+        return "perf"
+    if "refactor" in labels:
+        return "ref"
+    if labels.intersection({"test", "tests"}):
+        return "test"
+    return "feat"
+
+def slugify(title):
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:60].rstrip("-") or "issue"
+
+label_names = [label.get("name", "") for label in data.get("labels", []) if label.get("name")]
+labels = ", ".join(label_names) or "(none)"
 assignees = ", ".join(login(user) for user in data.get("assignees", []) if login(user)) or "(none)"
 author = login(data.get("author", {})) or "(unknown)"
+title = data.get("title", "")
+state = data.get("state", "")
+branch = f"{branch_prefix(label_names)}/{data.get('number')}-{slugify(title)}"
 
 lines = [
     f"# Issue #{data.get('number')}: {data.get('title', '')}",
@@ -108,35 +158,27 @@ else:
         ])
 
 context_path.write_text("\n".join(lines).rstrip() + "\n")
-print(context_path)
+metadata_path.write_text(
+    "\n".join(
+        [
+            f"issue_author={shell_quote(author)}",
+            f"issue_state={shell_quote(state)}",
+            f"issue_branch={shell_quote(branch)}",
+        ]
+    )
+    + "\n"
+)
 PY
 
-title="$(gh issue view "$issue" --json title --jq .title)"
-author="$(gh issue view "$issue" --json author --jq .author.login)"
-state="$(gh issue view "$issue" --json state --jq .state)"
-labels="$(gh issue view "$issue" --json labels --jq '[.labels[].name] | join(" ")')"
-
-prefix="feat"
-case " $labels " in
-  *" bug "*) prefix="fix" ;;
-  *" enhancement "*|*" feature "*) prefix="feat" ;;
-  *" documentation "*|*" docs "*) prefix="docs" ;;
-  *" performance "*|*" perf "*) prefix="perf" ;;
-  *" refactor "*) prefix="ref" ;;
-  *" test "*|*" tests "*) prefix="test" ;;
-esac
-
-slug="$(printf '%s' "$title" \
-  | tr '[:upper:]' '[:lower:]' \
-  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
-  | cut -c 1-60 \
-  | sed -E 's/-+$//')"
-[[ -n "$slug" ]] || slug="issue"
-branch="$prefix/$issue-$slug"
+issue_author=
+issue_state=
+issue_branch=
+# shellcheck disable=SC1090
+source "$metadata_file"
 
 printf 'Issue context: %s\n' "$context_file"
-printf 'Issue state: %s\n' "$state"
-printf 'Suggested branch: %s\n' "$branch"
+printf 'Issue state: %s\n' "$issue_state"
+printf 'Suggested branch: %s\n' "$issue_branch"
 
 if [[ "$setup" != true ]]; then
   exit 0
@@ -146,17 +188,17 @@ if [[ -n "$(git status --porcelain)" ]]; then
   die "worktree is dirty; inspect changes before creating a fresh issue branch"
 fi
 
-if [[ "$state" != "OPEN" ]]; then
-  die "issue is not open: $state"
+if [[ "$issue_state" != "OPEN" ]]; then
+  die "issue is not open: $issue_state"
 fi
 
-if [[ -n "$author" && "$author" != "null" ]]; then
-  if ! gh issue edit "$issue" --add-assignee "$author" >/dev/null; then
-    printf 'warning: could not assign issue author "%s"; continuing without changing assignee\n' "$author" >&2
+if [[ -n "$issue_author" && "$issue_author" != "(unknown)" ]]; then
+  if ! gh issue edit "$issue" --add-assignee "$issue_author" >/dev/null; then
+    printf 'warning: could not assign issue author "%s"; continuing without changing assignee\n' "$issue_author" >&2
   fi
 fi
 
 git switch main
 git pull --ff-only --prune
-git switch -c "$branch"
-printf 'Created branch: %s\n' "$branch"
+git switch -c "$issue_branch"
+printf 'Created branch: %s\n' "$issue_branch"

--- a/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
+++ b/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
@@ -71,22 +71,35 @@ done
 
 require_cmd gh
 require_cmd git
-require_cmd codex
 
 if [[ -z "$repo" ]]; then
   repo="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository; pass --repo"
 fi
 
+if [[ "$execute" == true ]]; then
+  require_cmd codex
+fi
+
 cd "$repo"
 repo="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not a git repository: $repo"
 lock_dir="$(git rev-parse --git-path codex-gh-issue-watch.lock)"
+lock_acquired=false
+
+release_lock() {
+  if [[ "$lock_acquired" == true ]]; then
+    rm -rf "$lock_dir"
+    lock_acquired=false
+  fi
+}
+
+trap release_lock EXIT INT TERM
 
 poll_once() {
   if ! mkdir "$lock_dir" 2>/dev/null; then
     printf 'another watcher appears to be running: %s\n' "$lock_dir" >&2
     return 0
   fi
-  trap 'rm -rf "$lock_dir"' RETURN
+  lock_acquired=true
 
   issue="$(
     gh issue list \
@@ -97,13 +110,15 @@ poll_once() {
   )"
 
   if [[ -z "$issue" ]]; then
-    printf '[%s] no open issues found\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '[%s] no open issues found\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    release_lock
     return 0
   fi
 
-  printf '[%s] next issue: #%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$issue"
+  printf '[%s] next issue: #%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$issue"
   if [[ "$execute" != true ]]; then
     printf 'dry-run: pass --execute to run Codex for #%s\n' "$issue"
+    release_lock
     return 0
   fi
 
@@ -112,6 +127,7 @@ poll_once() {
     --sandbox danger-full-access \
     --ask-for-approval never \
     "Use \$gh-issue for #$issue. Follow the skill completely: fetch the issue and comments, assign the author when possible, branch from fresh main, plan, use TDD, commit by context, add a final refactor commit, open a PR, make CI green, merge when allowed, update local main, then stop."
+  release_lock
 }
 
 while true; do

--- a/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
+++ b/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: watch-gh-issues.sh [--repo DIR] [--interval SECONDS] [--once] [--execute] [--limit N]
+
+Poll open GitHub issues and invoke Codex on the next candidate.
+
+Defaults to dry-run. Pass --execute to run:
+  codex exec -C <repo> "Use $gh-issue for #<number>..."
+
+Options:
+  --repo DIR            repository to operate in; defaults to current git root
+  --interval SECONDS    poll interval; defaults to 900
+  --once                run one poll cycle and exit
+  --execute             actually invoke Codex
+  --limit N             issue list page size; defaults to 20
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+repo=""
+interval=900
+once=false
+execute=false
+limit=20
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      [[ -n "$repo" ]] || die "--repo requires a directory"
+      shift 2
+      ;;
+    --interval)
+      interval="${2:-}"
+      [[ "$interval" =~ ^[0-9]+$ ]] || die "--interval requires seconds"
+      shift 2
+      ;;
+    --once)
+      once=true
+      shift
+      ;;
+    --execute)
+      execute=true
+      shift
+      ;;
+    --limit)
+      limit="${2:-}"
+      [[ "$limit" =~ ^[0-9]+$ ]] || die "--limit requires a number"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_cmd gh
+require_cmd git
+require_cmd codex
+
+if [[ -z "$repo" ]]; then
+  repo="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository; pass --repo"
+fi
+
+cd "$repo"
+repo="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not a git repository: $repo"
+lock_dir="$(git rev-parse --git-path codex-gh-issue-watch.lock)"
+
+poll_once() {
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    printf 'another watcher appears to be running: %s\n' "$lock_dir" >&2
+    return 0
+  fi
+  trap 'rm -rf "$lock_dir"' RETURN
+
+  issue="$(
+    gh issue list \
+      --state open \
+      --limit "$limit" \
+      --json number,title \
+      --jq 'sort_by(.number) | .[0].number // empty'
+  )"
+
+  if [[ -z "$issue" ]]; then
+    printf '[%s] no open issues found\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    return 0
+  fi
+
+  printf '[%s] next issue: #%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$issue"
+  if [[ "$execute" != true ]]; then
+    printf 'dry-run: pass --execute to run Codex for #%s\n' "$issue"
+    return 0
+  fi
+
+  codex exec \
+    -C "$repo" \
+    --sandbox danger-full-access \
+    --ask-for-approval never \
+    "Use \$gh-issue for #$issue. Follow the skill completely: fetch the issue and comments, assign the author when possible, branch from fresh main, plan, use TDD, commit by context, add a final refactor commit, open a PR, make CI green, merge when allowed, update local main, then stop."
+}
+
+while true; do
+  poll_once
+  if [[ "$once" == true ]]; then
+    exit 0
+  fi
+  sleep "$interval"
+done

--- a/.codex/skills/integration-fixture/SKILL.md
+++ b/.codex/skills/integration-fixture/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: integration-fixture
+description: Create or validate Phel compiler integration fixtures. Use when Codex needs a .test fixture under tests/php/Integration/Fixtures, expected emitted PHP, or guidance for --PHEL--/--PHP-- fixture format.
+---
+
+# Integration Fixture
+
+## Workflow
+
+1. Inspect available fixture categories:
+   ```bash
+   ls tests/php/Integration/Fixtures/
+   ```
+
+2. Parse the request as `<category> <name>`.
+   - Category must normally match an existing directory under `tests/php/Integration/Fixtures/`.
+   - If no category matches, list available categories and ask before creating a new one.
+   - Use a descriptive file stem such as `fn-variadic` or `try-one-catch`.
+
+3. Get the Phel input from the user or from the issue/task context. Keep one fixture focused on one behavior.
+
+4. Generate expected PHP from the compiler. Do not hand-write the `--PHP--` section; it must match byte-for-byte, including source locations.
+
+5. Write the fixture:
+   ```text
+   --PHEL--
+   <phel source>
+   --PHP--
+   <exact compiled output>
+   ```
+
+6. Run the integration suite filtered to the relevant category:
+   ```bash
+   ./vendor/bin/phpunit --testsuite=integration --filter=<Category>
+   ```
+
+7. If the fixture fails, investigate the compiler behavior. Do not edit expected PHP merely to hide a regression.
+
+## Constraints
+
+- One fixture per behavior.
+- Regenerate PHP output after every Phel input edit.
+- Fixture PHP output uses `\Phel::` static helpers and should not add `use` statements.

--- a/.codex/skills/integration-fixture/agents/openai.yaml
+++ b/.codex/skills/integration-fixture/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Integration Fixture"
+  short_description: "Create compiler .test fixtures."
+  default_prompt: "Use $integration-fixture to add a focused compiler fixture."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/module-new/SKILL.md
+++ b/.codex/skills/module-new/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: module-new
+description: Scaffold a new Phel PHP Gacela module. Use when Codex is asked to create a module under src/php with Facade, Factory, DependencyProvider, Domain/Infrastructure structure, and module CLAUDE.md notes.
+---
+
+# New Gacela Module
+
+## Workflow
+
+1. Validate the requested module name:
+   - PascalCase
+   - no existing directory under `src/php/`
+   - clear module responsibility
+
+2. Read a small reference module, such as `src/php/Printer/` or `src/php/Formatter/`, and mirror local patterns.
+
+3. Create only the files the module needs:
+   ```text
+   src/php/<ModuleName>/<ModuleName>Facade.php
+   src/php/<ModuleName>/<ModuleName>Factory.php
+   src/php/<ModuleName>/<ModuleName>DependencyProvider.php
+   src/php/<ModuleName>/Domain/
+   src/php/<ModuleName>/Infrastructure/
+   src/php/<ModuleName>/CLAUDE.md
+   ```
+
+4. Keep the Facade as the public module boundary. Every public Facade call should delegate through the Factory; do not instantiate dependencies inline in the Facade.
+
+5. Use this `CLAUDE.md` shape for module notes:
+   ```markdown
+   # <ModuleName>
+
+   <one-line purpose>
+
+   ## Gacela pattern
+
+   Facade -> Factory -> Domain
+
+   ## Public API
+
+   - `<ModuleName>Facade::method()` - <one line>
+
+   ## Dependencies
+
+   - <OtherModule>Facade (via DependencyProvider)
+
+   ## Structure
+
+   <ModuleName>/
+     Domain/
+     Infrastructure/
+
+   ## Constraints
+
+   - <key invariant or rule>
+   ```
+
+6. Do not register the module manually; Gacela discovers via PSR-4.
+
+7. Run focused quality checks, typically:
+   ```bash
+   composer test-quality
+   ```
+
+## Constraints
+
+- Cross-module access goes through Facades.
+- Mark classes `final` unless inheritance is required.
+- Use `readonly` properties where possible.

--- a/.codex/skills/module-new/agents/openai.yaml
+++ b/.codex/skills/module-new/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "New Module"
+  short_description: "Scaffold a Phel PHP module."
+  default_prompt: "Use $module-new to scaffold a new src/php module."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/phel-patterns/SKILL.md
+++ b/.codex/skills/phel-patterns/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: phel-patterns
+description: Phel language idioms and core-library conventions. Use when Codex edits src/phel, tests/phel, Phel functions, Phel metadata, Phel tests, or core library behavior.
+---
+
+# Phel Patterns
+
+## Core Library
+
+| Module | Purpose |
+|--------|---------|
+| `core.phel` | Fundamental functions |
+| `str.phel` | String manipulation |
+| `html.phel` | HTML generation |
+| `http.phel` | HTTP request and response helpers |
+| `json.phel` | JSON encoding and decoding |
+| `test.phel` | Test framework |
+| `pprint.phel` | Pretty printing |
+| `walk.phel` | Tree walking |
+| `mock.phel` | Mocking utilities |
+| `debug.phel` | Debugging utilities |
+| `repl.phel` | REPL functionality |
+| `base64.phel` | Base64 helpers |
+
+## Idioms
+
+```phel
+;; Public function with metadata
+(defn my-fn
+  {:doc "Description of what it does"
+   :see-also ["related-fn" "other-fn"]
+   :example "(my-fn arg) => result"}
+  [arg]
+  (body))
+
+;; Private function
+(defn- helper-fn [x] ...)
+
+(defstruct my-struct [field-a field-b])
+
+(-> value (fn1 arg) (fn2 arg))
+(->> value (fn1 arg) (fn2 arg))
+```
+
+## Tests
+
+```phel
+(ns phel-test\test\module-name
+  (:require phel\test :refer [deftest is are]))
+
+(deftest test-descriptive-name
+  (is (= expected (function-under-test input)))
+  (is (thrown? \Exception (function-that-throws))))
+```
+
+Run all Phel tests with:
+
+```bash
+./bin/phel test
+```
+
+Run a specific file with:
+
+```bash
+./bin/phel test tests/phel/<file>
+```
+
+## Conventions
+
+- Use `;` comments, with `;;` for standalone comments.
+- Use kebab-case for functions and variables.
+- Prefer `conj` over `put` for collections.
+- Prefer keyword arguments via maps over positional option lists.
+- Use destructuring in `let` and function parameter lists when it improves clarity.
+- Prefer pure functions and isolate side effects.

--- a/.codex/skills/phel-patterns/agents/openai.yaml
+++ b/.codex/skills/phel-patterns/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Phel Patterns"
+  short_description: "Use Phel language idioms."
+  default_prompt: "Use $phel-patterns while editing Phel source files."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/phel-repl/SKILL.md
+++ b/.codex/skills/phel-repl/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: phel-repl
+description: Evaluate Phel expressions and snippets. Use when Codex needs to verify Phel behavior interactively with ./bin/phel, run a one-off expression, or explain a Phel evaluation error.
+---
+
+# Phel REPL
+
+## Workflow
+
+1. Use the expression from the user or task context. If none is available, ask for it.
+
+2. Try direct evaluation:
+   ```bash
+   echo '<expression>' | timeout 10 ./bin/phel run --eval
+   ```
+
+3. If `--eval` is unavailable, create a temporary file outside the repo:
+   ```bash
+   printf '%s\n' '(ns repl-test)' '<expression>' >/tmp/phel-repl-test.phel
+   timeout 10 ./bin/phel run /tmp/phel-repl-test.phel
+   ```
+
+4. Report the result. For errors, include the relevant message and the likely cause.
+
+## Examples
+
+```phel
+(+ 1 2)
+(map inc [1 2 3])
+(defn greet [name] (str "Hello, " name "!"))
+```

--- a/.codex/skills/phel-repl/agents/openai.yaml
+++ b/.codex/skills/phel-repl/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Phel REPL"
+  short_description: "Evaluate Phel expressions."
+  default_prompt: "Use $phel-repl to evaluate this Phel expression: (+ 1 2)"
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pr
+description: Push the current branch and create a GitHub pull request. Use when Codex is asked to open a PR, prepare a PR body, apply the repository PR template, label a PR, or report the PR URL.
+---
+
+# Create Pull Request
+
+## Workflow
+
+1. Inspect branch context:
+   ```bash
+   git branch --show-current
+   git log main..HEAD --oneline
+   git diff main..HEAD --stat
+   ```
+
+2. Check whether `CHANGELOG.md` is required. Update and commit it only for user-facing changes that warrant release notes.
+
+3. Push the branch:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+4. Generate a concise PR title:
+   - conventional style, under 70 characters
+   - derive type from branch prefix when useful: `feat/`, `fix/`, `docs/`, `ref/`, `test/`, `chore/`
+   - if an issue number is provided, fetch the issue title with `gh issue view <number> --json title -q '.title'`
+
+5. Read `.github/PULL_REQUEST_TEMPLATE.md` and use its exact section headers, including emojis.
+
+6. Pick the most relevant label when labels are available:
+   - `bug` for fixes
+   - `enhancement` for features
+   - `documentation` for docs
+   - `refactoring` for behavior-preserving restructuring
+   - `pure testing` for test-only changes
+   - `dependencies` for dependency updates
+
+7. Create the PR:
+   ```bash
+   gh pr create --title "<title>" --assignee @me --label "<label>" --body-file <body-file>
+   ```
+
+8. Report the PR URL.
+
+## Body Guidance
+
+- Focus on what and why.
+- Keep the body concise.
+- Include `Closes #<number>` only when the PR fully resolves the issue.

--- a/.codex/skills/pr/agents/openai.yaml
+++ b/.codex/skills/pr/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Pull Request"
+  short_description: "Push branch and open a PR."
+  default_prompt: "Use $pr to open a pull request for the current branch."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/refactor-check/SKILL.md
+++ b/.codex/skills/refactor-check/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: refactor-check
+description: Analyze code for SOLID, clean-code, and Phel architecture issues. Use when Codex is asked to review refactoring opportunities, inspect a file or directory for design problems, or plan a cleanup pass.
+---
+
+# Refactor Check
+
+## Analyze
+
+Read the requested file or directory. If none is provided, inspect the current branch diff against `main`.
+
+## SOLID Symptoms
+
+| Principle | Symptoms |
+|-----------|----------|
+| SRP | Class has many unrelated methods or an unclear responsibility |
+| OCP | Switch or if-else chains that grow with every feature |
+| LSP | `instanceof` checks or overrides that weaken behavior |
+| ISP | Empty methods or "not implemented" interface methods |
+| DIP | Business logic directly constructs hard-to-test dependencies |
+
+## Clean Code Checks
+
+- Names are descriptive and intention-revealing.
+- Functions are small, focused, and usually have three or fewer arguments.
+- Comments explain why, not what.
+- Exceptions are specific and failures happen early.
+- Tests cover behavior instead of implementation trivia.
+
+## Architecture Checks
+
+| Area | Rule |
+|------|------|
+| `Lang/` | No dependencies on other modules |
+| Module boundaries | Cross-module access only via Facades |
+| `Shared/` | Only genuinely cross-cutting code |
+| Compiler | Preserve Lexer -> Parser -> Analyzer -> Emitter phase order |
+
+## Phel Source Checks
+
+- kebab-case names
+- public metadata includes `:doc`, `:see-also`, and `:example`
+- `:see-also` values are strings
+- semantics stay aligned with Clojure when intended
+
+## Output Format
+
+```markdown
+# Refactor Analysis: <file/directory>
+
+## Summary
+- **SOLID Violations:** X issues
+- **Clean Code Issues:** X issues
+- **Architecture Issues:** X issues
+
+## Critical Issues
+### [SRP] <Class> has multiple responsibilities
+**File:** `src/php/Module/Class.php:10`
+**Problem:** ...
+**Suggestion:** ...
+
+## Moderate Issues
+...
+
+## Minor Issues
+...
+
+## Recommended Refactoring Steps
+1. ...
+```

--- a/.codex/skills/refactor-check/agents/openai.yaml
+++ b/.codex/skills/refactor-check/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Refactor Check"
+  short_description: "Analyze SOLID and architecture risks."
+  default_prompt: "Use $refactor-check to analyze the current branch."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: release
+description: Create or dry-run a Phel release. Use when Codex is asked to prepare a versioned release, run build/release.sh, verify changelog release content, build the PHAR, tag, push, or inspect a GitHub release.
+---
+
+# Release
+
+## Preflight
+
+1. Confirm the branch is `main` and the worktree is clean:
+   ```bash
+   git branch --show-current
+   git status --porcelain
+   ```
+
+2. Check the current version:
+   ```bash
+   grep "VERSION = " src/php/Console/Application/VersionFinder.php
+   ```
+
+3. Verify `CHANGELOG.md` has release content since the latest tag:
+   ```bash
+   git diff $(git describe --tags --abbrev=0)..HEAD -- CHANGELOG.md
+   ```
+
+4. Determine the release version:
+   - use the user-provided `X.Y.Z` version when present
+   - otherwise infer the next minor version
+
+## Run
+
+For a dry run:
+
+```bash
+./build/release.sh --dry-run <version>
+```
+
+For a release:
+
+```bash
+./build/release.sh <version>
+```
+
+The release script handles version bump, changelog update, commit, PHAR build, tag, push, and GitHub release attachment.
+
+## Verify
+
+```bash
+gh release view v<version>
+```
+
+Report the release URL and any verification failures.
+
+## References
+
+- `.github/RELEASE.md`
+- `build/release.sh`
+- `src/php/Console/Application/VersionFinder.php`

--- a/.codex/skills/release/agents/openai.yaml
+++ b/.codex/skills/release/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Release"
+  short_description: "Run Phel release workflow."
+  default_prompt: "Use $release to dry-run the next Phel release."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/test/SKILL.md
+++ b/.codex/skills/test/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: test
+description: Run Phel tests with smart scope selection. Use when Codex is asked to run all tests, quality checks, compiler tests, core tests, phpunit filters, Phel test files, or benchmark-as-test checks.
+---
+
+# Test Runner
+
+## Workflow
+
+Choose the narrowest command that proves the change, then broaden before finalizing.
+
+| Request | Command |
+|---------|---------|
+| empty or `all` | `composer test` |
+| `quality` | `composer test-quality` |
+| `compiler` | `composer test-compiler` |
+| `core` | `composer test-core` |
+| `quick` | `composer test-compiler && composer test-core` |
+| `bench` | `composer phpbench` |
+| PHPUnit class or method | `./vendor/bin/phpunit --filter "<filter>"` |
+| PHP test file path | `./vendor/bin/phpunit "<path>"` |
+| Phel test file path | `./bin/phel test "<path>"` |
+
+Report the exact command, pass/fail status, and the relevant failure summary when tests fail.

--- a/.codex/skills/test/agents/openai.yaml
+++ b/.codex/skills/test/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Test Runner"
+  short_description: "Run scoped Phel test commands."
+  default_prompt: "Use $test to run the relevant tests for this change."
+
+policy:
+  allow_implicit_invocation: true

--- a/tools/git-hooks/pre-commit.sh
+++ b/tools/git-hooks/pre-commit.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-changed_files="$(git diff --cached --name-only --diff-filter=ACMRTUXB)"
+changed_files="$(git diff --cached --name-only)"
 
 if ! printf '%s\n' "$changed_files" | grep -Eq '\.(php|phel)$'; then
   echo "Skipping composer test-all: no staged PHP or Phel files changed."

--- a/tools/git-hooks/pre-commit.sh
+++ b/tools/git-hooks/pre-commit.sh
@@ -2,4 +2,11 @@
 
 set -e
 
+changed_files="$(git diff --cached --name-only --diff-filter=ACMRTUXB)"
+
+if ! printf '%s\n' "$changed_files" | grep -Eq '\.(php|phel)$'; then
+  echo "Skipping composer test-all: no staged PHP or Phel files changed."
+  exit 0
+fi
+
 composer test-all


### PR DESCRIPTION
## 🤔 Background

The repository already had Claude skills for common Phel maintenance workflows, but no shared Codex equivalents.

## 💡 Goal

Add repo-owned Codex skills so contributors can use the same workflows from Codex.

## 🔖 Changes

- Add Codex skill adaptations under `.codex/skills/`.
- Add helper scripts for the GitHub issue workflow.
- Document shared skill installation in `.codex/README.md`.
- Skip the pre-commit `composer test-all` gate when staged files contain no PHP or Phel changes.