### PR TITLE
fix: skip issues assigned to other users

### DIFF
--- a/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
+++ b/.codex/skills/gh-issue/scripts/watch-gh-issues.sh
@@ -110,16 +110,19 @@ poll_once() {
   fi
   lock_acquired=true
 
+  current_user="$(gh api user --jq '.login')"
+  [[ -n "$current_user" ]] || die "could not determine current GitHub user"
+
   issue="$(
     gh issue list \
       --state open \
       --limit "$limit" \
-      --json number,title \
-      --jq 'sort_by(.number) | .[0].number // empty'
+      --json number,title,assignees \
+      --jq "map(select((.assignees | length) == 0 or any(.assignees[]; .login == \"$current_user\"))) | sort_by(.number) | .[0].number // empty"
   )"
 
   if [[ -z "$issue" ]]; then
-    printf '[%s] no open issues found\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '[%s] no unassigned issues or issues assigned to %s found\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$current_user"
     release_lock
     return 1
   fi


### PR DESCRIPTION
## 🤔 Background

The GitHub issue watcher currently picks the lowest open issue without considering ownership. That can make a local watcher start work on an issue already assigned to another contributor.

## 💡 Goal

Make the watcher only select safe candidates for the current authenticated GitHub user: unassigned issues, or issues assigned to that same user.

## 🔖 Changes

- Resolve the current GitHub login through `gh api user`.
- Include issue assignees in the issue query.
- Filter candidates to unassigned issues or issues assigned to the current user.
- Update the empty-result message to explain the new filtering.

No changelog entry. This only changes Codex maintenance tooling.
