### PR TITLE
test(repl): cover dir namespace docs example

### DIFF
--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -284,7 +284,7 @@
   "Prints all public definitions in the given namespace symbol or string.
 
   Returns nil. Prints one name per line, sorted alphabetically."
-  {:example "(dir phel\\core)"}
+  {:example "(dir phel\\string)"}
   [ns]
   (if (string? ns)
     `(dir-fn ~ns)

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -207,6 +207,19 @@
     (is (= "side\n" (get result :out)) "eval-capturing captures side-effect output")
     (is (= true (get result :success)) "eval-capturing reports success")))
 
+(deftest test-eval-capturing-dir-accepts-bare-namespace-symbol
+  (let [original-ns *ns*]
+    (try
+      (eval-str "(ns user (:require phel\\repl :refer [dir]))")
+      (let [result (eval-capturing "(dir phel\\string)")
+            out    (get result :out)]
+        (is (= nil (get result :value)) "dir returns nil")
+        (is (= true (get result :success)) "dir succeeds from a REPL string")
+        (is (s/contains? out "split") "dir lists phel\\string definitions")
+        (is (s/contains? out "trim") "dir lists phel\\string definitions"))
+      (finally
+        (eval-str (str "(ns " original-ns ")"))))))
+
 (deftest test-eval-capturing-error-case
   (let [result (eval-capturing "(throw (php/new \\Exception \"boom\"))")]
     (is (= false (get result :success)) "eval-capturing reports failure on error")


### PR DESCRIPTION
## 🤔 Background

The REPL docs issue reports that `(dir phel\string)` failed with an unresolved namespace symbol error. The implementation fix is already on `main`; this PR adds coverage for the exact REPL-evaluated form and aligns the source example with the reported docs sample.

## 💡 Goal

Keep the documented `(dir phel\string)` REPL example covered so the docs and REPL behavior stay in agreement.

Closes #1542

## 🔖 Changes

- Add a Phel regression test for evaluating `(dir phel\string)` through `eval-capturing`.
- Update the `dir` metadata example from `phel\core` to `phel\string`.
- No changelog entry: this is documentation metadata plus regression coverage for behavior already fixed on `main`.

Verification:
- `./bin/phel test tests/phel/test/repl.phel`