### PR TITLE
fix: support cons on seqable collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
+- `cons` accepts strings, maps, sets, and empty seqable collections (#1598)
 - `parents`, `ancestors`, and `descendants` return `nil` for invalid hierarchy arguments (#1597)
 - `ancestors` includes inline protocols and PHP parents for records and types (#1591)
 - Sequential equality is symmetric across lists, vectors, and lazy seqs (#1546)

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -4,6 +4,8 @@
 (use InvalidArgumentException)
 (use Phel)
 (use Phel\Lang\AbstractType)
+(use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
+(use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\ConsInterface)
 (use Phel\Lang\RestInterface)
 
@@ -23,6 +25,24 @@
     (php/-> a (equals b))
     (php/=== a b)))
 
+(defn- cons-string [x coll]
+  (let [result (php/array x)]
+    (foreach [char (php/mb_str_split coll)]
+      (php/apush result char))
+    (php/:: Phel (vector result))))
+
+(defn- cons-map [x coll]
+  (let [result (php/array x)]
+    (foreach [k v coll]
+      (php/apush result [k v]))
+    (php/:: Phel (vector result))))
+
+(defn- cons-iterable [x coll]
+  (let [result (php/array x)]
+    (foreach [v coll]
+      (php/apush result v))
+    (php/:: Phel (vector result))))
+
 (defn cons
   "Prepends an element to the beginning of a collection."
   {:example "(cons 0 [1 2 3]) ; => [0 1 2 3]"}
@@ -35,8 +55,14 @@
       (php/-> coll (cons x))
       (if (php/=== coll nil)
         [x]
-        (throw (php/new InvalidArgumentException
-                        (php/. "cannot do cons " (php/print_r x true))))))))
+        (if (php/is_string coll)
+          (cons-string x coll)
+          (if (php/instanceof coll PersistentMapInterface)
+            (cons-map x coll)
+            (if (php/instanceof coll PersistentHashSetInterface)
+              (cons-iterable x coll)
+              (throw (php/new InvalidArgumentException
+                              (php/. "cannot do cons " (php/print_r x true)))))))))))
 
 (defn ffirst
   "Same as `(first (first coll))`."

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -42,6 +42,20 @@
       (php/apush result v))
     (php/:: Phel (vector result))))
 
+(defn- cons-non-array [x coll]
+  (if (php/instanceof coll ConsInterface)
+    (php/-> coll (cons x))
+    (if (php/=== coll nil)
+      [x]
+      (if (php/is_string coll)
+        (cons-string x coll)
+        (if (php/instanceof coll PersistentMapInterface)
+          (cons-map x coll)
+          (if (php/is_iterable coll)
+            (cons-iterable x coll)
+            (throw (php/new InvalidArgumentException
+                            (php/. "cannot do cons " (php/print_r x true))))))))))
+
 (defn cons
   "Prepends an element to the beginning of a collection."
   {:example "(cons 0 [1 2 3]) ; => [0 1 2 3]"}
@@ -50,18 +64,7 @@
     (do
       (php/array_unshift coll x)
       coll)
-    (if (php/instanceof coll ConsInterface)
-      (php/-> coll (cons x))
-      (if (php/=== coll nil)
-        [x]
-        (if (php/is_string coll)
-          (cons-string x coll)
-          (if (php/instanceof coll PersistentMapInterface)
-            (cons-map x coll)
-            (if (php/is_iterable coll)
-              (cons-iterable x coll)
-              (throw (php/new InvalidArgumentException
-                              (php/. "cannot do cons " (php/print_r x true)))))))))))
+    (cons-non-array x coll)))
 
 (defn ffirst
   "Same as `(first (first coll))`."

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -4,7 +4,6 @@
 (use InvalidArgumentException)
 (use Phel)
 (use Phel\Lang\AbstractType)
-(use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\ConsInterface)
 (use Phel\Lang\RestInterface)
@@ -59,7 +58,7 @@
           (cons-string x coll)
           (if (php/instanceof coll PersistentMapInterface)
             (cons-map x coll)
-            (if (php/instanceof coll PersistentHashSetInterface)
+            (if (php/is_iterable coll)
               (cons-iterable x coll)
               (throw (php/new InvalidArgumentException
                               (php/. "cannot do cons " (php/print_r x true)))))))))))

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -9,6 +9,12 @@
   (is (= [1 2 3] (cons 1 [2 3])) "cons vector multiple elements")
   (is (= [1 2] (cons 1 (rest [1 2]))) "cons sub vector")
   (is (= [1 2 3] (cons 1 (rest [1 2 3]))) "cons sub vector multiple elements")
+  (is (= ["1" "2" "3"] (cons "1" "23")) "cons string")
+  (is (= [1] (cons 1 "")) "cons empty string")
+  (is (= [1 1 2 3] (cons 1 (sorted-set 1 2 3))) "cons sorted set")
+  (is (= [1] (cons 1 #{})) "cons empty set")
+  (is (= [1 [:2 2] [:3 3]] (cons 1 {:2 2 :3 3})) "cons map")
+  (is (= [1] (cons 1 {})) "cons empty map")
   (is (= [1] (cons 1 nil)) "cons nil"))
 
 (deftest test-cons-32-more-elements

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -13,7 +13,7 @@
   (is (= [1] (cons 1 "")) "cons empty string")
   (is (= [1 1 2 3] (cons 1 (sorted-set 1 2 3))) "cons sorted set")
   (is (= [1] (cons 1 #{})) "cons empty set")
-  (is (= [1 [:2 2] [:3 3]] (cons 1 {:2 2 :3 3})) "cons map")
+  (is (= [1 [:2 2] [:3 3]] (cons 1 (sorted-map :2 2 :3 3))) "cons sorted map")
   (is (= [1] (cons 1 {})) "cons empty map")
   (is (= [1] (cons 1 nil)) "cons nil"))
 


### PR DESCRIPTION
## 🤔 Background

`cons` threw `InvalidArgumentException` for several seqable inputs covered by the Clojure compatibility suite, including strings, maps, sets, and empty collections.

Closes #1598

## 💡 Goal

Allow `cons` to prepend onto Phel seqable collections without changing the existing fast paths for PHP arrays, vectors, lists, lazy seqs, or `nil`.

## 🔖 Changes

- Added focused Phel core tests for `cons` on strings, sorted sets, empty sets, maps, and empty maps.
- Normalized unsupported seqable inputs inside `cons`: strings split into characters, maps produce `[k v]` entries, and other iterables append their values.
- Updated `CHANGELOG.md` under `Unreleased` for the user-facing core fix.
- Verification: `composer test`.