### PR TITLE
fix: normalize seq results for sets and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `seq` returns sequential values for sorted sets and PHP arrays (#1599)
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
 - `parents`, `ancestors`, and `descendants` return `nil` for invalid hierarchy arguments (#1597)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -361,6 +361,12 @@
     (and (php/instanceof coll Countable) (= 0 (count coll)))
     nil
 
+    (php/is_array coll)
+    (if (php/empty coll) nil (php/:: Phel (vector coll)))
+
+    (php/instanceof coll PersistentHashSetInterface)
+    (php/:: Phel (vector (to-php-array coll)))
+
     true
     coll))
 

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -338,7 +338,8 @@
 
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.
-  Collections are unchanged. Returns nil if coll is empty or nil.
+  Non-sequential collections and PHP arrays are converted to vectors.
+  Returns nil if coll is empty or nil.
 
   This function is useful for explicitly converting strings to sequences of characters,
   enabling sequence operations like map, filter, and frequencies."

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -51,6 +51,18 @@
   (is (= [] (rest [1])) "rest of one element vector")
   (is (= [] (rest [])) "rest of empty vector"))
 
+(deftest test-seq-converts-non-sequential-collections
+  (is (= '(-2.5 1 3 4) (seq (sorted-set 3 1 -2.5 4)))
+      "seq of sorted-set returns ordered sequential values")
+  (is (not (set? (seq (sorted-set 3 1 -2.5 4))))
+      "seq of sorted-set does not return a set"))
+
+(deftest test-seq-converts-php-arrays
+  (is (= '(0 0 0) (seq (int-array 3)))
+      "seq of int-array returns a Phel sequence")
+  (is (not (php/is_array (seq (int-array 3))))
+      "seq of int-array does not return a raw PHP array"))
+
 (deftest test-nfirst
   (is (= [2] (nfirst [[1 2]])) "(nfirst [[1 2]])")
   (is (= [1] (nfirst {:a 1})) "nfirst of single-entry map is the rest of the entry"))


### PR DESCRIPTION
## 🤔 Background

`seq` returned some non-sequential inputs unchanged. That meant `(seq (sorted-set ...))` still produced a set, and `(seq (int-array ...))` still produced a raw PHP array, which diverges from the expected Clojure-style sequence behavior reported in #1599.

## 💡 Goal

Make `seq` return sequential Phel values for sorted sets and PHP arrays while preserving existing nil/empty handling.

Closes #1599

## 🔖 Changes

- Convert non-empty PHP arrays to Phel vectors in `seq`.
- Convert persistent sets, including sorted sets, to vectors in `seq`.
- Add regression coverage for `sorted-set` and `int-array`.
- Clarify the `seq` docstring and add a changelog entry.

Verification:
- `./bin/phel test tests/phel/test/core/basic-sequence-operation.phel`
- `./bin/phel test tests/phel/test/core/sorted-collections.phel`
- `./bin/phel test tests/phel/test/core/sequence-functions.phel`