### PR TITLE
fix: align pop with Clojure collection behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `seq` returns sequential values for sorted sets and PHP arrays (#1599)
+- `pop` handles `nil`, vectors, and lists with Clojure-compatible results (#1600)
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
 - `parents`, `ancestors`, and `descendants` return `nil` for invalid hierarchy arguments (#1597)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -47,7 +47,7 @@
   (conj coll x))
 
 (defn- pop*
-  "Removes the last element of the array `coll`. If the array is empty returns nil."
+  "Removes the last element of `coll`. Returns nil for nil or empty PHP arrays."
   [^:reference coll]
   (cond
     (nil? coll) nil

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -46,13 +46,23 @@
   [coll x]
   (conj coll x))
 
-(defn pop
+(defn- pop*
   "Removes the last element of the array `coll`. If the array is empty returns nil."
   [^:reference coll]
   (cond
+    (nil? coll) nil
     (php-array? coll) (php/array_pop coll)
     (php/instanceof coll PopInterface) (php/-> coll (pop))
     (throw (php/new InvalidArgumentException "Cannot pop"))))
+
+(defmacro pop
+  "Removes the last element of a collection. Returns nil for nil."
+  [coll]
+  (if (symbol? coll)
+    `(pop* ~coll)
+    (let [coll-sym (gensym)]
+      `(let [~coll-sym ~coll]
+         (pop* ~coll-sym)))))
 
 (defn get
   "Gets the value at key in a collection. Returns default if not found."
@@ -242,4 +252,3 @@
    :superseded-by "dissoc"}
   [ds key]
   (dissoc ds key))
-

--- a/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
@@ -12,6 +12,7 @@ use Phel\Lang\ConcatInterface;
 use Phel\Lang\ConsInterface;
 use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
+use Phel\Lang\PopInterface;
 use Phel\Lang\SeqInterface;
 use Phel\Lang\TypeInterface;
 
@@ -23,9 +24,10 @@ use Phel\Lang\TypeInterface;
  * @extends ConsInterface<PersistentListInterface<TValue>>
  * @extends ArrayAccess<int, TValue>
  * @extends ConcatInterface<PersistentListInterface<TValue>>
+ * @extends PopInterface<PersistentListInterface<TValue>>
  * @extends ContainsInterface<int>
  */
-interface PersistentListInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ConsInterface, ArrayAccess, ConcatInterface, FnInterface, ContainsInterface
+interface PersistentListInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ConsInterface, ArrayAccess, ConcatInterface, PopInterface, FnInterface, ContainsInterface
 {
     /**
      * @param TValue $value

--- a/src/php/Lang/Collections/Vector/PersistentVectorInterface.php
+++ b/src/php/Lang/Collections/Vector/PersistentVectorInterface.php
@@ -12,6 +12,7 @@ use Phel\Lang\ConcatInterface;
 use Phel\Lang\ConsInterface;
 use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
+use Phel\Lang\PopInterface;
 use Phel\Lang\PushInterface;
 use Phel\Lang\SeqInterface;
 use Phel\Lang\SliceInterface;
@@ -24,11 +25,12 @@ use Phel\Lang\TypeInterface;
  * @extends IteratorAggregate<T>
  * @extends ArrayAccess<int, T>
  * @extends ConcatInterface<PersistentVectorInterface<T>>
+ * @extends PopInterface<PersistentVectorInterface<T>>
  * @extends PushInterface<PersistentVectorInterface<T>>
  * @extends AsTransientInterface<TransientVectorInterface>
  * @extends ContainsInterface<int>
  */
-interface PersistentVectorInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ConsInterface, ArrayAccess, ConcatInterface, PushInterface, SliceInterface, AsTransientInterface, FnInterface, ContainsInterface
+interface PersistentVectorInterface extends TypeInterface, SeqInterface, IteratorAggregate, Countable, ConsInterface, ArrayAccess, ConcatInterface, PopInterface, PushInterface, SliceInterface, AsTransientInterface, FnInterface, ContainsInterface
 {
     public const int BRANCH_FACTOR = 32;
 

--- a/src/php/Lang/PopInterface.php
+++ b/src/php/Lang/PopInterface.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+/**
+ * @template TSelf of PopInterface
+ */
 interface PopInterface
 {
     /**
-     * Removes the value at the beginning of a sequence and return this removed value.
+     * Removes a value from the data structure.
+     *
+     * @return TSelf
      */
-    public function pop(): mixed;
+    public function pop();
 }

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -224,7 +224,14 @@
   (let [x (php/array 1 2)
         y (pop x)]
     (is (= (php/array 1) x) "pop on PHP array: last element is removed")
-    (is (= 2 y) "pop on PHP array: last element is returned")))
+    (is (= 2 y) "pop on PHP array: last element is returned"))
+
+  (is (nil? (pop nil)) "pop on nil returns nil")
+  (is (= [1 2] (pop [1 2 3])) "pop on vector returns vector without last element")
+  (is (= [1 2] (pop [1 2 (range)])) "pop on vector does not realize popped value")
+  (is (= '(nil) (pop '(nil nil))) "pop on list of nil values returns rest")
+  (is (= '(2 3) (pop '(1 2 3))) "pop on list returns rest")
+  (is (= '(2 3) (pop '((range) 2 3))) "pop on quoted list does not evaluate popped value"))
 
 (deftest test-remove
   (is (= [1 3 5] (into [] (remove even? [1 2 3 4 5 6]))) "remove even numbers from vector")


### PR DESCRIPTION
## 🤔 Background

The clojure-test-suite `pop.cljc` cases report that `pop` errors for `nil`, vectors, and lists. PHP arrays also need to preserve the existing mutating behavior, which requires a by-reference implementation path.

## 💡 Goal

Make `pop` match Clojure-compatible behavior for `nil`, persistent vectors, and persistent lists without regressing PHP array mutation.

Closes #1600

## 🔖 Changes

- Add regression coverage for `pop nil`, vectors, lists, quoted list values, and lazy values inside vectors.
- Wrap `pop` in a macro so literal/nil expressions are bound before calling the by-reference helper.
- Make persistent vectors and lists implement `PopInterface`.
- Generalize `PopInterface` documentation and return typing.
- Add an Unreleased changelog entry.

Verification:
- `./bin/phel test tests/phel/test/core/sequence-operation.phel`