### PR TITLE
fix: print readable strings in test reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this project will be documented in this file.
 #### API
 - `phel analyze` preloads `phel\core` so core macros resolve (#1539)
 
+#### Test
+- Default test reporter prints string literals readably in failure output (#1601)
+
 #### REPL
 - `dir` accepts bare namespace symbols (#1588)
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -3,6 +3,7 @@
   (:use Phel.Lang.SourceLocationInterface)
   (:use Phel.Compiler.Application.Munge)
   (:use Phel.Command.CommandFacade)
+  (:use Phel.Printer.Printer)
   (:require phel.string :as s)
   (:require phel.test.selector :as selector))
 
@@ -474,54 +475,59 @@
 (defn- print-error-headline [data]
   (print-headline "Error" data))
 
+(def- readable-printer (php/:: Printer (readable)))
+
+(defn- readable-str [value]
+  (php/-> readable-printer (print value)))
+
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception :form form} data
         command-facade                    (php/new CommandFacade)
         printer                           (php/-> command-facade (getExceptionPrinter))]
-    (println "              Test:" form)
+    (println "              Test:" (readable-str form))
     (println "   threw exception:" (php/get_class exception))
     (println)
     (php/-> printer (printStackTrace exception))))
 
 (defn- print-predicate-failure [{:pred pred :value value :result result}]
-  (println "                 Test:" value)
-  (println "         evaluated to:" result)
-  (println "  but doesn't satisfy:" pred))
+  (println "                 Test:" (readable-str value))
+  (println "         evaluated to:" (readable-str result))
+  (println "  but doesn't satisfy:" (readable-str pred)))
 
 (defn- print-predicate-not-failure [{:pred pred :value value :result result}]
-  (println "              Test:" value)
-  (println "      evaluated to:" result)
-  (println "  but does satisfy:" pred " (it shouldn't)"))
+  (println "              Test:" (readable-str value))
+  (println "      evaluated to:" (readable-str result))
+  (println "  but does satisfy:" (readable-str pred) " (it shouldn't)"))
 
 (defn- print-binary-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "          Test:" actual)
-  (println "  evaluated to:" result)
-  (println "    but is not:" pred "to" expected))
+  (println "          Test:" (readable-str actual))
+  (println "  evaluated to:" (readable-str result))
+  (println "    but is not:" (readable-str pred) "to" (readable-str expected)))
 
 (defn- print-binary-not-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "          Test:" actual)
-  (println "  evaluated to:" result)
-  (println "        but is:" pred "to" expected "(it shouldn't be)"))
+  (println "          Test:" (readable-str actual))
+  (println "  evaluated to:" (readable-str result))
+  (println "        but is:" (readable-str pred) "to" (readable-str expected) "(it shouldn't be)"))
 
 (defn- print-thrown-failure [{:form form :exception-symbol exception-symbol}]
-  (println "    expected:" form)
+  (println "    expected:" (readable-str form))
   (println "  to throw a:" exception-symbol "(it didn't)"))
 
 (defn- print-thrown-with-msg-failure [{:form form :exception-symbol exception-symbol :expected-message expected-message :actual-message actual-message}]
   (if (nil? actual-message)
     (do
-      (println "    expected:" form)
+      (println "    expected:" (readable-str form))
       (println "  to throw a:" exception-symbol "(it didn't)"))
     (do
-      (println "      expected:" form)
+      (println "      expected:" (readable-str form))
       (println "    to throw a:" exception-symbol)
       (println "  with message:" expected-message)
       (println "       but got:" actual-message))))
 
 (defn- print-any-failure [{:form form :result result}]
-  (println "          Test:" form)
-  (println "  evaluated to:" result "(which is not truthy)"))
+  (println "          Test:" (readable-str form))
+  (println "  evaluated to:" (readable-str result) "(which is not truthy)"))
 
 (defn- print-failure [data]
   (print-failure-headline data)

--- a/tests/phel/test/reporters.phel
+++ b/tests/phel/test/reporters.phel
@@ -184,6 +184,21 @@
     (is (php/preg_match "/Failed: 1/" out) "prints Failed count")
     (is (php/preg_match "/Total: 3/" out) "prints Total count")))
 
+(deftest test-default-reporter-prints-error-forms-with-readable-strings
+  (let [rep   (t/resolve-reporter :default)
+        saved (t/get-stats)
+        prev  (t/get-reporters)
+        _     (t/set-reporters! [rep])
+        _     (t/reset-stats)
+        out   (with-output-buffer
+                (rep {:type :begin-test-run})
+                (is (= 0 (apply + "")))
+                (t/print-summary))
+        _     (t/set-reporters! prev)
+        _     (t/restore-stats saved)]
+    (is (php/preg_match "/Test: \\(= 0 \\(apply \\+ \"\"\\)\\)/" out)
+        "error output renders empty strings with quotes")))
+
 ;; ---------------------------------------------------------------------------
 ;; Default reporter — thrown-with-msg failure formatting
 ;; ---------------------------------------------------------------------------

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -89,6 +89,32 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
         self::assertStringContainsString('my-app:2> (php/+ 2 3)', $output);
     }
 
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function test_test_runner_error_output_prints_empty_strings_readably(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(
+            new InputLine('user:1> ', '(require phel\test :refer [deftest is run-tests])'),
+            new InputLine('user:2> ', '(deftest test-issue (is (= 0 (apply + ""))))'),
+            new InputLine('user:3> ', '(run-tests {} *ns*)'),
+            new InputLine('user:4> ', 'exit'),
+        );
+        $this->prepareRunFactory($io);
+
+        $replStartupFile = __DIR__ . '/../../../../../../src/php/Run/Domain/Repl/startup.phel';
+        ob_start();
+        new ReplCommand()->setReplStartupFile($replStartupFile)->run(
+            $this->createStub(InputInterface::class),
+            $this->stubOutput(),
+        );
+        $stdout = ob_get_clean();
+
+        $output = $io->getOutputString() . $stdout;
+        self::assertStringContainsString('Test: (= 0 (apply + ""))', $output);
+        self::assertStringNotContainsString('Test: (= 0 (apply + ))', $output);
+    }
+
     private function createReplTestIo(): ReplTestIo
     {
         $exceptionPrinter = new TextExceptionPrinter(

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -111,10 +111,10 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
                 $this->stubOutput(),
             );
             $stdout = ob_get_clean();
-        } catch (Throwable $e) {
+        } catch (Throwable $throwable) {
             ob_end_clean();
 
-            throw $e;
+            throw $throwable;
         }
 
         $output = $io->getOutputString() . $stdout;

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -23,6 +23,7 @@ use PhelTest\Integration\Run\Command\AbstractTestCommand;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Console\Input\InputInterface;
+use Throwable;
 
 final class ReplPromptNamespaceTest extends AbstractTestCommand
 {
@@ -104,11 +105,17 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
 
         $replStartupFile = __DIR__ . '/../../../../../../src/php/Run/Domain/Repl/startup.phel';
         ob_start();
-        new ReplCommand()->setReplStartupFile($replStartupFile)->run(
-            $this->createStub(InputInterface::class),
-            $this->stubOutput(),
-        );
-        $stdout = ob_get_clean();
+        try {
+            new ReplCommand()->setReplStartupFile($replStartupFile)->run(
+                $this->createStub(InputInterface::class),
+                $this->stubOutput(),
+            );
+            $stdout = ob_get_clean();
+        } catch (Throwable $e) {
+            ob_end_clean();
+
+            throw $e;
+        }
 
         $output = $io->getOutputString() . $stdout;
         self::assertStringContainsString('Test: (= 0 (apply + ""))', $output);


### PR DESCRIPTION
## 🤔 Background

Default test runner diagnostics printed assertion forms through non-readable output. Empty string literals were rendered as nothing, which made failures such as `(apply + "")` appear as `(apply + )`.

Closes #1601

## 💡 Goal

Make default test reporter failure and error diagnostics preserve readable string literals.

## 🔖 Changes

- Render default reporter assertion forms and evaluated values with the readable Phel printer.
- Add a REPL integration regression for the issue scenario.
- Add reporter-level coverage and an Unreleased changelog entry.