### PR TITLE
fix: handle non-map merge operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `merge` accepts non-map collection operands without TypeErrors (#1603)
 - `seq` returns sequential values for sorted sets and PHP arrays (#1599)
 - `pop` handles `nil`, vectors, and lists with Clojure-compatible results (#1600)
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1008,17 +1008,22 @@
   [a b]
   (zipmap a b))
 
+(defn- merge-two
+  [left right]
+  (cond
+    (nil? left) (if (nil? right) {} (conj {} right))
+    (and (map? left) (nil? right)) left
+    :else (conj left right)))
+
 (defn merge
   "Merges multiple maps into one new map.
 
   If a key appears in more than one collection, later values replace previous ones."
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1 :b 3 :c 4}"}
-  [& maps]
-  (persistent
-   (for [map :in maps
-         [k v] :pairs map
-         :reduce [res (transient {})]]
-     (assoc! res k v))))
+  ([] {})
+  ([map] map)
+  ([map other] (merge-two map other))
+  ([map other & more] (reduce merge-two (merge-two map other) more)))
 
 (defn select-keys
   "Returns a new map including key value pairs from `m` selected with keys `ks`."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1022,8 +1022,7 @@
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1 :b 3 :c 4}"}
   ([] {})
   ([map] map)
-  ([map other] (merge-two map other))
-  ([map other & more] (reduce merge-two (merge-two map other) more)))
+  ([map & more] (reduce merge-two map more)))
 
 (defn select-keys
   "Returns a new map including key value pairs from `m` selected with keys `ks`."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -350,7 +350,13 @@
   (is (= {:a 1 :b 2} (zipmap [:a :b] [1 2])) "zipmap equal length"))
 
 (deftest test-merge
-  (is (= {:a -1 :b 2 :c 3 :d 4} (merge {:a 1 :b 2} {:a -1 :c 3} {:d 4})) "merge"))
+  (is (= {:a -1 :b 2 :c 3 :d 4} (merge {:a 1 :b 2} {:a -1 :c 3} {:d 4})) "merge")
+  (is (= {:a 1} (merge nil {:a 1})) "merge treats nil as an empty map")
+  (is (= {:a 1} (merge {:a 1} nil)) "merge ignores nil after a map")
+  (is (= '(1 1 2 3) (merge '(1 2 3) 1)) "merge accepts a list and scalar value")
+  (is (= [1 2 3 4 5] (merge [1 2] 3 4 5)) "merge accepts a vector and scalar values")
+  (is (= [nil {} 1 {:a "c"}] (merge [] nil {} 1 {:a "c"})) "merge accepts mixed non-map values")
+  (is (= :foo (merge :foo)) "merge with one argument returns it unchanged"))
 
 (deftest test-merge-with-zero-args
   (is (= {} (merge-with identity))))


### PR DESCRIPTION
## 🤔 Background

Issue #1603 reports clojure-test-suite errors where `merge` throws TypeError for undefined but accepted Clojure cases involving non-map operands.

## 💡 Goal

Closes #1603 by making `merge` avoid TypeErrors for those non-map operand cases while preserving existing map merge behavior.

## 🔖 Changes

- Add focused core regression coverage for list, vector, mixed non-map, keyword, and nil map operands.
- Implement `merge` through existing `conj` semantics with nil handling for map-style merges.
- Add an Unreleased changelog entry for the core fix.

Focused local test:

- `./bin/phel test tests/phel/test/core/sequence-functions.phel`
