### PR TITLE
fix: reset test stats between runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - `phel analyze` preloads `phel\core` so core macros resolve (#1539)
 
 #### Test
+- `run-tests` resets assertion counts for each run (#1604)
 - Default test reporter prints string literals readably in failure output (#1601)
 
 #### REPL

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1121,6 +1121,7 @@
   {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
   (configure-run! options)
+  (reset! stats initial-stats)
   (fan-out! {:type :begin-test-run})
   (dofor [namespace :in namespaces
           :when (not (should-stop?))]

--- a/tests/phel/test/selectors-runtime.phel
+++ b/tests/phel/test/selectors-runtime.phel
@@ -31,9 +31,6 @@
 (defn- events-of [events type]
   (vec (for [e :in events :when (= type (:type e))] e)))
 
-(defn- summaries-of [events]
-  (events-of events :summary))
-
 (defn- skipped-names [events]
   (vec (for [e :in (events-of events :skipped)] (:test-name e))))
 
@@ -64,7 +61,7 @@
     (with-output-buffer
       (t/run-tests {:reporters [capture]} fixture-ns)
       (t/run-tests {:reporters [capture]} fixture-ns))
-    (let [summaries (summaries-of (deref events))]
+    (let [summaries (events-of (deref events) :summary)]
       (t/set-reporters! saved-reporters)
       (t/restore-stats saved-stats)
       (is (= 2 (count summaries)) "both runs emit a summary")

--- a/tests/phel/test/selectors-runtime.phel
+++ b/tests/phel/test/selectors-runtime.phel
@@ -31,6 +31,9 @@
 (defn- events-of [events type]
   (vec (for [e :in events :when (= type (:type e))] e)))
 
+(defn- summaries-of [events]
+  (events-of events :summary))
+
 (defn- skipped-names [events]
   (vec (for [e :in (events-of events :skipped)] (:test-name e))))
 
@@ -51,6 +54,24 @@
     (is (= 0 (count (skipped-names events))) "no tests are skipped")
     (is (= 3 (passing-count events))
         "all three fixtures run and pass")))
+
+(deftest test-run-tests-starts-each-run-with-fresh-stats
+  (let [saved-reporters (t/get-reporters)
+        saved-stats     (t/get-stats)
+        events          (atom [])
+        capture         (fn [e] (swap! events conj e))]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests {:reporters [capture]} fixture-ns)
+      (t/run-tests {:reporters [capture]} fixture-ns))
+    (let [summaries (summaries-of (deref events))]
+      (t/set-reporters! saved-reporters)
+      (t/restore-stats saved-stats)
+      (is (= 2 (count summaries)) "both runs emit a summary")
+      (is (= [3 3] (vec (map :pass summaries)))
+          "pass counts are reset between runs")
+      (is (= [3 3] (vec (map :total summaries)))
+          "total counts are reset between runs"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Include — only fixtures tagged :integration run


### PR DESCRIPTION
## 🤔 Background

Calling `phel\test/run-tests` repeatedly in the same process reused the previous assertion counters, so summary totals accumulated across runs.

Closes #1604

## 💡 Goal

Start each `run-tests` invocation with fresh assertion statistics, matching Clojure-style repeated test runs.

## 🔖 Changes

- Reset test stats after reporter configuration and before emitting run events.
- Add a regression test that calls `run-tests` twice and checks both summaries.
- Add an Unreleased changelog entry for the test framework fix.

Focused local test:
`./bin/phel test tests/phel/test/selectors-runtime.phel`