### PR TITLE
fix: support dissoc on records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `seq` returns sequential values for sorted sets and PHP arrays (#1599)
 - `pop` handles `nil`, vectors, and lists with Clojure-compatible results (#1600)
+- `dissoc` removes keys from records with Clojure-compatible map results (#1607)
 - Dynamic bindings are fiber-local and propagate through `future`/`async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
 - `cons` accepts strings, maps, sets, and empty seqable collections (#1598)

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -48,10 +48,6 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 
     public function contains($key): bool
     {
-        if (!$key instanceof Keyword) {
-            return false;
-        }
-
         return in_array($key->getName(), static::ALLOWED_KEYS, true);
     }
 

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -48,6 +48,10 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 
     public function contains($key): bool
     {
+        if (!$key instanceof Keyword) {
+            return false;
+        }
+
         return in_array($key->getName(), static::ALLOWED_KEYS);
     }
 
@@ -62,11 +66,22 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 
     public function remove($key): PersistentMapInterface
     {
-        $stringKey = $this->validateKey($key);
+        if (!$this->contains($key)) {
+            return $this;
+        }
 
-        $newInstance = clone $this;
-        $newInstance->{$stringKey} = null;
-        return $newInstance;
+        $kvs = [];
+        foreach (static::ALLOWED_KEYS as $allowedKey) {
+            $entryKey = Phel::keyword($allowedKey);
+            if ($this->equalizer->equals($entryKey, $key)) {
+                continue;
+            }
+
+            $kvs[] = $entryKey;
+            $kvs[] = $this->{$this->keyEncoder->encode($allowedKey)};
+        }
+
+        return TypeFactory::getInstance()->persistentMapFromArray($kvs);
     }
 
     public function count(): int

--- a/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
+++ b/src/php/Lang/Collections/Struct/AbstractPersistentStruct.php
@@ -52,7 +52,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
             return false;
         }
 
-        return in_array($key->getName(), static::ALLOWED_KEYS);
+        return in_array($key->getName(), static::ALLOWED_KEYS, true);
     }
 
     public function put($key, $value): PersistentMapInterface
@@ -70,18 +70,7 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
             return $this;
         }
 
-        $kvs = [];
-        foreach (static::ALLOWED_KEYS as $allowedKey) {
-            $entryKey = Phel::keyword($allowedKey);
-            if ($this->equalizer->equals($entryKey, $key)) {
-                continue;
-            }
-
-            $kvs[] = $entryKey;
-            $kvs[] = $this->{$this->keyEncoder->encode($allowedKey)};
-        }
-
-        return TypeFactory::getInstance()->persistentMapFromArray($kvs);
+        return $this->toPersistentMapWithout($key);
     }
 
     public function count(): int
@@ -133,5 +122,21 @@ abstract class AbstractPersistentStruct extends AbstractPersistentMap
 
         $structName = static::class;
         throw new InvalidArgumentException(sprintf("This key '%s' is not allowed for struct %s", (string) $key, $structName));
+    }
+
+    private function toPersistentMapWithout(Keyword $key): PersistentMapInterface
+    {
+        $kvs = [];
+        foreach (static::ALLOWED_KEYS as $allowedKey) {
+            $entryKey = Phel::keyword($allowedKey);
+            if ($this->equalizer->equals($entryKey, $key)) {
+                continue;
+            }
+
+            $kvs[] = $entryKey;
+            $kvs[] = $this->{$this->keyEncoder->encode($allowedKey)};
+        }
+
+        return TypeFactory::getInstance()->persistentMapFromArray($kvs);
     }
 }

--- a/tests/phel/test/core/records.phel
+++ b/tests/phel/test/core/records.phel
@@ -5,6 +5,8 @@
 
 (defrecord Point [x y])
 
+(defrecord TestDissocRecord [a b c])
+
 (deftest test-defrecord-positional-constructor
   (let [p (Point 1 2)]
     (is (= 1 (get p :x)) "defrecord: :x accessible via get")
@@ -27,6 +29,13 @@
 (deftest test-defrecord-equality
   (is (= (Point 1 2) (Point 1 2)) "defrecord instances with same values are equal")
   (is (not= (Point 1 2) (Point 1 3)) "defrecord instances with different values are not equal"))
+
+(deftest test-defrecord-dissoc
+  (let [r (TestDissocRecord 1 2 nil)]
+    (is (= {:b 2 :c nil} (apply dissoc r [:a])) "dissoc removes one record key")
+    (is (= {:b 2 :c nil} (apply dissoc r [:a :d])) "dissoc ignores missing record keys")
+    (is (= {} (apply dissoc r [:a :b :c])) "dissoc can remove all record keys")
+    (is (= r (apply dissoc r [:d])) "dissoc with only missing keys returns the record unchanged")))
 
 ;; --- defrecord with inline protocol methods ---
 

--- a/tests/php/Unit/Lang/Collections/Struct/StructTest.php
+++ b/tests/php/Unit/Lang/Collections/Struct/StructTest.php
@@ -46,14 +46,14 @@ final class StructTest extends TestCase
     {
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
         $s = $s->remove(Keyword::create('a'));
-        self::assertEquals(FakeStruct::fromKVs(Keyword::create('b'), 2), $s);
+        self::assertEquals([Keyword::create('b'), 2], $this->toKeyValueList($s));
+        self::assertNotInstanceOf(FakeStruct::class, $s);
     }
 
     public function test_remove_invalid_key(): void
     {
-        $this->expectException(InvalidArgumentException::class);
         $s = FakeStruct::fromKVs(Keyword::create('a'), 1, Keyword::create('b'), 2);
-        $s->remove(Keyword::create('c'));
+        self::assertSame($s, $s->remove(Keyword::create('c')));
     }
 
     public function test_offset_get(): void


### PR DESCRIPTION
## 🤔 Background

`dissoc` on `defrecord` values currently keeps removed fields as `nil` and throws when the key is not a record field. The Clojure-compatible behavior is to return a map when record fields are removed and to ignore missing keys.

Closes #1607

## 💡 Goal

Make `dissoc` work correctly with records, including `apply dissoc` with missing or multiple keys.

## 🔖 Changes

- Updated struct removal to return a persistent map without removed record keys.
- Made missing record keys a no-op for removal.
- Added focused Phel record tests for `apply dissoc`.
- Added an Unreleased changelog entry for the fix.

Focused local checks:
- `./bin/phel test tests/phel/test/core/records.phel tests/phel/test/core/sequence-operation.phel`
- `vendor/bin/php-cs-fixer fix --dry-run --diff src/php/Lang/Collections/Struct/AbstractPersistentStruct.php`