### PR TITLE
fix: align merge nil semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `merge` returns `nil` for no or all-`nil` arguments (#1606)
 - `merge` accepts non-map collection operands without TypeErrors (#1603)
 - `apply` accepts strings and maps as final arguments (#1602)
 - `seq` returns sequential values for sorted sets and PHP arrays (#1599)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1011,8 +1011,8 @@
 (defn- merge-two
   [left right]
   (cond
-    (nil? left) (if (nil? right) nil (conj {} right))
-    (and (map? left) (nil? right)) left
+    (nil? left)  (when-not (nil? right) (conj {} right))
+    (nil? right) (if (map? left) left (conj left right))
     :else (conj left right)))
 
 (defn merge

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1011,7 +1011,7 @@
 (defn- merge-two
   [left right]
   (cond
-    (nil? left) (if (nil? right) {} (conj {} right))
+    (nil? left) (if (nil? right) nil (conj {} right))
     (and (map? left) (nil? right)) left
     :else (conj left right)))
 
@@ -1020,7 +1020,7 @@
 
   If a key appears in more than one collection, later values replace previous ones."
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1 :b 3 :c 4}"}
-  ([] {})
+  ([] nil)
   ([map] map)
   ([map & more] (reduce merge-two map more)))
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -351,11 +351,22 @@
 
 (deftest test-merge
   (is (= {:a -1 :b 2 :c 3 :d 4} (merge {:a 1 :b 2} {:a -1 :c 3} {:d 4})) "merge")
+  (is (nil? (merge)) "merge without arguments returns nil")
+  (is (nil? (merge nil)) "merge with nil returns nil")
+  (is (nil? (merge nil nil)) "merge with nil arguments returns nil")
+  (is (nil? (merge nil nil nil)) "merge with multiple nil arguments returns nil")
   (is (= {:a 1} (merge nil {:a 1})) "merge treats nil as an empty map")
   (is (= {:a 1} (merge {:a 1} nil)) "merge ignores nil after a map")
+  (is (= {:a "a" :b "b"} (merge {:a nil} (first {:a "a"}) {:b "b"})) "merge accepts map entries")
+  (is (= {:foo "foo"} (merge {} [:foo "foo"])) "merge accepts vector map entries")
+  (is (= {'x 1} (merge {} ['x 1])) "merge accepts symbol vector map entries")
+  (is (= {'x 10 'y 10} (merge {'x 10} ['y 10])) "merge preserves existing entries with vector map entries")
+  (is (= {:foo "foo" :bar "bar"} (merge {} [:foo "foo"] [:bar "bar"])) "merge accepts multiple vector map entries")
+  (is (= {'x 10 'y 10 'z 10} (merge {'x 10} ['y 10] ['z 10])) "merge accepts multiple symbol vector map entries")
   (is (= '(1 1 2 3) (merge '(1 2 3) 1)) "merge accepts a list and scalar value")
   (is (= [1 2 3 4 5] (merge [1 2] 3 4 5)) "merge accepts a vector and scalar values")
   (is (= [nil {} 1 {:a "c"}] (merge [] nil {} 1 {:a "c"})) "merge accepts mixed non-map values")
+  (is (= [:foo] (merge [:foo])) "merge with one vector argument returns it unchanged")
   (is (= :foo (merge :foo)) "merge with one argument returns it unchanged"))
 
 (deftest test-merge-with-zero-args


### PR DESCRIPTION
## 🤔 Background

Issue #1606 reports clojure-test-suite failures in `merge.cljc` where Phel returned `{}` for no/all-`nil` merge arguments while Clojure returns `nil`. The issue also covers map-entry vector cases in later merge positions.

Closes #1606

## 💡 Goal

Align `merge` with the Clojure-suite nil semantics while preserving existing non-map collection behavior.

## 🔖 Changes

- Return `nil` from `(merge)` and all-`nil` merge inputs.
- Add focused Phel tests for no-arg, nil, map-entry, vector-entry, and single-vector merge behavior.
- Add an Unreleased changelog entry for the public core fix.

Focused local test run:

```
./bin/phel test tests/phel/test/core/sequence-functions.phel
```