### PR TITLE
fix: align assoc! trailing apply args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `assoc!` handles trailing keys from `apply` with `nil` values (#1609)
 - `merge` returns `nil` for no or all-`nil` arguments (#1606)
 - `merge` accepts non-map collection operands without TypeErrors (#1603)
 - `apply` accepts strings and maps as final arguments (#1602)

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -117,12 +117,16 @@
   [tcoll key value & more]
   (loop [acc       (assoc-bang-pair tcoll key value)
          remaining more]
-    (if (empty? remaining)
+    (cond
+      (empty? remaining)
       acc
-      (if (empty? (rest remaining))
-        (assoc-bang-pair acc (first remaining) nil)
-        (recur (assoc-bang-pair acc (first remaining) (second remaining))
-               (rest (rest remaining)))))))
+
+      (empty? (rest remaining))
+      (assoc-bang-pair acc (first remaining) nil)
+
+      :else
+      (recur (assoc-bang-pair acc (first remaining) (second remaining))
+             (rest (rest remaining))))))
 
 (defn- dissoc-bang-single
   [tcoll key]

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -108,23 +108,21 @@
 (defn assoc!
   "Associates one or more key-value pairs with a transient collection,
    mutating it in place. Works on transient hash-maps and transient vectors.
-   Variadic forms apply each `key-value` pair in order. Raises
+   Variadic forms apply each `key-value` pair in order. A trailing key
+   without a value is associated with `nil`. Raises
    `InvalidArgumentException` when `tcoll` is not a supported transient
-   collection or when an odd number of extra arguments is provided.
-   Matches Clojure's `assoc!` semantics."
+   collection. Matches Clojure's `assoc!` semantics."
   {:example "(persistent! (assoc! (transient {}) :a 1 :b 2)) ; => {:a 1 :b 2}"
    :see-also ["assoc" "conj!" "transient" "persistent!"]}
   [tcoll key value & more]
-  (when (php/!== 0 (php/& (count more) 1))
-    (throw (php/new InvalidArgumentException
-                    (str "assoc! expects an even number of extra arguments (key-value pairs), got "
-                         (count more)))))
   (loop [acc       (assoc-bang-pair tcoll key value)
          remaining more]
     (if (empty? remaining)
       acc
-      (recur (assoc-bang-pair acc (first remaining) (second remaining))
-             (rest (rest remaining))))))
+      (if (empty? (rest remaining))
+        (assoc-bang-pair acc (first remaining) nil)
+        (recur (assoc-bang-pair acc (first remaining) (second remaining))
+               (rest (rest remaining)))))))
 
 (defn- dissoc-bang-single
   [tcoll key]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -172,15 +172,19 @@
   (is (= {:a 1} (persistent! (assoc! (transient {}) :a 1))) "assoc! on empty transient map")
   (is (= {:a 1 :b 2} (persistent! (assoc! (transient {:a 1}) :b 2))) "assoc! on transient map")
   (is (= {:a 3 :b 2} (persistent! (assoc! (transient {:a 1 :b 2}) :a 3))) "assoc! overwrites existing key")
-  (is (= {:a 1 :b 2 :c 3} (persistent! (assoc! (transient {}) :a 1 :b 2 :c 3))) "assoc! variadic on transient map"))
+  (is (= {:a 1 :b 2 :c 3} (persistent! (assoc! (transient {}) :a 1 :b 2 :c 3))) "assoc! variadic on transient map")
+  (is (= {:a 1 :b 2 :c 3 :d nil}
+         (persistent! (apply assoc! (transient {:a 1}) [:b 2 :c 3 :d])))
+      "assoc! with apply treats a trailing key as nil"))
 
 (deftest test-assoc-bang-vector
   (is (= [9 2 3] (persistent! (assoc! (transient [1 2 3]) 0 9))) "assoc! on transient vector by index")
   (is (= [1 2 9] (persistent! (assoc! (transient [1 2 3]) 2 9))) "assoc! at last index")
-  (is (= [9 2 8] (persistent! (assoc! (transient [1 2 3]) 0 9 2 8))) "assoc! variadic on transient vector"))
+  (is (= [9 2 8] (persistent! (assoc! (transient [1 2 3]) 0 9 2 8))) "assoc! variadic on transient vector")
+  (is (= [1 nil] (persistent! (apply assoc! (transient []) [0 1 1])))
+      "assoc! with apply treats a trailing vector index as nil"))
 
 (deftest test-assoc-bang-errors
-  (is (thrown? \InvalidArgumentException (assoc! (transient {:a 1}) :b 2 :c)) "assoc! with odd extra args throws")
   (is (thrown? \InvalidArgumentException (assoc! {:a 1} :b 2)) "assoc! on persistent map throws")
   (is (thrown? \InvalidArgumentException (assoc! [1 2] 0 9)) "assoc! on persistent vector throws")
   (is (thrown? \InvalidArgumentException (assoc! (transient #{1 2}) 0 9)) "assoc! on transient set throws")


### PR DESCRIPTION
## 🤔 Background

`assoc!` threw `InvalidArgumentException` when `apply` supplied a trailing key without a value. Clojure transient `assoc!` treats that final key as having a `nil` value, which caused clojure-test-suite failures.

Closes #1609

## 💡 Goal

Match Clojure transient `assoc!` behavior for odd trailing arguments produced through `apply`.

## 🔖 Changes

- Add focused Phel core tests for transient map and vector `assoc!` with trailing keys from `apply`.
- Update `assoc!` to associate a leftover trailing key with `nil` instead of throwing.
- Add an Unreleased Core changelog entry for #1609.
- Refactor the `assoc!` loop to make the empty, trailing-key, and pair cases explicit.

Focused local test run:

```
./bin/phel test tests/phel/test/core/sequence-operation.phel
```