### PR TITLE
test: cover string conversion for sorting

### DIFF
--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -328,7 +328,8 @@
   (is (= [0 3 1 2 2 1] (kvs [3 2 1])) "kvs of vector"))
 
 (deftest test-to-php-array
-  (is (= (php/array 3 2 1) (to-php-array [3 2 1])) "to-php-array"))
+  (is (= (php/array 3 2 1) (to-php-array [3 2 1])) "to-php-array")
+  (is (= (php/array "a" "b" "c") (to-php-array "abc")) "to-php-array string characters"))
 
 (deftest test-sort
   (is (= [] (sort nil)) "sort nil")


### PR DESCRIPTION
## 🤔 Background

Issue #1612 reported that `(sort "clojure")` failed because sorting string input tried to unpack a PHP string directly. The current main branch already contains the implementation fix through the recent sequence/sort work, and the focused sort assertion now passes.

## 💡 Goal

Closes #1612 by keeping explicit regression coverage for the shared string-to-PHP-array path that `sort` relies on.

## 🔖 Changes

- Add a focused `to-php-array` assertion for string input so string characters are converted to a PHP array before sorting-related operations.
- Verified with `./bin/phel test tests/phel/test/core/sequence-functions.phel`.
- Refactor pass completed; no additional cleanup was justified for the test-only branch.