### PR TITLE
fix: accept comparator-first sort args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `sort` accepts Clojure-compatible `(sort comp coll)` argument order (#1613)
 - `assoc!` handles trailing keys from `apply` with `nil` values (#1609)
 - `sort` orders map entries and nested vectors with Clojure-compatible `compare` (#1610)
 - `merge` returns `nil` for no or all-`nil` arguments (#1606)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -739,14 +739,22 @@
   [coll val]
   (some? #(= % val) (vals coll)))
 
-(defn sort
-  "Returns a sorted vector. If no comparator is supplied compare is used."
-  {:example "(sort [3 1 4 1 5 9 2 6]) ; => [1 1 2 3 4 5 6 9]"
-   :see-also ["sort-by" "compare"]}
-  [coll & [comp]]
+(defn- sort-with
+  [coll comp]
   (let [php-array (to-php-array coll)]
     (php/usort php-array (or comp compare))
     (copy-meta coll (php/:: Phel (vector php-array)))))
+
+(defn sort
+  "Returns a sorted vector. If no comparator is supplied compare is used."
+  {:example "(sort [3 1 4 1 5 9 2 6]) ; => [1 1 2 3 4 5 6 9]\n(sort (fn [a b] (compare b a)) [1 2 3]) ; => [3 2 1]"
+   :see-also ["sort-by" "compare"]}
+  ([coll]
+   (sort-with coll compare))
+  ([a b]
+   (if (fn? a)
+     (sort-with b a)
+     (sort-with a b))))
 
 (defn sort-by
   "Returns a sorted vector where the sort order is determined by comparing `(keyfn item)`.

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -342,6 +342,7 @@
   (is (= [nil 2 3 4] (sort [3 nil 2 4])) "sort nil before values")
   (is (= [1 2 2 3 3] (sort [3 2 1 2 3] <=>)) "sort ascending order")
   (is (= [3 3 2 2 1] (sort [3 2 1 2 3] >=<)) "sort descending order")
+  (is (= [4 3 2 1] (sort #(- (compare %1 %2)) [1 2 3 4])) "sort comparator before collection")
   (is (= [4 3 2 1] (sort [1 2 3 4] #(- (compare %1 %2)))) "sort with custom comparator")
   (is (= [[1 :a] [1 :e] [2 :b] [2 :d] [3 :c]]
          (sort [[1 :a] [2 :b] [3 :c] [2 :d] [1 :e]]


### PR DESCRIPTION
## 🤔 Background

`sort` accepted Phel's existing `(sort coll comp)` order, but Clojure uses `(sort comp coll)`. The Clojure compatibility suite reported a TypeError when passing the comparator first.

## 💡 Goal

Closes #1613. Allow `sort` to accept Clojure-compatible comparator-first arguments while preserving the existing collection-first comparator form.

## 🔖 Changes

- Added a focused core test for `(sort comp coll)`.
- Split sorting through a private helper and dispatch the two-argument form by comparator position.
- Updated `CHANGELOG.md` under Unreleased/Core.
- Refactor pass completed; no separate refactor commit was justified because the implementation is already localized.

Focused local checks:
- `./bin/phel test tests/phel/test/core/sequence-functions.phel`
- `composer test-core`