### PR TITLE
feat: support list matchers in case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Standard library `:use` clauses now use dot-separated PHP class names (#1576)
 
 #### Core
+- `case` accepts list matchers for Clojure-compatible alternatives (#1615)
 - Hierarchy functions accept an optional hierarchy argument (#1543)
 - Added `into-array` for `.cljc` interop (#1550)
 - `==` now follows Clojure-compatible numeric equality (#1561)

--- a/src/phel/core/control.phel
+++ b/src/phel/core/control.phel
@@ -1,6 +1,7 @@
 (in-ns phel.core)
 
 (use InvalidArgumentException)
+(use Phel\Lang\Collections\LinkedList\PersistentListInterface)
 
 ;; Control-flow macros layered on the `if` special form: `if-not`, `when`,
 ;; `when-not`, `cond`, `case`, and `condp`. Pure macros — they expand at
@@ -42,6 +43,17 @@
               (second pairs)
               (cons 'cond (apply list (next (next pairs)))))))))
 
+(defn- case-list-tests [v matchers]
+  (if (php/=== matchers nil)
+    '()
+    (cons `(equals1 ~v '~(first matchers))
+          (case-list-tests v (next matchers)))))
+
+(defn- case-test [v matcher]
+  (if (php/instanceof matcher PersistentListInterface)
+    (cons 'or (case-list-tests v matcher))
+    `(equals1 ~v '~matcher)))
+
 (defmacro case
   "Evaluates expression and matches it against constant test values, returning the associated result."
   {:example "(case x 1 \"one\" 2 \"two\" \"other\") ; => \"one\" (when x is 1)"}
@@ -49,7 +61,7 @@
   (if (next pairs)
     (let [v (gensym)]
       `(let [~v ~e]
-         (if (equals1 ~v '~(first pairs))
+         (if ~(case-test v (first pairs))
            ~(first (next pairs))
            (case ~v ~@(next (next pairs))))))
     (first pairs)))

--- a/tests/phel/test/core/control-structures.phel
+++ b/tests/phel/test/core/control-structures.phel
@@ -26,7 +26,12 @@
   (is (= 1 (case true false 2 1)) "case one failed test with default")
   (is (= 2 (case true true 2)) "case one successful test without default")
   (is (= 2 (case true true 2 1)) "case one successful test with default")
-  (is (= :one (case (+ 1 0) 1 :one)) "case with expression"))
+  (is (= :one (case (+ 1 0) 1 :one)) "case with expression")
+  (is (= :small (case 0 (0 1) :small 2 :two)) "case list matcher matches first element")
+  (is (= :small (case 1 (0 1) :small 2 :two)) "case list matcher matches later element")
+  (is (= :keyword (case :four (:four :five) :keyword :other)) "case list matcher supports keywords")
+  (is (= :symbol (case 'range (range 0 5) :symbol :other)) "case list matcher treats symbols as constants")
+  (is (= :default (case 3 (0 1) :small 2 :two :default)) "case list matcher falls through"))
 
 (deftest test-condp
   (is (= "one" (condp = 1 1 "one" 2 "two")) "condp basic match first")


### PR DESCRIPTION
## 🤔 Background

`case` did not support the Clojure-compatible clause form where a list of constants matches any listed value. That left clojure-test-suite case examples returning the default or nil instead of matching alternatives.

## 💡 Goal

Closes #1615. Allow `case` clauses such as `(0 1) :small` to match any constant in the list while preserving existing single-matcher and default behavior.

## 🔖 Changes

- Expand list matchers in `case` into literal equality checks joined with `or`.
- Cover numeric, keyword, symbolic, and fall-through list matcher cases in core Phel tests.
- Add an Unreleased changelog entry.
- Refactor pass completed: no separate cleanup diff was justified after reviewing the branch changes.

Focused local tests:

- `./bin/phel test tests/phel/test/core/control-structures.phel`
- `./bin/phel test tests/phel/test/core/*.phel`