### PR TITLE
ref: clean up today issue fixes

### DIFF
--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -310,23 +310,35 @@
     (php/is_string coll) (and (php/is_int key) (php/>= key 0) (php/< key (php/mb_strlen coll)))
     (throw (php/new InvalidArgumentException (php/. "cannot call 'contains?' on " (php/get_class coll))))))
 
+(defn- comparable-number?
+  [x]
+  (or (php/is_int x) (php/is_float x)))
+
+(defn- comparable-sequential?
+  [x]
+  (or (php/instanceof x PersistentVectorInterface)
+      (php/instanceof x PersistentListInterface)))
+
+(defn- named-comparison-category?
+  [category]
+  (or (= category :keyword) (= category :symbol)))
+
 (defn- compare-category
   "Returns a coarse category for `compare`'s type compatibility check. `nil` is
   its own category so it can be treated as less than anything. Numbers share a
   category so `(compare 1 1.5)` works."
   [x]
   (cond
-    (php/=== x nil)                                                                                      :nil
-    (php/is_bool x)                                                                                      :bool
-    (or (php/is_int x) (php/is_float x))                                                                 :number
-    (php/is_string x)                                                                                    :string
-    (php/instanceof x Keyword)                                                                           :keyword
-    (php/instanceof x Symbol)                                                                            :symbol
-    (or (php/instanceof x PersistentVectorInterface)
-        (php/instanceof x PersistentListInterface)) :sequential
-    (php/instanceof x PersistentMapInterface)                                                            :map
-    (php/instanceof x PersistentHashSetInterface)                                                        :set
-    :else                                                                                                :other))
+    (php/=== x nil)                              :nil
+    (php/is_bool x)                              :bool
+    (comparable-number? x)                       :number
+    (php/is_string x)                            :string
+    (php/instanceof x Keyword)                   :keyword
+    (php/instanceof x Symbol)                    :symbol
+    (comparable-sequential? x)                   :sequential
+    (php/instanceof x PersistentMapInterface)    :map
+    (php/instanceof x PersistentHashSetInterface) :set
+    :else                                        :other))
 
 (declare compare)
 
@@ -349,7 +361,7 @@
 
 (defn- compare-same-category [category x y]
   (cond
-    (or (= category :keyword) (= category :symbol))
+    (named-comparison-category? category)
     (compare-named x y)
 
     (= category :sequential)

--- a/src/phel/core/control.phel
+++ b/src/phel/core/control.phel
@@ -43,15 +43,15 @@
               (second pairs)
               (cons 'cond (apply list (next (next pairs)))))))))
 
-(defn- case-list-tests [v matchers]
+(defn- case-list-match-tests [v matchers]
   (if (php/=== matchers nil)
     '()
     (cons `(equals1 ~v '~(first matchers))
-          (case-list-tests v (next matchers)))))
+          (case-list-match-tests v (next matchers)))))
 
-(defn- case-test [v matcher]
+(defn- case-match-test [v matcher]
   (if (php/instanceof matcher PersistentListInterface)
-    (cons 'or (case-list-tests v matcher))
+    (cons 'or (case-list-match-tests v matcher))
     `(equals1 ~v '~matcher)))
 
 (defmacro case
@@ -61,7 +61,7 @@
   (if (next pairs)
     (let [v (gensym)]
       `(let [~v ~e]
-         (if ~(case-test v (first pairs))
+         (if ~(case-match-test v (first pairs))
            ~(first (next pairs))
            (case ~v ~@(next (next pairs))))))
     (first pairs)))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -336,6 +336,10 @@
     (php-array? coll)                                (php/array)
     :else                                            nil))
 
+(defn- seq-vector
+  [values]
+  (if (php/empty values) nil (php/:: Phel (vector values))))
+
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.
   Non-sequential collections and PHP arrays are converted to vectors.
@@ -348,8 +352,7 @@
   [coll]
   (cond
     (php/is_string coll)
-    (let [chars (php/mb_str_split coll)]
-      (if (php/empty chars) nil (php/:: Phel (vector chars))))
+    (seq-vector (php/mb_str_split coll))
 
     (php/=== coll nil)
     nil
@@ -363,10 +366,10 @@
     nil
 
     (php/is_array coll)
-    (if (php/empty coll) nil (php/:: Phel (vector coll)))
+    (seq-vector coll)
 
     (php/instanceof coll PersistentHashSetInterface)
-    (php/:: Phel (vector (to-php-array coll)))
+    (seq-vector (to-php-array coll))
 
     true
     coll))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -83,6 +83,37 @@
     2 #((first fs) (apply (second fs) %&))
     (reduce comp fs)))
 
+(defn- map-entry-source?
+  [x]
+  (or (php/instanceof x PersistentMapInterface)
+      (and (php/is_array x) (not (indexed-php-array? x)))))
+
+(defn- into-entries
+  [from]
+  (if (map-entry-source? from)
+    (for [entry :pairs from] entry)
+    from))
+
+(defn- assoc-into-entry
+  [acc entry]
+  (if (not (indexed? entry))
+    (throw (php/new InvalidArgumentException
+                    "into expects a collection of [key value] pairs"))
+    (if (php/!= (count entry) 2)
+      (throw (php/new InvalidArgumentException
+                      "into expects a collection of [key value] pairs"))
+      (let [k (first entry)
+            v (second entry)]
+        (if (php/is_array acc)
+          (do
+            (php/aset acc k v)
+            acc)
+          (assoc acc k v))))))
+
+(defn- map-into-target?
+  [to]
+  (or (map-entry-source? to) (php/instanceof to TransientMapInterface)))
+
 (defn into
   "Returns `to` with all elements of `from` added.
 
@@ -99,27 +130,7 @@
     1 (let [from (first rest)]
         (if (php/=== nil from)
           to
-          (let [map-like?   (fn [x]
-                              (or (php/instanceof x PersistentMapInterface)
-                                  (and (php/is_array x) (not (indexed-php-array? x)))))
-                entries     (if (map-like? from)
-                              (for [entry :pairs from] entry)
-                              from)
-                assoc-entry (fn [acc entry]
-                              (if (indexed? entry)
-                                (if (php/!= (count entry) 2)
-                                  (throw (php/new InvalidArgumentException
-                                                  "into expects a collection of [key value] pairs"))
-                                  (let [k (first entry)
-                                        v (second entry)]
-                                    (if (php/is_array acc)
-                                      (do
-                                        (php/aset acc k v)
-                                        acc)
-                                      (assoc acc k v))))
-                                (throw (php/new InvalidArgumentException
-                                                "into expects a collection of [key value] pairs"))))
-                map-target? (or (map-like? to) (php/instanceof to TransientMapInterface))]
+          (let [entries (into-entries from)]
             (cond
               ;; Fast paths: persistent vector/set/hash-map targets build via transients,
               ;; turning O(N log N) repeated copy-on-write into O(N).
@@ -139,19 +150,19 @@
               (persistent
                (for [entry :in entries
                      :reduce [acc (transient to)]]
-                 (assoc-entry acc entry)))
+                 (assoc-into-entry acc entry)))
 
-              map-target?
+              (map-into-target? to)
               (for [entry :in entries
                     :reduce [acc to]]
-                (assoc-entry acc entry))
+                (assoc-into-entry acc entry))
 
-              (php/instanceof to TransientVectorInterface)
+              (transient-vector? to)
               (for [value :in entries
                     :reduce [acc to]]
                 (conj acc value))
 
-              (php/instanceof to TransientHashSetInterface)
+              (transient-set? to)
               (for [value :in entries
                     :reduce [acc to]]
                 (conj acc value))
@@ -174,13 +185,13 @@
 (defn- conj-single
   [coll value]
   (cond
-    (php/=== coll nil)                                                                                    (list value)
-    (php/instanceof coll PersistentListInterface)                                                         (cons value coll)
-    (php/is_array coll)                                                                                   (do (php/apush coll value) coll)
-    (or (php/instanceof coll PersistentVectorInterface) (php/instanceof coll TransientVectorInterface))   (php/-> coll (append value))
-    (or (php/instanceof coll PersistentHashSetInterface) (php/instanceof coll TransientHashSetInterface)) (php/-> coll (add value))
-    (or (php/instanceof coll PersistentMapInterface) (php/instanceof coll TransientMapInterface))         (conj-map-entry coll value)
-    (php/instanceof coll PushInterface)                                                                   (php/-> coll (push value))
+    (php/=== coll nil)                            (list value)
+    (php/instanceof coll PersistentListInterface)  (cons value coll)
+    (php/is_array coll)                            (do (php/apush coll value) coll)
+    (vector-target? coll)                          (php/-> coll (append value))
+    (set-target? coll)                             (php/-> coll (add value))
+    (map-target? coll)                             (conj-map-entry coll value)
+    (php/instanceof coll PushInterface)            (php/-> coll (push value))
     :else
     (throw (php/new InvalidArgumentException
                     (str "Cannot conj on type " (type coll))))))
@@ -739,11 +750,19 @@
   [coll val]
   (some? #(= % val) (vals coll)))
 
-(defn- sort-with
+(defn- sort-comparator
+  [comp]
+  (or comp compare))
+
+(defn- sorted-vector
   [coll comp]
   (let [php-array (to-php-array coll)]
-    (php/usort php-array (or comp compare))
+    (php/usort php-array comp)
     (copy-meta coll (php/:: Phel (vector php-array)))))
+
+(defn- sort-with
+  [coll comp]
+  (sorted-vector coll (sort-comparator comp)))
 
 (defn sort
   "Returns a sorted vector. If no comparator is supplied compare is used."
@@ -763,10 +782,8 @@
   {:example "(sort-by count [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]"
    :see-also ["sort" "compare"]}
   [keyfn coll & [comp]]
-  (let [php-array (to-php-array coll)
-        cmp       (or comp compare)]
-    (php/usort php-array #(cmp (keyfn %1) (keyfn %2)))
-    (copy-meta coll (php/:: Phel (vector php-array)))))
+  (let [cmp (sort-comparator comp)]
+    (sorted-vector coll #(cmp (keyfn %1) (keyfn %2)))))
 
 (defn shuffle
   "Returns a random permutation of coll."
@@ -1016,7 +1033,7 @@
   [a b]
   (zipmap a b))
 
-(defn- merge-two
+(defn- merge-right
   [left right]
   (cond
     (nil? left)  (when-not (nil? right) (conj {} right))
@@ -1030,7 +1047,7 @@
   {:example "(merge {:a 1 :b 2} {:b 3 :c 4}) ; => {:a 1 :b 3 :c 4}"}
   ([] nil)
   ([map] map)
-  ([map & more] (reduce merge-two map more)))
+  ([map & more] (reduce merge-right map more)))
 
 (defn select-keys
   "Returns a new map including key value pairs from `m` selected with keys `ks`."

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -172,6 +172,26 @@
       (recur (php/- i 1) (next s))
       s)))
 
+(defn- transient-vector?
+  [coll]
+  (php/instanceof coll TransientVectorInterface))
+
+(defn- transient-set?
+  [coll]
+  (php/instanceof coll TransientHashSetInterface))
+
+(defn- vector-target?
+  [coll]
+  (or (php/instanceof coll PersistentVectorInterface) (transient-vector? coll)))
+
+(defn- set-target?
+  [coll]
+  (or (php/instanceof coll PersistentHashSetInterface) (transient-set? coll)))
+
+(defn- map-target?
+  [coll]
+  (or (php/instanceof coll PersistentMapInterface) (php/instanceof coll TransientMapInterface)))
+
 (defn- assoc-pair
   "Associates a single key-value pair with a collection."
   [ds key value]
@@ -183,10 +203,10 @@
     (php-array? ds)
     (throw (php/new InvalidArgumentException "Cannot call assoc on pure PHP arrays. Use (php/aset ds key value)"))
 
-    (or (php/instanceof ds PersistentMapInterface) (php/instanceof ds TransientMapInterface))
+    (map-target? ds)
     (php/-> ds (put key value))
 
-    (or (php/instanceof ds PersistentVectorInterface) (php/instanceof ds TransientVectorInterface))
+    (vector-target? ds)
     (php/-> ds (update key value))
 
     ;; Explicit rejection for any other shape (string, list, set, sorted set,
@@ -226,10 +246,10 @@
     (php/is_array ds)
     (throw (php/new InvalidArgumentException "Cannot call dissoc on pure PHP arrays. Use (php/aunset ds key)"))
 
-    (or (php/instanceof ds PersistentMapInterface) (php/instanceof ds TransientMapInterface))
+    (map-target? ds)
     (php/-> ds (remove key))
 
-    (or (php/instanceof ds PersistentHashSetInterface) (php/instanceof ds TransientHashSetInterface))
+    (set-target? ds)
     (php/-> ds (remove key))
 
     (let [x ds]

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -117,16 +117,14 @@
   [tcoll key value & more]
   (loop [acc       (assoc-bang-pair tcoll key value)
          remaining more]
-    (cond
-      (empty? remaining)
+    (if (empty? remaining)
       acc
-
-      (empty? (rest remaining))
-      (assoc-bang-pair acc (first remaining) nil)
-
-      :else
-      (recur (assoc-bang-pair acc (first remaining) (second remaining))
-             (rest (rest remaining))))))
+      (let [next-key   (first remaining)
+            next-value (second remaining)]
+        (if (empty? (rest remaining))
+          (assoc-bang-pair acc next-key nil)
+          (recur (assoc-bang-pair acc next-key next-value)
+                 (rest (rest remaining))))))))
 
 (defn- dissoc-bang-single
   [tcoll key]

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -911,27 +911,29 @@
 ;; error/failure printer
 ;; ---------------------
 
+(defn- summary-event
+  [snapshot]
+  (let [{:failed failed :error error :pass pass :skipped skipped}
+        (:counts snapshot)
+        failures (:failed snapshot)
+        skips    (:skipped snapshot)
+        total    (+ failed error pass)]
+    {:type :summary
+     :failures failures
+     :skips skips
+     :pass pass
+     :failed failed
+     :error error
+     :skipped (or skipped 0)
+     :total total}))
+
 (defn print-summary
   "Emits the `:summary` event to the active reporter set.
   Kept for backwards compatibility; prefer letting `run-tests` emit the
   event at the end of the run."
   {:example "(print-summary)"}
   []
-  (let [snapshot                                                  (deref stats)
-        {:failed failed :error error :pass pass :skipped skipped}
-        (get snapshot :counts)
-        failures                                                  (get snapshot :failed)
-        skips                                                     (get snapshot :skipped)
-        total                                                     (+ failed error pass)
-        event                                                     {:type :summary
-                  :failures failures
-                  :skips skips
-                  :pass pass
-                  :failed failed
-                  :error error
-                  :skipped (or skipped 0)
-                  :total total}]
-    (fan-out! event)))
+  (fan-out! (summary-event (deref stats))))
 
 ;; --------
 ;; Fixtures

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
@@ -46,17 +46,25 @@ final class ApplyEmitter implements NodeEmitterInterface
 
     private function emitArguments(ApplyNode $node): void
     {
-        $argCount = count($node->getArguments());
-        foreach ($node->getArguments() as $i => $arg) {
-            if ($i < $argCount - 1) {
-                $this->outputEmitter->emitNode($arg);
-                $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
-            } else {
-                $this->outputEmitter->emitStr('...\\' . Seq::class . '::toApplyArguments(', $node->getStartSourceLocation());
-                $this->outputEmitter->emitNode($arg);
-                $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        $arguments = $node->getArguments();
+        $lastIndex = count($arguments) - 1;
+
+        foreach ($arguments as $i => $arg) {
+            if ($i === $lastIndex) {
+                $this->emitFinalArgument($node, $arg);
+                continue;
             }
+
+            $this->outputEmitter->emitNode($arg);
+            $this->outputEmitter->emitStr(', ', $node->getStartSourceLocation());
         }
+    }
+
+    private function emitFinalArgument(ApplyNode $node, AbstractNode $arg): void
+    {
+        $this->outputEmitter->emitStr('...\\' . Seq::class . '::toApplyArguments(', $node->getStartSourceLocation());
+        $this->outputEmitter->emitNode($arg);
+        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
     }
 
     private function phpVarNodeButNoInfix(ApplyNode $node, PhpVarNode $fnNode): void

--- a/src/php/Lang/Seq.php
+++ b/src/php/Lang/Seq.php
@@ -54,14 +54,7 @@ final class Seq
     public static function toApplyArguments(mixed $value): array
     {
         if ($value instanceof PersistentMapInterface) {
-            $typeFactory = TypeFactory::getInstance();
-            $args = [];
-
-            foreach ($value as $key => $item) {
-                $args[] = $typeFactory->persistentVectorFromArray([$key, $item]);
-            }
-
-            return $args;
+            return self::mapToApplyArguments($value);
         }
 
         if ($value === null) {
@@ -350,5 +343,20 @@ final class Seq
         string $escape = '\\',
     ): Generator {
         return FileGenerator::csvLines($filename, $separator, $enclosure, $escape);
+    }
+
+    /**
+     * @return list<PersistentVectorInterface>
+     */
+    private static function mapToApplyArguments(PersistentMapInterface $value): array
+    {
+        $typeFactory = TypeFactory::getInstance();
+        $args = [];
+
+        foreach ($value as $key => $item) {
+            $args[] = $typeFactory->persistentVectorFromArray([$key, $item]);
+        }
+
+        return $args;
     }
 }


### PR DESCRIPTION
## 🤔 Background

Today’s issue fixes touched several adjacent paths in core collection behavior, test reporting, and `apply` argument handling. The behavior is already covered by the issue fixes; this PR keeps the follow-up internal quality cleanup in one branch with commits split by context.

## 💡 Goal

Improve readability and maintainability around the recent fixes without changing behavior.

## 🔖 Changes

- Extract shared collection target predicates and simplify `into`, `conj`, `assoc`, and `dissoc` dispatch.
- Clarify `case` matcher helper names and sort/merge helper responsibilities.
- Extract test summary event construction from `print-summary`.
- Split `apply` final-argument emission and map argument conversion into focused helpers.
- No changelog entry: internal refactoring only.

Verification:
- `./bin/phel test tests/phel/test/core/control-structures.phel tests/phel/test/core/sequence-functions.phel tests/phel/test/core/sequence-operation.phel tests/phel/test/core/basic-sequence-operation.phel tests/phel/test/core/boolean-operation.phel tests/phel/test/reporters.phel tests/phel/test/selectors-runtime.phel`
- `vendor/bin/phpunit tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php tests/php/Unit/Lang/KeywordTest.php tests/php/Integration/Fixtures/Apply`
- `composer phpstan`

Note: the pre-commit hook’s `composer test-all` run passed Psalm, PHPStan, Rector, config validation, and started PHPUnit, but hit Composer’s 300s process timeout before completion.
