### PR TITLE
refactor: centralize sequence normalization

### DIFF
--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -308,7 +308,11 @@
     (php/instanceof coll ContainsInterface) (php/-> coll (contains key))
     (php/is_array coll) (php/array_key_exists key coll)
     (php/is_string coll) (and (php/is_int key) (php/>= key 0) (php/< key (php/mb_strlen coll)))
-    (throw (php/new InvalidArgumentException (php/. "cannot call 'contains?' on " (php/get_class coll))))))
+    (throw (php/new InvalidArgumentException
+                    (str "cannot call 'contains?' on "
+                         (if (php/is_object coll)
+                           (php/get_class coll)
+                           (php/gettype coll)))))))
 
 (defn- comparable-number?
   [x]
@@ -347,8 +351,8 @@
   (loop [xs xs
          ys ys]
     (cond
-      (nil? xs) (if (nil? ys) 0 -1)
-      (nil? ys) 1
+      (= 0 (count xs)) (if (= 0 (count ys)) 0 -1)
+      (= 0 (count ys)) 1
       :else
       (let [c (compare (first xs) (first ys))]
         (if (= c 0)

--- a/src/php/Lang/Generators/CombineGenerator.php
+++ b/src/php/Lang/Generators/CombineGenerator.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Generators;
 
-use ArrayIterator;
 use Generator;
 use Iterator;
-
-use function is_array;
-use function is_string;
-use function mb_str_split;
 
 /**
  * Multi-source and separator-aware combining generators.
  *
  * Each operation orchestrates one or more input sequences to produce a combined
  * output — concatenation, round-robin interleaving, element-wise zipping, and
- * separator insertion. The private helpers normalize arbitrary iterables into
- * Iterator instances so advancement can be controlled step by step.
+ * separator insertion. Shared sequence helpers normalize arbitrary iterables
+ * into Iterator instances so advancement can be controlled step by step.
  */
 final class CombineGenerator
 {
@@ -49,7 +44,7 @@ final class CombineGenerator
                 continue;
             }
 
-            foreach (self::toIterable($iterable) as $value) {
+            foreach (SequenceGenerator::toIterable($iterable) as $value) {
                 yield $value;
             }
         }
@@ -75,7 +70,7 @@ final class CombineGenerator
             return;
         }
 
-        $iterators = array_map(self::toIterator(...), $iterables);
+        $iterators = array_map(SequenceGenerator::toIterator(...), $iterables);
         $first = $iterators[0] ?? null;
 
         if ($first === null) {
@@ -114,7 +109,7 @@ final class CombineGenerator
     public static function interpose(mixed $separator, mixed $iterable): Generator
     {
         $first = true;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if (!$first) {
                 yield $separator;
             }
@@ -145,7 +140,7 @@ final class CombineGenerator
             return;
         }
 
-        $iterators = array_map(self::toIterator(...), $iterables);
+        $iterators = array_map(SequenceGenerator::toIterator(...), $iterables);
 
         while (self::allIteratorsValid($iterators)) {
             $values = self::extractCurrentValues($iterators);
@@ -181,39 +176,4 @@ final class CombineGenerator
         return $values;
     }
 
-    /**
-     * Converts an iterable or string to an Iterator.
-     *
-     * @return Iterator<int|string, mixed>
-     */
-    private static function toIterator(mixed $value): Iterator
-    {
-        $iterable = self::toIterable($value);
-
-        if ($iterable instanceof Iterator) {
-            return $iterable;
-        }
-
-        if (is_array($iterable)) {
-            return new ArrayIterator($iterable);
-        }
-
-        return (static fn() => yield from $iterable)();
-    }
-
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Generators/DedupeGenerator.php
+++ b/src/php/Lang/Generators/DedupeGenerator.php
@@ -10,8 +10,6 @@ use Phel\Lang\TypeFactory;
 use function count;
 use function in_array;
 use function is_object;
-use function is_string;
-use function mb_str_split;
 
 /**
  * Value-equality and sentinel-removal generators: distinct, dedupe, and compact.
@@ -43,7 +41,7 @@ final class DedupeGenerator
         $equalizer = $typeFactory->getEqualizer();
         $seen = [];
 
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $hash = $hasher->hash($value);
 
             // Check if we've seen an equal value with this hash
@@ -85,7 +83,7 @@ final class DedupeGenerator
         $first = true;
         $prev = null;
 
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($first || !$equalizer->equals($value, $prev)) {
                 yield $value;
                 $prev = $value;
@@ -136,7 +134,7 @@ final class DedupeGenerator
 
         $lookups = self::prepareCompactLookups($valuesToRemove);
 
-        foreach (self::toIterable($iterable) as $item) {
+        foreach (SequenceGenerator::toIterable($iterable) as $item) {
             if (!self::shouldRemoveItem($item, $lookups['scalarLookup'], $lookups['objects'])) {
                 yield $item;
             }
@@ -154,7 +152,7 @@ final class DedupeGenerator
      */
     private static function compactSingleValue(mixed $iterable, mixed $valueToRemove): Generator
     {
-        foreach (self::toIterable($iterable) as $item) {
+        foreach (SequenceGenerator::toIterable($iterable) as $item) {
             if ($item !== $valueToRemove) {
                 yield $item;
             }
@@ -200,19 +198,4 @@ final class DedupeGenerator
         return isset($scalarLookup[var_export($item, true)]);
     }
 
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Generators/InfiniteGenerator.php
+++ b/src/php/Lang/Generators/InfiniteGenerator.php
@@ -6,9 +6,6 @@ namespace Phel\Lang\Generators;
 
 use Generator;
 
-use function is_string;
-use function mb_str_split;
-
 final class InfiniteGenerator
 {
     /**
@@ -65,7 +62,7 @@ final class InfiniteGenerator
     public static function cycle(mixed $iterable): Generator
     {
         $values = [];
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $values[] = $value;
             yield $value;
         }
@@ -92,19 +89,4 @@ final class InfiniteGenerator
         }
     }
 
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Generators/PartitionGenerator.php
+++ b/src/php/Lang/Generators/PartitionGenerator.php
@@ -10,8 +10,6 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\TypeFactory;
 
 use function count;
-use function is_string;
-use function mb_str_split;
 
 final class PartitionGenerator
 {
@@ -31,7 +29,7 @@ final class PartitionGenerator
         }
 
         $partition = [];
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $partition[] = $value;
 
             if (count($partition) === $n) {
@@ -57,7 +55,7 @@ final class PartitionGenerator
         }
 
         $partition = [];
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $partition[] = $value;
 
             if (count($partition) === $n) {
@@ -85,7 +83,7 @@ final class PartitionGenerator
         $prevKey = null;
         $first = true;
 
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $key = $f($value);
 
             if ($first || $equalizer->equals($key, $prevKey)) {
@@ -104,19 +102,4 @@ final class PartitionGenerator
         }
     }
 
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Generators/SequenceGenerator.php
+++ b/src/php/Lang/Generators/SequenceGenerator.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Lang\Generators;
 
+use ArrayIterator;
 use Generator;
+use Iterator;
 
+use function is_array;
 use function is_string;
 use function mb_str_split;
 
@@ -38,6 +41,26 @@ final class SequenceGenerator
         }
 
         return $value ?? [];
+    }
+
+    /**
+     * Converts a value to an Iterator for code that needs controlled advancement.
+     *
+     * @return Iterator<int|string, mixed>
+     */
+    public static function toIterator(mixed $value): Iterator
+    {
+        $iterable = self::toIterable($value);
+
+        if ($iterable instanceof Iterator) {
+            return $iterable;
+        }
+
+        if (is_array($iterable)) {
+            return new ArrayIterator($iterable);
+        }
+
+        return (static fn(): Generator => yield from $iterable)();
     }
 
     /**

--- a/src/php/Lang/Generators/SliceGenerator.php
+++ b/src/php/Lang/Generators/SliceGenerator.php
@@ -6,9 +6,6 @@ namespace Phel\Lang\Generators;
 
 use Generator;
 
-use function is_string;
-use function mb_str_split;
-
 /**
  * Positional slicing generators: take and drop and their variants.
  *
@@ -35,7 +32,7 @@ final class SliceGenerator
     public static function take(int $n, mixed $iterable): Generator
     {
         $count = 0;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($count >= $n) {
                 break;
             }
@@ -62,7 +59,7 @@ final class SliceGenerator
      */
     public static function takeWhile(callable $predicate, mixed $iterable): Generator
     {
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if (!$predicate($value)) {
                 break;
             }
@@ -88,7 +85,7 @@ final class SliceGenerator
     public static function takeNth(int $n, mixed $iterable): Generator
     {
         $index = 0;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($index % $n === 0) {
                 yield $value;
             }
@@ -114,7 +111,7 @@ final class SliceGenerator
     public static function drop(int $n, mixed $iterable): Generator
     {
         $count = 0;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($count >= $n) {
                 yield $value;
             }
@@ -141,7 +138,7 @@ final class SliceGenerator
     public static function dropWhile(callable $predicate, mixed $iterable): Generator
     {
         $dropping = true;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($dropping && $predicate($value)) {
                 continue;
             }
@@ -151,19 +148,4 @@ final class SliceGenerator
         }
     }
 
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Generators/TransformGenerator.php
+++ b/src/php/Lang/Generators/TransformGenerator.php
@@ -6,9 +6,6 @@ namespace Phel\Lang\Generators;
 
 use Generator;
 
-use function is_string;
-use function mb_str_split;
-
 /**
  * Element-wise transformation generators: map, filter, and their variants.
  *
@@ -35,7 +32,7 @@ final class TransformGenerator
      */
     public static function map(callable $f, mixed $iterable): Generator
     {
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             yield $f($value);
         }
     }
@@ -56,7 +53,7 @@ final class TransformGenerator
      */
     public static function filter(callable $predicate, mixed $iterable): Generator
     {
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             if ($predicate($value)) {
                 yield $value;
             }
@@ -81,7 +78,7 @@ final class TransformGenerator
      */
     public static function keep(callable $f, mixed $iterable): Generator
     {
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $result = $f($value);
             if ($result !== null) {
                 yield $result;
@@ -107,7 +104,7 @@ final class TransformGenerator
     public static function keepIndexed(callable $f, mixed $iterable): Generator
     {
         $index = 0;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $result = $f($index, $value);
             if ($result !== null) {
                 yield $result;
@@ -145,7 +142,7 @@ final class TransformGenerator
      */
     public static function mapcat(callable $f, mixed $iterable): Generator
     {
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             $result = $f($value);
 
             // Skip null results - they contribute nothing to concatenation
@@ -153,7 +150,7 @@ final class TransformGenerator
                 continue;
             }
 
-            foreach (self::toIterable($result) as $item) {
+            foreach (SequenceGenerator::toIterable($result) as $item) {
                 yield $item;
             }
         }
@@ -178,25 +175,10 @@ final class TransformGenerator
     public static function mapIndexed(callable $f, mixed $iterable): Generator
     {
         $index = 0;
-        foreach (self::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::toIterable($iterable) as $value) {
             yield $f($index, $value);
             ++$index;
         }
     }
 
-    /**
-     * @template T
-     *
-     * @param iterable<T>|string|null $value
-     *
-     * @return iterable<string|T>
-     */
-    private static function toIterable(mixed $value): iterable
-    {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
-    }
 }

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -35,6 +35,10 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
         float|bool|int|string|TypeInterface|null $default = null,
     ) {
         if ($obj instanceof ArrayAccess) {
+            if ($obj instanceof ContainsInterface) {
+                return $obj->contains($this) ? $obj[$this] : $default;
+            }
+
             return $obj[$this] ?? $default;
         }
 

--- a/src/php/Lang/Seq.php
+++ b/src/php/Lang/Seq.php
@@ -22,7 +22,6 @@ use function array_values;
 use function is_array;
 use function is_string;
 use function iterator_to_array;
-use function mb_str_split;
 
 final class Seq
 {
@@ -39,11 +38,7 @@ final class Seq
      */
     public static function toIterable(mixed $value): iterable
     {
-        if (is_string($value)) {
-            return mb_str_split($value);
-        }
-
-        return $value ?? [];
+        return SequenceGenerator::toIterable($value);
     }
 
     /**
@@ -62,7 +57,7 @@ final class Seq
         }
 
         if (is_string($value)) {
-            return mb_str_split($value);
+            return iterator_to_array(SequenceGenerator::toIterator($value), false);
         }
 
         if (is_array($value)) {

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -1,5 +1,5 @@
 (ns phel-test\test\core\boolean-operation
-  (:require phel\test :refer [deftest is])
+  (:require phel\test :refer [deftest is thrown?])
   (:require phel\string :as s))
 
 (deftest test-or
@@ -256,6 +256,10 @@
   (is (false? (contains? "hello" -1)) "negative index")
   (is (false? (contains? "hello" "e")) "non-integer key"))
 
+(deftest test-contains?-scalar
+  (is (thrown? \InvalidArgumentException (contains? 1 0))
+      "contains? on scalar throws InvalidArgumentException"))
+
 (deftest test-contains?-string-multibyte
   (is (true? (contains? "🎉" 0)) "emoji first index")
   (is (false? (contains? "🎉" 1)) "emoji has only 1 character despite 4 bytes")
@@ -330,6 +334,10 @@
   (is (= -1 (compare 'a 'b)) "symbols compare by name")
   (is (= -1 (compare [1 :a] [1 :b])) "vectors compare lexicographically")
   (is (= -1 (compare [1] [1 2])) "shorter vector sorts first when prefix matches")
+  (is (= 1 (compare [nil] [])) "vector with nil element sorts after empty vector")
+  (is (= -1 (compare [] [nil])) "empty vector sorts before vector with nil element")
+  (is (= [[] [nil] [nil nil]] (sort [[nil nil] [nil] []]))
+      "sort orders sequential values by length when nil prefixes match")
   (is (= 0 (compare nil nil)) "nil equals nil")
   (is (= -1 (compare nil 1)) "nil is less than any non-nil")
   (is (= 1 (compare 1 nil)) "non-nil is greater than nil"))

--- a/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Lang\Generators;
 
+use ArrayIterator;
 use Generator;
+use IteratorAggregate;
 use Phel\Lang\Generators\SequenceGenerator;
 use PHPUnit\Framework\TestCase;
+use Traversable;
 
 final class SequenceGeneratorTest extends TestCase
 {
@@ -51,6 +54,48 @@ final class SequenceGeneratorTest extends TestCase
         $result = SequenceGenerator::toIterable($generator);
 
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
+    }
+
+    // ==================== toIterator tests ====================
+
+    public function test_to_iterator_reuses_iterator_instances(): void
+    {
+        $iterator = new ArrayIterator([1, 2, 3]);
+
+        $result = SequenceGenerator::toIterator($iterator);
+
+        self::assertSame($iterator, $result);
+        self::assertSame([1, 2, 3], iterator_to_array($result, false));
+    }
+
+    public function test_to_iterator_wraps_arrays(): void
+    {
+        $result = SequenceGenerator::toIterator(['a', 'b', 'c']);
+
+        self::assertInstanceOf(ArrayIterator::class, $result);
+        self::assertSame(['a', 'b', 'c'], iterator_to_array($result, false));
+    }
+
+    public function test_to_iterator_wraps_iterator_aggregate(): void
+    {
+        $aggregate = new class() implements IteratorAggregate {
+            public function getIterator(): Traversable
+            {
+                yield 'x';
+                yield 'y';
+            }
+        };
+
+        $result = SequenceGenerator::toIterator($aggregate);
+
+        self::assertSame(['x', 'y'], iterator_to_array($result, false));
+    }
+
+    public function test_to_iterator_splits_multibyte_strings(): void
+    {
+        $result = SequenceGenerator::toIterator('🎉🎊');
+
+        self::assertSame(['🎉', '🎊'], iterator_to_array($result, false));
     }
 
     // ==================== range tests ====================

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -130,6 +130,14 @@ final class KeywordTest extends TestCase
         $this->assertSame('xyz', $keyword2($table, 'xyz'));
     }
 
+    public function test_invoke_returns_null_for_present_null_value_with_default(): void
+    {
+        $keyword = Keyword::create('a');
+        $table = Phel::map($keyword, null);
+
+        $this->assertNull($keyword($table, 'fallback'));
+    }
+
     public function test_invoke_on_set_returns_keyword_when_present(): void
     {
         $keyword1 = Keyword::create('test1');


### PR DESCRIPTION
### Issue

Follow-up refactoring for today's sequence and comparison changes.

## Background

Several generator classes repeated the same nullable/string/iterable normalization helpers. That made string sequence semantics easy to drift and forced each generator to carry private conversion code.

## Goal

Improve maintainability, developer experience, testability, and performance in the files touched today while keeping the refactor focused.

## Changes

- Centralized generator input normalization in `SequenceGenerator::toIterable()` and `SequenceGenerator::toIterator()`.
- Reused the shared helpers across combine, dedupe, infinite, partition, slice, transform, and `Seq` code paths.
- Preserved multibyte string splitting behavior for lazy iteration and array conversion.
- Fixed keyword invocation on Phel maps so present `nil` values do not fall back to defaults.
- Hardened `contains?` scalar error handling and sequential comparison edge cases involving empty vectors and `nil` elements.
- Added focused PHP and Phel tests for the new shared iterator helper, keyword lookup semantics, `contains?`, and sequential sort/compare behavior.

## Tests

- `composer fix`
- `./vendor/bin/phpunit tests/php/Unit/Lang/Generators tests/php/Unit/Lang/KeywordTest.php tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php`
- `composer test-core`
- `composer test-compiler`
- `composer test-quality`
