### PR TITLE
refactor: centralize indexed sequence iteration

### DIFF
--- a/src/php/Lang/Generators/CombineGenerator.php
+++ b/src/php/Lang/Generators/CombineGenerator.php
@@ -175,5 +175,4 @@ final class CombineGenerator
 
         return $values;
     }
-
 }

--- a/src/php/Lang/Generators/SequenceGenerator.php
+++ b/src/php/Lang/Generators/SequenceGenerator.php
@@ -64,6 +64,24 @@ final class SequenceGenerator
     }
 
     /**
+     * Yields each value paired with its zero-based index.
+     *
+     * @template T
+     *
+     * @param iterable<T>|string|null $iterable
+     *
+     * @return Generator<int, array{0:int, 1:string|T}>
+     */
+    public static function indexed(mixed $iterable): Generator
+    {
+        $index = 0;
+        foreach (self::toIterable($iterable) as $value) {
+            yield [$index, $value];
+            ++$index;
+        }
+    }
+
+    /**
      * Generates a range of numbers [start, end) with given step.
      *
      * Examples:

--- a/src/php/Lang/Generators/TransformGenerator.php
+++ b/src/php/Lang/Generators/TransformGenerator.php
@@ -103,14 +103,11 @@ final class TransformGenerator
      */
     public static function keepIndexed(callable $f, mixed $iterable): Generator
     {
-        $index = 0;
-        foreach (SequenceGenerator::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::indexed($iterable) as [$index, $value]) {
             $result = $f($index, $value);
             if ($result !== null) {
                 yield $result;
             }
-
-            ++$index;
         }
     }
 
@@ -174,11 +171,8 @@ final class TransformGenerator
      */
     public static function mapIndexed(callable $f, mixed $iterable): Generator
     {
-        $index = 0;
-        foreach (SequenceGenerator::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::indexed($iterable) as [$index, $value]) {
             yield $f($index, $value);
-            ++$index;
         }
     }
-
 }

--- a/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php
@@ -98,6 +98,29 @@ final class SequenceGeneratorTest extends TestCase
         self::assertSame(['🎉', '🎊'], iterator_to_array($result, false));
     }
 
+    // ==================== indexed tests ====================
+
+    public function test_indexed_pairs_values_with_zero_based_indexes(): void
+    {
+        $result = SequenceGenerator::indexed(['a', 'b', 'c']);
+
+        self::assertSame([[0, 'a'], [1, 'b'], [2, 'c']], iterator_to_array($result, false));
+    }
+
+    public function test_indexed_splits_multibyte_strings(): void
+    {
+        $result = SequenceGenerator::indexed('🎉🎊');
+
+        self::assertSame([[0, '🎉'], [1, '🎊']], iterator_to_array($result, false));
+    }
+
+    public function test_indexed_treats_null_as_empty(): void
+    {
+        $result = SequenceGenerator::indexed(null);
+
+        self::assertSame([], iterator_to_array($result, false));
+    }
+
     // ==================== range tests ====================
 
     public function test_range_basic(): void

--- a/tests/php/Unit/Lang/Generators/TransformGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/TransformGeneratorTest.php
@@ -122,6 +122,16 @@ final class TransformGeneratorTest extends TestCase
         self::assertSame([], iterator_to_array($result, false));
     }
 
+    public function test_map_indexed_with_multibyte_string(): void
+    {
+        $result = TransformGenerator::mapIndexed(
+            static fn(int $idx, $val): string => sprintf('%d:%s', $idx, $val),
+            '🎉🎊',
+        );
+
+        self::assertSame(['0:🎉', '1:🎊'], iterator_to_array($result, false));
+    }
+
     // ==================== filter tests ====================
 
     public function test_filter_basic(): void
@@ -216,5 +226,15 @@ final class TransformGeneratorTest extends TestCase
         );
 
         self::assertSame([], iterator_to_array($result, false));
+    }
+
+    public function test_keep_indexed_with_multibyte_string(): void
+    {
+        $result = TransformGenerator::keepIndexed(
+            static fn(int $idx, $val): ?string => $idx === 1 ? sprintf('%d:%s', $idx, $val) : null,
+            '🎉🎊',
+        );
+
+        self::assertSame(['1:🎊'], iterator_to_array($result, false));
     }
 }


### PR DESCRIPTION
### Issue

Follow-up refactoring after #1634.

## Background

The previous pass centralized sequence normalization. The remaining indexed transform operations still duplicated the same zero-based index bookkeeping in each generator method.

## Goal

Keep the sequence generator layer easier to extend and test by centralizing indexed iteration behavior in the shared helper class.

## Changes

- Added `SequenceGenerator::indexed()` to pair normalized sequence values with zero-based indexes.
- Reused the shared helper from `TransformGenerator::mapIndexed()` and `TransformGenerator::keepIndexed()`.
- Added focused coverage for indexed arrays, multibyte strings, and nil input.
- Added transform-level multibyte string coverage for indexed map/keep behavior.
- Removed a tiny formatting leftover in `CombineGenerator`.

## Tests

- `composer fix`
- `./vendor/bin/phpunit tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php tests/php/Unit/Lang/Generators/TransformGeneratorTest.php`
- `composer test-core`
- `composer test-compiler`
- `composer test-quality`
