### PR TITLE
refactor: reuse indexed sequence helper for take nth

### DIFF
--- a/src/php/Lang/Generators/SliceGenerator.php
+++ b/src/php/Lang/Generators/SliceGenerator.php
@@ -84,13 +84,10 @@ final class SliceGenerator
      */
     public static function takeNth(int $n, mixed $iterable): Generator
     {
-        $index = 0;
-        foreach (SequenceGenerator::toIterable($iterable) as $value) {
+        foreach (SequenceGenerator::indexed($iterable) as [$index, $value]) {
             if ($index % $n === 0) {
                 yield $value;
             }
-
-            ++$index;
         }
     }
 

--- a/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
@@ -104,6 +104,13 @@ final class SliceGeneratorTest extends TestCase
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
     }
 
+    public function test_take_nth_with_multibyte_string(): void
+    {
+        $result = SliceGenerator::takeNth(2, '🎉a🎊b');
+
+        self::assertSame(['🎉', '🎊'], iterator_to_array($result, false));
+    }
+
     // ==================== drop tests ====================
 
     public function test_drop_basic(): void


### PR DESCRIPTION
### Issue

Follow-up refactoring after #1635.

## Background

`SequenceGenerator::indexed()` centralized zero-based sequence indexing for transform operations. `SliceGenerator::takeNth()` still had its own manual index bookkeeping.

## Goal

Keep indexed sequence traversal in one shared helper and preserve multibyte string behavior across slicing operations.

## Changes

- Reused `SequenceGenerator::indexed()` in `SliceGenerator::takeNth()`.
- Removed duplicate manual index increment logic.
- Added focused multibyte string coverage for `takeNth()`.

## Tests

- `composer fix`
- `./vendor/bin/phpunit tests/php/Unit/Lang/Generators/SequenceGeneratorTest.php tests/php/Unit/Lang/Generators/SliceGeneratorTest.php`
- `composer test-core`
- `composer test-compiler`
- `composer test-quality`
