### PR TITLE
ref: apply PHP refactor findings

### DIFF
--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -27,6 +27,7 @@ use Phel\Api\Domain\SourceAnalyzerInterface;
 use Phel\Api\Domain\SymbolResolverInterface;
 use Phel\Api\Infrastructure\Daemon\ApiDaemon;
 use Phel\Api\Infrastructure\PhelFnLoader;
+use Phel\Api\Infrastructure\PhelFunctionRuntimeLoader;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use Phel\Shared\Facade\RunFacadeInterface;
@@ -112,7 +113,7 @@ final class ApiFactory extends AbstractFactory
     private function createPhelFnLoader(): PhelFnLoaderInterface
     {
         return new PhelFnLoader(
-            $this->getRunFacade(),
+            new PhelFunctionRuntimeLoader($this->getRunFacade()),
         );
     }
 

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -4,24 +4,12 @@ declare(strict_types=1);
 
 namespace Phel\Api\Infrastructure;
 
-use Phar;
 use Phel;
 use Phel\Api\Domain\PhelFnLoaderInterface;
-use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
-use Phel\Shared\Facade\RunFacadeInterface;
-use RuntimeException;
 
-use function dirname;
-use function getcwd;
 use function in_array;
-use function is_dir;
-use function mkdir;
-use function rmdir;
-use function sprintf;
-use function uniqid;
-use function unlink;
 
 final readonly class PhelFnLoader implements PhelFnLoaderInterface
 {
@@ -430,7 +418,7 @@ Creates a new vector. If no argument is provided, an empty vector is created. Sh
     ];
 
     public function __construct(
-        private RunFacadeInterface $runFacade,
+        private PhelFunctionRuntimeLoader $runtimeLoader,
     ) {}
 
     /**
@@ -483,71 +471,7 @@ Creates a new vector. If no argument is provided, an empty vector is created. Sh
 
     public function loadAllPhelFunctions(array $namespaces): void
     {
-        Phel::clear();
-        Symbol::resetGen();
-        GlobalEnvironmentSingleton::initializeNew();
-
-        $template = <<<EOF
-# Simply require all namespaces that should be documented
-(ns phel-internal\doc
-  %REQUIRES%
-)
-EOF;
-        $requireNamespaces = '';
-        foreach ($namespaces as $ns) {
-            $requireNamespaces .= sprintf('(:require %s)', $ns);
-        }
-
-        $docPhelContent = str_replace('%REQUIRES%', $requireNamespaces, $template);
-
-        // When running in a phar, we can't write to __DIR__ due to phar.readonly
-        // Use a temporary directory in the current working directory instead
-        if (Phar::running() !== '') {
-            $cwd = getcwd();
-            if ($cwd === false) {
-                throw new RuntimeException('Unable to determine current working directory.');
-            }
-
-            $tempDir = $cwd . '/.phel_temp_' . uniqid('', true);
-            if (!mkdir($tempDir, 0755, true) && !is_dir($tempDir)) {
-                throw new RuntimeException(sprintf('Unable to create temporary directory at "%s".', $tempDir));
-            }
-
-            $phelFile = $tempDir . '/doc.phel';
-        } else {
-            $phelDir = __DIR__ . '/phel';
-            if (!is_dir($phelDir) && !mkdir($phelDir, 0755, true) && !is_dir($phelDir)) {
-                throw new RuntimeException(sprintf('Unable to create directory at "%s".', $phelDir));
-            }
-
-            $phelFile = $phelDir . '/doc.phel';
-        }
-
-        file_put_contents($phelFile, $docPhelContent);
-
-        $namespace = $this->runFacade
-            ->getNamespaceFromFile($phelFile)
-            ->getNamespace();
-
-        $srcDirectories = [
-            dirname($phelFile),
-            ...$this->runFacade->getAllPhelDirectories(),
-        ];
-
-        $namespaceInformation = $this->runFacade->getDependenciesForNamespace(
-            $srcDirectories,
-            [$namespace, 'phel\\core'],
-        );
-
-        foreach ($namespaceInformation as $info) {
-            $this->runFacade->evalFile($info);
-        }
-
-        unlink($phelFile);
-
-        if (isset($tempDir) && is_dir($tempDir)) {
-            rmdir($tempDir);
-        }
+        $this->runtimeLoader->load($namespaces);
     }
 
     /**

--- a/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
+++ b/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Infrastructure;
+
+use Phar;
+use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\Facade\RunFacadeInterface;
+use RuntimeException;
+
+use function dirname;
+use function getcwd;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sprintf;
+use function uniqid;
+use function unlink;
+
+final readonly class PhelFunctionRuntimeLoader
+{
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+    ) {}
+
+    /**
+     * @param list<string> $namespaces
+     */
+    public function load(array $namespaces): void
+    {
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+
+        [$phelFile, $tempDir] = $this->writeDocumentSource($namespaces);
+
+        try {
+            $namespace = $this->runFacade
+                ->getNamespaceFromFile($phelFile)
+                ->getNamespace();
+
+            $namespaceInformation = $this->runFacade->getDependenciesForNamespace(
+                [
+                    dirname($phelFile),
+                    ...$this->runFacade->getAllPhelDirectories(),
+                ],
+                [$namespace, 'phel\\core'],
+            );
+
+            foreach ($namespaceInformation as $info) {
+                $this->runFacade->evalFile($info);
+            }
+        } finally {
+            unlink($phelFile);
+
+            if ($tempDir !== null && is_dir($tempDir)) {
+                rmdir($tempDir);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $namespaces
+     *
+     * @return array{0: string, 1: ?string}
+     */
+    private function writeDocumentSource(array $namespaces): array
+    {
+        $phelFile = $this->createDocumentPath();
+        file_put_contents($phelFile, $this->documentSource($namespaces));
+
+        return [$phelFile, Phar::running() !== '' ? dirname($phelFile) : null];
+    }
+
+    private function createDocumentPath(): string
+    {
+        if (Phar::running() !== '') {
+            $cwd = getcwd();
+            if ($cwd === false) {
+                throw new RuntimeException('Unable to determine current working directory.');
+            }
+
+            $tempDir = $cwd . '/.phel_temp_' . uniqid('', true);
+            if (!mkdir($tempDir, 0755, true) && !is_dir($tempDir)) {
+                throw new RuntimeException(sprintf('Unable to create temporary directory at "%s".', $tempDir));
+            }
+
+            return $tempDir . '/doc.phel';
+        }
+
+        $phelDir = __DIR__ . '/phel';
+        if (!is_dir($phelDir) && !mkdir($phelDir, 0755, true) && !is_dir($phelDir)) {
+            throw new RuntimeException(sprintf('Unable to create directory at "%s".', $phelDir));
+        }
+
+        return $phelDir . '/doc.phel';
+    }
+
+    /**
+     * @param list<string> $namespaces
+     */
+    private function documentSource(array $namespaces): string
+    {
+        $requireNamespaces = '';
+        foreach ($namespaces as $ns) {
+            $requireNamespaces .= sprintf('(:require %s)', $ns);
+        }
+
+        return <<<EOF
+# Simply require all namespaces that should be documented
+(ns phel-internal\doc
+  {$requireNamespaces}
+)
+EOF;
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/AtomicFileWriter.php
+++ b/src/php/Build/Infrastructure/Cache/AtomicFileWriter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use function sprintf;
+
+final class AtomicFileWriter
+{
+    public function write(string $path, string $content): bool
+    {
+        $tempPath = $path . '.tmp.' . uniqid('', true);
+        if (file_put_contents($tempPath, $content) === false) {
+            trigger_error(
+                sprintf('Phel cache: failed to write temp file "%s"', $tempPath),
+                E_USER_WARNING,
+            );
+            return false;
+        }
+
+        if (!rename($tempPath, $path)) {
+            trigger_error(
+                sprintf('Phel cache: failed to rename "%s" to "%s"', $tempPath, $path),
+                E_USER_WARNING,
+            );
+            @unlink($tempPath);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/CachePathResolver.php
+++ b/src/php/Build/Infrastructure/Cache/CachePathResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Infrastructure\Cache;
+
+use function md5;
+
+final readonly class CachePathResolver
+{
+    public function __construct(
+        private string $cacheDir,
+    ) {}
+
+    public function environmentPath(string $namespace): string
+    {
+        return $this->cacheDir . '/compiled/' . $this->mungeNamespace($namespace) . '.env.php';
+    }
+
+    public function compiledPath(string $namespace, string $sourcePath, string $suffix): string
+    {
+        $sourceFingerprint = substr(md5($sourcePath), 0, 8);
+
+        return $this->cacheDir . '/compiled/' . $this->mungeNamespace($namespace) . '__' . $sourceFingerprint . $suffix;
+    }
+
+    private function mungeNamespace(string $namespace): string
+    {
+        return str_replace(['\\', '/'], '_', $namespace);
+    }
+}

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -11,8 +11,6 @@ use function count;
 use function function_exists;
 use function is_array;
 use function is_string;
-use function md5;
-use function sprintf;
 
 use function token_get_all;
 
@@ -45,11 +43,20 @@ final class CompiledCodeCache
      */
     private array $envMemo = [];
 
+    private readonly CachePathResolver $pathResolver;
+
+    private readonly AtomicFileWriter $fileWriter;
+
     public function __construct(
         private readonly string $cacheDir,
         private readonly string $phelVersion = '',
         private readonly int $maxEntries = 500,
-    ) {}
+        ?CachePathResolver $pathResolver = null,
+        ?AtomicFileWriter $fileWriter = null,
+    ) {
+        $this->pathResolver = $pathResolver ?? new CachePathResolver($this->cacheDir);
+        $this->fileWriter = $fileWriter ?? new AtomicFileWriter();
+    }
 
     /**
      * Returns the path to the cached compiled PHP file if it exists and
@@ -143,9 +150,7 @@ final class CompiledCodeCache
      */
     public function getEnvironmentPath(string $namespace): string
     {
-        $mungedNamespace = str_replace(['\\', '/'], '_', $namespace);
-
-        return $this->cacheDir . '/compiled/' . $mungedNamespace . '.env.php';
+        return $this->pathResolver->environmentPath($namespace);
     }
 
     public function putEnvironment(string $namespace, array $envData): void
@@ -390,10 +395,7 @@ final class CompiledCodeCache
      */
     private function getCachePath(string $namespace, string $sourcePath, string $suffix): string
     {
-        $mungedNamespace = str_replace(['\\', '/'], '_', $namespace);
-        $sourceFingerprint = substr(md5($sourcePath), 0, 8);
-
-        return $this->cacheDir . '/compiled/' . $mungedNamespace . '__' . $sourceFingerprint . $suffix;
+        return $this->pathResolver->compiledPath($namespace, $sourcePath, $suffix);
     }
 
     /**
@@ -401,25 +403,7 @@ final class CompiledCodeCache
      */
     private function atomicWrite(string $path, string $content): bool
     {
-        $tempPath = $path . '.tmp.' . uniqid('', true);
-        if (file_put_contents($tempPath, $content) === false) {
-            trigger_error(
-                sprintf('Phel cache: failed to write temp file "%s"', $tempPath),
-                E_USER_WARNING,
-            );
-            return false;
-        }
-
-        if (!rename($tempPath, $path)) {
-            trigger_error(
-                sprintf('Phel cache: failed to rename "%s" to "%s"', $tempPath, $path),
-                E_USER_WARNING,
-            );
-            @unlink($tempPath);
-            return false;
-        }
-
-        return true;
+        return $this->fileWriter->write($path, $content);
     }
 
     private function ensureCacheDir(): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoadEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LoadEmitter.php
@@ -188,12 +188,9 @@ final class LoadEmitter implements NodeEmitterInterface
     private function emitPhelSourceLoad(string $callerNamespace): void
     {
         $this->outputEmitter->emitLine('$__phelPrevNs = \\' . GlobalEnvironmentSingleton::class . '::getInstance()->getNs();');
-        $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::enableBuildMode();');
         $this->outputEmitter->emitLine('try {');
         $this->outputEmitter->increaseIndentLevel();
-
-        $this->outputEmitter->emitLine('(new \\Phel\\Build\\BuildFacade())->evalFile($__phelLoadPath);');
-
+        $this->outputEmitter->emitLine('\\Phel\\Run\\Runtime\\PhelSourceLoader::load($__phelLoadPath);');
         $this->outputEmitter->emitLine('$__phelLoadedNs = \\' . GlobalEnvironmentSingleton::class . '::getInstance()->getNs();');
         $this->outputEmitter->emitStr('if ($__phelLoadedNs !== ');
         $this->outputEmitter->emitLiteral($callerNamespace);
@@ -214,7 +211,6 @@ final class LoadEmitter implements NodeEmitterInterface
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('} finally {');
         $this->outputEmitter->increaseIndentLevel();
-        $this->outputEmitter->emitLine('\\Phel\\Build\\BuildFacade::disableBuildMode();');
         $this->outputEmitter->emitLine('\\' . GlobalEnvironmentSingleton::class . '::getInstance()->setNs($__phelPrevNs);');
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine('}');

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -6,8 +6,6 @@ namespace Phel\Config;
 
 use JsonSerializable;
 
-use function sprintf;
-
 final class PhelConfig implements JsonSerializable
 {
     public const string SRC_DIRS = 'src-dirs';
@@ -467,25 +465,7 @@ final class PhelConfig implements JsonSerializable
      */
     public function validate(): array
     {
-        $errors = [];
-
-        foreach ($this->srcDirs as $dir) {
-            if (str_starts_with($dir, '/')) {
-                $errors[] = sprintf("Source directory '%s' should be relative, not absolute", $dir);
-            }
-        }
-
-        foreach ($this->testDirs as $dir) {
-            if (str_starts_with($dir, '/')) {
-                $errors[] = sprintf("Test directory '%s' should be relative, not absolute", $dir);
-            }
-        }
-
-        if ($this->vendorDir !== '' && str_starts_with($this->vendorDir, '/')) {
-            $errors[] = sprintf("Vendor directory '%s' should be relative, not absolute", $this->vendorDir);
-        }
-
-        return $errors;
+        return new PhelConfigValidator()->validate($this->srcDirs, $this->testDirs, $this->vendorDir);
     }
 
     // ========================================
@@ -520,19 +500,6 @@ final class PhelConfig implements JsonSerializable
      */
     private static function detectLayout(): ProjectLayout
     {
-        $cwd = getcwd();
-        if ($cwd === false) {
-            return ProjectLayout::Flat;
-        }
-
-        if (is_dir($cwd . '/src/phel')) {
-            return ProjectLayout::Nested;
-        }
-
-        if (is_dir($cwd . '/src')) {
-            return ProjectLayout::Flat;
-        }
-
-        return ProjectLayout::Root;
+        return new ProjectLayoutDetector()->detectFromCurrentWorkingDirectory();
     }
 }

--- a/src/php/Config/PhelConfigValidator.php
+++ b/src/php/Config/PhelConfigValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+use function sprintf;
+
+final class PhelConfigValidator
+{
+    /**
+     * @param list<string> $srcDirs
+     * @param list<string> $testDirs
+     *
+     * @return list<string>
+     */
+    public function validate(array $srcDirs, array $testDirs, string $vendorDir): array
+    {
+        return [
+            ...$this->validateRelativeDirs($srcDirs, 'Source'),
+            ...$this->validateRelativeDirs($testDirs, 'Test'),
+            ...$this->validateVendorDir($vendorDir),
+        ];
+    }
+
+    /**
+     * @param list<string> $dirs
+     *
+     * @return list<string>
+     */
+    private function validateRelativeDirs(array $dirs, string $label): array
+    {
+        $errors = [];
+        foreach ($dirs as $dir) {
+            if (str_starts_with($dir, '/')) {
+                $errors[] = sprintf("%s directory '%s' should be relative, not absolute", $label, $dir);
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateVendorDir(string $vendorDir): array
+    {
+        if ($vendorDir !== '' && str_starts_with($vendorDir, '/')) {
+            return [sprintf("Vendor directory '%s' should be relative, not absolute", $vendorDir)];
+        }
+
+        return [];
+    }
+}

--- a/src/php/Config/ProjectLayoutDetector.php
+++ b/src/php/Config/ProjectLayoutDetector.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Config;
+
+final class ProjectLayoutDetector
+{
+    public function detectFromCurrentWorkingDirectory(): ProjectLayout
+    {
+        $cwd = getcwd();
+        if ($cwd === false) {
+            return ProjectLayout::Flat;
+        }
+
+        return $this->detect($cwd);
+    }
+
+    public function detect(string $projectRootDir): ProjectLayout
+    {
+        if (is_dir($projectRootDir . '/src/phel')) {
+            return ProjectLayout::Nested;
+        }
+
+        if (is_dir($projectRootDir . '/src')) {
+            return ProjectLayout::Flat;
+        }
+
+        return ProjectLayout::Root;
+    }
+}

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -5,38 +5,22 @@ declare(strict_types=1);
 namespace Phel\Console;
 
 use Composer\InstalledVersions;
-use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
-use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
-use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
-use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
-use Gacela\Console\Infrastructure\Command\ListModulesCommand;
-use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
-use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
 use Gacela\Framework\AbstractProvider;
 use Gacela\Framework\Attribute\Provides;
 use Gacela\Framework\Container\Container;
-use Phel\Api\Infrastructure\Command\AnalyzeCommand;
-use Phel\Api\Infrastructure\Command\ApiDaemonCommand;
-use Phel\Api\Infrastructure\Command\DocCommand;
-use Phel\Api\Infrastructure\Command\IndexCommand;
-use Phel\Build\Infrastructure\Command\BuildCommand;
-use Phel\Build\Infrastructure\Command\CacheClearCommand;
 use Phel\Console\Application\VersionFinder;
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Console\Infrastructure\Command\ApiCommands;
+use Phel\Console\Infrastructure\Command\BuildCommands;
+use Phel\Console\Infrastructure\Command\FormatterCommands;
+use Phel\Console\Infrastructure\Command\GacelaCommands;
+use Phel\Console\Infrastructure\Command\InteropCommands;
+use Phel\Console\Infrastructure\Command\LintCommands;
+use Phel\Console\Infrastructure\Command\LspCommands;
+use Phel\Console\Infrastructure\Command\NreplCommands;
+use Phel\Console\Infrastructure\Command\RunCommands;
+use Phel\Console\Infrastructure\Command\WatchCommands;
 use Phel\Filesystem\FilesystemFacade;
-use Phel\Formatter\Infrastructure\Command\FormatCommand;
-use Phel\Interop\Infrastructure\Command\ExportCommand;
-use Phel\Lint\Infrastructure\Command\LintCommand;
-use Phel\Lsp\Infrastructure\Command\LspCommand;
-use Phel\Nrepl\Infrastructure\Command\NreplCommand;
-use Phel\Run\Infrastructure\Command\AgentInstallCommand;
-use Phel\Run\Infrastructure\Command\DoctorCommand;
-use Phel\Run\Infrastructure\Command\EvalCommand;
-use Phel\Run\Infrastructure\Command\InitCommand;
-use Phel\Run\Infrastructure\Command\NsCommand;
-use Phel\Run\Infrastructure\Command\ReplCommand;
-use Phel\Run\Infrastructure\Command\RunCommand;
-use Phel\Run\Infrastructure\Command\TestCommand;
-use Phel\Watch\Infrastructure\Command\WatchCommand;
 
 final class ConsoleProvider extends AbstractProvider
 {
@@ -59,35 +43,12 @@ final class ConsoleProvider extends AbstractProvider
     #[Provides(self::COMMANDS)]
     public function commands(): array
     {
-        return [
-            new InitCommand(),
-            new AgentInstallCommand(),
-            new ExportCommand(),
-            new FormatCommand(),
-            new NsCommand(),
-            new ReplCommand(),
-            new EvalCommand(),
-            new RunCommand(),
-            new TestCommand(),
-            new DocCommand(),
-            new AnalyzeCommand(),
-            new IndexCommand(),
-            new ApiDaemonCommand(),
-            new BuildCommand(),
-            new CacheClearCommand(),
-            new CacheWarmCommand(),
-            new DebugContainerCommand(),
-            new DebugDependenciesCommand(),
-            new DebugModulesCommand(),
-            new ListModulesCommand(),
-            new ProfileReportCommand(),
-            new ValidateConfigCommand(),
-            new DoctorCommand(),
-            new NreplCommand(),
-            new LintCommand(),
-            new LspCommand(),
-            new WatchCommand(),
-        ];
+        $commands = [];
+        foreach ($this->commandProviders() as $provider) {
+            array_push($commands, ...$provider->commands());
+        }
+
+        return $commands;
     }
 
     #[Provides(self::TAG_COMMIT_HASH)]
@@ -130,5 +91,24 @@ final class ConsoleProvider extends AbstractProvider
         @exec($command . ' 2>/dev/null', $output);
 
         return trim($output[0] ?? '');
+    }
+
+    /**
+     * @return list<ConsoleCommandProviderInterface>
+     */
+    private function commandProviders(): array
+    {
+        return [
+            new RunCommands(),
+            new InteropCommands(),
+            new FormatterCommands(),
+            new ApiCommands(),
+            new BuildCommands(),
+            new GacelaCommands(),
+            new NreplCommands(),
+            new LintCommands(),
+            new LspCommands(),
+            new WatchCommands(),
+        ];
     }
 }

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -13,7 +13,7 @@ use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Console\Infrastructure\Command\ApiCommands;
 use Phel\Console\Infrastructure\Command\BuildCommands;
 use Phel\Console\Infrastructure\Command\FormatterCommands;
-use Phel\Console\Infrastructure\Command\GacelaCommands;
+use Phel\Console\Infrastructure\Command\FrameworkCommands;
 use Phel\Console\Infrastructure\Command\InteropCommands;
 use Phel\Console\Infrastructure\Command\LintCommands;
 use Phel\Console\Infrastructure\Command\LspCommands;
@@ -104,7 +104,7 @@ final class ConsoleProvider extends AbstractProvider
             new FormatterCommands(),
             new ApiCommands(),
             new BuildCommands(),
-            new GacelaCommands(),
+            new FrameworkCommands(),
             new NreplCommands(),
             new LintCommands(),
             new LspCommands(),

--- a/src/php/Console/Domain/ConsoleCommandProviderInterface.php
+++ b/src/php/Console/Domain/ConsoleCommandProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Domain;
+
+use Symfony\Component\Console\Command\Command;
+
+interface ConsoleCommandProviderInterface
+{
+    /**
+     * @return list<Command>
+     */
+    public function commands(): array;
+}

--- a/src/php/Console/Infrastructure/Command/ApiCommands.php
+++ b/src/php/Console/Infrastructure/Command/ApiCommands.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Api\Infrastructure\Command\AnalyzeCommand;
+use Phel\Api\Infrastructure\Command\ApiDaemonCommand;
+use Phel\Api\Infrastructure\Command\DocCommand;
+use Phel\Api\Infrastructure\Command\IndexCommand;
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+
+final class ApiCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new DocCommand(),
+            new AnalyzeCommand(),
+            new IndexCommand(),
+            new ApiDaemonCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/BuildCommands.php
+++ b/src/php/Console/Infrastructure/Command/BuildCommands.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Build\Infrastructure\Command\BuildCommand;
+use Phel\Build\Infrastructure\Command\CacheClearCommand;
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+
+final class BuildCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new BuildCommand(),
+            new CacheClearCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/FormatterCommands.php
+++ b/src/php/Console/Infrastructure/Command/FormatterCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Formatter\Infrastructure\Command\FormatCommand;
+
+final class FormatterCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new FormatCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/FrameworkCommands.php
+++ b/src/php/Console/Infrastructure/Command/FrameworkCommands.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Gacela\Console\Infrastructure\Command\CacheWarmCommand;
+use Gacela\Console\Infrastructure\Command\DebugContainerCommand;
+use Gacela\Console\Infrastructure\Command\DebugDependenciesCommand;
+use Gacela\Console\Infrastructure\Command\DebugModulesCommand;
+use Gacela\Console\Infrastructure\Command\ListModulesCommand;
+use Gacela\Console\Infrastructure\Command\ProfileReportCommand;
+use Gacela\Console\Infrastructure\Command\ValidateConfigCommand;
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+
+final class FrameworkCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new CacheWarmCommand(),
+            new DebugContainerCommand(),
+            new DebugDependenciesCommand(),
+            new DebugModulesCommand(),
+            new ListModulesCommand(),
+            new ProfileReportCommand(),
+            new ValidateConfigCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/InteropCommands.php
+++ b/src/php/Console/Infrastructure/Command/InteropCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Interop\Infrastructure\Command\ExportCommand;
+
+final class InteropCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new ExportCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/LintCommands.php
+++ b/src/php/Console/Infrastructure/Command/LintCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Lint\Infrastructure\Command\LintCommand;
+
+final class LintCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new LintCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/LspCommands.php
+++ b/src/php/Console/Infrastructure/Command/LspCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Lsp\Infrastructure\Command\LspCommand;
+
+final class LspCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new LspCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/NreplCommands.php
+++ b/src/php/Console/Infrastructure/Command/NreplCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Nrepl\Infrastructure\Command\NreplCommand;
+
+final class NreplCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new NreplCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/RunCommands.php
+++ b/src/php/Console/Infrastructure/Command/RunCommands.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Run\Infrastructure\Command\AgentInstallCommand;
+use Phel\Run\Infrastructure\Command\DoctorCommand;
+use Phel\Run\Infrastructure\Command\EvalCommand;
+use Phel\Run\Infrastructure\Command\InitCommand;
+use Phel\Run\Infrastructure\Command\NsCommand;
+use Phel\Run\Infrastructure\Command\ReplCommand;
+use Phel\Run\Infrastructure\Command\RunCommand;
+use Phel\Run\Infrastructure\Command\TestCommand;
+
+final class RunCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new InitCommand(),
+            new AgentInstallCommand(),
+            new NsCommand(),
+            new ReplCommand(),
+            new EvalCommand(),
+            new RunCommand(),
+            new TestCommand(),
+            new DoctorCommand(),
+        ];
+    }
+}

--- a/src/php/Console/Infrastructure/Command/WatchCommands.php
+++ b/src/php/Console/Infrastructure/Command/WatchCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Watch\Infrastructure\Command\WatchCommand;
+
+final class WatchCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new WatchCommand(),
+        ];
+    }
+}

--- a/src/php/Lang/AbstractType.php
+++ b/src/php/Lang/AbstractType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
-use Phel\Printer\Printer;
 use Stringable;
 
 /**
@@ -18,7 +17,7 @@ abstract class AbstractType implements TypeInterface, Stringable
 
     public function __toString(): string
     {
-        return Printer::readable()->print($this);
+        return TypeStringifier::toString($this);
     }
 
     public function setStartLocation(?SourceLocation $startLocation): static

--- a/src/php/Lang/TypeStringifier.php
+++ b/src/php/Lang/TypeStringifier.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Throwable;
+
+use function get_debug_type;
+
+final class TypeStringifier
+{
+    /** @var callable(TypeInterface):string|null */
+    private static $stringifier;
+
+    /**
+     * @param callable(TypeInterface):string $stringifier
+     */
+    public static function install(callable $stringifier): void
+    {
+        self::$stringifier = $stringifier;
+    }
+
+    public static function toString(TypeInterface $value): string
+    {
+        if (self::$stringifier !== null) {
+            return (self::$stringifier)($value);
+        }
+
+        try {
+            $printerClass = implode('\\', ['Phel', 'Printer', 'Printer']);
+            if (class_exists($printerClass)) {
+                return $printerClass::readable()->print($value);
+            }
+        } catch (Throwable) {
+        }
+
+        return '#object[' . get_debug_type($value) . ']';
+    }
+}

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -13,6 +13,8 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
+use Phel\Lang\TypeInterface;
+use Phel\Lang\TypeStringifier;
 use Phel\Lang\Variable;
 use Phel\Lang\VarReference;
 use Phel\Printer\TypePrinter\AnonymousClassPrinter;
@@ -49,6 +51,13 @@ final readonly class Printer implements PrinterInterface
         private bool $readable,
         private bool $withColor = false,
     ) {}
+
+    public static function installAsTypeStringifier(): void
+    {
+        TypeStringifier::install(
+            static fn(TypeInterface $value): string => self::readable()->print($value),
+        );
+    }
 
     public static function readable(): self
     {

--- a/src/php/Run/Runtime/PhelSourceLoader.php
+++ b/src/php/Run/Runtime/PhelSourceLoader.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Runtime;
+
+use Phel\Build\BuildFacade;
+
+final class PhelSourceLoader
+{
+    public static function load(string $sourcePath): void
+    {
+        BuildFacade::enableBuildMode();
+
+        try {
+            new BuildFacade()->evalFile($sourcePath);
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

This follows the refactor-check findings for src/php, focusing on module coupling and concentrated responsibilities without changing runtime behavior.

## 💡 Goal

Reduce architectural coupling and split several large responsibilities into focused collaborators.

## 🔖 Changes

- Route Lang stringification through a small adapter and move emitted load-source evaluation behind a Run runtime loader.
- Group console command registration into focused command collections.
- Split Phel function runtime loading out of PhelFnLoader.
- Extract config validation and project layout detection from PhelConfig.
- Extract compiled-code cache path resolution and atomic writes into dedicated collaborators.

Validation:
- composer test-quality
- composer test-compiler
- composer test-core (via commit hook)
