### PR TITLE
fix: support some over sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `some` accepts sets as seqable collections (#1639)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)
 - `assoc!` handles `apply` trailing keys with `nil` values (#1609)
 - `merge` handles no, `nil`, and non-map operands (#1603, #1606)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -138,9 +138,10 @@
   (fn [name]
     `(def ~name nil)))
 
-;; Forward-declare `nil?` so sub-files loaded before `core/booleans` (the
-;; file that defines it) can still pass compile-time symbol resolution.
+;; Forward-declare symbols used by sub-files loaded before their definitions
+;; so they can still pass compile-time symbol resolution.
 (declare nil?)
+(declare seq)
 
 (def *program*
   "The script path or namespace being executed."

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -263,12 +263,13 @@
   "Returns the first truthy value of applying predicate to elements, or nil if none found."
   {:example "(some #(when (> % 10) %) [5 15 8]) ; => 15"}
   [pred coll]
-  (if (empty? coll)
-    nil
-    (let [res (pred (first coll))]
-      (if (truthy? res)
-        res
-        (recur pred (next coll))))))
+  (loop [s (seq coll)]
+    (if (nil? s)
+      nil
+      (let [res (pred (first s))]
+        (if (truthy? res)
+          res
+          (recur (next s)))))))
 
 (defn true?
   "Checks if value is exactly true (not just truthy)."

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -264,12 +264,11 @@
   {:example "(some #(when (> % 10) %) [5 15 8]) ; => 15"}
   [pred coll]
   (loop [s (seq coll)]
-    (if (nil? s)
-      nil
-      (let [res (pred (first s))]
-        (if (truthy? res)
-          res
-          (recur (next s)))))))
+    (let [res (if (nil? s) nil (pred (first s)))]
+      (cond
+        (nil? s)      nil
+        (truthy? res) res
+        :else         (recur (next s))))))
 
 (defn true?
   "Checks if value is exactly true (not just truthy)."

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -186,6 +186,7 @@
 
 (deftest test-some
   (is (= 3 (some #(if (> % 2) % nil) [1 2 3 4])) "some returns first truthy")
+  (is (true? (some odd? #{1 2 3 4})) "some works on sets")
   (is (nil? (some #(if (> % 10) % nil) [1 2 3])) "some returns nil when none matches")
   (is (nil? (some #(if (> % 1) % nil) [])) "some on empty list"))
 


### PR DESCRIPTION
## 🤔 Background

Issue #1639 reports that `(some odd? #{1 2 3 4})` throws because `some` walks the set directly instead of through the seq abstraction.

## 💡 Goal

Closes #1639. Make `some` work for sets and preserve its existing first-truthy-result semantics.

## 🔖 Changes

- Normalize `some` input with `seq` before traversal.
- Add a focused regression test for `some` over set literals.
- Update `CHANGELOG.md` under Unreleased / Fixed / Core.

Focused local test: `./bin/phel test tests/phel/test/core/boolean-operation.phel`