### PR TITLE
fix: return empty sequence from rest nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `some` accepts sets as seqable collections (#1639)
+- `rest` returns an empty sequence for `nil` collections (#1638)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)
 - `assoc!` handles `apply` trailing keys with `nil` values (#1609)
 - `merge` handles no, `nil`, and non-map operands (#1603, #1606)

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -81,13 +81,15 @@
   "Returns the sequence after the first element, or empty sequence if none."
   {:example "(rest [1 2 3]) ; => [2 3]"}
   [coll]
-  (if (php/instanceof coll RestInterface)
-    (php/-> coll (rest))
-    (if (php/is_string coll)
-      (php/:: Phel (vector (php/array_slice (php/mb_str_split coll) 1)))
-      (if (php/is_array coll)
-        (php/array_slice coll 1)
-        (throw (php/new InvalidArgumentException "cannot do rest"))))))
+  (if (nil? coll)
+    []
+    (if (php/instanceof coll RestInterface)
+      (php/-> coll (rest))
+      (if (php/is_string coll)
+        (php/:: Phel (vector (php/array_slice (php/mb_str_split coll) 1)))
+        (if (php/is_array coll)
+          (php/array_slice coll 1)
+          (throw (php/new InvalidArgumentException "cannot do rest")))))))
 
 (defn nfirst
   "Same as `(next (first coll))`."

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -55,7 +55,8 @@
 (deftest test-rest
   (is (= [2] (rest [1 2])) "rest of two element vector")
   (is (= [] (rest [1])) "rest of one element vector")
-  (is (= [] (rest [])) "rest of empty vector"))
+  (is (= [] (rest [])) "rest of empty vector")
+  (is (= [] (rest nil)) "rest of nil"))
 
 (deftest test-seq-converts-non-sequential-collections
   (is (= '(-2.5 1 3 4) (seq (sorted-set 3 1 -2.5 4)))


### PR DESCRIPTION
## 🤔 Background

`(rest nil)` currently throws `InvalidArgumentException`, while Clojure returns an empty sequence. This surfaced in the clojure-test-suite and is tracked in #1638.

## 💡 Goal

Make `rest` handle `nil` as an empty collection and close #1638.

## 🔖 Changes

- Return `[]` from `rest` when the collection is `nil`.
- Add a focused core sequence test for `(rest nil)`.
- Update `CHANGELOG.md` under Unreleased / Fixed / Core.
- Refactor pass: no separate refactor commit was warranted because `seq-basics` loads before `cond`, so the existing `if` dispatch avoids a bootstrapping dependency.

Closes #1638