### PR TITLE
fix: handle too-deep get-in traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `get-in` returns `nil` or the default value when traversal goes too deep (#1640)
 - `some` accepts sets as seqable collections (#1639)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)
 - `assoc!` handles `apply` trailing keys with `nil` values (#1609)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -264,6 +264,10 @@
      (for [x :in coll :reduce [acc (transient [])]]
        (conj! acc x)))))
 
+(defn- get-in-traversable?
+  [x]
+  (or (coll? x) (php/is_array x)))
+
 (defn get-in
   "Accesses a value in a nested data structure via a sequence of keys.
 
@@ -278,7 +282,7 @@
       (if (nil? res) opt res)
 
       (or (nil? res)
-          (not (or (coll? res) (php/is_array res))))
+          (not (get-in-traversable? res)))
       opt
 
       :else

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -271,8 +271,18 @@
   {:example "(get-in {:a {:b {:c 42}}} [:a :b :c]) ; => 42"
    :see-also ["assoc-in" "update-in"]}
   [ds ks & [opt]]
-  (let [res (reduce get ds ks)]
-    (if (nil? res) opt res)))
+  (loop [res ds
+         path ks]
+    (cond
+      (empty? path)
+      (if (nil? res) opt res)
+
+      (or (nil? res)
+          (not (or (coll? res) (php/is_array res))))
+      opt
+
+      :else
+      (recur (get res (first path)) (next path)))))
 
 (defn assoc-in
   "Associates a value in a nested data structure at the given path.

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -271,7 +271,9 @@
   (is (= "a" (get-in ["a"] [0])) "get-in level 1")
   (is (= "a" (get-in {:a ["a"]} [:a 0])) "get-in level 2")
   (is (= "a" (get-in {:a [["b" "a"]]} [:a 0 1])) "get-in level 3")
-  (is (= "x" (get-in {:a [["b" "a"]]} [:b 0 1] "x")) "get-in level 3 with default"))
+  (is (= "x" (get-in {:a [["b" "a"]]} [:b 0 1] "x")) "get-in level 3 with default")
+  (is (nil? (get-in {:a {:b {:c :d}}} [:a :b :c :d])) "get-in too deep returns nil")
+  (is (= :not-found (get-in {:a {:b {:c :d}}} [:a :b :c :d] :not-found)) "get-in too deep returns default"))
 
 (deftest test-nth
   (is (= 2 (nth [1 2 3] 1)) "nth on vector")


### PR DESCRIPTION
## 🤔 Background

`get-in` currently throws when a path continues after reaching a scalar leaf value, such as traversing beyond `:d`. Clojure returns `nil` or the supplied not-found value for that case.

## 💡 Goal

Make `get-in` return `nil` or the supplied default when traversal goes too deep.

Closes #1640

## 🔖 Changes

- Added focused core tests for too-deep `get-in` traversal with and without a default value.
- Updated `get-in` to stop before reading from non-traversable leaf values.
- Added an Unreleased changelog entry for the core bug fix.