### PR TITLE
fix: support nth on transient vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)
+- `nth` handles transient vectors (#1641)
 - `some` accepts sets as seqable collections (#1639)
 - `rest` returns an empty sequence for `nil` collections (#1638)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -97,6 +97,10 @@
         opt
         res))))
 
+(defn- transient-vector?
+  [coll]
+  (php/instanceof coll TransientVectorInterface))
+
 (defn nth
   "Returns the value at `index` in `coll`. Throws an
    OutOfBoundsException if the index is out of range and no
@@ -114,7 +118,7 @@
        (php/mb_substr coll index 1 "UTF-8")
        (throw (php/new OutOfBoundsException (str "String index " index " out of bounds"))))
 
-     (vector? coll)
+     (or (vector? coll) (transient-vector? coll))
      (if (and (php/>= index 0) (php/< index (count coll)))
        (get coll index)
        (throw (php/new OutOfBoundsException (str "Vector index " index " out of bounds"))))
@@ -136,7 +140,7 @@
        (php/mb_substr coll index 1 "UTF-8")
        not-found)
 
-     (vector? coll)
+     (or (vector? coll) (transient-vector? coll))
      (if (and (php/>= index 0) (php/< index (count coll)))
        (get coll index)
        not-found)
@@ -171,10 +175,6 @@
     (if (and (php/> i 0) s)
       (recur (php/- i 1) (next s))
       s)))
-
-(defn- transient-vector?
-  [coll]
-  (php/instanceof coll TransientVectorInterface))
 
 (defn- transient-set?
   [coll]

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -101,6 +101,10 @@
   [coll]
   (php/instanceof coll TransientVectorInterface))
 
+(defn- indexed-vector?
+  [coll]
+  (or (vector? coll) (transient-vector? coll)))
+
 (defn nth
   "Returns the value at `index` in `coll`. Throws an
    OutOfBoundsException if the index is out of range and no
@@ -118,7 +122,7 @@
        (php/mb_substr coll index 1 "UTF-8")
        (throw (php/new OutOfBoundsException (str "String index " index " out of bounds"))))
 
-     (or (vector? coll) (transient-vector? coll))
+     (indexed-vector? coll)
      (if (and (php/>= index 0) (php/< index (count coll)))
        (get coll index)
        (throw (php/new OutOfBoundsException (str "Vector index " index " out of bounds"))))
@@ -140,7 +144,7 @@
        (php/mb_substr coll index 1 "UTF-8")
        not-found)
 
-     (or (vector? coll) (transient-vector? coll))
+     (indexed-vector? coll)
      (if (and (php/>= index 0) (php/< index (count coll)))
        (get coll index)
        not-found)

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -280,6 +280,8 @@
   (is (= 1 (nth [1 2 3] 0)) "nth on vector first")
   (is (= 3 (nth [1 2 3] 2)) "nth on vector last")
   (is (= :default (nth [1 2 3] 5 :default)) "nth on vector out of bounds with default")
+  (is (= 2 (nth (transient [1 2 3]) 1)) "nth on transient vector")
+  (is (= :default (nth (transient [1 2 3]) 5 :default)) "nth on transient vector out of bounds with default")
   (is (= "b" (nth "abc" 1)) "nth on string")
   (is (= :default (nth "abc" 5 :default)) "nth on string out of bounds with default")
   (is (= 3 (nth '(1 2 3) 2)) "nth on list")
@@ -287,6 +289,7 @@
 
 (deftest test-nth-throws-on-out-of-bounds
   (is (thrown? OutOfBoundsException (nth [1 2 3] 5)) "nth throws on vector out of bounds")
+  (is (thrown? OutOfBoundsException (nth (transient [1 2 3]) 5)) "nth throws on transient vector out of bounds")
   (is (thrown? OutOfBoundsException (nth "abc" 5)) "nth throws on string out of bounds")
   (is (thrown? OutOfBoundsException (nth nil 0)) "nth throws on nil"))
 


### PR DESCRIPTION
## 🤔 Background

`nth` treated persistent vectors as indexed collections, but transient vectors fell through to the sequence path and errored by calling `next` on the transient object.

## 💡 Goal

Closes #1641. Make `(nth (transient [1 2 3]) 1)` return the indexed value while preserving not-found and out-of-bounds behavior.

## 🔖 Changes

- Add focused Phel core tests for `nth` on transient vectors.
- Treat transient vectors as indexed vector targets in `nth`.
- Add an Unreleased changelog entry for the core bug fix.

Focused test: `./bin/phel test tests/phel/test/core/sequence-operation.phel`