### PR TITLE
fix: handle set sequence primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst` handle sets (#1642)
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)
 - `some` accepts sets as seqable collections (#1639)
 - `rest` returns an empty sequence for `nil` collections (#1638)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -56,6 +56,15 @@
   (fn [& xs]
     (php/:: Phel (map (apply php/array xs)))))
 
+(def next-of-set
+  {:private true
+   :doc "Returns all values after the first persistent set value, or nil."}
+  (fn [s]
+    (let [sliced (php/array_slice (php/-> s (toPhpArray)) 1)]
+      (if (php/empty sliced)
+        nil
+        (php/:: Phel (vector sliced))))))
+
 (def next
   {:doc "Returns the sequence after the first element, or nil if empty."
    :example "(next [1 2 3]) ; => [2 3]"}
@@ -75,10 +84,7 @@
                   nil
                   sliced))
               (if (php/instanceof xs PersistentHashSetInterface)
-                (let [sliced (php/array_slice (php/-> xs (toPhpArray)) 1)]
-                  (if (php/empty sliced)
-                    nil
-                    (php/:: Phel (vector sliced))))
+                (next-of-set xs)
                 (throw (php/new InvalidArgumentException
                                 (php/. "cannot call 'next on " (php/gettype xs)))))))))))
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -2,6 +2,7 @@
   (:use InvalidArgumentException)
   (:use Phel)
   (:use Phel.Lang.CdrInterface)
+  (:use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
   (:use Phel.Lang.Collections.Map.PersistentMapInterface)
   (:use Phel.Lang.ConcatInterface)
   (:use Phel.Lang.FirstInterface))
@@ -68,13 +69,18 @@
             (if (php/<= (php/count chars) 1)
               nil
               (php/:: Phel (vector (php/array_slice chars 1)))))
-          (if (php/is_array xs)
-            (let [sliced (php/array_slice xs 1)]
-              (if (php/empty sliced)
-                nil
-                sliced))
-            (throw (php/new InvalidArgumentException
-                            (php/. "cannot call 'next on " (php/gettype xs))))))))))
+            (if (php/is_array xs)
+              (let [sliced (php/array_slice xs 1)]
+                (if (php/empty sliced)
+                  nil
+                  sliced))
+              (if (php/instanceof xs PersistentHashSetInterface)
+                (let [sliced (php/array_slice (php/-> xs (toPhpArray)) 1)]
+                  (if (php/empty sliced)
+                    nil
+                    (php/:: Phel (vector sliced))))
+                (throw (php/new InvalidArgumentException
+                                (php/. "cannot call 'next on " (php/gettype xs)))))))))))
 
 (def first-map-entry
   {:private true
@@ -92,6 +98,13 @@
   (fn [s]
     (if (php/=== "" s) nil (php/mb_substr s 0 1))))
 
+(def first-of-set
+  {:private true
+   :doc "Returns the first value of a persistent set, or nil if empty."}
+  (fn [s]
+    (let [values (php/-> s (toPhpArray))]
+      (if (php/empty values) nil (php/aget values 0)))))
+
 (def first
   {:doc "Returns the first element of a sequence, or nil if empty.
 
@@ -103,7 +116,8 @@
     (if (php/instanceof xs FirstInterface)         (php/-> xs (first))
         (if (php/instanceof xs PersistentMapInterface) (first-map-entry xs)
             (if (php/is_string xs)                      (first-of-string xs)
-                (php/aget xs 0))))))
+                (if (php/instanceof xs PersistentHashSetInterface) (first-of-set xs)
+                    (php/aget xs 0)))))))
 
 (def concat1
   {:private true

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -4,6 +4,7 @@
 (use InvalidArgumentException)
 (use Phel)
 (use Phel\Lang\AbstractType)
+(use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\ConsInterface)
 (use Phel\Lang\RestInterface)
@@ -87,9 +88,11 @@
       (php/-> coll (rest))
       (if (php/is_string coll)
         (php/:: Phel (vector (php/array_slice (php/mb_str_split coll) 1)))
-        (if (php/is_array coll)
-          (php/array_slice coll 1)
-          (throw (php/new InvalidArgumentException "cannot do rest")))))))
+        (if (php/instanceof coll PersistentHashSetInterface)
+          (php/:: Phel (vector (php/array_slice (php/-> coll (toPhpArray)) 1)))
+          (if (php/is_array coll)
+            (php/array_slice coll 1)
+            (throw (php/new InvalidArgumentException "cannot do rest"))))))))
 
 (defn nfirst
   "Same as `(next (first coll))`."

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -67,6 +67,9 @@
       coll)
     (cons-non-array x coll)))
 
+(defn- rest-of-set [coll]
+  (php/:: Phel (vector (php/array_slice (php/-> coll (toPhpArray)) 1))))
+
 (defn ffirst
   "Same as `(first (first coll))`."
   [coll]
@@ -89,7 +92,7 @@
       (if (php/is_string coll)
         (php/:: Phel (vector (php/array_slice (php/mb_str_split coll) 1)))
         (if (php/instanceof coll PersistentHashSetInterface)
-          (php/:: Phel (vector (php/array_slice (php/-> coll (toPhpArray)) 1)))
+          (rest-of-set coll)
           (if (php/is_array coll)
             (php/array_slice coll 1)
             (throw (php/new InvalidArgumentException "cannot do rest"))))))))

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -55,7 +55,8 @@
   (is (= 2 (second (php/array 1 2))) "second of pgp array")
   (is (nil? (second (php/array))) "second of empty php array")
   (is (nil? (second #{})) "second of empty set")
-  (is (= #{[1] [2]} (set [(first #{[1] [2]}) (second #{[1] [2]})])) "second of set")
+  (let [values #{[1] [2]}]
+    (is (= values (set [(first values) (second values)])) "second of set"))
   (is (nil? (second nil)) "second of nil"))
 
 (deftest test-rest

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -36,6 +36,8 @@
   (is (nil? (first [])) "frist of empty vector")
   (is (= 1 (first (php/array 1))) "first of php array")
   (is (nil? (first (php/array))) "frist of empty php array")
+  (is (nil? (first #{})) "first of empty set")
+  (is (contains? #{[1] [2]} (first #{[1] [2]})) "first of set")
   (is (nil? (first nil)) "frist of nil"))
 
 (deftest test-ffirst
@@ -43,19 +45,25 @@
   (is (nil? (ffirst [1])) "ffirst of vector")
   (is (nil? (ffirst nil)) "ffirst of nil")
   (is (= :a (ffirst {:a 1})) "ffirst of single-entry map is its key")
-  (is (nil? (ffirst {})) "ffirst of empty map is nil"))
+  (is (nil? (ffirst {})) "ffirst of empty map is nil")
+  (is (nil? (ffirst #{})) "ffirst of empty set")
+  (is (contains? #{1 2} (ffirst #{[1] [2]})) "ffirst of set"))
 
 (deftest test-second
   (is (= 2 (second [1 2])) "second of vector")
   (is (nil? (second [])) "second of empty vector")
   (is (= 2 (second (php/array 1 2))) "second of pgp array")
   (is (nil? (second (php/array))) "second of empty php array")
+  (is (nil? (second #{})) "second of empty set")
+  (is (= #{[1] [2]} (set [(first #{[1] [2]}) (second #{[1] [2]})])) "second of set")
   (is (nil? (second nil)) "second of nil"))
 
 (deftest test-rest
   (is (= [2] (rest [1 2])) "rest of two element vector")
   (is (= [] (rest [1])) "rest of one element vector")
   (is (= [] (rest [])) "rest of empty vector")
+  (is (= [] (rest #{})) "rest of empty set")
+  (is (= 1 (count (rest #{[1] [2]}))) "rest of set")
   (is (= [] (rest nil)) "rest of nil"))
 
 (deftest test-seq-converts-non-sequential-collections
@@ -72,7 +80,9 @@
 
 (deftest test-nfirst
   (is (= [2] (nfirst [[1 2]])) "(nfirst [[1 2]])")
-  (is (= [1] (nfirst {:a 1})) "nfirst of single-entry map is the rest of the entry"))
+  (is (= [1] (nfirst {:a 1})) "nfirst of single-entry map is the rest of the entry")
+  (is (nil? (nfirst #{})) "nfirst of empty set")
+  (is (nil? (nfirst #{[1] [2]})) "nfirst of set"))
 
 (deftest test-first-map
   (is (= [:a 1] (first {:a 1})) "first of map returns first entry as 2-vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -354,7 +354,9 @@
 (deftest test-next
   (is (nil? (next [])) "next of empty vector")
   (is (nil? (next [1])) "next of one element vector")
-  (is (= [2] (next [1 2])) "next of two element vector"))
+  (is (= [2] (next [1 2])) "next of two element vector")
+  (is (nil? (next #{})) "next of empty set")
+  (is (= 1 (count (next #{[1] [2]}))) "next of set"))
 
 (deftest test-concat
   (is (= [1 2] (concat [1 2])) "concat one argument")


### PR DESCRIPTION
## 🤔 Background

Sets are seqable in Clojure, but Phel's `first`, `next`, and `rest` paths did not handle persistent hash sets directly. That caused PHP object/array errors for set inputs and affected derived functions such as `ffirst`, `second`, and `nfirst`.

Closes #1642

## 💡 Goal

Make core sequence primitives handle sets consistently with existing `seq` behavior.

## 🔖 Changes

- Add set handling for `first`, `next`, and `rest` in `phel\core`.
- Cover empty and non-empty set behavior for `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst`.
- Add an Unreleased changelog entry for the fix.
