### PR TITLE
fix: support take-last on finite ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)
 - `nth` handles transient vectors (#1641)
+- `take-last` handles finite ranges (#1643)
 - `some` accepts sets as seqable collections (#1639)
 - `rest` returns an empty sequence for `nil` collections (#1638)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -434,12 +434,25 @@
               (copy-meta coll result)))))
     (throw (php/new InvalidArgumentException "take expects 1 or 2 arguments"))))
 
+(defn- take-last-seqable
+  [n coll]
+  (let [buffer (php/array)]
+    (dofor [x :in coll]
+      (php/apush buffer x)
+      (when (php/> (php/count buffer) n)
+        (php/array_shift buffer)))
+    (php/:: Phel (vector buffer))))
+
 (defn take-last
   "Takes the last `n` elements of `coll`."
   {:example "(take-last 3 [1 2 3 4 5]) ; => [3 4 5]"
    :see-also ["take" "drop-last"]}
   [n coll]
-  (if (php/<= n 0) [] (slice coll (php/* -1 n))))
+  (cond
+    (php/<= n 0) []
+    (or (php-array? coll)
+        (php/instanceof coll SliceInterface)) (slice coll (php/* -1 n))
+    :else (take-last-seqable n coll)))
 
 (defn take-while
   "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -434,7 +434,7 @@
               (copy-meta coll result)))))
     (throw (php/new InvalidArgumentException "take expects 1 or 2 arguments"))))
 
-(defn- take-last-seqable
+(defn- take-last-buffered
   [n coll]
   (let [buffer (php/array)]
     (dofor [x :in coll]
@@ -452,7 +452,7 @@
     (php/<= n 0) []
     (or (php-array? coll)
         (php/instanceof coll SliceInterface)) (slice coll (php/* -1 n))
-    :else (take-last-seqable n coll)))
+    :else (take-last-buffered n coll)))
 
 (defn take-while
   "Takes all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -174,7 +174,8 @@
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number on vector")
   (is (= (php/array "b" "c") (take-last 2 (php/array "a" "b" "c"))) "take-last on php array")
   (is (= (php/array) (take-last 1 (php/array))) "take-last on empty php array")
-  (is (= [] (take-last -1 (php/array "a" "b" "c"))) "take-last with negative number on php array"))
+  (is (= [] (take-last -1 (php/array "a" "b" "c"))) "take-last with negative number on php array")
+  (is (= [8 9] (take-last 2 (range 0 10))) "take-last on finite range"))
 
 (deftest test-take-while
   (is (= [-1 -2 -3] (take-while neg? [-1 -2 -3 1 2 3 4 -4 -5 -6])) "take-while: first three element")


### PR DESCRIPTION
## 🤔 Background

`take-last` used `slice` directly, so finite lazy ranges raised `InvalidArgumentException: Cannot slice`.

## 💡 Goal

Closes #1643. Make `(take-last n (range ...))` return the final finite range values.

## 🔖 Changes

- Add a focused regression test for `(take-last 2 (range 0 10))`.
- Keep existing slice fast paths for vectors and PHP arrays.
- Add a bounded-buffer fallback for finite seqable collections.
- Update `CHANGELOG.md` under Unreleased.