### PR TITLE
fix: handle nil in take-last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `take-last` returns `nil` for `nil` collections (#1644)
 - `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst` handle sets (#1642)
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)
 - `nth` handles transient vectors (#1641)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -450,6 +450,7 @@
   [n coll]
   (cond
     (php/<= n 0) []
+    (nil? coll)    nil
     (or (php-array? coll)
         (php/instanceof coll SliceInterface)) (slice coll (php/* -1 n))
     :else (take-last-buffered n coll)))

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -169,7 +169,7 @@
   (is (= ["a" "b" "c"] (take-last 4 ["a" "b" "c"])) "take-last four elements")
   (is (= [] (take-last 0 ["a" "b" "c"])) "take-last zero elements")
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number")
-  (is (= nil (take-last 2 nil)) "take-last on nil")
+  (is (nil? (take-last 2 nil)) "take-last on nil")
   (is (= ["b" "c"] (take-last 2 ["a" "b" "c"])) "take-last on vector")
   (is (= [] (take-last 1 [])) "take-last on empty vector")
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number on vector")

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -169,6 +169,7 @@
   (is (= ["a" "b" "c"] (take-last 4 ["a" "b" "c"])) "take-last four elements")
   (is (= [] (take-last 0 ["a" "b" "c"])) "take-last zero elements")
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number")
+  (is (= nil (take-last 2 nil)) "take-last on nil")
   (is (= ["b" "c"] (take-last 2 ["a" "b" "c"])) "take-last on vector")
   (is (= [] (take-last 1 [])) "take-last on empty vector")
   (is (= [] (take-last -1 ["a" "b" "c"])) "take-last with negative number on vector")


### PR DESCRIPTION
## 🤔 Background

`take-last` currently delegates positive counts directly to `slice`. Passing `nil` therefore throws `InvalidArgumentException`, while Clojure and Phel `take` tolerate `nil` collections.

Closes #1644

## 💡 Goal

Make `(take-last n nil)` return `nil` for positive `n` instead of throwing.

## 🔖 Changes

- Add a focused Phel regression test for `take-last` on `nil`.
- Return `nil` from `take-last` before slicing `nil` collections.
- Add an Unreleased changelog entry under Core fixes.

Focused test run:

```bash
./bin/phel test tests/phel/test/core/sequence-functions.phel
```