### PR TITLE
fix: support negative take-nth arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `take-last` returns `nil` for `nil` collections (#1644)
+- `take-nth` supports negative integer arguments (#1645)
 - `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst` handle sets (#1642)
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)
 - `nth` handles transient vectors (#1641)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -487,12 +487,11 @@
                             (rf result input) result))))))
     1 (let [coll (first args)
             s    (seq coll)]
-        (if (nil? s)
-          []
-          (if (php/<= n 0)
-            (copy-meta coll (lazy-seq-from-generator (php/:: Seq (repeat (first s)))))
-            (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
-              (copy-meta coll (or result []))))))
+        (cond
+          (nil? s)      []
+          (php/<= n 0) (copy-meta coll (lazy-seq-from-generator (php/:: Seq (repeat (first s)))))
+          :else        (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
+                         (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
 
 (defn filter

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -478,8 +478,6 @@
   {:example "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; => (0 2 4 6 8)"
    :see-also ["take" "filter" "transduce"]}
   [n & args]
-  (when (< n 1)
-    (throw (php/new InvalidArgumentException "First argument of 'take-nth must be greater than 0")))
   (case (count args)
     0 (fn [rf]
         (let [iv (volatile! -1)]
@@ -487,11 +485,14 @@
                         (let [i (vreset! iv (php/+ @iv 1))]
                           (if (php/=== 0 (php/% i n))
                             (rf result input) result))))))
-    1 (let [coll (first args)]
-        (if (nil? coll)
+    1 (let [coll (first args)
+            s    (seq coll)]
+        (if (nil? s)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
-            (copy-meta coll (or result [])))))
+          (if (php/<= n 0)
+            (copy-meta coll (lazy-seq-from-generator (php/:: Seq (repeat (first s)))))
+            (let [result (lazy-seq-from-generator (php/:: Seq (takeNth n coll)))]
+              (copy-meta coll (or result []))))))
     (throw (php/new InvalidArgumentException "take-nth expects 1 or 2 arguments"))))
 
 (defn filter

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -266,6 +266,12 @@
   (is (= [1] (doall (take-nth 10 [1 2 3])))
       "take-nth larger than collection should return first element"))
 
+(deftest test-take-nth-negative-repeats-first-element
+  (is (= [1 1 1] (take 3 (take-nth -1 [1 2 3 4])))
+      "take-nth with -1 should repeat the first element lazily")
+  (is (= [1 1 1] (take 3 (take-nth -2 [1 2 3 4])))
+      "take-nth with a negative step should repeat the first element lazily"))
+
 (deftest test-take-nth-preserves-metadata
   (let [m {:foo "bar"}
         data (set-meta! [1 2 3 4 5 6] m)]

--- a/tests/phel/test/core/transducers.phel
+++ b/tests/phel/test/core/transducers.phel
@@ -98,6 +98,14 @@
   (is (= [0 2 4 6 8] (into [] (take-nth 2) [0 1 2 3 4 5 6 7 8]))
       "take-nth xf every 2nd"))
 
+(deftest test-take-nth-negative-transducer
+  (is (= [0 1 2 3 4 5 6 7 8 9]
+         (transduce (take-nth -1) conj [] (range 10)))
+      "take-nth -1 xf keeps every item")
+  (is (= [0 2 4 6 8]
+         (transduce (take-nth -2) conj [] (range 10)))
+      "take-nth -2 xf keeps every second item"))
+
 (deftest test-keep-transducer
   (is (= [4 16] (into [] (keep #(when (even? %) (* % %))) [1 2 3 4 5]))
       "keep xf non-nil results"))

--- a/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/SliceGeneratorTest.php
@@ -104,6 +104,13 @@ final class SliceGeneratorTest extends TestCase
         self::assertSame([1, 2, 3], iterator_to_array($result, false));
     }
 
+    public function test_take_nth_negative(): void
+    {
+        $result = SliceGenerator::takeNth(-2, [1, 2, 3, 4, 5, 6]);
+
+        self::assertSame([1, 3, 5], iterator_to_array($result, false));
+    }
+
     public function test_take_nth_with_multibyte_string(): void
     {
         $result = SliceGenerator::takeNth(2, '🎉a🎊b');


### PR DESCRIPTION
## 🤔 Background

`take-nth` rejected negative integer arguments, but Clojure allows them. Issue #1645 reported both collection and transducer mismatches for negative values.

## 💡 Goal

Closes #1645. Align `take-nth` behavior for negative integers with Clojure for lazy collection usage and transducers.

## 🔖 Changes

- Allow negative `take-nth` values in the transducer arity.
- Return a lazy repeat of the first element for non-positive collection calls.
- Add focused Phel regression tests for negative collection and transducer behavior.
- Add PHP generator coverage for negative nth stepping.
- Update `CHANGELOG.md` under Unreleased.