### PR TITLE
fix: support map lookup in find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `find` supports Clojure-style map entry lookup (#1646)
 - `take-last` returns `nil` for `nil` collections (#1644)
 - `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst` handle sets (#1642)
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -560,14 +560,18 @@
     (throw (php/new InvalidArgumentException "keep-indexed expects 1 or 2 arguments"))))
 
 (defn find
-  "Returns the first item in `coll` where `(pred item)` evaluates to true."
-  {:example "(find #(> % 5) [1 2 3 6 7 8]) ; => 6"
+  "When called with a collection first, returns `[key value]` when `key` is present.
+  Otherwise returns the first item in `coll` where `(pred item)` evaluates to true."
+  {:example "(find {:a 1} :a) ; => [:a 1]\n(find #(> % 5) [1 2 3 6 7 8]) ; => 6"
    :see-also ["find-index" "filter" "some?"]}
-  [pred coll]
-  (loop [s coll]
-    (when-not (empty? s)
-      (let [x (first s)]
-        (if (pred x) x (recur (next s)))))))
+  [pred-or-coll coll-or-key]
+  (if (or (nil? pred-or-coll) (associative? pred-or-coll))
+    (when (contains? pred-or-coll coll-or-key)
+      [coll-or-key (get pred-or-coll coll-or-key)])
+    (loop [s coll-or-key]
+      (when-not (empty? s)
+        (let [x (first s)]
+          (if (pred-or-coll x) x (recur (next s))))))))
 
 (defn find-index
   "Returns the index of the first item in `coll` where `(pred item)` evaluates to true."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -559,6 +559,18 @@
             (copy-meta coll (or result [])))))
     (throw (php/new InvalidArgumentException "keep-indexed expects 1 or 2 arguments"))))
 
+(defn- find-entry
+  [coll key]
+  (when (contains? coll key)
+    [key (get coll key)]))
+
+(defn- find-by-pred
+  [pred coll]
+  (loop [s coll]
+    (when-not (empty? s)
+      (let [x (first s)]
+        (if (pred x) x (recur (next s)))))))
+
 (defn find
   "When called with a collection first, returns `[key value]` when `key` is present.
   Otherwise returns the first item in `coll` where `(pred item)` evaluates to true."
@@ -566,12 +578,8 @@
    :see-also ["find-index" "filter" "some?"]}
   [pred-or-coll coll-or-key]
   (if (or (nil? pred-or-coll) (associative? pred-or-coll))
-    (when (contains? pred-or-coll coll-or-key)
-      [coll-or-key (get pred-or-coll coll-or-key)])
-    (loop [s coll-or-key]
-      (when-not (empty? s)
-        (let [x (first s)]
-          (if (pred-or-coll x) x (recur (next s))))))))
+    (find-entry pred-or-coll coll-or-key)
+    (find-by-pred pred-or-coll coll-or-key)))
 
 (defn find-index
   "Returns the index of the first item in `coll` where `(pred item)` evaluates to true."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -210,6 +210,11 @@
   (is (nil? (find neg? [1 2 3 2 3])) "find: nothing to find")
   (is (nil? (find neg? [])) "find on empty array"))
 
+(deftest test-find-map-entry
+  (is (= [:a 1] (find {:a 1 :b 2 :c 3} :a)) "find returns map entry for existing key")
+  (is (= [:a nil] (find {:a nil} :a)) "find returns map entry when value is nil")
+  (is (nil? (find {:a 1 :b 2 :c 3} :d)) "find returns nil for missing key"))
+
 (deftest test-find-empty-element
   (is (nil? (find #(throw (php/new \Exception)) [])) "`pred` is not executed when searching for empty vectors."))
 


### PR DESCRIPTION
## 🤔 Background

`find` currently treats its first argument as a predicate. The Clojure test suite also exercises Clojure-style `(find map key)` lookup semantics from #1646, #1647, and #1648.

## 💡 Goal

Support map entry lookup in `find` while preserving the existing predicate-search behavior.

Closes #1646
Related to #1647
Related to #1648

## 🔖 Changes

- Add focused Phel core tests for map entry lookup, missing keys, and present keys with `nil` values.
- Return `[key value]` when `find` receives a map-like collection and present key.
- Keep the existing predicate search path for non-collection predicates.
- Update `CHANGELOG.md` under Unreleased.
- Refactor `find` dispatch into private lookup and predicate helpers.

Focused local test: `./bin/phel test tests/phel/test/core/sequence-functions.phel`