### PR TITLE
fix: handle maps in sequence next helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `fnext` and `nnext` handle maps and sets consistently (#1649)
 - `find` supports Clojure-style map entry lookup (#1646)
 - `take-last` returns `nil` for `nil` collections (#1644)
 - `take-nth` supports negative integer arguments (#1645)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -65,6 +65,18 @@
         nil
         (php/:: Phel (vector sliced))))))
 
+(def next-of-map
+  {:private true
+   :doc "Returns all `[k v]` entries after the first persistent map entry, or nil."}
+  (fn [m]
+    (let [entries (php/array)]
+      (foreach [k v m]
+        (php/apush entries [k v]))
+      (let [sliced (php/array_slice entries 1)]
+        (if (php/empty sliced)
+          nil
+          (php/:: Phel (vector sliced)))))))
+
 (def next
   {:doc "Returns the sequence after the first element, or nil if empty."
    :example "(next [1 2 3]) ; => [2 3]"}
@@ -85,8 +97,10 @@
                   sliced))
               (if (php/instanceof xs PersistentHashSetInterface)
                 (next-of-set xs)
-                (throw (php/new InvalidArgumentException
-                                (php/. "cannot call 'next on " (php/gettype xs)))))))))))
+                (if (php/instanceof xs PersistentMapInterface)
+                  (next-of-map xs)
+                  (throw (php/new InvalidArgumentException
+                                  (php/. "cannot call 'next on " (php/gettype xs))))))))))))
 
 (def first-map-entry
   {:private true

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -56,14 +56,20 @@
   (fn [& xs]
     (php/:: Phel (map (apply php/array xs)))))
 
+(def next-vector-or-nil
+  {:private true
+   :doc "Returns all values after the first array value as a persistent vector, or nil."}
+  (fn [values]
+    (let [sliced (php/array_slice values 1)]
+      (if (php/empty sliced)
+        nil
+        (php/:: Phel (vector sliced))))))
+
 (def next-of-set
   {:private true
    :doc "Returns all values after the first persistent set value, or nil."}
   (fn [s]
-    (let [sliced (php/array_slice (php/-> s (toPhpArray)) 1)]
-      (if (php/empty sliced)
-        nil
-        (php/:: Phel (vector sliced))))))
+    (next-vector-or-nil (php/-> s (toPhpArray)))))
 
 (def next-of-map
   {:private true
@@ -72,10 +78,7 @@
     (let [entries (php/array)]
       (foreach [k v m]
         (php/apush entries [k v]))
-      (let [sliced (php/array_slice entries 1)]
-        (if (php/empty sliced)
-          nil
-          (php/:: Phel (vector sliced)))))))
+      (next-vector-or-nil entries))))
 
 (def next
   {:doc "Returns the sequence after the first element, or nil if empty."

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -90,7 +90,9 @@
   (is (nil? (first {})) "first of empty map is nil"))
 
 (deftest test-nnext
-  (is (= [3] (nnext [1 2 3])) "(nnext [1 2 3])"))
+  (is (= [3] (nnext [1 2 3])) "(nnext [1 2 3])")
+  (is (= '([:c 3] [:d 4]) (nnext {:a 1 :b 2 :c 3 :d 4})) "nnext on map")
+  (is (nil? (nnext #{})) "nnext on empty set"))
 
 (deftest test-count
   (is (= 0 (count [])) "count of empty vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -5,6 +5,10 @@
 (deftest test-fnext
   (is (= 2 (fnext [1 2 3])) "fnext on vector")
   (is (= 2 (fnext '(1 2 3))) "fnext on list")
+  (is (nil? (fnext {})) "fnext on empty map")
+  (is (nil? (fnext {:a :b})) "fnext on single-entry map")
+  (is (nil? (fnext #{})) "fnext on empty set")
+  (is (nil? (fnext #{"abcd"})) "fnext on single-entry set")
   (is (nil? (fnext [1])) "fnext on single-element vector")
   (is (nil? (fnext [])) "fnext on empty vector")
   (is (nil? (fnext nil)) "fnext on nil")


### PR DESCRIPTION
## 🤔 Background

`fnext` and `nnext` delegate through `next`, but `next` did not treat persistent maps as seqable entries. That made the Clojure compatibility cases from #1649 throw instead of returning `nil` or the remaining map entries.

Closes #1649

## 💡 Goal

Make `fnext` and `nnext` handle maps and sets consistently with Clojure-compatible sequence behavior.

## 🔖 Changes

- Add persistent map support to `next` by returning remaining `[k v]` entries.
- Cover the reported `fnext` and `nnext` map/set cases in focused Phel tests.
- Add an Unreleased changelog entry for the core fix.
- Refactor shared vector-tail handling for map and set `next`.

Focused tests:

- `./bin/phel test tests/phel/test/core/sequence-operation.phel`
- `./bin/phel test tests/phel/test/core/basic-sequence-operation.phel`