### PR TITLE
fix: support map next semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `find` supports Clojure-style map entry lookup (#1646)
+- `fnext` and `nnext` handle maps and sets (#1649)
 - `take-last` returns `nil` for `nil` collections (#1644)
 - `first`, `ffirst`, `second`, `next`, `rest`, and `nfirst` handle sets (#1642)
 - `get-in` returns `nil` or default when traversal goes too deep (#1640)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -56,14 +56,19 @@
   (fn [& xs]
     (php/:: Phel (map (apply php/array xs)))))
 
+(def non-empty-vector
+  {:private true
+   :doc "Returns a Phel vector for non-empty PHP array values, or nil."}
+  (fn [values]
+    (if (php/empty values)
+      nil
+      (php/:: Phel (vector values)))))
+
 (def next-of-set
   {:private true
    :doc "Returns all values after the first persistent set value, or nil."}
   (fn [s]
-    (let [sliced (php/array_slice (php/-> s (toPhpArray)) 1)]
-      (if (php/empty sliced)
-        nil
-        (php/:: Phel (vector sliced))))))
+    (non-empty-vector (php/array_slice (php/-> s (toPhpArray)) 1))))
 
 (def next-of-map
   {:private true
@@ -83,9 +88,7 @@
                 (recur))
               nil)))
         nil)
-      (if (php/empty entries)
-        nil
-        (php/:: Phel (vector entries))))))
+      (non-empty-vector entries))))
 
 (def next
   {:doc "Returns the sequence after the first element, or nil if empty."

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -65,6 +65,28 @@
         nil
         (php/:: Phel (vector sliced))))))
 
+(def next-of-map
+  {:private true
+   :doc "Returns all entries after the first persistent map entry, or nil."}
+  (fn [m]
+    (let [it      (php/-> m (getIterator))
+          entries (php/array)]
+      (php/-> it (rewind))
+      (if (php/-> it (valid))
+        (do
+          (php/-> it (next))
+          (loop []
+            (if (php/-> it (valid))
+              (do
+                (php/apush entries [(php/-> it (key)) (php/-> it (current))])
+                (php/-> it (next))
+                (recur))
+              nil)))
+        nil)
+      (if (php/empty entries)
+        nil
+        (php/:: Phel (vector entries))))))
+
 (def next
   {:doc "Returns the sequence after the first element, or nil if empty."
    :example "(next [1 2 3]) ; => [2 3]"}
@@ -85,8 +107,10 @@
                   sliced))
               (if (php/instanceof xs PersistentHashSetInterface)
                 (next-of-set xs)
-                (throw (php/new InvalidArgumentException
-                                (php/. "cannot call 'next on " (php/gettype xs)))))))))))
+                (if (php/instanceof xs PersistentMapInterface)
+                  (next-of-map xs)
+                  (throw (php/new InvalidArgumentException
+                                  (php/. "cannot call 'next on " (php/gettype xs))))))))))))
 
 (def first-map-entry
   {:private true

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -90,7 +90,10 @@
   (is (nil? (first {})) "first of empty map is nil"))
 
 (deftest test-nnext
-  (is (= [3] (nnext [1 2 3])) "(nnext [1 2 3])"))
+  (is (= [3] (nnext [1 2 3])) "(nnext [1 2 3])")
+  (is (= [[:c 3] [:d 4]] (nnext {:a 1 :b 2 :c 3 :d 4}))
+      "nnext on map returns entries after the first two")
+  (is (nil? (nnext #{})) "nnext on empty set"))
 
 (deftest test-count
   (is (= 0 (count [])) "count of empty vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -7,6 +7,10 @@
   (is (= 2 (fnext '(1 2 3))) "fnext on list")
   (is (nil? (fnext [1])) "fnext on single-element vector")
   (is (nil? (fnext [])) "fnext on empty vector")
+  (is (nil? (fnext {})) "fnext on empty map")
+  (is (nil? (fnext #{})) "fnext on empty set")
+  (is (nil? (fnext {:a :b})) "fnext on single-entry map")
+  (is (nil? (fnext #{"abcd"})) "fnext on single-entry set")
   (is (nil? (fnext nil)) "fnext on nil")
   (is (= (second [1 2 3]) (fnext [1 2 3])) "fnext equals second"))
 


### PR DESCRIPTION
## 🤔 Background

`fnext` and `nnext` failed on maps because `next` did not handle persistent maps as seqable entries. Issue #1649 also covered empty and single-entry set cases from the Clojure test suite.

## 💡 Goal

Closes #1649. Make `fnext` and `nnext` follow Clojure-style sequence semantics for maps and sets.

## 🔖 Changes

- Add regression coverage for `fnext` on empty maps/sets and single-entry maps/sets.
- Add regression coverage for `nnext` on maps and empty sets.
- Teach `next` to return map entries after the first entry.
- Update `CHANGELOG.md` under Unreleased.