### PR TITLE
fix: conj lazy sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `conj` prepends values to lazy sequences like `(range)` (#1650)
 - `fnext` and `nnext` handle maps and sets consistently (#1649)
 - `find` supports Clojure-style map entry lookup (#1646)
 - `take-last` returns `nil` for `nil` collections (#1644)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -5,6 +5,7 @@
 (use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
 (use Phel\Lang\Collections\HashSet\TransientHashSetInterface)
 (use Phel\Lang\Collections\LazySeq\LazySeq)
+(use Phel\Lang\Collections\LazySeq\LazySeqInterface)
 (use Phel\Lang\Collections\LinkedList\PersistentListInterface)
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\Collections\Map\TransientMapInterface)
@@ -187,6 +188,7 @@
   (cond
     (php/=== coll nil)                            (list value)
     (php/instanceof coll PersistentListInterface)  (cons value coll)
+    (php/instanceof coll LazySeqInterface)         (cons value coll)
     (php/is_array coll)                            (do (php/apush coll value) coll)
     (vector-target? coll)                          (php/-> coll (append value))
     (set-target? coll)                             (php/-> coll (add value))

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -101,6 +101,7 @@
          (conj {:firstname "John" :lastname "Doe"} {:age 25 :nationality "Chinese"}))
       "conj on a map merges associative collections")
   (is (= #{1 2 3 4} (conj #{1 3 4} 2)) "conj on a set adds elements")
+  (is (= -1 (first (conj (range) -1))) "conj on a lazy range adds elements at the beginning")
   (is (= (list 1) (conj nil 1)) "conj on nil with a value returns a single-item list"))
 
 (deftest test-conj-php-arrays


### PR DESCRIPTION
## 🤔 Background

`conj` currently rejects lazy sequences such as `(range)` with `InvalidArgumentException`, even though list-like sequence semantics should prepend values.

Closes #1650

## 💡 Goal

Allow `(conj (range) -1)` to behave like Clojure by making the newly conjoined value the first element without realizing the infinite range.

## 🔖 Changes

- Add a focused regression test for `(first (conj (range) -1))`.
- Handle `LazySeqInterface` in `conj-single` by delegating to `cons`.
- Add an `Unreleased / Fixed / Core` changelog entry.
- Refactor pass: no separate cleanup was justified beyond the narrow fix.