### PR TITLE
fix: flatten map entries in mapcat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `mapcat` flattens map key-value entries (#1651)
 - `conj` prepends values to lazy sequences like `(range)` (#1650)
 - `fnext` and `nnext` handle maps and sets consistently (#1649)
 - `find` supports Clojure-style map entry lookup (#1646)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -929,8 +929,9 @@
     1 (let [coll (first args)]
         (if (php/=== nil coll)
           '()
-          (let [result (lazy-seq-from-generator
-                        (php/:: \Phel\Lang\Seq (mapcat f coll)))]
+          (let [input  (if (map? coll) (pairs coll) coll)
+                result (lazy-seq-from-generator
+                        (php/:: \Phel\Lang\Seq (mapcat f input)))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -447,6 +447,10 @@
   (is (= [1 2 3 4 5 6] (doall (mapcat identity [[1 2] [3 4] [5 6]])))
       "mapcat identity should flatten one level"))
 
+(deftest test-mapcat-identity-flattens-map-entries
+  (is (= [:a 1 :b 2 :c 3] (doall (mapcat identity {:a 1 :b 2 :c 3})))
+      "mapcat identity should flatten map key-value entries"))
+
 (deftest test-mapcat-with-infinite-sequence
   (is (= [0 0 1 1 2 2 3 3 4 4] (take 10 (mapcat #(list % %) (iterate inc 0))))
       "mapcat should work with infinite sequences"))


### PR DESCRIPTION
## 🤔 Background

`mapcat` over a map currently maps over the map values. With `identity`, the first mapped result is a scalar value, so the lazy mapcat generator tries to flatten an integer and throws a `TypeError`.

Closes #1651

## 💡 Goal

Make `(mapcat identity {:a 1 :b 2 :c 3})` flatten map entries as key/value pairs, matching the clojure-test-suite expectation.

## 🔖 Changes

- Feed map inputs to single-collection `mapcat` as `(pairs coll)` before lazy flattening.
- Add a focused Phel regression test for `mapcat identity` over a map.
- Update `CHANGELOG.md` under Unreleased/Core.
- Refactor pass completed; no separate cleanup diff was justified.

Focused local test:

```bash
./bin/phel test tests/phel/test/core/infinite-seqs.phel
```
