### PR TITLE
docs: link rest nil fix to issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 - `nth` handles transient vectors (#1641)
 - `take-last` handles finite ranges (#1643)
 - `some` accepts sets as seqable collections (#1639)
-- `rest` returns an empty sequence for `nil` collections (#1638)
+- `rest` returns an empty sequence for `nil` collections (#1638, #1652)
 - `sort` handles `(sort comp coll)`, maps, and nested vectors (#1610, #1611, #1613)
 - `assoc!` handles `apply` trailing keys with `nil` values (#1609)
 - `merge` handles no, `nil`, and non-map operands (#1603, #1606)


### PR DESCRIPTION
## 🤔 Background

Issue #1652 reports that `(rest nil)` throws, while Clojure returns an empty sequence. Current `main` already contains the code fix and focused Phel coverage for this behavior.

## 💡 Goal

Close #1652 by linking the existing unreleased `rest nil` fix to the issue in the changelog.

## 🔖 Changes

- Update `CHANGELOG.md` so the existing `rest` on `nil` fix references #1652.
- Refactor pass: no code refactor was justified because the implementation and regression coverage are already present on `main`.

Focused test run:

```bash
./bin/phel test tests/phel/test/core/basic-sequence-operation.phel
```

Closes #1652