### PR TITLE
docs: link dissoc record fix to issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to this project will be documented in this file.
 - `merge` handles no, `nil`, and non-map operands (#1603, #1606)
 - `apply` accepts strings and maps as final arguments (#1602)
 - `seq`, `cons`, and `pop` handle more seqable and empty values (#1598, #1599, #1600)
-- `dissoc` removes record keys with consistent map results (#1607)
+- `dissoc` removes record keys with consistent map results (#1607, #1653)
 - Dynamic bindings are fiber-local and propagate through `future` and `async` (#1536)
 - `contains?` returns `false` for `nil` collections (#1592)
 - Hierarchy lookups handle invalid arguments, inline protocols, and PHP parents (#1591, #1597)


### PR DESCRIPTION
## 🤔 Background

`dissoc` on records was fixed by #1625, which added the Clojure-compatible behavior and the regression tests that match #1653. Issue #1653 remained open because the merged PR only closed #1607.

Closes #1653

## 💡 Goal

Attach #1653 to the existing Unreleased changelog entry so the duplicate report closes cleanly without changing already-correct runtime behavior.

## 🔖 Changes

- Updated the `dissoc` record changelog entry to reference #1653 alongside #1607.
- Confirmed the focused record tests still pass.
- Refactor pass: no runtime refactor was justified because the implementation already exists upstream.

Focused local check:
- `./bin/phel test tests/phel/test/core/records.phel`