### PR TITLE
test: cover zipmap with sorted-map keys

### DIFF
--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -369,7 +369,9 @@
 (deftest test-zipmap
   (is (= {:a 1 :b 2} (zipmap [:a :b :c] [1 2])) "zipmap drops extra keys")
   (is (= {:a 1 :b 2} (zipmap [:a :b] [1 2 3])) "zipmap drops extra values")
-  (is (= {:a 1 :b 2} (zipmap [:a :b] [1 2])) "zipmap equal length"))
+  (is (= {:a 1 :b 2} (zipmap [:a :b] [1 2])) "zipmap equal length")
+  (is (= {[:a 1] "a" [:b 2] "b"} (apply zipmap [(sorted-map :a 1 :b 2) ["a" "b"]]))
+      "zipmap supports sorted-map keys"))
 
 (deftest test-merge
   (is (= {:a -1 :b 2 :c 3 :d 4} (merge {:a 1 :b 2} {:a -1 :c 3} {:d 4})) "merge")


### PR DESCRIPTION
## 🤔 Background

Issue #1654 reported that `(apply zipmap [(sorted-map :a 1 :b 2) ["a" "b"]])` raised `InvalidArgumentException: cannot call next on object` instead of matching Clojure behavior.

## 💡 Goal

Close the regression gap by covering `zipmap` with sorted-map key entries.

Closes #1654

## 🔖 Changes

- Add a focused Phel core test for `zipmap` using sorted-map keys through the reported `apply` form.
- No changelog entry: this is a test-only PR for behavior already passing on current `main`.