### PR TITLE
fix: return nil for rand-nth on nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `rand-nth` returns `nil` for `nil` collections (#1655)
 - `mapcat` flattens map key-value entries (#1651)
 - `conj` prepends values to lazy sequences like `(range)` (#1650)
 - `fnext` and `nnext` handle maps and sets consistently (#1649)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -346,7 +346,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 (defn rand-nth
   "Returns a random item from xs."
   [xs]
-  (get xs (rand-int (dec (count xs)))))
+  (when-not (nil? xs)
+    (get xs (rand-int (dec (count xs))))))
 
 (defn extreme
   "Returns the most extreme value in `args` based on the binary `order` function."
@@ -406,4 +407,3 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
       (if (odd? cnt)
         (php/aget arr mid)
         (/ (+ (php/aget arr (dec mid)) (php/aget arr mid)) 2)))))
-

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -113,6 +113,9 @@
 (deftest test-max
   (is (= 3 (max 1 2 3)) "(max 1 2 3)"))
 
+(deftest test-rand-nth
+  (is (nil? (rand-nth nil)) "(rand-nth nil)"))
+
 (deftest test-min-key
   (is (= {:a 1} (min-key :a {:a 1} {:a 3} {:a 2}))
       "min-key with keyword key")

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -113,7 +113,7 @@
 (deftest test-max
   (is (= 3 (max 1 2 3)) "(max 1 2 3)"))
 
-(deftest test-rand-nth
+(deftest test-rand-nth-on-nil
   (is (nil? (rand-nth nil)) "(rand-nth nil)"))
 
 (deftest test-min-key


### PR DESCRIPTION
## 🤔 Background

`(rand-nth nil)` currently calls `random_int` with an invalid range and raises `ValueError`. Clojure returns `nil` for the same expression.

Closes #1655

## 💡 Goal

Make `rand-nth` return `nil` for `nil` collections.

## 🔖 Changes

- Add a Phel core regression test for `(rand-nth nil)`.
- Guard `rand-nth` against `nil` before choosing a random index.
- Update `CHANGELOG.md` under Unreleased / Fixed / Core.
- Refactor the regression test name for clarity.