### PR TITLE
fix: return nil for nth on nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `nth` returns `nil` for `nil` collections (#1656)
 - `rand-nth` returns `nil` for `nil` collections (#1655)
 - `mapcat` flattens map key-value entries (#1651)
 - `conj` prepends values to lazy sequences like `(range)` (#1650)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -105,6 +105,10 @@
   [coll]
   (or (vector? coll) (transient-vector? coll)))
 
+(defn- in-bounds?
+  [index size]
+  (and (php/>= index 0) (php/< index size)))
+
 (defn nth
   "Returns the value at `index` in `coll`. Throws an
    OutOfBoundsException if the index is out of range and no
@@ -118,12 +122,12 @@
      nil
 
      (php/is_string coll)
-     (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))
+     (if (in-bounds? index (php/mb_strlen coll "UTF-8"))
        (php/mb_substr coll index 1 "UTF-8")
        (throw (php/new OutOfBoundsException (str "String index " index " out of bounds"))))
 
      (indexed-vector? coll)
-     (if (and (php/>= index 0) (php/< index (count coll)))
+     (if (in-bounds? index (count coll))
        (get coll index)
        (throw (php/new OutOfBoundsException (str "Vector index " index " out of bounds"))))
 
@@ -140,12 +144,12 @@
      (nil? coll)          not-found
 
      (php/is_string coll)
-     (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))
+     (if (in-bounds? index (php/mb_strlen coll "UTF-8"))
        (php/mb_substr coll index 1 "UTF-8")
        not-found)
 
      (indexed-vector? coll)
-     (if (and (php/>= index 0) (php/< index (count coll)))
+     (if (in-bounds? index (count coll))
        (get coll index)
        not-found)
 

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -115,7 +115,7 @@
   ([coll index]
    (cond
      (nil? coll)
-     (throw (php/new OutOfBoundsException (str "Index " index " out of bounds on nil")))
+     nil
 
      (php/is_string coll)
      (if (and (php/>= index 0) (php/< index (php/mb_strlen coll "UTF-8")))

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -290,13 +290,13 @@
   (is (= "b" (nth "abc" 1)) "nth on string")
   (is (= :default (nth "abc" 5 :default)) "nth on string out of bounds with default")
   (is (= 3 (nth '(1 2 3) 2)) "nth on list")
+  (is (nil? (nth nil 10)) "nth on nil returns nil")
   (is (= :default (nth nil 0 :default)) "nth on nil with default"))
 
 (deftest test-nth-throws-on-out-of-bounds
   (is (thrown? OutOfBoundsException (nth [1 2 3] 5)) "nth throws on vector out of bounds")
   (is (thrown? OutOfBoundsException (nth (transient [1 2 3]) 5)) "nth throws on transient vector out of bounds")
-  (is (thrown? OutOfBoundsException (nth "abc" 5)) "nth throws on string out of bounds")
-  (is (thrown? OutOfBoundsException (nth nil 0)) "nth throws on nil"))
+  (is (thrown? OutOfBoundsException (nth "abc" 5)) "nth throws on string out of bounds"))
 
 (deftest test-nthrest
   (is (= [3 4 5] (nthrest [1 2 3 4 5] 2)) "nthrest drops first n")


### PR DESCRIPTION
## 🤔 Background

Issue #1656 reports that `(nth nil 10)` throws `OutOfBoundsException`, while Clojure returns `nil`.

## 💡 Goal

Make `nth` return `nil` for `nil` collections when no not-found value is supplied.

Closes #1656

## 🔖 Changes

- Add a focused Phel core regression test for `(nth nil 10)`.
- Return `nil` from the two-arity `nth` nil branch.
- Keep out-of-bounds exceptions for non-nil strings and vectors without a not-found value.
- Update `CHANGELOG.md` under Unreleased / Fixed / Core.
- Refactor repeated `nth` bounds checks into `in-bounds?`.