### PR TITLE
fix: align sort-by comparator argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `sort-by` accepts the comparator before the collection (#1657)
 - `nth` returns `nil` for `nil` collections (#1656)
 - `rand-nth` returns `nil` for `nil` collections (#1655)
 - `mapcat` flattens map key-value entries (#1651)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -806,6 +806,11 @@
   [coll comp]
   (sorted-vector coll (sort-comparator comp)))
 
+(defn- sort-by-with
+  [keyfn coll comp]
+  (let [cmp (sort-comparator comp)]
+    (sorted-vector coll #(cmp (keyfn %1) (keyfn %2)))))
+
 (defn sort
   "Returns a sorted vector. If no comparator is supplied compare is used."
   {:example "(sort [3 1 4 1 5 9 2 6]) ; => [1 1 2 3 4 5 6 9]\n(sort (fn [a b] (compare b a)) [1 2 3]) ; => [3 2 1]"
@@ -821,11 +826,14 @@
   "Returns a sorted vector where the sort order is determined by comparing `(keyfn item)`.
 
   If no comparator is supplied compare is used."
-  {:example "(sort-by count [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]"
+  {:example "(sort-by count [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]\n(sort-by count compare [\"aaa\" \"c\" \"bb\"]) ; => [\"c\" \"bb\" \"aaa\"]"
    :see-also ["sort" "compare"]}
-  [keyfn coll & [comp]]
-  (let [cmp (sort-comparator comp)]
-    (sorted-vector coll #(cmp (keyfn %1) (keyfn %2)))))
+  ([keyfn coll]
+   (sort-by-with keyfn coll compare))
+  ([keyfn a b]
+   (if (fn? a)
+     (sort-by-with keyfn b a)
+     (sort-by-with keyfn a b))))
 
 (defn shuffle
   "Returns a random permutation of coll."

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -830,10 +830,10 @@
    :see-also ["sort" "compare"]}
   ([keyfn coll]
    (sort-by-with keyfn coll compare))
-  ([keyfn a b]
-   (if (fn? a)
-     (sort-by-with keyfn b a)
-     (sort-by-with keyfn a b))))
+  ([keyfn comp-or-coll coll-or-comp]
+   (if (fn? comp-or-coll)
+     (sort-by-with keyfn coll-or-comp comp-or-coll)
+     (sort-by-with keyfn comp-or-coll coll-or-comp))))
 
 (defn shuffle
   "Returns a random permutation of coll."

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -357,6 +357,9 @@
   (is (thrown? \TypeError (sort 1)) "sort non-seqable throws")
   (is (thrown? \InvalidArgumentException (sort [1 []])) "sort incomparable values throws")
   (is (= [1 2 3] (sort-by identity [3 2 1])) "sort-by identity")
+  (is (= [{:a 1 :b 10} {:a 2 :b 9} {:a 3 :b 8} {:a 4 :b 7}]
+         (sort-by :a compare [{:a 2 :b 9} {:a 1 :b 10} {:a 4 :b 7} {:a 3 :b 8}]))
+      "sort-by comparator before collection")
   (is (= [3 2 1] (sort-by - [3 2 1])) "sort-by reversed"))
 
 (deftest test-group-by


### PR DESCRIPTION
## 🤔 Background

`sort-by` accepted the custom comparator only after the collection, which does not match the Clojure-compatible `(sort-by keyfn comp coll)` form reported in #1657.

## 💡 Goal

Closes #1657. Support the comparator-before-collection argument order while preserving the existing two-argument and comparator-after-collection forms.

## 🔖 Changes

- Add a focused Phel core regression test for `(sort-by :a compare coll)`.
- Dispatch `sort-by` three-argument calls by comparator position.
- Update the `sort-by` metadata example and Unreleased changelog entry.

Focused tests run locally:

- `./bin/phel test tests/phel/test/core/sequence-functions.phel`
- `./bin/phel test tests/phel/test/core/meta.phel`