### PR TITLE
fix: preserve non-finite division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `/` preserves `##Inf`, `##-Inf`, and `##NaN` when dividing by zero (#1658)
 - `sort-by` accepts the comparator before the collection (#1657)
 - `nth` returns `nil` for `nil` collections (#1656)
 - `rand-nth` returns `nil` for `nil` collections (#1655)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -18,10 +18,18 @@
     (when (php/=== nil x)
       (throw (php/new \InvalidArgumentException "Arithmetic functions do not accept nil values")))))
 
+(defn- zero-divisor?
+  [x]
+  (or (= x 0) (= x 0.0)))
+
+(defn- non-finite-number?
+  [x]
+  (or (php/is_infinite x) (php/is_nan x)))
+
 (defn- divide
   [nominator denominator]
-  (if (and (or (= denominator 0) (= denominator 0.0))
-           (or (php/is_infinite nominator) (php/is_nan nominator)))
+  (if (and (zero-divisor? denominator)
+           (non-finite-number? nominator))
     (php/fdiv nominator denominator)
     (php// nominator denominator)))
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -18,6 +18,13 @@
     (when (php/=== nil x)
       (throw (php/new \InvalidArgumentException "Arithmetic functions do not accept nil values")))))
 
+(defn- divide
+  [nominator denominator]
+  (if (and (or (= denominator 0) (= denominator 0.0))
+           (or (php/is_infinite nominator) (php/is_nan nominator)))
+    (php/fdiv nominator denominator)
+    (php// nominator denominator)))
+
 ;; -----------------
 ;; Bitwise operation
 ;; -----------------
@@ -135,15 +142,15 @@ numbers. If `xs` is empty, return 1."
 (defn /
   "Returns the nominator divided by all the denominators. If `xs` is empty,
 returns 1. If `xs` has one value, returns the reciprocal of x."
-  {:inline (fn [& xs] `(do (assert-non-nil ~@xs) (php// ~@xs)))
-   :inline-arity (fn [n] (> n 1))}
+  {:inline (fn [& xs] `(do (assert-non-nil ~@xs) (divide ~@xs)))
+   :inline-arity (fn [n] (= n 2))}
   [& xs]
   (apply assert-non-nil xs)
   (case (count xs)
     0 1
-    1 (php// 1 (first xs))
-    2 (php// (first xs) (second xs))
-    (reduce #(php// %1 %2) xs)))
+    1 (divide 1 (first xs))
+    2 (divide (first xs) (second xs))
+    (reduce #(divide %1 %2) xs)))
 
 (defn %
   "Return the remainder of `dividend` / `divisor`."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -23,6 +23,12 @@
   (is (= 2 (/ 4 2)) "/ two arguments")
   (is (= 2 (/ 16 4 2)) "/ three arguments"))
 
+(deftest test-special-floating-point-division-by-zero
+  (is (= ##Inf (/ ##Inf 0)) "##Inf divided by zero remains ##Inf")
+  (is (= ##-Inf (/ ##-Inf 0)) "##-Inf divided by zero remains ##-Inf")
+  (is (NaN? (/ ##NaN 0)) "##NaN divided by zero remains ##NaN")
+  (is (thrown? \DivisionByZeroError (/ 1 0)) "finite division by zero still throws"))
+
 (deftest test-%
   (is (= 0 (% 10 2)) "10 % 2")
   (is (= 1 (% 11 2)) "11 % 2"))

--- a/tests/php/Integration/Fixtures/Inline/div.test
+++ b/tests/php/Integration/Fixtures/Inline/div.test
@@ -5,5 +5,4 @@
 (/ 1 2 3)
 --PHP--
 (\Phel::getDefinition("phel\\core", "/"))();(\Phel::getDefinition("phel\\core", "/"))(1);(\Phel::getDefinition("phel\\core", "assert-non-nil"))(1, 2);
-(1 / 2);(\Phel::getDefinition("phel\\core", "assert-non-nil"))(1, 2, 3);
-(1 / 2 / 3);
+(\Phel::getDefinition("phel\\core", "divide"))(1, 2);(\Phel::getDefinition("phel\\core", "/"))(1, 2, 3);


### PR DESCRIPTION
## 🤔 Background

Issue #1658 reports that `(/ ##Inf 0)`, `(/ ##-Inf 0)`, and `(/ ##NaN 0)` throw `DivisionByZeroError`, while Clojure-compatible behavior preserves the non-finite value.

Closes #1658

## 💡 Goal

Preserve `##Inf`, `##-Inf`, and `##NaN` when divided by zero without changing finite division-by-zero errors.

## 🔖 Changes

- Add focused core math regression coverage for non-finite division by zero.
- Route `/` through a shared helper that uses `fdiv` only for non-finite zero-divisor cases.
- Keep finite `(/ 1 0)` behavior throwing `DivisionByZeroError`.
- Add the fix to `CHANGELOG.md` under Unreleased Core fixes.

Focused local test: `./bin/phel test tests/phel/test/core/math-operation.phel`