### PR TITLE
feat: support unicode escapes in string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Resolve dot-separated PHP class names and root-class aliases (#1553)
 - Warn optionally about deprecated backslash namespace separators (#1567)
 - Use dot-separated names in stdlib namespaces and `:use` clauses (#1567, #1576)
+- Support `\uNNNN` Unicode escapes in string literals (#1679)
 
 #### Core
 - Add list matchers to `case` (#1615)

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -13,6 +13,7 @@ use function chr;
 final class StringParser
 {
     private const int BRACED_UNICODE_ESCAPE_MATCH = 2;
+
     private const int FIXED_UNICODE_ESCAPE_MATCH = 3;
 
     private const array STRING_REPLACEMENTS = [
@@ -79,11 +80,13 @@ final class StringParser
      */
     private function parseUnicodeEscape(array $matches): string
     {
-        $hexCodepoint = ($matches[self::BRACED_UNICODE_ESCAPE_MATCH] ?? '') !== ''
-            ? $matches[self::BRACED_UNICODE_ESCAPE_MATCH]
-            : $matches[self::FIXED_UNICODE_ESCAPE_MATCH];
+        $hexCodepoint = $matches[self::BRACED_UNICODE_ESCAPE_MATCH] ?? '';
 
-        return $this->codePointToUtf8(hexdec((string) $hexCodepoint));
+        if ($hexCodepoint === '') {
+            $hexCodepoint = $matches[self::FIXED_UNICODE_ESCAPE_MATCH] ?? '';
+        }
+
+        return $this->codePointToUtf8(hexdec($hexCodepoint));
     }
 
     /**

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -50,14 +50,16 @@ final class StringParser
             }
 
             if ($str[0] === 'u') {
-                return $this->codePointToUtf8(hexdec((string) $matches[2]));
+                $hexCodepoint = ($matches[2] ?? '') !== '' ? $matches[2] : $matches[3];
+
+                return $this->codePointToUtf8(hexdec((string) $hexCodepoint));
             }
 
             return chr((int) octdec((string) $str));
         };
 
         $result = preg_replace_callback(
-            '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}|u\{([0-9a-fA-F]+)\})~',
+            '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}|u\{([0-9a-fA-F]+)\}|u([0-9a-fA-F]{4}))~',
             $callback,
             str_replace('\\"', '"', $str),
         );

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -12,6 +12,9 @@ use function chr;
 
 final class StringParser
 {
+    private const int BRACED_UNICODE_ESCAPE_MATCH = 2;
+    private const int FIXED_UNICODE_ESCAPE_MATCH = 3;
+
     private const array STRING_REPLACEMENTS = [
         '\\' => '\\',
         '$' => '$',
@@ -50,9 +53,7 @@ final class StringParser
             }
 
             if ($str[0] === 'u') {
-                $hexCodepoint = ($matches[2] ?? '') !== '' ? $matches[2] : $matches[3];
-
-                return $this->codePointToUtf8(hexdec((string) $hexCodepoint));
+                return $this->parseUnicodeEscape($matches);
             }
 
             return chr((int) octdec((string) $str));
@@ -69,6 +70,20 @@ final class StringParser
         }
 
         return $result;
+    }
+
+    /**
+     * @param list<string> $matches
+     *
+     * @throws StringParserException
+     */
+    private function parseUnicodeEscape(array $matches): string
+    {
+        $hexCodepoint = ($matches[self::BRACED_UNICODE_ESCAPE_MATCH] ?? '') !== ''
+            ? $matches[self::BRACED_UNICODE_ESCAPE_MATCH]
+            : $matches[self::FIXED_UNICODE_ESCAPE_MATCH];
+
+        return $this->codePointToUtf8(hexdec((string) $hexCodepoint));
     }
 
     /**

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/StringParser.php
@@ -12,6 +12,8 @@ use function chr;
 
 final class StringParser
 {
+    private const string ESCAPE_SEQUENCE_PATTERN = '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}|u\{([0-9a-fA-F]+)\}|u([0-9a-fA-F]{4}))~';
+
     private const int BRACED_UNICODE_ESCAPE_MATCH = 2;
 
     private const int FIXED_UNICODE_ESCAPE_MATCH = 3;
@@ -61,7 +63,7 @@ final class StringParser
         };
 
         $result = preg_replace_callback(
-            '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}|u\{([0-9a-fA-F]+)\}|u([0-9a-fA-F]{4}))~',
+            self::ESCAPE_SEQUENCE_PATTERN,
             $callback,
             str_replace('\\"', '"', $str),
         );

--- a/tests/phel/test/json/encode/flags.phel
+++ b/tests/phel/test/json/encode/flags.phel
@@ -14,7 +14,7 @@
 
 (deftest test-json-encode-flag
   (is (=
-       "{\"and\":\"a \u0026 b\"}"
+       "{\"and\":\"a \\u0026 b\"}"
        (json/encode
         {:and "a & b"}
         {:flags JSON_HEX_AMP}))
@@ -22,7 +22,7 @@
 
 (deftest test-json-encode-flags
   (is (=
-       "{\"comparison\":\"a \u003E b\",\"and\":\"a \u0026 b\"}"
+       "{\"comparison\":\"a \\u003E b\",\"and\":\"a \\u0026 b\"}"
        (json/encode
         {:comparison "a > b"  :and "a & b"}
         {:flags (bit-or JSON_HEX_AMP JSON_HEX_TAG)}))

--- a/tests/php/Integration/Compiler/Parser/ParserTest.php
+++ b/tests/php/Integration/Compiler/Parser/ParserTest.php
@@ -303,6 +303,11 @@ final class ParserTest extends TestCase
         );
 
         self::assertEquals(
+            new StringNode('"\u2007"', $this->loc(1, 0), $this->loc(1, 8), "\u{2007}"),
+            $this->parse('"\u2007"'),
+        );
+
+        self::assertEquals(
             new StringNode('"\77"', $this->loc(1, 0), $this->loc(1, 5), "\77"),
             $this->parse('"\77"'),
         );

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -505,6 +505,11 @@ final class ReaderTest extends TestCase
         );
 
         self::assertSame(
+            "\u{2007}",
+            $this->read('"\u2007"'),
+        );
+
+        self::assertSame(
             "\77",
             $this->read('"\77"'),
         );

--- a/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
+++ b/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
@@ -1,0 +1,20 @@
+--PHEL--
+(def x "\u2007")
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "x",
+  " ",
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/string-literal-unicode-escape.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/string-literal-unicode-escape.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 16
+    )
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Phel string literals currently preserve Clojure-style `\uNNNN` escape sequences as literal characters. Issue #1679 surfaced this with `"\u2007"`, which should read as the U+2007 figure space character instead of the six-character string `\u2007`.

Closes #1679

## 💡 Goal

Decode fixed-width Unicode escapes inside string literals while preserving the existing `\u{...}` string escape behavior.

## 🔖 Changes

- Add parser and reader coverage for `"\u2007"` string literals.
- Decode `\uNNNN` escapes in `StringParser` using the existing UTF-8 codepoint path.
- Add an integration fixture for emitted PHP containing the decoded Unicode character.
- Update `CHANGELOG.md` under `Unreleased`.
