### PR TITLE
fix: make sorted sets reversible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, and `##NaN` when dividing by zero (#1658)
 - `sort-by` accepts the comparator before the collection (#1657)
 - `nth` returns `nil` for `nil` collections (#1656)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -9,8 +9,6 @@
 (use Phel\Lang\Collections\LinkedList\PersistentListInterface)
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\Collections\Map\TransientMapInterface)
-(use Phel\Lang\Collections\SortedMap\PersistentSortedMap)
-(use Phel\Lang\Collections\SortedSet\PersistentSortedSet)
 (use Phel\Lang\Collections\Vector\PersistentVectorInterface)
 (use Phel\Lang\Collections\Vector\TransientVectorInterface)
 (use Phel\Lang\ConcatInterface)
@@ -635,8 +633,7 @@
    :see-also ["rseq" "reverse"]}
   [coll]
   (or (vector? coll)
-      (php/instanceof coll PersistentSortedMap)
-      (php/instanceof coll PersistentSortedSet)))
+      (sorted? coll)))
 
 (defn rseq
   "Returns, in constant time, a sequence of the items in `rev` in reverse

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -10,6 +10,7 @@
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\Collections\Map\TransientMapInterface)
 (use Phel\Lang\Collections\SortedMap\PersistentSortedMap)
+(use Phel\Lang\Collections\SortedSet\PersistentSortedSet)
 (use Phel\Lang\Collections\Vector\PersistentVectorInterface)
 (use Phel\Lang\Collections\Vector\TransientVectorInterface)
 (use Phel\Lang\ConcatInterface)
@@ -629,24 +630,25 @@
 
 (defn reversible?
   "Returns true if `coll` can be reverse-iterated in constant time.
-  Currently this is true for vectors and sorted-maps."
+  Currently this is true for vectors, sorted-maps, and sorted-sets."
   {:example "(reversible? [1 2 3]) ; => true"
    :see-also ["rseq" "reverse"]}
   [coll]
   (or (vector? coll)
-      (php/instanceof coll PersistentSortedMap)))
+      (php/instanceof coll PersistentSortedMap)
+      (php/instanceof coll PersistentSortedSet)))
 
 (defn rseq
   "Returns, in constant time, a sequence of the items in `rev` in reverse
-  order. `rev` must be reversible (a vector or sorted-map); otherwise an
-  exception is thrown. For sorted-maps, returns reversed `[key value]` pairs.
+  order. `rev` must be reversible (a vector, sorted-map, or sorted-set);
+  otherwise an exception is thrown. For sorted-maps, returns reversed `[key value]` pairs.
   Returns nil if `rev` is empty."
   {:example "(rseq [1 2 3]) ; => [3 2 1]"
    :see-also ["reversible?" "reverse"]}
   [rev]
   (when-not (reversible? rev)
     (throw (php/new InvalidArgumentException
-                    "rseq requires a reversible collection (vector or sorted-map)")))
+                    "rseq requires a reversible collection (vector, sorted-map, or sorted-set)")))
   (when (php/> (count rev) 0)
     (reverse (if (vector? rev) rev (vec rev)))))
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -246,6 +246,7 @@
   (is (true? (reversible? [])) "empty vector is reversible")
   (is (true? (reversible? [1 2 3])) "vector is reversible")
   (is (true? (reversible? (sorted-map :a 1 :b 2))) "sorted-map is reversible")
+  (is (true? (reversible? (sorted-set :a))) "sorted-set is reversible")
   (is (false? (reversible? '(1 2 3))) "list is not reversible")
   (is (false? (reversible? {:a 1})) "hash-map is not reversible")
   (is (false? (reversible? "abc")) "string is not reversible")
@@ -257,6 +258,8 @@
   (is (= [[:c 3] [:b 2] [:a 1]] (rseq (sorted-map :a 1 :b 2 :c 3)))
       "rseq: sorted-map returns reversed entries")
   (is (nil? (rseq (sorted-map))) "rseq: empty sorted-map returns nil")
+  (is (= [3 2 1] (rseq (sorted-set 1 2 3))) "rseq: sorted-set returns reversed values")
+  (is (nil? (rseq (sorted-set))) "rseq: empty sorted-set returns nil")
   (is (thrown? \InvalidArgumentException (rseq '(1 2 3))) "rseq: throws on list")
   (is (thrown? \InvalidArgumentException (rseq {:a 1})) "rseq: throws on hash-map"))
 


### PR DESCRIPTION
## 🤔 Background

Issue #1681 reports that `(reversible? (sorted-set :a))` returns `false` in Phel while Clojure returns `true`.

Closes #1681

## 💡 Goal

Make sorted sets participate in the existing reversible collection behavior for `reversible?` and `rseq`.

## 🔖 Changes

- Treat sorted collections as reversible through the existing `sorted?` predicate.
- Allow `rseq` to return sorted-set values in reverse sorted order.
- Add focused Phel regression coverage and a changelog entry.
- Add a final refactor commit to reuse the shared sorted-collection predicate.