### PR TITLE
fix: ignore nil map entries in conj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `conj` and `conj!` ignore `nil` entries on maps (#1683)
 - `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, and `##NaN` when dividing by zero (#1658)
 - `sort-by` accepts the comparator before the collection (#1657)

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -48,6 +48,9 @@
                      acc)
                    (php/-> acc (put key value))))]
     (cond
+      (php/=== entry nil)
+      coll
+
       (indexed? entry)
       (if (php/!= (count entry) 2)
         (throw (php/new InvalidArgumentException

--- a/src/phel/core/transients.phel
+++ b/src/phel/core/transients.phel
@@ -41,30 +41,29 @@
 
 (defn- conj-map-entry
   [coll entry]
-  (let [assign (fn [acc key value]
-                 (if (php/is_array acc)
-                   (do
-                     (php/aset acc key value)
-                     acc)
-                   (php/-> acc (put key value))))]
-    (cond
-      (php/=== entry nil)
-      coll
+  (if (php/=== entry nil)
+    coll
+    (let [assign (fn [acc key value]
+                   (if (php/is_array acc)
+                     (do
+                       (php/aset acc key value)
+                       acc)
+                     (php/-> acc (put key value))))]
+      (cond
+        (indexed? entry)
+        (if (php/!= (count entry) 2)
+          (throw (php/new InvalidArgumentException
+                          "conj on a map expects entries of length 2"))
+          (assign coll (first entry) (second entry)))
 
-      (indexed? entry)
-      (if (php/!= (count entry) 2)
+        (associative? entry)
+        (for [[key value] :pairs entry
+              :reduce [acc coll]]
+          (assign acc key value))
+
+        :else
         (throw (php/new InvalidArgumentException
-                        "conj on a map expects entries of length 2"))
-        (assign coll (first entry) (second entry)))
-
-      (associative? entry)
-      (for [[key value] :pairs entry
-            :reduce [acc coll]]
-        (assign acc key value))
-
-      :else
-      (throw (php/new InvalidArgumentException
-                      "conj on a map expects a [key value] pair or an associative collection")))))
+                        "conj on a map expects a [key value] pair or an associative collection"))))))
 
 (defn- conj-bang-single
   [tcoll value]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -111,7 +111,8 @@
 (deftest test-conj-transients
   (is (= [1 2 3] (persistent (conj (transient [1 2]) 3))) "conj on transient vector appends")
   (is (= #{1 2 3} (persistent (conj (transient #{1 2}) 3))) "conj on transient set adds element")
-  (is (= {:a 1} (persistent (conj (transient {}) [:a 1]))) "conj on transient map with [key value] pair"))
+  (is (= {:a 1} (persistent (conj (transient {}) [:a 1]))) "conj on transient map with [key value] pair")
+  (is (= {} (persistent (conj (transient {}) nil))) "conj on transient map with nil is a no-op"))
 
 (deftest test-transient-invocation
   (is (= 20 ((transient [10 20 30]) 1)) "transient vector is callable by index")
@@ -125,6 +126,7 @@
 
 (deftest test-conj-empty-collections
   (is (= {:a 1} (conj {} [:a 1])) "conj on empty map with [key value] pair")
+  (is (= {} (conj {} nil)) "conj on empty map with nil is a no-op")
   (is (= #{1} (conj #{} 1)) "conj on empty set adds element")
   (is (= [1 2 3] (conj [] 1 2 3)) "conj on empty vector with multiple values"))
 
@@ -159,7 +161,8 @@
 
 (deftest test-conj-bang-map
   (is (= {:a 1} (persistent (conj! (transient {}) [:a 1]))) "conj! on transient map with [key value] pair")
-  (is (= {:a 1 :b 2 :c 3} (persistent (conj! (transient {:a 1}) [:b 2] [:c 3]))) "conj! variadic on transient map"))
+  (is (= {:a 1 :b 2 :c 3} (persistent (conj! (transient {:a 1}) [:b 2] [:c 3]))) "conj! variadic on transient map")
+  (is (= {} (persistent (conj! (transient {}) nil))) "conj! on transient map with nil is a no-op"))
 
 (deftest test-conj-bang-error-on-persistent
   (is (thrown? \InvalidArgumentException (conj! [1 2] 3)) "conj! on persistent vector throws")


### PR DESCRIPTION
## 🤔 Background

`conj` and `conj!` currently throw when `nil` is added to a map target. Clojure treats that as a no-op, and issue #1683 reports the mismatch for empty persistent and transient maps.

Closes #1683

## 💡 Goal

Make `nil` map entries a no-op for both persistent `conj` and transient `conj!` map paths.

## 🔖 Changes

- Add focused Phel tests for `conj`, `conj` on transient maps, and `conj!` with `nil` map entries.
- Return the existing map target unchanged when the shared map-entry helper receives `nil`.
- Update `CHANGELOG.md` under Unreleased Core fixes.
- Refactor pass: make the nil no-op an explicit early return before map-entry assignment handling.

Focused local test: `./bin/phel test tests/phel/test/core/sequence-operation.phel`