### PR TITLE
test: cover bare stdClass in eval and repl

### DIFF
--- a/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
@@ -27,6 +27,18 @@ final class EvalCommandTest extends AbstractTestCommand
         );
     }
 
+    public function test_eval_resolves_bare_stdclass(): void
+    {
+        $this->expectOutputRegex('/Printer cannot print this type: .*stdClass/');
+
+        $exitCode = $this->createEvalCommand()->run(
+            $this->stubInput('(new stdClass)'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
     public function test_eval_empty_expression(): void
     {
         $exitCode = $this->createEvalCommand()->run(

--- a/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Repl;
+
+use Gacela\Framework\Gacela;
+use Phel\Command\Application\TextExceptionPrinter;
+use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Command\Domain\Exceptions\ExceptionArgsPrinter;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractor;
+use Phel\Command\Infrastructure\SourceMapExtractor;
+use Phel\Compiler\Application\Munge;
+use Phel\Printer\Printer;
+use Phel\Printer\PrinterInterface;
+use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Phel\Run\Infrastructure\Command\ReplCommand;
+use Phel\Run\RunFactory;
+use Phel\Shared\ColorStyle;
+use Phel\Shared\ColorStyleInterface;
+use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_keys;
+
+final class ReplBareStdClassTest extends AbstractTestCommand
+{
+    public function test_repl_resolves_bare_stdclass(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(
+            new InputLine('user:1> ', '(php/new stdClass)'),
+            new InputLine('user:2> ', '(new stdClass)'),
+            new InputLine('user:3> ', 'exit'),
+        );
+
+        $this->prepareRunFactory($io);
+
+        $exitCode = (new ReplCommand())->run(
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
+        );
+
+        self::assertSame(0, $exitCode);
+        self::assertCount(
+            2,
+            array_keys($io->getRawOutputs(), 'Printer cannot print this type: stdClass', strict: true),
+        );
+    }
+
+    private function createReplTestIo(): ReplTestIo
+    {
+        $exceptionPrinter = new TextExceptionPrinter(
+            new ExceptionArgsPrinter(Printer::readable()),
+            ColorStyle::noStyles(),
+            new Munge(),
+            new FilePositionExtractor(new SourceMapExtractor()),
+            $this->createStub(ErrorLogInterface::class),
+        );
+
+        return new ReplTestIo($exceptionPrinter);
+    }
+
+    private function prepareRunFactory(ReplCommandIoInterface $io): void
+    {
+        Gacela::overrideExistingResolvedClass(
+            RunFactory::class,
+            new class($io) extends RunFactory {
+                public function __construct(private readonly ReplCommandIoInterface $io) {}
+
+                public function createColorStyle(): ColorStyleInterface
+                {
+                    return ColorStyle::noStyles();
+                }
+
+                public function createPrinter(): PrinterInterface
+                {
+                    return Printer::nonReadable();
+                }
+
+                public function createReplCommandIo(): ReplCommandIoInterface
+                {
+                    return $this->io;
+                }
+            },
+        );
+    }
+}

--- a/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php
@@ -37,7 +37,7 @@ final class ReplBareStdClassTest extends AbstractTestCommand
 
         $this->prepareRunFactory($io);
 
-        $exitCode = (new ReplCommand())->run(
+        $exitCode = new ReplCommand()->run(
             $this->createStub(InputInterface::class),
             $this->createStub(OutputInterface::class),
         );


### PR DESCRIPTION
## 🤔 Background

Issue #1686 reported that `phel eval` and `phel repl` could not resolve bare `stdClass` class names without the old leading-backslash syntax.

## 💡 Goal

Closes #1686 by locking the eval and REPL command behavior with focused regression coverage for bare `stdClass` resolution.

## 🔖 Changes

- Adds eval command coverage for `(new stdClass)`.
- Adds REPL command coverage for `(php/new stdClass)` and `(new stdClass)`.
- Applies the final refactor/style pass in a separate Rector cleanup commit.
- Skips changelog because this branch only adds regression tests for behavior already present on `main`.

Focused local tests:

- `vendor/bin/phpunit tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php tests/php/Integration/Compiler/PhpNewRuntimeTest.php tests/php/Integration/Run/Command/Eval/EvalCommandTest.php tests/php/Integration/Run/Command/Repl/ReplBareStdClassTest.php`
- `./bin/phel eval '(php/new stdClass)'`
- `./bin/phel eval '(new stdClass)'`
