### PR TITLE
fix: reject unknown use imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 
 #### Compiler
 - Resolve PHP class aliases consistently regardless of case (#1567)
+- Reject unknown PHP symbols in `use` imports (#1688)
 - Imported PHP classes can be used as class-string values (#1560)
 - Lowercase root PHP classes resolve in constructor positions (#1567)
 - `php/new` reports invalid target types clearly (#1538)

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -11,8 +11,7 @@
   (:use Symfony.Component.Console.Output.BufferedOutput)
   (:use Symfony.Component.Console.Output.NullOutput)
   (:use Symfony.Component.Console.Output.OutputInterface)
-  (:use Symfony.Component.Console.Style.SymfonyStyle)
-  (:use Symfony.Component.EventDispatcher.EventDispatcher))
+  (:use Symfony.Component.Console.Style.SymfonyStyle))
 
 ;; =============================================================================
 ;; Mode & coercion tables
@@ -373,7 +372,7 @@
 ;; ---- Application --------------------------------------------------------
 
 (defn- build-dispatcher [spec]
-  (let [d      (php/new EventDispatcher)
+  (let [d      (php/new \Symfony\Component\EventDispatcher\EventDispatcher)
         before (get spec :before)
         after  (get spec :after)
         on-err (get spec :on-error)]

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/UseAliasRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/UseAliasRegistrar.php
@@ -11,11 +11,17 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
+use function class_exists;
 use function count;
+use function defined;
+use function enum_exists;
 use function explode;
+use function interface_exists;
+use function ltrim;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+use function trait_exists;
 
 final readonly class UseAliasRegistrar
 {
@@ -91,6 +97,8 @@ final readonly class UseAliasRegistrar
                 );
             }
 
+            $this->assertImportExists($useSymbol, $form);
+
             $alias = $this->createAliasFromSymbol($aliasValue, $useSymbol);
             $this->analyzer->addUseAlias($ns, $alias, $useSymbol);
         }
@@ -107,6 +115,24 @@ final readonly class UseAliasRegistrar
             $symbol->getNamespace(),
             str_replace('.', '\\', $name),
         )->copyLocationFrom($symbol);
+    }
+
+    private function assertImportExists(Symbol $symbol, PersistentListInterface $form): void
+    {
+        $name = $symbol->getName();
+        $lookupName = ltrim($name, '\\');
+
+        if (
+            class_exists($lookupName)
+            || interface_exists($lookupName)
+            || trait_exists($lookupName)
+            || enum_exists($lookupName)
+            || defined($name)
+        ) {
+            return;
+        }
+
+        throw AnalyzerException::withLocation(sprintf('Cannot import unknown PHP symbol %s.', $name), $form);
     }
 
     private function createAliasFromSymbol(?Symbol $alias, Symbol $symbol): Symbol

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/UseAliasRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/UseAliasRegistrar.php
@@ -120,19 +120,23 @@ final readonly class UseAliasRegistrar
     private function assertImportExists(Symbol $symbol, PersistentListInterface $form): void
     {
         $name = $symbol->getName();
-        $lookupName = ltrim($name, '\\');
 
-        if (
-            class_exists($lookupName)
-            || interface_exists($lookupName)
-            || trait_exists($lookupName)
-            || enum_exists($lookupName)
-            || defined($name)
-        ) {
+        if ($this->importExists($name)) {
             return;
         }
 
         throw AnalyzerException::withLocation(sprintf('Cannot import unknown PHP symbol %s.', $name), $form);
+    }
+
+    private function importExists(string $name): bool
+    {
+        $lookupName = ltrim($name, '\\');
+
+        return class_exists($lookupName)
+            || interface_exists($lookupName)
+            || trait_exists($lookupName)
+            || enum_exists($lookupName)
+            || defined($name);
     }
 
     private function createAliasFromSymbol(?Symbol $alias, Symbol $symbol): Symbol

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -1,6 +1,5 @@
 --PHEL--
-(ns test
-  (:use \Phel\Lang\Nil))
+(ns test)
 
 (loop [[x & xs] [1 2 3 4]
        sum 0]

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -1,7 +1,7 @@
 --PHEL--
 (ns hello-world
   (:require my-namespace\core)
-  (:use my_other-name\test))
+  (:use DateTimeImmutable))
 
 (def x :private 10)
 

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -535,7 +535,7 @@ final class NsSymbolTest extends TestCase
 
         $phpClassNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNode);
-        self::assertSame('\\Phel\\Lang\\Keyword', $phpClassNode->getName()->getName());
+        self::assertSame('\\' . Keyword::class, $phpClassNode->getName()->getName());
     }
 
     public function test_mixed_separators_are_normalized(): void
@@ -751,11 +751,11 @@ final class NsSymbolTest extends TestCase
 
         $libraryNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $libraryNode);
-        self::assertSame('\\Phel\\Lang\\Keyword', $libraryNode->getName()->getName());
+        self::assertSame('\\' . Keyword::class, $libraryNode->getName()->getName());
 
         $toolkitNode = $this->globalEnv->resolve(Symbol::create('Symbol'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $toolkitNode);
-        self::assertSame('\\Phel\\Lang\\Symbol', $toolkitNode->getName()->getName());
+        self::assertSame('\\' . Symbol::class, $toolkitNode->getName()->getName());
     }
 
     public function test_dot_separator_in_use_with_explicit_as_alias(): void
@@ -777,7 +777,7 @@ final class NsSymbolTest extends TestCase
 
         $kitNode = $this->globalEnv->resolve(Symbol::create('Kit'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $kitNode);
-        self::assertSame('\\Phel\\Lang\\Symbol', $kitNode->getName()->getName());
+        self::assertSame('\\' . Symbol::class, $kitNode->getName()->getName());
     }
 
     public function test_clojure_namespace_remapped_to_phel_in_require(): void
@@ -1090,8 +1090,8 @@ final class NsSymbolTest extends TestCase
             Symbol::create('my\\project'),
             Phel::list([
                 Keyword::create('use'),
-                Symbol::create('Phel\\Lang\\Keyword'),
-                Symbol::create('Phel\\Lang\\Symbol'),
+                Symbol::create('\\' . Keyword::class),
+                Symbol::create('\\' . Symbol::class),
                 Keyword::create('as'),
                 Symbol::create('Kit'),
             ]),
@@ -1126,11 +1126,11 @@ final class NsSymbolTest extends TestCase
 
         $phpClassNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNode);
-        self::assertSame('\\Phel\\Lang\\Keyword', $phpClassNode->getName()->getName());
+        self::assertSame('\\' . Keyword::class, $phpClassNode->getName()->getName());
 
         $phpClassNodeAlias = $this->globalEnv->resolve(Symbol::create('Kit'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNodeAlias);
-        self::assertSame('\\Phel\\Lang\\Symbol', $phpClassNodeAlias->getName()->getName());
+        self::assertSame('\\' . Symbol::class, $phpClassNodeAlias->getName()->getName());
 
         Phel::addDefinition('vendor\\package', 'foo', 'value', Phel::map());
         $globalVarNode = $this->globalEnv->resolve(Symbol::create('foo'), NodeEnvironment::empty());
@@ -1192,14 +1192,14 @@ final class NsSymbolTest extends TestCase
             $this->locatedSymbol('my.project', '/app/user.phel'),
             Phel::list([
                 Keyword::create('use'),
-                $this->locatedSymbol('Phel\\Lang\\Keyword', '/app/user.phel'),
+                $this->locatedSymbol('\\' . Keyword::class, '/app/user.phel'),
             ]),
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
         $useWarnings = array_values(array_filter(
             $captured,
-            static fn(string $m): bool => str_contains($m, "'Phel\\Lang\\Keyword'"),
+            static fn(string $m): bool => str_contains($m, "'\\Phel\\Lang\\Keyword'"),
         ));
 
         self::assertCount(1, $useWarnings, 'exactly one warning for the backslash use symbol');

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -143,6 +143,23 @@ final class NsSymbolTest extends TestCase
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
     }
 
+    public function test_use_import_must_exist(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Cannot import unknown PHP symbol \\Missing\\NsUseClass.');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('foo\\bar'),
+            Phel::list([
+                Keyword::create('use'),
+                Symbol::create('Missing\\NsUseClass'),
+            ]),
+        ]);
+
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
     public function test_use_alias_must_be_symbol(): void
     {
         $this->expectException(AnalyzerException::class);
@@ -508,17 +525,17 @@ final class NsSymbolTest extends TestCase
             Symbol::create('app.core'),
             Phel::list([
                 Keyword::create('use'),
-                Symbol::create('Vendor.Library'),
+                Symbol::create('Phel.Lang.Keyword'),
             ]),
         ]);
 
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Library')));
+        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Keyword')));
 
-        $phpClassNode = $this->globalEnv->resolve(Symbol::create('Library'), NodeEnvironment::empty());
+        $phpClassNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNode);
-        self::assertSame('\\Vendor\\Library', $phpClassNode->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Keyword', $phpClassNode->getName()->getName());
     }
 
     public function test_mixed_separators_are_normalized(): void
@@ -722,23 +739,23 @@ final class NsSymbolTest extends TestCase
             Symbol::create('app.core'),
             Phel::list([
                 Keyword::create('use'),
-                Symbol::create('Vendor.Library'),
-                Symbol::create('Vendor.Toolkit'),
+                Symbol::create('Phel.Lang.Keyword'),
+                Symbol::create('Phel.Lang.Symbol'),
             ]),
         ]);
 
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
-        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Library')));
-        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Toolkit')));
+        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Keyword')));
+        self::assertTrue($this->globalEnv->hasUseAlias('app\\core', Symbol::create('Symbol')));
 
-        $libraryNode = $this->globalEnv->resolve(Symbol::create('Library'), NodeEnvironment::empty());
+        $libraryNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $libraryNode);
-        self::assertSame('\\Vendor\\Library', $libraryNode->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Keyword', $libraryNode->getName()->getName());
 
-        $toolkitNode = $this->globalEnv->resolve(Symbol::create('Toolkit'), NodeEnvironment::empty());
+        $toolkitNode = $this->globalEnv->resolve(Symbol::create('Symbol'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $toolkitNode);
-        self::assertSame('\\Vendor\\Toolkit', $toolkitNode->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Symbol', $toolkitNode->getName()->getName());
     }
 
     public function test_dot_separator_in_use_with_explicit_as_alias(): void
@@ -748,7 +765,7 @@ final class NsSymbolTest extends TestCase
             Symbol::create('app.core'),
             Phel::list([
                 Keyword::create('use'),
-                Symbol::create('Vendor.Toolkit'),
+                Symbol::create('Phel.Lang.Symbol'),
                 Keyword::create('as'),
                 Symbol::create('Kit'),
             ]),
@@ -760,7 +777,7 @@ final class NsSymbolTest extends TestCase
 
         $kitNode = $this->globalEnv->resolve(Symbol::create('Kit'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $kitNode);
-        self::assertSame('\\Vendor\\Toolkit', $kitNode->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Symbol', $kitNode->getName()->getName());
     }
 
     public function test_clojure_namespace_remapped_to_phel_in_require(): void
@@ -1073,8 +1090,8 @@ final class NsSymbolTest extends TestCase
             Symbol::create('my\\project'),
             Phel::list([
                 Keyword::create('use'),
-                Symbol::create('Vendor\\Library'),
-                Symbol::create('Vendor\\Toolkit'),
+                Symbol::create('Phel\\Lang\\Keyword'),
+                Symbol::create('Phel\\Lang\\Symbol'),
                 Keyword::create('as'),
                 Symbol::create('Kit'),
             ]),
@@ -1102,18 +1119,18 @@ final class NsSymbolTest extends TestCase
         ], $nsNode->getRequireNs());
         self::assertSame(['src/config.phel'], $nsNode->getRequireFiles());
         self::assertSame('my\\project', $this->analyzer->getNamespace());
-        self::assertTrue($this->globalEnv->hasUseAlias('my\\project', Symbol::create('Library')));
+        self::assertTrue($this->globalEnv->hasUseAlias('my\\project', Symbol::create('Keyword')));
         self::assertTrue($this->globalEnv->hasUseAlias('my\\project', Symbol::create('Kit')));
         self::assertTrue($this->globalEnv->hasRequireAlias('my\\project', Symbol::create('package')));
         self::assertSame('vendor\\package', $this->globalEnv->resolveAlias('package'));
 
-        $phpClassNode = $this->globalEnv->resolve(Symbol::create('Library'), NodeEnvironment::empty());
+        $phpClassNode = $this->globalEnv->resolve(Symbol::create('Keyword'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNode);
-        self::assertSame('\\Vendor\\Library', $phpClassNode->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Keyword', $phpClassNode->getName()->getName());
 
         $phpClassNodeAlias = $this->globalEnv->resolve(Symbol::create('Kit'), NodeEnvironment::empty());
         self::assertInstanceOf(PhpClassNameNode::class, $phpClassNodeAlias);
-        self::assertSame('\\Vendor\\Toolkit', $phpClassNodeAlias->getName()->getName());
+        self::assertSame('\\Phel\\Lang\\Symbol', $phpClassNodeAlias->getName()->getName());
 
         Phel::addDefinition('vendor\\package', 'foo', 'value', Phel::map());
         $globalVarNode = $this->globalEnv->resolve(Symbol::create('foo'), NodeEnvironment::empty());
@@ -1175,18 +1192,18 @@ final class NsSymbolTest extends TestCase
             $this->locatedSymbol('my.project', '/app/user.phel'),
             Phel::list([
                 Keyword::create('use'),
-                $this->locatedSymbol('Phel\\Lang\\Foo', '/app/user.phel'),
+                $this->locatedSymbol('Phel\\Lang\\Keyword', '/app/user.phel'),
             ]),
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
 
         $useWarnings = array_values(array_filter(
             $captured,
-            static fn(string $m): bool => str_contains($m, "'Phel\\Lang\\Foo'"),
+            static fn(string $m): bool => str_contains($m, "'Phel\\Lang\\Keyword'"),
         ));
 
         self::assertCount(1, $useWarnings, 'exactly one warning for the backslash use symbol');
-        self::assertStringContainsString("'Phel.Lang.Foo'", $useWarnings[0]);
+        self::assertStringContainsString("'Phel.Lang.Keyword'", $useWarnings[0]);
 
         BackslashSeparatorDeprecator::resetInstance();
     }
@@ -1201,7 +1218,7 @@ final class NsSymbolTest extends TestCase
             $this->locatedSymbol('my.project', '/app/user.phel'),
             Phel::list([
                 Keyword::create('use'),
-                $this->locatedSymbol('Phel.Lang.Foo', '/app/user.phel'),
+                $this->locatedSymbol('Phel.Lang.Keyword', '/app/user.phel'),
             ]),
         ]);
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/UseSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/UseSymbolTest.php
@@ -99,6 +99,19 @@ final class UseSymbolTest extends TestCase
         $this->analyze($list);
     }
 
+    public function test_rejects_unknown_import(): void
+    {
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('Cannot import unknown PHP symbol \\Missing\\UseClass.');
+
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_USE),
+            Symbol::create('Missing\\UseClass'),
+        ]);
+
+        $this->analyze($list);
+    }
+
     public function test_preserves_source_location(): void
     {
         $list = Phel::list([


### PR DESCRIPTION
## 🤔 Background

`use` currently registers PHP import aliases without checking whether the target exists. In the REPL, `(use nonsense)` succeeds and later references fail with lower-level parse/runtime errors.

## 💡 Goal

Fail during `use` analysis when a PHP class, interface, trait, enum, or constant import cannot be resolved. Closes #1688.

## 🔖 Changes

- Validate `use` and `(:use ...)` imports before registering aliases.
- Preserve valid PHP class and constant imports, including dot/backslash normalization.
- Add focused analyzer tests for unknown imports.
- Update the namespace fixture placeholder import to a real PHP class.
- Add an Unreleased changelog entry.
- Refactor pass completed; no separate cleanup diff was justified.