### PR TITLE
feat: Improve default test reporter output

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -485,29 +485,29 @@
   (let [{:exception exception :form form} data
         command-facade                    (php/new CommandFacade)
         printer                           (php/-> command-facade (getExceptionPrinter))]
-    (println "            Assert:" (readable-str form))
+    (println "              Form:" (readable-str form))
     (println "             threw:" (php/get_class exception))
     (when-let [exception-message (ex-message exception)]
       (println "      with message:" exception-message))
     (php/-> printer (printStackTrace exception))))
 
 (defn- print-predicate-failure [{:pred pred :value value :result result}]
-  (println "               Assert:" (readable-str value))
+  (println "                 Form:" (readable-str value))
   (println "         evaluated to:" (readable-str result))
   (println "  but doesn't satisfy:" (readable-str pred)))
 
 (defn- print-predicate-not-failure [{:pred pred :value value :result result}]
-  (println "            Assert:" (readable-str value))
+  (println "              Form:" (readable-str value))
   (println "      evaluated to:" (readable-str result))
   (println "  but does satisfy:" (readable-str pred) " (it shouldn't)"))
 
 (defn- print-binary-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "        Assert:" (readable-str actual))
+  (println "          Form:" (readable-str actual))
   (println "  evaluated to:" (readable-str result))
   (println "    but is not:" (readable-str pred) "to" (readable-str expected)))
 
 (defn- print-binary-not-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "        Assert:" (readable-str actual))
+  (println "          Form:" (readable-str actual))
   (println "  evaluated to:" (readable-str result))
   (println "        but is:" (readable-str pred) "to" (readable-str expected) "(it shouldn't be)"))
 
@@ -527,7 +527,7 @@
       (println "       but got:" actual-message))))
 
 (defn- print-any-failure [{:form form :result result}]
-  (println "        Assert:" (readable-str form))
+  (println "          Form:" (readable-str form))
   (println "  evaluated to:" (readable-str result) "(which is not truthy)"))
 
 (defn- print-failure [data]

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -461,19 +461,19 @@
 ;; Built-in reporters
 ;; ---------------------
 
-(defn- print-headline [prefix {:message message :location location}]
+(defn- print-headline [prefix {:test-name test-name :message message :location location}]
   (print prefix)
   (when message
-    (print (str " in '" message "'")))
+    (print (str " in (" test-name " '" message "')")))
   (when location
-    (print (str " (" (php/realpath (get location :file)) ":" (get location :line) ")")))
+    (print (str " (" (php/basename (get location :file)) ":" (get location :line) ")")))
   (println))
 
 (defn- print-failure-headline [data]
-  (print-headline "Failure" data))
+  (print-headline "FAIL" data))
 
 (defn- print-error-headline [data]
-  (print-headline "Error" data))
+  (print-headline "ERROR" data))
 
 (def- readable-printer (php/:: Printer (readable)))
 
@@ -485,28 +485,29 @@
   (let [{:exception exception :form form} data
         command-facade                    (php/new CommandFacade)
         printer                           (php/-> command-facade (getExceptionPrinter))]
-    (println "              Test:" (readable-str form))
-    (println "   threw exception:" (php/get_class exception))
-    (println)
+    (println "            Assert:" (readable-str form))
+    (println "             threw:" (php/get_class exception))
+    (when-let [exception-message (ex-message exception)]
+      (println "      with message:" exception-message))
     (php/-> printer (printStackTrace exception))))
 
 (defn- print-predicate-failure [{:pred pred :value value :result result}]
-  (println "                 Test:" (readable-str value))
+  (println "               Assert:" (readable-str value))
   (println "         evaluated to:" (readable-str result))
   (println "  but doesn't satisfy:" (readable-str pred)))
 
 (defn- print-predicate-not-failure [{:pred pred :value value :result result}]
-  (println "              Test:" (readable-str value))
+  (println "            Assert:" (readable-str value))
   (println "      evaluated to:" (readable-str result))
   (println "  but does satisfy:" (readable-str pred) " (it shouldn't)"))
 
 (defn- print-binary-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "          Test:" (readable-str actual))
+  (println "        Assert:" (readable-str actual))
   (println "  evaluated to:" (readable-str result))
   (println "    but is not:" (readable-str pred) "to" (readable-str expected)))
 
 (defn- print-binary-not-failure [{:pred pred :expected expected :actual actual :result result}]
-  (println "          Test:" (readable-str actual))
+  (println "        Assert:" (readable-str actual))
   (println "  evaluated to:" (readable-str result))
   (println "        but is:" (readable-str pred) "to" (readable-str expected) "(it shouldn't be)"))
 
@@ -526,7 +527,7 @@
       (println "       but got:" actual-message))))
 
 (defn- print-any-failure [{:form form :result result}]
-  (println "          Test:" (readable-str form))
+  (println "        Assert:" (readable-str form))
   (println "  evaluated to:" (readable-str result) "(which is not truthy)"))
 
 (defn- print-failure [data]

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -118,8 +118,8 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
         }
 
         $output = $io->getOutputString() . $stdout;
-        self::assertStringContainsString('Test: ""', $output);
-        self::assertStringNotContainsString('Test: ' . PHP_EOL, $output);
+        self::assertStringContainsString('Assert: ""', $output);
+        self::assertStringNotContainsString('Assert: ' . PHP_EOL, $output);
     }
 
     private function createReplTestIo(): ReplTestIo

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -118,8 +118,8 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
         }
 
         $output = $io->getOutputString() . $stdout;
-        self::assertStringContainsString('Assert: ""', $output);
-        self::assertStringNotContainsString('Assert: ' . PHP_EOL, $output);
+        self::assertStringContainsString('Form: ""', $output);
+        self::assertStringNotContainsString('Form: ' . PHP_EOL, $output);
     }
 
     private function createReplTestIo(): ReplTestIo


### PR DESCRIPTION
## 🤔 Background

Default test report is not as informative as it could be.

## 💡 Goal

Adds missing information and applies minor formatting to make test reports more convenient.

## 🔖 Changes

- Include the test name
- Upper case headline prefix
- Rename "Test:" to ~~"Assert:"~~ "Form:" for clarity
- Rename "threw exception:" to "threw:"
- Show test file basename instead of absolute path (absolute path is too verbose)
- Show exception's message in addition to it's class if it's set

Modified formatting loosely follows default Clojure test runner.

## Preview
### Old format:
```
~~~~~~~~~~
Failure in 'special symbols' (/home/user/clojure-test-suite/test/clojure/core_test/special_symbol_qmark.cljc:5)
                 Test: (quote var)
         evaluated to: var
  but doesn't satisfy: special-symbol?
~~~~~~~~~~
Error in 'records' (/home/user/clojure-test-suite/test/clojure/core_test/dissoc.cljc:5)
              Test: (= {:b 2, :c nil} (apply dissoc r [:a]))
   threw exception: Error
~~~~~~~~~~
Failure in 'metadata' (/home/user/clojure-test-suite/test/clojure/core_test/atom.cljc:6)
          Test: (meta (atom nil :meta (sorted-map :a "a")))
  evaluated to: nil
    but is not: = to {:a "a"}
~~~~~~~~~~
```
### New format:
```
~~~~~~~~~~
FAIL in (test-special-symbol? 'special symbols') (special_symbol_qmark.cljc:5)
                 Form: (quote var)
         evaluated to: var
  but doesn't satisfy: special-symbol?
~~~~~~~~~~
ERROR in (test-dissoc 'records') (dissoc.cljc:5)
              Form: (= {:b 2, :c nil} (apply dissoc r [:a]))
             threw: Error
      with message: Cannot use object of type Phel\Lang\AbstractFn@anonymous as array
~~~~~~~~~~
FAIL in (test-atom 'metadata') (atom.cljc:6)
          Form: (meta (atom nil :meta (sorted-map :a "a")))
  evaluated to: nil
    but is not: = to {:a "a"}
~~~~~~~~~~
```