### PR TITLE
feat(repl): accept vector syntax in `require` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Compare numeric values consistently in `==` (#1561)
 - Support `[size init-val-or-seq]` in primitive array helpers (#1562)
 
+#### REPL
+- `require` accepts vector syntax: `(require '[phel\string :as s])` (#1693)
+
 ### Changed
 
 - **BREAKING**: Require PHP 8.4

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -131,14 +131,19 @@
     namespace))
 
 (defmacro require
-  "Requires a Phel module into the environment."
-  {:example "(require 'phel\\http :as http :refer [request]) ; => phel\\http"}
+  "Requires a Phel module into the environment.
+  Accepts either flat or vector syntax:
+    (require 'phel\\http :as http :refer [request])
+    (require '[phel\\http :as http :refer [request]])"
+  {:example "(require '[phel\\http :as http :refer [request]]) ; => phel\\http"}
   [sym & args]
   (let [sym     (unquote-sym sym)
-        options (apply hash-map args)
-        alias   (extract-alias sym options)
+        vec?    (vector? sym)
+        ns-sym  (if vec? (first sym) sym)
+        options (if vec? (apply hash-map (rest sym)) (apply hash-map args))
+        alias   (extract-alias ns-sym options)
         refers  (or (:refer options) [])]
-    `(require-namespace '~sym '~alias '~refers)))
+    `(require-namespace '~ns-sym '~alias '~refers)))
 
 (defn- use-namespace
   [namespace alias]

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -254,6 +254,20 @@
                           (string/upper-case \"hello\")")]
     (is (= "HELLO" result) "runtime require resolves symbols without explicit src-dirs init")))
 
+(deftest test-eval-str-require-vector-with-alias
+  (let [result (eval-str "(ns test-rt-require-vec-alias
+                            (:require phel\\repl :refer [require]))
+                          (require '[phel\\string :as s])
+                          (s/upper-case \"hello\")")]
+    (is (= "HELLO" result) "require with vector syntax and :as alias works")))
+
+(deftest test-eval-str-require-vector-bare
+  (let [result (eval-str "(ns test-rt-require-vec-bare
+                            (:require phel\\repl :refer [require]))
+                          (require '[phel\\string])
+                          (string/upper-case \"hello\")")]
+    (is (= "HELLO" result) "require with vector syntax and no alias auto-generates alias")))
+
 (deftest test-eval-str-require-nonexistent-throws
   (let [result (eval-capturing "(ns test-rt-require-missing
                                   (:require phel\\repl :refer [require]))

--- a/tests/php/Integration/Run/Command/Repl/FixturesWithCoreLib/require-vector-syntax.test
+++ b/tests/php/Integration/Run/Command/Repl/FixturesWithCoreLib/require-vector-syntax.test
@@ -1,0 +1,4 @@
+user:1> (require '[phel\html :as h])
+phel\html
+user:2> (h/html [:div])
+<div></div>


### PR DESCRIPTION
## 🤔 Background

The REPL `require` macro only accepted flat syntax (`(require 'phel\string :as s)`), which diverges from how `ns` forms declare requirements using vector syntax.

## 💡 Goal

Support the vector form `(require '[phel\string :as s])` so REPL sessions align with `ns`-form syntax.

## 🔖 Changes

- `require` macro detects when its argument is a quoted vector and parses the namespace and options from it
- Both flat and vector forms continue to work
- New Phel tests and a REPL integration fixture cover the vector syntax

Closes #1693