### PR TITLE
docs(skills): gh-issue must merge PR via admin bypass after CI green

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -75,7 +75,7 @@ disable-model-invocation: true
    Related to #<issue-number>"
    ```
 
-10. **Final refactor pass (mandatory before PR)**:
+10. **Final refactor commit (mandatory, last commit before PR)**:
     Re-review every file touched by this change. Look for:
     - duplication introduced by the new code (extract or reuse)
     - dead branches, unused params, leftover debug
@@ -83,25 +83,48 @@ disable-model-invocation: true
     - violations of `.claude/rules/php.md`, `modules.md`, `compiler.md`
     - over-engineering: speculative abstractions, premature interfaces
 
-    Apply fixes. Re-run `composer test`. Commit as a separate refactor commit:
+    Apply fixes. Re-run `composer test`. Commit as a separate `ref(...)` commit — must be the final commit on the branch before PR:
     ```bash
     git commit -m "ref(<scope>): polish <area> after #<issue-number>
 
     Related to #<issue-number>"
     ```
-    Skip this commit only if the review surfaces zero changes.
+    If review surfaces zero changes, record that fact in the PR body instead of skipping silently.
 
 11. **Create PR** using `/pr #<issue-number>`
+
+### Phase 5: Verify & Merge
+
+12. **Wait for CI green** on the PR:
+    ```bash
+    gh pr checks <pr-number-or-branch> --watch
+    ```
+    Fix red checks on the branch (push fixes; re-watch). Do not proceed while any required check is failing.
+
+13. **Merge with mandatory approval bypass when possible**:
+    Once every required check is green, merge via admin bypass to satisfy the mandatory-approval rule:
+    ```bash
+    gh pr merge <pr-number> --squash --admin --delete-branch
+    ```
+    If `--admin` is rejected (token lacks admin, branch protection blocks bypass), fall back to `--auto --squash --delete-branch` and surface that the PR is awaiting human approval. Never `--no-verify` past a failing required check.
+
+14. **Sync local main** after merge:
+    ```bash
+    git checkout main && git fetch origin main && git reset --hard origin/main
+    ```
 
 ## Checklist
 - [ ] Issue fetched and understood
 - [ ] Self-assigned
-- [ ] Branch created from main
+- [ ] Branch created from fresh `origin/main`
 - [ ] Plan created and approved
 - [ ] Tests written first (TDD)
 - [ ] Implementation complete
 - [ ] `composer test` passes
 - [ ] Changelog updated
-- [ ] Commit with issue reference
-- [ ] Final refactor pass over all touched files (separate commit)
+- [ ] Feature commit with issue reference
+- [ ] Final refactor commit (last commit on branch, separate `ref(...)`)
 - [ ] PR created via `/pr`
+- [ ] CI green (`gh pr checks --watch`)
+- [ ] PR merged via `--admin --squash` (or `--auto` fallback if admin blocked)
+- [ ] Local `main` synced to `origin/main`

--- a/.codex/skills/gh-issue/SKILL.md
+++ b/.codex/skills/gh-issue/SKILL.md
@@ -46,12 +46,12 @@ Use repository instructions as the authority for local practice. In the Phel rep
    - implement the minimum correct behavior
    - keep tests green as scope expands
 7. Commit by context as work lands. Use precise staged files, not blanket `git add .`, unless the status is fully understood.
-8. After the issue plan is complete, perform one explicit refactor pass over only the branch changes. Commit that pass separately when it produces a real diff. If no refactor is justified, mention that in the PR body or final summary instead of creating a ceremonial commit.
+8. After the issue plan is complete, perform one explicit refactor pass over only the branch changes. Commit that pass separately as the **last commit on the branch** when it produces a real diff. If no refactor is justified, record that in the PR body instead of creating a ceremonial commit.
 9. Run the repository quality gate. For Phel, prefer `composer test`; use narrower tests first while iterating.
 10. Update changelog only for user-facing changes, following repository policy.
 11. Open a PR with `gh pr create`, following the repository PR template exactly when present.
-12. Watch CI with `gh pr checks --watch`. Fix failures until all required checks are green.
-13. Merge the PR when CI is green and policy allows it. Update local `main` with `git switch main && git pull --ff-only --prune`.
+12. Watch CI with `gh pr checks --watch`. Fix failures on the branch until every required check is green.
+13. Merge once CI is green. Prefer admin bypass to satisfy mandatory-approval rules: `gh pr merge <num> --squash --admin --delete-branch`. If `--admin` is rejected by branch protection or token scope, fall back to `gh pr merge <num> --auto --squash --delete-branch` and surface that the PR is awaiting human approval. Then sync `main` with `git switch main && git pull --ff-only --prune`.
 
 ## Branch and Commit Rules
 


### PR DESCRIPTION
## 🤔 Background

The `/gh-issue` skill (Claude variant) ended at "Create PR via /pr". CI watching and merge logic only lived in `/gh-issues` (plural batch driver) and the codex variant. A single-issue run therefore left every PR open, waiting for a manual merge step.

## 💡 Goal

Make `/gh-issue` own the full lifecycle: implement, refactor, ship, watch CI, merge. Mandatory approval rules satisfied via `--admin` bypass when permitted, with `--auto` as a non-bypassable fallback.

## 🔖 Changes

- `.claude/skills/gh-issue/SKILL.md`:
  - New Phase 5 (Verify & Merge) covering `gh pr checks --watch`, `gh pr merge --squash --admin --delete-branch`, fallback to `--auto`, and `main` sync.
  - Refactor commit explicitly mandated as the **last** commit on the branch (no slipping fixup commits after it).
  - Checklist extended with CI-green and merge entries.
- `.codex/skills/gh-issue/SKILL.md`:
  - Step 8 reworded so the refactor commit is the last commit on the branch.
  - Step 13 spelled out: prefer `--admin --squash`; fall back to `--auto --squash` when branch protection blocks bypass; sync `main` after merge.

No code changes. No changelog entry (skill docs are not user-facing).