### PR TITLE
feat(core): namespace introspection in phel\core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Add `into-array` for `.cljc` interop (#1550)
 - Compare numeric values consistently in `==` (#1561)
 - Support `[size init-val-or-seq]` in primitive array helpers (#1562)
+- Add namespace introspection: `loaded-namespaces`, `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `load-file` (#1694)
 
 ### Changed
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -240,3 +240,6 @@
 (load "core/loops")
 (load "core/futures")
 (load "core/async")
+
+;; Namespace introspection and manipulation
+(load "core/ns")

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -1,0 +1,132 @@
+(in-ns phel.core)
+
+(use Phel)
+(use Phel\Compiler\Application\Munge)
+(use Phel\Compiler\CompilerFacade)
+(use Phel\Compiler\Infrastructure\CompileOptions)
+(use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton)
+(use Phel\Lang\Symbol)
+
+;; --- Namespace introspection and manipulation ---
+
+(defn loaded-namespaces
+  "Returns all namespaces currently loaded."
+  {:example "(loaded-namespaces) ; => [\"phel\\core\" \"phel\\repl\"]"}
+  []
+  (php/:: Phel (getNamespaces)))
+
+(defn- core-munge-ns
+  "Encodes a namespace string for registry lookup."
+  [ns-str]
+  (let [munge (php/new Munge)]
+    (php/-> munge (encodeNs ns-str))))
+
+(defn find-ns
+  "Returns the namespace name if it is loaded, or nil if no namespace of
+  that name exists."
+  {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
+   :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
+  [ns-str]
+  (when (php/:: Phel (hasNamespace (core-munge-ns ns-str)))
+    ns-str))
+
+(defn create-ns
+  "Creates the given namespace if it does not already exist. Returns the
+  namespace name. Existing namespaces are left untouched."
+  {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
+   :see-also ["find-ns" "remove-ns" "intern"]}
+  [ns-str]
+  (php/:: Phel (registerNamespace (core-munge-ns ns-str)))
+  ns-str)
+
+(defn remove-ns
+  "Removes the namespace and all of its definitions from the registry.
+  Use with caution. Returns nil."
+  {:example "(remove-ns \"my-app\\tmp\")"
+   :see-also ["find-ns" "create-ns"]}
+  [ns-str]
+  (php/:: Phel (removeNamespace (core-munge-ns ns-str)))
+  nil)
+
+(defn intern
+  "Finds or creates a definition named by name-str in namespace ns-str,
+  setting its root value to val when supplied (defaults to nil). The
+  namespace is auto-registered by the underlying `addDefinition` call.
+  Returns the fully qualified symbol naming the definition."
+  {:example "(intern \"user\" \"x\" 42) ; => user/x"
+   :see-also ["find-ns" "create-ns" "ns-interns"]}
+  [ns-str name-str & rest]
+  (let [encoded-ns   (core-munge-ns ns-str)
+        encoded-name (php/-> (php/new Munge) (encode name-str))
+        value        (first rest)]
+    (php/:: Phel (addDefinition encoded-ns encoded-name value))
+    (php/:: Symbol (createForNamespace ns-str name-str))))
+
+(defn ns-interns
+  "Returns a hash-map of {name => value} for every definition in the
+  given namespace, including private ones. Returns an empty map if the
+  namespace has no definitions."
+  {:example "(ns-interns \"phel\\core\")"
+   :see-also ["ns-publics" "intern" "find-ns"]}
+  [ns-str]
+  (let [defs   (php/:: Phel (getDefinitionInNamespace (core-munge-ns ns-str)))
+        munge  (php/new Munge)
+        result (transient {})]
+    (foreach [fn-name value defs]
+      (assoc! result (php/-> munge (decodeNs fn-name)) value))
+    (persistent result)))
+
+(defn ns-publics
+  "Returns a hash-map of {name => value} for all public definitions in the
+  given namespace string. Private definitions are excluded."
+  {:example "(ns-publics \"phel\\core\") ; => {\"map\" <fn> \"filter\" <fn> ...}"
+   :see-also ["ns-aliases" "ns-refers" "loaded-namespaces"]}
+  [ns-str]
+  (let [encoded (core-munge-ns ns-str)
+        defs    (php/:: Phel (getDefinitionInNamespace encoded))
+        munge   (php/new Munge)
+        result  (transient {})]
+    (foreach [fn-name value defs]
+      (let [meta (php/:: Phel (getDefinitionMetaData encoded fn-name))]
+        (when-not (get meta :private)
+          (assoc! result (php/-> munge (decodeNs fn-name)) value))))
+    (persistent result)))
+
+(defn ns-aliases
+  "Returns a hash-map of {alias => namespace} for all require aliases in the
+  given namespace string."
+  {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel\\repl\" ...}"
+   :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
+  [ns-str]
+  (let [env     (php/:: GlobalEnvironmentSingleton (getInstance))
+        aliases (php/-> env (getRequireAliases ns-str))
+        result  (transient {})]
+    (foreach [alias-name target-sym aliases]
+      (assoc! result alias-name (php/-> target-sym (getName))))
+    (persistent result)))
+
+(defn ns-refers
+  "Returns a hash-map of {name => source-namespace} for all referred symbols
+  in the given namespace string."
+  {:example "(ns-refers *ns*) ; => {\"doc\" \"phel\\repl\" ...}"
+   :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
+  [ns-str]
+  (let [env    (php/:: GlobalEnvironmentSingleton (getInstance))
+        refers (php/-> env (getRefers ns-str))
+        result (transient {})]
+    (foreach [refer-name source-sym refers]
+      (assoc! result refer-name (php/-> source-sym (getName))))
+    (persistent result)))
+
+(defn load-file
+  "Loads and evaluates a Phel source file. Reads the file content and
+  evaluates it using the compiler. Returns the result of the last
+  expression, or nil if the file cannot be read."
+  {:example "(load-file \"src/my-module.phel\")"
+   :see-also ["loaded-namespaces"]}
+  [path]
+  (let [content (php/file_get_contents path)]
+    (when content
+      (let [cf   (php/new CompilerFacade)
+            opts (php/-> (php/new CompileOptions) (setSource path))]
+        (php/-> cf (eval content opts))))))

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -55,11 +55,10 @@
   Returns the fully qualified symbol naming the definition."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
-  [ns-str name-str & rest]
+  [ns-str name-str & [val]]
   (let [encoded-ns   (core-munge-ns ns-str)
-        encoded-name (php/-> (php/new Munge) (encode name-str))
-        value        (first rest)]
-    (php/:: Phel (addDefinition encoded-ns encoded-name value))
+        encoded-name (php/-> (php/new Munge) (encode name-str))]
+    (php/:: Phel (addDefinition encoded-ns encoded-name val))
     (php/:: Symbol (createForNamespace ns-str name-str))))
 
 (defn ns-interns

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -1,0 +1,39 @@
+(ns phel-test\test\core\ns
+  (:require phel\test :refer [deftest is]))
+
+(deftest test-loaded-namespaces-includes-core
+  (is (php/in_array "phel\\core" (loaded-namespaces))
+      "loaded-namespaces lists phel\\core"))
+
+(deftest test-find-ns-known
+  (is (= "phel\\core" (find-ns "phel\\core"))
+      "find-ns returns the namespace name when loaded"))
+
+(deftest test-find-ns-unknown
+  (is (nil? (find-ns "no-such-ns\\nope"))
+      "find-ns returns nil for unknown namespace"))
+
+(deftest test-create-and-remove-ns
+  (let [name "phel-test\\tmp\\ns-roundtrip"]
+    (is (nil? (find-ns name)) "namespace does not exist initially")
+    (create-ns name)
+    (is (= name (find-ns name)) "namespace exists after create-ns")
+    (remove-ns name)
+    (is (nil? (find-ns name)) "namespace removed after remove-ns")))
+
+(deftest test-intern-and-ns-interns
+  (let [ns "phel-test\\tmp\\intern-test"]
+    (intern ns "x" 42)
+    (let [interns (ns-interns ns)]
+      (is (= 42 (get interns "x")) "ns-interns contains the interned value"))
+    (remove-ns ns)))
+
+(deftest test-ns-publics-returns-map
+  (let [publics (ns-publics "phel\\core")]
+    (is (hash-map? publics) "ns-publics returns a hash-map")
+    (is (> (count publics) 0) "ns-publics has entries for phel\\core")
+    (is (not (nil? (get publics "map"))) "ns-publics contains 'map'")))
+
+(deftest test-ns-aliases-and-refers
+  (is (hash-map? (ns-aliases "phel\\core")) "ns-aliases returns a hash-map")
+  (is (hash-map? (ns-refers "phel\\core")) "ns-refers returns a hash-map"))


### PR DESCRIPTION
## 🤔 Background

`phel\repl` exposes namespace inspection helpers (`loaded-namespaces`, `find-ns`, `ns-publics`, …) that are only convenient inside an interactive session. Issue #1694 asks for them to be reachable from any namespace, so tooling and library code can introspect the registry without depending on `phel\repl`.

## 💡 Goal

Expose a stable subset of namespace functions from `phel\core` so they are auto-available everywhere, while keeping existing `phel\repl` definitions untouched for backward compatibility.

## 🔖 Changes

- New module `src/phel/core/ns.phel` wired via `(load \"core/ns\")` in `core.phel`
- Adds: `loaded-namespaces`, `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `load-file`
- Test coverage in `tests/phel/test/core/ns.phel`
- Changelog entry under `## Unreleased`

Closes #1694