### PR TITLE
feat(core): add (rand n) arity returning a number in [0, n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Compare numeric values consistently in `==` (#1561)
 - Support `[size init-val-or-seq]` in primitive array helpers (#1562)
 - Add namespace introspection: `loaded-namespaces`, `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `load-file` (#1694)
+- `rand` accepts an optional limit argument: `(rand n)` returns a number in `[0, n)` (#1696)
 
 #### REPL
 - `require` accepts vector syntax: `(require '[phel\string :as s])` (#1693)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -349,9 +349,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                     "char expects a non-negative integer or a single-character string"))))
 
 (defn rand
-  "Returns a random number between 0 and 1."
-  []
-  (/ (php/random_int 0 php/PHP_INT_MAX) php/PHP_INT_MAX))
+  "Without arguments, returns a random number in `[0, 1)`. With one
+  argument `n`, returns a random number in `[0, n)`."
+  {:example "(rand) ; => 0.42\n(rand 100) ; => 73.2"
+   :see-also ["rand-int" "rand-nth"]}
+  ([]
+   (/ (php/random_int 0 php/PHP_INT_MAX) php/PHP_INT_MAX))
+  ([n]
+   (* n (rand))))
 
 (defn rand-int
   "Returns a random number between 0 and `n`."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -134,7 +134,7 @@
         "(rand n) returns a number in [0, n)")))
 
 (deftest test-rand-with-zero-limit
-  (is (= 0 (rand 0)) "(rand 0) returns 0"))
+  (is (zero? (rand 0)) "(rand 0) returns 0"))
 
 (deftest test-min-key
   (is (= {:a 1} (min-key :a {:a 1} {:a 3} {:a 2}))

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -123,13 +123,13 @@
   (is (nil? (rand-nth nil)) "(rand-nth nil)"))
 
 (deftest test-rand-no-arg-bounds
-  (let [samples (for [_ :range [0 200]] (rand))]
+  (let [samples (repeatedly 200 rand)]
     (is (every? #(and (>= % 0) (< % 1)) samples)
         "(rand) returns a number in [0, 1)")))
 
 (deftest test-rand-with-limit-bounds
   (let [limit 0.01
-        samples (for [_ :range [0 200]] (rand limit))]
+        samples (repeatedly 200 #(rand limit))]
     (is (every? #(and (>= % 0) (< % limit)) samples)
         "(rand n) returns a number in [0, n)")))
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -122,6 +122,20 @@
 (deftest test-rand-nth-on-nil
   (is (nil? (rand-nth nil)) "(rand-nth nil)"))
 
+(deftest test-rand-no-arg-bounds
+  (let [samples (for [_ :range [0 200]] (rand))]
+    (is (every? #(and (>= % 0) (< % 1)) samples)
+        "(rand) returns a number in [0, 1)")))
+
+(deftest test-rand-with-limit-bounds
+  (let [limit 0.01
+        samples (for [_ :range [0 200]] (rand limit))]
+    (is (every? #(and (>= % 0) (< % limit)) samples)
+        "(rand n) returns a number in [0, n)")))
+
+(deftest test-rand-with-zero-limit
+  (is (= 0 (rand 0)) "(rand 0) returns 0"))
+
 (deftest test-min-key
   (is (= {:a 1} (min-key :a {:a 1} {:a 3} {:a 2}))
       "min-key with keyword key")


### PR DESCRIPTION
## 🤔 Background

Closes #1696. Phel's `rand` only accepted zero arguments, returning a number in `[0, 1)`. Clojure also has `(rand n)` returning a number in `[0, n)`.

## 💡 Goal

Bring Phel's `rand` to arity parity with Clojure so the snippet from the issue passes:

```phel
(let [length 100
      limit 0.01
      x (repeatedly length #(rand limit))]
  (every? #(< % limit) x))
;; => true
```

## 🔖 Changes

- `src/phel/core/math.phel`: `rand` now has two arities — `[]` (existing behaviour) and `[n]` returning `(* n (rand))`. Docstring updated with examples and `:see-also`.
- `tests/phel/test/core/math-operation.phel`: regression coverage for `(rand)`, `(rand n)` upper bound, and `(rand 0)`.
- `CHANGELOG.md`: entry under Added > Core.