### PR TITLE
fix(core): make symbols callable so (ifn? 'a) is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Hierarchy checks include PHP parents and interfaces for class-string tags (#1560)
 - Bare `apply` resolves as a first-class function (#1564)
 - `eval` returns already-evaluated PHP objects unchanged (#1563)
+- Symbols are now callable like keywords (`('a {'a 1}) ; => 1`) so `(ifn? 'a)` is `true` (#1697)
 
 #### Build
 - Skip unparseable `.phel` files during directory scans

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -18,7 +18,6 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
-use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use Phel\Printer\Printer;
 use RuntimeException;
@@ -74,9 +73,9 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
 
     /**
      * Guards against call-position literals that PHP would reject with a raw
-     * `TypeError` at runtime (quoted symbols, numbers, strings, booleans,
-     * `nil`). Keywords and persistent maps/sets/vectors stay callable and are
-     * handled at runtime as before.
+     * `TypeError` at runtime (numbers, strings, booleans, `nil`). Keywords,
+     * symbols and persistent maps/sets/vectors stay callable and are handled
+     * at runtime.
      */
     private function rejectNonCallableLiteral(AbstractNode $f, PersistentListInterface $list): void
     {
@@ -87,15 +86,6 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         if ($value === self::UNHANDLED) {
             return;
-        }
-
-        if ($value instanceof Symbol) {
-            throw AnalyzerException::notCallable(
-                Printer::readable()->print($value),
-                'Symbol',
-                $list,
-                'Did you quote or escape a symbol by mistake?',
-            );
         }
 
         if ($value === null || is_bool($value) || is_int($value) || is_float($value) || is_string($value)) {

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
+use ArrayAccess;
 use Override;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 
-final class Symbol extends AbstractType implements IdenticalInterface, NamedInterface
+final class Symbol extends AbstractType implements IdenticalInterface, FnInterface, NamedInterface
 {
     use MetaTrait;
 
@@ -113,6 +115,29 @@ final class Symbol extends AbstractType implements IdenticalInterface, NamedInte
     public function __toString(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Symbol-as-accessor, mirroring `Keyword::__invoke`. `nil` target
+     * returns the default so `('foo nil)` is `nil` rather than raising.
+     */
+    public function __invoke(
+        mixed $obj,
+        float|bool|int|string|TypeInterface|null $default = null,
+    ) {
+        if ($obj instanceof ArrayAccess) {
+            if ($obj instanceof ContainsInterface) {
+                return $obj->contains($this) ? $obj[$this] : $default;
+            }
+
+            return $obj[$this] ?? $default;
+        }
+
+        if ($obj instanceof PersistentHashSetInterface) {
+            return $obj->contains($this) ? $this : $default;
+        }
+
+        return $default;
     }
 
     public static function create(string $name): self

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -178,6 +178,7 @@
 (deftest test-ifn?
   (is (true? (ifn? inc)) "ifn? on function")
   (is (true? (ifn? :a)) "ifn? on keyword")
+  (is (true? (ifn? 'a)) "ifn? on symbol")
   (is (true? (ifn? {})) "ifn? on map")
   (is (true? (ifn? [])) "ifn? on vector")
   (is (true? (ifn? #{})) "ifn? on set")
@@ -185,6 +186,11 @@
   (is (false? (ifn? 42)) "ifn? on integer")
   (is (false? (ifn? "str")) "ifn? on string")
   (is (false? (ifn? nil)) "ifn? on nil"))
+
+(deftest test-symbol-as-fn
+  (is (= 1 ('a {'a 1})) "symbol looks itself up in a map")
+  (is (= "default" ('a {} "default")) "symbol returns default when key missing")
+  (is (nil? ('a nil)) "symbol on nil returns nil"))
 
 (deftest test-hash-map?
   (is (true? (hash-map? {})) "hash-map?"))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -98,11 +98,10 @@ final class InvokeSymbolTest extends TestCase
         $this->analyzer = new Analyzer($env);
     }
 
-    public function test_quoted_symbol_in_call_position_raises_phel011(): void
+    public function test_quoted_symbol_in_call_position_is_callable(): void
     {
-        $this->expectException(AnalyzerException::class);
-        $this->expectExceptionMessage('Value foobar of type Symbol is not callable. Did you quote or escape a symbol by mistake?');
-
+        // Symbols implement FnInterface (look themselves up in collections),
+        // so a quoted-symbol call head must be accepted by the analyzer.
         $list = Phel::list([
             Phel::list([
                 Symbol::create(Symbol::NAME_QUOTE),
@@ -110,7 +109,9 @@ final class InvokeSymbolTest extends TestCase
             ]),
         ]);
 
-        new InvokeSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+        $node = new InvokeSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        self::assertNotNull($node);
     }
 
     public function test_integer_literal_in_call_position_raises_phel011(): void


### PR DESCRIPTION
## 🤔 Background

Closes #1697. `(ifn? (quote symbol))` returned `false` because `Symbol` did not implement `FnInterface` and was not `is_callable`. Surfaced by clojure-test-suite.

## 💡 Goal

Match Clojure's `IFn` contract on symbols: `(ifn? 'a) ; => true`. As a consequence, symbols look themselves up in collections, like keywords do — `('a {'a 1}) ; => 1`.

## 🔖 Changes

- `src/php/Lang/Symbol.php`: implement `FnInterface`; add `__invoke(\$obj, \$default = null)` mirroring `Keyword::__invoke` (handles `ArrayAccess`/`ContainsInterface`, `PersistentHashSetInterface`, returns default on `nil`).
- `tests/phel/test/core/type-operation.phel`: add `ifn?` assertion for symbols and a regression test for the lookup semantics.
- `CHANGELOG.md`: entry under Fixed > Core.