### PR TITLE
feat(test): gate stack traces behind --stack-trace flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 #### Test
 - `run-tests` resets assertion counts for each run (#1604)
 - Default reporter prints string literals readably in failures (#1601)
+- `phel test --stack-trace` opts into the full PHP stack trace for errored tests; default report omits it (#1695)
 
 #### REPL
 - Accept bare namespace symbols in `dir` (#1588)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -12,6 +12,7 @@
 ;; ------
 
 (def- fail-fast? (atom false))
+(def- print-stack-trace? (atom false))
 
 (def- ^:dynamic *current-test-name* nil)
 
@@ -489,7 +490,8 @@
     (println "             threw:" (php/get_class exception))
     (when-let [exception-message (ex-message exception)]
       (println "      with message:" exception-message))
-    (php/-> printer (printStackTrace exception))))
+    (when (deref print-stack-trace?)
+      (php/-> printer (printStackTrace exception)))))
 
 (defn- print-predicate-failure [{:pred pred :value value :result result}]
   (println "                 Form:" (readable-str value))
@@ -1109,6 +1111,7 @@
 
 (defn- configure-run! [options]
   (reset! fail-fast? (:fail-fast options))
+  (reset! print-stack-trace? (:stack-trace options))
   (when-let [path (:junit-output options)]
     (set-junit-output! path))
   (set-reporters! (resolve-reporters-option options)))

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -18,6 +18,8 @@ final readonly class TestCommandOptions
 
     public const string FAIL_FAST = 'fail-fast';
 
+    public const string STACK_TRACE = 'stack-trace';
+
     public const string REPORTERS = 'reporters';
 
     public const string JUNIT_OUTPUT = 'junit-output';
@@ -41,6 +43,7 @@ final readonly class TestCommandOptions
         private ?string $filter,
         private bool $testdox,
         private bool $failFast,
+        private bool $stackTrace,
         private array $reporters,
         private ?string $junitOutput,
         private array $includes,
@@ -68,6 +71,7 @@ final readonly class TestCommandOptions
             $options[self::FILTER] ?? null,
             !empty($options[self::TESTDOX]),
             !empty($options[self::FAIL_FAST]),
+            !empty($options[self::STACK_TRACE]),
             $reporters,
             is_string($junitOutput) ? $junitOutput : null,
             self::normalizeStringList($options[self::INCLUDE] ?? null),
@@ -82,10 +86,11 @@ final readonly class TestCommandOptions
         $printer = Printer::readable();
 
         return sprintf(
-            '{:filter %s :testdox %s :fail-fast %s%s%s%s%s%s%s}',
+            '{:filter %s :testdox %s :fail-fast %s :stack-trace %s%s%s%s%s%s%s}',
             $this->filter === null ? 'nil' : $printer->print($this->filter),
             $printer->print($this->testdox),
             $printer->print($this->failFast),
+            $printer->print($this->stackTrace),
             $this->keywordVector(':reporters', $this->reporters),
             $this->optionalString(':junit-output', $this->junitOutput, $printer),
             $this->keywordVector(':include', $this->includes),

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -41,6 +41,8 @@ final class TestCommand extends Command
 
     private const string OPT_FAIL_FAST = 'fail-fast';
 
+    private const string OPT_STACK_TRACE = 'stack-trace';
+
     private const string OPT_REPORTER = 'reporter';
 
     private const string OPT_OUTPUT = 'output';
@@ -78,6 +80,11 @@ final class TestCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Stop running tests after the first failure or error.',
+            )->addOption(
+                self::OPT_STACK_TRACE,
+                null,
+                InputOption::VALUE_NONE,
+                'Print the full PHP stack trace for each errored test.',
             )->addOption(
                 self::OPT_REPORTER,
                 null,
@@ -218,6 +225,7 @@ final class TestCommand extends Command
                 TestCommandOptions::FILTER => null,
                 TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
                 TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
+                TestCommandOptions::STACK_TRACE => (bool) $input->getOption(self::OPT_STACK_TRACE),
                 TestCommandOptions::REPORTERS => $reporters,
                 TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
                 TestCommandOptions::INCLUDE => $includes,

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -13,14 +13,14 @@ final class TestCommandOptionsTest extends TestCase
     {
         $options = TestCommandOptions::empty();
 
-        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_random_filter(): void
     {
         $options = TestCommandOptions::fromArray(['filter' => 'example']);
 
-        self::assertSame('{:filter "example" :testdox false :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter "example" :testdox false :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_include_tag_list(): void
@@ -30,7 +30,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :include [:integration :smoke]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :include [:integration :smoke]}',
             $options->asPhelHashMap(),
         );
     }
@@ -42,7 +42,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :exclude [:slow]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :exclude [:slow]}',
             $options->asPhelHashMap(),
         );
     }
@@ -54,7 +54,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :ns-patterns ["phel.http.*" "phel.json.**"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :ns-patterns ["phel.http.*" "phel.json.**"]}',
             $options->asPhelHashMap(),
         );
     }
@@ -66,7 +66,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :filters ["foo-"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :filters ["foo-"]}',
             $options->asPhelHashMap(),
         );
     }
@@ -81,7 +81,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :include [:integration] :exclude [:slow] :ns-patterns ["phel.http.*"] :filters ["get-"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :include [:integration] :exclude [:slow] :ns-patterns ["phel.http.*"] :filters ["get-"]}',
             $options->asPhelHashMap(),
         );
     }
@@ -96,7 +96,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :include [:integration :smoke] :ns-patterns ["phel.http.*"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :include [:integration :smoke] :ns-patterns ["phel.http.*"]}',
             $options->asPhelHashMap(),
         );
     }
@@ -109,7 +109,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false}',
             $options->asPhelHashMap(),
         );
     }
@@ -118,35 +118,42 @@ final class TestCommandOptionsTest extends TestCase
     {
         $options = TestCommandOptions::fromArray([]);
 
-        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_false_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => false]);
 
-        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_null_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => null]);
 
-        self::assertSame('{:filter nil :testdox false :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_true_testdox(): void
     {
         $options = TestCommandOptions::fromArray(['testdox' => 'true']);
 
-        self::assertSame('{:filter nil :testdox true :fail-fast false}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox true :fail-fast false :stack-trace false}', $options->asPhelHashMap());
     }
 
     public function test_fail_fast(): void
     {
         $options = TestCommandOptions::fromArray(['fail-fast' => true]);
 
-        self::assertSame('{:filter nil :testdox false :fail-fast true}', $options->asPhelHashMap());
+        self::assertSame('{:filter nil :testdox false :fail-fast true :stack-trace false}', $options->asPhelHashMap());
+    }
+
+    public function test_stack_trace(): void
+    {
+        $options = TestCommandOptions::fromArray(['stack-trace' => true]);
+
+        self::assertSame('{:filter nil :testdox false :fail-fast false :stack-trace true}', $options->asPhelHashMap());
     }
 
     public function test_single_reporter(): void
@@ -154,7 +161,7 @@ final class TestCommandOptionsTest extends TestCase
         $options = TestCommandOptions::fromArray(['reporters' => ['dot']]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :reporters [:dot]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :reporters [:dot]}',
             $options->asPhelHashMap(),
         );
     }
@@ -164,7 +171,7 @@ final class TestCommandOptionsTest extends TestCase
         $options = TestCommandOptions::fromArray(['reporters' => ['dot', 'junit-xml']]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :reporters [:dot :junit-xml]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :reporters [:dot :junit-xml]}',
             $options->asPhelHashMap(),
         );
     }
@@ -174,7 +181,7 @@ final class TestCommandOptionsTest extends TestCase
         $options = TestCommandOptions::fromArray(['reporters' => ['dot', '', 'tap']]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :reporters [:dot :tap]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :reporters [:dot :tap]}',
             $options->asPhelHashMap(),
         );
     }
@@ -187,7 +194,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :reporters [:junit-xml] :junit-output "build/junit.xml"}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :reporters [:junit-xml] :junit-output "build/junit.xml"}',
             $options->asPhelHashMap(),
         );
     }
@@ -200,7 +207,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :reporters [:junit-xml]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :reporters [:junit-xml]}',
             $options->asPhelHashMap(),
         );
     }
@@ -256,7 +263,7 @@ final class TestCommandOptionsTest extends TestCase
         ])->asPhelHashMap();
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :include [:a :b] :exclude [:c] :ns-patterns ["x.*"] :filters ["y"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :include [:a :b] :exclude [:c] :ns-patterns ["x.*"] :filters ["y"]}',
             $printed,
         );
     }
@@ -280,7 +287,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter nil :testdox false :fail-fast false :include [:ok :smoke] :filters ["keep"]}',
+            '{:filter nil :testdox false :fail-fast false :stack-trace false :include [:ok :smoke] :filters ["keep"]}',
             $options->asPhelHashMap(),
         );
     }
@@ -304,7 +311,7 @@ final class TestCommandOptionsTest extends TestCase
         ]);
 
         self::assertSame(
-            '{:filter "add-" :testdox false :fail-fast false}',
+            '{:filter "add-" :testdox false :fail-fast false :stack-trace false}',
             $options->asPhelHashMap(),
         );
     }

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -53,6 +53,15 @@ final class TestCommandOptionsWiringTest extends TestCase
         self::assertSame([], $definition->getOption('filter')->getDefault());
     }
 
+    public function test_it_declares_stack_trace_flag(): void
+    {
+        $option = $this->optionFor('stack-trace');
+
+        self::assertFalse($option->isValueRequired(), 'stack-trace is a flag');
+        self::assertFalse($option->getDefault(), 'stack-trace defaults to false');
+        self::assertStringContainsString('stack trace', strtolower($option->getDescription()));
+    }
+
     public function test_description_mentions_selector_semantics(): void
     {
         $include = $this->optionFor('include');


### PR DESCRIPTION
## 🤔 Background

The default test report calls `printStackTrace` for every errored test (`src/phel/test.phel:492`). When an error occurs, the resulting trace can be tens of frames long, drowning the actual failure message and slowing down triage. Issue #1695 asks to keep the trace available but make it opt-in.

## 💡 Goal

Hide the PHP stack trace from the default test runner output. Provide a `--stack-trace` flag (and a matching `:stack-trace` option for `run-tests`) so it can be re-enabled when needed.

## 🔖 Changes

- `src/phel/test.phel`: new private `print-stack-trace?` atom; `print-error` only prints the trace when set
- `TestCommand`: new `--stack-trace` flag (`InputOption::VALUE_NONE`)
- `TestCommandOptions`: new `STACK_TRACE` constant threaded through `fromArray` and `asPhelHashMap`
- Unit tests cover the new flag wiring and the rendered hash-map shape
- Changelog entry under `## Unreleased`

Closes #1695