### PR TITLE
fix(core): nthrest returns empty list when exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `sort-by` accepts the comparator before the collection (#1657)
 - `conj` prepends values to lazy sequences like `(range)` (#1650)
 - Improve `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, and `contains?` (#1592, #1638, #1644, #1652, #1655, #1656)
+- `nthrest` returns `()` instead of `nil` when the collection is exhausted or `nil` (#1699)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -162,15 +162,16 @@
          :else         (recur (php/- i 1) (next s)))))))
 
 (defn nthrest
-  "Returns the nth rest of `coll`, `coll` when `n` is 0."
-  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)"
+  "Returns the nth rest of `coll`, `coll` when `n` is 0. Returns an empty
+  list once the collection is exhausted or when `coll` is `nil`."
+  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
   (loop [i n
          s coll]
     (if (and (php/> i 0) s)
       (recur (php/- i 1) (next s))
-      s)))
+      (if (nil? s) '() s))))
 
 (defn nthnext
   "Returns the nth next of `coll`, `(seq coll)` when `n` is 0.

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -304,8 +304,10 @@
 (deftest test-nthrest
   (is (= [3 4 5] (nthrest [1 2 3 4 5] 2)) "nthrest drops first n")
   (is (= [1 2 3] (nthrest [1 2 3] 0)) "nthrest 0 returns coll")
-  (is (nil? (nthrest [1 2] 5)) "nthrest past end returns nil")
-  (is (nil? (nthrest nil 3)) "nthrest on nil returns nil"))
+  (is (= '() (nthrest [1 2] 5)) "nthrest past end returns empty list")
+  (is (= '() (nthrest nil 3)) "nthrest on nil returns empty list")
+  (is (= '() (nthrest [] 100)) "nthrest on empty vector returns empty list")
+  (is (= '() (nthrest (range 0 10) 10)) "nthrest exhausting a range returns empty list"))
 
 (deftest test-nthnext
   (is (= [3 4 5] (nthnext [1 2 3 4 5] 2)) "nthnext drops first n")


### PR DESCRIPTION
## 🤔 Background

`nthrest` returned `nil` whenever the requested rest fell off the end of the collection (`(nthrest [] 100)`, `(nthrest nil 3)`, `(nthrest (range 0 10) 10)`). Issue #1699 calls this out — sequential semantics expect an empty list.

## 💡 Goal

Return `()` once the collection is exhausted or when `coll` is `nil`, while keeping the existing happy-path behavior intact.

## 🔖 Changes

- `src/phel/core/sequences.phel`: convert the trailing `nil` returned by the loop into `'()`
- Updated `test-nthrest` in `tests/phel/test/core/sequence-operation.phel` to assert the new contract and added coverage for `[]` and `(range)` exhaustion
- Changelog entry under `## Unreleased`

Closes #1699