### PR TITLE
fix(fiber): make promises callable so (ifn? (promise)) is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Hierarchy checks include PHP parents and interfaces for class-string tags (#1560)
 - Bare `apply` resolves as a first-class function (#1564)
 - `eval` returns already-evaluated PHP objects unchanged (#1563)
+- Promises implement IFn (`(p val)` delivers, `(p)` derefs) so `(ifn? (promise))` is `true` (#1698)
 
 #### Build
 - Skip unparseable `.phel` files during directory scans

--- a/src/php/Fiber/Domain/Promise.php
+++ b/src/php/Fiber/Domain/Promise.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Fiber\Domain;
 
 use Fiber;
+use Phel\Lang\FnInterface;
 
 use function microtime;
 use function usleep;
@@ -18,7 +19,7 @@ use function usleep;
  * the delivered flag each time. Top-level callers (no active Fiber)
  * drain the scheduler's ready queue and sleep briefly between polls.
  */
-final class Promise implements Awaitable
+final class Promise implements Awaitable, FnInterface
 {
     private bool $delivered = false;
 
@@ -27,6 +28,22 @@ final class Promise implements Awaitable
     public function __construct(
         private readonly Scheduler $scheduler,
     ) {}
+
+    /**
+     * Promise-as-IFn, matching Clojure: `(p val)` delivers `val` and
+     * returns the promise (or the existing value when already delivered);
+     * `(p)` blocks until the promise is realized and returns the value.
+     */
+    public function __invoke(mixed ...$args): mixed
+    {
+        if ($args === []) {
+            return $this->deref();
+        }
+
+        $this->deliver($args[0]);
+
+        return $this;
+    }
 
     /**
      * Deliver $value and freeze the promise. Returns true on the first

--- a/tests/phel/test/async-fiber.phel
+++ b/tests/phel/test/async-fiber.phel
@@ -74,3 +74,11 @@
   (let [p (promise)]
     (deliver p :via-reader)
     (is (= :via-reader @p) "@ reader shortcut derefs a promise")))
+
+(deftest test-promise-is-ifn
+  (is (true? (ifn? (promise))) "(ifn? (promise)) is true"))
+
+(deftest test-promise-as-fn-delivers
+  (let [p (promise)]
+    (p 99)
+    (is (= 99 @p) "calling a promise with one arg delivers that value")))


### PR DESCRIPTION
## 🤔 Background

Closes #1698. `(ifn? (promise))` returned `false` because `Promise` did not implement `FnInterface`.

## 💡 Goal

Match Clojure's `IFn` contract on promises so the predicate returns `true` and `(p val)` / `(p)` work.

## 🔖 Changes

- `src/php/Fiber/Domain/Promise.php`: implement `FnInterface`. `__invoke(val)` delegates to `deliver(\$val)` and returns the promise; `__invoke()` blocks via `deref()` and returns the value.
- `tests/phel/test/async-fiber.phel`: `(ifn? (promise))` regression and a delivery-via-call test.
- `CHANGELOG.md`: entry under Fixed > Core.