### PR TITLE
fix(core): seq? handles lists, seq, and rseq results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `conj` prepends values to lazy sequences like `(range)` (#1650)
 - Improve `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, and `contains?` (#1592, #1638, #1644, #1652, #1655, #1656)
 - `nthrest` returns `()` instead of `nil` when the collection is exhausted or `nil` (#1699)
+- `seq?` recognizes lists and the result of `seq`/`rseq` over vectors, sorted-maps, and sorted-sets (#1700)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -300,10 +300,11 @@
   (= (type x) :php/object))
 
 (defn seq?
-  "Returns true if `x` is a seq (implements LazySeqInterface), false otherwise."
+  "Returns true if `x` is a seq (a list or a lazy sequence)."
   {:see-also ["seq" "lazy-seq"]}
   [x]
-  (php/instanceof x LazySeqInterface))
+  (or (php/instanceof x LazySeqInterface)
+      (php/instanceof x PersistentListInterface)))
 
 (defn empty?
   "Returns true if x would be 0, \"\" or empty collection, false otherwise.
@@ -342,12 +343,12 @@
 
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.
-  Non-sequential collections and PHP arrays are converted to vectors.
-  Returns nil if coll is empty or nil.
+  Other non-empty collections (vectors, sets, sorted-maps, sorted-sets, PHP arrays)
+  are converted to a list. Returns nil if `coll` is empty or nil.
 
   This function is useful for explicitly converting strings to sequences of characters,
   enabling sequence operations like map, filter, and frequencies."
-  {:example "(seq \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]"
+  {:example "(seq \"hello\") ; => [\"h\" \"e\" \"l\" \"l\" \"o\"]\n(seq [1 2 3]) ; => (1 2 3)"
    :see-also ["count"]}
   [coll]
   (cond
@@ -357,7 +358,7 @@
     (php/=== coll nil)
     nil
 
-    ;; For lazy sequences, don't force them - just check if first element exists
+    ;; For lazy sequences and lists, don't force them - just check if first element exists
     (seq? coll)
     (if (php/=== nil (php/-> coll (first))) nil coll)
 
@@ -366,13 +367,13 @@
     nil
 
     (php/is_array coll)
-    (seq-vector coll)
+    (apply list coll)
 
     (php/instanceof coll PersistentHashSetInterface)
-    (seq-vector (to-php-array coll))
+    (apply list (to-php-array coll))
 
     true
-    coll))
+    (apply list coll)))
 
 (defn- indexed-php-array?
   [x]

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -640,14 +640,14 @@
   order. `rev` must be reversible (a vector, sorted-map, or sorted-set);
   otherwise an exception is thrown. For sorted-maps, returns reversed `[key value]` pairs.
   Returns nil if `rev` is empty."
-  {:example "(rseq [1 2 3]) ; => [3 2 1]"
+  {:example "(rseq [1 2 3]) ; => (3 2 1)"
    :see-also ["reversible?" "reverse"]}
   [rev]
   (when-not (reversible? rev)
     (throw (php/new InvalidArgumentException
                     "rseq requires a reversible collection (vector, sorted-map, or sorted-set)")))
   (when (php/> (count rev) 0)
-    (reverse (if (vector? rev) rev (vec rev)))))
+    (apply list (reverse (if (vector? rev) rev (vec rev))))))
 
 (defn frequencies
   "Returns a map from distinct items in `coll` to the number of times they appear.
@@ -1014,10 +1014,7 @@
   {:example "(doall (map println [1 2 3])) ; => [nil nil nil]"}
   [coll]
   (if (seq? coll)
-    (let [arr (php/-> coll (toArray))]
-      (if (php/empty arr)
-        nil
-        (php/:: Phel (vector arr))))
+    (php/:: Phel (vector (php/-> coll (toArray))))
     coll))
 
 (defn dorun
@@ -1036,7 +1033,8 @@
    :see-also ["delay" "force" "lazy-seq" "future"]}
   [coll]
   (cond
-    (seq? coll) (php/-> coll (isRealized))
+    (php/instanceof coll LazySeqInterface) (php/-> coll (isRealized))
+    (php/instanceof coll PersistentListInterface) true
     (php/instanceof coll Delay) (php/-> coll (isRealized))
     (php/instanceof coll \Phel\Lang\PhelFuture) (php/-> coll (isRealized))
     (php/instanceof coll \Phel\Fiber\Domain\Future) (php/-> coll (isRealized))

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -752,8 +752,8 @@
     (is (= 1 (deref side-effect)) "lazy-seq should cache result and not re-evaluate")))
 
 (deftest test-lazy-seq-with-nil
-  (is (= nil (doall (lazy-seq nil)))
-      "lazy-seq with nil should return nil"))
+  (is (= [] (doall (lazy-seq nil)))
+      "lazy-seq with nil produces an empty sequence"))
 
 (deftest test-lazy-seq-recursive-range
   (is (= [5 4 3 2 1] (doall (my-range 5)))
@@ -774,8 +774,8 @@
     (is (= 3 (first (rest (rest result)))) "third element should be 3")))
 
 (deftest test-lazy-seq-empty-collection
-  (is (= nil (doall (lazy-seq [])))
-      "lazy-seq with empty vector should return nil"))
+  (is (= [] (doall (lazy-seq [])))
+      "lazy-seq with empty vector produces an empty sequence"))
 
 (deftest test-lazy-seq-single-element
   (is (= [42] (doall (lazy-seq [42])))

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -279,7 +279,12 @@
 (deftest test-seq?
   (is (true? (seq? (take 5 (iterate inc 1)))) "seq? on lazy sequence")
   (is (false? (seq? [])) "seq? on vector")
-  (is (false? (seq? '())) "seq? on list")
+  (is (true? (seq? '())) "seq? on empty list")
+  (is (true? (seq? '(1 2 3))) "seq? on quoted list")
+  (is (true? (seq? (seq [1 2 3]))) "seq? on (seq vector)")
+  (is (true? (seq? (rseq [1 2 3]))) "seq? on (rseq vector)")
+  (is (true? (seq? (seq (sorted-map :a 1)))) "seq? on (seq sorted-map)")
+  (is (true? (seq? (seq (sorted-set :a)))) "seq? on (seq sorted-set)")
   (is (false? (seq? {})) "seq? on map")
   (is (false? (seq? nil)) "seq? on nil"))
 


### PR DESCRIPTION
## 🤔 Background

`seq?` only recognized `LazySeqInterface`, so `(seq? '(1 2 3))`, `(seq? (seq [1 2 3]))`, `(seq? (rseq [1 2 3]))`, and `(seq? (seq (sorted-map :a 1)))` all returned `false`. Issue #1700 calls these out as failing the clojure-test-suite expectations.

## 💡 Goal

Treat lists as seqs and make `seq`/`rseq` return seq-shaped values so the predicate behaves consistently with the rest of the sequence API.

## 🔖 Changes

- `seq?` (`predicates.phel`) now returns `true` for both `LazySeqInterface` and `PersistentListInterface`
- `seq` returns a list for vectors, sets, sorted-maps, sorted-sets, and PHP arrays; strings still produce a vector of characters
- `rseq` (`seq-fns.phel`) wraps its reversed result in a list
- `realized?` treats lists as already realized
- `doall` returns a vector for any seq input, including the empty case (no longer collapses to `nil`)
- Tests updated to cover quoted lists, `(seq ...)` and `(rseq ...)` results, plus the empty-`doall` shape
- Changelog entry under `## Unreleased`

Closes #1700