### PR TITLE
fix(core): binding accepts nil values for dynamic vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `nthrest` returns `()` instead of `nil` when the collection is exhausted or `nil` (#1699)
 - `seq?` recognizes lists and the result of `seq`/`rseq` over vectors, sorted-maps, and sorted-sets (#1700)
 - `special-symbol?` recognizes the rest-args marker `&` and the `try` sub-forms `catch` and `finally` (#1701)
+- `binding` rebinds dynamic vars to `nil` correctly (#1702)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -390,9 +390,10 @@
   mutation restored on exit — convenient for tests but shared
   across fibers."
   [bindings & body]
-  (let [names    (take-nth 2 bindings)
-        vals     (take-nth 2 (drop 1 bindings))
-        set-vars (map (fn [n v] (list 'set-var n v)) names vals)]
+  (let [pairs    (php/array_chunk (apply php/array bindings) 2)
+        set-vars (map (fn [pair]
+                        (list 'set-var (php/aget pair 0) (php/aget pair 1)))
+                      pairs)]
     `(do
        (php/:: \Phel (openBindingFrame))
        (try

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -60,3 +60,14 @@
   (binding [*not-dynamic* :rebound]
     (is (= :rebound *not-dynamic*) "non-dynamic var is mutated in-place"))
   (is (= :root *not-dynamic*) "non-dynamic var is restored on exit"))
+
+;; --- nil values in dynamic bindings ---
+(deftest test-binding-with-nil-value
+  (binding [*x* nil]
+    (is (nil? *x*) "binding to nil makes the dynamic var read as nil")))
+
+(deftest test-binding-mixed-nil-and-value
+  (def ^:dynamic *y* :unset-y)
+  (binding [*x* :only-x *y* nil]
+    (is (= :only-x *x*) "non-nil entry retains its value")
+    (is (nil? *y*) "nil entry binds the var to nil")))


### PR DESCRIPTION
## 🤔 Background

`(binding [*x* nil] ...)` left `*x*` at its previous root value instead of rebinding it to `nil`. Issue #1702 surfaced this through the clojure-test-suite. The `binding` macro split its binding vector with `(take-nth 2 (drop 1 bindings))` to extract values; when the trailing value was `nil` the lazy-seq path treated the seq as empty (Phel's `seq` returns `nil` when a seq's first element is `nil`), so `map` produced zero `set-var` forms and the dynamic frame stayed empty.

## 💡 Goal

Walk the binding vector without going through `take-nth`/`drop` so `nil` values survive into the emitted `set-var` calls.

## 🔖 Changes

- `src/phel/core/io.phel`: `binding` now chunks the input vector with `php/array_chunk` and reads each pair via `php/aget`, leaving `nil` values intact
- `tests/phel/test/core/binding-conveyance.phel`: regression tests for `binding` with `nil` and mixed `nil`/value pairs
- Changelog entry under `## Unreleased`

Closes #1702