### PR TITLE
fix(core): min and max propagate NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `seq?` recognizes lists and the result of `seq`/`rseq` over vectors, sorted-maps, and sorted-sets (#1700)
 - `special-symbol?` recognizes the rest-args marker `&` and the `try` sub-forms `catch` and `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` correctly (#1702)
+- `min` and `max` return `##NaN` whenever any argument is `##NaN` (#1703)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -375,14 +375,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (reduce #(if (order %1 %2) %1 %2) args))
 
 (defn min
-  "Returns the numeric minimum of all numbers."
+  "Returns the numeric minimum of all numbers. Returns `##NaN` whenever any
+  argument is `##NaN`."
   [& numbers]
-  (extreme < numbers))
+  (if (some nan? numbers)
+    ##NaN
+    (extreme < numbers)))
 
 (defn max
-  "Returns the numeric maximum of all numbers."
+  "Returns the numeric maximum of all numbers. Returns `##NaN` whenever any
+  argument is `##NaN`."
   [& numbers]
-  (extreme > numbers))
+  (if (some nan? numbers)
+    ##NaN
+    (extreme > numbers)))
 
 (defn min-key
   "Returns the arg for which (k arg) is smallest. On ties, returns the latest argument, matching Clojure semantics."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -114,10 +114,14 @@
   (is (true? (neg? ##-Inf)) "##-Inf is negative"))
 
 (deftest test-min
-  (is (= 1 (min 1 2 3)) "(min 1 2 3)"))
+  (is (= 1 (min 1 2 3)) "(min 1 2 3)")
+  (is (nan? (min ##NaN 1)) "min propagates NaN")
+  (is (nan? (min ##-Inf ##NaN ##Inf)) "min returns NaN regardless of position"))
 
 (deftest test-max
-  (is (= 3 (max 1 2 3)) "(max 1 2 3)"))
+  (is (= 3 (max 1 2 3)) "(max 1 2 3)")
+  (is (nan? (max ##NaN 1)) "max propagates NaN")
+  (is (nan? (max ##-Inf ##NaN ##Inf)) "max returns NaN regardless of position"))
 
 (deftest test-rand-nth-on-nil
   (is (nil? (rand-nth nil)) "(rand-nth nil)"))


### PR DESCRIPTION
## 🤔 Background

`(min ##NaN 1)` returned `1` and `(max ##-Inf ##NaN ##Inf)` returned `##Inf`. The underlying `extreme` reducer compares with `<`/`>`, both of which return `false` for any `##NaN` operand, so `##NaN` was always discarded. Issue #1703 reports the divergence.

## 💡 Goal

Make `min` and `max` short-circuit to `##NaN` whenever any argument is `##NaN`, regardless of position.

## 🔖 Changes

- `src/phel/core/math.phel`: `min` and `max` check `(some nan? numbers)` and return `##NaN` when present
- `tests/phel/test/core/math-operation.phel`: regression cases for `(min ##NaN 1)`, `(min ##-Inf ##NaN ##Inf)`, and the `max` mirrors
- Changelog entry under `## Unreleased`

Closes #1703