### PR TITLE
fix(core): dissoc rejects unsupported types with a clear error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `special-symbol?` recognizes the rest-args marker `&` and the `try` sub-forms `catch` and `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` correctly (#1702)
 - `min` and `max` return `##NaN` whenever any argument is `##NaN` (#1703)
+- `dissoc` throws a clear `InvalidArgumentException` instead of a low-level PHP error when called with a value that is not a map, set, or struct (#1704)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -261,9 +261,8 @@
     (set-target? ds)
     (php/-> ds (remove key))
 
-    (let [x ds]
-      (php/aunset x key)
-      x)))
+    (throw (php/new InvalidArgumentException
+                    (str "dissoc requires a map, set, or struct; got " (type ds))))))
 
 (defn dissoc
   "Returns `ds` without the given keys. With no keys returns `ds` unchanged."

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -350,7 +350,18 @@
   (is (= {:b 2} (dissoc {:a 1 :b 2 :c 3} :a :c)) "dissoc variadic removes multiple keys")
   (is (= {:a 1} (dissoc {:a 1} :missing :also-missing)) "dissoc skips missing keys")
   (is (= {} (apply dissoc {} [])) "apply dissoc with no keys does not raise")
-  (is (= {:b 2} (apply dissoc {:a 1 :b 2 :c 3} [:a :c])) "apply dissoc variadic through seq"))
+  (is (= {:b 2} (apply dissoc {:a 1 :b 2 :c 3} [:a :c])) "apply dissoc variadic through seq")
+  (is (thrown? \InvalidArgumentException (dissoc 42 :a)) "dissoc rejects scalars")
+  (is (thrown? \InvalidArgumentException (dissoc dissoc :a)) "dissoc rejects functions"))
+
+(defstruct dissoc-rec [a b c])
+
+(deftest test-dissoc-record
+  (let [r (dissoc-rec 1 2 nil)]
+    (is (= {:b 2 :c nil} (apply dissoc r [:a])) "dissoc on struct removes a key, preserving nil entries")
+    (is (= {:b 2 :c nil} (apply dissoc r [:a :d])) "dissoc on struct ignores unknown keys")
+    (is (= {} (apply dissoc r [:a :b :c])) "dissoc removing every key yields an empty map")
+    (is (= r (apply dissoc r [:d])) "dissoc with no matching keys returns the record itself")))
 
 (deftest test-apply
   (is (fn? apply) "bare apply resolves to a function")


### PR DESCRIPTION
## 🤔 Background

Issue #1704 reports `dissoc` on a record produced "Cannot use object of type Phel\Lang\AbstractFn@anonymous as array". The reported repro used the trailing-dot constructor `(TestDissocRecord. 1 2 nil)`, which Phel rewrites to `(php/new TestDissocRecord ...)`. For a `defrecord`, that resolves to the constructor function, not a struct instance. `dissoc` then fell through to `(php/aunset ds key)` and PHP raised a low-level "Cannot use object as array".

Records constructed via the documented `(TestDissocRecord 1 2 nil)` form already round-trip through `dissoc` correctly; this PR focuses on improving the failure mode of the unsupported-type path so the error is actionable.

## 💡 Goal

Replace the low-level fallthrough in `dissoc` with a clear `InvalidArgumentException`, and lock in the record happy path.

## 🔖 Changes

- `src/phel/core/sequences.phel`: `dissoc-one` throws `InvalidArgumentException` for any value that is not a map, set, or struct
- `tests/phel/test/core/sequence-operation.phel`:
  - regression: `dissoc` on scalars/functions raises
  - regression: `apply dissoc` on a `defstruct` record across each scenario from the issue
- Changelog entry under `## Unreleased`

Closes #1704