### PR TITLE
fix(core): sorted-map-by accepts predicate comparators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `binding` rebinds dynamic vars to `nil` correctly (#1702)
 - `min` and `max` return `##NaN` whenever any argument is `##NaN` (#1703)
 - `dissoc` throws a clear `InvalidArgumentException` instead of a low-level PHP error when called with a value that is not a map, set, or struct (#1704)
+- `sorted-map-by` and `sorted-set-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1705)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/PersistentSortedMap.php
@@ -40,7 +40,9 @@ final class PersistentSortedMap extends AbstractPersistentMap
         private readonly ?Closure $userComparator = null,
     ) {
         parent::__construct($hasher, $equalizer, $meta);
-        $this->effectiveComparator = SortedArrayHelper::resolveComparator($userComparator);
+        $this->effectiveComparator = SortedArrayHelper::adaptForBinarySearch(
+            SortedArrayHelper::resolveComparator($userComparator),
+        );
     }
 
     /**

--- a/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
+++ b/src/php/Lang/Collections/SortedMap/SortedArrayHelper.php
@@ -8,6 +8,7 @@ use Closure;
 use Phel\Lang\NamedInterface;
 
 use function count;
+use function is_int;
 
 /**
  * Shared binary search and comparator logic for sorted collections.
@@ -40,6 +41,28 @@ final class SortedArrayHelper
         }
 
         return $comparator instanceof Closure ? $comparator : Closure::fromCallable($comparator);
+    }
+
+    /**
+     * Wraps a comparator so the binary search receives an int regardless
+     * of whether the user passed a spaceship-style comparator (returning
+     * negative/zero/positive) or a predicate-style comparator returning
+     * a boolean (such as `<` or `>`).
+     */
+    public static function adaptForBinarySearch(Closure $comparator): Closure
+    {
+        return static function (mixed $a, mixed $b) use ($comparator): int {
+            $result = $comparator($a, $b);
+            if (is_int($result)) {
+                return $result;
+            }
+
+            if ($result) {
+                return -1;
+            }
+
+            return $comparator($b, $a) ? 1 : 0;
+        };
     }
 
     /**

--- a/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
+++ b/src/php/Lang/Collections/SortedMap/TransientSortedMap.php
@@ -33,7 +33,9 @@ final class TransientSortedMap implements TransientMapInterface
         private array $array,
         private readonly ?Closure $userComparator = null,
     ) {
-        $this->effectiveComparator = SortedArrayHelper::resolveComparator($userComparator);
+        $this->effectiveComparator = SortedArrayHelper::adaptForBinarySearch(
+            SortedArrayHelper::resolveComparator($userComparator),
+        );
     }
 
     public function contains($key): bool

--- a/tests/phel/test/core/sorted-collections.phel
+++ b/tests/phel/test/core/sorted-collections.phel
@@ -55,6 +55,18 @@
     (is (= "a" (get m 1)) "get works with custom comparator")
     (is (= [3 2 1] (keys (put m 3 "c"))) "put maintains custom order")))
 
+(deftest test-sorted-map-by-with-predicate-comparator
+  (is (= [13 14 15] (keys (sorted-map-by < 13 :a 14 :b 15 :c)))
+      "predicate comparator < produces ascending order")
+  (is (= [15 14 13] (keys (sorted-map-by > 13 :a 14 :b 15 :c)))
+      "predicate comparator > produces descending order"))
+
+(deftest test-sorted-set-by-with-predicate-comparator
+  (is (= [1 2 3] (vec (sorted-set-by < 3 1 2)))
+      "predicate comparator < produces ascending order")
+  (is (= [3 2 1] (vec (sorted-set-by > 1 3 2)))
+      "predicate comparator > produces descending order"))
+
 ;; ---- sorted-set ----
 
 (deftest test-sorted-set-empty


### PR DESCRIPTION
## 🤔 Background

`(sorted-map-by > 13 :a 14 :b 15 :c)` returned `{13 :c}` instead of `{15 :c, 14 :b, 13 :a}`. The binary search inside `PersistentSortedMap` interpreted the boolean result of `>` as `0`, so every key compared "equal" to the previous one and overwrote it. `<` happened to work for ascending order because `(false === 0)` placed insertions at the end.

## 💡 Goal

Let `sorted-map-by` and `sorted-set-by` accept predicate-style comparators (functions returning `bool`) in addition to spaceship-style ones, while keeping the public `getComparator()` accessor returning the user's original closure.

## 🔖 Changes

- `SortedArrayHelper::adaptForBinarySearch` converts the user comparator to an int-returning closure: truthy → `-1`, reverse-truthy → `+1`, otherwise `0`
- `PersistentSortedMap` and `TransientSortedMap` use the adapted closure for their internal binary search; `userComparator` still stores the unwrapped value
- `tests/phel/test/core/sorted-collections.phel`: regression for both `<`/`>` on `sorted-map-by` and `sorted-set-by`
- Changelog entry under `## Unreleased`

Closes #1705