### PR TITLE
fix(core): set equality ignores underlying ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `min` and `max` return `##NaN` whenever any argument is `##NaN` (#1703)
 - `dissoc` throws a clear `InvalidArgumentException` instead of a low-level PHP error when called with a value that is not a map, set, or struct (#1704)
 - `sorted-map-by` and `sorted-set-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1705)
+- Sets compare equal regardless of their underlying ordering: `(= (sorted-set 4 2 6) #{4 2 6})` returns `true` (#1708)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/php/Lang/Collections/HashSet/PersistentHashSet.php
+++ b/src/php/Lang/Collections/HashSet/PersistentHashSet.php
@@ -90,7 +90,7 @@ final class PersistentHashSet extends AbstractType implements PersistentHashSetI
 
     public function equals(mixed $other): bool
     {
-        if (!$other instanceof self) {
+        if (!$other instanceof PersistentHashSetInterface) {
             return false;
         }
 

--- a/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
+++ b/src/php/Lang/Collections/SortedSet/PersistentSortedSet.php
@@ -90,7 +90,7 @@ final class PersistentSortedSet extends AbstractType implements PersistentHashSe
 
     public function equals(mixed $other): bool
     {
-        if (!$other instanceof self) {
+        if (!$other instanceof PersistentHashSetInterface) {
             return false;
         }
 

--- a/tests/phel/test/core/sorted-collections.phel
+++ b/tests/phel/test/core/sorted-collections.phel
@@ -67,6 +67,11 @@
   (is (= [3 2 1] (vec (sorted-set-by > 1 3 2)))
       "predicate comparator > produces descending order"))
 
+(deftest test-sorted-set-equals-hash-set
+  (is (= (sorted-set 4 2 6) #{4 2 6}) "sorted-set equals unsorted set with the same values")
+  (is (= #{4 2 6} (sorted-set 4 2 6)) "comparison is symmetric")
+  (is (not= (sorted-set 4 2 6) #{4 2}) "different counts are not equal"))
+
 ;; ---- sorted-set ----
 
 (deftest test-sorted-set-empty


### PR DESCRIPTION
## 🤔 Background

`(= (sorted-set 4 2 6) #{4 2 6})` returned `false`. Both `PersistentHashSet::equals` and `PersistentSortedSet::equals` short-circuited on `!$other instanceof self`, so a hash-set and a sorted-set with the same members were never considered equal even though their hashes already matched.

## 💡 Goal

Treat any pair of `PersistentHashSetInterface` instances with the same elements as equal, in either direction.

## 🔖 Changes

- `PersistentHashSet::equals` and `PersistentSortedSet::equals` now type-check `PersistentHashSetInterface` rather than the concrete class
- `tests/phel/test/core/sorted-collections.phel`: regression covering both directions and a count mismatch
- Changelog entry under `## Unreleased`

Closes #1708