### PR TITLE
fix(core): empty returns () for lazy sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `dissoc` throws a clear `InvalidArgumentException` instead of a low-level PHP error when called with a value that is not a map, set, or struct (#1704)
 - `sorted-map-by` and `sorted-set-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1705)
 - Sets compare equal regardless of their underlying ordering: `(= (sorted-set 4 2 6) #{4 2 6})` returns `true` (#1708)
+- `empty` returns `()` for lazy sequences such as `(range)` instead of `nil` (#1710)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -328,7 +328,7 @@
 
 (defn empty
   "Returns an empty collection of the same category as `coll`, or nil."
-  {:example "(empty [1 2 3]) ; => []\n(empty {:a 1}) ; => {}"
+  {:example "(empty [1 2 3]) ; => []\n(empty {:a 1}) ; => {}\n(empty (range 10)) ; => ()"
    :see-also ["empty?" "not-empty"]}
   [coll]
   (cond
@@ -337,6 +337,7 @@
     (map? coll)                                      {}
     (php/instanceof coll PersistentHashSetInterface) (hash-set)
     (list? coll)                                     '()
+    (php/instanceof coll LazySeqInterface)           '()
     (php-array? coll)                                (php/array)
     :else                                            nil))
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -319,6 +319,8 @@
   (is (= {} (empty {:a 1})) "empty of map")
   (is (= (hash-set) (empty (set [1 2]))) "empty of set")
   (is (= '() (empty '(1 2 3))) "empty of list")
+  (is (= '() (empty (range 10))) "empty of finite range")
+  (is (= '() (empty (range))) "empty of infinite range")
   (is (nil? (empty nil)) "empty of nil"))
 
 (deftest test-pairs


### PR DESCRIPTION
## 🤔 Background

`(empty (range))` and `(empty (range 10))` returned `nil`. Issue #1710 expects an empty list, matching the behaviour of `(empty '(1 2 3))`. The `empty` cond had no branch for `LazySeqInterface`, so any lazy seq fell through to the catch-all `nil` clause.

## 💡 Goal

Return `'()` for any `LazySeqInterface` so lazy seqs report an empty seq just like lists do.

## 🔖 Changes

- `src/phel/core/predicates.phel`: `empty` recognises `LazySeqInterface`
- `tests/phel/test/core/sequence-functions.phel`: regression for finite and infinite `range`
- Changelog entry under `## Unreleased`

Closes #1710