### PR TITLE
fix(core): empty preserves the source collection's metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `sorted-map-by` and `sorted-set-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1705)
 - Sets compare equal regardless of their underlying ordering: `(= (sorted-set 4 2 6) #{4 2 6})` returns `true` (#1708)
 - `empty` returns `()` for lazy sequences such as `(range)` instead of `nil` (#1710)
+- `empty` preserves the metadata of the original collection (#1711)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -12,6 +12,7 @@
 (use Phel\Lang\Collections\Vector\PersistentVectorInterface)
 (use Phel\Lang\FnInterface)
 (use Phel\Lang\Keyword)
+(use Phel\Lang\MetaInterface)
 (use Phel\Lang\Symbol)
 (use Phel\Lang\Variable)
 
@@ -327,19 +328,23 @@
     coll))
 
 (defn empty
-  "Returns an empty collection of the same category as `coll`, or nil."
+  "Returns an empty collection of the same category as `coll`, preserving
+  the original metadata, or nil if `coll` has no empty equivalent."
   {:example "(empty [1 2 3]) ; => []\n(empty {:a 1}) ; => {}\n(empty (range 10)) ; => ()"
    :see-also ["empty?" "not-empty"]}
   [coll]
-  (cond
-    (nil? coll)                                      nil
-    (vector? coll)                                   []
-    (map? coll)                                      {}
-    (php/instanceof coll PersistentHashSetInterface) (hash-set)
-    (list? coll)                                     '()
-    (php/instanceof coll LazySeqInterface)           '()
-    (php-array? coll)                                (php/array)
-    :else                                            nil))
+  (let [empty-coll (cond
+                     (nil? coll)                                      nil
+                     (vector? coll)                                   []
+                     (map? coll)                                      {}
+                     (php/instanceof coll PersistentHashSetInterface) (hash-set)
+                     (list? coll)                                     '()
+                     (php/instanceof coll LazySeqInterface)           '()
+                     (php-array? coll)                                (php/array)
+                     :else                                            nil)]
+    (if (and empty-coll (php/instanceof coll MetaInterface))
+      (copy-meta coll empty-coll)
+      empty-coll)))
 
 (defn- seq-vector
   [values]

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -323,6 +323,14 @@
   (is (= '() (empty (range))) "empty of infinite range")
   (is (nil? (empty nil)) "empty of nil"))
 
+(deftest test-empty-preserves-meta
+  (let [m          {:foo 42}
+        apply-meta #(-> % (with-meta m) empty meta)]
+    (is (= m (apply-meta {})) "empty preserves meta on a map")
+    (is (= m (apply-meta [])) "empty preserves meta on a vector")
+    (is (= m (apply-meta #{})) "empty preserves meta on a set")
+    (is (= m (apply-meta '())) "empty preserves meta on a list")))
+
 (deftest test-pairs
   (is (= [[:a 1] [:b 2] [:c 3]] (pairs {:a 1 :b 2 :c 3})) "pairs of maps")
   (is (= [[0 3] [1 2] [2 1]] (pairs [3 2 1])) "pairs of vector"))


### PR DESCRIPTION
## 🤔 Background

`(-> coll (with-meta {:foo 42}) empty meta)` returned `nil` because `empty` always produced a fresh literal (`[]`, `{}`, `(hash-set)`, `'()`), discarding the original metadata. Issue #1711 reports this as a regression against the documented `with-meta`/`empty`/`meta` round-trip.

## 💡 Goal

Preserve the metadata of the source collection on the empty value returned by `empty`.

## 🔖 Changes

- `src/phel/core/predicates.phel`: `empty` chooses an empty container as before, then forwards the source metadata via `copy-meta` whenever the input implements `MetaInterface`
- `tests/phel/test/core/sequence-functions.phel`: regression covering map, vector, set, and list inputs
- Changelog entry under `## Unreleased`

Closes #1711