### PR TITLE
fix(core): butlast returns nil when no items remain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Sets compare equal regardless of their underlying ordering: `(= (sorted-set 4 2 6) #{4 2 6})` returns `true` (#1708)
 - `empty` returns `()` for lazy sequences such as `(range)` instead of `nil` (#1710)
 - `empty` preserves the metadata of the original collection (#1711)
+- `butlast` returns `nil` instead of an empty vector when `coll` is `nil` or has fewer than two items (#1712)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -387,11 +387,13 @@
     (peek coll)))
 
 (defn butlast
-  "Returns all but the last item in `coll`."
-  {:example "(butlast [1 2 3 4]) ; => [1 2 3]"
+  "Returns all but the last item in `coll`. Returns `nil` when `coll` is
+  `nil` or has fewer than two items."
+  {:example "(butlast [1 2 3 4]) ; => [1 2 3]\n(butlast [0]) ; => nil"
    :see-also ["last" "drop-last"]}
   [coll]
-  (drop-last 1 coll))
+  (when (next coll)
+    (drop-last 1 coll)))
 
 (defn drop-while
   "Drops all elements at the front of `coll` where `(pred x)` is true. Returns a lazy sequence.

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -130,8 +130,11 @@
 
 (deftest test-butlast
   (is (= ["a" "b"] (doall (butlast ["a" "b" "c"]))) "butlast element")
-  (is (= [] (doall (butlast ["a"]))) "butlast single element")
-  (is (= [] (doall (butlast []))) "butlast empty vector")
+  (is (nil? (butlast ["a"])) "butlast single element returns nil")
+  (is (nil? (butlast [])) "butlast empty vector returns nil")
+  (is (nil? (butlast '(0))) "butlast single-element list returns nil")
+  (is (nil? (butlast (range 1))) "butlast single-element range returns nil")
+  (is (nil? (butlast nil)) "butlast on nil returns nil")
   (is (= ["a" "b"] (doall (butlast (php/array "a" "b" "c")))) "butlast on php array"))
 
 (deftest test-drop-while


### PR DESCRIPTION
## 🤔 Background

`butlast` returned `[]` for inputs that should yield `nil` per the issue: zero- or single-element collections, and `nil` itself. The implementation forwarded straight to `drop-last 1`, which always returns a (possibly empty) sequence.

## 💡 Goal

Short-circuit on inputs with fewer than two items so `butlast` returns `nil`, matching the behaviour exercised by the clojure-test-suite.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: `butlast` returns `nil` unless `(next coll)` reports a remaining tail
- `tests/phel/test/core/sequence-functions.phel`: regression for vector/list/range single-element inputs and `nil`
- Changelog entry under `## Unreleased`

Closes #1712