### PR TITLE
test(core): lock in get-in default for nil data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `empty` returns `()` for lazy sequences such as `(range)` instead of `nil` (#1710)
 - `empty` preserves the metadata of the original collection (#1711)
 - `butlast` returns `nil` instead of an empty vector when `coll` is `nil` or has fewer than two items (#1712)
+- `get-in` returns the supplied default when the data structure is `nil` regardless of whether the key path is `nil`, empty, or missing (#1713)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -281,7 +281,10 @@
   (is (= "a" (get-in {:a [["b" "a"]]} [:a 0 1])) "get-in level 3")
   (is (= "x" (get-in {:a [["b" "a"]]} [:b 0 1] "x")) "get-in level 3 with default")
   (is (nil? (get-in {:a {:b {:c :d}}} [:a :b :c :d])) "get-in too deep returns nil")
-  (is (= :d (get-in {:a {:b {:c :d} :e (range)}} [:a :b :c :d] :d)) "get-in too deep returns default"))
+  (is (= :d (get-in {:a {:b {:c :d} :e (range)}} [:a :b :c :d] :d)) "get-in too deep returns default")
+  (is (= "not found" (get-in nil nil "not found")) "get-in on nil ds with nil keys returns the default")
+  (is (= "not found" (get-in nil [] "not found")) "get-in on nil ds with empty path returns the default")
+  (is (= "not found" (get-in nil [:a] "not found")) "get-in on nil ds with missing key returns the default"))
 
 (deftest test-nth
   (is (= 2 (nth [1 2 3] 1)) "nth on vector")


### PR DESCRIPTION
## 🤔 Background

Issue #1713 reports that `(get-in nil nil "not found")` should return `"not found"`. Phel already does (likely as a side effect of #1640) but no test currently asserts this combination of `nil` data, `nil`/empty/missing path, and a supplied default.

## 💡 Goal

Document the existing behaviour with regression tests so it cannot drift.

## 🔖 Changes

- `tests/phel/test/core/sequence-operation.phel`: three new assertions in `test-get-in` covering `nil` keys, an empty key path, and a missing top-level key when the data structure is `nil`
- Changelog entry under `## Unreleased`

Closes #1713