### PR TITLE
fix(core): some-fn returns false when no predicate matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `empty` preserves the metadata of the original collection (#1711)
 - `butlast` returns `nil` instead of an empty vector when `coll` is `nil` or has fewer than two items (#1712)
 - `get-in` returns the supplied default when the data structure is `nil` regardless of whether the key path is `nil`, empty, or missing (#1713)
+- `some-fn` returns `false` instead of `nil` when no predicate matches (#1714)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -108,18 +108,17 @@
   "Takes a variadic set of predicates and returns a function `f` that,
    when called with any number of arguments, returns the first logical
    true value produced by applying any of the composing predicates to
-   any of its arguments, and `nil` otherwise. The returned function
-   short-circuits on the first truthy result: arguments after it are
-   not inspected, and predicates after it are not tried.
+   any of its arguments, and `false` when none match. The returned
+   function short-circuits on the first truthy result: arguments after
+   it are not inspected, and predicates after it are not tried.
    Predicates are consulted in the order supplied; for a given
-   predicate, arguments are consulted left-to-right. Matches Clojure's
-   `some-fn` semantics."
-  {:example "((some-fn even? nil?) 1 2) ; => true\n((some-fn pos? even?) -3 -1) ; => nil"
+   predicate, arguments are consulted left-to-right."
+  {:example "((some-fn even? nil?) 1 2) ; => true\n((some-fn pos? even?) -3 -1) ; => false"
    :see-also ["some" "complement" "every?" "not-any?"]}
   [p & ps]
   (let [preds (cons p ps)]
     (fn [& args]
-      (some (fn [pred] (some pred args)) preds))))
+      (or (some (fn [pred] (some pred args)) preds) false))))
 
 (defn juxt
   "Takes a list of functions and returns a new function that is the juxtaposition of those functions."

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -14,15 +14,16 @@
 
 (deftest test-some-fn-single-pred
   (is (true? ((some-fn even?) 2)) "some-fn with one pred, single truthy arg")
-  (is (nil? ((some-fn even?) 1)) "some-fn with one pred, single falsy arg")
+  (is (false? ((some-fn even?) 1)) "some-fn with one pred, single falsy arg")
   (is (true? ((some-fn even?) 1 2)) "some-fn with one pred, any arg truthy")
-  (is (nil? ((some-fn even?) 1 3 5)) "some-fn with one pred, all args falsy")
-  (is (nil? ((some-fn even?))) "some-fn with one pred, zero args returns nil"))
+  (is (false? ((some-fn even?) 1 3 5)) "some-fn with one pred, all args falsy")
+  (is (false? ((some-fn even?))) "some-fn with one pred, zero args returns false")
+  (is (false? ((some-fn neg? #(> % 10)) 1 2 3)) "some-fn returns false when no pred matches across multiple args"))
 
 (deftest test-some-fn-multiple-preds
   (is (true? ((some-fn pos? even?) -2)) "some-fn returns on second pred")
   (is (true? ((some-fn pos? even?) 1)) "some-fn returns on first pred")
-  (is (nil? ((some-fn pos? even?) -1 -3)) "some-fn returns nil when no pred matches")
+  (is (false? ((some-fn pos? even?) -1 -3)) "some-fn returns false when no pred matches")
   (is (true? ((some-fn neg? zero? pos?) 0)) "some-fn with three preds matches middle"))
 
 (deftest test-some-fn-returns-actual-value


### PR DESCRIPTION
## 🤔 Background

`((some-fn even?) 1)` returned `nil`. Issue #1714 asks for `false`, matching the documented contract that the returned function yields the first truthy value or `false` when nothing matches across all predicate × argument combinations.

## 💡 Goal

Coerce the no-match result of the function returned by `some-fn` to `false` while preserving the actual truthy value on a hit.

## 🔖 Changes

- `src/phel/core/fns-sets.phel`: wrap the inner `some` call with `(or … false)` and refresh the docstring/example
- `tests/phel/test/core/function-operation.phel`: update the existing assertions that expected `nil` and add a regression for `((some-fn neg? #(> % 10)) 1 2 3)`
- Changelog entry under `## Unreleased`

Closes #1714