### PR TITLE
test(core): vector? returns false on seq and rseq results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `get-in` returns the supplied default when the data structure is `nil` regardless of whether the key path is `nil`, empty, or missing (#1713)
 - `some-fn` returns `false` instead of `nil` when no predicate matches (#1714)
 - `compare` orders namespaced keywords and symbols by namespace first, with unqualified entries sorting before namespaced ones (#1715)
+- `vector?` reports `false` for the result of `seq` and `rseq` over any input (#1716)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -200,7 +200,10 @@
 
 (deftest test-vector?
   (is (true? (vector? [])) "vector?")
-  (is (false? (vector? '())) "vector? on list"))
+  (is (false? (vector? '())) "vector? on list")
+  (is (false? (vector? (seq [1 2 3]))) "vector? on (seq vector) is false")
+  (is (false? (vector? (seq (sorted-set :a)))) "vector? on (seq sorted-set) is false")
+  (is (false? (vector? (rseq [1 2 3]))) "vector? on (rseq vector) is false"))
 
 (deftest test-list?
   (is (false? (list? [])) "list? on vector")


### PR DESCRIPTION
## 🤔 Background

Issue #1716 reports `(vector? (seq [1 2 3]))` and `(vector? (seq (sorted-set :a)))` returned `true`. This was a side-effect of `seq` returning the original collection unchanged. Since #1700, `seq` and `rseq` produce list-shaped values, so `vector?` already reports `false` in all the cases the issue lists.

## 💡 Goal

Lock in the new contract with explicit assertions so a future regression cannot reintroduce the previous behaviour.

## 🔖 Changes

- `tests/phel/test/core/type-operation.phel`: extend `test-vector?` with three assertions covering `(seq [...])`, `(seq (sorted-set ...))`, and `(rseq [...])`
- Changelog entry under `## Unreleased`

Closes #1716