### PR TITLE
fix(emitter): keyword and symbol literals keep apostrophes intact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `some-fn` returns `false` instead of `nil` when no predicate matches (#1714)
 - `compare` orders namespaced keywords and symbols by namespace first, with unqualified entries sorting before namespaced ones (#1715)
 - `vector?` reports `false` for the result of `seq` and `rseq` over any input (#1716)
+- Keyword and symbol literals containing special characters such as `'`, `"`, or `\` round-trip through compilation without leaking escape characters into their names (#1718)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -119,12 +119,12 @@ final readonly class LiteralEmitter
     {
         if ($x->getNamespace() !== null && $x->getNamespace() !== '') {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . addslashes($x->getName()) . '", "' . addslashes($x->getNamespace()) . '")',
+                '\Phel::keyword("' . $this->escapeForDoubleQuotedString($x->getName()) . '", "' . $this->escapeForDoubleQuotedString($x->getNamespace()) . '")',
                 $x->getStartLocation(),
             );
         } else {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . addslashes($x->getName()) . '")',
+                '\Phel::keyword("' . $this->escapeForDoubleQuotedString($x->getName()) . '")',
                 $x->getStartLocation(),
             );
         }
@@ -133,9 +133,24 @@ final readonly class LiteralEmitter
     private function emitSymbol(Symbol $x): void
     {
         $this->outputEmitter->emitStr(
-            '(\Phel\Lang\Symbol::create("' . addslashes($x->getFullName()) . '"))',
+            '(\Phel\Lang\Symbol::create("' . $this->escapeForDoubleQuotedString($x->getFullName()) . '"))',
             $x->getStartLocation(),
         );
+    }
+
+    /**
+     * Escape a string so it can be embedded inside a PHP double-quoted
+     * literal without losing characters. `addslashes` is wrong here
+     * because it escapes the apostrophe with a backslash that PHP keeps
+     * verbatim inside `"..."`, polluting symbol/keyword names.
+     */
+    private function escapeForDoubleQuotedString(string $value): string
+    {
+        return strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            '$' => '\\$',
+        ]);
     }
 
     private function emitMap(PersistentMapInterface $x): void

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -26,7 +26,12 @@
   (is (= :ns/name (keyword "ns" "name")) "keyword with namespace and name")
   (is (= :ns/name (keyword 'ns 'name)) "keyword accepts symbols as ns/name")
   (is (= :name (keyword nil "name")) "keyword with nil namespace is unqualified")
-  (is (nil? (keyword "ns" nil)) "keyword with nil name is nil"))
+  (is (nil? (keyword "ns" nil)) "keyword with nil name is nil")
+  (is (= :abc*+!-_'?<>= (keyword "abc*+!-_'?<>="))
+      "keyword literal with special characters round-trips against (keyword string)")
+  (is (= :abc*+!-_'?<>=/abc*+!-_'?<>=
+         (keyword "abc*+!-_'?<>=" "abc*+!-_'?<>="))
+      "namespaced keyword literal with special characters round-trips against (keyword ns name)"))
 
 (deftest create-hash-map
   (is (= {:a 1 :b 2} (hash-map :a 1 :b 2)) "construct hash-map"))


### PR DESCRIPTION
## 🤔 Background

`(= :abc*+!-_'?<>= (keyword "abc*+!-_'?<>="))` returned `false`. The literal emitter wrapped the name in `addslashes`, which prefixes apostrophes with a backslash. Because the emitted string lived inside a PHP double-quoted literal (`"..."`), `\'` is not a recognised escape, so the backslash survived into the keyword name and broke equality with the same keyword constructed via `(keyword string)`.

The same wrapper drove symbol literal emission, so any symbol containing an apostrophe was hit too.

## 💡 Goal

Round-trip keyword and symbol names through compilation byte-for-byte, regardless of the special characters they contain.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php`: replace `addslashes` for keyword/symbol emission with a small helper that escapes only the three characters PHP treats specially inside double-quoted strings: `\`, `"`, `$`
- `tests/phel/test/core/basic-constructors.phel`: regression checking `:abc*+!-_'?<>=` and the namespaced variant against the `(keyword …)` constructor
- Changelog entry under `## Unreleased`

Closes #1718