### PR TITLE
fix(core): interleave stops at the shortest input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `compare` orders namespaced keywords and symbols by namespace first, with unqualified entries sorting before namespaced ones (#1715)
 - `vector?` reports `false` for the result of `seq` and `rseq` over any input (#1716)
 - Keyword and symbol literals containing special characters such as `'`, `"`, or `\` round-trip through compilation without leaking escape characters into their names (#1718)
+- `interleave` stops at the shortest input, returns an empty sequence when any input is `nil`, and yields `[key value]` pairs for maps (#1726)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -992,21 +992,24 @@
         '()
         (copy-meta coll result)))))
 
-;; Redefine interleave as lazy
 (defn interleave
-  "Interleaves multiple collections. Returns a lazy sequence.
-
-  Returns elements by taking one from each collection in turn.
-  Pads with nil when collections have different lengths.
-  Works with infinite sequences."
-  {:example "(interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)"}
+  "Returns a lazy sequence of the first item in each `colls`, then the
+  second item in each, until any one of the collections is exhausted.
+  Any remaining items in the other collections are ignored. Returns an
+  empty sequence when no collections are supplied or when any
+  collection is empty or `nil`. Maps are iterated as `[key value]`
+  pairs."
+  {:example "(interleave [1 2 3] [:a :b :c]) ; => (1 :a 2 :b 3 :c)\n(interleave [1 2 3] [:a :b]) ; => (1 :a 2 :b)"}
   [& colls]
-  (if (php/=== nil colls)
-    '()
-    (let [result (lazy-seq-from-generator
+  (cond
+    (php/=== nil colls) '()
+    (some nil? colls)   '()
+    :else
+    (let [seqs   (apply php/array (map (fn [c] (or (seq c) (php/array))) colls))
+          result (lazy-seq-from-generator
                   (php/call_user_func_array
                    (php/array "\\Phel\\Lang\\Seq" "interleave")
-                   (apply php/array colls)))]
+                   seqs))]
       (if (php/=== nil result)
         '()
         (copy-meta (first colls) result)))))

--- a/src/php/Lang/Generators/CombineGenerator.php
+++ b/src/php/Lang/Generators/CombineGenerator.php
@@ -70,21 +70,24 @@ final class CombineGenerator
             return;
         }
 
-        $iterators = array_map(SequenceGenerator::toIterator(...), $iterables);
-        $first = $iterators[0] ?? null;
-
-        if ($first === null) {
-            return;
+        foreach ($iterables as $iterable) {
+            if ($iterable === null) {
+                return;
+            }
         }
 
-        while ($first->valid()) {
+        $iterators = array_map(SequenceGenerator::toIterator(...), $iterables);
+
+        while (true) {
             foreach ($iterators as $iterator) {
-                if ($iterator->valid()) {
-                    yield $iterator->current();
-                    $iterator->next();
-                } else {
-                    yield null;
+                if (!$iterator->valid()) {
+                    return;
                 }
+            }
+
+            foreach ($iterators as $iterator) {
+                yield $iterator->current();
+                $iterator->next();
             }
         }
     }

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -268,10 +268,13 @@
 
 (deftest test-interleave
   (is (= [:a 1 :b 2 :c 3] (interleave [:a :b :c] [1 2 3])) "interleave equal size")
-  (is (= [:a 1 :b 2 :c nil] (interleave [:a :b :c] [1 2])) "interleave different size; more keys")
-  (is (= [:a 1 :b 2] (interleave [:a :b] [1 2 3])) "interleave different size; more values")
-  (is (= [:a 1 nil 2 :c 3] (interleave [:a nil :c] [1 2 3])) "interleave include nil keys")
-  (is (= [:a 1 :b nil :c 3] (interleave [:a :b :c] [1 nil 3])) "interleave include nil values"))
+  (is (= [:a 1 :b 2] (interleave [:a :b :c] [1 2])) "interleave stops at the shortest")
+  (is (= [:a 1 :b 2] (interleave [:a :b] [1 2 3])) "interleave stops when the first input ends first")
+  (is (= [:a 1 nil 2 :c 3] (interleave [:a nil :c] [1 2 3])) "interleave preserves nil values inside collections")
+  (is (= [:a 1 :b nil :c 3] (interleave [:a :b :c] [1 nil 3])) "interleave preserves nil values across collections")
+  (is (= [] (interleave (range) nil)) "interleave returns empty when any input is nil")
+  (is (= [[:a 1] "x" [:b 2] "y"] (interleave (sorted-map :a 1 :b 2) ["x" "y"])) "interleave on a map yields key-value pairs")
+  (is (= [0 "a" 1 "b"] (vec (take 4 (interleave (range) ["a" "b"])))) "interleave terminates against a finite collection"))
 
 (deftest test-interpose
   (is (= ["a" "," "b" "," "c"] (interpose "," ["a" "b" "c"])) "interpose"))

--- a/tests/php/Unit/Lang/Generators/CombineGeneratorTest.php
+++ b/tests/php/Unit/Lang/Generators/CombineGeneratorTest.php
@@ -68,7 +68,14 @@ final class CombineGeneratorTest extends TestCase
     {
         $result = CombineGenerator::interleave([1, 2, 3], ['a', 'b']);
 
-        self::assertSame([1, 'a', 2, 'b', 3, null], iterator_to_array($result, false));
+        self::assertSame([1, 'a', 2, 'b'], iterator_to_array($result, false));
+    }
+
+    public function test_interleave_stops_on_nil_input(): void
+    {
+        $result = CombineGenerator::interleave([1, 2, 3], null);
+
+        self::assertSame([], iterator_to_array($result, false));
     }
 
     public function test_interleave_empty(): void


### PR DESCRIPTION
## 🤔 Background

Issue #1726 reports several `interleave` regressions:
- `(interleave [:a :b :c] [1 2])` returned `[:a 1 :b 2 :c nil]` instead of stopping at the shorter input.
- `(interleave (range) nil)` looped forever instead of returning the empty sequence.
- `(interleave (sorted-map :a 1 :b 2) ["x" "y"])` yielded raw map values instead of `[key value]` pairs.
- `(interleave (range) ["a" "b"])` produced trailing `nil` padding past the finite collection.

## 💡 Goal

Match the documented contract: stop iteration as soon as any collection is exhausted, treat a `nil` collection as immediate termination, and let map inputs flow through as their `seq` representation (key/value pairs).

## 🔖 Changes

- `src/php/Lang/Generators/CombineGenerator.php`: rewrite `interleave` to bail out when any iterator becomes invalid; bail early when an input is literally `nil`
- `src/phel/core/seq-fns.phel`: the Phel wrapper now `seq`-coerces every input before delegating to the generator and short-circuits on `nil` inputs
- `tests/phel/test/core/sequence-functions.phel`: new contract: shortest-stop, map pairs, finite-vs-infinite termination, `nil` collapse
- `tests/php/Unit/Lang/Generators/CombineGeneratorTest.php`: matching unit-level expectations
- Changelog entry under `## Unreleased`

Closes #1726