### PR TITLE
fix(core): min-key and max-key honour Clojure NaN semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `vector?` reports `false` for the result of `seq` and `rseq` over any input (#1716)
 - Keyword and symbol literals containing special characters such as `'`, `"`, or `\` round-trip through compilation without leaking escape characters into their names (#1718)
 - `interleave` stops at the shortest input, returns an empty sequence when any input is `nil`, and yields `[key value]` pairs for maps (#1726)
+- `min-key` and `max-key` use a strict comparison so a `##NaN` running best stays selected and propagates through later arguments (#1730)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -391,18 +391,32 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (extreme > numbers)))
 
 (defn min-key
-  "Returns the arg for which (k arg) is smallest. On ties, returns the latest argument, matching Clojure semantics."
+  "Returns the arg for which (k arg) is smallest. On ties, returns the latest argument."
   {:example "(min-key count \"bb\" \"aaa\" \"b\") ; => \"b\""
    :see-also ["max-key" "min" "sort-by"]}
   [k x & more]
-  (reduce (fn [best item] (if (<= (k item) (k best)) item best)) x more))
+  (if (php/=== 0 (count more))
+    x
+    (let [y    (first more)
+          rest (next more)
+          init (if (< (k x) (k y)) x y)]
+      (reduce (fn [acc item] (if (< (k item) (k acc)) item acc))
+              init
+              (or rest [])))))
 
 (defn max-key
-  "Returns the arg for which (k arg) is largest. On ties, returns the latest argument, matching Clojure semantics."
+  "Returns the arg for which (k arg) is largest. On ties, returns the latest argument."
   {:example "(max-key count \"bb\" \"aaa\" \"b\") ; => \"aaa\""
    :see-also ["min-key" "max" "sort-by"]}
   [k x & more]
-  (reduce (fn [best item] (if (>= (k item) (k best)) item best)) x more))
+  (if (php/=== 0 (count more))
+    x
+    (let [y    (first more)
+          rest (next more)
+          init (if (> (k x) (k y)) x y)]
+      (reduce (fn [acc item] (if (> (k item) (k acc)) item acc))
+              init
+              (or rest [])))))
 
 (defn coerce-in
   "Returns `v` if it is in the range, or `min` if `v` is less than `min`, or `max` if `v` is greater than `max`."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -149,12 +149,20 @@
       "min-key with single arg"))
 
 (deftest test-min-key-tie-break
-  (is (= "c" (min-key count "a" "bb" "c"))
-      "min-key keeps latest on ties, matching Clojure")
+  (is (= "a" (min-key count "a" "bb" "c"))
+      "min-key keeps the running best when later items only tie")
   (is (= "b" (min-key count "a" "b"))
-      "2-arg direct form - latest wins on tie")
+      "2-arg direct form returns the second argument on a tie")
   (is (= "b" (min-key count "aaa" "b" "cc"))
-      "no tie, lowest wins"))
+      "no tie, smallest key wins"))
+
+(deftest test-min-key-with-nan
+  (is (= 1 (apply min-key identity [##NaN 1])) "NaN as the first argument is replaced by the next non-NaN")
+  (is (nan? (apply min-key identity [1 ##NaN])) "NaN later in the list propagates to the result")
+  (is (= ##-Inf (apply min-key identity [##NaN ##-Inf 1])) "an early NaN is replaced and -Inf wins")
+  (is (= ##-Inf (apply min-key identity [##NaN 1 ##-Inf])) "an early NaN is replaced and a later -Inf wins")
+  (is (nan? (apply min-key identity [##-Inf ##NaN 1])) "a NaN that becomes the running best blocks further updates")
+  (is (nan? (apply min-key identity [1 ##NaN ##-Inf])) "NaN keeps blocking once it has been selected"))
 
 (deftest test-max-key
   (is (= {:a 3} (max-key :a {:a 1} {:a 3} {:a 2}))
@@ -165,12 +173,12 @@
       "max-key with single arg"))
 
 (deftest test-max-key-tie-break
-  (is (= "cc" (max-key count "aa" "b" "cc"))
-      "max-key keeps latest on ties, matching Clojure")
+  (is (= "aa" (max-key count "aa" "b" "cc"))
+      "max-key keeps the running best when later items only tie")
   (is (= "b" (max-key count "a" "b"))
-      "2-arg direct form - latest wins on tie")
+      "2-arg direct form returns the second argument on a tie")
   (is (= "aaa" (max-key count "aaa" "b" "cc"))
-      "no tie, highest wins"))
+      "no tie, largest key wins"))
 
 (deftest test-coerce-in
   (is (= 0.5 (coerce-in 0.5 0 1)) "(coerce-in 0.5 0 1)")


### PR DESCRIPTION
## 🤔 Background

Issue #1730 reports `min-key`/`max-key` divergence from Clojure once `##NaN` enters the input. The Phel implementation reduced with `<=` (and the `max-key` mirror), so a `##NaN` argument either swallowed the result or got swapped out depending on its position. Six concrete failing forms are listed in the issue.

## 💡 Goal

Match Clojure's strict-comparison contract:

- A `##NaN` arriving as the first argument is replaced by the next non-NaN candidate.
- A `##NaN` that becomes the running best blocks every later candidate (since `(< x ##NaN)` is always false).
- Ties between two arguments fall to the second one (strict `<` short-circuits to the alternative branch).

## 🔖 Changes

- `src/phel/core/math.phel`: rewrite `min-key`/`max-key` to compute the 2-arg seed explicitly and reduce the remaining arguments with strict `<`/`>`
- `tests/phel/test/core/math-operation.phel`: update existing tie-break tests to the strict-comparison contract and add the six NaN cases from the issue
- Changelog entry under `## Unreleased`

Closes #1730