### PR TITLE
fix(core): cycle over a map yields key-value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - Keyword and symbol literals containing special characters such as `'`, `"`, or `\` round-trip through compilation without leaking escape characters into their names (#1718)
 - `interleave` stops at the shortest input, returns an empty sequence when any input is `nil`, and yields `[key value]` pairs for maps (#1726)
 - `min-key` and `max-key` use a strict comparison so a `##NaN` running best stays selected and propagates through later arguments (#1730)
+- `cycle` over a map yields `[key value]` pairs (#1734)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -893,13 +893,14 @@
   (lazy-seq-from-generator (php/:: Seq (iterate f x))))
 
 (defn cycle
-  "Returns an infinite lazy sequence that cycles through the elements of collection."
+  "Returns an infinite lazy sequence that cycles through the elements of
+  collection. Maps are iterated as `[key value]` pairs."
   {:example "(take 7 (cycle [1 2 3])) ; => (1 2 3 1 2 3 1)"
    :see-also ["iterate" "repeat"]}
   [coll]
-  (if (empty? coll)
+  (if (or (php/=== nil coll) (empty? coll))
     []
-    (lazy-seq-from-generator (php/:: Seq (cycle coll)))))
+    (lazy-seq-from-generator (php/:: Seq (cycle (or (seq coll) coll))))))
 
 (defn concat
   "Concatenates multiple collections into a lazy sequence."

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -330,6 +330,10 @@
   (is (= [2 4 2 4 2] (take 5 (filter even? (cycle [1 2 3 4]))))
       "cycle should work with filter"))
 
+(deftest test-cycle-on-map
+  (is (= [[:a 1] [:b 2] [:a 1]] (vec (take 3 (cycle (sorted-map :a 1 :b 2)))))
+      "cycle on a map yields key-value pairs"))
+
 (deftest test-keep-on-vector-returns-lazy
   (is (= [2 4] (doall (keep #(when (even? %) %) [1 2 3 4])))
       "keep on vector should return lazy sequence"))


### PR DESCRIPTION
## 🤔 Background

`(take 3 (cycle {:a 1 :b 2}))` returned `(1 2 1)` instead of `([:a 1] [:b 2] [:a 1])`. The Phel wrapper passed the map straight to the underlying iterator, which yields plain values rather than entries.

## 💡 Goal

Treat a map input as its `seq` representation, so cycling produces `[key value]` pairs and matches the contract documented for `seq` after #1700.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: `cycle` calls `seq` on the input before delegating to the generator
- `tests/phel/test/core/infinite-seqs.phel`: regression for `(cycle (sorted-map :a 1 :b 2))`
- Changelog entry under `## Unreleased`

Closes #1734