### PR TITLE
fix(core): odd? handles negative odd numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `interleave` stops at the shortest input, returns an empty sequence when any input is `nil`, and yields `[key value]` pairs for maps (#1726)
 - `min-key` and `max-key` use a strict comparison so a `##NaN` running best stays selected and propagates through later arguments (#1730)
 - `cycle` over a map yields `[key value]` pairs (#1734)
+- `odd?` reports negative odd numbers as odd; previously `(odd? -119)` returned `false` because PHP's `%` truncates towards zero (#1736)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -196,7 +196,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 (defn odd?
   "Checks if `x` is odd."
   [x]
-  (= 1 (% x 2)))
+  (not (even? x)))
 
 (defn zero?
   "Checks if `x` is zero."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -64,7 +64,10 @@
 (deftest test-odd?
   (is (false? (odd? 0)) "(odd? 0)")
   (is (true? (odd? 1)) "(odd? 1)")
-  (is (false? (odd? 2)) "(odd? 2)"))
+  (is (false? (odd? 2)) "(odd? 2)")
+  (is (true? (odd? -119)) "(odd? -119)")
+  (is (true? (odd? -1)) "(odd? -1)")
+  (is (false? (odd? -2)) "(odd? -2)"))
 
 (deftest test-zero?
   (is (true? (zero? 0)) "(zero? 0)")


### PR DESCRIPTION
## 🤔 Background

`(odd? -119)` returned `false` because PHP's `%` operator truncates towards zero, so `(% -119 2)` is `-1` rather than the `1` Phel's previous implementation expected. Issue #1736 surfaces this through clojure-test-suite.

## 💡 Goal

Make `odd?` agree with `even?` for negative inputs.

## 🔖 Changes

- `src/phel/core/math.phel`: define `odd?` as `(not (even? x))`
- `tests/phel/test/core/math-operation.phel`: regression for `(odd? -119)`, `(odd? -1)`, and `(odd? -2)`
- Changelog entry under `## Unreleased`

Closes #1736