### PR TITLE
fix(core): sort and sort-by accept predicate comparators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `min-key` and `max-key` use a strict comparison so a `##NaN` running best stays selected and propagates through later arguments (#1730)
 - `cycle` over a map yields `[key value]` pairs (#1734)
 - `odd?` reports negative odd numbers as odd; previously `(odd? -119)` returned `false` because PHP's `%` truncates towards zero (#1736)
+- `sort` and `sort-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1737)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -794,8 +794,21 @@
   (some? #(= % val) (vals coll)))
 
 (defn- sort-comparator
+  "Wraps the user-supplied comparator (or `compare` when absent) so its
+  result is always an integer. A predicate-style comparator that
+  returns a boolean follows Clojure semantics: a truthy result means
+  the first argument should sort earlier (`-1`), the reverse-truthy
+  case means it should sort later (`+1`), otherwise the items are
+  considered equal."
   [comp]
-  (or comp compare))
+  (let [cmp (or comp compare)]
+    (fn [a b]
+      (let [result (cmp a b)]
+        (cond
+          (int? result)        result
+          result               -1
+          (cmp b a)            1
+          :else                0)))))
 
 (defn- sorted-vector
   [coll comp]

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -379,7 +379,15 @@
   (is (= [{:a 1 :b 10} {:a 2 :b 9} {:a 3 :b 8} {:a 4 :b 7}]
          (sort-by :a compare [{:a 2 :b 9} {:a 1 :b 10} {:a 4 :b 7} {:a 3 :b 8}]))
       "sort-by comparator before collection")
-  (is (= [3 2 1] (sort-by - [3 2 1])) "sort-by reversed"))
+  (is (= [3 2 1] (sort-by - [3 2 1])) "sort-by reversed")
+  (is (= [1 2 3] (sort < [3 1 2])) "sort with predicate `<` is ascending")
+  (is (= [3 2 1] (sort > [3 1 2])) "sort with predicate `>` is descending")
+  (is (= [{:a 1} {:a 2} {:a 3}]
+         (sort-by :a < [{:a 2} {:a 1} {:a 3}]))
+      "sort-by with predicate `<` is ascending")
+  (is (= [{:a 3} {:a 2} {:a 1}]
+         (sort-by :a > [{:a 2} {:a 1} {:a 3}]))
+      "sort-by with predicate `>` is descending"))
 
 (deftest test-group-by
   (is (= {1 ["a"] 2 ["as" "aa"] 3 ["asd"] 4 ["asdf" "qwer"]}


### PR DESCRIPTION
## 🤔 Background

`(sort-by :a < coll)` returned the collection in descending order; `(sort-by :a > coll)` returned ascending. The boolean result of `<`/`>` flowed straight into `usort`, where `true` is interpreted as a positive number (`a` should sort after `b`), inverting the intended direction. PHP also now emits a deprecation notice when comparators return booleans.

## 💡 Goal

Match the same predicate-style comparator semantics already adopted for sorted maps in #1705 across `sort` and `sort-by`.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: replace `sort-comparator` with a wrapper that converts boolean results into `-1`/`+1`/`0`, leaves integer results untouched, and falls back to `compare` when no comparator is supplied
- `tests/phel/test/core/sequence-functions.phel`: regression covering `(sort < ...)`, `(sort > ...)`, and the `sort-by` mirrors over a vector of maps
- Changelog entry under `## Unreleased`

Closes #1737