### PR TITLE
fix(core): dissoc returns nil for a nil data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `cycle` over a map yields `[key value]` pairs (#1734)
 - `odd?` reports negative odd numbers as odd; previously `(odd? -119)` returned `false` because PHP's `%` truncates towards zero (#1736)
 - `sort` and `sort-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1737)
+- `dissoc` returns `nil` when the data structure is `nil`, regardless of the keys supplied (#1738)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -252,6 +252,9 @@
 (defn- dissoc-one
   [ds key]
   (cond
+    (php/=== nil ds)
+    nil
+
     (php/is_array ds)
     (throw (php/new InvalidArgumentException "Cannot call dissoc on pure PHP arrays. Use (php/aunset ds key)"))
 

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -355,7 +355,10 @@
   (is (= {} (apply dissoc {} [])) "apply dissoc with no keys does not raise")
   (is (= {:b 2} (apply dissoc {:a 1 :b 2 :c 3} [:a :c])) "apply dissoc variadic through seq")
   (is (thrown? \InvalidArgumentException (dissoc 42 :a)) "dissoc rejects scalars")
-  (is (thrown? \InvalidArgumentException (dissoc dissoc :a)) "dissoc rejects functions"))
+  (is (thrown? \InvalidArgumentException (dissoc dissoc :a)) "dissoc rejects functions")
+  (is (nil? (dissoc nil :a)) "dissoc on nil returns nil")
+  (is (nil? (dissoc nil)) "dissoc on nil with no keys returns nil")
+  (is (nil? (apply dissoc nil [nil])) "apply dissoc on nil with a nil key returns nil"))
 
 (defstruct dissoc-rec [a b c])
 


### PR DESCRIPTION
## 🤔 Background

`(apply dissoc nil [nil])` raised `InvalidArgumentException` after the unsupported-type guard from #1704 started rejecting non-collection inputs. Issue #1738 reports the regression.

## 💡 Goal

Restore the documented Clojure behaviour: `(dissoc nil …)` returns `nil` regardless of the supplied keys.

## 🔖 Changes

- `src/phel/core/sequences.phel`: `dissoc-one` short-circuits to `nil` when `ds` is `nil`
- `tests/phel/test/core/sequence-operation.phel`: regressions for `(dissoc nil :a)`, `(dissoc nil)`, and `(apply dissoc nil [nil])`
- Changelog entry under `## Unreleased`

Closes #1738