### PR TITLE
fix(core): min and max handle single non-numeric arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `odd?` reports negative odd numbers as odd; previously `(odd? -119)` returned `false` because PHP's `%` truncates towards zero (#1736)
 - `sort` and `sort-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1737)
 - `dissoc` returns `nil` when the data structure is `nil`, regardless of the keys supplied (#1738)
+- `min` and `max` accept a single non-numeric argument, returning it unchanged instead of forwarding to `is_nan` (#1740)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -374,21 +374,27 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   [order args]
   (reduce #(if (order %1 %2) %1 %2) args))
 
+(defn- numeric-nan?
+  [x]
+  (and (php/is_float x) (php/is_nan x)))
+
 (defn min
-  "Returns the numeric minimum of all numbers. Returns `##NaN` whenever any
-  argument is `##NaN`."
+  "Returns the minimum of all arguments. Returns `##NaN` whenever any
+  numeric argument is `##NaN`."
   [& numbers]
-  (if (some nan? numbers)
-    ##NaN
-    (extreme < numbers)))
+  (cond
+    (php/=== 1 (count numbers)) (first numbers)
+    (some numeric-nan? numbers) ##NaN
+    :else                       (extreme < numbers)))
 
 (defn max
-  "Returns the numeric maximum of all numbers. Returns `##NaN` whenever any
-  argument is `##NaN`."
+  "Returns the maximum of all arguments. Returns `##NaN` whenever any
+  numeric argument is `##NaN`."
   [& numbers]
-  (if (some nan? numbers)
-    ##NaN
-    (extreme > numbers)))
+  (cond
+    (php/=== 1 (count numbers)) (first numbers)
+    (some numeric-nan? numbers) ##NaN
+    :else                       (extreme > numbers)))
 
 (defn min-key
   "Returns the arg for which (k arg) is smallest. On ties, returns the latest argument."

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -118,11 +118,13 @@
 
 (deftest test-min
   (is (= 1 (min 1 2 3)) "(min 1 2 3)")
+  (is (= "x" (min "x")) "min with a single non-numeric argument returns it unchanged")
   (is (nan? (min ##NaN 1)) "min propagates NaN")
   (is (nan? (min ##-Inf ##NaN ##Inf)) "min returns NaN regardless of position"))
 
 (deftest test-max
   (is (= 3 (max 1 2 3)) "(max 1 2 3)")
+  (is (= "x" (max "x")) "max with a single non-numeric argument returns it unchanged")
   (is (nan? (max ##NaN 1)) "max propagates NaN")
   (is (nan? (max ##-Inf ##NaN ##Inf)) "max returns NaN regardless of position"))
 


### PR DESCRIPTION
## 🤔 Background

`(max "x")` raised a `TypeError` because the NaN short-circuit added in #1703 ran `php/is_nan` on every argument, including non-numeric ones. Issue #1740 reports the regression and notes Clojure simply returns the single argument.

## 💡 Goal

Treat the single-argument call as a pass-through and gate the NaN check on float operands so non-numeric inputs flow through.

## 🔖 Changes

- `src/phel/core/math.phel`: short-circuit `min`/`max` for the 1-arg case and add a small `numeric-nan?` helper that only fires when the value is a float
- `tests/phel/test/core/math-operation.phel`: regression coverage for `(min "x")` / `(max "x")` alongside the existing NaN tests
- Changelog entry under `## Unreleased`

Closes #1740