### PR TITLE
fix(core): symbol accepts keywords and symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `sort` and `sort-by` accept predicate-style comparators such as `<` and `>`, treating a truthy result as "first arg sorts earlier" (#1737)
 - `dissoc` returns `nil` when the data structure is `nil`, regardless of the keys supplied (#1738)
 - `min` and `max` accept a single non-numeric argument, returning it unchanged instead of forwarding to `is_nan` (#1740)
+- `symbol` accepts keywords and symbols, extracting their name; `(symbol 'foo)` returns the same symbol (#1750)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -11,16 +11,31 @@
 ;;     Handles nil → "", booleans → "true"/"false", integer-valued floats
 ;;     keeping the trailing `.0`.
 
-(defn symbol
-  "Returns a new symbol for given string with optional namespace.
+(defn- to-symbol-part
+  "Extracts the underlying string from `x` for use as a symbol or
+  namespace component. Keywords and symbols pass through their `name`."
+  [x]
+  (if (php/=== nil x)
+    nil
+    (if (php/instanceof x \Phel\Lang\NamedInterface)
+      (php/-> x (getName))
+      x)))
 
-  With one argument, creates a symbol without namespace.
-  With two arguments, creates a symbol in the given namespace."
-  {:example "(symbol \"foo\") ; => foo"}
+(defn symbol
+  "Returns a new symbol for the given name with an optional namespace.
+
+  With one argument, creates a symbol without namespace. Accepts a
+  string, a keyword, or another symbol. With two arguments, creates a
+  symbol in the given namespace."
+  {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc"}
   [name-or-ns & [name]]
   (if name
-    (php/:: Symbol (createForNamespace name-or-ns name))
-    (php/:: Symbol (create name-or-ns))))
+    (php/:: Symbol (createForNamespace
+                    (to-symbol-part name-or-ns)
+                    (to-symbol-part name)))
+    (if (php/instanceof name-or-ns Symbol)
+      name-or-ns
+      (php/:: Symbol (create (to-symbol-part name-or-ns))))))
 
 (defn gensym
   "Generates a new unique symbol."

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -399,7 +399,11 @@
   (is (= 'foo/bar (symbol "foo" "bar")) "symbol on string with namespace")
   (is (= "foo" (php/-> (symbol "foo" "bar") (getNamespace))) "symbol on string with namespace using getNamespace")
   (is (= nil (php/-> (symbol "bar") (getNamespace))) "symbol on string without namespace using getNamespace")
-  (is (= 'foo (php/:: (symbol (str "\Phel" "\Lang" "\Symbol")) (create "foo"))) "symbol on PHP class identifier string"))
+  (is (= 'foo (php/:: (symbol (str "\Phel" "\Lang" "\Symbol")) (create "foo"))) "symbol on PHP class identifier string")
+  (is (= 'abc (symbol :abc)) "symbol on a keyword extracts the name")
+  (is (= '+ (symbol :+)) "symbol on a single-character keyword")
+  (is (= 'a/b (symbol :a :b)) "symbol with keyword namespace and keyword name")
+  (is (identical? 'foo (symbol 'foo)) "symbol on a symbol returns it unchanged"))
 
 (deftest test-namespace
   (is (= nil (namespace 'symbol)) "namespace on symbol without ns")


### PR DESCRIPTION
## 🤔 Background

`(= 'abc (symbol :abc))` returned `false` because the implementation forwarded keywords straight to `Symbol::create`, which stringified them as `:abc` and built a symbol named literally `:abc`. Issue #1750 reports the failure plus the same problem for the namespaced/special-character variants.

The two other Clojure-only forms in the issue (`(symbol #'+)` and the `clojure.core/+` namespace alignment) require a real Var concept, which Phel does not implement (#1717), so they remain out of scope here.

## 💡 Goal

Coerce any `NamedInterface` value (keywords or symbols) to its underlying name component before constructing the symbol, and short-circuit `(symbol some-symbol)` to return the input unchanged.

## 🔖 Changes

- `src/phel/core/strings.phel`: introduce a small `to-symbol-part` helper and rewrite `symbol` to use it for both arities; symbols pass through untouched
- `tests/phel/test/core/type-operation.phel`: regression for keyword names, single-character keywords, namespaced keyword pairs, and the symbol-passthrough case
- Changelog entry under `## Unreleased`

Closes #1750