### PR TITLE
fix(core): parse-boolean only matches exact "true"/"false"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `dissoc` returns `nil` when the data structure is `nil`, regardless of the keys supplied (#1738)
 - `min` and `max` accept a single non-numeric argument, returning it unchanged instead of forwarding to `is_nan` (#1740)
 - `symbol` accepts keywords and symbols, extracting their name; `(symbol 'foo)` returns the same symbol (#1750)
+- `parse-boolean` is case-sensitive and no longer trims whitespace: only the exact strings `"true"` and `"false"` round-trip (#1753)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/parsing.phel
+++ b/src/phel/core/parsing.phel
@@ -34,12 +34,14 @@
         :else                                               nil))))
 
 (defn parse-boolean
-  "Parses a string as a boolean. Returns true for \"true\", false for \"false\", nil otherwise."
-  {:example "(parse-boolean \"true\") ; => true"}
+  "Parses a string as a boolean. Returns `true` for the exact string
+  `\"true\"`, `false` for `\"false\"`, and `nil` for any other input.
+  The match is case-sensitive and does not tolerate surrounding
+  whitespace."
+  {:example "(parse-boolean \"true\") ; => true\n(parse-boolean \"True\") ; => nil"}
   [s]
   (when (string? s)
-    (let [lower (php/strtolower (php/trim s))]
-      (cond
-        (= lower "true")  true
-        (= lower "false") false))))
+    (cond
+      (= s "true")  true
+      (= s "false") false)))
 

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -62,9 +62,9 @@
 (deftest test-parse-boolean
   (is (true? (parse-boolean "true")) "parse-boolean true")
   (is (false? (parse-boolean "false")) "parse-boolean false")
-  (is (true? (parse-boolean "TRUE")) "parse-boolean TRUE")
-  (is (false? (parse-boolean "FALSE")) "parse-boolean FALSE")
-  (is (true? (parse-boolean "  true  ")) "parse-boolean with whitespace")
+  (is (nil? (parse-boolean "TRUE")) "parse-boolean is case-sensitive")
+  (is (nil? (parse-boolean "False")) "parse-boolean rejects mixed-case input")
+  (is (nil? (parse-boolean "  true  ")) "parse-boolean does not trim whitespace")
   (is (nil? (parse-boolean "yes")) "parse-boolean invalid")
   (is (nil? (parse-boolean "1")) "parse-boolean 1")
   (is (nil? (parse-boolean "")) "parse-boolean empty")


### PR DESCRIPTION
## 🤔 Background

`parse-boolean` lower-cased and trimmed its argument, so `"True"`, `"FALSE"`, and `" true "` all parsed successfully. Issue #1753 asks for the strict Clojure semantics where only the exact strings `"true"` and `"false"` parse, everything else returns `nil`.

## 💡 Goal

Match Clojure's contract: case-sensitive, no whitespace tolerance.

## 🔖 Changes

- `src/phel/core/parsing.phel`: drop the `strtolower`/`trim` pre-processing
- `tests/phel/test/core/utility-functions.phel`: assert that mixed-case and whitespace-padded inputs now return `nil`
- Changelog entry under `## Unreleased`

Closes #1753