### PR TITLE
fix(core): interpose over a map yields key-value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `min` and `max` accept a single non-numeric argument, returning it unchanged instead of forwarding to `is_nan` (#1740)
 - `symbol` accepts keywords and symbols, extracting their name; `(symbol 'foo)` returns the same symbol (#1750)
 - `parse-boolean` is case-sensitive and no longer trims whitespace: only the exact strings `"true"` and `"false"` round-trip (#1753)
+- `interpose` over a map yields `[key value]` pairs (#1757)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -983,8 +983,9 @@
     1 (let [coll (first args)]
         (if (php/=== nil coll)
           '()
-          (let [result (lazy-seq-from-generator
-                        (php/:: \Phel\Lang\Seq (interpose sep coll)))]
+          (let [seqd   (or (seq coll) coll)
+                result (lazy-seq-from-generator
+                        (php/:: \Phel\Lang\Seq (interpose sep seqd)))]
             (if (php/=== nil result)
               '()
               (copy-meta coll result)))))

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -277,7 +277,9 @@
   (is (= [0 "a" 1 "b"] (vec (take 4 (interleave (range) ["a" "b"])))) "interleave terminates against a finite collection"))
 
 (deftest test-interpose
-  (is (= ["a" "," "b" "," "c"] (interpose "," ["a" "b" "c"])) "interpose"))
+  (is (= ["a" "," "b" "," "c"] (interpose "," ["a" "b" "c"])) "interpose")
+  (is (= [[:a 1] "x" [:b 2]] (vec (interpose "x" (sorted-map :a 1 :b 2))))
+      "interpose on a sorted-map yields key-value pairs"))
 
 (deftest test-frequencies
   (is (= {1 2 2 3 3 2 4 1} (frequencies [1 1 2 3 2 2 3 4])) "frequencies on vector")


### PR DESCRIPTION
## 🤔 Background

`(apply interpose ["x" (sorted-map :a 1 :b 2)])` returned `(1 "x" 2)` instead of `([:a 1] "x" [:b 2])`. The Phel wrapper handed the map straight to the underlying iterator, which yields bare values.

## 💡 Goal

Match the post-#1700 contract: maps flow through their `seq` representation, so `interpose` weaves the separator between `[key value]` pairs.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: `interpose` calls `seq` on the input before delegating to the generator (falling back to the original collection when `seq` returns nil)
- `tests/phel/test/core/sequence-functions.phel`: regression for `(interpose "x" (sorted-map :a 1 :b 2))`
- Changelog entry under `## Unreleased`

Closes #1757