### PR TITLE
fix(core): peek returns the head of lists and lazy seqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This release focuses on Clojure-compatible core behavior, PHP interop consistenc
 - `symbol` accepts keywords and symbols, extracting their name; `(symbol 'foo)` returns the same symbol (#1750)
 - `parse-boolean` is case-sensitive and no longer trims whitespace: only the exact strings `"true"` and `"false"` round-trip (#1753)
 - `interpose` over a map yields `[key value]` pairs (#1757)
+- `peek` returns the first element of a list or lazy sequence and the last element of a vector / PHP array (#1761)
 - Improve set support in sequence functions including `first`, `ffirst`, `second`, `next`, `nfirst`, `fnext`, `nnext`, and `some` (#1639, #1642, #1649)
 - Improve collection edge cases in `seq`, `cons`, `pop`, `nth`, `take-last`, and `take-nth` (#1598, #1599, #1600, #1641, #1643, #1645)
 - Improve map and seq behavior in `apply`, `merge`, `dissoc`, `find`, and `mapcat` (#1602, #1603, #1606, #1607, #1646, #1651, #1653)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -4,6 +4,7 @@
 (use OutOfBoundsException)
 (use Phel\Lang\Collections\HashSet\PersistentHashSetInterface)
 (use Phel\Lang\Collections\HashSet\TransientHashSetInterface)
+(use Phel\Lang\Collections\LazySeq\LazySeqInterface)
 (use Phel\Lang\Collections\Map\PersistentMapInterface)
 (use Phel\Lang\Collections\Map\TransientMapInterface)
 (use Phel\Lang\Collections\Vector\PersistentVectorInterface)
@@ -21,22 +22,26 @@
 ;; ------------------
 
 (defn peek
-  "Returns the last element of a sequence, or nil if empty or nil.
-  Works on vectors, PHP arrays, lists, and lazy sequences."
-  {:example "(peek [1 2 3]) ; => 3"}
+  "Returns the head of a vector / PHP array (the last element) or the
+  head of a list / lazy sequence (the first element). Returns nil if
+  `coll` is empty or nil."
+  {:example "(peek [1 2 3]) ; => 3\n(peek '(:a :b :c)) ; => :a"}
   [coll]
   (cond
     (nil? coll)
     nil
 
-    (seq? coll)
-    (loop [s coll last-val nil]
-      (if (nil? (seq s))
-        last-val
-        (recur (next s) (first s))))
+    (list? coll)
+    (first coll)
+
+    (php/instanceof coll LazySeqInterface)
+    (first coll)
 
     :else
-    (php/aget coll (php/- (count coll) 1))))
+    (let [n (count coll)]
+      (if (php/=== 0 n)
+        nil
+        (php/aget coll (php/- n 1))))))
 
 
 (defn push

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -15,14 +15,16 @@
   (is (= (second [1 2 3]) (fnext [1 2 3])) "fnext equals second"))
 
 (deftest test-peek
-  (is (= 3 (peek [1 2 3])) "peek on vector")
+  (is (= 3 (peek [1 2 3])) "peek on a vector returns the last element")
   (is (nil? (peek [])) "peek on empty vector")
-  (is (= 3 (peek (php/array 1 2 3))) "peek on php array")
+  (is (= 3 (peek (php/array 1 2 3))) "peek on php array returns the last element")
   (is (nil? (peek (php/array))) "peek on empty php array")
   (is (nil? (peek nil)) "peek on nil")
-  ;; Lazy sequences (produced by filter, map, etc.) must also be supported
-  (is (= 3 (peek (filter #(> % 0) [1 2 3]))) "peek on lazy seq from filter")
-  (is (= 6 (peek (map #(* % 2) [1 2 3]))) "peek on lazy seq from map")
+  (is (= :a (peek '(:a :b :c))) "peek on a list returns the first element")
+  (is (nil? (peek '())) "peek on an empty list")
+  ;; Lazy sequences expose their head — the first element — like lists do
+  (is (= 1 (peek (filter #(> % 0) [1 2 3]))) "peek on lazy seq returns the first element")
+  (is (= 2 (peek (map #(* % 2) [1 2 3]))) "peek on lazy seq from map returns the head")
   (is (nil? (peek (filter false? [1 2 3]))) "peek on empty lazy seq"))
 
 (def- testing-set-global-array (php/array 1 2 3))


### PR DESCRIPTION
## 🤔 Background

`(peek '(:a :b :c))` returned `:c`, but Clojure (and the documented O(1) head access for lists) wants `:a`. Phel walked every element and returned the last one for any seq input.

## 💡 Goal

Mirror Clojure's `peek` contract: the head of a list / lazy sequence is its first element; vectors and PHP arrays still expose their last element as the head.

## 🔖 Changes

- `src/phel/core/sequences.phel`: branch on `list?` and `LazySeqInterface` to call `first`; keep the last-element behaviour for vectors / PHP arrays; short-circuit empty containers to `nil`
- `tests/phel/test/core/sequence-operation.phel`: regression coverage for the list and lazy-seq branches; existing vector/PHP array assertions unchanged
- Changelog entry under `## Unreleased`

Closes #1761