### PR TITLE
test(core): cover dissoc on defrecord instances

### DIFF
--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -371,6 +371,16 @@
     (is (= {} (apply dissoc r [:a :b :c])) "dissoc removing every key yields an empty map")
     (is (= r (apply dissoc r [:d])) "dissoc with no matching keys returns the record itself")))
 
+(defrecord DissocDefRecord [a b c])
+
+(deftest test-dissoc-defrecord
+  (let [r (DissocDefRecord 1 2 nil)]
+    (is (= {:b 2 :c nil} (dissoc r :a)) "dissoc on defrecord removes a key, preserving nil entries")
+    (is (= {:b 2 :c nil} (apply dissoc r [:a])) "apply dissoc on defrecord removes a key")
+    (is (= {:b 2 :c nil} (apply dissoc r [:a :d])) "dissoc on defrecord ignores unknown keys")
+    (is (= {} (apply dissoc r [:a :b :c])) "dissoc removing every key yields an empty map")
+    (is (= r (apply dissoc r [:d])) "dissoc with no matching keys returns the defrecord itself")))
+
 (deftest test-apply
   (is (fn? apply) "bare apply resolves to a function")
   (is (= 6 ((identity apply) + [1 2 3])) "apply can be invoked as a value")


### PR DESCRIPTION
## 🤔 Background

Issue #1704 reported that `(apply dissoc r [...])` on a record raised `Cannot use object of type Phel\Lang\AbstractFn@anonymous as array`. The underlying dissoc dispatch was already hardened in #1733 and #1763, but the test suite only covered `defstruct` instances. Records produced via `defrecord` exercise the same `map-target?` path through generated factory functions, so a regression there would silently bypass coverage.

## 💡 Goal

Add explicit regression coverage for `dissoc` over `defrecord` instances mirroring the `clojure-test-suite` fixture in the issue.

## 🔖 Changes

- Add `test-dissoc-defrecord` covering bare `dissoc`, `apply dissoc`, unknown keys, removing every key, and the no-op-key case.
