### PR TITLE
docs: tighten prose across docs/ guides

### DIFF
--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -1,6 +1,6 @@
 # AI coding agents
 
-`resources/agents/` ships docs, task recipes, and skill files so AI coding tools (Claude Code, Cursor, Codex, Gemini, Copilot, Aider) can build apps with Phel without scraping the website on cold start.
+`resources/agents/` ships docs, task recipes, and skill files so AI coding tools (Claude Code, Cursor, Codex, Gemini, Copilot, Aider) can build Phel apps without scraping the website on cold start.
 
 ## Install
 
@@ -32,9 +32,9 @@ Each installed file routes the agent to `.agents/index.md` for task recipes: sca
 
 `resources/agents/examples/` ships three projects:
 
-- `todo-app/` — HTTP CRUD on `phel\router`, atom store, tests
-- `http-json-api/` — three JSON endpoints
-- `cli-wordcount/` — stdin + argv, PHP shim binary
+- `todo-app/`: HTTP CRUD on `phel\router`, atom store, tests
+- `http-json-api/`: three JSON endpoints
+- `cli-wordcount/`: stdin + argv, PHP shim binary
 
 ## Sync
 
@@ -42,8 +42,7 @@ Each installed file routes the agent to `.agents/index.md` for task recipes: sca
 
 ## Repository maintenance adapters
 
-The repository also contains AI tool config for maintaining phel-lang itself. Keep these separate from the downstream
-`resources/agents/` package:
+The repository also contains AI tool config for maintaining phel-lang itself. Keep these separate from the downstream `resources/agents/` package:
 
 | Path | Audience |
 |------|----------|
@@ -54,4 +53,4 @@ The repository also contains AI tool config for maintaining phel-lang itself. Ke
 
 ## Feedback
 
-Cold-start metrics and transcripts of agents building real apps surface gaps fastest. Open an issue with a failing transcript attached.
+Cold-start metrics and transcripts of agents building real apps surface gaps fastest. Open an issue with a failing transcript.

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -1,6 +1,6 @@
 # Cold-start metrics
 
-Template for tracking how long each agent takes to build a representative app from a cold session, with and without the Phel agent skill installed.
+Template for tracking how long each agent takes to build a representative app from a cold session, with and without the Phel agent skill.
 
 ## Scenario
 
@@ -38,4 +38,4 @@ Target:
 
 ## Why this matters
 
-The baseline before bundled agent assets for a cold run was around 23 minutes for Claude Code building a todo app, most of it spent scraping phel-lang.org. The goal of `resources/agents/` is to drive that well under 5 minutes for any supported agent.
+Before bundled agent assets, a cold run took around 23 minutes for Claude Code to build a todo app, most of it scraping phel-lang.org. The goal of `resources/agents/` is to drive that well under 5 minutes for any supported agent.

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -1,6 +1,6 @@
 # AI Module Guide
 
-`phel\ai` provides a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
+`phel\ai` is a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
 
 Supported providers:
 
@@ -38,7 +38,7 @@ Supported providers:
 | `:timeout` | `120` | HTTP timeout in seconds |
 | `:max-retries` | `2` | Retry 429/5xx with exponential backoff |
 
-Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys (including `:max-retries`) to override per request.
+Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, and `extract-many` accepts the same keys (including `:max-retries`) for per-request overrides.
 
 ```phel
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
@@ -122,7 +122,7 @@ Vector math primitives are exported for custom pipelines: `dot-product`, `magnit
 
 ## Retry & timeouts
 
-`:max-retries` (default `2`) retries on HTTP 429 and 5xx with exponential backoff (500ms, 1s, 2s, ...). Network errors bubble up. Tune per call:
+`:max-retries` (default `2`) retries on HTTP 429 and 5xx with exponential backoff (500ms, 1s, 2s, ...). Network errors bubble up. Tune per call.
 
 ```phel
 (ai/complete "long task" {:timeout 300 :max-retries 4})
@@ -134,7 +134,7 @@ All failures throw `\RuntimeException`. The message includes the HTTP status and
 
 ## Testing without a live API
 
-`phel\ai` exposes an internal HTTP seam `*http-post*` that tests can rebind to return canned responses. Combined with `phel\mock`, this removes any dependency on a real provider.
+`phel\ai` exposes an internal HTTP seam `*http-post*` that tests can rebind to return canned responses. With `phel\mock`, this removes the dependency on a real provider.
 
 ```phel
 (ns my-app\test\ai-test
@@ -150,7 +150,7 @@ All failures throw `\RuntimeException`. The message includes the HTTP status and
       (is (= 1 (call-count fake))))))
 ```
 
-Note: `phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string rather than going through `json/encode`.
+`phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string rather than going through `json/encode`.
 
 ## See also
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -1,6 +1,6 @@
 # Async Module Guide
 
-Phel ships two cooperating concurrency layers over PHP fibers, both available **from `phel.core` without an explicit require** so `.cljc` portable code mirrors `clojure.core`'s defaults. The single exception is `delay`, which stays in `phel.async` because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy-thunk wrapper — keeping the names separated avoids silently hijacking Clojure semantics.
+Phel ships two cooperating concurrency layers over PHP fibers, both available **from `phel.core` without an explicit require** so `.cljc` portable code mirrors `clojure.core`'s defaults. The exception is `delay`, kept in `phel.async`: Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy-thunk wrapper, so the names stay separate to avoid hijacking Clojure semantics.
 
 ## Contents
 
@@ -16,9 +16,9 @@ Phel ships two cooperating concurrency layers over PHP fibers, both available **
 
 ## Overview
 
-**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` are in `phel.core`; `delay` is in `phel.async`. Use this layer when you already run inside an event loop or when you need timers, IO multiplexing, or fan-out across many Futures.
+**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` are in `phel.core`; `delay` is in `phel.async`. Use this layer inside an event loop, or when you need timers, IO multiplexing, or fan-out across many Futures.
 
-**Fiber-backed layer.** Uses a cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade` with no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, and `future?` are in `phel.core`. Safe to call from the top level of a script or REPL and convenient for CPU coordination, producer/consumer handoffs, and lightweight deref-with-timeout.
+**Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, and `future?` are in `phel.core`. Safe at the top level of a script or REPL; convenient for CPU coordination, producer/consumer handoffs, and lightweight deref-with-timeout.
 
 ## When to use which
 
@@ -30,7 +30,7 @@ Phel ships two cooperating concurrency layers over PHP fibers, both available **
 | Mixing AMPHP-based libs (HTTP clients, servers) | AMPHP layer |
 | Clojure-style `future` with `deref` timeout inside a loop | AMPHP `future` inside `async`, or fiber `future-call` at top level |
 
-Rule of thumb: reach for the fiber layer first for plain scripts, and for the AMPHP layer whenever IO, timers, or existing AMPHP code are involved.
+Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or existing AMPHP code are involved.
 
 ## AMPHP layer reference
 
@@ -40,7 +40,7 @@ Rule of thumb: reach for the fiber layer first for plain scripts, and for the AM
 (async body...)
 ```
 
-Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Future`. Gotcha: needs an active event loop; call this inside `Amp\Loop::run` or a command that opens one. Exceptions raised inside the body surface when the Future is awaited.
+Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Future`. Gotcha: needs an active event loop; call inside `Amp\Loop::run` or a command that opens one. Exceptions raised in the body surface when the Future is awaited.
 
 ```phel
 (await (async (+ 1 2))) ;; => 3
@@ -52,7 +52,7 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Futur
 (await future)
 ```
 
-Blocks the current fiber until the Future resolves, then returns its value. Accepts either a raw `Amp\Future` or a `PhelFuture` wrapper. Gotcha: must be called from inside a fiber.
+Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `PhelFuture` wrapper. Gotcha: must be called from inside a fiber.
 
 ### `delay` (in `phel.async`)
 
@@ -60,9 +60,9 @@ Blocks the current fiber until the Future resolves, then returns its value. Acce
 (delay seconds)
 ```
 
-Suspends execution for `seconds` (float). At the top level it behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* (not the whole process) and the delay becomes cancellable via `future-cancel`. Uses `Amp\delay` under the hood.
+Suspends execution for `seconds` (float). At the top level behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* (not the process) and the delay becomes cancellable via `future-cancel`. Uses `Amp\delay`.
 
-> **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) precisely so this difference stays visible to `.cljc` portable code.
+> **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) so the difference stays visible to `.cljc` portable code.
 
 ```phel
 (:require phel\async :refer [delay])
@@ -76,7 +76,7 @@ Suspends execution for `seconds` (float). At the top level it behaves like `php/
 (await-all futures)
 ```
 
-Awaits every Future in the collection and returns a vector of their resolved values in order. Gotcha: if any Future fails, the exception propagates and the others keep running until their next checkpoint.
+Awaits every Future in the collection and returns a vector of resolved values in order. Gotcha: if any Future fails, the exception propagates and the others keep running until their next checkpoint.
 
 ```phel
 (await-all [(async (fetch :a)) (async (fetch :b))])
@@ -96,7 +96,7 @@ Returns the value of the first Future to resolve. Gotcha: losing Futures are not
 (pmap f coll) (pmap f coll1 coll2 ...)
 ```
 
-Concurrent `map` via fibers. Results are returned in input order. Gotcha: PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU-bound computations across cores — unlike `clojure.core/pmap`, which uses a thread pool. ClojureScript and Basilisp follow the same single-threaded model.
+Concurrent `map` via fibers; results returned in input order. PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU-bound work across cores. Unlike `clojure.core/pmap`, which uses a thread pool; ClojureScript and Basilisp follow the same single-threaded model.
 
 ### `future`
 
@@ -104,7 +104,7 @@ Concurrent `map` via fibers. Results are returned in input order. Gotcha: PHP fi
 (future body...)
 ```
 
-Wraps `body` in an `Amp\Future` and returns a `PhelFuture` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, and `future-done?`. Gotcha: requires a fiber context (call inside `async` or an AMPHP loop).
+Wraps `body` in an `Amp\Future` and returns a `PhelFuture` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, and `future-done?`. Gotcha: requires a fiber context; call inside `async` or an AMPHP loop.
 
 ```phel
 (async
@@ -118,7 +118,7 @@ Wraps `body` in an `Amp\Future` and returns a `PhelFuture` supporting `deref`, `
 (future-cancel f)
 ```
 
-Signals the Future's internal `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Gotcha: cancellation is cooperative; the body keeps running until it hits a cancellation-aware checkpoint.
+Signals the Future's internal `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Cancellation is cooperative; the body keeps running until it hits a cancellation-aware checkpoint.
 
 ### `future-cancelled?`
 
@@ -126,7 +126,7 @@ Signals the Future's internal `DeferredCancellation` token. Pending and subseque
 (future-cancelled? f)
 ```
 
-Returns `true` once `future-cancel` has been called. Gotcha: does not imply the body has stopped; use `future-done?` to check terminal state.
+Returns `true` once `future-cancel` was called. Does not imply the body has stopped; use `future-done?` for terminal state.
 
 ## Fiber layer reference
 
@@ -136,7 +136,7 @@ Returns `true` once `future-cancel` has been called. Gotcha: does not imply the 
 (promise)
 ```
 
-Returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from the top level. Gotcha: not thread-safe across processes; it lives in a single PHP process.
+Returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from the top level. Not thread-safe across processes; lives in a single PHP process.
 
 ### `deliver`
 
@@ -144,7 +144,7 @@ Returns a new unrealized promise. Single delivery: once set, the value is frozen
 (deliver p value)
 ```
 
-Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Gotcha: idempotent in the sense that the second call is a no-op; the stored value never changes.
+Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Idempotent: the second call is a no-op and the stored value never changes.
 
 ```phel
 (let [p (promise)]
@@ -159,7 +159,7 @@ Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already
 (future-call f)
 ```
 
-Runs the zero-arg function `f` in a new fiber via the cooperative scheduler. Returns a `PhelFiberFuture` that supports `deref`, `realized?`, `future-done?`, and `future-cancel`. Gotcha: `f` must be zero-arg; use a closure to capture state.
+Runs the zero-arg function `f` in a new fiber via the cooperative scheduler. Returns a `PhelFiberFuture` supporting `deref`, `realized?`, `future-done?`, and `future-cancel`. `f` must be zero-arg; use a closure to capture state.
 
 ### `future-fiber`
 
@@ -167,7 +167,7 @@ Runs the zero-arg function `f` in a new fiber via the cooperative scheduler. Ret
 (future-fiber body...)
 ```
 
-Macro over `future-call`. Lets you write `@(future-fiber (expensive))` without an outer `async` block. Gotcha: unlike AMPHP `future`, this cannot take advantage of the event loop, so blocking PHP calls freeze the scheduler until they return.
+Macro over `future-call`. Lets you write `@(future-fiber (expensive))` without an outer `async` block. Unlike AMPHP `future`, this cannot use the event loop, so blocking PHP calls freeze the scheduler until they return.
 
 ### `future?`
 
@@ -175,11 +175,11 @@ Macro over `future-call`. Lets you write `@(future-fiber (expensive))` without a
 (future? x)
 ```
 
-Returns `true` if `x` is either a fiber-future or a `PhelFuture`. Useful when you receive Futures from code that may use either layer.
+Returns `true` if `x` is a fiber-future or a `PhelFuture`. Useful when receiving Futures from code that may use either layer.
 
 ## Shared primitives
 
-Phel's `deref` is overloaded and dispatches to the right layer at runtime.
+`deref` is overloaded and dispatches to the right layer at runtime.
 
 | Form | Behavior |
 |------|----------|
@@ -190,21 +190,21 @@ Phel's `deref` is overloaded and dispatches to the right layer at runtime.
 
 ## Error and cancellation model
 
-- **AMPHP path**: exceptions thrown inside a `future` or `async` body surface out of `await` / `deref`. Cancellation uses `Amp\DeferredCancellation`; after `future-cancel` any `deref` raises `Amp\CancelledException`, and the 3-arg form returns its fallback.
+- **AMPHP path**: exceptions thrown inside a `future` or `async` body surface out of `await` / `deref`. Cancellation uses `Amp\DeferredCancellation`; after `future-cancel`, any `deref` raises `Amp\CancelledException`, and the 3-arg form returns its fallback.
 - **Fiber path**: exceptions thrown in a `future-call` body are re-raised on `deref`. `future-cancel` flips a flag checked at cooperative checkpoints; the 3-arg `deref` returns its fallback without waiting.
-- **`deliver` is idempotent**: the first call wins and the return value tells you whether you set it. Use this to implement "first writer wins" handoffs without locks.
+- **`deliver` is idempotent**: the first call wins; the return value tells you whether you set it. Use for "first writer wins" handoffs without locks.
 
 ## Interop
 
-- `->closure` converts a Phel function into a PHP `\Closure`. Many PHP libraries, including AMPHP and ReactPHP, type-hint `\Closure` and reject Phel's `AbstractFn` even though it is callable. Wrap before handing a Phel fn to such a library.
-- Bare `Amp\Future` values returned by AMPHP libs can be passed to `await`, `await-all`, and `await-any` directly; no wrapping required.
-- To feed a fiber-layer result to AMPHP code, deref it from inside an `async` block: `(async (use-value @(future-fiber ...)))`.
+- `->closure` converts a Phel function into a PHP `\Closure`. Many PHP libraries (AMPHP, ReactPHP) type-hint `\Closure` and reject Phel's `AbstractFn` even though it is callable. Wrap before handing a Phel fn to such a library.
+- Bare `Amp\Future` values from AMPHP libs pass to `await`, `await-all`, and `await-any` directly; no wrapping required.
+- To feed a fiber-layer result to AMPHP code, deref it inside an `async` block: `(async (use-value @(future-fiber ...)))`.
 
 ## Pitfalls
 
 - **Calling `future` outside an event loop**. The AMPHP `future` macro needs a fiber context; use `future-fiber` for top-level scripts.
-- **Mixing future types**. `future?` is the safe predicate when you might receive either; type-specific dispatch is already baked into `deref`, `realized?`, and `future-done?`.
-- **CPU-bound `pmap`**. PHP fibers share one thread. If `f` is CPU-heavy, `pmap` will not speed it up and may add overhead. Shell out to workers for real parallelism.
+- **Mixing future types**. `future?` is the safe predicate when either may arrive; type-specific dispatch is baked into `deref`, `realized?`, and `future-done?`.
+- **CPU-bound `pmap`**. PHP fibers share one thread. If `f` is CPU-heavy, `pmap` will not speed it up and may add overhead. Shell out to workers for parallelism.
 - **Blocking PHP calls inside fiber futures**. `sleep`, `usleep`, synchronous `curl`, and blocking socket reads freeze the cooperative scheduler. Use `delay` (AMPHP) or non-blocking IO.
 
 ## Recipes
@@ -272,7 +272,7 @@ Wall time tracks the slowest branch, not the sum.
 (println (await (launch)))
 ```
 
-`future-cancel` is cooperative, so `slow` finishes its current step before observing the cancellation, but any `deref` on it now throws `Amp\CancelledException`.
+`future-cancel` is cooperative, so `slow` finishes its current step before observing cancellation, but any `deref` on it now throws `Amp\CancelledException`.
 
 ## See also
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,8 +1,8 @@
 # Building CLIs with `phel\cli`
 
-`phel\cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html) that lets you build full-featured command-line tools in Phel — subcommands, arguments, options, interactive prompts, tables, progress bars, shell completion, signal handling — all described as plain Phel maps.
+`phel\cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html) for building command-line tools in Phel: subcommands, arguments, options, interactive prompts, tables, progress bars, shell completion, signal handling, all described as plain Phel maps.
 
-Because `symfony/console` is already a runtime dependency of `phel-lang`, using `phel\cli` adds zero new dependencies.
+`symfony/console` is already a runtime dependency of `phel-lang`, so `phel\cli` adds no new dependencies.
 
 ## Quickstart
 
@@ -46,27 +46,27 @@ Run:
 | `:help`     | string            | Long help text shown in `<cmd> --help`              |
 | `:aliases`  | vector of strings | Alternate names users can type                      |
 | `:hidden?`  | bool              | Hide from `list` but still invocable                |
-| `:args`    | vector of maps    | Positional argument specs — see below               |
-| `:opts`    | vector of maps    | Option (flag) specs — see below                     |
-| `:run`     | fn (required)     | Handler `(fn [ctx] ...)` — see "Handler contract"   |
+| `:args`    | vector of maps    | Positional argument specs, see below                |
+| `:opts`    | vector of maps    | Option (flag) specs, see below                      |
+| `:run`     | fn (required)     | Handler `(fn [ctx] ...)`, see "Handler contract"    |
 
 ### Argument spec (`:args`)
 
 | Key         | Type                              | Description                                        |
 | ----------- | --------------------------------- | -------------------------------------------------- |
-| `:name`     | string (required)                 | Arg name — used to read via `(arg ctx name)`       |
+| `:name`     | string (required)                 | Arg name, read via `(arg ctx name)`                |
 | `:mode`     | `:required` / `:optional` / `:array` | Default `:optional`                              |
 | `:doc`      | string                            | Shown in help output                               |
 | `:default`  | any                               | Default value when omitted                         |
 | `:coerce`   | `:int` / `:float` / `:bool` / `:keyword` / `:edn` | Value conversion applied by `arg`   |
-| `:complete` | fn                                | `(fn [input] [...])` — shell completion suggestions |
+| `:complete` | fn                                | `(fn [input] [...])`, shell completion suggestions |
 
 ### Option spec (`:opts`)
 
 | Key         | Type                                                              | Description                      |
 | ----------- | ----------------------------------------------------------------- | -------------------------------- |
-| `:name`     | string (required)                                                 | Option name — the `--name` flag  |
-| `:short`    | string                                                            | Single-char shortcut — e.g. `"v"` |
+| `:name`     | string (required)                                                 | Option name, the `--name` flag   |
+| `:short`    | string                                                            | Single-char shortcut, e.g. `"v"` |
 | `:mode`     | `:none` / `:required` / `:optional` / `:array` / `:negatable`     | Default `:optional`              |
 | `:doc`      | string                                                            | Shown in help                    |
 | `:default`  | any                                                               | Default when flag omitted        |
@@ -82,10 +82,10 @@ Run:
 | `:commands`   | vector of command specs| Commands to register                                              |
 | `:default`    | string                 | Name of command to run when no arg passed                         |
 | `:auto-exit?` | bool                   | When `false` (default), `run` returns exit code instead of `exit` |
-| `:before`     | fn                     | Hook on `ConsoleCommandEvent` — receives raw event                |
+| `:before`     | fn                     | Hook on `ConsoleCommandEvent`, receives raw event                 |
 | `:after`      | fn                     | Hook on `ConsoleTerminateEvent`                                   |
 | `:on-error`   | fn                     | Hook on `ConsoleErrorEvent`                                       |
-| `:on-signal`  | map                    | `{:sigint cleanup-fn :sigterm cleanup-fn …}`                      |
+| `:on-signal`  | map                    | `{:sigint cleanup-fn :sigterm cleanup-fn ...}`                    |
 
 ## Handler contract
 
@@ -101,10 +101,10 @@ Your `:run` handler receives a **context map**:
 
 Return:
 
-- `nil` or `0` → success
-- any other `int` → exit code
+- `nil` or `0` -> success
+- any other `int` -> exit code
 
-Uncaught `Throwable` becomes a red `<error>` line plus exit code `1`. With `-v`, the stack trace is also written.
+Uncaught `Throwable` becomes a red `<error>` line plus exit code `1`. With `-v`, the stack trace is written.
 
 ## Writing to output
 
@@ -116,7 +116,7 @@ Uncaught `Throwable` becomes a red `<error>` line plus exit code `1`. With `-v`,
 (cli/comment-line ctx "yellow comment")
 (cli/error        ctx "red error")
 
-;; Verbosity-aware — only emit when user passes -v / -vv / -vvv
+;; Verbosity-aware: only emit when user passes -v / -vv / -vvv
 (cli/info-v   ctx "extra detail")
 (cli/info-vv  ctx "even more")
 (cli/debug    ctx "only in -vvv")
@@ -160,7 +160,7 @@ Available `:style` values: `:default`, `:borderless`, `:compact`, `:symfony`, `:
 ## Progress bars
 
 ```phel
-;; Easy form — iterate and let cli manage start/advance/finish
+;; Easy form: iterate and let cli manage start/advance/finish
 (cli/run-with-progress ctx files
   (fn [f _bar] (process-file f)))
 
@@ -206,7 +206,7 @@ my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
 
 ## Testing your CLI
 
-`phel\cli` ships test helpers so handlers can be exercised without spawning a process:
+`phel\cli` ships test helpers so handlers run without spawning a process:
 
 ```phel
 (ns my-tool-test\test\main
@@ -236,7 +236,7 @@ For prompt testing, pipe canned STDIN:
 
 ## Running under `phel run`
 
-When you run a CLI script via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. The user-facing arguments come through as the Phel core var `argv`. Pass them to `cli/run` explicitly:
+When running a CLI script via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. User-facing arguments come through the Phel core var `argv`. Pass them to `cli/run` explicitly:
 
 ```phel
 ;; Bad: reads the wrapper's argv, so "run" looks like your first command.
@@ -250,14 +250,14 @@ This is only needed when the script is invoked via `phel run`. A compiled standa
 
 ## Best practices
 
-- **Spec validation is eager.** Malformed maps throw `InvalidArgumentException` at build time with a Phel-friendly message — catch bugs before ship.
-- **Return exit codes.** Never call `php/exit` from a handler (except in signal handlers). Return an `int`, and `phel\cli` takes care of it.
-- **Use `:coerce`.** Don't `(php/intval (arg ctx "port"))` in every handler — specify `:coerce :int` once.
+- **Spec validation is eager.** Malformed maps throw `InvalidArgumentException` at build time with a Phel-friendly message: catch bugs before ship.
+- **Return exit codes.** Never call `php/exit` from a handler (except in signal handlers). Return an `int`, and `phel\cli` handles it.
+- **Use `:coerce`.** Don't `(php/intval (arg ctx "port"))` in every handler; specify `:coerce :int` once.
 - **Lift handlers to top-level fns.** Keeps `:run` small and testable.
-- **Keep `:default`** set to a safe command. If users run your tool with no args and there's no default, Symfony shows help — usually fine, but explicit is nicer.
+- **Keep `:default`** set to a safe command. With no args and no default, Symfony shows help, usually fine but explicit is nicer.
 
 ## See also
 
-- [`phel\router`](../src/phel/router.phel) — companion for HTTP apps
-- [`phel\http-client`](../src/phel/http-client.phel) — outbound HTTP
-- [symfony/console docs](https://symfony.com/doc/current/components/console.html) — full underlying API
+- [`phel\router`](../src/phel/router.phel): companion for HTTP apps
+- [`phel\http-client`](../src/phel/http-client.phel): outbound HTTP
+- [symfony/console docs](https://symfony.com/doc/current/components/console.html): full underlying API

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -1,6 +1,6 @@
 # Clojure to Phel Migration Guide
 
-Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know Clojure, you already know most of Phel. This guide covers the differences. Jump to [Quick reference](#quick-reference) if you just want the at-a-glance view.
+Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know Clojure, you already know most of Phel. This guide covers the differences. Jump to [Quick reference](#quick-reference) for the at-a-glance view.
 
 ## Quick reference
 
@@ -43,7 +43,7 @@ Most of Clojure's core library works identically in Phel:
 
 ## Reader syntax
 
-Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still work but are deprecated in favour of the Clojure form:
+Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still work but are deprecated:
 
 | Syntax | Meaning | Old Phel form (deprecated) |
 |--------|---------|----------------------------|
@@ -62,9 +62,9 @@ Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still w
 
 Notes:
 
-- Named `fn` for self-recursion works: `(fn fact [n] (if (zero? n) 1 (* n (fact (dec n)))))`. Multi-arity named fns resolve the name across arities.
-- `defmacro` bodies have access to `&form` (the original macro call) and `&env` (a map of locals at the call site), enabling dialect detection via `(:ns &env)` in `.cljc` sources.
-- Phel has no first-class `Var` or `Char` type. `#'foo` compiles to a bare symbol reference, `\A` compiles to the single-character string `"A"`.
+- Named `fn` for self-recursion: `(fn fact [n] (if (zero? n) 1 (* n (fact (dec n)))))`. Multi-arity named fns resolve the name across arities.
+- `defmacro` bodies have `&form` (original macro call) and `&env` (locals at the call site), enabling dialect detection via `(:ns &env)` in `.cljc` sources.
+- No first-class `Var` or `Char` type. `#'foo` compiles to a bare symbol reference; `\A` compiles to the single-character string `"A"`.
 - Unknown `#<tag>` literals inside unselected `#?` branches parse without error, so `.cljc` files with foreign tags like `#cpp` in non-`:phel` branches work.
 
 ## Namespace syntax
@@ -82,7 +82,7 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 
 **Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists, so `.cljc` files that `(:require [clojure.string :as str])` work without changes.
 
-**Importing PHP classes**: use `(:use ...)` in the `ns` form to import a PHP class by short name, similar to PHP's `use` statement. This is Phel's equivalent of Clojure's `(:import ...)`:
+**Importing PHP classes**: use `(:use ...)` in the `ns` form to import a PHP class by short name, like PHP's `use` statement. This is Phel's equivalent of Clojure's `(:import ...)`:
 
 ```phel
 (ns my\app
@@ -94,7 +94,7 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 (php/:: Symbol (create "foo"))  ; FQN Phel\Lang\Symbol is aliased
 ```
 
-`:use` is optional. Classes can always be referenced by fully-qualified name directly at the call site: `(php/new \DateTime)`.
+`:use` is optional. Classes can always be referenced by fully-qualified name at the call site: `(php/new \DateTime)`.
 
 ## PHP interop (vs Java interop)
 
@@ -163,26 +163,26 @@ The deprecated names will be removed in a future major version.
 
 ## What's not available (and why)
 
-Phel runs on PHP. A handful of Clojure features don't translate directly:
+Phel runs on PHP. Some Clojure features don't translate directly:
 
 | Clojure feature | Why it's absent | Alternative |
 |-----------------|----------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
-| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs — all in `phel\core`, no require needed | See [docs/async-guide.md](async-guide.md) |
+| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel\core`, no require needed | See [docs/async-guide.md](async-guide.md) |
 | **BigInt / BigDecimal / Ratio** | PHP number model | Suffix literals (`1N`, `1.5M`) and ratio literals (`1/2`) are accepted; ratios evaluate to `num / den` as a float. Use `bcmath` / `gmp` via `php/` interop for real arbitrary precision |
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
 | **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |
 | **`alter-var-root`** | No first-class vars to re-root | Use an `atom` with `swap!` for mutable state, or redefine the top-level binding with `def`. Calling `alter-var-root` at runtime throws `BadMethodCallException` with this hint |
 
-The Clojure-parity async surface lives in `phel\core` and is reachable without any require: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus the Phel fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where they can (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). The one async symbol that still needs `(:require phel\async)` is `delay`, deliberately kept out of core because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md) for the decision guide.
+The Clojure-parity async surface lives in `phel\core`, reachable without any require: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus the Phel fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). The one async symbol that still needs `(:require phel\async)` is `delay`, kept out of core because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md) for the decision guide.
 
 ## Structural differences
 
 ### defstruct, defrecord, and deftype
 
-Phel's native type form is `defstruct`. Clojure-compatible `defrecord` and `deftype` are thin macros over `defstruct` and produce the same `->Name` / `map->Name` factory functions Clojure programmers expect:
+Phel's native type form is `defstruct`. `defrecord` and `deftype` are thin macros over `defstruct` and produce the `->Name` / `map->Name` factory functions Clojure programmers expect:
 
 ```phel
 ;; defstruct (native)
@@ -200,7 +200,7 @@ Phel's native type form is `defstruct`. Clojure-compatible `defrecord` and `deft
 (->PointT 1 2)           ;; positional factory (no map-> counterpart)
 ```
 
-Inline protocol methods work in both macro bodies and are spliced into an `extend-type` call:
+Inline protocol methods work in both macro bodies; they are spliced into an `extend-type` call:
 
 ```phel
 (defprotocol Drawable
@@ -218,7 +218,7 @@ Inline protocol methods work in both macro bodies and are spliced into an `exten
   (draw [this canvas] (str canvas ":anon")))
 ```
 
-Note: Phel's `deftype` shares the map-backed `defstruct` infrastructure, so instances remain map-like (keys accessible via `get`). Clojure's `deftype` creates a non-map type; if you need that, fall back to native PHP interop.
+Phel's `deftype` shares the map-backed `defstruct` infrastructure, so instances remain map-like (keys accessible via `get`). Clojure's `deftype` creates a non-map type; if you need that, fall back to native PHP interop.
 
 ### No lazy-seq by default
 
@@ -263,5 +263,5 @@ Run tests with `./bin/phel test`.
 2. Update namespace separators: `my.app.core` → `my\app\core` (or keep `.`, both work)
 3. Replace Java interop with PHP interop (`(.method obj)` → `(php/-> obj (method))`)
 4. Rewrite `(:import [java.util Date])` clauses as `(:use DateTime)` in the `ns` form
-5. Check for concurrency primitives (refs, agents, core.async) and replace with `atom` or the AMPHP-backed primitives in `phel\core` (`future`, `pmap`, `promise`, `deliver`, …); add `(:require phel\async :refer [delay])` only when you need the sleep primitive
+5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed primitives in `phel\core` (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel\async :refer [delay])` only for the sleep primitive
 6. Run `./bin/phel test` to verify

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -1,6 +1,6 @@
 # Data Structures Manipulation Guide
 
-This guide covers all functions for manipulating Phel's immutable data structures: vectors, maps, sets, and lists.
+Functions for manipulating Phel's immutable data structures: vectors, maps, sets, and lists.
 
 ## Contents
 
@@ -19,15 +19,15 @@ This guide covers all functions for manipulating Phel's immutable data structure
 
 ## Introduction
 
-Phel's data structures are **immutable** and **persistent**. Operations return new versions of the collection while sharing structure with the original, so reads stay O(1) amortized and updates cost log32(n).
+Phel's data structures are **immutable** and **persistent**. Operations return new versions while sharing structure with the original: reads stay O(1) amortized, updates cost log32(n).
 
-The function names follow the same conventions as most Lisps (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). A short [quick reference](#quick-reference) appears at the end of the guide.
+Function names follow common Lisp conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). See the [quick reference](#quick-reference) at the end.
 
 ---
 
 ## String Iteration
 
-Strings work directly with all sequence functions, just like Clojure:
+Strings work directly with all sequence functions:
 
 ```phel
 ;; Iterate with for
@@ -104,7 +104,7 @@ All string operations properly handle multibyte UTF-8 characters:
 (map identity "🎉🎊🎈")  ; => ["🎉" "🎊" "🎈"]
 ```
 
-**Note:** Phel strings are now fully seqable, matching Clojure's behavior. The `seq` function is still available for backward compatibility and explicit conversion when needed.
+**Note:** Phel strings are fully seqable. `seq` remains available for backward compatibility and explicit conversion.
 
 ---
 
@@ -112,7 +112,7 @@ All string operations properly handle multibyte UTF-8 characters:
 
 ### `conj` - Conjoin (Universal Add)
 
-The universal function for adding elements to any collection type. Behavior varies by collection:
+Adds elements to any collection type. Behavior varies by collection:
 
 ```phel
 ;; Vectors - appends to end
@@ -150,7 +150,7 @@ The universal function for adding elements to any collection type. Behavior vari
 
 ### `assoc` - Associate Key-Value Pairs
 
-Associates a value with a key in a collection. For maps, adds/updates key-value pairs. For vectors, updates by index.
+Associates a value with a key. For maps, adds or updates key-value pairs. For vectors, updates by index.
 
 ```phel
 ;; Maps - add or update key
@@ -167,7 +167,7 @@ Associates a value with a key in a collection. For maps, adds/updates key-value 
 
 **Signature:** `[ds key value]`
 
-**See also:** For maps with structured data, consider `conj`. For nested updates, use `assoc-in`.
+**See also:** `conj` for structured data, `assoc-in` for nested updates.
 
 ---
 
@@ -195,7 +195,7 @@ Returns a collection with all elements from one or more source collections added
 
 **Signatures:** `[to from]`, `[to xform from]`
 
-See [Transducers](transducers.md) for building reusable transformations.
+See [Transducers](transducers.md).
 
 ---
 
@@ -203,7 +203,7 @@ See [Transducers](transducers.md) for building reusable transformations.
 
 ### `get` - Safe Access
 
-Gets the value at a key in a collection. Returns `nil` or an optional default if not found.
+Gets the value at a key. Returns `nil` or an optional default if not found.
 
 ```phel
 (get {:a 1 :b 2} :a)
@@ -226,7 +226,7 @@ Gets the value at a key in a collection. Returns `nil` or an optional default if
 
 ### `get-in` - Nested Access
 
-Accesses a value in a nested data structure via a sequence of keys.
+Accesses a value in nested data via a sequence of keys.
 
 ```phel
 (get-in {:a {:b {:c 1}}} [:a :b :c])
@@ -274,7 +274,7 @@ Returns a sequence of all values in a map.
 
 ### `contains?` - Check for Key
 
-Returns `true` if a key exists in the collection. **Important:** Checks for keys/indices, not values.
+Returns `true` if a key exists. **Important:** Checks keys/indices, not values.
 
 ```phel
 (contains? {:a 1 :b 2} :a)
@@ -293,7 +293,7 @@ Returns `true` if a key exists in the collection. **Important:** Checks for keys
 
 ### `find` - Find First Match
 
-Returns the first item in a collection where the predicate returns true.
+Returns the first item where the predicate returns true.
 
 ```phel
 (find #(> % 5) [1 3 7 2 9])
@@ -305,7 +305,7 @@ Returns the first item in a collection where the predicate returns true.
 
 **Signature:** `[pred coll]`
 
-**Clojure note:** Different from Clojure! Clojure's `find` returns a map entry `[key value]` for associative structures. Phel's `find` is a general search function.
+**Clojure note:** Differs from Clojure: Clojure's `find` returns a map entry `[key value]` for associative structures. Phel's `find` is a general search function.
 
 ---
 
@@ -313,7 +313,7 @@ Returns the first item in a collection where the predicate returns true.
 
 ### `update` - Transform a Value
 
-Updates a value in a data structure by applying a function to the current value.
+Applies a function to the value at a key.
 
 ```phel
 (update {:a 1} :a inc)
@@ -332,7 +332,7 @@ Updates a value in a data structure by applying a function to the current value.
 
 ### `update-in` - Nested Transform
 
-Updates a value in a nested data structure by applying a function.
+Applies a function to a nested value.
 
 ```phel
 (update-in {:a {:b 1}} [:a :b] inc)
@@ -348,7 +348,7 @@ Updates a value in a nested data structure by applying a function.
 
 ### `assoc-in` - Nested Association
 
-Associates a value in a nested data structure. Creates intermediate structures as needed.
+Associates a nested value, creating intermediate structures as needed.
 
 ```phel
 (assoc-in {:a {}} [:a :b :c] 1)
@@ -364,7 +364,7 @@ Associates a value in a nested data structure. Creates intermediate structures a
 
 ### `dissoc` - Dissociate Keys
 
-Removes a key from a data structure.
+Removes a key.
 
 ```phel
 (dissoc {:a 1 :b 2 :c 3} :b)
@@ -380,7 +380,7 @@ Removes a key from a data structure.
 
 ### `dissoc-in` - Nested Dissociation ⭐
 
-Removes a key from a nested data structure.
+Removes a nested key.
 
 ```phel
 (dissoc-in {:a {:b {:c 1 :d 2}}} [:a :b :c])
@@ -389,7 +389,7 @@ Removes a key from a nested data structure.
 
 **Signature:** `[ds [k & ks]]`
 
-**⭐ Phel-specific:** This function is not in Clojure core. It's a convenient extension for nested dissociation.
+**⭐ Phel-specific:** Not in Clojure core.
 
 ---
 
@@ -413,7 +413,7 @@ Merges multiple maps into one. Later values override earlier ones for duplicate 
 
 ### `merge-with` - Merge with Function
 
-Merges maps, using a function to resolve duplicate keys.
+Merges maps, resolving duplicate keys with a function.
 
 ```phel
 (merge-with + {:a 1 :b 2} {:b 3 :c 4})
@@ -444,7 +444,7 @@ Recursively merges nested data structures (maps, sets, vectors).
 
 **Signature:** `[& args]`
 
-**⭐ Phel-specific:** This recursive merge is not in Clojure core. It's particularly useful for configuration merging.
+**⭐ Phel-specific:** Not in Clojure core. Useful for configuration merging.
 
 ---
 
@@ -466,7 +466,7 @@ Returns a new map with only the specified keys.
 
 ### `zipmap` - Create Map from Sequences
 
-Creates a map by pairing up keys and values from two sequences.
+Pairs keys and values from two sequences into a map.
 
 ```phel
 (zipmap [:a :b :c] [1 2 3])
@@ -483,7 +483,7 @@ Creates a map by pairing up keys and values from two sequences.
 
 ### `invert` - Swap Keys and Values
 
-Returns a new map where keys and values are swapped.
+Returns a map with keys and values swapped.
 
 ```phel
 (invert {:a 1 :b 2})
@@ -492,7 +492,7 @@ Returns a new map where keys and values are swapped.
 
 **Signature:** `[map]`
 
-**Clojure note:** In Clojure, this is `clojure.set/map-invert`, not in core. Phel includes it in core.
+**Clojure note:** Equivalent to `clojure.set/map-invert`. Phel includes it in core.
 
 ---
 
@@ -500,7 +500,7 @@ Returns a new map where keys and values are swapped.
 
 ### `frequencies` - Count Occurrences
 
-Returns a map of items to the number of times they appear.
+Returns a map of items to occurrence counts.
 
 ```phel
 (frequencies [:a :b :a :c :b :a])
@@ -512,13 +512,13 @@ Returns a map of items to the number of times they appear.
 
 **Signature:** `[coll]`
 
-**Clojure note:** Identical behavior to Clojure's `frequencies`. Phel supports strings as iterable sequences!
+**Clojure note:** Identical to Clojure's `frequencies`. Phel also supports strings as iterable sequences.
 
 ---
 
 ### `group-by` - Organize by Function
 
-Groups elements by the result of applying a function to each element.
+Groups elements by the result of applying a function.
 
 ```phel
 (group-by count ["a" "bb" "ccc" "dd" "e"])
@@ -534,7 +534,7 @@ Groups elements by the result of applying a function to each element.
 
 ## Working with Nested Structures
 
-Phel provides powerful functions for working with deeply nested data structures. All `*-in` functions accept a path (sequence of keys) to navigate the structure.
+All `*-in` functions accept a path (sequence of keys) to navigate the structure.
 
 ### Common Patterns
 
@@ -573,7 +573,7 @@ Paths work with any combination of map keys and vector indices:
 
 ## Transient Collections
 
-For performance-critical code with many sequential updates, use **transient collections**. They allow efficient mutable operations, then convert back to persistent structures.
+For performance-critical code with many sequential updates, use **transient collections**. They allow efficient mutable operations, then convert back to persistent.
 
 ### Workflow
 
@@ -603,32 +603,30 @@ For performance-critical code with many sequential updates, use **transient coll
     (persistent t)))
 ```
 
-**Clojure note:** Phel uses `persistent` while Clojure uses `persistent!` (with exclamation mark).
+**Clojure note:** Phel uses `persistent`; Clojure uses `persistent!`.
 
-**Important:** After calling `persistent`, don't use the transient version anymore.
+**Important:** Don't use the transient version after calling `persistent`.
 
 ---
 
 ## Phel-Specific Extensions ⭐
 
-Phel includes several functions not found in Clojure core that provide additional convenience.
+Functions not found in Clojure core.
 
 ### `dissoc-in` - Nested Dissociation
 
-Remove keys from nested structures without manual path traversal.
+Removes keys from nested structures without manual path traversal.
 
 ```phel
 (dissoc-in {:a {:b {:c 1 :d 2} :e 3}} [:a :b :c])
 ;; => {:a {:b {:d 2} :e 3}}
 ```
 
-This is more convenient than manually navigating and updating each level.
-
 ---
 
 ### `deep-merge` - Recursive Merge
 
-Intelligently merges nested structures of the same type.
+Recursively merges nested structures of the same type.
 
 ```phel
 ;; Nested maps
@@ -646,13 +644,13 @@ Intelligently merges nested structures of the same type.
 ;; => {:tags #{:a :b :c}}
 ```
 
-Perfect for configuration merging and defaults.
+Useful for configuration merging and defaults.
 
 ---
 
 ### `pairs` - Get Key-Value Pairs
 
-Returns key-value pairs from an associative data structure.
+Returns key-value pairs from an associative structure.
 
 ```phel
 (pairs {:a 1 :b 2})
@@ -676,7 +674,7 @@ Useful for APIs that expect key-value arguments.
 
 ### `find-index` - Find with Index
 
-Returns the index of the first item where the predicate (called with index and item) returns true.
+Returns the index of the first item where the predicate (called with index and item) is true.
 
 ```phel
 (find-index #(> %2 5) [1 3 7 2 9])
@@ -686,7 +684,7 @@ Returns the index of the first item where the predicate (called with index and i
 ;; => 1  (first even index)
 ```
 
-The predicate receives two arguments: `%1` (index) and `%2` (item).
+The predicate receives `%1` (index) and `%2` (item).
 
 ---
 
@@ -737,7 +735,7 @@ These functions have been deprecated in favor of Clojure-compatible alternatives
 | `put-in` | `assoc-in` | Align with Clojure naming |
 | `unset-in` | `dissoc-in` | Align with Clojure naming |
 
-**Migration:** Simply replace the old function name with the new one. The function signatures and behavior are identical.
+**Migration:** Replace the old name with the new one. Signatures and behavior are identical.
 
 ```phel
 ;; Old (deprecated)
@@ -753,13 +751,13 @@ These functions have been deprecated in favor of Clojure-compatible alternatives
 
 ## Summary
 
-Phel provides a comprehensive set of functions for manipulating immutable data structures with strong Clojure compatibility. Key takeaways:
+Key takeaways:
 
-- Use **`conj`** as the universal "add" function
-- Use **`assoc`** for explicit key-value pairs
-- Use **`*-in` functions** for nested operations
-- Leverage **Phel-specific extensions** like `deep-merge` and `dissoc-in` for enhanced productivity
-- Use **transient collections** for performance-critical batch updates
+- **`conj`** is the universal "add" function
+- **`assoc`** sets explicit key-value pairs
+- **`*-in` functions** handle nested operations
+- **Phel extensions** like `deep-merge` and `dissoc-in` simplify nested work
+- **Transient collections** speed up performance-critical batch updates
 - Migrate from **deprecated functions** to Clojure-compatible names
 
-For more examples, see `docs/examples/05_data-structures.phel`.
+See `docs/examples/05_data-structures.phel`.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Phel single-file showcase
 
-Standalone scripts that walk from primitive literals up to concurrency and a full CLI. Each file runs with:
+Standalone scripts from primitive literals through concurrency to a full CLI. Run any file with:
 
 ```bash
 ./bin/phel run docs/examples/<file>.phel
@@ -26,7 +26,7 @@ Standalone scripts that walk from primitive literals up to concurrency and a ful
 
 Copy any file into your project and tweak it.
 
-## Run them all
+## Run all
 
 ```bash
 find docs/examples -name "*.phel" -type f | \
@@ -39,4 +39,4 @@ find docs/examples -name "*.phel" -type f | \
     '
 ```
 
-This is the same command the CI `examples` job runs on every push.
+CI's `examples` job runs the same command on every push.

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -8,20 +8,20 @@ Add Phel to an existing PHP project without touching `app/` or `src/`.
 2. Mark public functions with `{:export true}`.
 3. Create **one boot namespace** (`app\boot`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
 4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
-5. In prod, build once at deploy (`phel build`) and `require 'build/app/boot.php'` at boot. In dev, `\Phel::run($root, 'app\\boot')` compiles on first call.
+5. Prod: build at deploy (`phel build`), `require 'build/app/boot.php'` at boot. Dev: `\Phel::run($root, 'app\\boot')` compiles on first call.
 
 Two ways to call Phel from PHP:
 
 | Flavor | How | When |
 |--------|-----|------|
-| Exported wrappers | `{:export true}` + `vendor/bin/phel export` → typed PHP class | Production, IDE autocomplete |
+| Exported wrappers | `{:export true}` + `vendor/bin/phel export` to typed PHP class | Production, IDE autocomplete |
 | Dynamic lookup | `\Phel::getDefinition($ns, $name)(...)` | Scripts, prototyping |
 
 Two load modes, same provider/kernel hook:
 
 | Mode | What | Per-request cost |
 |------|------|------------------|
-| Prod (AOT) | `require 'build/app/boot.php'` — precompiled | Zero compile, one `require` |
+| Prod (AOT) | `require 'build/app/boot.php'`, precompiled | Zero compile, one `require` |
 | Dev (JIT) | `\Phel::run($root, 'app\\boot')` | Gacela bootstrap + compile on first call |
 
 Namespaces need at least two segments (`shop\pricing`, not `pricing`).
@@ -58,7 +58,7 @@ phel/
   (:require auth\tokens))
 ```
 
-Loading `app\boot` (via `require` or `\Phel::run()`) registers **every** exported function across all three namespaces. Any controller in your app can then call any wrapper:
+Loading `app\boot` (via `require` or `\Phel::run()`) registers **every** exported function across all three namespaces. Any controller can then call any wrapper:
 
 ```php
 App\PhelGenerated\Shop\Pricing::applyDiscount(...)
@@ -66,7 +66,7 @@ App\PhelGenerated\Reports\Daily::summary(...)
 App\PhelGenerated\Auth\Tokens::makeToken(...)
 ```
 
-Add a new Phel feature = add the file + add one `:require` line to `app/boot.phel`. Run `phel export` + `phel build`. Done.
+New Phel feature: add the file, add one `:require` in `app/boot.phel`, run `phel export` + `phel build`.
 
 ---
 
@@ -91,7 +91,7 @@ return PhelConfig::forProject()
         ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
 ```
 
-`app/Providers/PhelServiceProvider.php` (loads the boot ns once — all wrappers ready):
+`app/Providers/PhelServiceProvider.php` (loads the boot ns once, all wrappers ready):
 
 ```php
 namespace App\Providers;
@@ -194,7 +194,7 @@ public function boot(): void
 }
 ```
 
-Controllers use any wrapper — `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the single boot load.
+Controllers use any wrapper: `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the single boot load.
 
 ---
 
@@ -238,11 +238,11 @@ echo $greet('World') . "\n";
 
 ## Notes
 
-- **Boot namespace**: `phel/app/boot.phel` lists one `(:require other\ns)` per feature namespace. The build step walks those requires transitively, so the compiled `build/app/boot.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function in one shot — controllers then call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` line in `app/boot.phel`, rerun `phel export` + `phel build`.
-- Namespace path matches directory: `phel/shop/pricing.phel` → `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
-- Hyphens become camelCase: `(ns my-lib\core)` → `App\PhelGenerated\MyLib\Core`; `apply-discount` → `applyDiscount`.
-- Prod path (`require build/app/boot.php`): self-contained — no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls.
-- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag — never call from Laravel `register()` or per-request hot paths.
+- **Boot namespace**: `phel/app/boot.phel` lists one `(:require other\ns)` per feature namespace. The build step walks those requires transitively, so `build/app/boot.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function in one shot. Controllers then call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` in `app/boot.phel`, rerun `phel export` + `phel build`.
+- Namespace path matches directory: `phel/shop/pricing.phel` to `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
+- Hyphens become camelCase: `(ns my-lib\core)` to `App\PhelGenerated\MyLib\Core`; `apply-discount` to `applyDiscount`.
+- Prod path (`require build/app/boot.php`): self-contained, no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls.
+- Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag; never call from Laravel `register()` or per-request hot paths.
 - `setBuildConfig()` dest dir is relative to the project root.
 - Commit `build/` in the deploy artifact or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -1,22 +1,22 @@
 # Benchmarking Phel
 
-This project keeps [PHPBench](https://phpbench.readthedocs.io/) in `require-dev` so we can measure the runtime cost of important developer workflows and core data structures. Running the benchmark suite regularly makes it easier to spot performance regressions before they reach a release.
+[PHPBench](https://phpbench.readthedocs.io/) is in `require-dev` to measure runtime cost of developer workflows and core data structures. Run the suite regularly to spot regressions before release.
 
-The suite currently focuses on three high-impact areas:
+The suite covers three areas:
 
-- **CLI commands** &ndash; `phel run` and `phel test` are exercised end-to-end to make sure command line tooling stays responsive.
-- **Persistent collections** &ndash; vectors and hash maps are checked for hot operations such as `append`, `update`, and `put`.
-- **Core bootstrap** &ndash; loading and executing the bundled `phel\core` namespace ensures the compiler pipeline keeps its startup time predictable.
+- **CLI commands**: `phel run` and `phel test` exercised end-to-end.
+- **Persistent collections**: vectors and hash maps checked for hot operations like `append`, `update`, and `put`.
+- **Core bootstrap**: loading and executing the bundled `phel\core` namespace keeps compiler startup time predictable.
 
 ## Running the suite
 
-You can execute the complete suite with:
+Execute the full suite with:
 
 ```bash
 composer phpbench
 ```
 
-To keep historical measurements for comparison, record a baseline run and then compare the current branch against it:
+Record a baseline and compare the current branch against it:
 
 ```bash
 # Create or update the baseline numbers (stored under the `baseline` tag)
@@ -26,12 +26,12 @@ composer phpbench-base
 composer phpbench-ref
 ```
 
-The assertion configured in [`phpbench.json`](../../phpbench.json) will fail the comparison when the measured mode deviates by more than some % from the baseline.
+The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when the measured mode deviates beyond the configured threshold.
 
-For quick local checks you can override the number of iterations and revolutions:
+For quick local checks, override iterations and revolutions:
 
 ```bash
 composer phpbench -- --iterations=2 --revs=10
 ```
 
-Refer to the [official documentation](https://phpbench.readthedocs.io/) for advanced reporting and configuration options.
+See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting and configuration.

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -1,23 +1,21 @@
 # Compiler Internals
 
-This document describes how the Phel compiler processes source code. The compiler is organized as a pipeline of several steps. Each step transforms the input and passes the result to the next step.
+How the Phel compiler processes source code. The compiler is a pipeline; each step transforms its input and passes the result to the next.
 
 ## Compiler pipeline
 
-1. **Lexer** – converts the source string into a stream of tokens.
-2. **Parser** – turns tokens into a parse tree that still includes whitespace and comments.
-3. **Reader** – builds Phel data structures from the parse tree. Trivia such as whitespace is removed.
-4. **Analyzer** – validates the data structures and produces an abstract syntax tree (AST).
-5. **Emitter** – transforms the AST into PHP code.
-6. **Evaluator** – executes the generated PHP code.
+1. **Lexer**: source string into a stream of tokens.
+2. **Parser**: tokens into a parse tree retaining whitespace and comments.
+3. **Reader**: parse tree into Phel data structures. Trivia like whitespace is dropped.
+4. **Analyzer**: validates the data structures and produces an abstract syntax tree (AST).
+5. **Emitter**: AST into PHP code.
+6. **Evaluator**: executes the generated PHP code.
 
-The examples below use the expression `(print "hi")` to illustrate each stage of the pipeline.
-
-The following sections describe each stage in more detail.
+Examples below use `(print "hi")` to illustrate each stage.
 
 ## Lexer
 
-The lexer splits the input string into tokens. Every token has a `type`, the lexeme `code` and start/end `SourceLocation` information. Tokens are collected inside a `TokenStream`, which is consumed by the parser.
+The lexer splits the input string into tokens. Every token has a `type`, the lexeme `code`, and start/end `SourceLocation`. Tokens are collected in a `TokenStream` consumed by the parser.
 
 Example output:
 
@@ -31,7 +29,7 @@ T_CLOSE_PARENTHESIS ")"
 
 ## Parser
 
-The parser reads from the `TokenStream` and produces a parse tree. The tree contains every token, including whitespace and comments, so macros can work with the original layout when required.
+The parser reads from the `TokenStream` and produces a parse tree. The tree retains every token, including whitespace and comments, so macros can access the original layout.
 
 Example output:
 
@@ -43,7 +41,7 @@ ListNode
 
 ## Reader
 
-The reader converts the parse tree into Phel data structures. Unnecessary trivia tokens are removed at this stage. The result is wrapped into a `ReaderResult` object that keeps a reference to the original snippet for error reporting.
+The reader converts the parse tree into Phel data structures, dropping trivia tokens. The result is wrapped in a `ReaderResult` that keeps a reference to the original snippet for error reporting.
 
 Example output:
 
@@ -53,7 +51,7 @@ Example output:
 
 ## Analyzer
 
-During analysis the forms produced by the reader are validated and transformed into an AST. The analyzer enriches a global environment with information such as variables or macro definitions. When successful, an `AbstractNode` tree is returned.
+The analyzer validates the reader's forms and transforms them into an AST. It enriches a global environment with variables and macro definitions. On success, returns an `AbstractNode` tree.
 
 Example output:
 
@@ -65,7 +63,7 @@ CallNode
 
 ## Emitter
 
-The emitter walks the AST and converts it to PHP source code. To produce valid PHP identifiers the emitter uses the *munge* component. Munge replaces special characters in Phel symbols with safe alternatives (for example `-` becomes `_` or `+` becomes `_PLUS_`). Depending on the options, the emitter can also generate source maps.
+The emitter walks the AST and produces PHP source code. To produce valid PHP identifiers it uses the *munge* component, which replaces special characters in Phel symbols (e.g. `-` becomes `_`, `+` becomes `_PLUS_`). The emitter can also generate source maps.
 
 Example output:
 
@@ -75,7 +73,7 @@ print("hi");
 
 ## Evaluator
 
-Finally the evaluator executes the emitted PHP code. The `RequireEvaluator` implementation writes the code to a temporary file and includes it so that macros and top level forms have side effects during compilation.
+The evaluator executes the emitted PHP. `RequireEvaluator` writes the code to a temp file and includes it so macros and top-level forms have side effects during compilation.
 
 Example output:
 

--- a/docs/lazy-sequences.md
+++ b/docs/lazy-sequences.md
@@ -1,16 +1,16 @@
 # Lazy Sequences in Phel
 
-Lazy sequences allow you to work with potentially infinite collections by deferring computation until values are actually needed.
+Work with potentially infinite collections by deferring computation until values are needed.
 
 ## Overview
 
-Phel provides two key constructs for working with lazy sequences:
-- **`lazy-seq`**: Creates a lazy sequence from an expression
-- **`lazy-cat`**: Lazily concatenates multiple collections
+Two constructs:
+- **`lazy-seq`**: creates a lazy sequence from an expression
+- **`lazy-cat`**: lazily concatenates multiple collections
 
 ## The `lazy-seq` Macro
 
-`lazy-seq` takes a body of expressions that returns a sequence or nil, and yields a LazySeq that will invoke the body only the first time the sequence is accessed, caching the result for subsequent accesses.
+`lazy-seq` takes a body returning a sequence or nil and yields a LazySeq that invokes the body on first access, caching the result.
 
 ### Basic Usage
 
@@ -28,7 +28,7 @@ Phel provides two key constructs for working with lazy sequences:
 
 ### Infinite Sequences with `lazy-seq`
 
-The real power of `lazy-seq` is creating infinite sequences using recursion:
+Combine `lazy-seq` with recursion to build infinite sequences:
 
 ```phel
 ;; Generate infinite sequence of integers starting from n
@@ -42,18 +42,18 @@ The real power of `lazy-seq` is creating infinite sequences using recursion:
 
 ### How It Works
 
-When you wrap an expression in `lazy-seq`, it:
-1. Creates a thunk (a function with no arguments) that will evaluate the body
-2. Returns a LazySeq object that holds this thunk
-3. On first access (via `first`, `rest`, `take`, etc.), evaluates the thunk
-4. Caches the result for subsequent accesses
+`lazy-seq`:
+1. Creates a thunk (zero-arg function) that evaluates the body
+2. Returns a LazySeq holding the thunk
+3. On first access (`first`, `rest`, `take`, etc.), evaluates the thunk
+4. Caches the result
 
 ## The `lazy-cat` Macro
 
-`lazy-cat` provides a convenient syntax for concatenating collections.
+Convenient syntax for concatenating collections.
 
 **Important:** `lazy-cat` expands to `concat` and evaluates all arguments eagerly.
-It works well for combining finite or already-realized lazy sequences, but is
+Fine for combining finite or already-realized lazy sequences, but
 **NOT suitable for recursive infinite sequences**.
 
 ### Basic Concatenation
@@ -68,7 +68,7 @@ It works well for combining finite or already-realized lazy sequences, but is
 
 ### With Finite Lazy Sequences
 
-`lazy-cat` works with lazy sequences that will eventually terminate:
+Works with lazy sequences that terminate:
 
 ```phel
 (lazy-cat (take 3 (range 100)) (take 3 (range 10 20)))
@@ -91,9 +91,9 @@ When building recursive infinite sequences, use `cons` instead:
   (lazy-seq (lazy-cat [n] (ints (inc n)))))  ; Don't do this!
 ```
 
-**Why?** Since `lazy-cat` evaluates all arguments before concatenating, the
-recursive call `(ints (inc n))` immediately executes, causing infinite recursion.
-Use `cons` to properly defer evaluation.
+**Why?** `lazy-cat` evaluates all arguments before concatenating, so the
+recursive call `(ints (inc n))` runs immediately and recurses forever.
+Use `cons` to defer evaluation.
 
 ## Common Patterns
 
@@ -140,7 +140,7 @@ Use `cons` to properly defer evaluation.
 
 ## Built-in Lazy Functions
 
-Many Phel core functions return lazy sequences:
+Many core functions return lazy sequences:
 
 - **`range`** - Lazy sequence of numbers
 - **`iterate`** - Infinite sequence by repeatedly applying a function
@@ -191,7 +191,7 @@ Many Phel core functions return lazy sequences:
 
 ### Chunking
 
-Phel's lazy sequences use chunking for performance - they realize elements in chunks rather than one at a time. This reduces overhead but means:
+Phel's lazy sequences realize elements in chunks rather than one at a time. This reduces overhead but means:
 
 ```phel
 ;; Side effects may happen in chunks
@@ -201,7 +201,7 @@ Phel's lazy sequences use chunking for performance - they realize elements in ch
 
 ### Realizing Sequences
 
-Force full realization when needed:
+Force realization when needed:
 
 ```phel
 (doall lazy-seq)  ; Realizes entire sequence, returns it
@@ -225,7 +225,7 @@ Force full realization when needed:
 
 ### 2. Lazy Sequences in Tests
 
-When testing lazy sequences, realize them first:
+Realize lazy sequences before asserting:
 
 ```phel
 ;; ❌ May not fail even if lazy-seq has issues
@@ -237,7 +237,7 @@ When testing lazy sequences, realize them first:
 
 ### 3. Side Effects in Lazy Sequences
 
-Side effects in lazy sequences execute when realized, not when created:
+Side effects run on realization, not creation:
 
 ```phel
 (def log-and-inc
@@ -277,18 +277,18 @@ Side effects in lazy sequences execute when realized, not when created:
 
 - Lazy sequence examples: `docs/examples/`
 - Core function reference: docstrings in `src/phel/core.phel`
-- Clojure lazy sequences (similar concepts): https://clojure.org/reference/sequences
+- Clojure lazy sequences: https://clojure.org/reference/sequences
 
 ## Summary
 
-Lazy sequences in Phel provide:
-- **Memory efficiency** - process large datasets without loading everything
-- **Composability** - chain transformations elegantly
-- **Infinite sequences** - work with conceptually infinite collections
-- **Performance** - compute only what you need
+Lazy sequences provide:
+- **Memory efficiency**: process large datasets without loading everything
+- **Composability**: chain transformations
+- **Infinite sequences**: work with conceptually infinite collections
+- **Performance**: compute only what's needed
 
 Key takeaways:
 - Use `lazy-seq` for custom lazy sequences
 - Use `cons` (not `lazy-cat`) for recursive infinite sequences
-- Be aware of chunking and head retention
-- Realize sequences explicitly when needed with `doall`/`dorun`
+- Watch for chunking and head retention
+- Force realization with `doall`/`dorun` when needed

--- a/docs/lint-guide.md
+++ b/docs/lint-guide.md
@@ -1,6 +1,6 @@
 # Linter Guide
 
-`phel lint` is a semantic linter that catches common mistakes without running code. It runs on source files or directories and emits diagnostics in human, JSON, or GitHub Actions format.
+`phel lint` is a semantic linter that catches common mistakes without running code. Runs on source files or directories; emits diagnostics in human, JSON, or GitHub Actions format.
 
 ## Contents
 
@@ -37,9 +37,9 @@
 
 ## Output formats
 
-- `human` (default): colored terminal output, suitable for local use
+- `human` (default): colored terminal output for local use
 - `json`: array of `{file, line, column, rule, severity, message}` records
-- `github`: `::error file=...` directives for GitHub Actions annotations
+- `github`: `::error file=...` directives for GitHub Actions
 
 ## Configuration
 
@@ -57,11 +57,11 @@ Pass a custom path with `--config=path/to/lint.phel`.
 
 ## Cache
 
-Lint results are cached per file by content hash; subsequent runs only reanalyze changed files. Disable with `--no-cache`.
+Results are cached per file by content hash; subsequent runs only reanalyze changed files. Disable with `--no-cache`.
 
 ## Editor integration
 
-Use `--format=json` from an editor plugin, or launch `phel lsp` for real-time diagnostics as you type.
+Use `--format=json` from an editor plugin, or run `phel lsp` for real-time diagnostics as you type.
 
 ## See also
 

--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -1,6 +1,6 @@
 # Language Server Guide
 
-`phel lsp` speaks LSP v3.17 over stdio (JSON-RPC 2.0 with Content-Length framing). It gives editors hover, goto-definition, completion, references, rename, formatting, document/workspace symbols, and live diagnostics.
+`phel lsp` speaks LSP v3.17 over stdio (JSON-RPC 2.0 with Content-Length framing). Provides hover, goto-definition, completion, references, rename, formatting, document/workspace symbols, and live diagnostics.
 
 ## Contents
 
@@ -16,7 +16,7 @@
 ./vendor/bin/phel lsp
 ```
 
-The server reads LSP messages on stdin and writes responses on stdout. Logs go to stderr.
+Reads LSP messages on stdin, writes responses on stdout, logs to stderr.
 
 ## Capabilities
 
@@ -58,13 +58,13 @@ vim.lsp.start({
 
 ## Diagnostics
 
-Diagnostics include compiler errors, unresolved symbols, arity mismatches, and lint rule violations. Publication is debounced so typing does not thrash.
+Diagnostics include compiler errors, unresolved symbols, arity mismatches, and lint violations. Publication is debounced so typing does not thrash.
 
 ## Pitfalls
 
-- The server scans files under the project root; keep `phel-config.php` up to date so require resolution works
-- Huge projects benefit from running `phel index` ahead of time to warm the symbol cache
-- LSP runs in the same PHP process; long-running REPL state is not shared with a running `phel nrepl`
+- The server scans files under the project root; keep `phel-config.php` current for require resolution
+- Large projects benefit from running `phel index` ahead of time to warm the symbol cache
+- LSP runs in its own PHP process; REPL state is not shared with a running `phel nrepl`
 
 ## See also
 

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -62,5 +62,5 @@
 
 ## See also
 
-- `phel\schema` for declaring shapes reusable across validation and matching
-- `cond`, `case`, `condp` for simpler dispatch without destructuring
+- `phel\schema`: shapes reusable across validation and matching
+- `cond`, `case`, `condp`: simpler dispatch without destructuring

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -2,17 +2,16 @@
 
 Phel historically uses the PHP-style backslash (`\`) as the namespace
 separator in every position: `ns` forms, `:require`/`:use` clauses,
-fully-qualified call sites, and class FQNs. Clojure — and therefore
-`.cljc` code shared with sibling dialects — uses the dot (`.`). For
-long-term Clojure compatibility, the backslash form is being
-**deprecated** and will be removed in a future release.
+fully-qualified call sites, and class FQNs. The dot (`.`) is the
+target form going forward. The backslash form is **deprecated** and
+will be removed in a future release.
 
 See tracking issue:
 [phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
 
 ## Opt-in to deprecation warnings
 
-Two equivalent ways to turn the warnings on — pick whichever fits
+Three equivalent ways to enable warnings; pick whichever fits
 your pipeline:
 
 **CLI flag** (recommended for one-off runs and CI configs):
@@ -37,13 +36,13 @@ return PhelConfig::forProject()
 
 When enabled, the compiler emits one `E_USER_DEPRECATED` per unique
 `(file, symbol)` pair so large projects do not drown in duplicates.
-The `--warn-deprecations` flag is consumed by the `phel` bootstrap
-before Symfony's per-command parsers run, so it works with every
-subcommand.
+`--warn-deprecations` is consumed by the `phel` bootstrap before
+Symfony's per-command parsers run, so it works with every subcommand.
+
 
 ## What is detected today
 
-Symbols flowing through the analyzer's `SymbolResolver` **or** the
+Symbols flowing through the analyzer's `SymbolResolver` or the
 `ns`-form analyzer emit warnings:
 
 - **Namespace declarations** (Phase 1b): `(ns phel\foo)` → use

--- a/docs/nrepl-guide.md
+++ b/docs/nrepl-guide.md
@@ -1,6 +1,6 @@
 # nREPL Guide
 
-`phel nrepl` starts a bencode-over-TCP nREPL server for editor tooling and interactive development. Any client that speaks the nREPL protocol (CIDER, Calva, vim-iced, neovim-nrepl clients) can connect.
+`phel nrepl` starts a bencode-over-TCP nREPL server for editor tooling and interactive development. Any nREPL client (CIDER, Calva, vim-iced, neovim-nrepl) can connect.
 
 ## Contents
 
@@ -17,7 +17,7 @@
 ./vendor/bin/phel nrepl --host=0.0.0.0 --port=7888
 ```
 
-The server prints the actual port to stdout on startup so clients can auto-discover it.
+The server prints the bound port to stdout for client auto-discovery.
 
 ## Operations
 
@@ -53,11 +53,11 @@ Both detect `.nrepl-port` in the repo root; set it after launching the server.
 
 ## Pitfalls
 
-- The server is single-user by default; multiple clients sharing a session will see interleaved output
-- Bind to `127.0.0.1` unless you are inside a trusted network; there is no auth
-- `interrupt` only stops the eval in that session, not other sessions or fibers
+- Single-user by default; multiple clients sharing a session see interleaved output
+- Bind to `127.0.0.1` unless on a trusted network; there is no auth
+- `interrupt` stops the eval in that session only, not other sessions or fibers
 
 ## See also
 
 - [LSP Guide](./lsp-guide.md)
-- [Quickstart](./quickstart.md) for the basic built-in REPL
+- [Quickstart](./quickstart.md): basic built-in REPL

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,7 +1,5 @@
 # Common Patterns and Idioms
 
-Practical patterns for writing idiomatic Phel code.
-
 ## Table of Contents
 
 - [Working with Nil](#working-with-nil)
@@ -222,8 +220,7 @@ Threads value as **last** argument:
 
 ## Pattern Matching
 
-`phel\match` provides a `match` macro that destructures by shape and binds symbols in one step. Use it when `cond`/`case` would force you to re-query the same value from multiple angles.
-
+`phel\match` destructures by shape and binds symbols in one step. Use it when `cond`/`case` would force you to re-query the same value from multiple angles.
 ```phel
 (ns app\commands
   (:require phel\match :refer [match]))
@@ -251,7 +248,7 @@ Pattern elements:
 | `(pat :as x)` | Match `pat` and also bind whole value to `x` |
 | `(:or a b c)` | Any of the alternatives |
 
-`match` requires multi-target targets (the outer `[event]` vector) so you can match several values at once:
+The outer `[event]` vector lets you match several values at once:
 
 ```phel
 (match [http-status role]
@@ -262,7 +259,7 @@ Pattern elements:
   :else              :unknown)
 ```
 
-Without an `:else` clause, `match` throws `RuntimeException` when nothing fits — add `:else` when "none of these" is a valid outcome.
+Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. Add `:else` when "none of these" is a valid outcome.
 
 ## Error Handling
 
@@ -565,7 +562,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits �
 
 ### Auto-gensym for Hygienic Bindings
 
-Inside a syntax-quote (`` ` ``), a symbol ending in `#` is replaced with a freshly generated, unique symbol. Reuse the same `name#` to refer to the same generated binding:
+Inside a syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique symbol. Reuse the same `name#` to refer to the same generated binding:
 
 ```phel
 (defmacro unless
@@ -582,14 +579,14 @@ Inside a syntax-quote (`` ` ``), a symbol ending in `#` is replaced with a fresh
      ret#))
 ```
 
-`start#` and `ret#` will not collide with bindings in user code, even if the caller already has a `start` or `ret` in scope.
+`start#` and `ret#` won't collide with caller bindings, even if `start` or `ret` are already in scope.
 
 ### Implicit `&form` and `&env`
 
-Every `defmacro` body has two implicit symbols available, matching Clojure:
+Every `defmacro` body has two implicit symbols:
 
-- `&form` — the original macro call as written by the user (useful for source-aware error messages)
-- `&env` — a map of locals in scope at the call site, keyed by symbol
+- `&form`: the original macro call as written by the user (useful for source-aware error messages)
+- `&env`: a map of locals in scope at the call site, keyed by symbol
 
 ```phel
 ;; Inspect lexical scope at the call site
@@ -606,7 +603,7 @@ Every `defmacro` body has two implicit symbols available, matching Clojure:
                    " in " (quote ~&form))))))
 ```
 
-`.cljc` dialect detection works the same way as Clojure ↔ ClojureScript. `(:ns &env)` is always `nil` under Phel (just like Clojure on the JVM), so a portability macro lands on the right branch:
+`(:ns &env)` is always `nil` under Phel, so portability macros land on the right branch:
 
 ```phel
 (defmacro dialect [] (if (:ns &env) "cljs" "phel"))
@@ -615,7 +612,7 @@ Every `defmacro` body has two implicit symbols available, matching Clojure:
 
 ### Extending `is` with Custom Assertions
 
-`phel\test/assert-expr` is an open multimethod, so you can teach the `is` macro how to expand new assertion forms. A `defmethod` takes the original `form` and the user-supplied `message`, and returns the code that the outer `is` should run instead:
+`phel\test/assert-expr` is an open multimethod, so you can teach the `is` macro to expand new assertion forms. A `defmethod` takes the original `form` and the user-supplied `message`, and returns the code that the outer `is` should run:
 
 ```phel
 (ns my-app\test\helpers
@@ -632,9 +629,9 @@ Every `defmacro` body has two implicit symbols available, matching Clojure:
   (is (approx= 3.14159 (calc-pi)) "calc-pi should land near pi"))
 ```
 
-When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the multimethod's `:default` arm handles binary equality and predicate forms exactly as before, so existing tests are unaffected.
+When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:default` arm handles binary equality and predicate forms, so existing tests are unaffected.
 
-> Cross-namespace registration must use the fully-qualified `phel\test/assert-expr` so the methods table is resolved in `phel\test` rather than the local namespace.
+> Cross-namespace registration must use the fully-qualified `phel\test/assert-expr` so the methods table resolves in `phel\test` rather than the local namespace.
 
 ## Tips for Writing Idiomatic Phel
 
@@ -697,7 +694,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the mul
 
 ## Build-safe Entry Points
 
-`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register correctly. Top-level **side effects** (starting a game loop, reading `stdin`, opening sockets, sleeping) also run, which can block the build indefinitely.
+`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register correctly. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run, which can block the build indefinitely.
 
 Guard imperative entry calls with `*build-mode*`:
 
@@ -714,7 +711,7 @@ Guard imperative entry calls with `*build-mode*`:
   (play))
 ```
 
-`*build-mode*` is set to `true` while the compiler evaluates your file during `phel build`, and `false` during `phel run` or when the compiled artifact is loaded at runtime. The same idea applies to any stdin/network/sleep call at top level:
+`*build-mode*` is `true` while the compiler evaluates your file during `phel build`, and `false` during `phel run` or when the compiled artifact loads at runtime. The same applies to any stdin/network/sleep call at top level:
 
 ```phel
 ;; Bad: blocks `phel build` forever on fgets.
@@ -730,13 +727,13 @@ Guard imperative entry calls with `*build-mode*`:
   (println (read-line)))
 ```
 
-`defn`, `def` of pure values, `ns`, and `(:require ...)` forms are always safe at top level. Only imperative work needs the guard.
+`defn`, `def` of pure values, `ns`, and `(:require ...)` are always safe at top level. Only imperative work needs the guard.
 
-> Note: `phel build` suppresses stdout produced by compiled code during compilation, so stray `println` calls no longer leak to the terminal. Execution still happens though, so anything that **blocks** (stdin reads, `sleep`, sockets, infinite loops) still needs `(when-not *build-mode* ...)`.
+> `phel build` suppresses stdout from compiled code during compilation, so stray `println` calls no longer leak to the terminal. Execution still happens, so anything that **blocks** (stdin reads, `sleep`, sockets, infinite loops) still needs `(when-not *build-mode* ...)`.
 
 ## See Also
 
-- [PHP Interop](php-interop.md) - Working with PHP code
-- [Quick Start](quickstart.md) - Get started quickly
-- [Reader Shortcuts](reader-shortcuts.md) - Syntax reference
-- [Lazy Sequences](lazy-sequences.md) - Performance patterns
+- [PHP Interop](php-interop.md): Working with PHP code
+- [Quick Start](quickstart.md): Get started
+- [Reader Shortcuts](reader-shortcuts.md): Syntax reference
+- [Lazy Sequences](lazy-sequences.md): Performance patterns

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,6 +1,6 @@
 # Performance Tips
 
-Guidance for making `phel test`, `phel run`, and other CLI commands fast on your machine. Applies to source-checkout use; PHAR users get the same benefits.
+How to make `phel test`, `phel run`, and other CLI commands fast. Applies to source-checkout use; PHAR users get the same benefits.
 
 ## TL;DR
 
@@ -17,15 +17,15 @@ Create the directory once: `mkdir -p /tmp/php-opcache`. Restart your shell. Repe
 
 ## Why it is slow without opcache
 
-Every `bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file on every run: `vendor/`, Phel compiler, Symfony console, the project's own classes. With `opcache.file_cache` enabled, compiled bytecode persists across processes.
+Every `bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file on every run: `vendor/`, Phel compiler, Symfony console, project classes. With `opcache.file_cache` enabled, compiled bytecode persists across processes.
 
-Phel also maintains a compiled-code cache of its own (stored under `sys_get_temp_dir() . '/phel'` by default) that memoizes Phel-to-PHP compilation per source hash. The two caches are complementary: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
+Phel also maintains its own compiled-code cache (under `sys_get_temp_dir() . '/phel'` by default) that memoizes Phel-to-PHP compilation per source hash. The two caches are complementary: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
 
-Cache invalidation is automatic. Each run hashes the `.phel` source content (`md5`) and compares against the stored entry; on mismatch, the file is recompiled and transitive dependents are invalidated. No manual clear needed after editing a `.phel` file. Fresh compiles also call `opcache_compile_file()` on the generated PHP. Use the reset steps below only if something gets wedged.
+Cache invalidation is automatic. Each run hashes the `.phel` source (`md5`) and compares against the stored entry; on mismatch, the file is recompiled and transitive dependents are invalidated. No manual clear is needed after editing a `.phel` file. Fresh compiles also call `opcache_compile_file()` on the generated PHP. Use the reset steps below only if something gets wedged.
 
 ## Memory limit
 
-`bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php bin/phel ...`) or embed Phel in another tool, bump the limit yourself; the compiler's `token_get_all` validation can exceed 128M on sizable projects.
+`bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php bin/phel ...`) or embed Phel in another tool, bump the limit yourself; the compiler's `token_get_all` validation can exceed 128M on large projects.
 
 ```bash
 php -d memory_limit=-1 bin/phel test
@@ -49,7 +49,7 @@ Prints `bool(true)` when CLI opcache is on.
 
 ## Cache reset
 
-If a run behaves oddly (stale compiled code, missing definitions, cache-hit crashes), nuke both caches and retry:
+If a run behaves oddly (stale compiled code, missing definitions, cache-hit crashes), wipe both caches and retry:
 
 ```bash
 rm -rf "$(php -r 'echo sys_get_temp_dir();')/phel"
@@ -72,5 +72,5 @@ Full suite (4 440 tests) dropped from ~76 s to ~61 s after enabling opcache CLI.
 
 ## Related
 
-- [`docs/internals/benchmarks.md`](internals/benchmarks.md) — PHPBench suite for tracking regressions in the Phel compiler itself
+- [`docs/internals/benchmarks.md`](internals/benchmarks.md): PHPBench suite for tracking regressions in the Phel compiler itself
 - PHP manual: [opcache configuration](https://www.php.net/manual/en/opcache.configuration.php)

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -1,6 +1,6 @@
 # PHP/Phel Interoperability Guide
 
-This guide shows how to seamlessly work between PHP and Phel code.
+How to work between PHP and Phel code.
 
 ## Quick Reference
 
@@ -35,17 +35,14 @@ Prefix PHP functions with `php/`:
 (php/abs -5)                      ; => 5
 (php/max 1 5 3)                   ; => 5
 
-;; Namespaced functions — keep the original casing
+;; Namespaced functions: keep the original casing
 (php/Amp\trapSignal [php/SIGINT php/SIGTERM])
 (php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
 ```
 
-The `php/` prefix resolves any global or namespaced PHP function. For
-namespaced functions the name after `php/` is the full PHP path (use `\\`
-to disambiguate from the root namespace when needed). Case is preserved,
-so `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
+The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path (use `\\` to disambiguate from the root namespace). Case is preserved, so `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
 
-To keep calls short, capture the function reference with `def`:
+Capture the function reference with `def` to shorten calls:
 
 ```phel
 (def trap-signal php/\Amp\trapSignal)
@@ -71,11 +68,11 @@ To keep calls short, capture the function reference with `def`:
 (php/-> now (format "Y-m-d"))     ; => "2024-01-15"
 (php/-> now (getTimestamp))       ; => 1705334400
 
-;; Method call shorthand — `.method` expands to `(php/-> ...)`
+;; Method call shorthand: `.method` expands to `(php/-> ...)`
 (.format now "Y-m-d")             ; => "2024-01-15"
 (.getTimestamp now)               ; => 1705334400
 
-;; Property access shorthand — `.-field` expands to `(php/-> ...)`
+;; Property access shorthand: `.-field` expands to `(php/-> ...)`
 (.-y (new DateInterval "P1D"))    ; => 0
 
 ;; Chain method calls
@@ -87,7 +84,7 @@ To keep calls short, capture the function reference with `def`:
 (php/:: DateTime (createFromFormat "Y-m-d" "2024-01-15"))
 (DateTime/createFromFormat "Y-m-d" "2024-01-15")   ; shorthand
 
-;; Static constants and properties — bare `Class/MEMBER` shorthand
+;; Static constants and properties: bare `Class/MEMBER` shorthand
 (php/:: \DateTimeImmutable ATOM)                   ; => "Y-m-d\\TH:i:sP"
 \DateTimeImmutable/ATOM                            ; shorthand
 
@@ -121,32 +118,32 @@ Use `:use` for PHP classes:
 
 ```phel
 (ns app\services
-  (:use PDO)                      ; Import single class
-  (:use DateTime DateInterval)   ; Import multiple classes
+  (:use PDO)                      ; Single class
+  (:use DateTime DateInterval)   ; Multiple classes
   (:use Symfony\Component\HttpFoundation\Request))
 
-;; Now use them without namespace prefix
+;; Use them without namespace prefix
 (php/new PDO "mysql:host=localhost" "user" "pass")
 (php/new Request)
 ```
 
 ### Requiring Phel Namespaces
 
-`:require` accepts both list-style and Clojure-style vector entries, so the same form works in plain `.phel` files and shared `.cljc` files:
+`:require` accepts both list-style and vector entries, so the same form works in `.phel` and shared `.cljc` files:
 
 ```phel
-;; Phel-style list entry
+;; List entry
 (ns app\services
   (:require phel\string :as str)
   (:require phel\json :as json :refer [encode decode]))
 
-;; Clojure-style vector entry — same meaning
+;; Vector entry, same meaning
 (ns app\services
   (:require [phel\string :as str]
             [phel\json :as json :refer [encode decode]]))
 ```
 
-You can also use `.` as an alternate namespace separator (in addition to `\`), which makes Clojure-shaped namespaces parse cleanly in `.cljc` files:
+`.` works as an alternate namespace separator (alongside `\`):
 
 ```phel
 (ns my.cljc.file
@@ -160,24 +157,24 @@ Both `phel\string` and `phel.string` resolve to the same namespace.
 ### Phel → PHP
 
 ```phel
-;; Vectors → PHP arrays
+;; Vectors to PHP arrays
 (to-php-array [1 2 3])            ; => PHP [1, 2, 3]
 
-;; Maps → PHP associative arrays
+;; Maps to PHP associative arrays
 (to-php-array {:a 1 :b 2})        ; => PHP ["a" => 1, "b" => 2]
 
-;; Keywords → strings
+;; Keywords to strings
 (name :keyword)                   ; => "keyword"
 ```
 
 ### PHP → Phel
 
 ```phel
-;; PHP arrays → Phel collections
+;; PHP arrays to Phel collections
 (php-array-to-map $php_assoc_array)  ; => {:key value}
 (vals $php_indexed_array)            ; => [val1 val2 val3]
 
-;; Indexed PHP array → vector
+;; Indexed PHP array to vector
 [1 2 3]                           ; Already works as Phel vector
 ```
 
@@ -292,10 +289,10 @@ $response->send();
 ### Use Transients for Batch Updates
 
 ```phel
-;; Slow - creates new collection each time
+;; Slow: new collection each step
 (reduce (fn [acc x] (conj acc (* x 2))) [] large-list)
 
-;; Fast - mutable during build
+;; Fast: mutable during build
 (persistent
   (reduce (fn [acc x] (conj acc (* x 2))) (transient []) large-list))
 ```
@@ -303,10 +300,10 @@ $response->send();
 ### Prefer PHP Functions for Heavy Lifting
 
 ```phel
-;; Good - use PHP's optimized functions
+;; PHP's optimized functions
 (php/array_map #(* % 2) php-array)
 
-;; When you need Phel collections
+;; Phel collections
 (map #(* % 2) phel-vector)
 ```
 
@@ -316,7 +313,7 @@ $response->send();
 ;; Inefficient
 (to-php-array (map inc (php-array-to-map php-data)))
 
-;; Better - stay in PHP
+;; Better: stay in PHP
 (php/array_map inc php-data)
 ```
 
@@ -377,29 +374,29 @@ $response->send();
 
 ## Tips for PHP Developers
 
-- **Immutability**: Phel collections don't mutate. `(conj vec item)` returns a *new* vector
-- **No `$` sigil**: Variables don't need `$` in Phel
-- **Keywords**: Use `:keyword` instead of strings for map keys
-- **Truthiness**: Only `false` and `nil` are falsy (not `0` or `""`)
-- **Parens matter**: `(func arg)` calls the function, `func` is just the value
+- **Immutability**: collections don't mutate. `(conj vec item)` returns a *new* vector
+- **No `$` sigil**: variables don't need `$`
+- **Keywords**: use `:keyword` for map keys
+- **Truthiness**: only `false` and `nil` are falsy (not `0` or `""`)
+- **Parens matter**: `(func arg)` calls the function, `func` is the value
 
 ## Tips for Clojure Developers
 
-- **PHP interop**: Use `php/` prefix (not `.` or `..`)
+- **PHP interop**: use `php/` prefix (not `.` or `..`)
 - **Method calls**: `(php/-> obj (method))` not `(.method obj)`
-- **Deref**: `@my-atom` works as shorthand for `(deref my-atom)`, just like Clojure
-- **Import classes**: Use `:use` in `ns`, not `:import`
-- **Require vectors**: Clojure-style `(:require [phel\string :as str :refer [upper-case]])` works alongside the older list form
-- **Namespace separators**: Both `\` and `.` work — `phel\string` and `phel.string` resolve to the same namespace
-- **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` work for cross-platform `.cljc` files
-- **Unquote**: Use `~` and `~@` inside syntax-quote (the older `,` / `,@` are deprecated)
-- **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (the older `name$` is deprecated)
-- **Macro env**: `&form` and `&env` are implicitly bound inside every `defmacro`, just like Clojure. `&env` is a map of in-scope locals keyed by symbol; `(:ns &env)` is always `nil` (matching Clojure on the JVM), so the standard `.cljc` `(if (:ns &env) "cljs" ...)` dialect-detection trick lands on the non-cljs branch
-- **Lambda syntax**: `#(+ %1 %2)` is the recommended syntax. `|(+ $1 $2)` is deprecated
-- **PHP arrays**: Work with them directly or convert to Phel collections
+- **Deref**: `@my-atom` is shorthand for `(deref my-atom)`
+- **Import classes**: use `:use` in `ns`, not `:import`
+- **Require vectors**: `(:require [phel\string :as str :refer [upper-case]])` works alongside the list form
+- **Namespace separators**: both `\` and `.` work; `phel\string` and `phel.string` resolve to the same namespace
+- **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files
+- **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` are deprecated)
+- **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated)
+- **Macro env**: `&form` and `&env` are implicitly bound inside every `defmacro`. `&env` is a map of in-scope locals keyed by symbol; `(:ns &env)` is always `nil`, so the `.cljc` `(if (:ns &env) "cljs" ...)` dialect-detection trick lands on the non-cljs branch
+- **Lambda syntax**: `#(+ %1 %2)` recommended; `|(+ $1 $2)` deprecated
+- **PHP arrays**: work with them directly or convert to Phel collections
 
 ## See Also
 
-- [Examples](examples/README.md) - Practical code samples
-- [Reader Shortcuts](reader-shortcuts.md) - Syntax reference
-- [Common Patterns](patterns.md) - Idiomatic Phel code
+- [Examples](examples/README.md): practical code samples
+- [Reader Shortcuts](reader-shortcuts.md): syntax reference
+- [Common Patterns](patterns.md): idiomatic Phel code

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,9 +11,9 @@ composer require phel-lang/phel-lang
 ./vendor/bin/phel init
 ```
 
-That's it. `phel init` creates a `phel-config.php`, a starter `src/phel/main.phel`, and a matching `tests/phel/main_test.phel` so you can run, test, and REPL immediately.
+`phel init` creates a `phel-config.php`, a starter `src/phel/main.phel`, and a matching `tests/phel/main_test.phel` so you can run, test, and REPL immediately.
 
-For a single-file experiment or sandbox, use the root layout instead:
+For a single-file experiment or sandbox, use the root layout:
 
 ```bash
 ./vendor/bin/phel init --minimal
@@ -34,7 +34,7 @@ Useful `init` flags:
 
 ### Option 2: Add to an existing PHP project manually
 
-If `phel init` doesn't fit your existing project structure, you can write `phel-config.php` by hand:
+If `phel init` doesn't fit your project structure, write `phel-config.php` by hand:
 
 ```php
 <?php
@@ -102,7 +102,7 @@ user:5> (/ 1 0)
 user:6> *e                        ; last exception
 ```
 
-The prompt shows the current namespace (it switches on `(ns ...)` / `(in-ns ...)`) and `*1`, `*2`, `*3` hold the last three REPL results, `*e` the last exception. Type `(exit)` or press Ctrl-D to quit.
+The prompt shows the current namespace (it switches on `(ns ...)` / `(in-ns ...)`). `*1`, `*2`, `*3` hold the last three REPL results; `*e` the last exception. Type `(exit)` or press Ctrl-D to quit.
 
 ### 3. Working with Collections (1 minute)
 
@@ -130,7 +130,7 @@ The prompt shows the current namespace (it switches on `(ns ...)` / `(in-ns ...)
 ;; Tagged literals
 (def slug-rx #regex "^[a-z0-9-]+$")    ; PCRE pattern string
 
-;; `#inst` reads ISO-8601 into \DateTimeImmutable at read time — use in let/fn,
+;; `#inst` reads ISO-8601 into \DateTimeImmutable at read time. Use in let/fn,
 ;; not `def` (persistent defs require TypeInterface or scalar).
 (let [released #inst "2026-04-20T00:00:00Z"]
   (.format released "Y-m-d"))          ; => "2026-04-20"
@@ -189,7 +189,7 @@ See [Pattern Matching Guide](match-guide.md) for guards, destructuring, and more
 
 ## First Web Application (5 minutes)
 
-Let's build a simple API endpoint using modern Phel interop shortcuts.
+Build an API endpoint using the interop shortcuts.
 
 ### Step 1: Install Dependencies
 
@@ -228,7 +228,7 @@ Create `src/routes.phel`:
                   {:id 2 :name "Bob"   :email "bob@example.com"}] 200))
 ```
 
-The `(new Response ...)` form and `#php {...}` literal are the modern shortcuts for `(php/new Response ...)` and `(php-associative-array ...)`. They compile identically.
+`(new Response ...)` and `#php {...}` are shortcuts for `(php/new Response ...)` and `(php-associative-array ...)`. They compile identically.
 
 ### Step 3: Create PHP Entry Point
 
@@ -322,14 +322,14 @@ curl http://localhost:8000/users
 (defn days-between [d1 d2]
   (.-days (.diff d1 d2)))
 
-;; `#inst` reads ISO-8601 into \DateTimeImmutable at read time — no runtime cost.
+;; `#inst` reads ISO-8601 into \DateTimeImmutable at read time, no runtime cost.
 ;; Keep such values local; persistent `def` is reserved for scalars/TypeInterface.
 (let [launch   #inst "2026-04-20T00:00:00Z"
       tomorrow (add-days launch 1)]
   (format-date tomorrow "Y-m-d"))      ; => "2026-04-21"
 ```
 
-`.method`, `.-field`, and `(new ClassName ...)` are the modern shorthands for `php/->` and `php/new`. Both styles compile to identical PHP.
+`.method`, `.-field`, and `(new ClassName ...)` are shorthands for `php/->` and `php/new`. Both styles compile to identical PHP.
 
 ### Database Queries
 
@@ -357,21 +357,21 @@ curl http://localhost:8000/users
 
 ### Learn More
 
-- **[Common Patterns](patterns.md)** — Idiomatic Phel code including pattern matching
-- **[Data Structures Guide](data-structures-guide.md)** — Vectors, maps, sets, transients
-- **[PHP Interop](php-interop.md)** — Deep dive into PHP integration and shortcuts
-- **[Reader Shortcuts](reader-shortcuts.md)** — Syntax reference, `#inst`, `#regex`, `#php`
-- **[Async Guide](async-guide.md)** — Concurrency with fibers and AMPHP
-- **[CLI Guide](cli-guide.md)** — Build CLIs with `phel\cli`
-- **[Schema Guide](schema-guide.md)** — Data-driven validation, coercion, generation
-- **[Pattern Matching Guide](match-guide.md)** — `match` macro with guards and destructuring
-- **[Linter Guide](lint-guide.md)** — `phel lint` rules and configuration
-- **[Language Server Guide](lsp-guide.md)** — `phel lsp` editor integration
-- **[nREPL Guide](nrepl-guide.md)** — `phel nrepl` for editor tooling
-- **[Watch Guide](watch-guide.md)** — `phel watch` hot-reload
-- **[Framework Integration](framework-integration.md)** — Laravel, Symfony, framework-less
-- **[Performance Tips](performance.md)** — Opcache CLI setup, cache reset
-- **[Examples](examples/)** — Runnable single-file samples
+- **[Common Patterns](patterns.md)**: idiomatic Phel including pattern matching
+- **[Data Structures Guide](data-structures-guide.md)**: vectors, maps, sets, transients
+- **[PHP Interop](php-interop.md)**: PHP integration and shortcuts
+- **[Reader Shortcuts](reader-shortcuts.md)**: syntax reference, `#inst`, `#regex`, `#php`
+- **[Async Guide](async-guide.md)**: concurrency with fibers and AMPHP
+- **[CLI Guide](cli-guide.md)**: build CLIs with `phel\cli`
+- **[Schema Guide](schema-guide.md)**: data-driven validation, coercion, generation
+- **[Pattern Matching Guide](match-guide.md)**: `match` with guards and destructuring
+- **[Linter Guide](lint-guide.md)**: `phel lint` rules and configuration
+- **[Language Server Guide](lsp-guide.md)**: `phel lsp` editor integration
+- **[nREPL Guide](nrepl-guide.md)**: `phel nrepl` for editor tooling
+- **[Watch Guide](watch-guide.md)**: `phel watch` hot-reload
+- **[Framework Integration](framework-integration.md)**: Laravel, Symfony, framework-less
+- **[Performance Tips](performance.md)**: Opcache CLI setup, cache reset
+- **[Examples](examples/)**: runnable single-file samples
 
 ### REPL Workflow
 
@@ -421,32 +421,32 @@ Run tests:
 
 **For PHP Developers:**
 - Think immutable: functions return new values, don't modify arguments
-- Embrace recursion: use `loop`/`recur` instead of `for`/`while`
-- Use threading macros: `->` and `->>` for readable pipelines
-- Maps are better than classes for most data
-- Prefer the modern interop shortcuts (`.method`, `(new Class)`, `#php [...]`)
+- Recursion: use `loop`/`recur` instead of `for`/`while`
+- Threading macros: `->` and `->>` for readable pipelines
+- Maps beat classes for most data
+- Prefer interop shortcuts (`.method`, `(new Class)`, `#php [...]`)
 
 **For Clojure Developers:**
-- PHP interop uses `php/` prefix; shortcuts `.method`, `.-field`, `ClassName/method`, `(new Class)` are available too
-- Import PHP classes with `:use` in the `ns` form, not `:import`
+- PHP interop uses `php/` prefix; shortcuts `.method`, `.-field`, `ClassName/method`, `(new Class)` also work
+- Import PHP classes with `:use` in `ns`, not `:import`
 - Regex literals are `#"pattern"`; `#regex "..."` reads as a delimited PCRE string
-- Some Clojure functions have different names (check [Clojure Migration](clojure-migration.md))
+- Some function names differ (see [Clojure Migration](clojure-migration.md))
 
 ## Common Gotchas
 
 ```phel
-;; Wrong — forgot parens for function call
+;; Wrong: forgot parens for function call
 map square [1 2 3]              ; Error: not a function
 
 ;; Right
 (map square [1 2 3])            ; => [1 4 9]
 
-;; Wrong — trying to mutate
+;; Wrong: trying to mutate
 (def nums [1 2 3])
 (conj nums 4)                   ; Returns NEW vector
 nums                            ; Still [1 2 3]!
 
-;; Right — rebind or use result
+;; Right: rebind or use result
 (def nums [1 2 3])
 (def nums (conj nums 4))        ; Rebind to new vector
 nums                            ; => [1 2 3 4]

--- a/docs/reader-conditionals.md
+++ b/docs/reader-conditionals.md
@@ -4,7 +4,7 @@
 
 Reader conditionals allow platform-specific code in shared source files. They are evaluated at read time (during parsing), before compilation. The Phel compiler selects the `:phel` branch, ignores branches for other platforms (`:clj`, `:cljs`, etc.), and optionally falls back to `:default`.
 
-This enables `.cljc` files — source files that can be shared between Phel, Clojure, and other Lisp dialects that support reader conditionals.
+This enables `.cljc` files: source files shared between Phel, Clojure, and other Lisp dialects that support reader conditionals.
 
 ## Basic usage: `#?()`
 
@@ -44,9 +44,9 @@ A reader conditional selects one form based on the platform:
 #?(:clj 99 :default 0)
 ; => 0
 
-;; No matching branch — form is dropped entirely
+;; No matching branch: form is dropped entirely
 #?(:clj 99 :cljs 88)
-; => (nothing — treated as whitespace)
+; => (nothing: treated as whitespace)
 ```
 
 ## Splicing: `#?@()`
@@ -61,7 +61,7 @@ Reader conditional splicing inserts multiple elements from a collection into the
 ; => array(0, 1, 2, 3, 4)
 ```
 
-The matched branch **must be a sequential collection** (vector or list). Its elements are spliced into the parent — the collection wrapper is removed.
+The matched branch **must be a sequential collection** (vector or list). Its elements are spliced into the parent; the collection wrapper is removed.
 
 ### Splicing with fallback
 
@@ -90,7 +90,7 @@ The matched branch **must be a sequential collection** (vector or list). Its ele
 
 ### Cross-platform source files (`.cljc`)
 
-Phel automatically discovers and compiles `.cljc` files alongside `.phel` files. This lets you share code between Phel and Clojure:
+Phel discovers and compiles `.cljc` files alongside `.phel` files, letting you share code between Phel and Clojure:
 
 ```phel
 ;; src/shared/utils.cljc
@@ -121,7 +121,7 @@ Phel automatically discovers and compiles `.cljc` files alongside `.phel` files.
      :clj  (json/read-str s)))
 ```
 
-> Phel accepts both Clojure-style vector entries (`[phel.json :as json :refer [encode]]`) and the older list form (`phel\json :as json`) inside `:require`, so the same `(ns ...)` form parses on both sides.
+> Phel accepts both vector entries (`[phel.json :as json :refer [encode]]`) and the older list form (`phel\json :as json`) inside `:require`, so the same `(ns ...)` form parses on both sides.
 
 ### Conditional data structures
 
@@ -148,7 +148,7 @@ Reader conditionals resolve at parse time, so they work naturally inside any for
 
 ## How it works
 
-Reader conditionals are resolved during the **parsing phase** of compilation (Lexer -> **Parser** -> Analyzer -> Emitter). The parser:
+Reader conditionals resolve during the **parsing phase** (Lexer -> **Parser** -> Analyzer -> Emitter). The parser:
 
 1. Reads keyword-form pairs inside `#?()` or `#?@()`
 2. Selects the `:phel` branch if present, otherwise `:default`
@@ -156,7 +156,7 @@ Reader conditionals are resolved during the **parsing phase** of compilation (Le
 4. For `#?@()`: splices the selected collection's elements into the parent
 5. If no branch matches: the conditional is dropped as trivia (like a comment)
 
-Since this happens at parse time, the analyzer and emitter never see the reader conditional — they only see the selected form.
+Since this happens at parse time, the analyzer and emitter never see the reader conditional; they only see the selected form.
 
 ## Summary
 

--- a/docs/reader-shortcuts.md
+++ b/docs/reader-shortcuts.md
@@ -1,6 +1,6 @@
 # Reader Shortcuts and Special Syntax
 
-Phel provides several reader shortcuts and special syntax forms for concise code. These shortcuts are processed by the reader during compilation.
+Reader shortcuts are processed by the reader during compilation.
 
 ## Collection Literals
 
@@ -56,7 +56,7 @@ Evaluates an expression within a quasiquote:
   `(1 ~x 3))      ; => (1 5 3)
 ```
 
-> **Deprecated:** `,` as an unquote reader macro is deprecated. Use `~` instead to match Clojure's syntax.
+> **Deprecated:** `,` as an unquote reader macro. Use `~` instead.
 
 ### Unquote-splicing `~@`
 Evaluates and splices a sequence into the containing form:
@@ -65,10 +65,10 @@ Evaluates and splices a sequence into the containing form:
   `(1 ~@xs 5))    ; => (1 2 3 4 5)
 ```
 
-> **Deprecated:** `,@` as an unquote-splicing reader macro is deprecated. Use `~@` instead to match Clojure's syntax.
+> **Deprecated:** `,@` as an unquote-splicing reader macro. Use `~@` instead.
 
 ### Auto-gensym `name#`
-Inside a syntax-quote, a symbol ending in `#` is replaced with a freshly generated, unique symbol. All occurrences of the same `name#` within the same syntax-quote resolve to the same generated name, which makes hygienic macros easy to write without manually calling `gensym`:
+Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique symbol. All occurrences of the same `name#` within one syntax-quote resolve to the same generated name, enabling hygienic macros without calling `gensym`:
 
 ```phel
 (defmacro time
@@ -79,9 +79,9 @@ Inside a syntax-quote, a symbol ending in `#` is replaced with a freshly generat
      ret#))
 ```
 
-Each macro expansion produces a fresh `start__123__auto__` / `ret__124__auto__` pair, so the generated bindings cannot collide with user code.
+Each expansion produces a fresh `start__123__auto__` / `ret__124__auto__` pair, so generated bindings can't collide with user code.
 
-> **Deprecated:** `name$` as an auto-gensym suffix is deprecated. Use `name#` instead to match Clojure's reader macro.
+> **Deprecated:** `name$` as an auto-gensym suffix. Use `name#` instead.
 
 ## Reader Conditionals
 
@@ -113,7 +113,7 @@ Shorthand for `(deref ...)`:
 
 ## Tagged Literals `#<tag> form`
 
-Tagged literals let the reader convert an arbitrary form into a different value. Phel ships two built-ins:
+Tagged literals convert a form into a different value at read time. Two built-ins ship with Phel:
 
 ```phel
 #inst "2026-01-01T00:00:00Z"     ; reads as \DateTimeImmutable
@@ -133,7 +133,7 @@ Register your own with `phel\reader/register-tag`:
 ;; => {:kind :money :raw "10.00 EUR"}
 ```
 
-For project-wide tags, drop a `data-readers.phel` at any source root — it is auto-loaded and should register each tag explicitly:
+For project-wide tags, drop a `data-readers.phel` at any source root. It's auto-loaded and should register each tag explicitly:
 
 ```phel
 ;; src/phel/data-readers.phel
@@ -155,8 +155,8 @@ Creates a PCRE pattern string:
 
 ## Anonymous Functions
 
-### Clojure-Style `#(...)`
-Creates anonymous functions with `%` parameter placeholders:
+### `#(...)` syntax
+Anonymous function with `%` parameter placeholders:
 ```phel
 #(+ %1 %2)           ; Function taking 2 args
 #(* % %)             ; % is shorthand for %1
@@ -164,9 +164,9 @@ Creates anonymous functions with `%` parameter placeholders:
 ```
 
 ### Short Function Syntax `|(...)` (Deprecated)
-> **Deprecated:** Use `#(...)` with `%` placeholders instead. `|(...)` will be removed in a future release.
+> **Deprecated:** Use `#(...)` with `%` placeholders. `|(...)` will be removed in a future release.
 
-Creates anonymous functions with positional parameters:
+Anonymous function with positional parameters:
 ```phel
 |(+ $1 $2)        ; Function taking 2 args
 |(* $1 $1)        ; Function squaring its argument
@@ -174,23 +174,14 @@ Creates anonymous functions with positional parameters:
 ```
 
 **Parameters:**
-- `$1`, `$2`, `$3`, ... - Positional arguments (1-indexed)
-- `$&` - All arguments as a sequence (rest args)
+- `$1`, `$2`, `$3`, ...: positional arguments (1-indexed)
+- `$&`: rest args as a sequence
 
-**Examples:**
 ```phel
-(map |(* $ 2) [1 2 3])
-;; => [2 4 6]
+(map |(* $ 2) [1 2 3])         ; => [2 4 6]
+(filter |(> $ 5) [3 6 2 8 4])  ; => [6 8]
+(reduce |(+ $1 $2) 0 [1 2 3 4]) ; => 10
 
-(filter |(> $ 5) [3 6 2 8 4])
-;; => [6 8]
-
-(reduce |(+ $1 $2) 0 [1 2 3 4])
-;; => 10
-```
-
-Equivalent to traditional `fn` syntax:
-```phel
 |(* $ $)        ; Same as (fn [x] (* x x))
 |(+ $1 $2)      ; Same as (fn [a b] (+ a b))
 ```
@@ -198,14 +189,13 @@ Equivalent to traditional `fn` syntax:
 ## Comments
 
 ### Line Comments `;`
-Comment from the character to the end of the line. By convention, use `;;` for
-standalone line comments and `;` for inline comments after code:
+Comment to end of line. Convention: `;;` for standalone lines, `;` inline after code:
 ```phel
 ;; This is a standalone comment
 (+ 1 2)           ; inline comment
 ```
 
-> **Deprecated:** `#` as a line comment character is deprecated. Use `;` instead.
+> **Deprecated:** `#` as a line comment character. Use `;` instead.
 
 ### Multiline Comments `#| |#` (Deprecated)
 > **Deprecated:** Use `(comment ...)` instead. `#| |#` will be removed in a future release.
@@ -259,7 +249,7 @@ Attaches metadata to the following form:
 
 ## See Also
 
-- [Reader Conditionals](reader-conditionals.md) - Cross-platform code with `#?()` and `#?@()`
+- [Reader Conditionals](reader-conditionals.md): Cross-platform code with `#?()` and `#?@()`
 - Core library functions: `vector`, `hash-map`, `hash-set`, `list`
 - Coercion functions: `vec`, `set`
 - Quote functions: `quote`, `quasiquote`, `unquote`

--- a/docs/transducers.md
+++ b/docs/transducers.md
@@ -2,9 +2,9 @@
 
 ## What are transducers?
 
-Transducers are composable transformation pipelines that decouple the "what" (map, filter, take, etc.) from the "how" (building a vector, summing, writing to a file). They transform one reducing function into another, without creating intermediate collections at each step.
+Transducers are composable transformation pipelines that decouple the "what" (map, filter, take) from the "how" (building a vector, summing, writing to a file). They transform one reducing function into another without creating intermediate collections at each step.
 
-A regular pipeline like this creates a temporary sequence at every step:
+A regular pipeline creates a temporary sequence at every step:
 
 ```phel
 ;; Two intermediate lazy sequences created
@@ -21,11 +21,11 @@ With transducers, the transformations fuse into a single pass:
 
 ## Basic usage
 
-There are three ways to consume a transducer:
+Three ways to consume a transducer:
 
 ### `transduce` -- reduce with a transformation
 
-Applies a transducer, then reduces with a combining function:
+Apply a transducer, then reduce with a combining function:
 
 ```phel
 ;; Sum all values after incrementing
@@ -59,7 +59,7 @@ A shorthand for `(into [] xf coll)`:
 
 ## Transducer-producing functions
 
-Most sequence functions in Phel are dual-purpose: call them **with** a collection and they return a lazy sequence; call them **without** a collection and they return a transducer.
+Most sequence functions are dual-purpose: call them **with** a collection and they return a lazy sequence; call them **without** and they return a transducer.
 
 | Function | Transducer form | Description |
 |---|---|---|
@@ -93,7 +93,7 @@ Use `comp` to build a pipeline. Transducers compose left-to-right (the leftmost 
 ; => [4 16 36]
 ```
 
-This is the opposite of normal function composition, but matches the order you would write with threading:
+This is the opposite of normal function composition, but matches the order written with threading:
 
 ```phel
 ;; Equivalent lazy-sequence version (creates intermediates):
@@ -107,7 +107,7 @@ This is the opposite of normal function composition, but matches the order you w
 
 ### `reduced`, `reduced?`, `unreduced`
 
-A reducing function can signal "I'm done, stop iterating" by wrapping its return value in `reduced`:
+A reducing function signals "stop iterating" by wrapping its return value in `reduced`:
 
 ```phel
 ;; Sum until the accumulator exceeds 10
@@ -124,7 +124,7 @@ A reducing function can signal "I'm done, stop iterating" by wrapping its return
 
 ### How built-in transducers use early termination
 
-`take` and `take-while` rely on `reduced` internally. When `take` has collected enough elements, it wraps the result in `reduced` so the outer `reduce`/`transduce` stops iterating immediately rather than walking the rest of the collection.
+`take` and `take-while` use `reduced` internally. When `take` has collected enough elements, it wraps the result in `reduced` so the outer `reduce`/`transduce` stops immediately rather than walking the rest of the collection.
 
 ```phel
 ;; Stops processing after 2 elements, does not touch the rest
@@ -134,7 +134,7 @@ A reducing function can signal "I'm done, stop iterating" by wrapping its return
 
 ## Stateful transducers
 
-Some transducers need mutable state across steps (counters, sets of seen values, etc.). Phel provides volatile references for this:
+Some transducers need mutable state across steps (counters, sets of seen values). Phel provides volatile references:
 
 - `(volatile! val)` -- create a mutable reference initialized to `val`
 - `@vol` (deref) -- read the current value
@@ -153,7 +153,7 @@ For example, `distinct` internally uses a volatile hash-set to track seen elemen
 
 ## Custom transducers
 
-A transducer is a function that takes a reducing function `rf` and returns a new reducing function. The returned function must handle three arities:
+A transducer takes a reducing function `rf` and returns a new reducing function. The returned function handles three arities:
 
 - **0-arity** (init): return `(rf)` -- delegate to the downstream init
 - **1-arity** (completion): return `(rf result)` -- delegate completion, optionally flush state
@@ -163,7 +163,7 @@ Due to a compiler limitation with nested multi-arity `fn`, use variadic `[& args
 
 ### Using `xf-step` (recommended)
 
-The private helper `xf-step` handles the 0/1 arity boilerplate. You only write the 2-arity step:
+The private helper `xf-step` handles the 0/1 arity boilerplate. Write only the 2-arity step:
 
 ```phel
 ;; A transducer that doubles every element
@@ -178,7 +178,7 @@ The private helper `xf-step` handles the 0/1 arity boilerplate. You only write t
 
 ### Full manual example
 
-When you need custom completion logic (e.g., flushing buffered state), write all three arities:
+For custom completion logic (e.g. flushing buffered state), write all three arities:
 
 ```phel
 ;; A transducer that batches elements into groups of n
@@ -208,7 +208,7 @@ When you need custom completion logic (e.g., flushing buffered state), write all
 
 ### With early termination
 
-If your transducer needs to stop processing, wrap the result in `reduced`:
+To stop processing, wrap the result in `reduced`:
 
 ```phel
 ;; Take until predicate returns true (inclusive)
@@ -239,10 +239,10 @@ Every dual-purpose function works in two modes:
 
 **When to use which:**
 
-- **Lazy sequences** are fine for simple, linear pipelines. They compose naturally with `->>`.
-- **Transducers** shine when you need to:
+- **Lazy sequences** for simple, linear pipelines. Compose naturally with `->>`.
+- **Transducers** when you need to:
   - Avoid intermediate collections in a multi-step pipeline
-  - Reuse the same transformation with different sources or destinations
+  - Reuse one transformation with different sources or destinations
   - Reduce into something other than a sequence (sums, maps, side effects)
 
 ```phel

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -1,6 +1,6 @@
 # Watch Guide
 
-`phel watch` recompiles and reloads changed namespaces in dependency order so you can iterate without restarting the REPL or a long-running process. Backends: `inotify` (Linux), `fswatch` (macOS), `polling` (everywhere).
+`phel watch` recompiles and reloads changed namespaces in dependency order, so you can iterate without restarting the REPL or a long-running process. Backends: `inotify` (Linux), `fswatch` (macOS), `polling` (everywhere).
 
 ## Contents
 
@@ -17,7 +17,7 @@
 ./vendor/bin/phel watch -b polling --poll=250   # force polling, 250ms interval
 ```
 
-On each change, `phel watch` reloads the changed namespace plus any downstream namespaces that depend on it, in topological order.
+On each change, `phel watch` reloads the changed namespace and its dependents in topological order.
 
 ## Options
 
@@ -36,13 +36,13 @@ On each change, `phel watch` reloads the changed namespace plus any downstream n
 (watch! ["src/" "tests/"])
 ```
 
-Returns a handle you can stop with `(stop-watch! h)`.
+Returns a handle. Stop with `(stop-watch! h)`.
 
 ## Pitfalls
 
-- The polling backend has the highest CPU cost; prefer `inotify` or `fswatch` when available
-- Reload order follows the dependency graph; cyclic requires will break live reload
-- Editors that write files atomically (rename) emit two events; `--debounce` handles this by default
+- Polling has the highest CPU cost; prefer `inotify` or `fswatch` when available
+- Reload follows the dependency graph; cyclic requires break live reload
+- Editors that write atomically (rename) emit two events; `--debounce` handles this by default
 
 ## See also
 


### PR DESCRIPTION
## 🤔 Background

Filler accumulated across `docs/` guides: marketing adjectives, lead-in clauses, em dashes, editorial cross-language framing.

## 💡 Goal

Same content density, fewer words. No structural changes.

## 🔖 Changes

- 25 files touched under `docs/`.
- Cut: "powerful", "robust", "comprehensive", "elegant", "simply", "just", "really", "basically", "actually", "easily".
- Cut lead-ins: "In this section we will...", "Let's explore...", "This guide covers...".
- Replaced em dashes with `:`, `,`, or split sentences.
- Rephrased editorial "Clojure-aligned/-style/-compatible/-semantics" to describe behavior on its own terms (kept where factually descriptive in `clojure-migration.md`).
- No code blocks, headings, anchors, link targets, file paths, or function names touched.