### PR TITLE
feat(repl): add var-get, preserve existing values in intern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Core behavior, PHP interop consistency, and stricter compiler diagnostics.
 - Consistent numeric comparison in `==` (#1561)
 - `[size init-val-or-seq]` in primitive array helpers (#1562)
 - Namespace introspection: `loaded-namespaces`, `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `load-file` (#1694)
+- `var-get` resolves a symbol to its registry value (#1774)
 - `(rand n)` returns a number in `[0, n)` (#1696)
 
 #### REPL
@@ -33,6 +34,7 @@ Core behavior, PHP interop consistency, and stricter compiler diagnostics.
 
 #### Core
 - Expose `future` from `phel\core` (#1537)
+- `intern` without a value preserves an existing root instead of resetting it to `nil` (#1774)
 
 ### Fixed
 

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -69,9 +69,9 @@
 (defn intern
   "Finds or creates a definition named by name-str in namespace ns-str.
   When a value is supplied, sets the root value to val (overwriting any
-  existing value). When no value is supplied, finds an existing definition
-  without overwriting it, or creates it with a nil value if it doesn't exist.
-  The namespace is auto-registered by the underlying `addDefinition` call.
+  existing value). When no value is supplied, returns the existing
+  definition unchanged, or creates it with nil if it doesn't exist.
+  Creating a definition auto-registers the namespace.
   Returns the fully qualified symbol naming the definition."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -18,8 +18,12 @@
 (defn- core-munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
-  (let [munge (php/new Munge)]
-    (php/-> munge (encodeNs ns-str))))
+  (php/-> (php/new Munge) (encodeNs ns-str)))
+
+(defn- core-munge-name
+  "Encodes a definition name for registry lookup."
+  [name-str]
+  (php/-> (php/new Munge) (encode name-str)))
 
 (defn find-ns
   "Returns the namespace name if it is loaded, or nil if no namespace of
@@ -73,7 +77,7 @@
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
   (let [encoded-ns   (core-munge-ns ns-str)
-        encoded-name (php/-> (php/new Munge) (encode name-str))]
+        encoded-name (core-munge-name name-str)]
     (if (seq rest)
       (php/:: Phel (addDefinition encoded-ns encoded-name (first rest)))
       ;; skip when no value is provided and the definition already exists
@@ -90,11 +94,8 @@
   {:example "(var-get (intern \"user\" \"x\" 42)) ; => 42"
    :see-also ["intern" "ns-interns" "find-ns"]}
   [x]
-  (let [ns-str (namespace x)]
-    (when ns-str
-      (let [encoded-ns   (core-munge-ns ns-str)
-            encoded-name (php/-> (php/new Munge) (encode (name x)))]
-        (php/:: Phel (getDefinition encoded-ns encoded-name))))))
+  (when-let [ns-str (namespace x)]
+    (php/:: Phel (getDefinition (core-munge-ns ns-str) (core-munge-name (name x))))))
 
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -48,19 +48,6 @@
   (php/:: Phel (removeNamespace (core-munge-ns ns-str)))
   nil)
 
-(defn intern
-  "Finds or creates a definition named by name-str in namespace ns-str,
-  setting its root value to val when supplied (defaults to nil). The
-  namespace is auto-registered by the underlying `addDefinition` call.
-  Returns the fully qualified symbol naming the definition."
-  {:example "(intern \"user\" \"x\" 42) ; => user/x"
-   :see-also ["find-ns" "create-ns" "ns-interns"]}
-  [ns-str name-str & [val]]
-  (let [encoded-ns   (core-munge-ns ns-str)
-        encoded-name (php/-> (php/new Munge) (encode name-str))]
-    (php/:: Phel (addDefinition encoded-ns encoded-name val))
-    (php/:: Symbol (createForNamespace ns-str name-str))))
-
 (defn ns-interns
   "Returns a hash-map of {name => value} for every definition in the
   given namespace, including private ones. Returns an empty map if the
@@ -74,6 +61,31 @@
     (foreach [fn-name value defs]
       (assoc! result (php/-> munge (decodeNs fn-name)) value))
     (persistent result)))
+
+(defn intern
+  "Finds or creates a definition named by name-str in namespace ns-str.
+  When a value is supplied, sets the root value to val (overwriting any
+  existing value). When no value is supplied, finds an existing definition
+  without overwriting it, or creates it with a nil value if it doesn't exist.
+  The namespace is auto-registered by the underlying `addDefinition` call.
+  Returns the fully qualified symbol naming the definition."
+  [ns-str name-str & rest]
+  (let [encoded-ns   (core-munge-ns ns-str)
+        encoded-name (php/-> (php/new Munge) (encode name-str))]
+    (if (seq rest)
+      (php/:: Phel (addDefinition encoded-ns encoded-name (first rest)))
+      ;; skip when no value is provided and the definition already exists
+      (when-not (php/:: Phel (hasDefinition encoded-ns encoded-name))
+        (php/:: Phel (addDefinition encoded-ns encoded-name nil))))
+    (php/:: Symbol (createForNamespace ns-str name-str))))
+
+(defn var-get
+  "Takes a fully-qualified symbol and resolves it from namespace registry,
+  returning it's value or nil if the symbol is not defined.
+  This is useful for dereferencing symbols returned by `intern` or
+  other functions that return symbol references rather than values."
+  [x]
+  (get (ns-interns (namespace x)) (name x)))
 
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -15,15 +15,19 @@
   []
   (php/:: Phel (getNamespaces)))
 
+(def ^:private munge-instance
+  ;; Munge is a final readonly class; reuse a single instance to avoid per-call allocation.
+  (php/new Munge))
+
 (defn- core-munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
-  (php/-> (php/new Munge) (encodeNs ns-str)))
+  (php/-> munge-instance (encodeNs ns-str)))
 
 (defn- core-munge-name
   "Encodes a definition name for registry lookup."
   [name-str]
-  (php/-> (php/new Munge) (encode name-str)))
+  (php/-> munge-instance (encode name-str)))
 
 (defn find-ns
   "Returns the namespace name if it is loaded, or nil if no namespace of
@@ -70,32 +74,39 @@
   "Finds or creates a definition named by name-str in namespace ns-str.
   When a value is supplied, sets the root value to val (overwriting any
   existing value). When no value is supplied, returns the existing
-  definition unchanged, or creates it with nil if it doesn't exist.
-  Creating a definition auto-registers the namespace.
+  definition unchanged, or creates a new one with nil if none exists.
+  Auto-registers the namespace when creating a new definition; the
+  arity-2 form is a no-op when the definition already exists.
   Returns the fully qualified symbol naming the definition."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
-   :see-also ["find-ns" "create-ns" "ns-interns"]}
+   :see-also ["var-get" "find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
   (let [encoded-ns   (core-munge-ns ns-str)
         encoded-name (core-munge-name name-str)]
     (if (seq rest)
       (php/:: Phel (addDefinition encoded-ns encoded-name (first rest)))
       ;; skip when no value is provided and the definition already exists
-      (when-not (php/:: Phel (hasDefinition encoded-ns encoded-name))
+      (when-not (php/:: Phel (isDefined encoded-ns encoded-name))
         (php/:: Phel (addDefinition encoded-ns encoded-name nil))))
     (php/:: Symbol (createForNamespace ns-str name-str))))
 
 (defn var-get
   "Takes a fully-qualified symbol and resolves it from the namespace registry,
-  returning its value or nil if the symbol is not defined. Useful for
-  dereferencing symbols returned by `intern`. Returns nil for symbols whose
-  namespace is missing; a stored value of nil is indistinguishable from
-  'not defined'."
-  {:example "(var-get (intern \"user\" \"x\" 42)) ; => 42"
+  returning its value. With one argument, returns nil when the symbol is not
+  defined. With two arguments, returns `not-found` instead, which lets callers
+  disambiguate a stored nil from a missing definition. Returns `not-found`
+  for non-symbol or unqualified inputs."
+  {:example "(var-get (intern \"user\" \"x\" 42)) ; => 42\n(var-get 'user/missing ::none) ; => ::none"
    :see-also ["intern" "ns-interns" "find-ns"]}
-  [x]
-  (when-let [ns-str (namespace x)]
-    (php/:: Phel (getDefinition (core-munge-ns ns-str) (core-munge-name (name x))))))
+  ([x] (var-get x nil))
+  ([x not-found]
+   (if (and (symbol? x) (namespace x))
+     (let [encoded-ns   (core-munge-ns (namespace x))
+           encoded-name (core-munge-name (name x))]
+       (if (php/:: Phel (isDefined encoded-ns encoded-name))
+         (php/:: Phel (getDefinition encoded-ns encoded-name))
+         not-found))
+     not-found)))
 
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -82,12 +82,19 @@
     (php/:: Symbol (createForNamespace ns-str name-str))))
 
 (defn var-get
-  "Takes a fully-qualified symbol and resolves it from namespace registry,
-  returning its value or nil if the symbol is not defined.
-  This is useful for dereferencing symbols returned by `intern` or
-  other functions that return symbol references rather than values."
+  "Takes a fully-qualified symbol and resolves it from the namespace registry,
+  returning its value or nil if the symbol is not defined. Useful for
+  dereferencing symbols returned by `intern`. Returns nil for symbols whose
+  namespace is missing; a stored value of nil is indistinguishable from
+  'not defined'."
+  {:example "(var-get (intern \"user\" \"x\" 42)) ; => 42"
+   :see-also ["intern" "ns-interns" "find-ns"]}
   [x]
-  (get (ns-interns (namespace x)) (name x)))
+  (let [ns-str (namespace x)]
+    (when ns-str
+      (let [encoded-ns   (core-munge-ns ns-str)
+            encoded-name (php/-> (php/new Munge) (encode (name x)))]
+        (php/:: Phel (getDefinition encoded-ns encoded-name))))))
 
 (defn ns-publics
   "Returns a hash-map of {name => value} for all public definitions in the

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -69,6 +69,8 @@
   without overwriting it, or creates it with a nil value if it doesn't exist.
   The namespace is auto-registered by the underlying `addDefinition` call.
   Returns the fully qualified symbol naming the definition."
+  {:example "(intern \"user\" \"x\" 42) ; => user/x"
+   :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
   (let [encoded-ns   (core-munge-ns ns-str)
         encoded-name (php/-> (php/new Munge) (encode name-str))]
@@ -81,7 +83,7 @@
 
 (defn var-get
   "Takes a fully-qualified symbol and resolves it from namespace registry,
-  returning it's value or nil if the symbol is not defined.
+  returning its value or nil if the symbol is not defined.
   This is useful for dereferencing symbols returned by `intern` or
   other functions that return symbol references rather than values."
   [x]

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -74,6 +74,16 @@ final class Registry
         return isset($this->definitions[$ns][$name]);
     }
 
+    /**
+     * Like {@see self::hasDefinition()} but treats a stored `null` as present.
+     * Use this when you need to disambiguate "stored null" from "not defined".
+     */
+    public function isDefined(string $ns, string $name): bool
+    {
+        return isset($this->definitions[$ns])
+            && array_key_exists($name, $this->definitions[$ns]);
+    }
+
     public function hasNamespace(string $ns): bool
     {
         return isset($this->definitions[$ns]);

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -58,11 +58,18 @@
       (is (= 99 (var-get a-var)) "retrieves value when intern is called with value"))
     (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x)]
       (is (= 99 (var-get a-var)) "preserves existing value when intern called without value"))
+    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x nil)]
+      (is (= nil (var-get a-var)) "explicit nil overwrites existing value"))
     (let [new-ns (create-ns 'new-ns-name)
           a-var (intern new-ns 'x 99)]
       (is (= 99 (var-get a-var)) "works with explicitly created namespace"))
     (let [a-var (intern 'new-ns-name 'x)]
-      (is (= 99 (var-get a-var)) "works when intern auto-creates namespace"))))
+      (is (= 99 (var-get a-var)) "works when intern auto-creates namespace"))
+    (remove-ns "phel-test\\tmp\\intern-var-get-test")
+    (remove-ns "new-ns-name"))
+
+  (testing "var-get on unqualified input returns nil"
+    (is (nil? (var-get (symbol "no-ns"))) "unqualified symbol resolves to nil")))
 
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -1,5 +1,6 @@
 (ns phel-test\test\core\ns
-  (:require phel\test :refer [deftest is]))
+  (:require phel\test :refer [deftest is testing])
+  (:use Phel\Lang\Symbol))
 
 (deftest test-loaded-namespaces-includes-core
   (is (php/in_array "phel\\core" (loaded-namespaces))
@@ -28,16 +29,43 @@
       (is (= 42 (get interns "x")) "ns-interns contains the interned value"))
     (remove-ns ns)))
 
-(deftest test-intern-and-var-get
-  (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x 99)]
-    (is (= 99 (var-get a-var)) "var-get retrieves value when intern is called with value"))
-  (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x)]
-    (is (= 99 (var-get a-var)) "var-get preserves existing value when intern called without value"))
-  (let [new-ns (create-ns 'new-ns-name)
-        a-var (intern new-ns 'x 99)]
-    (is (= 99 (var-get a-var)) "var-get works with explicitly created namespace"))
-  (let [a-var (intern 'new-ns-name 'x)]
-    (is (= 99 (var-get a-var)) "var-get works when intern auto-creates namespace")))
+(deftest test-var-get
+  (testing "general var-get behavior"
+    (let [test-ns "phel-test-var-get"]
+      (remove-ns test-ns)
+      (intern test-ns "existing" 100)
+      (intern test-ns "another" "hello")
+
+      (testing "successful lookups"
+        (def test-var-get-def 123)
+        (is (= 123 (var-get (symbol *ns* "test-var-get-def"))) "def in current namespace")
+
+        (let [sym1 (Symbol/createForNamespace test-ns "existing")
+              sym2 (Symbol/createForNamespace test-ns "another")]
+          (is (= 100 (var-get sym1)) "existing int value")
+          (is (= "hello" (var-get sym2)) "existing string value")))
+
+      (testing "failing lookups"
+        (let [missing-sym (Symbol/createForNamespace test-ns "missing")]
+          (is (= nil (var-get missing-sym)) "returns nil for non-existent symbol"))
+        (let [empty-ns "phel-test-empty"
+              empty-sym (Symbol/createForNamespace empty-ns "anything")]
+          (remove-ns empty-ns)
+          (is (= nil (var-get empty-sym)) "returns nil for empty namespace")))
+
+      (remove-ns test-ns)
+      (remove-ns "phel-test-empty")))
+
+  (testing "var-get with return value of intern"
+    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x 99)]
+      (is (= 99 (var-get a-var)) "retrieves value when intern is called with value"))
+    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x)]
+      (is (= 99 (var-get a-var)) "preserves existing value when intern called without value"))
+    (let [new-ns (create-ns 'new-ns-name)
+          a-var (intern new-ns 'x 99)]
+      (is (= 99 (var-get a-var)) "works with explicitly created namespace"))
+    (let [a-var (intern 'new-ns-name 'x)]
+      (is (= 99 (var-get a-var)) "works when intern auto-creates namespace"))))
 
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -61,7 +61,16 @@
       (remove-ns "new-ns-name")))
 
   (testing "var-get on unqualified input returns nil"
-    (is (nil? (var-get (symbol "no-ns"))) "unqualified symbol resolves to nil")))
+    (is (nil? (var-get (symbol "no-ns"))) "unqualified symbol resolves to nil"))
+
+  (testing "var-get not-found arity disambiguates nil-vs-missing"
+    (let [tmp-ns "phel-test\\tmp\\var-get-not-found"]
+      (intern tmp-ns "stored-nil" nil)
+      (is (nil? (var-get (symbol tmp-ns "stored-nil") :missing)) "stored nil returns nil, not the sentinel")
+      (is (= :missing (var-get (symbol tmp-ns "absent") :missing)) "missing definition returns the sentinel")
+      (is (= :missing (var-get (symbol "absent") :missing)) "unqualified symbol returns the sentinel")
+      (is (= :missing (var-get "not-a-symbol" :missing)) "non-symbol input returns the sentinel")
+      (remove-ns tmp-ns))))
 
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -28,6 +28,17 @@
       (is (= 42 (get interns "x")) "ns-interns contains the interned value"))
     (remove-ns ns)))
 
+(deftest test-intern-and-var-get
+  (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x 99)]
+    (is (= 99 (var-get a-var)) "var-get retrieves value when intern is called with value"))
+  (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x)]
+    (is (= 99 (var-get a-var)) "var-get preserves existing value when intern called without value"))
+  (let [new-ns (create-ns 'new-ns-name)
+        a-var (intern new-ns 'x 99)]
+    (is (= 99 (var-get a-var)) "var-get works with explicitly created namespace"))
+  (let [a-var (intern 'new-ns-name 'x)]
+    (is (= 99 (var-get a-var)) "var-get works when intern auto-creates namespace")))
+
 (deftest test-ns-publics-returns-map
   (let [publics (ns-publics "phel\\core")]
     (is (hash-map? publics) "ns-publics returns a hash-map")

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -51,6 +51,7 @@
     (let [tmp-ns "phel-test\\tmp\\intern-var-get-test"]
       (is (= 99 (var-get (intern tmp-ns "x" 99))) "retrieves value when intern is called with value")
       (is (= 99 (var-get (intern tmp-ns "x"))) "preserves existing value when intern called without value")
+      (is (= 100 (var-get (intern tmp-ns "x" 100))) "arity-3 overwrites existing value")
       (is (nil? (var-get (intern tmp-ns "x" nil))) "explicit nil overwrites existing value")
       (remove-ns tmp-ns))
 

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -37,9 +37,6 @@
       (intern test-ns "another" "hello")
 
       (testing "successful lookups"
-        (def test-var-get-def 123)
-        (is (= 123 (var-get (symbol *ns* "test-var-get-def"))) "def in current namespace")
-
         (let [sym1 (Symbol/createForNamespace test-ns "existing")
               sym2 (Symbol/createForNamespace test-ns "another")]
           (is (= 100 (var-get sym1)) "existing int value")

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -1,6 +1,5 @@
 (ns phel-test\test\core\ns
-  (:require phel\test :refer [deftest is testing])
-  (:use Phel\Lang\Symbol))
+  (:require phel\test :refer [deftest is testing]))
 
 (deftest test-loaded-namespaces-includes-core
   (is (php/in_array "phel\\core" (loaded-namespaces))
@@ -31,42 +30,34 @@
 
 (deftest test-var-get
   (testing "general var-get behavior"
-    (let [test-ns "phel-test-var-get"]
+    (let [test-ns  "phel-test-var-get"
+          empty-ns "phel-test-empty"]
       (remove-ns test-ns)
+      (remove-ns empty-ns)
       (intern test-ns "existing" 100)
       (intern test-ns "another" "hello")
 
       (testing "successful lookups"
-        (let [sym1 (Symbol/createForNamespace test-ns "existing")
-              sym2 (Symbol/createForNamespace test-ns "another")]
-          (is (= 100 (var-get sym1)) "existing int value")
-          (is (= "hello" (var-get sym2)) "existing string value")))
+        (is (= 100 (var-get (symbol test-ns "existing"))) "existing int value")
+        (is (= "hello" (var-get (symbol test-ns "another"))) "existing string value"))
 
       (testing "failing lookups"
-        (let [missing-sym (Symbol/createForNamespace test-ns "missing")]
-          (is (= nil (var-get missing-sym)) "returns nil for non-existent symbol"))
-        (let [empty-ns "phel-test-empty"
-              empty-sym (Symbol/createForNamespace empty-ns "anything")]
-          (remove-ns empty-ns)
-          (is (= nil (var-get empty-sym)) "returns nil for empty namespace")))
+        (is (nil? (var-get (symbol test-ns "missing"))) "returns nil for non-existent symbol")
+        (is (nil? (var-get (symbol empty-ns "anything"))) "returns nil for empty namespace"))
 
-      (remove-ns test-ns)
-      (remove-ns "phel-test-empty")))
+      (remove-ns test-ns)))
 
   (testing "var-get with return value of intern"
-    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x 99)]
-      (is (= 99 (var-get a-var)) "retrieves value when intern is called with value"))
-    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x)]
-      (is (= 99 (var-get a-var)) "preserves existing value when intern called without value"))
-    (let [a-var (intern 'phel-test\tmp\intern-var-get-test 'x nil)]
-      (is (= nil (var-get a-var)) "explicit nil overwrites existing value"))
-    (let [new-ns (create-ns 'new-ns-name)
-          a-var (intern new-ns 'x 99)]
-      (is (= 99 (var-get a-var)) "works with explicitly created namespace"))
-    (let [a-var (intern 'new-ns-name 'x)]
-      (is (= 99 (var-get a-var)) "works when intern auto-creates namespace"))
-    (remove-ns "phel-test\\tmp\\intern-var-get-test")
-    (remove-ns "new-ns-name"))
+    (let [tmp-ns "phel-test\\tmp\\intern-var-get-test"]
+      (is (= 99 (var-get (intern tmp-ns "x" 99))) "retrieves value when intern is called with value")
+      (is (= 99 (var-get (intern tmp-ns "x"))) "preserves existing value when intern called without value")
+      (is (nil? (var-get (intern tmp-ns "x" nil))) "explicit nil overwrites existing value")
+      (remove-ns tmp-ns))
+
+    (let [created-ns (create-ns "new-ns-name")]
+      (is (= 99 (var-get (intern created-ns "x" 99))) "works with explicitly created namespace")
+      (is (= 99 (var-get (intern "new-ns-name" "x"))) "works when intern auto-creates namespace")
+      (remove-ns "new-ns-name")))
 
   (testing "var-get on unqualified input returns nil"
     (is (nil? (var-get (symbol "no-ns"))) "unqualified symbol resolves to nil")))

--- a/tests/php/Unit/Lang/RegistryTest.php
+++ b/tests/php/Unit/Lang/RegistryTest.php
@@ -108,4 +108,36 @@ final class RegistryTest extends TestCase
 
         self::assertFalse($this->registry->hasNamespace('never-registered'));
     }
+
+    public function test_has_definition_false_when_missing(): void
+    {
+        self::assertFalse($this->registry->hasDefinition('ns', 'missing'));
+    }
+
+    public function test_has_definition_true_after_add(): void
+    {
+        $this->registry->addDefinition('ns', 'x', 1);
+
+        self::assertTrue($this->registry->hasDefinition('ns', 'x'));
+    }
+
+    public function test_has_definition_false_for_stored_null(): void
+    {
+        $this->registry->addDefinition('ns', 'x', null);
+
+        self::assertFalse($this->registry->hasDefinition('ns', 'x'));
+    }
+
+    public function test_is_defined_true_for_stored_null(): void
+    {
+        $this->registry->addDefinition('ns', 'x', null);
+
+        self::assertTrue($this->registry->isDefined('ns', 'x'));
+        self::assertNull($this->registry->getDefinition('ns', 'x'));
+    }
+
+    public function test_is_defined_false_when_missing(): void
+    {
+        self::assertFalse($this->registry->isDefined('ns', 'missing'));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

https://github.com/phel-lang/phel-lang/issues/1773

## 💡 Goal

Add `var-get` that passes clojure-test-suite.

## 🔖 Changes

Modified intern to find existing definitions without overwriting when called without a value argument, matching Clojure semantics. Added var-get helper function to dereference symbols returned by intern, passing clojure-test-suite intern.cljc