### PR TITLE
docs(internals): expand internals docs for compiler, runtime, macros, special forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ All notable changes to this project will be documented in this file.
 - Alias-qualified required calls no longer flagged as unresolved (#1540)
 - Vendored stdlib files skipped when linting with no arguments (#1541)
 
+### Docs
+- `docs/internals/`: architecture, special forms, macros, runtime, FAQ; expanded compiler pipeline
+
 ## [0.34.1](https://github.com/phel-lang/phel-lang/compare/v0.34.0...v0.34.1) - 2026-04-21
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,15 +40,15 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 
 ## Internals
 
-Start with the [internals overview](internals/README.md) for a guided path.
+Overview: [internals/](internals/README.md).
 
-- [Architecture](internals/architecture.md) — modules, Gacela pattern, dependency map
-- [Compiler](internals/compiler.md) — phases, AST, emitter
-- [Special forms](internals/special-forms.md) — full list, dispatch, how to add one
-- [Macros](internals/macros.md) — `macroexpand`, quasiquote, gensym
-- [Runtime](internals/runtime.md) — `Lang/`, persistent collections, `Registry`
-- [FAQ](internals/faq.md) — questions grouped by reader
-- [Benchmarks](internals/benchmarks.md) — PHPBench setup
+- [Architecture](internals/architecture.md): modules, Gacela pattern, dependency map
+- [Compiler](internals/compiler.md): phases, AST, emitter
+- [Special forms](internals/special-forms.md): list, dispatch, how to add one
+- [Macros](internals/macros.md): `macroexpand`, quasiquote, gensym
+- [Runtime](internals/runtime.md): `Lang/`, persistent collections, `Registry`
+- [FAQ](internals/faq.md): questions grouped by reader
+- [Benchmarks](internals/benchmarks.md): PHPBench setup
 - [Migration: backslash to dot](migration/backslash-to-dot.md)
 
 ## AI agents

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,14 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 
 ## Internals
 
+Start with the [internals overview](internals/README.md) for a guided path.
+
+- [Architecture](internals/architecture.md) — modules, Gacela pattern, dependency map
 - [Compiler](internals/compiler.md) — phases, AST, emitter
+- [Special forms](internals/special-forms.md) — full list, dispatch, how to add one
+- [Macros](internals/macros.md) — `macroexpand`, quasiquote, gensym
+- [Runtime](internals/runtime.md) — `Lang/`, persistent collections, `Registry`
+- [FAQ](internals/faq.md) — questions grouped by reader
 - [Benchmarks](internals/benchmarks.md) — PHPBench setup
 - [Migration: backslash to dot](migration/backslash-to-dot.md)
 

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,0 +1,30 @@
+# Phel Internals
+
+How Phel is built. Read these in order if you want a full mental model; jump straight to a topic if you only need one answer.
+
+## Map
+
+1. [Architecture](architecture.md) — module layout, the Gacela pattern, dependency map. Where things live and why.
+2. [Compiler](compiler.md) — the six-stage pipeline (Lexer → Parser → Reader → Analyzer → Emitter → Evaluator), worked example, source paths.
+3. [Special forms](special-forms.md) — full list, how dispatch works, how to add one.
+4. [Macros](macros.md) — `macroexpand`, quasiquote rewriting, auto-gensym, hygiene.
+5. [Runtime](runtime.md) — `Lang/`: persistent collections, `Registry`, `Variable`, the `\Phel` static facade.
+6. [Benchmarks](benchmarks.md) — PHPBench setup and how to spot regressions.
+7. [FAQ](faq.md) — common questions, grouped by reader (PHP dev, Clojure dev, compiler hacker, tool builder, bug hunter).
+
+## When to read what
+
+| You want to… | Read |
+|--------------|------|
+| Understand the whole system in one sitting | architecture → compiler → runtime |
+| Add a special form or fix the analyzer | compiler → special-forms |
+| Write or debug a macro | macros (and `(macroexpand-1 ...)` in the REPL) |
+| Build an editor / linter / static tool | architecture → faq ("I'm building a tool") |
+| Track down a compilation bug | compiler → faq ("I'm investigating a bug") |
+| Profile the compiler or core ops | benchmarks |
+
+## Adjacent reading
+
+- Each module under `src/php/` ships a `CLAUDE.md` with its public API and constraints — start there before editing the module.
+- `.claude/rules/compiler.md` and `.claude/rules/integration-tests.md` cover phase ordering and fixture conventions enforced by tooling.
+- User-facing docs live one directory up: `docs/quickstart.md`, `docs/php-interop.md`, `docs/data-structures-guide.md`.

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,30 +1,28 @@
 # Phel Internals
 
-How Phel is built. Read these in order if you want a full mental model; jump straight to a topic if you only need one answer.
+## Pages
 
-## Map
+1. [Architecture](architecture.md): module layout, Gacela pattern, dependency map.
+2. [Compiler](compiler.md): six-stage pipeline with worked example.
+3. [Special forms](special-forms.md): list, dispatch, how to add one.
+4. [Macros](macros.md): `macroexpand`, quasiquote, auto-gensym.
+5. [Runtime](runtime.md): `Lang/`, persistent collections, `Registry`, `\Phel` facade.
+6. [Benchmarks](benchmarks.md): PHPBench setup.
+7. [FAQ](faq.md): grouped by reader (PHP dev, Clojure dev, compiler hacker, tool builder, bug hunter).
 
-1. [Architecture](architecture.md) — module layout, the Gacela pattern, dependency map. Where things live and why.
-2. [Compiler](compiler.md) — the six-stage pipeline (Lexer → Parser → Reader → Analyzer → Emitter → Evaluator), worked example, source paths.
-3. [Special forms](special-forms.md) — full list, how dispatch works, how to add one.
-4. [Macros](macros.md) — `macroexpand`, quasiquote rewriting, auto-gensym, hygiene.
-5. [Runtime](runtime.md) — `Lang/`: persistent collections, `Registry`, `Variable`, the `\Phel` static facade.
-6. [Benchmarks](benchmarks.md) — PHPBench setup and how to spot regressions.
-7. [FAQ](faq.md) — common questions, grouped by reader (PHP dev, Clojure dev, compiler hacker, tool builder, bug hunter).
+## What to read for what
 
-## When to read what
+| Goal | Path |
+|------|------|
+| Whole system | architecture → compiler → runtime |
+| Add a special form / fix analyzer | compiler → special-forms |
+| Write or debug a macro | macros + `(macroexpand-1 ...)` |
+| Build an editor / linter / tool | architecture → faq (tool builder) |
+| Compilation bug | compiler → faq (bug hunting) |
+| Profile | benchmarks |
 
-| You want to… | Read |
-|--------------|------|
-| Understand the whole system in one sitting | architecture → compiler → runtime |
-| Add a special form or fix the analyzer | compiler → special-forms |
-| Write or debug a macro | macros (and `(macroexpand-1 ...)` in the REPL) |
-| Build an editor / linter / static tool | architecture → faq ("I'm building a tool") |
-| Track down a compilation bug | compiler → faq ("I'm investigating a bug") |
-| Profile the compiler or core ops | benchmarks |
+## Adjacent
 
-## Adjacent reading
-
-- Each module under `src/php/` ships a `CLAUDE.md` with its public API and constraints — start there before editing the module.
-- `.claude/rules/compiler.md` and `.claude/rules/integration-tests.md` cover phase ordering and fixture conventions enforced by tooling.
-- User-facing docs live one directory up: `docs/quickstart.md`, `docs/php-interop.md`, `docs/data-structures-guide.md`.
+- Each `src/php/<Module>/CLAUDE.md`: public API + constraints. Read before editing.
+- `.claude/rules/compiler.md`, `.claude/rules/integration-tests.md`: phase ordering, fixture conventions.
+- User docs one level up: [quickstart](../quickstart.md), [php-interop](../php-interop.md), [data-structures-guide](../data-structures-guide.md).

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+How the codebase is organised and why. If [compiler.md](compiler.md) is "what each pipeline stage does", this page is "where each stage lives, who depends on whom, and how to find your way around `src/php/`".
+
+## Top-level layout
+
+```
+src/php/         Compiler, runtime, CLI (PHP, PSR-4 prefix Phel\)
+src/phel/        Core library written in Phel: core, string, html, http, json, test
+tests/php/       PHPUnit unit + integration tests (compiler-side)
+tests/phel/      Phel test files (core-side, run via `./bin/phel test`)
+build/           PHAR build, release tooling
+resources/       Agent prompts, docs assets, schemas
+```
+
+The compiler is PHP. The standard library that ships with Phel is itself written in Phel and lives next door in `src/phel/` — see `phel/core.phel` for the bulk of it.
+
+## Modules under `src/php/`
+
+Every directory is a [Gacela](https://gacela-project.com/) module. Each one owns one concern, communicates with others only via its `Facade`, and pulls in collaborators with a `DependencyProvider`. New code lives in the module that already owns the concern, not somewhere "more general".
+
+| Module | Purpose |
+|--------|---------|
+| `Lang/` | Runtime type system: persistent collections, `Symbol`, `Keyword`, `Variable`, `Registry`. **Foundational, no facade.** |
+| `Compiler/` | Lexer → Parser → Reader → Analyzer → Emitter → Evaluator. See [compiler.md](compiler.md). |
+| `Printer/` | Pretty-print Phel values; readable vs. non-readable forms. |
+| `Run/` | `phel run`, the interactive REPL (`Run/Domain/Repl/`), namespace bootstrap (`Run/Runtime/`), runtime-side autoloader for compiled namespaces. |
+| `Build/` | Compiles a project to PHP on disk; resolves namespace dependency order. |
+| `Command/` | CLI command registry shared across `phel` subcommands. |
+| `Console/` | Symfony Console wiring; the binary entry points. |
+| `Api/` | Programmatic access to documented Phel symbols (used by `doc`, `lsp`, generators). |
+| `Interop/` | Generates PHP wrapper classes so PHP code can call Phel from a normal IDE. |
+| `Lint/` | `phel lint` — runs over parse trees from `Compiler/`. |
+| `Formatter/` | Pretty-prints `.phel` source by walking the parse tree. |
+| `Lsp/` | Language Server Protocol over stdio. Reuses `Compiler/`, `Api/`. |
+| `Nrepl/` | nREPL server (bencode/TCP). Reuses `Compiler/`, `Run/`. |
+| `Watch/` | Filesystem watcher for hot reload. |
+| `HttpClient/` | Thin client used by `phel\http`. |
+| `Fiber/` | Fibers + futures runtime helpers. |
+| `Filesystem/` | File I/O abstraction (test seam for the rest of the compiler). |
+| `Config/` | `phel-config.php` loading and access. |
+| `Shared/` | Tiny cross-module utilities (only what truly has no better home). |
+| `Phel.php` | Static facade used by *generated PHP*: `\Phel::addDefinition(...)`, `\Phel::keyword(...)`, etc. |
+
+## The Gacela pattern
+
+Every non-foundational module follows the same skeleton. `Run/` is a representative example:
+
+```
+Run/
+├── RunFacade.php            ← public API (the only thing other modules import)
+├── RunFactory.php           ← wires up its own classes
+├── RunConfig.php            ← typed config
+├── RunProvider.php          ← declares dependencies on other facades
+├── Application/             ← orchestration / use cases
+├── Domain/                  ← pure logic, value objects, interfaces
+├── Infrastructure/          ← adapters: filesystem, console, env
+└── Runtime/                 ← module-specific runtime helpers (here: Phel namespace bootstrap)
+```
+
+Rules:
+
+- **Never instantiate a class from another module directly.** Always go through the other module's `Facade`.
+- **Never reach into another module's `Domain/`.** That's its private surface.
+- **Add a method to your own facade** before you reach for someone else's.
+- The constructor of a `Facade` is empty; collaborators come from the `Factory`/`Provider`.
+
+The provider declares dependencies as facade constants. Example from `RunProvider`:
+
+```php
+public const string FACADE_COMPILER = 'FACADE_COMPILER';
+
+#[Provides(self::FACADE_COMPILER)]
+public function compilerFacade(Container $container): CompilerFacade
+{
+    return $container->getLocator()->getRequired(CompilerFacade::class);
+}
+```
+
+Every module ships its own `CLAUDE.md` documenting public API, dependencies, and constraints. Read that first when you touch a module.
+
+## Dependency map (high-level)
+
+```
+                          Console / Command
+                                   │
+                ┌──────────┬───────┼─────────┬───────────┐
+                ▼          ▼       ▼         ▼           ▼
+               Run       Build   Lint   Formatter      Watch
+                │          │       │         \         /
+                └──────────┴───┬───┘          \       /
+                               ▼               ▼     ▼
+                        Compiler  ◄────── Api  ◄── Lsp / Nrepl / Watch
+                            │
+                            ▼
+                          Lang (foundational)
+                            ▲
+                            │
+                       Printer (rendering)
+```
+
+A few load-bearing edges:
+
+- **Everything depends on `Compiler/`** for parsing/analysing Phel.
+- **Everything depends on `Lang/`** for the runtime types.
+- **`Lang/` is a leaf**: no inbound dependencies on other modules except a single `__toString()` link to `Printer\Printer::readable()` (see `Lang/CLAUDE.md`).
+- **`Lsp/`, `Nrepl/`, `Watch/`** are tools, not part of the core compile path; they reuse the compiler facade.
+
+## Compile-time vs. runtime
+
+This trips up almost everyone the first time. There are two PHP processes worth keeping straight in your head:
+
+1. **The compiler process** — what `composer test-compiler` exercises and what runs when you call `CompilerFacade::compile()`. This process holds the `GlobalEnvironment`, the macro definitions, and the `TypeFactory`/`Registry` singletons in memory while it walks your forms.
+2. **The runtime process** — what executes the PHP that the compiler emitted. It only sees `\Phel::addDefinition(...)` calls, `\phel\core\…` functions, and the `Lang/` types. It does not see the analyzer, the parser, or the special-form handlers.
+
+Compile time and runtime can be the same physical PHP process (REPL, `phel run`) or different (cached `.php` files served by a framework). The boundary is conceptual: "is this code being analysed, or is it being executed?"
+
+## Where to add a feature
+
+| You want to… | Touch this |
+|--------------|------------|
+| Add a new reader macro (`#foo`) | `Lang/TagHandlers/`, register in `TagRegistry` |
+| Add a new special form | `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` + matching `NodeEmitter`. See [special forms](special-forms.md). |
+| Add a new core function in Phel | `src/phel/core/...` |
+| Add a CLI subcommand | `Run/` or its own module + `Command/` registration |
+| Add an LSP capability | `Lsp/Domain/` |
+| Add a linter rule | `Lint/Domain/Analyzer/` |
+
+When in doubt, run `grep -r "FACADE_" src/php/<Module>/<Module>Provider.php` to see what a module already pulls in — that's the cheapest map of how it talks to the rest of the system.

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,75 +1,62 @@
 # Architecture
 
-How the codebase is organised and why. If [compiler.md](compiler.md) is "what each pipeline stage does", this page is "where each stage lives, who depends on whom, and how to find your way around `src/php/`".
-
-## Top-level layout
+## Layout
 
 ```
-src/php/         Compiler, runtime, CLI (PHP, PSR-4 prefix Phel\)
-src/phel/        Core library written in Phel: core, string, html, http, json, test
-tests/php/       PHPUnit unit + integration tests (compiler-side)
-tests/phel/      Phel test files (core-side, run via `./bin/phel test`)
-build/           PHAR build, release tooling
-resources/       Agent prompts, docs assets, schemas
+src/php/      Compiler, runtime, CLI (PSR-4 prefix Phel\)
+src/phel/     Stdlib in Phel: core, string, html, http, json, test
+tests/php/    PHPUnit unit + integration
+tests/phel/   Phel tests via `./bin/phel test`
+build/        PHAR + release tooling
 ```
 
-The compiler is PHP. The standard library that ships with Phel is itself written in Phel and lives next door in `src/phel/` — see `phel/core.phel` for the bulk of it.
+Compiler is PHP. Stdlib is Phel: bulk in `src/phel/core.phel`.
 
-## Modules under `src/php/`
+## Modules
 
-Every directory is a [Gacela](https://gacela-project.com/) module. Each one owns one concern, communicates with others only via its `Facade`, and pulls in collaborators with a `DependencyProvider`. New code lives in the module that already owns the concern, not somewhere "more general".
+Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) module: `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring.
 
 | Module | Purpose |
 |--------|---------|
-| `Lang/` | Runtime type system: persistent collections, `Symbol`, `Keyword`, `Variable`, `Registry`. **Foundational, no facade.** |
-| `Compiler/` | Lexer → Parser → Reader → Analyzer → Emitter → Evaluator. See [compiler.md](compiler.md). |
-| `Printer/` | Pretty-print Phel values; readable vs. non-readable forms. |
-| `Run/` | `phel run`, the interactive REPL (`Run/Domain/Repl/`), namespace bootstrap (`Run/Runtime/`), runtime-side autoloader for compiled namespaces. |
-| `Build/` | Compiles a project to PHP on disk; resolves namespace dependency order. |
-| `Command/` | CLI command registry shared across `phel` subcommands. |
-| `Console/` | Symfony Console wiring; the binary entry points. |
-| `Api/` | Programmatic access to documented Phel symbols (used by `doc`, `lsp`, generators). |
-| `Interop/` | Generates PHP wrapper classes so PHP code can call Phel from a normal IDE. |
-| `Lint/` | `phel lint` — runs over parse trees from `Compiler/`. |
-| `Formatter/` | Pretty-prints `.phel` source by walking the parse tree. |
-| `Lsp/` | Language Server Protocol over stdio. Reuses `Compiler/`, `Api/`. |
-| `Nrepl/` | nREPL server (bencode/TCP). Reuses `Compiler/`, `Run/`. |
-| `Watch/` | Filesystem watcher for hot reload. |
-| `HttpClient/` | Thin client used by `phel\http`. |
-| `Fiber/` | Fibers + futures runtime helpers. |
-| `Filesystem/` | File I/O abstraction (test seam for the rest of the compiler). |
-| `Config/` | `phel-config.php` loading and access. |
-| `Shared/` | Tiny cross-module utilities (only what truly has no better home). |
-| `Phel.php` | Static facade used by *generated PHP*: `\Phel::addDefinition(...)`, `\Phel::keyword(...)`, etc. |
+| `Lang/` | Runtime types: persistent collections, `Symbol`, `Keyword`, `Variable`, `Registry`. Foundational, no facade. |
+| `Compiler/` | Lex → Parse → Read → Analyze → Emit → Eval. See [compiler.md](compiler.md). |
+| `Printer/` | Render Phel values. |
+| `Run/` | `phel run`, REPL (`Run/Domain/Repl/`), namespace bootstrap (`Run/Runtime/`). |
+| `Build/` | Compile project to PHP on disk; namespace dependency order. |
+| `Command/` | CLI command registry. |
+| `Console/` | Symfony Console wiring; binary entry. |
+| `Api/` | Programmatic access to documented symbols (used by `doc`, `lsp`). |
+| `Interop/` | Generates PHP wrappers so PHP can call Phel from an IDE. |
+| `Lint/` | `phel lint` over parse trees. |
+| `Formatter/` | Pretty-prints `.phel`. |
+| `Lsp/` | LSP over stdio. |
+| `Nrepl/` | nREPL bencode/TCP. |
+| `Watch/` | Hot reload watcher. |
+| `HttpClient/`, `Fiber/`, `Filesystem/`, `Config/`, `Shared/` | Helpers. |
+| `Phel.php` | Static facade called by *emitted* PHP: `\Phel::addDefinition(...)`, `\Phel::keyword(...)`. |
 
-## The Gacela pattern
-
-Every non-foundational module follows the same skeleton. `Run/` is a representative example:
+## Gacela skeleton
 
 ```
 Run/
-├── RunFacade.php            ← public API (the only thing other modules import)
-├── RunFactory.php           ← wires up its own classes
-├── RunConfig.php            ← typed config
-├── RunProvider.php          ← declares dependencies on other facades
-├── Application/             ← orchestration / use cases
-├── Domain/                  ← pure logic, value objects, interfaces
-├── Infrastructure/          ← adapters: filesystem, console, env
-└── Runtime/                 ← module-specific runtime helpers (here: Phel namespace bootstrap)
+├── RunFacade.php       public API
+├── RunFactory.php      internal wiring
+├── RunConfig.php       typed config
+├── RunProvider.php     cross-module deps
+├── Application/        orchestration
+├── Domain/             pure logic, value objects
+└── Infrastructure/     adapters
 ```
 
 Rules:
 
-- **Never instantiate a class from another module directly.** Always go through the other module's `Facade`.
-- **Never reach into another module's `Domain/`.** That's its private surface.
-- **Add a method to your own facade** before you reach for someone else's.
-- The constructor of a `Facade` is empty; collaborators come from the `Factory`/`Provider`.
+- Never instantiate another module's class directly. Go via Facade.
+- Never reach into another module's `Domain/`.
+- Add a method to *your* facade before consuming someone else's internals.
 
-The provider declares dependencies as facade constants. Example from `RunProvider`:
+Provider declares deps as facade constants:
 
 ```php
-public const string FACADE_COMPILER = 'FACADE_COMPILER';
-
 #[Provides(self::FACADE_COMPILER)]
 public function compilerFacade(Container $container): CompilerFacade
 {
@@ -77,53 +64,46 @@ public function compilerFacade(Container $container): CompilerFacade
 }
 ```
 
-Every module ships its own `CLAUDE.md` documenting public API, dependencies, and constraints. Read that first when you touch a module.
+Each module ships `CLAUDE.md` with API + constraints. Read it before editing.
 
-## Dependency map (high-level)
+## Dependency map
 
 ```
-                          Console / Command
-                                   │
-                ┌──────────┬───────┼─────────┬───────────┐
-                ▼          ▼       ▼         ▼           ▼
-               Run       Build   Lint   Formatter      Watch
-                │          │       │         \         /
-                └──────────┴───┬───┘          \       /
-                               ▼               ▼     ▼
-                        Compiler  ◄────── Api  ◄── Lsp / Nrepl / Watch
-                            │
-                            ▼
-                          Lang (foundational)
-                            ▲
-                            │
-                       Printer (rendering)
+              Console / Command
+                     │
+   ┌────┬─────┬──────┼──────┬──────┐
+   ▼    ▼     ▼      ▼      ▼      ▼
+  Run  Build Lint Formatter Watch  …
+   └────┴────┬┴──────┘
+            ▼
+        Compiler ◄── Api ◄── Lsp / Nrepl
+            │
+            ▼
+          Lang  ◄── Printer
 ```
 
-A few load-bearing edges:
+- Everything → `Compiler/`, `Lang/`.
+- `Lang/` is a leaf (one outbound `__toString()` to `Printer`).
+- `Lsp/`, `Nrepl/`, `Watch/` reuse the compiler facade; not on the compile path.
 
-- **Everything depends on `Compiler/`** for parsing/analysing Phel.
-- **Everything depends on `Lang/`** for the runtime types.
-- **`Lang/` is a leaf**: no inbound dependencies on other modules except a single `__toString()` link to `Printer\Printer::readable()` (see `Lang/CLAUDE.md`).
-- **`Lsp/`, `Nrepl/`, `Watch/`** are tools, not part of the core compile path; they reuse the compiler facade.
+## Compile-time vs runtime
 
-## Compile-time vs. runtime
+Two conceptual processes:
 
-This trips up almost everyone the first time. There are two PHP processes worth keeping straight in your head:
+- **Compile**: `CompilerFacade::compile()`. Holds `GlobalEnvironment`, macros, `TypeFactory`/`Registry`.
+- **Runtime**: executes emitted PHP. Sees only `\Phel::*`, `\phel\core\*`, `Lang/` types.
 
-1. **The compiler process** — what `composer test-compiler` exercises and what runs when you call `CompilerFacade::compile()`. This process holds the `GlobalEnvironment`, the macro definitions, and the `TypeFactory`/`Registry` singletons in memory while it walks your forms.
-2. **The runtime process** — what executes the PHP that the compiler emitted. It only sees `\Phel::addDefinition(...)` calls, `\phel\core\…` functions, and the `Lang/` types. It does not see the analyzer, the parser, or the special-form handlers.
-
-Compile time and runtime can be the same physical PHP process (REPL, `phel run`) or different (cached `.php` files served by a framework). The boundary is conceptual: "is this code being analysed, or is it being executed?"
+Same physical PHP process (REPL, `phel run`) or different (cached files in a framework). Boundary is "being analysed" vs "being executed".
 
 ## Where to add a feature
 
-| You want to… | Touch this |
-|--------------|------------|
-| Add a new reader macro (`#foo`) | `Lang/TagHandlers/`, register in `TagRegistry` |
-| Add a new special form | `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` + matching `NodeEmitter`. See [special forms](special-forms.md). |
-| Add a new core function in Phel | `src/phel/core/...` |
-| Add a CLI subcommand | `Run/` or its own module + `Command/` registration |
-| Add an LSP capability | `Lsp/Domain/` |
-| Add a linter rule | `Lint/Domain/Analyzer/` |
+| Want | Touch |
+|------|-------|
+| Reader macro `#foo` | `Lang/TagHandlers/` + `TagRegistry` |
+| Special form | `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` + matching `NodeEmitter` ([special-forms.md](special-forms.md)) |
+| Core fn in Phel | `src/phel/core/…` |
+| CLI subcommand | new module or `Run/` + `Command/` registration |
+| LSP capability | `Lsp/Domain/` |
+| Lint rule | `Lint/Domain/Analyzer/` |
 
-When in doubt, run `grep -r "FACADE_" src/php/<Module>/<Module>Provider.php` to see what a module already pulls in — that's the cheapest map of how it talks to the rest of the system.
+`grep -r "FACADE_" src/php/<Module>/<Module>Provider.php` shows a module's deps.

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -1,82 +1,132 @@
 # Compiler Internals
 
-How the Phel compiler processes source code. The compiler is a pipeline; each step transforms its input and passes the result to the next.
+How the Phel compiler turns source code into running PHP. The compiler is a six-stage pipeline; each stage consumes only the output of the previous stage. Source locations propagate through every stage so error messages can point back at the original `.phel` file.
 
-## Compiler pipeline
+## Pipeline at a glance
 
-1. **Lexer**: source string into a stream of tokens.
-2. **Parser**: tokens into a parse tree retaining whitespace and comments.
-3. **Reader**: parse tree into Phel data structures. Trivia like whitespace is dropped.
-4. **Analyzer**: validates the data structures and produces an abstract syntax tree (AST).
-5. **Emitter**: AST into PHP code.
-6. **Evaluator**: executes the generated PHP code.
+| Stage | Class | Input | Output |
+|-------|-------|-------|--------|
+| Lexer | `Compiler/Application/Lexer.php` | Phel source `string` | `TokenStream` |
+| Parser | `Compiler/Application/Parser.php` | `TokenStream` | parse tree (`NodeInterface`) |
+| Reader | `Compiler/Application/Reader.php` | parse tree | `ReaderResult` (Phel data) |
+| Analyzer | `Compiler/Application/Analyzer.php` | Phel data | `AbstractNode` (AST) |
+| Emitter | `Compiler/Domain/Emitter/OutputEmitter.php` | `AbstractNode` | PHP `string` |
+| Evaluator | `Compiler/Domain/Evaluator/` (`InMemoryEvaluator`, `RequireEvaluator`) | PHP `string` | runtime values / side effects |
 
-Examples below use `(print "hi")` to illustrate each stage.
+The public entry points live on `CompilerFacade`:
 
-## Lexer
+- `compile()` / `compileForCache()` — full pipeline, returns `EmitterResult`
+- `compileForm()` — same, but starts from already-read Phel data
+- `eval()` / `evalForm()` — compile and execute
+- `lexString()` / `parseNext()` / `parseAll()` / `read()` / `analyze()` — single-stage hooks for tools (LSP, nREPL, linter)
 
-The lexer splits the input string into tokens. Every token has a `type`, the lexeme `code`, and start/end `SourceLocation`. Tokens are collected in a `TokenStream` consumed by the parser.
+The example below traces `(print "hi")` through every stage.
 
-Example output:
+## 1. Lexer
+
+`Compiler/Application/Lexer.php` walks the source string and emits a `TokenStream` of `Token` objects. Each `Token` carries:
+
+- `type` — one of the `T_*` constants on `Token`
+- `code` — the raw lexeme
+- start/end `SourceLocation` — file, line, column
+
+Whitespace and comments become real tokens (`T_WHITESPACE`, `T_COMMENT`) so the parser can preserve formatting for tools that need it (formatter, linter).
 
 ```text
-T_OPEN_PARENTHESIS "("
-T_ATOM "print"
-T_WHITESPACE " "
-T_STRING "\"hi\""
+T_OPEN_PARENTHESIS  "("
+T_ATOM              "print"
+T_WHITESPACE        " "
+T_STRING            "\"hi\""
 T_CLOSE_PARENTHESIS ")"
+T_EOF               ""
 ```
 
-## Parser
+## 2. Parser
 
-The parser reads from the `TokenStream` and produces a parse tree. The tree retains every token, including whitespace and comments, so macros can access the original layout.
+`Compiler/Application/Parser.php` consumes a `TokenStream` and produces a parse tree of `NodeInterface` values (`Compiler/Domain/Parser/ParserNode/`). The tree retains every token, including trivia, so the formatter and the linter can rewrite source without losing comments.
 
-Example output:
+Specialised sub-parsers live under `Compiler/Domain/Parser/ExpressionParser/` and are wired together by `ExpressionParserFactory`. Examples: `ListParser`, `VectorParser`, `MapParser`, `MetaParser`, `QuoteParser`.
 
 ```text
 ListNode
-  AtomNode("print")
-  StringNode("hi")
+├── SymbolNode("print")
+├── WhitespaceNode(" ")
+└── StringNode("\"hi\"")
 ```
 
-## Reader
+## 3. Reader
 
-The reader converts the parse tree into Phel data structures, dropping trivia tokens. The result is wrapped in a `ReaderResult` that keeps a reference to the original snippet for error reporting.
+`Compiler/Application/Reader.php` turns the parse tree into Phel data — symbols, keywords, lists, vectors, maps, sets — backed by the persistent collections in `Lang/Collections/`. Trivia is dropped here. The result is a `ReaderResult` that keeps a reference to the original snippet for error reporting.
 
-Example output:
+The reader also expands reader macros: `'x` → `(quote x)`, `` `x `` → quasiquote, `~x` → unquote, `~@x` → unquote-splicing, `#(...)` → anonymous fn, `#inst`, `#regex`, `#php`, custom `#` tag handlers (`Lang/TagHandlers/`, `Lang/TagRegistry.php`).
+
+Quasiquote is non-trivial: `Compiler/Domain/Reader/QuasiquoteTransformer.php` rewrites `` `(...) `` into explicit `concat`/`list` calls, with auto-gensym (`x#`) handled by `Compiler/Domain/Reader/GensymContext.php`.
 
 ```lisp
 (print "hi")
 ```
 
-## Analyzer
+## 4. Analyzer
 
-The analyzer validates the reader's forms and transforms them into an AST. It enriches a global environment with variables and macro definitions. On success, returns an `AbstractNode` tree.
+`Compiler/Application/Analyzer.php` validates Phel data and produces a typed AST of `AbstractNode` subclasses (`Compiler/Domain/Analyzer/Ast/`). Two things happen in parallel:
 
-Example output:
+1. **Side effects on the global environment** (`GlobalEnvironment`): top-level `def`, `defmacro`, `def-struct`, `ns`, and friends register names so subsequent forms in the same compile unit can resolve them.
+2. **Tree construction**: each form maps to one `*Node` (`DefNode`, `FnNode`, `LetNode`, `IfNode`, `CallNode`, …).
+
+Dispatch by Phel value type happens in `Compiler/Domain/Analyzer/TypeAnalyzer/`:
+
+- `AnalyzeLiteral` — strings, numbers, booleans, `nil`, keywords
+- `AnalyzeSymbol` — local lookup, then global, then suggestion-driven error
+- `AnalyzePersistentList` — first decides if the head is a special form (see [special forms](special-forms.md)), then dispatches to a `SpecialForm/*Symbol` handler or falls back to `InvokeSymbol` for ordinary calls
+- `AnalyzePersistentVector` / `AnalyzePersistentMap` / `AnalyzePersistentSet` — collection literals, recursing into children
+
+Every `AbstractNode` carries a `NodeEnvironment` (`Compiler/Domain/Analyzer/Environment/NodeEnvironment.php`) describing:
+
+- **Context**: `Expression`, `Statement`, or `Return` — controls whether the emitter must produce a value, a statement, or a `return`
+- **Locals** + **shadowed names** — tracked via `withMergedLocals`, `withShadowedLocal`
+- **Recur frame** — the innermost `loop`/`fn` that `recur` will jump to
+
+Wrong context = wrong PHP. The emitter trusts what the analyzer wrote.
 
 ```text
-CallNode
-  Symbol("print")
-  Literal("hi")
+CallNode (context=Statement)
+├── fn:    GlobalVarNode("phel\\core/print")
+└── args:  [LiteralNode("hi")]
 ```
 
-## Emitter
+## 5. Emitter
 
-The emitter walks the AST and produces PHP source code. To produce valid PHP identifiers it uses the *munge* component, which replaces special characters in Phel symbols (e.g. `-` becomes `_`, `+` becomes `_PLUS_`). The emitter can also generate source maps.
+`Compiler/Domain/Emitter/OutputEmitter.php` walks the AST and writes PHP. Per-node logic lives in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` — one emitter per AST node type (`DefEmitter`, `FnAsClassEmitter`, `LetEmitter`, `IfEmitter`, `CallEmitter`, …). Unknown node types must throw, never silently no-op.
 
-Example output:
+Two responsibilities worth knowing:
+
+- **Munge** (`Compiler/Application/Munge.php`) — Phel symbols allow characters PHP forbids. `my-fn?` becomes `my_fn_QMARK_`, `+` becomes `_PLUS_`, `-` becomes `_`, etc. The same algorithm is used by `Lang/Collections/Struct/StructKeyEncoder` so structs and emitted code agree on names.
+- **Source maps** (`Compiler/Domain/Emitter/OutputEmitter/SourceMap/`) — every emitted line can be mapped back to the originating Phel `SourceLocation`, used by error reporting and the LSP.
+
+The emitter also has two modes (`EmitMode`): `STATEMENT` for `eval` and the REPL (no leading `<?php`), `FILE` for cached compilation (full file with namespace bootstrap). `FileEmitter` orchestrates a multi-form file; `StatementEmitter` does a single form.
 
 ```php
-print("hi");
+\phel\core\print_("hi");
 ```
 
-## Evaluator
+## 6. Evaluator
 
-The evaluator executes the emitted PHP. `RequireEvaluator` writes the code to a temp file and includes it so macros and top-level forms have side effects during compilation.
+The evaluator runs the emitted PHP. Two implementations:
 
-Example output:
+- `RequireEvaluator` (`Compiler/Domain/Evaluator/RequireEvaluator.php`) — writes the code to a temp file and `require`s it. This is the production path: `require` triggers the autoloader and respects opcache, which is what makes hot reload + cache reuse fast.
+- `InMemoryEvaluator` — `eval()`s the string. Used in tests to avoid touching the filesystem.
 
-```
+Top-level forms have side effects at compile time: a `def` registers a definition before later forms see it; a `defmacro` is *available immediately* to expand subsequent forms in the same file. That is why each top-level form takes a full lex → … → eval round-trip, not the whole file at once. See `Compiler/Application/CodeCompiler.php`.
+
+```text
 hi
 ```
+
+## Where to look next
+
+- [Special forms](special-forms.md) — full list and how dispatch works
+- [Macros](macros.md) — `macroexpand`, gensym, quasiquote
+- [Architecture](architecture.md) — module boundaries and Gacela layout
+- [Runtime](runtime.md) — persistent collections and the `Registry`
+- [Internals FAQ](faq.md) — common questions from different angles
+- `src/php/Compiler/CLAUDE.md` — facade-level cheat sheet for agents

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -1,36 +1,28 @@
-# Compiler Internals
+# Compiler
 
-How the Phel compiler turns source code into running PHP. The compiler is a six-stage pipeline; each stage consumes only the output of the previous stage. Source locations propagate through every stage so error messages can point back at the original `.phel` file.
+Six-stage pipeline. Each stage consumes only the previous stage's output. Source locations propagate end-to-end.
 
-## Pipeline at a glance
+| Stage | Class | In | Out |
+|-------|-------|----|-----|
+| Lexer | `Application/Lexer.php` | `string` | `TokenStream` |
+| Parser | `Application/Parser.php` | `TokenStream` | parse tree (`NodeInterface`) |
+| Reader | `Application/Reader.php` | parse tree | `ReaderResult` (Phel data) |
+| Analyzer | `Application/Analyzer.php` | Phel data | `AbstractNode` |
+| Emitter | `Domain/Emitter/OutputEmitter.php` | `AbstractNode` | PHP `string` |
+| Evaluator | `Domain/Evaluator/` | PHP `string` | values / side effects |
 
-| Stage | Class | Input | Output |
-|-------|-------|-------|--------|
-| Lexer | `Compiler/Application/Lexer.php` | Phel source `string` | `TokenStream` |
-| Parser | `Compiler/Application/Parser.php` | `TokenStream` | parse tree (`NodeInterface`) |
-| Reader | `Compiler/Application/Reader.php` | parse tree | `ReaderResult` (Phel data) |
-| Analyzer | `Compiler/Application/Analyzer.php` | Phel data | `AbstractNode` (AST) |
-| Emitter | `Compiler/Domain/Emitter/OutputEmitter.php` | `AbstractNode` | PHP `string` |
-| Evaluator | `Compiler/Domain/Evaluator/` (`InMemoryEvaluator`, `RequireEvaluator`) | PHP `string` | runtime values / side effects |
+Paths are relative to `src/php/Compiler/`.
 
-The public entry points live on `CompilerFacade`:
+## Public entry points (`CompilerFacade`)
 
-- `compile()` / `compileForCache()` — full pipeline, returns `EmitterResult`
-- `compileForm()` — same, but starts from already-read Phel data
-- `eval()` / `evalForm()` — compile and execute
-- `lexString()` / `parseNext()` / `parseAll()` / `read()` / `analyze()` — single-stage hooks for tools (LSP, nREPL, linter)
+- `compile()` / `compileForCache()`: full pipeline → `EmitterResult`
+- `compileForm()`: start from already-read Phel data
+- `eval()` / `evalForm()`: compile + execute
+- `lexString()` / `parseAll()` / `read()` / `analyze()`: single-stage hooks for LSP, nREPL, linter
 
-The example below traces `(print "hi")` through every stage.
+## Tracing `(print "hi")`
 
-## 1. Lexer
-
-`Compiler/Application/Lexer.php` walks the source string and emits a `TokenStream` of `Token` objects. Each `Token` carries:
-
-- `type` — one of the `T_*` constants on `Token`
-- `code` — the raw lexeme
-- start/end `SourceLocation` — file, line, column
-
-Whitespace and comments become real tokens (`T_WHITESPACE`, `T_COMMENT`) so the parser can preserve formatting for tools that need it (formatter, linter).
+**Lexer**: `Token` per lexeme with type, code, `SourceLocation`. Trivia kept (`T_WHITESPACE`, `T_COMMENT`) for formatter/linter.
 
 ```text
 T_OPEN_PARENTHESIS  "("
@@ -38,95 +30,51 @@ T_ATOM              "print"
 T_WHITESPACE        " "
 T_STRING            "\"hi\""
 T_CLOSE_PARENTHESIS ")"
-T_EOF               ""
 ```
 
-## 2. Parser
-
-`Compiler/Application/Parser.php` consumes a `TokenStream` and produces a parse tree of `NodeInterface` values (`Compiler/Domain/Parser/ParserNode/`). The tree retains every token, including trivia, so the formatter and the linter can rewrite source without losing comments.
-
-Specialised sub-parsers live under `Compiler/Domain/Parser/ExpressionParser/` and are wired together by `ExpressionParserFactory`. Examples: `ListParser`, `VectorParser`, `MapParser`, `MetaParser`, `QuoteParser`.
+**Parser**: sub-parsers under `Domain/Parser/ExpressionParser/` (`ListParser`, `VectorParser`, `MapParser`, …) wired by `ExpressionParserFactory`. Tree retains trivia.
 
 ```text
-ListNode
-├── SymbolNode("print")
-├── WhitespaceNode(" ")
-└── StringNode("\"hi\"")
+ListNode → SymbolNode("print"), WhitespaceNode, StringNode("\"hi\"")
 ```
 
-## 3. Reader
+**Reader**: parse tree → Phel data backed by `Lang/Collections/`. Drops trivia. Expands reader macros: `'x`, `` `x ``, `~x`, `~@x`, `#(...)`, `#inst`, `#regex`, `#php`, custom `#tag` (`Lang/TagHandlers/`). Quasiquote rewrite + auto-gensym in `Domain/Reader/QuasiquoteTransformer.php`.
 
-`Compiler/Application/Reader.php` turns the parse tree into Phel data — symbols, keywords, lists, vectors, maps, sets — backed by the persistent collections in `Lang/Collections/`. Trivia is dropped here. The result is a `ReaderResult` that keeps a reference to the original snippet for error reporting.
+**Analyzer**: Phel data → AST in `Domain/Analyzer/Ast/`. Dispatch by value type in `Domain/Analyzer/TypeAnalyzer/`:
 
-The reader also expands reader macros: `'x` → `(quote x)`, `` `x `` → quasiquote, `~x` → unquote, `~@x` → unquote-splicing, `#(...)` → anonymous fn, `#inst`, `#regex`, `#php`, custom `#` tag handlers (`Lang/TagHandlers/`, `Lang/TagRegistry.php`).
+- `AnalyzeLiteral`: scalars, keywords
+- `AnalyzeSymbol`: locals → globals → suggestion error
+- `AnalyzePersistentList`: special form (see [special-forms.md](special-forms.md)) or `InvokeSymbol`
+- `AnalyzePersistentVector` / `Map` / `Set`: collection literals
 
-Quasiquote is non-trivial: `Compiler/Domain/Reader/QuasiquoteTransformer.php` rewrites `` `(...) `` into explicit `concat`/`list` calls, with auto-gensym (`x#`) handled by `Compiler/Domain/Reader/GensymContext.php`.
+Side effect: top-level `def`/`defmacro`/`ns` register names in `GlobalEnvironment` so later forms resolve.
 
-```lisp
-(print "hi")
-```
+Every node carries `NodeEnvironment` with:
 
-## 4. Analyzer
+- **context**: `Expression`, `Statement`, `Return` (drives emitter output shape)
+- **locals** + **shadowed**: `withMergedLocals`, `withShadowedLocal`
+- **recur frame**: innermost `loop`/`fn`
 
-`Compiler/Application/Analyzer.php` validates Phel data and produces a typed AST of `AbstractNode` subclasses (`Compiler/Domain/Analyzer/Ast/`). Two things happen in parallel:
+Wrong context → wrong PHP. Emitter trusts what analyzer wrote.
 
-1. **Side effects on the global environment** (`GlobalEnvironment`): top-level `def`, `defmacro`, `def-struct`, `ns`, and friends register names so subsequent forms in the same compile unit can resolve them.
-2. **Tree construction**: each form maps to one `*Node` (`DefNode`, `FnNode`, `LetNode`, `IfNode`, `CallNode`, …).
+**Emitter**: one `*Emitter.php` per AST node under `Domain/Emitter/OutputEmitter/NodeEmitter/`. Unknown node = throw.
 
-Dispatch by Phel value type happens in `Compiler/Domain/Analyzer/TypeAnalyzer/`:
-
-- `AnalyzeLiteral` — strings, numbers, booleans, `nil`, keywords
-- `AnalyzeSymbol` — local lookup, then global, then suggestion-driven error
-- `AnalyzePersistentList` — first decides if the head is a special form (see [special forms](special-forms.md)), then dispatches to a `SpecialForm/*Symbol` handler or falls back to `InvokeSymbol` for ordinary calls
-- `AnalyzePersistentVector` / `AnalyzePersistentMap` / `AnalyzePersistentSet` — collection literals, recursing into children
-
-Every `AbstractNode` carries a `NodeEnvironment` (`Compiler/Domain/Analyzer/Environment/NodeEnvironment.php`) describing:
-
-- **Context**: `Expression`, `Statement`, or `Return` — controls whether the emitter must produce a value, a statement, or a `return`
-- **Locals** + **shadowed names** — tracked via `withMergedLocals`, `withShadowedLocal`
-- **Recur frame** — the innermost `loop`/`fn` that `recur` will jump to
-
-Wrong context = wrong PHP. The emitter trusts what the analyzer wrote.
-
-```text
-CallNode (context=Statement)
-├── fn:    GlobalVarNode("phel\\core/print")
-└── args:  [LiteralNode("hi")]
-```
-
-## 5. Emitter
-
-`Compiler/Domain/Emitter/OutputEmitter.php` walks the AST and writes PHP. Per-node logic lives in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` — one emitter per AST node type (`DefEmitter`, `FnAsClassEmitter`, `LetEmitter`, `IfEmitter`, `CallEmitter`, …). Unknown node types must throw, never silently no-op.
-
-Two responsibilities worth knowing:
-
-- **Munge** (`Compiler/Application/Munge.php`) — Phel symbols allow characters PHP forbids. `my-fn?` becomes `my_fn_QMARK_`, `+` becomes `_PLUS_`, `-` becomes `_`, etc. The same algorithm is used by `Lang/Collections/Struct/StructKeyEncoder` so structs and emitted code agree on names.
-- **Source maps** (`Compiler/Domain/Emitter/OutputEmitter/SourceMap/`) — every emitted line can be mapped back to the originating Phel `SourceLocation`, used by error reporting and the LSP.
-
-The emitter also has two modes (`EmitMode`): `STATEMENT` for `eval` and the REPL (no leading `<?php`), `FILE` for cached compilation (full file with namespace bootstrap). `FileEmitter` orchestrates a multi-form file; `StatementEmitter` does a single form.
+- **Munge** (`Application/Munge.php`): `my-fn?` → `my_fn_QMARK_`, `+` → `_PLUS_`. Same algorithm in `Lang/Collections/Struct/StructKeyEncoder`.
+- **Source maps** (`Domain/Emitter/OutputEmitter/SourceMap/`): emitted line → Phel `SourceLocation`.
+- **Modes** (`EmitMode`): `STATEMENT` (REPL, `eval`), `FILE` (cached compilation). `StatementEmitter` vs `FileEmitter`.
 
 ```php
 \phel\core\print_("hi");
 ```
 
-## 6. Evaluator
+**Evaluator**
 
-The evaluator runs the emitted PHP. Two implementations:
+- `RequireEvaluator`: temp file + `require`. Production path; opcache-friendly.
+- `InMemoryEvaluator`: `eval()` for tests.
 
-- `RequireEvaluator` (`Compiler/Domain/Evaluator/RequireEvaluator.php`) — writes the code to a temp file and `require`s it. This is the production path: `require` triggers the autoloader and respects opcache, which is what makes hot reload + cache reuse fast.
-- `InMemoryEvaluator` — `eval()`s the string. Used in tests to avoid touching the filesystem.
+Each top-level form runs lex→…→eval before the next is analysed, so `defmacro` is available to following forms. See `Application/CodeCompiler.php`.
 
-Top-level forms have side effects at compile time: a `def` registers a definition before later forms see it; a `defmacro` is *available immediately* to expand subsequent forms in the same file. That is why each top-level form takes a full lex → … → eval round-trip, not the whole file at once. See `Compiler/Application/CodeCompiler.php`.
+## See also
 
-```text
-hi
-```
-
-## Where to look next
-
-- [Special forms](special-forms.md) — full list and how dispatch works
-- [Macros](macros.md) — `macroexpand`, gensym, quasiquote
-- [Architecture](architecture.md) — module boundaries and Gacela layout
-- [Runtime](runtime.md) — persistent collections and the `Registry`
-- [Internals FAQ](faq.md) — common questions from different angles
-- `src/php/Compiler/CLAUDE.md` — facade-level cheat sheet for agents
+- [special-forms.md](special-forms.md), [macros.md](macros.md), [architecture.md](architecture.md), [runtime.md](runtime.md), [faq.md](faq.md)
+- `src/php/Compiler/CLAUDE.md`

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -1,111 +1,61 @@
 # Internals FAQ
 
-Common questions about how Phel works internally, grouped by who is asking. If you only have five minutes, skim the headings.
+Grouped by reader.
 
----
+## PHP developer
 
-## I'm a PHP developer
+**Interpreter or compiler?** Compiler. Each top-level form lowers to PHP source, written to a file, then `require`d. No runtime AST walker.
 
-### Is Phel an interpreter or does it actually compile?
+**What does emitted PHP look like?** Cached files under `var/cache/` after one `phel run`, or the `--PHP--` section of any fixture in `tests/php/Integration/Fixtures/`. Regular PHP calling `\Phel::*` and `\phel\core\*`.
 
-It compiles. Each top-level Phel form is lowered to PHP source code, written to a file, and `require`d. There is no runtime interpreter walking AST nodes.
+**Why `\Phel::addDefinition()` instead of plain functions?** Phel namespaces are runtime values (see [runtime.md](runtime.md)). Single static surface tracks definitions, metadata, reloads. One `require` registers a whole namespace, no per-definition class-loading.
 
-### What does the generated PHP look like?
+**How does `(my-fn arg)` reach my PHP?** Phel function: compiles to a class with `__invoke`, call site emits `(($lookup))($arg)`. Interop: `(php/-> $obj method arg)` and friends compile to literal `$obj->method($arg)`. See [special-forms.md](special-forms.md).
 
-Open any cached file under `var/cache/` after running `phel run` once, or look at `tests/php/Integration/Fixtures/**/*.test` — the `--PHP--` section is exactly what the compiler emits. It is regular PHP that calls into `\Phel::*` and `\phel\core\*`.
+**Xdebug, Psalm, PHPStan?** Yes, on the generated PHP. Source maps point traces back to `.phel`. `composer test-quality` runs Psalm + PHPStan on `src/php/`.
 
-### Why does compiled code go through `\Phel::addDefinition()` instead of just defining functions?
+**Call cost?** Function: one `__invoke` plus arg unpacking. Negligible. Collections: trie-backed, O(log32 n) with small constants. See [benchmarks.md](benchmarks.md).
 
-Phel namespaces are first-class runtime values (see [runtime.md](runtime.md)). The static facade gives the runtime a single place to track definitions, metadata, and reloads. It also means a single PHP `require` is enough to register everything in a namespace — no class-loading dance per definition.
+## Coming from Clojure
 
-### How does `(my-fn arg)` reach my PHP code?
+**Missing features.** No agents, no STM/refs (use `Variable` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (use `definterface`), no records (use `defstruct`).
 
-If `my-fn` is a Phel function: it compiles to a small PHP class with `__invoke`, and the call site emits `(($globalLookup))($arg)`.
+**Real persistent collections?** Yes. `PersistentVector` (32-way trie), `PersistentHashMap` (HAMT), `LazySeq` (per-element realisation). Under `Lang/Collections/`.
 
-If `my-fn` is PHP code, you wrote `(php/-> $obj method arg)` or one of the `php/*` interop forms. Those compile to literal `$obj->method($arg)` — see the PHP-interop rows in [special-forms.md](special-forms.md).
+**Hygienic macros?** Quasiquote namespace-qualifies symbols at read time. `x#` inside a quasiquote expands to a fresh gensym consistent within that quasiquote. See [macros.md](macros.md).
 
-### Can I drop into PHP debug tooling (Xdebug, Psalm, PHPStan)?
+**REPL? nREPL?** Both. `phel repl` interactive; `phel nrepl` over bencode/TCP. See [nrepl-guide.md](../nrepl-guide.md).
 
-Yes, on the *generated* PHP. The compiler writes source maps so stack traces point back at the original `.phel` file. Static analysers run against the cached PHP just fine; `composer test-quality` includes Psalm and PHPStan over `src/php/`.
+**`recur` and tail calls.** Loop body becomes `while (true) { ... }` rebinding parameters. No stack growth. PHP has no TCO; `recur` does not need it.
 
-### What's the cost of a Phel call vs. a PHP call?
+## Modifying the compiler
 
-For functions: one method call (`__invoke`) plus argument unpacking. Negligible.
+**Where to start.** `src/php/Compiler/CLAUDE.md` for facade overview, then [compiler.md](compiler.md). Most edits hit one of:
 
-For collections: persistent maps and vectors are tries — operations are O(log32 n) but with small constants. See [internals/benchmarks.md](benchmarks.md).
+- `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`
+- `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`
+- `Compiler/Domain/Reader/`
+- `Compiler/Application/Lexer.php`
 
----
-
-## I'm coming from Clojure
-
-### Which Clojure features are missing?
-
-The big ones: no agents, no STM/refs (use `Variable` and `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (Phel has interfaces via `definterface`), no records (Phel has structs via `defstruct`).
-
-### Are persistent collections the real thing or a thin wrapper over PHP arrays?
-
-Real persistent data structures with structural sharing. `PersistentVector` is a 32-way trie, `PersistentHashMap` is a HAMT, `LazySeq` realises one element at a time. See `Lang/Collections/`.
-
-### How do macros work? Are they hygienic?
-
-Standard Clojure-style: quasiquote namespaces symbols at read time, and `x#` inside a quasiquote becomes an auto-gensym consistent within that quasiquote. See [macros.md](macros.md). Hygiene is the same model as Clojure — sufficient for almost everything, not airtight if you go out of your way to break it.
-
-### Is there a REPL? An nREPL?
-
-Both. `phel repl` is the interactive REPL; `phel nrepl` speaks bencode/TCP for editor integrations (CIDER-style). See [nrepl-guide.md](../nrepl-guide.md).
-
-### Does `recur` actually do tail-call elimination on the PHP VM?
-
-It compiles the loop body to a `while (true) { ... }` and rebinds parameters in place — no stack growth. PHP itself has no TCO, but `recur` doesn't need it.
-
----
-
-## I'm modifying the compiler
-
-### Where do I start?
-
-`src/php/Compiler/CLAUDE.md` for the facade-level overview. Then [compiler.md](compiler.md) for the pipeline. Then the module you actually want to touch — most changes live in one of:
-
-- `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` — special forms
-- `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` — PHP code generation
-- `Compiler/Domain/Reader/` — reader macros and quasiquote
-- `Compiler/Application/Lexer.php` — tokenisation
-
-### How do I see what a form lexes/parses/reads/analyses to?
-
-Use the facade hooks on `CompilerFacade`:
+**Inspect a single phase.** Facade hooks:
 
 ```php
-$tokens   = $facade->lexString('(print "hi")');
-$tree     = $facade->parseAll($tokens);
-$readResult = $facade->read($tree->getChildren()[0]);
-$ast      = $facade->analyze($readResult->getAst(), NodeEnvironment::empty());
-$emit     = $facade->compile('(print "hi")', new CompileOptions());
+$tokens = $facade->lexString('(print "hi")');
+$tree   = $facade->parseAll($tokens);
+$read   = $facade->read($tree->getChildren()[0]);
+$ast    = $facade->analyze($read->getAst(), NodeEnvironment::empty());
+$emit   = $facade->compile('(print "hi")', new CompileOptions());
 ```
 
-For a one-liner, the integration fixture format under `tests/php/Integration/Fixtures/` documents end-to-end expectations.
+**Add a special form.** [special-forms.md](special-forms.md#adding-one). Most common miss: dispatch wiring in `AnalyzePersistentList`.
 
-### How do I add a new special form?
+**Add a core function.** Pure Phel: `src/phel/core/...` with `:doc`, `:see-also`, `:example`. Run `composer test-core`. Needs PHP: thin wrapper under `src/phel/...` calling a PHP helper, run `composer test-compiler` + `composer test-core`.
 
-Five-step recipe in [special-forms.md](special-forms.md#adding-a-new-special-form). Skipping the dispatch wiring in `AnalyzePersistentList` is the most common mistake.
+**`NodeEnvironment` context.** `Expression`, `Statement`, `Return`. Analyzer picks based on position (function body last form: `Return`; `if` branch in expression position: `Expression`). Wrong PHP output? 90% of the time wrong context, not the emitter. Helpers: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
 
-### How do I add a new core function?
+**Broken integration fixture.** Update only if new PHP is intentional. Verify by hand first. The `fixture-reviewer` agent (`.claude/agents/`) audits drift.
 
-If it can be written in Phel: add it to `src/phel/core/...`, with `:doc`, `:see-also`, `:example` metadata. Run `composer test-core`.
-
-If it must be in PHP (interop with a system facility): add it under `src/phel/...` as a thin wrapper that calls into `\Phel::php(...)` or a dedicated PHP helper, then run both `composer test-compiler` and `composer test-core`.
-
-### What's the rule for `NodeEnvironment` context?
-
-Three contexts: `Expression`, `Statement`, `Return`. The analyzer chooses based on where the form sits — a function body's last form is `Return`, an `if` branch in expression position is `Expression`, etc. The emitter trusts what was written. If you produce wrong PHP (extra/missing `return`, value where statement expected), 90% of the time the bug is the context, not the emitter.
-
-Helpers on `NodeEnvironment`: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
-
-### My change broke an integration fixture. Do I update the fixture?
-
-Only if the new PHP is intentionally what you want. Read the old `--PHP--`, run the form by hand, confirm the new output is correct, then update. The `fixture-reviewer` agent (see `.claude/agents/`) is built for this audit pass.
-
-### How do I run just my failing test?
+**Run one test.**
 
 ```bash
 ./vendor/bin/phpunit --filter=test_method_name
@@ -113,69 +63,39 @@ Only if the new PHP is intentionally what you want. Read the old `--PHP--`, run 
 ./bin/phel test tests/phel/path/to/test.phel
 ```
 
----
+## Building tools around Phel
 
-## I'm building a tool around Phel
+**Public API.** Every `*Facade.php` under `src/php/*/`, with `*FacadeInterface.php` for typing. `CLAUDE.md` per module documents it. Tooling-relevant: `CompilerFacade`, `ApiFacade`, `LintFacade`, `FormatterFacade`. `Lsp/` and `Nrepl/` are worked examples.
 
-### What's the public API?
+**Run compiler without CLI.** Bootstrap Gacela, fetch `CompilerFacade`, call `compile()` / `eval()`. `tests/php/Integration/` does this.
 
-Every facade in `src/php/*/`. Each one has a `*Facade.php` plus a `*FacadeInterface.php` you should depend on. `CLAUDE.md` files document them.
+**Source locations.** Every readable form, AST node, and emitted line carries a `SourceLocation` (file + line + col). Parse tree node: ask first/last token. AST node: stored in constructor. Emitted PHP: reverse via source map in `Compiler/Domain/Emitter/OutputEmitter/SourceMap/`.
 
-For language tooling specifically: `CompilerFacade`, `ApiFacade`, `LintFacade`, `FormatterFacade`. The LSP and nREPL servers under `Lsp/` and `Nrepl/` are themselves consumers of these — they're the worked examples for "build a tool".
+**Macroexpand from PHP.** `CompilerFacade::macroexpand1($form)`, `macroexpand($form)`. Returns Phel forms. Same path nREPL uses.
 
-### Can I run the compiler without the CLI?
+**Introspect a namespace at runtime.** `ApiFacade`: symbol search, doc, `:see-also`, source locations. `Lang\Registry` is the store but private.
 
-Yes. Bootstrap Gacela, fetch `CompilerFacade`, call `compile()` / `eval()`. `tests/php/Integration/` does exactly this.
+**Cache invalidation.** Keyed by source hash + Phel version. Phel bump busts automatically. Local generated-code change: `phel cache:reset` or `rm -rf var/cache/`.
 
-### How do I get source locations for diagnostics?
+## Bug hunting
 
-Every readable form, every AST node, and every emitted line preserves a `SourceLocation` (file + line + column). For a parse tree node, ask its first/last token. For an AST node, the constructor stored one. For emitted PHP, the source map under `Compiler/Domain/Emitter/OutputEmitter/SourceMap/` reverses the mapping.
+**"Cannot resolve symbol X".** `AnalyzeSymbol` checks locals → current ns globals → `use` aliases → `phel\core`. Miss: `SymbolSuggestionProvider` builds a suggestion + throws with `SourceLocation`. Common cause: missing `(require ...)`.
 
-### How do I expand a macro from PHP without compiling?
+**"Type X cannot be coerced" or unexpected `nil`.** Run `(macroexpand-1 'form)`. Often a macro expansion surprise.
 
-`CompilerFacade::macroexpand1($form)` and `CompilerFacade::macroexpand($form)` return Phel forms (not PHP). That is the same path the nREPL macroexpand op uses.
+**Compiles fine, runtime is weird.** Read the cached `.php`. Surprising emit = analyzer bug (wrong context, wrong recur frame, wrong locals). Emitter just transcribes.
 
-### How do I introspect a Phel namespace at runtime?
+**`Lang/` change breaks ten modules.** Working as designed. `composer test` before push. Faster signal: `composer test-compiler`.
 
-`ApiFacade` is the supported surface — symbol search, doc strings, `:see-also` links, source locations. `Lang\Registry` is the underlying store, but treat it as private.
-
-### Is the cache safe across PHP versions / Phel versions?
-
-The cache is keyed by Phel source hash plus Phel version. Bumping Phel busts it automatically. If you change generated-code shape during development, run `phel cache:reset` (or just delete `var/cache/`).
-
----
-
-## I'm investigating a bug
-
-### "Cannot resolve symbol X" — what does the analyzer actually do?
-
-`AnalyzeSymbol` checks: locals (lexical scope), then the current namespace's globals, then `use`d aliases, then `phel\core`. If still nothing, it builds a suggestion via `SymbolSuggestionProvider` and throws with a `SourceLocation`.
-
-Common cause: you `def`d in one file but didn't `(require ...)` from the consuming namespace.
-
-### "Type X cannot be coerced" or unexpected `nil`
-
-Run `(macroexpand-1 'form)` first. Many "weird type" bugs are macro expansions that aren't doing what you think.
-
-### Compilation succeeds but the runtime behaves oddly
-
-Look at the cached `.php`. If the emitter produced something surprising, the bug is almost always in the analyzer (wrong context, wrong recur frame, wrong locals map). The emitter just transcribes.
-
-### A change in `Lang/` breaks ten other modules
-
-That's the contract working as intended — `Lang/` is foundational. Run `composer test` (everything) at least once before you push. For a faster signal, `composer test-compiler` covers most consumers.
-
----
-
-## Where to look in the source
+## Source map
 
 | Question | File |
 |----------|------|
-| What special forms exist? | `src/php/Lang/Symbol.php` (`NAME_*` constants) |
-| How is a special form analysed? | `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` |
-| How is a node emitted? | `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` |
-| How is a reader macro handled? | `src/php/Compiler/Domain/Reader/ExpressionReader/` |
-| How does quasiquote rewrite? | `src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php` |
-| How are macros expanded? | `src/php/Compiler/Application/MacroExpander.php` |
-| What does an AST node carry? | `src/php/Compiler/Domain/Analyzer/Ast/` (one file per node) |
-| What does each module expose? | the `*Facade.php` and `CLAUDE.md` in that module |
+| Special forms list | `src/php/Lang/Symbol.php` (`NAME_*`) |
+| Special form analysis | `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` |
+| Node emission | `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` |
+| Reader macros | `Compiler/Domain/Reader/ExpressionReader/` |
+| Quasiquote rewrite | `Compiler/Domain/Reader/QuasiquoteTransformer.php` |
+| Macro expansion | `Compiler/Application/MacroExpander.php` |
+| AST nodes | `Compiler/Domain/Analyzer/Ast/` |
+| Module API | each `*Facade.php` + `CLAUDE.md` |

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -1,0 +1,181 @@
+# Internals FAQ
+
+Common questions about how Phel works internally, grouped by who is asking. If you only have five minutes, skim the headings.
+
+---
+
+## I'm a PHP developer
+
+### Is Phel an interpreter or does it actually compile?
+
+It compiles. Each top-level Phel form is lowered to PHP source code, written to a file, and `require`d. There is no runtime interpreter walking AST nodes.
+
+### What does the generated PHP look like?
+
+Open any cached file under `var/cache/` after running `phel run` once, or look at `tests/php/Integration/Fixtures/**/*.test` — the `--PHP--` section is exactly what the compiler emits. It is regular PHP that calls into `\Phel::*` and `\phel\core\*`.
+
+### Why does compiled code go through `\Phel::addDefinition()` instead of just defining functions?
+
+Phel namespaces are first-class runtime values (see [runtime.md](runtime.md)). The static facade gives the runtime a single place to track definitions, metadata, and reloads. It also means a single PHP `require` is enough to register everything in a namespace — no class-loading dance per definition.
+
+### How does `(my-fn arg)` reach my PHP code?
+
+If `my-fn` is a Phel function: it compiles to a small PHP class with `__invoke`, and the call site emits `(($globalLookup))($arg)`.
+
+If `my-fn` is PHP code, you wrote `(php/-> $obj method arg)` or one of the `php/*` interop forms. Those compile to literal `$obj->method($arg)` — see the PHP-interop rows in [special-forms.md](special-forms.md).
+
+### Can I drop into PHP debug tooling (Xdebug, Psalm, PHPStan)?
+
+Yes, on the *generated* PHP. The compiler writes source maps so stack traces point back at the original `.phel` file. Static analysers run against the cached PHP just fine; `composer test-quality` includes Psalm and PHPStan over `src/php/`.
+
+### What's the cost of a Phel call vs. a PHP call?
+
+For functions: one method call (`__invoke`) plus argument unpacking. Negligible.
+
+For collections: persistent maps and vectors are tries — operations are O(log32 n) but with small constants. See [internals/benchmarks.md](benchmarks.md).
+
+---
+
+## I'm coming from Clojure
+
+### Which Clojure features are missing?
+
+The big ones: no agents, no STM/refs (use `Variable` and `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (Phel has interfaces via `definterface`), no records (Phel has structs via `defstruct`).
+
+### Are persistent collections the real thing or a thin wrapper over PHP arrays?
+
+Real persistent data structures with structural sharing. `PersistentVector` is a 32-way trie, `PersistentHashMap` is a HAMT, `LazySeq` realises one element at a time. See `Lang/Collections/`.
+
+### How do macros work? Are they hygienic?
+
+Standard Clojure-style: quasiquote namespaces symbols at read time, and `x#` inside a quasiquote becomes an auto-gensym consistent within that quasiquote. See [macros.md](macros.md). Hygiene is the same model as Clojure — sufficient for almost everything, not airtight if you go out of your way to break it.
+
+### Is there a REPL? An nREPL?
+
+Both. `phel repl` is the interactive REPL; `phel nrepl` speaks bencode/TCP for editor integrations (CIDER-style). See [nrepl-guide.md](../nrepl-guide.md).
+
+### Does `recur` actually do tail-call elimination on the PHP VM?
+
+It compiles the loop body to a `while (true) { ... }` and rebinds parameters in place — no stack growth. PHP itself has no TCO, but `recur` doesn't need it.
+
+---
+
+## I'm modifying the compiler
+
+### Where do I start?
+
+`src/php/Compiler/CLAUDE.md` for the facade-level overview. Then [compiler.md](compiler.md) for the pipeline. Then the module you actually want to touch — most changes live in one of:
+
+- `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` — special forms
+- `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` — PHP code generation
+- `Compiler/Domain/Reader/` — reader macros and quasiquote
+- `Compiler/Application/Lexer.php` — tokenisation
+
+### How do I see what a form lexes/parses/reads/analyses to?
+
+Use the facade hooks on `CompilerFacade`:
+
+```php
+$tokens   = $facade->lexString('(print "hi")');
+$tree     = $facade->parseAll($tokens);
+$readResult = $facade->read($tree->getChildren()[0]);
+$ast      = $facade->analyze($readResult->getAst(), NodeEnvironment::empty());
+$emit     = $facade->compile('(print "hi")', new CompileOptions());
+```
+
+For a one-liner, the integration fixture format under `tests/php/Integration/Fixtures/` documents end-to-end expectations.
+
+### How do I add a new special form?
+
+Five-step recipe in [special-forms.md](special-forms.md#adding-a-new-special-form). Skipping the dispatch wiring in `AnalyzePersistentList` is the most common mistake.
+
+### How do I add a new core function?
+
+If it can be written in Phel: add it to `src/phel/core/...`, with `:doc`, `:see-also`, `:example` metadata. Run `composer test-core`.
+
+If it must be in PHP (interop with a system facility): add it under `src/phel/...` as a thin wrapper that calls into `\Phel::php(...)` or a dedicated PHP helper, then run both `composer test-compiler` and `composer test-core`.
+
+### What's the rule for `NodeEnvironment` context?
+
+Three contexts: `Expression`, `Statement`, `Return`. The analyzer chooses based on where the form sits — a function body's last form is `Return`, an `if` branch in expression position is `Expression`, etc. The emitter trusts what was written. If you produce wrong PHP (extra/missing `return`, value where statement expected), 90% of the time the bug is the context, not the emitter.
+
+Helpers on `NodeEnvironment`: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
+
+### My change broke an integration fixture. Do I update the fixture?
+
+Only if the new PHP is intentionally what you want. Read the old `--PHP--`, run the form by hand, confirm the new output is correct, then update. The `fixture-reviewer` agent (see `.claude/agents/`) is built for this audit pass.
+
+### How do I run just my failing test?
+
+```bash
+./vendor/bin/phpunit --filter=test_method_name
+./vendor/bin/phpunit tests/php/path/to/Test.php
+./bin/phel test tests/phel/path/to/test.phel
+```
+
+---
+
+## I'm building a tool around Phel
+
+### What's the public API?
+
+Every facade in `src/php/*/`. Each one has a `*Facade.php` plus a `*FacadeInterface.php` you should depend on. `CLAUDE.md` files document them.
+
+For language tooling specifically: `CompilerFacade`, `ApiFacade`, `LintFacade`, `FormatterFacade`. The LSP and nREPL servers under `Lsp/` and `Nrepl/` are themselves consumers of these — they're the worked examples for "build a tool".
+
+### Can I run the compiler without the CLI?
+
+Yes. Bootstrap Gacela, fetch `CompilerFacade`, call `compile()` / `eval()`. `tests/php/Integration/` does exactly this.
+
+### How do I get source locations for diagnostics?
+
+Every readable form, every AST node, and every emitted line preserves a `SourceLocation` (file + line + column). For a parse tree node, ask its first/last token. For an AST node, the constructor stored one. For emitted PHP, the source map under `Compiler/Domain/Emitter/OutputEmitter/SourceMap/` reverses the mapping.
+
+### How do I expand a macro from PHP without compiling?
+
+`CompilerFacade::macroexpand1($form)` and `CompilerFacade::macroexpand($form)` return Phel forms (not PHP). That is the same path the nREPL macroexpand op uses.
+
+### How do I introspect a Phel namespace at runtime?
+
+`ApiFacade` is the supported surface — symbol search, doc strings, `:see-also` links, source locations. `Lang\Registry` is the underlying store, but treat it as private.
+
+### Is the cache safe across PHP versions / Phel versions?
+
+The cache is keyed by Phel source hash plus Phel version. Bumping Phel busts it automatically. If you change generated-code shape during development, run `phel cache:reset` (or just delete `var/cache/`).
+
+---
+
+## I'm investigating a bug
+
+### "Cannot resolve symbol X" — what does the analyzer actually do?
+
+`AnalyzeSymbol` checks: locals (lexical scope), then the current namespace's globals, then `use`d aliases, then `phel\core`. If still nothing, it builds a suggestion via `SymbolSuggestionProvider` and throws with a `SourceLocation`.
+
+Common cause: you `def`d in one file but didn't `(require ...)` from the consuming namespace.
+
+### "Type X cannot be coerced" or unexpected `nil`
+
+Run `(macroexpand-1 'form)` first. Many "weird type" bugs are macro expansions that aren't doing what you think.
+
+### Compilation succeeds but the runtime behaves oddly
+
+Look at the cached `.php`. If the emitter produced something surprising, the bug is almost always in the analyzer (wrong context, wrong recur frame, wrong locals map). The emitter just transcribes.
+
+### A change in `Lang/` breaks ten other modules
+
+That's the contract working as intended — `Lang/` is foundational. Run `composer test` (everything) at least once before you push. For a faster signal, `composer test-compiler` covers most consumers.
+
+---
+
+## Where to look in the source
+
+| Question | File |
+|----------|------|
+| What special forms exist? | `src/php/Lang/Symbol.php` (`NAME_*` constants) |
+| How is a special form analysed? | `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/` |
+| How is a node emitted? | `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` |
+| How is a reader macro handled? | `src/php/Compiler/Domain/Reader/ExpressionReader/` |
+| How does quasiquote rewrite? | `src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php` |
+| How are macros expanded? | `src/php/Compiler/Application/MacroExpander.php` |
+| What does an AST node carry? | `src/php/Compiler/Domain/Analyzer/Ast/` (one file per node) |
+| What does each module expose? | the `*Facade.php` and `CLAUDE.md` in that module |

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -1,0 +1,102 @@
+# Macros
+
+A macro is a function that runs at compile time, takes Phel forms as input, and returns Phel forms. By the time the analyzer sees a macro call, the call has already been replaced by whatever the macro returned. The emitter never sees the macro itself — only its expansion.
+
+This page covers how the compiler finds and runs macros, how `macroexpand` works, how quasiquote rewriting and gensym keep hygiene under control, and the few ways this can bite.
+
+## Compile-time vs. runtime, again
+
+`(defmacro when [test & body] ...)` is a `def` whose `Variable` is tagged with `:macro true`. At runtime it is just a function. What makes it a macro is the analyzer:
+
+1. Analyzer sees a list `(when x y)`.
+2. It resolves the head `when` to a `GlobalVarNode`.
+3. The node says `isMacro() === true`.
+4. The analyzer calls the function **right now**, passing the unevaluated form, an env map, and the rest of the args.
+5. Whatever the macro returns gets analysed in place of the original list.
+
+Source: `Compiler/Application/Analyzer.php` (the macro-call branch) and `Compiler/Application/MacroExpander.php`. Top-level forms are compiled and evaluated one at a time so a `defmacro` is available to subsequent forms in the same file.
+
+## `macroexpand-1` vs `macroexpand`
+
+The Phel facade exposes both via `CompilerFacade`:
+
+- `macroexpand1($form)` — expand once. If the head isn't a macro, returns the form unchanged.
+- `macroexpand($form)`  — expand repeatedly until the result is no longer a macro call (fixed point).
+
+This is what the REPL's `(macroexpand-1 'form)` and the nREPL `macroexpand` op call into. Use them constantly when authoring macros.
+
+```phel
+(macroexpand-1 '(when x y z))
+;; => (if x (do y z) nil)
+
+(macroexpand '(or a b c))
+;; => (let [or__1 a] (if or__1 or__1 (let [or__2 b] (if or__2 or__2 c))))
+```
+
+The expander only walks the *outermost* form — it does not recurse into subforms. That is the analyzer's job.
+
+## How a macro receives its arguments
+
+A macro call `(my-macro a b c)` invokes the macro function as `myMacro($form, $env, a, b, c)`:
+
+- `$form` — the *whole* call list, including the head symbol. Useful for source location and error messages.
+- `$env` — a Phel map of currently-known locals (empty for top-level / `macroexpand-1` calls outside an analyzer context).
+- The remaining positional args are the unevaluated argument forms.
+
+This matches the `&form` / `&env` convention exposed in user-facing macros.
+
+## Quasiquote rewriting
+
+Almost every non-trivial macro is built around `` `(...) ``. The reader rewrites quasiquote into explicit list construction *before* the analyzer ever sees the form. The transform lives in `Compiler/Domain/Reader/QuasiquoteTransformer.php`.
+
+Roughly:
+
+| Reader input | Quasiquote output |
+|--------------|-------------------|
+| `` `x `` | `(quote x)` |
+| `` `~x `` | `x` |
+| `` `(a b) `` | `(list (quote a) (quote b))` |
+| `` `(a ~x) `` | `(list (quote a) x)` |
+| `` `(a ~@xs b) `` | `(concat (list (quote a)) xs (list (quote b)))` |
+| `` `[a ~x] `` | `(vec (concat (list (quote a)) (list x)))` |
+
+Symbols inside a quasiquote are namespace-qualified to the *defining* namespace. That is the easy half of macro hygiene: a macro that writes `` `(map f xs) `` always refers to `phel\core/map`, even if the caller has shadowed `map` with their own local.
+
+## Auto-gensym (`x#`)
+
+The hard half of hygiene is binding names. Inside a quasiquote, any symbol ending with `#` becomes a fresh gensym, consistent within that quasiquote.
+
+```phel
+`(let [x# 1] (+ x# x#))
+;; expands to something like:
+(let [x__123__auto__ 1] (+ x__123__auto__ x__123__auto__))
+```
+
+Mechanism: `Compiler/Domain/Reader/GensymContext.php` keeps a per-quasiquote map from `"x#"` to a freshly generated `Symbol`. First sighting calls `Symbol::gen("x")`; subsequent sightings reuse it. A new gensym context is created for each top-level quasiquote.
+
+Without auto-gensym, a macro like `(when x ...)` that introduced its own `x` binding would shadow a caller's `x`. With auto-gensym, the introduced name is unique by construction.
+
+`gensym` is also available as an explicit function: `(gensym)` or `(gensym "prefix")`.
+
+## When macros bite
+
+- **Order matters at the top level.** A `defmacro` only affects forms that come *after* it in the same file or any file `require`d later. Tests that run `(defmacro foo ...)` and `(foo ...)` in the same form will fail; split them.
+- **Macros must return Phel data, not PHP values.** `(rand)` inside a macro body runs at compile time and bakes a random number into the source. That is almost never what you want.
+- **Side effects at compile time are real.** `println` inside a macro fires during compilation. Useful for debugging; surprising in production builds.
+- **Equality comparison ends recursion.** `macroexpand` stops when consecutive expansions are `equals()`. A macro that returns a structurally identical form (e.g. wraps in a no-op) terminates fine; one that produces a non-converging chain is your bug.
+
+## Debugging macros
+
+| Tool | What it shows |
+|------|---------------|
+| `(macroexpand-1 'form)` in the REPL | First expansion only |
+| `(macroexpand 'form)` in the REPL | Full fixed point |
+| nREPL `macroexpand` op | Same, exposed to editors |
+| `Compiler/Application/MacroExpander.php` | The exact PHP that resolves and invokes the macro |
+| Integration fixtures `tests/php/Integration/Fixtures/<form>/` | Round-trip checks for built-in macros that compile to special forms |
+
+## See also
+
+- [special-forms.md](special-forms.md) — what macros ultimately expand into
+- [compiler.md](compiler.md) — how each top-level form is compiled and evaluated before the next
+- `src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php` — the quasiquote rewrite, line by line

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -1,29 +1,27 @@
 # Macros
 
-A macro is a function that runs at compile time, takes Phel forms as input, and returns Phel forms. By the time the analyzer sees a macro call, the call has already been replaced by whatever the macro returned. The emitter never sees the macro itself — only its expansion.
+Compile-time function. Takes Phel forms, returns Phel forms. Analyzer replaces the call with the result. Emitter never sees the macro.
 
-This page covers how the compiler finds and runs macros, how `macroexpand` works, how quasiquote rewriting and gensym keep hygiene under control, and the few ways this can bite.
+## Mechanism
 
-## Compile-time vs. runtime, again
+`(defmacro when [test & body] ...)` is a `def` whose `Variable` carries `:macro true`. At runtime: a function. At compile time, the analyzer:
 
-`(defmacro when [test & body] ...)` is a `def` whose `Variable` is tagged with `:macro true`. At runtime it is just a function. What makes it a macro is the analyzer:
+1. Sees `(when x y)`.
+2. Resolves head to `GlobalVarNode`.
+3. Checks `isMacro() === true`.
+4. Calls the function now: form, env, then args.
+5. Analyses the returned form in place.
 
-1. Analyzer sees a list `(when x y)`.
-2. It resolves the head `when` to a `GlobalVarNode`.
-3. The node says `isMacro() === true`.
-4. The analyzer calls the function **right now**, passing the unevaluated form, an env map, and the rest of the args.
-5. Whatever the macro returns gets analysed in place of the original list.
-
-Source: `Compiler/Application/Analyzer.php` (the macro-call branch) and `Compiler/Application/MacroExpander.php`. Top-level forms are compiled and evaluated one at a time so a `defmacro` is available to subsequent forms in the same file.
+Source: `Compiler/Application/Analyzer.php` (macro branch), `Compiler/Application/MacroExpander.php`. Top-level forms compile + eval one at a time, so `defmacro` is available to subsequent forms in the same file.
 
 ## `macroexpand-1` vs `macroexpand`
 
-The Phel facade exposes both via `CompilerFacade`:
+`CompilerFacade`:
 
-- `macroexpand1($form)` — expand once. If the head isn't a macro, returns the form unchanged.
-- `macroexpand($form)`  — expand repeatedly until the result is no longer a macro call (fixed point).
+- `macroexpand1($form)`: expand once. Not a macro head: unchanged.
+- `macroexpand($form)`: fixed point.
 
-This is what the REPL's `(macroexpand-1 'form)` and the nREPL `macroexpand` op call into. Use them constantly when authoring macros.
+REPL `(macroexpand-1 'form)` and nREPL `macroexpand` op route here.
 
 ```phel
 (macroexpand-1 '(when x y z))
@@ -33,26 +31,24 @@ This is what the REPL's `(macroexpand-1 'form)` and the nREPL `macroexpand` op c
 ;; => (let [or__1 a] (if or__1 or__1 (let [or__2 b] (if or__2 or__2 c))))
 ```
 
-The expander only walks the *outermost* form — it does not recurse into subforms. That is the analyzer's job.
+Outermost only. No recursion into subforms (analyzer's job).
 
-## How a macro receives its arguments
+## Macro arguments
 
-A macro call `(my-macro a b c)` invokes the macro function as `myMacro($form, $env, a, b, c)`:
+`(my-macro a b c)` invokes `myMacro($form, $env, a, b, c)`:
 
-- `$form` — the *whole* call list, including the head symbol. Useful for source location and error messages.
-- `$env` — a Phel map of currently-known locals (empty for top-level / `macroexpand-1` calls outside an analyzer context).
-- The remaining positional args are the unevaluated argument forms.
+- `$form`: full call list including head. Useful for source location.
+- `$env`: Phel map of locals (empty for top-level / `macroexpand-1`).
+- Remaining args: unevaluated argument forms.
 
-This matches the `&form` / `&env` convention exposed in user-facing macros.
+Matches user-facing `&form` / `&env`.
 
-## Quasiquote rewriting
+## Quasiquote
 
-Almost every non-trivial macro is built around `` `(...) ``. The reader rewrites quasiquote into explicit list construction *before* the analyzer ever sees the form. The transform lives in `Compiler/Domain/Reader/QuasiquoteTransformer.php`.
+`Compiler/Domain/Reader/QuasiquoteTransformer.php` rewrites `` `(...) `` before the analyzer:
 
-Roughly:
-
-| Reader input | Quasiquote output |
-|--------------|-------------------|
+| Input | Output |
+|-------|--------|
 | `` `x `` | `(quote x)` |
 | `` `~x `` | `x` |
 | `` `(a b) `` | `(list (quote a) (quote b))` |
@@ -60,43 +56,38 @@ Roughly:
 | `` `(a ~@xs b) `` | `(concat (list (quote a)) xs (list (quote b)))` |
 | `` `[a ~x] `` | `(vec (concat (list (quote a)) (list x)))` |
 
-Symbols inside a quasiquote are namespace-qualified to the *defining* namespace. That is the easy half of macro hygiene: a macro that writes `` `(map f xs) `` always refers to `phel\core/map`, even if the caller has shadowed `map` with their own local.
+Symbols inside quasiquote get namespace-qualified to the *defining* namespace. Easy half of hygiene: `` `(map f xs) `` resolves to `phel\core/map` regardless of caller shadowing.
 
 ## Auto-gensym (`x#`)
 
-The hard half of hygiene is binding names. Inside a quasiquote, any symbol ending with `#` becomes a fresh gensym, consistent within that quasiquote.
+Hard half of hygiene: binding names. Inside a quasiquote, trailing `#` produces a fresh gensym consistent within that quasiquote.
 
 ```phel
 `(let [x# 1] (+ x# x#))
-;; expands to something like:
-(let [x__123__auto__ 1] (+ x__123__auto__ x__123__auto__))
+;; ≈ (let [x__123__auto__ 1] (+ x__123__auto__ x__123__auto__))
 ```
 
-Mechanism: `Compiler/Domain/Reader/GensymContext.php` keeps a per-quasiquote map from `"x#"` to a freshly generated `Symbol`. First sighting calls `Symbol::gen("x")`; subsequent sightings reuse it. A new gensym context is created for each top-level quasiquote.
+`Compiler/Domain/Reader/GensymContext.php`: per-quasiquote map from `"x#"` to a generated `Symbol`. First sight: `Symbol::gen("x")`. Subsequent: reuse. New context per top-level quasiquote.
 
-Without auto-gensym, a macro like `(when x ...)` that introduced its own `x` binding would shadow a caller's `x`. With auto-gensym, the introduced name is unique by construction.
+Explicit form: `(gensym)` or `(gensym "prefix")`.
 
-`gensym` is also available as an explicit function: `(gensym)` or `(gensym "prefix")`.
+## Common bites
 
-## When macros bite
+- **Order matters.** `defmacro` only affects later forms. `(defmacro foo ...)` and `(foo ...)` in the same compilation unit will not see each other; split.
+- **Return Phel data, not PHP values.** `(rand)` in a macro body bakes one number into source.
+- **Compile-time side effects fire during compile.** `println` in a macro runs at build, not runtime.
+- **`macroexpand` ends on `equals()`.** A macro that produces a structurally identical form terminates fine; non-converging chain is a bug.
 
-- **Order matters at the top level.** A `defmacro` only affects forms that come *after* it in the same file or any file `require`d later. Tests that run `(defmacro foo ...)` and `(foo ...)` in the same form will fail; split them.
-- **Macros must return Phel data, not PHP values.** `(rand)` inside a macro body runs at compile time and bakes a random number into the source. That is almost never what you want.
-- **Side effects at compile time are real.** `println` inside a macro fires during compilation. Useful for debugging; surprising in production builds.
-- **Equality comparison ends recursion.** `macroexpand` stops when consecutive expansions are `equals()`. A macro that returns a structurally identical form (e.g. wraps in a no-op) terminates fine; one that produces a non-converging chain is your bug.
+## Debugging
 
-## Debugging macros
-
-| Tool | What it shows |
-|------|---------------|
-| `(macroexpand-1 'form)` in the REPL | First expansion only |
-| `(macroexpand 'form)` in the REPL | Full fixed point |
-| nREPL `macroexpand` op | Same, exposed to editors |
-| `Compiler/Application/MacroExpander.php` | The exact PHP that resolves and invokes the macro |
-| Integration fixtures `tests/php/Integration/Fixtures/<form>/` | Round-trip checks for built-in macros that compile to special forms |
+| Tool | Shows |
+|------|-------|
+| `(macroexpand-1 'form)` | One expansion |
+| `(macroexpand 'form)` | Fixed point |
+| nREPL `macroexpand` op | Same, for editors |
+| `Compiler/Application/MacroExpander.php` | Resolution + invocation path |
+| `tests/php/Integration/Fixtures/<form>/` | Round-trip checks |
 
 ## See also
 
-- [special-forms.md](special-forms.md) — what macros ultimately expand into
-- [compiler.md](compiler.md) — how each top-level form is compiled and evaluated before the next
-- `src/php/Compiler/Domain/Reader/QuasiquoteTransformer.php` — the quasiquote rewrite, line by line
+[special-forms.md](special-forms.md), [compiler.md](compiler.md), `Compiler/Domain/Reader/QuasiquoteTransformer.php`.

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -1,0 +1,110 @@
+# Runtime
+
+What the emitted PHP actually runs against. Everything in `src/php/Lang/` is the runtime — types, persistent collections, the namespace registry, and the static `\Phel` facade that compiled code calls into.
+
+## What "runtime" means here
+
+The compiler produces PHP that looks roughly like this:
+
+```php
+\Phel::addDefinition(
+    "user",
+    "greet",
+    function ($name) {
+        return \phel\core\str("hello, ", $name);
+    },
+    \Phel::map(\Phel::keyword("doc"), "Greet someone."),
+);
+```
+
+Three runtime concerns are visible here:
+
+1. **Types** — `Phel\Lang\Keyword`, `Phel\Lang\Symbol`, `Phel\Lang\Collections\Map\PersistentArrayMap`, …
+2. **Per-namespace registry** — `\Phel::addDefinition()` writes into `Lang\Registry`.
+3. **Equality and hashing** — every collection key needs `equals()` and `hash()` that match Phel semantics, not PHP's.
+
+The `Lang/` module never depends on `Compiler/`. You can use the runtime types from plain PHP code with no compiler involved.
+
+## Core types
+
+| Type | Purpose |
+|------|---------|
+| `Symbol` | Identifier with optional namespace. Special constants name language forms (`def`, `fn`, `if`, `recur`, …). Compared by name. |
+| `Keyword` | Interned, immutable name (`:foo`). Implements `FnInterface` so `(:foo m)` works as a map lookup. |
+| `Variable` | Mutable cell with watches and validators (`def`-defined values are wrapped in one). |
+| `Delay` | One-shot lazy value — like `lazy-seq` but not a sequence. |
+| `Volatile` | Lightweight mutable box; the canonical accumulator for transducers. |
+| `Reduced` | Sentinel that signals early termination from a `reduce`/`transduce`. |
+| `PhelFuture` | Promise/future used by `Fiber/`. |
+| `SourceLocation` | File + line + column attached to every readable form. |
+
+Every type implements `TypeInterface` which composes `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`. That is what lets you put any Phel value into a hash map and get it back out.
+
+## Persistent collections
+
+Collections live under `Lang/Collections/`. They are immutable; "modification" returns a new value sharing structure with the old.
+
+| Collection | Implementation |
+|------------|----------------|
+| Vector | `PersistentVector` — 32-way trie, O(log32 n) random access |
+| Hash map | `PersistentArrayMap` for small N, `PersistentHashMap` (HAMT) for larger |
+| List | `PersistentList` (singly linked) |
+| Hash set | `PersistentHashSet` (backed by a hash map) |
+| Lazy seq | `LazySeq` — realises one element at a time, caches results |
+| Struct | `AbstractPersistentStruct` — a fixed-key map; subclassed by `defstruct` |
+
+Bulk building uses transients: `as-transient` returns a mutable variant, and `persistent!` snaps it back to immutable. Use this for hot paths inside a function — never let a transient escape.
+
+`TypeFactory` (singleton, `getInstance()`) is the entry point: `emptyVector()`, `emptyMap()`, `vectorFromArray()`, etc. The compiler emits calls into it via `\Phel::vector(...)`, `\Phel::map(...)`, `\Phel::set(...)`.
+
+## Equality and hashing
+
+Phel equality is value equality — `(= [1 2] [1 2])` is true even if the two vectors are different PHP objects. Two pieces fit together:
+
+- **`Equalizer`** — pairwise comparison; falls back to `===` for scalars, structural for collections.
+- **`Hasher`** — produces `int` hashes that agree with `Equalizer`. Without this, hash maps would lose entries silently.
+
+Anything you store as a map key has to participate in this protocol. The built-in types do. PHP objects you stuff into a Phel map use identity hashing by default (via `spl_object_hash`).
+
+## Namespace registry
+
+`Lang\Registry` (singleton) is the runtime side of `def`. It stores, per namespace, a map of `name → value` and a parallel map of `name → metadata`.
+
+Important distinction:
+
+- **`GlobalEnvironment`** (`Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php`) is the *compile-time* picture — what the analyzer knows about declared names.
+- **`Registry`** is the *runtime* picture — actual values currently bound.
+
+When the compiler emits `\Phel::addDefinition("user", "greet", $fn, $meta)`, that hits the `Registry`. When the analyzer sees `(greet "x")` it uses `GlobalEnvironment`. The two are kept in sync because each top-level form is compiled and evaluated before the next one is analysed (see [compiler.md](compiler.md), section "Evaluator").
+
+Reset both with `CompilerFacade::resetGlobalEnvironment()` if you need a clean slate (test isolation, REPL `:reset`).
+
+## The `\Phel` static facade
+
+`src/php/Phel.php` (top-level, not under `Lang/`) is the static surface that *generated* PHP calls. Treat it as the runtime ABI: changes here are breaking changes for every cached `.php` file in the wild.
+
+The most-used members:
+
+- `\Phel::addDefinition($ns, $name, $value, $meta = null)`
+- `\Phel::keyword($name)` / `\Phel::namespacedKeyword($ns, $name)`
+- `\Phel::symbol($name)`
+- `\Phel::vector(...$items)` / `\Phel::map(...$kvs)` / `\Phel::set(...$items)`
+- `\Phel::ns($name)` — switch the current namespace at runtime
+
+If you change a method signature here, audit all `*Emitter.php` files under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` to match.
+
+## TagHandlers and reader macros
+
+Custom reader tags live in `Lang/TagHandlers/`. Each handler implements a small interface that takes a Phel form and returns one. They are looked up at read time via `Lang/TagRegistry.php`. Built-in handlers: `#inst`, `#regex`, `#php`. Adding `#mything` is a `TagRegistry::register('mything', new MyHandler())` call.
+
+## Source locations
+
+Every readable form carries a `SourceLocation` from the lexer all the way through the AST to the emitted PHP source map. Don't drop it: error messages, the LSP, and the linter all rely on it.
+
+If you build a form by hand inside a special-form handler, copy the location from a nearby form with `Symbol::copyLocationFrom($other)` — there are dozens of examples in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`.
+
+## See also
+
+- `src/php/Lang/CLAUDE.md` — module-level cheat sheet
+- [data-structures-guide.md](../data-structures-guide.md) — user-facing perspective on the same collections
+- [compiler.md](compiler.md) — how the compiler emits calls into this runtime

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -1,110 +1,91 @@
 # Runtime
 
-What the emitted PHP actually runs against. Everything in `src/php/Lang/` is the runtime — types, persistent collections, the namespace registry, and the static `\Phel` facade that compiled code calls into.
+What emitted PHP runs against. `src/php/Lang/` plus `src/php/Phel.php`. Independent of `Compiler/`: usable from plain PHP.
 
-## What "runtime" means here
-
-The compiler produces PHP that looks roughly like this:
+## Shape of emitted code
 
 ```php
 \Phel::addDefinition(
     "user",
     "greet",
-    function ($name) {
-        return \phel\core\str("hello, ", $name);
-    },
+    function ($name) { return \phel\core\str("hello, ", $name); },
     \Phel::map(\Phel::keyword("doc"), "Greet someone."),
 );
 ```
 
-Three runtime concerns are visible here:
-
-1. **Types** — `Phel\Lang\Keyword`, `Phel\Lang\Symbol`, `Phel\Lang\Collections\Map\PersistentArrayMap`, …
-2. **Per-namespace registry** — `\Phel::addDefinition()` writes into `Lang\Registry`.
-3. **Equality and hashing** — every collection key needs `equals()` and `hash()` that match Phel semantics, not PHP's.
-
-The `Lang/` module never depends on `Compiler/`. You can use the runtime types from plain PHP code with no compiler involved.
+Three concerns: types, per-namespace `Registry`, value equality + hashing.
 
 ## Core types
 
-| Type | Purpose |
-|------|---------|
-| `Symbol` | Identifier with optional namespace. Special constants name language forms (`def`, `fn`, `if`, `recur`, …). Compared by name. |
-| `Keyword` | Interned, immutable name (`:foo`). Implements `FnInterface` so `(:foo m)` works as a map lookup. |
-| `Variable` | Mutable cell with watches and validators (`def`-defined values are wrapped in one). |
-| `Delay` | One-shot lazy value — like `lazy-seq` but not a sequence. |
-| `Volatile` | Lightweight mutable box; the canonical accumulator for transducers. |
-| `Reduced` | Sentinel that signals early termination from a `reduce`/`transduce`. |
-| `PhelFuture` | Promise/future used by `Fiber/`. |
-| `SourceLocation` | File + line + column attached to every readable form. |
+| Type | Notes |
+|------|-------|
+| `Symbol` | Identifier with optional ns. `NAME_*` constants name special forms. |
+| `Keyword` | Interned `:foo`. Implements `FnInterface` → `(:foo m)` is a map lookup. |
+| `Variable` | Mutable cell with watches/validators; `def` wraps values in one. |
+| `Delay` | One-shot lazy value (not a sequence). |
+| `Volatile` | Mutable box for transducer state. |
+| `Reduced` | Early-termination sentinel for `reduce`/`transduce`. |
+| `PhelFuture` | Promise/future for `Fiber/`. |
+| `SourceLocation` | File + line + column on every readable form. |
 
-Every type implements `TypeInterface` which composes `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`. That is what lets you put any Phel value into a hash map and get it back out.
+All types implement `TypeInterface` (composes `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`).
 
-## Persistent collections
+## Persistent collections (`Lang/Collections/`)
 
-Collections live under `Lang/Collections/`. They are immutable; "modification" returns a new value sharing structure with the old.
+Immutable; "modify" returns a new value with structural sharing.
 
-| Collection | Implementation |
-|------------|----------------|
-| Vector | `PersistentVector` — 32-way trie, O(log32 n) random access |
-| Hash map | `PersistentArrayMap` for small N, `PersistentHashMap` (HAMT) for larger |
+| Type | Impl |
+|------|------|
+| Vector | `PersistentVector`: 32-way trie |
+| Map | `PersistentArrayMap` (small) → `PersistentHashMap` (HAMT) |
 | List | `PersistentList` (singly linked) |
-| Hash set | `PersistentHashSet` (backed by a hash map) |
-| Lazy seq | `LazySeq` — realises one element at a time, caches results |
-| Struct | `AbstractPersistentStruct` — a fixed-key map; subclassed by `defstruct` |
+| Set | `PersistentHashSet` (over hash map) |
+| Lazy seq | `LazySeq`: realise + cache per element |
+| Struct | `AbstractPersistentStruct`: fixed-key map, subclassed by `defstruct` |
 
-Bulk building uses transients: `as-transient` returns a mutable variant, and `persistent!` snaps it back to immutable. Use this for hot paths inside a function — never let a transient escape.
+Transients for bulk building: `as-transient` → mutate → `persistent!`. Never let a transient escape its scope.
 
-`TypeFactory` (singleton, `getInstance()`) is the entry point: `emptyVector()`, `emptyMap()`, `vectorFromArray()`, etc. The compiler emits calls into it via `\Phel::vector(...)`, `\Phel::map(...)`, `\Phel::set(...)`.
+`TypeFactory` (singleton): `emptyVector()`, `emptyMap()`, `vectorFromArray()`. Compiler emits via `\Phel::vector(...)`, `\Phel::map(...)`, `\Phel::set(...)`.
 
-## Equality and hashing
+## Equality + hashing
 
-Phel equality is value equality — `(= [1 2] [1 2])` is true even if the two vectors are different PHP objects. Two pieces fit together:
+Value equality: `(= [1 2] [1 2])` true regardless of object identity.
 
-- **`Equalizer`** — pairwise comparison; falls back to `===` for scalars, structural for collections.
-- **`Hasher`** — produces `int` hashes that agree with `Equalizer`. Without this, hash maps would lose entries silently.
+- `Equalizer`: `===` for scalars, structural for collections.
+- `Hasher`: `int` hashes that agree with `Equalizer`. Mismatch = lost map entries.
 
-Anything you store as a map key has to participate in this protocol. The built-in types do. PHP objects you stuff into a Phel map use identity hashing by default (via `spl_object_hash`).
+Built-in types participate. PHP objects fall back to `spl_object_hash` (identity).
 
-## Namespace registry
+## Registry vs GlobalEnvironment
 
-`Lang\Registry` (singleton) is the runtime side of `def`. It stores, per namespace, a map of `name → value` and a parallel map of `name → metadata`.
+| | When | Stores |
+|--|------|--------|
+| `Lang\Registry` (singleton) | runtime | `ns → name → value` + metadata |
+| `GlobalEnvironment` (`Compiler/Domain/Analyzer/Environment/`) | compile time | what analyzer knows about declared names |
 
-Important distinction:
+Each top-level form compiles + evaluates before the next is analysed → both stay in sync. `defmacro` becomes available immediately to following forms. Reset both: `CompilerFacade::resetGlobalEnvironment()`.
 
-- **`GlobalEnvironment`** (`Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php`) is the *compile-time* picture — what the analyzer knows about declared names.
-- **`Registry`** is the *runtime* picture — actual values currently bound.
+## `\Phel` static facade
 
-When the compiler emits `\Phel::addDefinition("user", "greet", $fn, $meta)`, that hits the `Registry`. When the analyzer sees `(greet "x")` it uses `GlobalEnvironment`. The two are kept in sync because each top-level form is compiled and evaluated before the next one is analysed (see [compiler.md](compiler.md), section "Evaluator").
+`src/php/Phel.php` is the runtime ABI. Cached `.php` files in the wild call into it. Signature changes = breaking.
 
-Reset both with `CompilerFacade::resetGlobalEnvironment()` if you need a clean slate (test isolation, REPL `:reset`).
+- `addDefinition($ns, $name, $value, $meta = null)`
+- `keyword($name)` / `namespacedKeyword($ns, $name)` / `symbol($name)`
+- `vector(...$items)` / `map(...$kvs)` / `set(...$items)`
+- `ns($name)`: switch current namespace
 
-## The `\Phel` static facade
+Change a signature → audit `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/*Emitter.php`.
 
-`src/php/Phel.php` (top-level, not under `Lang/`) is the static surface that *generated* PHP calls. Treat it as the runtime ABI: changes here are breaking changes for every cached `.php` file in the wild.
+## Reader tags (`#tag`)
 
-The most-used members:
-
-- `\Phel::addDefinition($ns, $name, $value, $meta = null)`
-- `\Phel::keyword($name)` / `\Phel::namespacedKeyword($ns, $name)`
-- `\Phel::symbol($name)`
-- `\Phel::vector(...$items)` / `\Phel::map(...$kvs)` / `\Phel::set(...$items)`
-- `\Phel::ns($name)` — switch the current namespace at runtime
-
-If you change a method signature here, audit all `*Emitter.php` files under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/` to match.
-
-## TagHandlers and reader macros
-
-Custom reader tags live in `Lang/TagHandlers/`. Each handler implements a small interface that takes a Phel form and returns one. They are looked up at read time via `Lang/TagRegistry.php`. Built-in handlers: `#inst`, `#regex`, `#php`. Adding `#mything` is a `TagRegistry::register('mything', new MyHandler())` call.
+`Lang/TagHandlers/` implementations registered in `Lang/TagRegistry.php`. Built-ins: `#inst`, `#regex`, `#php`. Add: `TagRegistry::register('mything', new MyHandler())`.
 
 ## Source locations
 
-Every readable form carries a `SourceLocation` from the lexer all the way through the AST to the emitted PHP source map. Don't drop it: error messages, the LSP, and the linter all rely on it.
-
-If you build a form by hand inside a special-form handler, copy the location from a nearby form with `Symbol::copyLocationFrom($other)` — there are dozens of examples in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`.
+Carried lexer → AST → emitted source map. Don't drop. When constructing a form inside a special-form handler, `Symbol::copyLocationFrom($nearby)` (examples throughout `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`).
 
 ## See also
 
-- `src/php/Lang/CLAUDE.md` — module-level cheat sheet
-- [data-structures-guide.md](../data-structures-guide.md) — user-facing perspective on the same collections
-- [compiler.md](compiler.md) — how the compiler emits calls into this runtime
+- `src/php/Lang/CLAUDE.md`
+- [data-structures-guide.md](../data-structures-guide.md): user view
+- [compiler.md](compiler.md): emit path

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -1,0 +1,107 @@
+# Special Forms
+
+A special form is a list whose head symbol the analyzer recognises and dispatches to a dedicated handler. Anything that is not a special form, a macro, or a literal collection is an ordinary function call. Macros expand into special forms and calls — special forms are the bottom of the stack.
+
+## How dispatch works
+
+`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` reads the first element of the list. If it is a `Symbol` whose name matches one of the `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`, the list is treated as a special form and routed to a `SpecialFormAnalyzerInterface` implementation in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Otherwise the list is a call and goes to `InvokeSymbol`.
+
+The mapping is one big `match` on the symbol name (excerpt from `AnalyzePersistentList::analyzeSpecialForm()`):
+
+```php
+match ($symbolName) {
+    Symbol::NAME_DEF        => new DefSymbol($this->analyzer),
+    Symbol::NAME_FN         => new FnSymbol($this->analyzer, $this->assertsEnabled),
+    Symbol::NAME_IF         => new IfSymbol($this->analyzer),
+    Symbol::NAME_LET        => new LetSymbol($this->analyzer, ...),
+    Symbol::NAME_LOOP       => new LoopSymbol($this->analyzer, ...),
+    Symbol::NAME_RECUR      => new RecurSymbol($this->analyzer),
+    // ...
+};
+```
+
+Each handler returns one `AbstractNode` subclass (`DefNode`, `FnNode`, `IfNode`, …). The emitter has a one-to-one mapping from node type to `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
+
+## The list
+
+Most users only see ten or so of these — the rest are either implementation details (`*` suffix means "use the macro, not this") or PHP-interop primitives.
+
+### Core
+
+| Form | Symbol const | Analyzer | AST node | Notes |
+|------|--------------|----------|----------|-------|
+| `def` | `NAME_DEF` | `DefSymbol` | `DefNode` | Top-level binding; registers in `GlobalEnvironment` and `Registry`. |
+| `fn` | `NAME_FN` | `FnSymbol` | `FnNode` / `MultiFnNode` | Compiled to a PHP class implementing `__invoke`. |
+| `if` | `NAME_IF` | `IfSymbol` | `IfNode` | Three-arg form; `nil` and `false` are falsy. |
+| `let` | `NAME_LET` | `LetSymbol` | `LetNode` | Sequential bindings; supports destructuring. |
+| `loop` | `NAME_LOOP` | `LoopSymbol` | `LetNode` (with recur frame) | Establishes a `recur` target. |
+| `recur` | `NAME_RECUR` | `RecurSymbol` | `RecurNode` | Tail-call rebinds the innermost frame. |
+| `do` | `NAME_DO` | `DoSymbol` | `DoNode` | Sequence of forms; value is the last. |
+| `quote` | `NAME_QUOTE` | `QuoteSymbol` | `QuoteNode` | Returns its argument unevaluated. |
+| `apply` | `NAME_APPLY` | `ApplySymbol` | `ApplyNode` | Calls a function with a sequence of args. |
+| `foreach` | `NAME_FOREACH` | `ForeachSymbol` | `ForeachNode` | Iteration with side effects, `nil` result. |
+| `try` / `catch` / `finally` | `NAME_TRY` | `TrySymbol` | `TryNode`, `CatchNode` | `catch` and `finally` only valid inside `try`. |
+| `throw` | `NAME_THROW` | `ThrowSymbol` | `ThrowNode` | Throws any `\Throwable`. |
+| `set-var` | `NAME_SET_VAR` | `SetVarSymbol` | `SetVarNode` | Assigns a `Variable` (rare; prefer `swap!`). |
+
+### Namespacing
+
+| Form | Symbol const | Analyzer | AST node |
+|------|--------------|----------|----------|
+| `ns` | `NAME_NS` | `NsSymbol` | `NsNode` |
+| `in-ns` | `NAME_IN_NS` | `InNsSymbol` | `InNsNode` |
+| `use` | `NAME_USE` | `UseSymbol` | `UseNode` |
+| `load` | `NAME_LOAD` | `LoadSymbol` | `LoadNode` |
+
+### Type definitions (low-level forms)
+
+These have a trailing `*` and are not meant to be written directly — public macros (`defstruct`, `definterface`, `defexception`, `reify`) expand into them.
+
+| Form | Symbol const | Analyzer | AST node |
+|------|--------------|----------|----------|
+| `defstruct*` | `NAME_DEF_STRUCT` | `DefStructSymbol` | `DefStructNode` |
+| `definterface*` | `NAME_DEF_INTERFACE` | `DefInterfaceSymbol` | `DefInterfaceNode` |
+| `defexception*` | `NAME_DEF_EXCEPTION` | `DefExceptionSymbol` | `DefExceptionNode` |
+| `reify*` | `NAME_REIFY` | `ReifySymbol` | `ReifyNode` |
+
+### PHP interop
+
+These map almost directly to PHP syntax. If a function would need to call into PHP at the syntactic level (e.g. `new Foo()` or `$obj->bar`), it goes through one of these.
+
+| Form | Symbol const | What it emits |
+|------|--------------|---------------|
+| `php/new` (alias `new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
+| `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` or `$obj->property` |
+| `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` or `Foo::CONST` |
+| `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v` |
+| `php/aget` | `NAME_PHP_ARRAY_GET` | `$arr[$k]` |
+| `php/aset` | `NAME_PHP_ARRAY_SET` | `$arr[$k] = $v` |
+| `php/apush` | `NAME_PHP_ARRAY_PUSH` | `$arr[] = $v` |
+| `php/aunset` | `NAME_PHP_ARRAY_UNSET` | `unset($arr[$k])` |
+| `php/aget-in`, `php/aset-in`, `php/apush-in`, `php/aunset-in` | … | nested-path variants |
+
+## What is *not* a special form
+
+- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`, `loop` body destructuring → **macros** in `phel\core`. Expand them with `(macroexpand-1 'form)` to see what they reduce to.
+- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify` → **macros** that wrap the `*` forms above.
+- `+`, `-`, `=`, `map`, `filter`, … → **functions** in `phel\core`.
+
+When in doubt: open a REPL, run `(macroexpand-1 'your-form)`, and see what comes back.
+
+## Adding a new special form
+
+This is a five-touch change. Skip a step and the analyzer or emitter will throw at compile time.
+
+1. **Reserve the symbol name.** Add a `public const string NAME_FOO = 'foo';` to `src/php/Lang/Symbol.php`.
+2. **Create the AST node.** Add `FooNode extends AbstractNode` under `Compiler/Domain/Analyzer/Ast/`. Constructor takes a `NodeEnvironment` plus whatever child fields you need.
+3. **Create the analyzer handler.** Add `FooSymbol implements SpecialFormAnalyzerInterface` under `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Validate arity and shape; recurse into children with `$this->analyzer->analyze(...)`; return a `FooNode`.
+4. **Wire dispatch.** Add a branch to the `match` in `Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php`.
+5. **Create the emitter.** Add `FooEmitter` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, register it in `NodeEmitterFactory`. Use the node's `NodeEnvironment` context to decide between expression / statement / return output.
+
+Then add an integration fixture under `tests/php/Integration/Fixtures/Foo/foo-basic.test` (`--PHEL--` / `--PHP--` sections — see `.claude/rules/integration-tests.md`) and at least one PHPUnit test for the analyzer.
+
+## See also
+
+- [compiler.md](compiler.md) — the pipeline that wraps this
+- [macros.md](macros.md) — how user-defined macros expand to special forms
+- `src/php/Compiler/CLAUDE.md` — module facade reference

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -1,107 +1,97 @@
 # Special Forms
 
-A special form is a list whose head symbol the analyzer recognises and dispatches to a dedicated handler. Anything that is not a special form, a macro, or a literal collection is an ordinary function call. Macros expand into special forms and calls — special forms are the bottom of the stack.
+List with a recognised head symbol routed to a dedicated analyzer. Anything else (not a special form, not a macro, not a literal collection) is a function call. Macros expand into special forms: special forms are the bottom.
 
-## How dispatch works
+## Dispatch
 
-`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` reads the first element of the list. If it is a `Symbol` whose name matches one of the `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`, the list is treated as a special form and routed to a `SpecialFormAnalyzerInterface` implementation in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Otherwise the list is a call and goes to `InvokeSymbol`.
-
-The mapping is one big `match` on the symbol name (excerpt from `AnalyzePersistentList::analyzeSpecialForm()`):
+`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. Match → `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Miss → `InvokeSymbol`.
 
 ```php
 match ($symbolName) {
-    Symbol::NAME_DEF        => new DefSymbol($this->analyzer),
-    Symbol::NAME_FN         => new FnSymbol($this->analyzer, $this->assertsEnabled),
-    Symbol::NAME_IF         => new IfSymbol($this->analyzer),
-    Symbol::NAME_LET        => new LetSymbol($this->analyzer, ...),
-    Symbol::NAME_LOOP       => new LoopSymbol($this->analyzer, ...),
-    Symbol::NAME_RECUR      => new RecurSymbol($this->analyzer),
+    Symbol::NAME_DEF   => new DefSymbol($this->analyzer),
+    Symbol::NAME_FN    => new FnSymbol($this->analyzer, $this->assertsEnabled),
+    Symbol::NAME_IF    => new IfSymbol($this->analyzer),
+    Symbol::NAME_LET   => new LetSymbol($this->analyzer, ...),
+    Symbol::NAME_LOOP  => new LoopSymbol($this->analyzer, ...),
+    Symbol::NAME_RECUR => new RecurSymbol($this->analyzer),
     // ...
 };
 ```
 
-Each handler returns one `AbstractNode` subclass (`DefNode`, `FnNode`, `IfNode`, …). The emitter has a one-to-one mapping from node type to `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
+Each handler returns one `AbstractNode`. Emitter has 1:1 mapping to `*Emitter.php` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`.
 
-## The list
+## Core
 
-Most users only see ten or so of these — the rest are either implementation details (`*` suffix means "use the macro, not this") or PHP-interop primitives.
+| Form | Const | Handler | Node | Notes |
+|------|-------|---------|------|-------|
+| `def` | `NAME_DEF` | `DefSymbol` | `DefNode` | Top-level binding; registers in `GlobalEnvironment` + `Registry`. |
+| `fn` | `NAME_FN` | `FnSymbol` | `FnNode` / `MultiFnNode` | Compiles to PHP class with `__invoke`. |
+| `if` | `NAME_IF` | `IfSymbol` | `IfNode` | Three-arg; `nil`/`false` falsy. |
+| `let` | `NAME_LET` | `LetSymbol` | `LetNode` | Sequential bindings + destructuring. |
+| `loop` | `NAME_LOOP` | `LoopSymbol` | `LetNode` + recur frame | `recur` target. |
+| `recur` | `NAME_RECUR` | `RecurSymbol` | `RecurNode` | Tail-rebind innermost frame. |
+| `do` | `NAME_DO` | `DoSymbol` | `DoNode` | Sequence; value = last. |
+| `quote` | `NAME_QUOTE` | `QuoteSymbol` | `QuoteNode` | Returns arg unevaluated. |
+| `apply` | `NAME_APPLY` | `ApplySymbol` | `ApplyNode` | Call fn with seq of args. |
+| `foreach` | `NAME_FOREACH` | `ForeachSymbol` | `ForeachNode` | Side-effect iteration; `nil` result. |
+| `try` / `catch` / `finally` | `NAME_TRY` | `TrySymbol` | `TryNode`, `CatchNode` | `catch`/`finally` only inside `try`. |
+| `throw` | `NAME_THROW` | `ThrowSymbol` | `ThrowNode` | Any `\Throwable`. |
+| `set-var` | `NAME_SET_VAR` | `SetVarSymbol` | `SetVarNode` | Rare; prefer `swap!`. |
 
-### Core
+## Namespacing
 
-| Form | Symbol const | Analyzer | AST node | Notes |
-|------|--------------|----------|----------|-------|
-| `def` | `NAME_DEF` | `DefSymbol` | `DefNode` | Top-level binding; registers in `GlobalEnvironment` and `Registry`. |
-| `fn` | `NAME_FN` | `FnSymbol` | `FnNode` / `MultiFnNode` | Compiled to a PHP class implementing `__invoke`. |
-| `if` | `NAME_IF` | `IfSymbol` | `IfNode` | Three-arg form; `nil` and `false` are falsy. |
-| `let` | `NAME_LET` | `LetSymbol` | `LetNode` | Sequential bindings; supports destructuring. |
-| `loop` | `NAME_LOOP` | `LoopSymbol` | `LetNode` (with recur frame) | Establishes a `recur` target. |
-| `recur` | `NAME_RECUR` | `RecurSymbol` | `RecurNode` | Tail-call rebinds the innermost frame. |
-| `do` | `NAME_DO` | `DoSymbol` | `DoNode` | Sequence of forms; value is the last. |
-| `quote` | `NAME_QUOTE` | `QuoteSymbol` | `QuoteNode` | Returns its argument unevaluated. |
-| `apply` | `NAME_APPLY` | `ApplySymbol` | `ApplyNode` | Calls a function with a sequence of args. |
-| `foreach` | `NAME_FOREACH` | `ForeachSymbol` | `ForeachNode` | Iteration with side effects, `nil` result. |
-| `try` / `catch` / `finally` | `NAME_TRY` | `TrySymbol` | `TryNode`, `CatchNode` | `catch` and `finally` only valid inside `try`. |
-| `throw` | `NAME_THROW` | `ThrowSymbol` | `ThrowNode` | Throws any `\Throwable`. |
-| `set-var` | `NAME_SET_VAR` | `SetVarSymbol` | `SetVarNode` | Assigns a `Variable` (rare; prefer `swap!`). |
-
-### Namespacing
-
-| Form | Symbol const | Analyzer | AST node |
-|------|--------------|----------|----------|
+| Form | Const | Handler | Node |
+|------|-------|---------|------|
 | `ns` | `NAME_NS` | `NsSymbol` | `NsNode` |
 | `in-ns` | `NAME_IN_NS` | `InNsSymbol` | `InNsNode` |
 | `use` | `NAME_USE` | `UseSymbol` | `UseNode` |
 | `load` | `NAME_LOAD` | `LoadSymbol` | `LoadNode` |
 
-### Type definitions (low-level forms)
+## Type definitions (low-level)
 
-These have a trailing `*` and are not meant to be written directly — public macros (`defstruct`, `definterface`, `defexception`, `reify`) expand into them.
+Trailing `*` = not user-facing. Macros `defstruct`, `definterface`, `defexception`, `reify` expand into these.
 
-| Form | Symbol const | Analyzer | AST node |
-|------|--------------|----------|----------|
+| Form | Const | Handler | Node |
+|------|-------|---------|------|
 | `defstruct*` | `NAME_DEF_STRUCT` | `DefStructSymbol` | `DefStructNode` |
 | `definterface*` | `NAME_DEF_INTERFACE` | `DefInterfaceSymbol` | `DefInterfaceNode` |
 | `defexception*` | `NAME_DEF_EXCEPTION` | `DefExceptionSymbol` | `DefExceptionNode` |
 | `reify*` | `NAME_REIFY` | `ReifySymbol` | `ReifyNode` |
 
-### PHP interop
+## PHP interop
 
-These map almost directly to PHP syntax. If a function would need to call into PHP at the syntactic level (e.g. `new Foo()` or `$obj->bar`), it goes through one of these.
-
-| Form | Symbol const | What it emits |
-|------|--------------|---------------|
-| `php/new` (alias `new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
-| `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` or `$obj->property` |
-| `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` or `Foo::CONST` |
+| Form | Const | Emits |
+|------|-------|-------|
+| `php/new` (`new`) | `NAME_PHP_NEW` / `NAME_NEW` | `new Foo(...)` |
+| `php/->` | `NAME_PHP_OBJECT_CALL` | `$obj->method(...)` / `$obj->prop` |
+| `php/::` | `NAME_PHP_OBJECT_STATIC_CALL` | `Foo::method(...)` / `Foo::CONST` |
 | `php/oset` | `NAME_PHP_OBJECT_SET` | `$obj->prop = $v` |
 | `php/aget` | `NAME_PHP_ARRAY_GET` | `$arr[$k]` |
 | `php/aset` | `NAME_PHP_ARRAY_SET` | `$arr[$k] = $v` |
 | `php/apush` | `NAME_PHP_ARRAY_PUSH` | `$arr[] = $v` |
 | `php/aunset` | `NAME_PHP_ARRAY_UNSET` | `unset($arr[$k])` |
-| `php/aget-in`, `php/aset-in`, `php/apush-in`, `php/aunset-in` | … | nested-path variants |
+| `php/aget-in` / `aset-in` / `apush-in` / `aunset-in` | … | nested-path variants |
 
-## What is *not* a special form
+## Not special forms
 
-- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`, `loop` body destructuring → **macros** in `phel\core`. Expand them with `(macroexpand-1 'form)` to see what they reduce to.
-- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify` → **macros** that wrap the `*` forms above.
-- `+`, `-`, `=`, `map`, `filter`, … → **functions** in `phel\core`.
+- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>` → macros in `phel\core`
+- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify` → macros over `*` forms
+- `+`, `-`, `=`, `map`, `filter`, … → functions in `phel\core`
 
-When in doubt: open a REPL, run `(macroexpand-1 'your-form)`, and see what comes back.
+`(macroexpand-1 'form)` to see the truth.
 
-## Adding a new special form
+## Adding one
 
-This is a five-touch change. Skip a step and the analyzer or emitter will throw at compile time.
+5 touches. Skip → throws at compile time.
 
-1. **Reserve the symbol name.** Add a `public const string NAME_FOO = 'foo';` to `src/php/Lang/Symbol.php`.
-2. **Create the AST node.** Add `FooNode extends AbstractNode` under `Compiler/Domain/Analyzer/Ast/`. Constructor takes a `NodeEnvironment` plus whatever child fields you need.
-3. **Create the analyzer handler.** Add `FooSymbol implements SpecialFormAnalyzerInterface` under `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Validate arity and shape; recurse into children with `$this->analyzer->analyze(...)`; return a `FooNode`.
-4. **Wire dispatch.** Add a branch to the `match` in `Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php`.
-5. **Create the emitter.** Add `FooEmitter` under `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, register it in `NodeEmitterFactory`. Use the node's `NodeEnvironment` context to decide between expression / statement / return output.
+1. `public const string NAME_FOO = 'foo';` in `src/php/Lang/Symbol.php`
+2. `FooNode extends AbstractNode` in `Compiler/Domain/Analyzer/Ast/`
+3. `FooSymbol implements SpecialFormAnalyzerInterface` in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`: validate, recurse via `$this->analyzer->analyze(...)`, return `FooNode`
+4. Branch in `AnalyzePersistentList`'s `match`
+5. `FooEmitter` in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`, register in `NodeEmitterFactory`. Honor `NodeEnvironment` context
 
-Then add an integration fixture under `tests/php/Integration/Fixtures/Foo/foo-basic.test` (`--PHEL--` / `--PHP--` sections — see `.claude/rules/integration-tests.md`) and at least one PHPUnit test for the analyzer.
+Add fixture `tests/php/Integration/Fixtures/Foo/foo-basic.test` + analyzer PHPUnit test.
 
 ## See also
 
-- [compiler.md](compiler.md) — the pipeline that wraps this
-- [macros.md](macros.md) — how user-defined macros expand to special forms
-- `src/php/Compiler/CLAUDE.md` — module facade reference
+[compiler.md](compiler.md), [macros.md](macros.md), `src/php/Compiler/CLAUDE.md`


### PR DESCRIPTION
## 🤔 Background

`docs/internals/` previously held two short pages (`compiler.md`, `benchmarks.md`). New contributors had to read source to understand pipeline phases, module boundaries, special-form dispatch, macro expansion, and runtime types.

## 💡 Goal

Give developers multiple angles into how Phel works internally so they can ramp up without spelunking through `src/php/`. One guided index, deep dives per concern, and an FAQ grouped by reader role.

## 🔖 Changes

- New `docs/internals/README.md`: guided index with reading order and "when to read what" table
- New `docs/internals/architecture.md`: module map, Gacela pattern, dependency graph, compile-time vs runtime split, where to add features
- New `docs/internals/runtime.md`: `Lang/` types, persistent collections, equality/hashing, `Registry` vs `GlobalEnvironment`, the `\Phel` static facade ABI
- New `docs/internals/special-forms.md`: full table grouped by category (core, namespacing, type defs, PHP interop), dispatch via `AnalyzePersistentList`, 5-step recipe to add a new special form
- New `docs/internals/macros.md`: `macroexpand1`/`macroexpand` mechanics, quasiquote rewrite table, auto-gensym (`x#`), debugging
- New `docs/internals/faq.md`: Q&A grouped by reader (PHP dev, Clojure dev, compiler hacker, tool builder, bug hunter)
- Expanded `docs/internals/compiler.md`: source paths per phase, `NodeEnvironment` context model, source maps, FILE/STATEMENT emitter modes, evaluator implementations
