### PR TITLE
🐛 fix(core): list? returns false for seq results (#1759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - `some-fn` returns `false` when no predicate matches (#1714)
 - `compare` orders namespaced keywords and symbols by namespace first (#1715)
 - `vector?` reports `false` for `seq` and `rseq` results (#1716)
+- `list?` reports `false` for `seq` and `rseq` results over vectors, sorted-maps, sorted-sets (#1759)
 - Keyword and symbol literals preserve `'`, `"`, `\` through compilation (#1718)
 - `interleave`, `cycle`, `interpose` over maps yield `[key value]` pairs; `interleave` stops at shortest input (#1726, #1734, #1757)
 - `odd?` reports negative odd numbers as odd (#1736)

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -213,6 +213,18 @@ final class Phel extends InternalPhel
     }
 
     /**
+     * Create a non-list persistent list, used as the seq view over
+     * non-list collections (vector, set, sorted map/set, php array).
+     * The resulting value satisfies `seq?` but not `list?`.
+     *
+     * @param list<mixed>|null $values
+     */
+    public static function seqList(?array $values = []): PersistentListInterface
+    {
+        return TypeFactory::getInstance()->persistentSeqListFromArray($values ?? []);
+    }
+
+    /**
      * Create a persistent map from key-value pairs.
      *
      * @param mixed ...$kvs

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -252,9 +252,11 @@
   (php/instanceof x PersistentVectorInterface))
 
 (defn list?
-  "Returns true if `x` is a list, false otherwise."
+  "Returns true if `x` is a list, false otherwise.
+  Returns false for the seq view of non-list collections produced by `seq`."
   [x]
-  (php/instanceof x PersistentListInterface))
+  (and (php/instanceof x PersistentListInterface)
+       (php/-> x (isList))))
 
 (defn boolean?
   "Returns true if `x` is a boolean, false otherwise."
@@ -350,10 +352,14 @@
   [values]
   (if (php/empty values) nil (php/:: Phel (vector values))))
 
+(defn- seq-list
+  [values]
+  (php/:: Phel (seqList values)))
+
 (defn seq
   "Returns a seq on the collection. Strings are converted to a vector of characters.
   Other non-empty collections (vectors, sets, sorted-maps, sorted-sets, PHP arrays)
-  are converted to a list. Returns nil if `coll` is empty or nil.
+  are converted to a non-list seq. Returns nil if `coll` is empty or nil.
 
   This function is useful for explicitly converting strings to sequences of characters,
   enabling sequence operations like map, filter, and frequencies."
@@ -376,13 +382,13 @@
     nil
 
     (php/is_array coll)
-    (apply list coll)
+    (seq-list coll)
 
     (php/instanceof coll PersistentHashSetInterface)
-    (apply list (to-php-array coll))
+    (seq-list (to-php-array coll))
 
     true
-    (apply list coll)))
+    (seq-list (to-php-array coll))))
 
 (defn- indexed-php-array?
   [x]

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -384,9 +384,6 @@
     (php/is_array coll)
     (seq-list coll)
 
-    (php/instanceof coll PersistentHashSetInterface)
-    (seq-list (to-php-array coll))
-
     true
     (seq-list (to-php-array coll))))
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -649,7 +649,7 @@
     (throw (php/new InvalidArgumentException
                     "rseq requires a reversible collection (vector, sorted-map, or sorted-set)")))
   (when (php/> (count rev) 0)
-    (apply list (reverse (if (vector? rev) rev (vec rev))))))
+    (php/:: Phel (seqList (apply php/array (reverse (if (vector? rev) rev (vec rev))))))))
 
 (defn frequencies
   "Returns a map from distinct items in `coll` to the number of times they appear.

--- a/src/php/Lang/Collections/LinkedList/EmptyList.php
+++ b/src/php/Lang/Collections/LinkedList/EmptyList.php
@@ -28,6 +28,7 @@ final class EmptyList extends AbstractType implements PersistentListInterface
         private readonly HasherInterface $hasher,
         private readonly EqualizerInterface $equalizer,
         private readonly ?PersistentMapInterface $meta,
+        private readonly bool $isList = true,
     ) {}
 
     public function getMeta(): ?PersistentMapInterface
@@ -37,7 +38,12 @@ final class EmptyList extends AbstractType implements PersistentListInterface
 
     public function withMeta(?PersistentMapInterface $meta): static
     {
-        return new self($this->hasher, $this->equalizer, $meta);
+        return new self($this->hasher, $this->equalizer, $meta, $this->isList);
+    }
+
+    public function isList(): bool
+    {
+        return $this->isList;
     }
 
     /**
@@ -47,7 +53,7 @@ final class EmptyList extends AbstractType implements PersistentListInterface
      */
     public function prepend($value): PersistentListInterface
     {
-        return new PersistentList($this->hasher, $this->equalizer, $this->meta, $value, $this, 1);
+        return new PersistentList($this->hasher, $this->equalizer, $this->meta, $value, $this, 1, $this->isList);
     }
 
     public function pop(): PersistentListInterface
@@ -125,7 +131,7 @@ final class EmptyList extends AbstractType implements PersistentListInterface
      */
     public function concat($xs): PersistentListInterface
     {
-        return PersistentList::fromArray($this->hasher, $this->equalizer, $xs);
+        return PersistentList::fromArray($this->hasher, $this->equalizer, $xs, $this->isList);
     }
 
     public function cons(mixed $x): PersistentListInterface

--- a/src/php/Lang/Collections/LinkedList/PersistentList.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentList.php
@@ -39,6 +39,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
         private readonly mixed $first,
         private $rest,
         private readonly int $count,
+        private readonly bool $isList = true,
     ) {}
 
     /**
@@ -56,18 +57,18 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
     /**
      * @return EmptyList<T>
      */
-    public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): PersistentListInterface
+    public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer, bool $isList = true): PersistentListInterface
     {
-        return new EmptyList($hasher, $equalizer, null);
+        return new EmptyList($hasher, $equalizer, null, $isList);
     }
 
-    public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $values): PersistentListInterface
+    public static function fromArray(HasherInterface $hasher, EqualizerInterface $equalizer, array $values, bool $isList = true): PersistentListInterface
     {
         if ($values === []) {
-            return self::empty($hasher, $equalizer);
+            return self::empty($hasher, $equalizer, $isList);
         }
 
-        $result = self::empty($hasher, $equalizer);
+        $result = self::empty($hasher, $equalizer, $isList);
         for ($i = count($values) - 1; $i >= 0; --$i) {
             $result = $result->prepend($values[$i]);
         }
@@ -82,7 +83,12 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
 
     public function withMeta(?PersistentMapInterface $meta): static
     {
-        return new self($this->hasher, $this->equalizer, $meta, $this->first, $this->rest, $this->count);
+        return new self($this->hasher, $this->equalizer, $meta, $this->first, $this->rest, $this->count, $this->isList);
+    }
+
+    public function isList(): bool
+    {
+        return $this->isList;
     }
 
     /**
@@ -92,7 +98,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
      */
     public function prepend($value): PersistentListInterface
     {
-        return new self($this->hasher, $this->equalizer, $this->meta, $value, $this, $this->count + 1);
+        return new self($this->hasher, $this->equalizer, $this->meta, $value, $this, $this->count + 1, $this->isList);
     }
 
     /**
@@ -222,7 +228,7 @@ final class PersistentList extends AbstractType implements PersistentListInterfa
      */
     public function concat($xs): PersistentListInterface
     {
-        return self::fromArray($this->hasher, $this->equalizer, [...$this->toArray(), ...$xs]);
+        return self::fromArray($this->hasher, $this->equalizer, [...$this->toArray(), ...$xs], $this->isList);
     }
 
     public function cons(mixed $x): PersistentListInterface

--- a/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
+++ b/src/php/Lang/Collections/LinkedList/PersistentListInterface.php
@@ -47,4 +47,11 @@ interface PersistentListInterface extends TypeInterface, SeqInterface, IteratorA
      * @return PersistentListInterface<TValue>
      */
     public function pop(): self;
+
+    /**
+     * Returns true when this value originated from a list literal or the
+     * `list` constructor; false when it was synthesised by `seq` over a
+     * non-list collection.
+     */
+    public function isList(): bool;
 }

--- a/src/php/Lang/TypeFactory.php
+++ b/src/php/Lang/TypeFactory.php
@@ -73,6 +73,11 @@ final class TypeFactory
         return PersistentList::fromArray($this->hasher, $this->equalizer, $values);
     }
 
+    public function persistentSeqListFromArray(array $values): PersistentListInterface
+    {
+        return PersistentList::fromArray($this->hasher, $this->equalizer, $values, false);
+    }
+
     public function persistentVectorFromArray(array $values): PersistentVectorInterface
     {
         return PersistentVector::fromArray($this->hasher, $this->equalizer, $values);

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -207,7 +207,14 @@
 
 (deftest test-list?
   (is (false? (list? [])) "list? on vector")
-  (is (true? (list? '())) "list?"))
+  (is (true? (list? '())) "list?")
+  (is (true? (list? '(1 2 3))) "list? on quoted list")
+  (is (true? (list? (list 1 2 3))) "list? on list constructor")
+  (is (false? (list? (seq [1 2 3]))) "list? on (seq vector)")
+  (is (false? (list? (seq (sorted-map :a 1)))) "list? on (seq sorted-map)")
+  (is (false? (list? (seq (sorted-set :a)))) "list? on (seq sorted-set)")
+  (is (false? (list? (rest (seq [1 2 3])))) "list? on (rest (seq vector))")
+  (is (false? (list? (cons 0 (seq [1 2 3])))) "list? on cons over (seq vector)"))
 
 (deftest test-boolean?
   (is (true? (boolean? true)) "boolean? on true")


### PR DESCRIPTION
## 🤔 Background

`(list? (seq [1 2 3]))`, `(list? (seq (sorted-map :a 1)))`, and `(list? (seq (sorted-set :a)))` all returned `true`. The expected result is `false`: a value produced by `seq` over a non-list collection is a seq, not a list, so `list?` should not match it. PR #1728 made `seq?` recognise both kinds of value, but `list?` stayed too loose.

Closes #1759

## 💡 Goal

Tighten `list?` so it only matches list literals and the `list` constructor, while keeping `seq?` true for `seq`/`rseq` results.

## 🔖 Changes

- `PersistentList`/`EmptyList` carry an `isList` flag (default `true`); preserved through `prepend`, `pop`, `cons`, `concat`, `withMeta`
- New `\Phel::seqList(...)` static plus `TypeFactory::persistentSeqListFromArray` produce `isList=false` instances
- `seq` (predicates.phel) routes vector / set / sorted-map / sorted-set / php-array inputs through `seqList`; the redundant explicit hash-set branch is dropped
- `rseq` (seq-fns.phel) routes its reversed result through `seqList`
- `list?` (predicates.phel) checks both the interface and the `isList` flag
- `PersistentListInterface` exposes `isList(): bool` so the predicate can ask the value directly
- Tests added in `tests/phel/test/core/type-operation.phel` for the three issue forms plus `(rest (seq …))` and `(cons 0 (seq …))` regressions
- CHANGELOG entry under `## Unreleased`

## ✅ Local checks

- `composer test-core` (4848 passed)
- `./vendor/bin/phpunit --testsuite=unit,integration` (2762 passed)
- `composer test-quality` (no errors)

## 🔧 Refactor pass

A second commit dropped the redundant `PersistentHashSetInterface` branch from `seq` once the default case handled it via `to-php-array`.