### PR TITLE
🐛 fix(core): keyword preserves empty-string namespace (#1775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - `compare` orders namespaced keywords and symbols by namespace first (#1715)
 - `vector?` reports `false` for `seq` and `rseq` results (#1716)
 - `list?` reports `false` for `seq` and `rseq` results over vectors, sorted-maps, sorted-sets (#1759)
+- `keyword` preserves an empty-string namespace; `(namespace (keyword "" "hi"))` returns `""` and the keyword prints as `:/hi` (#1775)
 - Keyword and symbol literals preserve `'`, `"`, `\` through compilation (#1718)
 - `interleave`, `cycle`, `interpose` over maps yield `[key value]` pairs; `interleave` stops at shortest input (#1726, #1734, #1757)
 - `odd?` reports negative odd numbers as odd (#1736)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -117,7 +117,7 @@ final readonly class LiteralEmitter
 
     private function emitKeyword(Keyword $x): void
     {
-        if ($x->getNamespace() !== null && $x->getNamespace() !== '') {
+        if ($x->getNamespace() !== null) {
             $this->outputEmitter->emitStr(
                 '\Phel::keyword("' . $this->escapeForDoubleQuotedString($x->getName()) . '", "' . $this->escapeForDoubleQuotedString($x->getNamespace()) . '")',
                 $x->getStartLocation(),

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -21,7 +21,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
         private readonly ?string $namespace,
         private readonly string $name,
     ) {
-        $this->hash = $namespace !== null && $namespace !== ''
+        $this->hash = $namespace !== null
             ? crc32(':' . $namespace . '/' . $name)
             : crc32(':' . $name);
     }
@@ -52,7 +52,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
     #[Override]
     public function __toString(): string
     {
-        if ($this->namespace !== null && $this->namespace !== '') {
+        if ($this->namespace !== null) {
             return ':' . $this->namespace . '/' . $this->name;
         }
 
@@ -61,7 +61,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
 
     public static function create(string $name, ?string $namespace = null): self
     {
-        $key = $namespace !== null && $namespace !== ''
+        $key = $namespace !== null
             ? $namespace . '/' . $name
             : $name;
 
@@ -80,7 +80,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
 
     public function getFullName(): string
     {
-        if ($this->namespace !== null && $this->namespace !== '') {
+        if ($this->namespace !== null) {
             return $this->namespace . '/' . $this->name;
         }
 

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -52,11 +52,7 @@ final class Keyword extends AbstractType implements IdenticalInterface, FnInterf
     #[Override]
     public function __toString(): string
     {
-        if ($this->namespace !== null) {
-            return ':' . $this->namespace . '/' . $this->name;
-        }
-
-        return ':' . $this->name;
+        return ':' . $this->getFullName();
     }
 
     public static function create(string $name, ?string $namespace = null): self

--- a/src/php/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Printer/TypePrinter/KeywordPrinter.php
@@ -20,11 +20,7 @@ final class KeywordPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        if ($form->getNamespace() !== null) {
-            return $this->color(':' . $form->getNamespace() . '/' . $form->getName());
-        }
-
-        return $this->color(':' . $form->getName());
+        return $this->color($form->__toString());
     }
 
     private function color(string $str): string

--- a/src/php/Printer/TypePrinter/KeywordPrinter.php
+++ b/src/php/Printer/TypePrinter/KeywordPrinter.php
@@ -20,7 +20,7 @@ final class KeywordPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        if ($form->getNamespace()) {
+        if ($form->getNamespace() !== null) {
             return $this->color(':' . $form->getNamespace() . '/' . $form->getName());
         }
 

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -27,6 +27,10 @@
   (is (= :ns/name (keyword 'ns 'name)) "keyword accepts symbols as ns/name")
   (is (= :name (keyword nil "name")) "keyword with nil namespace is unqualified")
   (is (nil? (keyword "ns" nil)) "keyword with nil name is nil")
+  (is (= "" (namespace (keyword "" "hi"))) "keyword with empty-string namespace preserves it")
+  (is (= "hi" (name (keyword "" "hi"))) "keyword with empty-string namespace keeps name")
+  (is (= ":/hi" (str (keyword "" "hi"))) "keyword with empty-string namespace prints as :/hi")
+  (is (nil? (namespace (keyword "hi"))) "single-arg keyword still has nil namespace")
   (is (= :abc*+!-_'?<>= (keyword "abc*+!-_'?<>="))
       "keyword literal with special characters round-trips against (keyword string)")
   (is (= :abc*+!-_'?<>=/abc*+!-_'?<>=

--- a/tests/php/Unit/Lang/KeywordTest.php
+++ b/tests/php/Unit/Lang/KeywordTest.php
@@ -34,6 +34,33 @@ final class KeywordTest extends TestCase
         $this->assertNull($keyword->getNamespace());
     }
 
+    public function test_empty_string_namespace_is_preserved(): void
+    {
+        $keyword = Keyword::create('hi', '');
+        $this->assertSame('', $keyword->getNamespace());
+        $this->assertSame('hi', $keyword->getName());
+        $this->assertSame('/hi', $keyword->getFullName());
+        $this->assertSame(':/hi', $keyword->__toString());
+    }
+
+    public function test_empty_string_namespace_distinct_from_null(): void
+    {
+        $withEmptyNs = Keyword::create('hi', '');
+        $withNullNs = Keyword::create('hi');
+
+        $this->assertSame('', $withEmptyNs->getNamespace());
+        $this->assertNull($withNullNs->getNamespace());
+        $this->assertNotSame($withEmptyNs, $withNullNs);
+        $this->assertFalse($withEmptyNs->equals($withNullNs));
+    }
+
+    public function test_empty_string_namespace_interns_same_instance(): void
+    {
+        $keyword1 = Keyword::create('hi', '');
+        $keyword2 = Keyword::create('hi', '');
+        $this->assertSame($keyword1, $keyword2);
+    }
+
     public function test_equals(): void
     {
         $keyword1 = Keyword::create('test');

--- a/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/KeywordPrinterTest.php
@@ -32,5 +32,10 @@ final class KeywordPrinterTest extends TestCase
             ':\\?#__\|\/',
             Keyword::create('\\?#__\|\/'),
         ];
+
+        yield 'empty string namespace' => [
+            ':/hi',
+            Keyword::create('hi', ''),
+        ];
     }
 }


### PR DESCRIPTION
## 🤔 Background

`(keyword "" "hi")` was building a keyword with no namespace: `(namespace (keyword "" "hi"))` returned `nil` and the keyword printed as `:hi`. The expected behavior treats an explicit empty string as a valid namespace.

## 💡 Goal

Closes #1775. Distinguish "no namespace" (`null`) from "empty-string namespace" (`""`) so `(namespace (keyword "" "hi"))` returns `""` and the keyword prints as `:/hi`.

## 🔖 Changes

- `Keyword::create` keeps the empty-string namespace: intern key, hash, `getFullName`, and `__toString` now branch on `$namespace !== null` only.
- `KeywordPrinter` and `LiteralEmitter::emitKeyword` follow the same rule, so the printed form and the compiled `\Phel::keyword(...)` call both round-trip an empty-string namespace.
- `KeywordPrinter::print` delegates to `Keyword::__toString`, and `Keyword::__toString` reuses `getFullName` (ref pass).
- Tests: PHPUnit cases for `Keyword` and `KeywordPrinter`, plus Phel-level assertions in `basic-constructors.phel` covering `namespace`, `name`, `str`, and the single-arg regression.

Tests run locally: `composer test-compiler`, `composer test-core`, `composer test-quality` all green. Final ref pass produced one additional commit.