### PR TITLE
🐛 fix(core): last returns final element of ranges and lists (#1776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - `vector?` reports `false` for `seq` and `rseq` results (#1716)
 - `list?` reports `false` for `seq` and `rseq` results over vectors, sorted-maps, sorted-sets (#1759)
 - `keyword` preserves an empty-string namespace; `(namespace (keyword "" "hi"))` returns `""` and the keyword prints as `:/hi` (#1775)
+- `last` returns the final element of ranges and lists (#1776)
 - Keyword and symbol literals preserve `'`, `"`, `\` through compilation (#1718)
 - `interleave`, `cycle`, `interpose` over maps yield `[key value]` pairs; `interleave` stops at shortest input (#1726, #1734, #1757)
 - `odd?` reports negative odd numbers as odd (#1736)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -382,9 +382,14 @@
   {:example "(last [1 2 3]) ; => 3"
    :see-also ["first" "peek" "butlast"]}
   [coll]
-  (if (or (php/=== coll nil) (empty? coll))
-    nil
-    (peek coll)))
+  (cond
+    (or (php/=== coll nil) (empty? coll)) nil
+    (seq? coll) (loop [s coll]
+                  (let [n (next s)]
+                    (if (nil? n)
+                      (first s)
+                      (recur n))))
+    :else (peek coll)))
 
 (defn butlast
   "Returns all but the last item in `coll`. Returns `nil` when `coll` is

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -126,7 +126,13 @@
   (is (= "c" (last ["a" "b" "c"])) "last element")
   (is (nil? (last [])) "last on empty vector")
   (is (= "c" (last (php/array "a" "b" "c"))) "last on php array")
-  (is (nil? (last (php/array))) "last on empty php array"))
+  (is (nil? (last (php/array))) "last on empty php array")
+  (is (= 3 (last [1 2 3])) "last on numeric vector")
+  (is (nil? (last nil)) "last on nil")
+  (is (= "c" (last "abc")) "last on string")
+  (is (= 9 (last (range 0 10))) "last on range")
+  (is (= :c (last '(:a :b :c))) "last on quoted list")
+  (is (= 3 (last '(1 2 3))) "last on numeric list"))
 
 (deftest test-butlast
   (is (= ["a" "b"] (doall (butlast ["a" "b" "c"]))) "butlast element")


### PR DESCRIPTION
Closes #1776

## 🤔 Background

`(last (range 0 10))` returned `0` and `(last '(:a :b :c))` returned `:a`. `last` delegated to `peek`, but `peek` returns the head of lists and lazy seqs (not the tail), so it produced the first element instead of the final one.

## 💡 Goal

Make `last` return the final element for every seqable input, matching the documented behaviour and existing vector/PHP-array cases.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: `last` now walks lists and lazy seqs with `next`/`first`; vectors and PHP arrays still go through `peek`.
- `tests/phel/test/core/sequence-functions.phel`: extended `test-last` with range, quoted list, numeric list, nil, string, and numeric vector cases.
- `CHANGELOG.md`: one-line fix entry under Unreleased / Fixed / Core.

## ✅ Test plan

- `composer test-core` (4858 passed)
- `composer test-compiler` (2766 tests, 7788 assertions)
- `composer test-quality` (cs-fixer, psalm, phpstan, rector all OK)

## 🧹 Refactor pass

Re-read every touched file. The fix is already a minimum-diff `cond` over `seq?` reusing existing primitives; no further refactor required.