### PR TITLE
🐛 fix(core): get-in returns coll when path is nil or empty (#1777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - `list?` reports `false` for `seq` and `rseq` results over vectors, sorted-maps, sorted-sets (#1759)
 - `keyword` preserves an empty-string namespace; `(namespace (keyword "" "hi"))` returns `""` and the keyword prints as `:/hi` (#1775)
 - `last` returns the final element of ranges and lists (#1776)
+- `get-in` returns the collection (or nil) when the path is nil or empty; the default only applies on missing keys (#1777)
 - Keyword and symbol literals preserve `'`, `"`, `\` through compilation (#1718)
 - `interleave`, `cycle`, `interpose` over maps yield `[key value]` pairs; `interleave` stops at shortest input (#1726, #1734, #1757)
 - `odd?` reports negative odd numbers as odd (#1736)

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -272,22 +272,25 @@
 (defn get-in
   "Accesses a value in a nested data structure via a sequence of keys.
 
-  Returns `opt` (default nil) if the path doesn't exist."
+  Returns `opt` (default nil) when a key is missing mid-traversal.
+  When the path is nil or empty, returns `ds` as-is (which may be nil)."
   {:example "(get-in {:a {:b {:c 42}}} [:a :b :c]) ; => 42"
    :see-also ["assoc-in" "update-in"]}
   [ds ks & [opt]]
-  (loop [res ds
-         path ks]
-    (cond
-      (empty? path)
-      (if (nil? res) opt res)
+  (if (empty? ks)
+    ds
+    (loop [res ds
+           path ks]
+      (cond
+        (empty? path)
+        (if (nil? res) opt res)
 
-      (or (nil? res)
-          (not (get-in-traversable? res)))
-      opt
+        (or (nil? res)
+            (not (get-in-traversable? res)))
+        opt
 
-      :else
-      (recur (get res (first path)) (next path)))))
+        :else
+        (recur (get res (first path)) (next path))))))
 
 (defn assoc-in
   "Associates a value in a nested data structure at the given path.

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -284,9 +284,14 @@
   (is (= "x" (get-in {:a [["b" "a"]]} [:b 0 1] "x")) "get-in level 3 with default")
   (is (nil? (get-in {:a {:b {:c :d}}} [:a :b :c :d])) "get-in too deep returns nil")
   (is (= :d (get-in {:a {:b {:c :d} :e (range)}} [:a :b :c :d] :d)) "get-in too deep returns default")
-  (is (= "not found" (get-in nil nil "not found")) "get-in on nil ds with nil keys returns the default")
-  (is (= "not found" (get-in nil [] "not found")) "get-in on nil ds with empty path returns the default")
-  (is (= "not found" (get-in nil [:a] "not found")) "get-in on nil ds with missing key returns the default"))
+  (is (= 1 (get-in {:a {:b 1}} [:a :b])) "get-in nested map")
+  (is (= :missing (get-in {:a {:b 1}} [:a :c] :missing)) "get-in missing nested key returns default")
+  (is (= 1 (get-in {:a 1} [:a])) "get-in single key hit")
+  (is (nil? (get-in nil nil "not found")) "get-in on nil ds with nil keys returns the coll (nil)")
+  (is (nil? (get-in nil [] "not found")) "get-in on nil ds with empty path returns the coll (nil)")
+  (is (= "not found" (get-in nil [:a] "not found")) "get-in on nil ds with missing key returns the default")
+  (is (= {:a 1} (get-in {:a 1} [])) "get-in with empty path returns the coll")
+  (is (= {:a 1} (get-in {:a 1} nil)) "get-in with nil path returns the coll"))
 
 (deftest test-nth
   (is (= 2 (nth [1 2 3] 1)) "nth on vector")


### PR DESCRIPTION
Closes #1777

## 🤔 Background

`(get-in nil nil "not found")` returned `"not found"`. The default should only apply when a key is missing during traversal, not when there is no traversal to perform.

## 💡 Goal

Return the collection as-is (which may be `nil`) when the path is `nil` or empty.

## 🔖 Changes

- `src/phel/core/seq-fns.phel`: short-circuit `get-in` when `ks` is empty/nil; preserve the existing default-on-missing-key behavior for non-empty paths.
- `tests/phel/test/core/sequence-operation.phel`: update `test-get-in` to assert the corrected nil/empty path semantics and add coverage for nested hits, missing-key default, and single-key hit regressions.
- `CHANGELOG.md`: one-line entry under `## Unreleased` `### Fixed` `#### Core`.

## ✅ Tests

- `composer test-core`: 4863 passed
- `composer test-compiler`: 2766 passed (3 skipped)
- `composer test-quality`: clean
- `composer test`: green

Final ref pass over the touched files yielded no further changes; the fix is a single early-return guard.