### PR TITLE
fix(core): nthrest preserves nil collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, `##NaN` on division by zero (#1658)
 - `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, `contains?`, `nthrest`, `butlast`, `get-in`, `dissoc` (#1592, #1638, #1640, #1644, #1652, #1655, #1656, #1699, #1712, #1713, #1738)
+- `nthrest` over a nil collection returns nil (#1778)
 - `seq?` recognizes lists and `seq`/`rseq` over vectors, sorted-maps, sorted-sets (#1700)
 - `special-symbol?` recognizes `&`, `catch`, `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` (#1702)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -167,16 +167,18 @@
          :else         (recur (php/- i 1) (next s)))))))
 
 (defn nthrest
-  "Returns the nth rest of `coll`, `coll` when `n` is 0. Returns an empty
-  list once the collection is exhausted or when `coll` is `nil`."
-  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()"
+  "Returns the nth rest of `coll`, `coll` when `n` is 0. Returns `nil` when
+  `coll` is `nil`, or an empty list once the collection is exhausted."
+  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 3) ; => nil"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
-  (loop [i n
-         s coll]
-    (if (and (php/> i 0) s)
-      (recur (php/- i 1) (next s))
-      (if (nil? s) '() s))))
+  (if (nil? coll)
+    nil
+    (loop [i n
+           s coll]
+      (if (and (php/> i 0) s)
+        (recur (php/- i 1) (next s))
+        (if (nil? s) '() s)))))
 
 (defn nthnext
   "Returns the nth next of `coll`, `(seq coll)` when `n` is 0.

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -315,7 +315,8 @@
   (is (= [3 4 5] (nthrest [1 2 3 4 5] 2)) "nthrest drops first n")
   (is (= [1 2 3] (nthrest [1 2 3] 0)) "nthrest 0 returns coll")
   (is (= '() (nthrest [1 2] 5)) "nthrest past end returns empty list")
-  (is (= '() (nthrest nil 3)) "nthrest on nil returns empty list")
+  (is (nil? (nthrest nil 0)) "nthrest on nil with 0 returns nil")
+  (is (nil? (nthrest nil 3)) "nthrest on nil returns nil")
   (is (= '() (nthrest [] 100)) "nthrest on empty vector returns empty list")
   (is (= '() (nthrest (range 0 10) 10)) "nthrest exhausting a range returns empty list"))
 


### PR DESCRIPTION
## 🤔 Background

Closes #1778

`(nthrest nil 0)` returned `()` instead of `nil`, leaking an empty list when callers expected the nil seed to propagate. The clojure-test-suite caught this as a `nil?` assertion failure.

## 💡 Goal

When `coll` is `nil`, `nthrest` returns `nil` regardless of `n`. Other paths keep their existing contract: `n = 0` returns `coll` as-is, exhausting a non-nil collection still returns `()`.

## 🔖 Changes

- Guard `nthrest` with an early `(nil? coll)` check so a nil input passes through.
- Refresh the docstring and example to mention the nil case.
- Update `test-nthrest` with `(nthrest nil 0)` and `(nthrest nil 3)` cases asserting `nil?`.