### PR TITLE
🐛 fix(core): atom accepts :meta and :validator options (#1785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 #### Core
+- `atom` accepts `:meta` and `:validator` options (#1785)
 - `conj`/`conj!` ignore `nil` map entries; `conj` prepends to lazy seqs (#1650, #1683)
 - `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, `##NaN` on division by zero (#1658)

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -21,11 +21,19 @@
   "Creates a new atom with the given value.
 
   Atoms provide a way to manage mutable state. Use `reset!` to set a new value
-  and `swap!` to update based on the current value."
-  {:example "(def counter (atom 0))"
-   :see-also ["reset!" "deref" "swap!"]}
-  [value]
-  (php/:: Phel (variable value)))
+  and `swap!` to update based on the current value.
+
+  Optional `:meta` and `:validator` keyword arguments may follow the value in
+  any order. The validator is applied to the initial value when set."
+  {:example "(def counter (atom 0))\n(atom 0 :meta {:tag :counter} :validator number?)"
+   :see-also ["reset!" "deref" "swap!" "set-validator!"]}
+  [value & opts]
+  (let [pairs (apply hash-map opts)
+        m     (get pairs :meta)
+        vf    (get pairs :validator)
+        v     (php/:: Phel (variable value m))]
+    (when vf (php/-> v (setValidator vf)))
+    v))
 
 (defn var
   "Creates a new variable with the given value."

--- a/tests/phel/test/core/atom-options.phel
+++ b/tests/phel/test/core/atom-options.phel
@@ -1,0 +1,43 @@
+(ns phel-test\test\core\atom-options
+  (:require phel\test :refer [deftest is]))
+
+(deftest test-atom-meta-empty
+  (is (= {} (meta (atom nil :meta {}))) "atom :meta {} preserves empty map"))
+
+(deftest test-atom-meta-hash-map-literal
+  (is (= {:foo "foo"} (meta (atom nil :meta {:foo "foo"}))) "atom :meta with hash-map literal"))
+
+(deftest test-atom-meta-hash-map-fn
+  (is (= {:a "a"} (meta (atom nil :meta (hash-map :a "a")))) "atom :meta with hash-map fn"))
+
+(deftest test-atom-meta-array-map
+  (is (= {:a "a"} (meta (atom nil :meta (array-map :a "a")))) "atom :meta with array-map"))
+
+(deftest test-atom-meta-sorted-map
+  (let [sm (sorted-map :a "a")]
+    (is (= {:a "a"} (meta (atom nil :meta sm))) "atom :meta with sorted-map")))
+
+(deftest test-atom-validator-stored
+  (let [a (atom 0 :validator even?)]
+    (is (= even? (get-validator a)) "atom :validator stored")
+    (is (= 0 (deref a)) "atom :validator does not change value")))
+
+(deftest test-atom-validator-rejects-on-set
+  (let [a (atom 0 :validator even?)
+        rejected? (atom false)]
+    (try
+      (reset! a 3)
+      (catch \InvalidArgumentException _e
+        (reset! rejected? true)))
+    (is (true? (deref rejected?)) "validator throws on rejected value")
+    (is (= 0 (deref a)) "rejected value does not mutate atom")))
+
+(deftest test-atom-meta-and-validator-both-orders
+  (let [m  {:foo "foo"}
+        vf even?
+        a  (atom 0 :validator vf :meta m)
+        b  (atom 0 :meta m :validator vf)]
+    (is (= vf (get-validator a)) "validator first, meta second")
+    (is (= m (meta a)) "meta after validator")
+    (is (= vf (get-validator b)) "meta first, validator second")
+    (is (= m (meta b)) "validator after meta")))


### PR DESCRIPTION
## 🤔 Background

Closes #1785.

`atom` accepted only a value, so passing `:meta` or `:validator` after the initial value as kwargs raised an arity error. This blocked the clojure-test-suite atom tests that rely on `(atom v :meta m :validator vf)` in either order.

## 💡 Goal

Allow optional `:meta` and `:validator` keyword arguments after the initial value, in any order, so creating an atom with metadata or a validator works in a single call.

## 🔖 Changes

- `src/phel/core/atoms.phel`: `atom` is now variadic. After `value`, it parses `:meta` and `:validator` kwargs (any order) using `apply hash-map`. Meta is wired through `Phel::variable`; the validator is installed via `setValidator` so the initial value is validated when set.
- `tests/phel/test/core/atom-options.phel`: new test namespace covering all reproductions from the issue (empty meta, hash-map literal, `hash-map` fn, `array-map`, `sorted-map`, validator stored, validator rejects on `reset!`, both kwarg orders).
- `CHANGELOG.md`: entry under Unreleased / Fixed / Core.

## 🧪 Test plan

- `./bin/phel test tests/phel/test/core/atom-options.phel`: 13 passed.
- `composer test-core`: 4877 passed.
- `composer test-quality`: clean.