### PR TITLE
fix(core): min-key/max-key return latest argument on tie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `atom` accepts `:meta` and `:validator` options (#1785)
+- `min-key`/`max-key` return the latest argument on a tie (#1787)
 - `conj`/`conj!` ignore `nil` map entries; `conj` prepends to lazy seqs (#1650, #1683)
 - `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, `##NaN` on division by zero (#1658)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -406,7 +406,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (let [y    (first more)
           rest (next more)
           init (if (< (k x) (k y)) x y)]
-      (reduce (fn [acc item] (if (< (k item) (k acc)) item acc))
+      (reduce (fn [acc item] (if (<= (k item) (k acc)) item acc))
               init
               (or rest [])))))
 
@@ -420,7 +420,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     (let [y    (first more)
           rest (next more)
           init (if (> (k x) (k y)) x y)]
-      (reduce (fn [acc item] (if (> (k item) (k acc)) item acc))
+      (reduce (fn [acc item] (if (>= (k item) (k acc)) item acc))
               init
               (or rest [])))))
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -189,7 +189,7 @@
   (is (= "aaa" (max-key count "aaa" "b" "cc"))
       "no tie, largest key wins")
   (is (= "dd" (apply max-key count ["a" "bb" "c" "dd"]))
-      "apply form returns the last argument on a tie among the maxes"))
+      "apply form returns the last argument on a tie"))
 
 (deftest test-coerce-in
   (is (= 0.5 (coerce-in 0.5 0 1)) "(coerce-in 0.5 0 1)")

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -154,12 +154,16 @@
       "min-key with single arg"))
 
 (deftest test-min-key-tie-break
-  (is (= "a" (min-key count "a" "bb" "c"))
-      "min-key keeps the running best when later items only tie")
+  (is (= "c" (min-key count "a" "bb" "c"))
+      "min-key returns the last argument on a tie")
   (is (= "b" (min-key count "a" "b"))
       "2-arg direct form returns the second argument on a tie")
   (is (= "b" (min-key count "aaa" "b" "cc"))
-      "no tie, smallest key wins"))
+      "no tie, smallest key wins")
+  (is (= "c" (apply min-key count ["a" "bb" "c"]))
+      "apply form returns the last argument on a tie")
+  (is (= "a" (apply min-key (constantly 5) [nil 1 {:k 2} [3] '(4) #{5} "a"]))
+      "apply form with constant key returns the last argument"))
 
 (deftest test-min-key-with-nan
   (is (= 1 (apply min-key identity [##NaN 1])) "NaN as the first argument is replaced by the next non-NaN")
@@ -178,12 +182,14 @@
       "max-key with single arg"))
 
 (deftest test-max-key-tie-break
-  (is (= "aa" (max-key count "aa" "b" "cc"))
-      "max-key keeps the running best when later items only tie")
+  (is (= "cc" (max-key count "aa" "b" "cc"))
+      "max-key returns the last argument on a tie")
   (is (= "b" (max-key count "a" "b"))
       "2-arg direct form returns the second argument on a tie")
   (is (= "aaa" (max-key count "aaa" "b" "cc"))
-      "no tie, largest key wins"))
+      "no tie, largest key wins")
+  (is (= "dd" (apply max-key count ["a" "bb" "c" "dd"]))
+      "apply form returns the last argument on a tie among the maxes"))
 
 (deftest test-coerce-in
   (is (= 0.5 (coerce-in 0.5 0 1)) "(coerce-in 0.5 0 1)")


### PR DESCRIPTION
## 🤔 Background

`min-key` and `max-key` already documented "On ties, returns the latest argument", but the implementation used strict `<`/`>` in the reduction step, so the first tied element was returned instead.

clojure-test-suite caught two cases:
- `(apply min-key count ["a" "bb" "c"])` returned `"a"` instead of `"c"`
- `(apply min-key (constantly 5) [nil 1 {:k 2} [3] '(4) #{5} "a"])` returned `1` instead of `"a"`

## 💡 Goal

Make ties resolve to the last argument, matching the docstring and common semantics.

## 🔖 Changes

- `min-key` reduces with `<=` so a tie favors the later element
- `max-key` reduces with `>=` for the same reason
- Update `test-min-key-tie-break` / `test-max-key-tie-break` to assert the corrected behavior and cover the `apply` cases from the issue
- NaN propagation tests stay green: NaN comparisons remain `false` under `<=`/`>=`
- Changelog entry under Fixed/Core

Closes #1787