### PR TITLE
fix: align core fns with the Clojure test suite (batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 - `reversible?` and `rseq` handle sorted sets (#1681)
 - `/` preserves `##Inf`, `##-Inf`, `##NaN` on division by zero (#1658)
 - `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, `contains?`, `nthrest`, `butlast`, `get-in`, `dissoc` (#1592, #1638, #1640, #1644, #1652, #1655, #1656, #1699, #1712, #1713, #1738)
-- `nthrest` over a nil collection returns nil (#1778)
+- `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
 - `seq?` recognizes lists and `seq`/`rseq` over vectors, sorted-maps, sorted-sets (#1700)
 - `special-symbol?` recognizes `&`, `catch`, `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` (#1702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this project will be documented in this file.
 - Expose `future` from `phel\core` (#1537)
 - `intern` without a value preserves an existing root instead of resetting to `nil` (#1774)
 
+#### Lang
+- `(str sym)` and printer output for a qualified symbol now include the namespace (`namespace/name`)
+
 ### Fixed
 
 #### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, `contains?`, `nthrest`, `butlast`, `get-in`, `dissoc` (#1592, #1638, #1640, #1644, #1652, #1655, #1656, #1699, #1712, #1713, #1738)
 - `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
 - `get-in` traverses into strings by integer index
+- `parents`, `ancestors`, `descendants` find derive entries when the tag is a struct/record constructor function
 
 #### String
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ All notable changes to this project will be documented in this file.
 - `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, `contains?`, `nthrest`, `butlast`, `get-in`, `dissoc` (#1592, #1638, #1640, #1644, #1652, #1655, #1656, #1699, #1712, #1713, #1738)
 - `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
 - `get-in` traverses into strings by integer index
+
+#### String
+
+- `blank?` excludes non-breaking separators `U+00A0`, `U+2007`, `U+202F` from whitespace
 - `seq?` recognizes lists and `seq`/`rseq` over vectors, sorted-maps, sorted-sets (#1700)
 - `special-symbol?` recognizes `&`, `catch`, `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` (#1702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - `/` preserves `##Inf`, `##-Inf`, `##NaN` on division by zero (#1658)
 - `nil` handling in `nth`, `rand-nth`, `take-last`, `rest`, `contains?`, `nthrest`, `butlast`, `get-in`, `dissoc` (#1592, #1638, #1640, #1644, #1652, #1655, #1656, #1699, #1712, #1713, #1738)
 - `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
+- `get-in` traverses into strings by integer index
 - `seq?` recognizes lists and `seq`/`rseq` over vectors, sorted-maps, sorted-sets (#1700)
 - `special-symbol?` recognizes `&`, `catch`, `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` (#1702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
 - `get-in` traverses into strings by integer index
 - `parents`, `ancestors`, `descendants` find derive entries when the tag is a struct/record constructor function
+- `take` realizes exactly `n` elements from a lazy source (no off-by-one over-realization)
 
 #### String
 

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -87,10 +87,15 @@
   (get @*type-tag-registry* tag tag))
 
 (defn- direct-parents
-  "Returns manually-derived parents plus PHP type parents for tag."
+  "Returns manually-derived parents plus PHP type parents for tag.
+
+  Looks up the parents map under both the original tag and the resolved
+  tag (constructor function vs PHP class string) so a `derive` call made
+  with a record/type constructor still surfaces in `parents`/`ancestors`."
   [parents-map tag]
   (let [resolved-tag (hierarchy-tag tag)]
-    (union (get parents-map resolved-tag (hash-set))
+    (union (get parents-map tag (hash-set))
+           (get parents-map resolved-tag (hash-set))
            (php-class-relations resolved-tag))))
 
 (defn- compute-ancestors

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -267,7 +267,7 @@
 
 (defn- get-in-traversable?
   [x]
-  (or (coll? x) (php/is_array x)))
+  (or (coll? x) (php/is_array x) (string? x)))
 
 (defn get-in
   "Accesses a value in a nested data structure via a sequence of keys.

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -167,13 +167,13 @@
          :else         (recur (php/- i 1) (next s)))))))
 
 (defn nthrest
-  "Returns the nth rest of `coll`, `coll` when `n` is 0. Returns `nil` when
-  `coll` is `nil`, or an empty list once the collection is exhausted."
-  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 3) ; => nil"
+  "Returns the nth rest of `coll`, `coll` when `n` is less than 1. Returns
+  an empty list once the collection is exhausted."
+  {:example "(nthrest [1 2 3 4 5] 2) ; => (3 4 5)\n(nthrest [1 2] 5) ; => ()\n(nthrest nil 0) ; => nil\n(nthrest nil 3) ; => ()"
    :see-also ["nth" "nthnext" "drop"]}
   [coll n]
-  (if (nil? coll)
-    nil
+  (if (php/< n 1)
+    coll
     (loop [i n
            s coll]
       (if (and (php/> i 0) s)

--- a/src/phel/string.phel
+++ b/src/phel/string.phel
@@ -134,11 +134,14 @@
   (php/preg_replace "/[\s]+$/u" "" s))
 
 (defn blank?
-  "True if s is nil, empty, or contains only whitespace."
+  "True if s is nil, empty, or contains only whitespace. Non-breaking
+  separators (`U+00A0`, `U+2007`, `U+202F`) are not treated as whitespace."
   {:example "(blank? \"   \") ; => true"}
   [s]
   (if s
-    (not= 0 (php/preg_match "/^\\s*$/u" s))
+    (not= 0 (php/preg_match
+             "/^[\\t\\n\\x0B\\f\\r\\x1C-\\x1F \\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]*$/u"
+             s))
     true))
 
 (defn starts-with?

--- a/src/php/Lang/Generators/SliceGenerator.php
+++ b/src/php/Lang/Generators/SliceGenerator.php
@@ -31,14 +31,17 @@ final class SliceGenerator
      */
     public static function take(int $n, mixed $iterable): Generator
     {
+        if ($n <= 0) {
+            return;
+        }
+
         $count = 0;
         foreach (SequenceGenerator::toIterable($iterable) as $value) {
-            if ($count >= $n) {
-                break;
-            }
-
             yield $value;
             ++$count;
+            if ($count >= $n) {
+                return;
+            }
         }
     }
 

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -114,7 +114,7 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
     #[Override]
     public function __toString(): string
     {
-        return $this->name;
+        return $this->getFullName();
     }
 
     /**

--- a/src/php/Printer/TypePrinter/SymbolPrinter.php
+++ b/src/php/Printer/TypePrinter/SymbolPrinter.php
@@ -20,7 +20,7 @@ final class SymbolPrinter implements TypePrinterInterface
      */
     public function print(mixed $form): string
     {
-        return $this->color($form->getName());
+        return $this->color($form->getFullName());
     }
 
     private function color(string $str): string

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -168,6 +168,12 @@
 (deftest test-take-generator
   (is (= [0 1 2] (take 3 (naturals))) "take on generator"))
 
+(deftest test-take-realizes-exactly-n
+  (let [calls  (atom 0)
+        seq-fn (fn s [] (lazy-seq (swap! calls inc) (cons 1 (s))))]
+    (doall (take 5 (seq-fn)))
+    (is (= 5 @calls) "take pulls exactly n elements from a lazy source")))
+
 (deftest test-iterate
   (is (= [0 1 2] (take 3 (iterate inc 0))) "iterate infinite sequence"))
 

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -291,7 +291,8 @@
   (is (nil? (get-in nil [] "not found")) "get-in on nil ds with empty path returns the coll (nil)")
   (is (= "not found" (get-in nil [:a] "not found")) "get-in on nil ds with missing key returns the default")
   (is (= {:a 1} (get-in {:a 1} [])) "get-in with empty path returns the coll")
-  (is (= {:a 1} (get-in {:a 1} nil)) "get-in with nil path returns the coll"))
+  (is (= {:a 1} (get-in {:a 1} nil)) "get-in with nil path returns the coll")
+  (is (= "a" (get-in {:k "abc"} [:k 0])) "get-in steps into a string by index"))
 
 (deftest test-nth
   (is (= 2 (nth [1 2 3] 1)) "nth on vector")

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -316,7 +316,7 @@
   (is (= [1 2 3] (nthrest [1 2 3] 0)) "nthrest 0 returns coll")
   (is (= '() (nthrest [1 2] 5)) "nthrest past end returns empty list")
   (is (nil? (nthrest nil 0)) "nthrest on nil with 0 returns nil")
-  (is (nil? (nthrest nil 3)) "nthrest on nil returns nil")
+  (is (= '() (nthrest nil 3)) "nthrest on nil with positive n returns empty list")
   (is (= '() (nthrest [] 100)) "nthrest on empty vector returns empty list")
   (is (= '() (nthrest (range 0 10) 10)) "nthrest exhausting a range returns empty list"))
 

--- a/tests/phel/test/string.phel
+++ b/tests/phel/test/string.phel
@@ -114,7 +114,11 @@
   (is (s/blank? ""))
   (is (s/blank? " "))
   (is (s/blank? " \t \n  \r "))
-  (is (not (s/blank? "  foo  "))))
+  (is (not (s/blank? "  foo  ")))
+  (is (not (s/blank? " ")) "U+00A0 NBSP is not blank")
+  (is (not (s/blank? " ")) "U+2007 figure space is not blank")
+  (is (not (s/blank? " ")) "U+202F narrow NBSP is not blank")
+  (is (s/blank? " ") "U+2003 em space is blank"))
 
 (deftest test-split-lines
   (let [result (s/split-lines "one\ntwo\r\nthree")]

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/InvokeSymbolTest.php
@@ -283,7 +283,7 @@ final class InvokeSymbolTest extends TestCase
             self::fail('Expected AnalyzerException to be thrown');
         } catch (AnalyzerException $analyzerException) {
             self::assertStringContainsString('Error in expanding macro "user\\my-failed-macro"', $analyzerException->getMessage());
-            self::assertStringContainsString('Expanding: (my-failed-macro [1])', $analyzerException->getMessage());
+            self::assertStringContainsString('Expanding: (user/my-failed-macro [1])', $analyzerException->getMessage());
             self::assertStringContainsString('Cause: my-failed-macro message', $analyzerException->getMessage());
         }
     }

--- a/tests/php/Unit/Lang/SymbolTest.php
+++ b/tests/php/Unit/Lang/SymbolTest.php
@@ -44,6 +44,12 @@ final class SymbolTest extends TestCase
     public function test_to_string(): void
     {
         $s = Symbol::createForNamespace('namespace', 'test');
+        $this->assertSame('namespace/test', $s->__toString());
+    }
+
+    public function test_to_string_without_namespace(): void
+    {
+        $s = Symbol::create('test');
         $this->assertSame('test', $s->__toString());
     }
 

--- a/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/SymbolPrinterTest.php
@@ -24,7 +24,7 @@ final class SymbolPrinterTest extends TestCase
     public static function printerDataProvider(): Generator
     {
         yield 'symbol with namespace' => [
-            'name',
+            'ns/test/name',
             Symbol::createForNamespace('ns/test', 'name'),
         ];
 
@@ -34,7 +34,7 @@ final class SymbolPrinterTest extends TestCase
         ];
 
         yield 'symbol with namespace explicit' => [
-            '\/?#__\|',
+            'ns/\/?#__\|',
             Symbol::create('ns/\\/?#__\|'),
         ];
 


### PR DESCRIPTION
## 🤔 Background

The external Clojure test suite (`jasalt/clojure-test-suite`, `phel-integration` branch) drives Phel through a port of the `clojure.core` and `clojure.string` test files. The current run reports 22 failing assertions across 10 cljc files. Each commit here addresses one root cause behind a group of those failures.

## 💡 Goal

Fix every failure that does not require a structural change to Phel's protocol/type model. Four assertions about protocol-as-class ancestors remain (they need `defprotocol` to emit a PHP interface that records implement) and are tracked separately.

## 🔖 Changes

One commit per fix, ordered by smallest blast radius first:

1. `fix(core): nthrest returns empty list when n>0 over a nil collection`
   Restores the contract for `(nthrest nil n)`: `nil` only when `n` is 0, `()` otherwise. Resolves the `nthrest.cljc` failure without regressing #1778.

2. `fix(core): get-in traverses into strings by integer index`
   `get-in-traversable?` now accepts strings, so `(get-in {:k \"abc\"} [:k 0])` returns `\"a\"`. Fixes the `random_uuid.cljc` `has-format-4?` assertion.

3. `fix(string): blank? excludes Java non-breaking whitespace separators`
   `blank?` no longer treats `U+00A0`, `U+2007`, `U+202F` as whitespace, matching Java's `Character.isWhitespace` set used by Clojure.

4. `fix(core): hierarchy lookups find struct/record constructor entries`
   `direct-parents` now consults the global hierarchy under both the original tag and its resolved PHP class, so `(derive Record ::tag)` is visible from `parents`, `ancestors`, and `descendants`. Fixes 9 assertions across `parents.cljc`, `ancestors.cljc`, `descendants.cljc`.

5. `fix(lang): symbol __toString and printer include the namespace`
   `Symbol::__toString` and `SymbolPrinter` now return `ns/name` (matching `Keyword`). Fixes `upper-case`, `lower-case`, `capitalize`, and the two `starts-with?` assertions for qualified symbols.

6. `fix(lang): take generator yields exactly n elements`
   `SliceGenerator::take` reorders so the count check happens after `yield`, removing the off-by-one over-realization. Fixes the `when_let.cljc` 'seq is only called once' assertion.

## Out of scope

Four `ancestors.cljc` assertions still fail because Phel protocols are maps (not PHP interfaces), so `(ancestors Record)` cannot contain `TestAncestorsProtocol` without changing how `defprotocol`/`defrecord` interoperate at the class level. Tracking that separately rather than bundling it here.

## Test plan

- [x] `composer test-quality`
- [x] `composer test-compiler`
- [x] `composer test-core`
- [x] Manual repros for each failure pass