### PR TITLE
fix(core): include protocol value in record/type ancestors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - `nthrest` over a nil collection returns nil only when `n` is 0; otherwise an empty list (#1778)
 - `get-in` traverses into strings by integer index
 - `parents`, `ancestors`, `descendants` find derive entries when the tag is a struct/record constructor function
+- `parents`/`ancestors` of a record/type extended with a protocol include the protocol value itself, not only its FQN string (#1791)
 - `take` realizes exactly `n` elements from a lazy source (no off-by-one over-realization)
 
 #### String

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -81,22 +81,50 @@
   "Maps generated struct constructor functions to their PHP class tag."
   (atom {}))
 
+(def ^:private *protocol-type-relations*
+  "Maps PHP class tags to the set of protocol values they implement.
+
+  Maintained in parallel with `derive`'s class -> proto-class-string entry
+  so hierarchy queries surface the protocol value itself (the map produced
+  by `defprotocol`) and not just its FQN string."
+  (atom {}))
+
 (defn- hierarchy-tag
   "Resolves public type constructor functions to their generated PHP class tag."
   [tag]
   (get @*type-tag-registry* tag tag))
+
+(defn- protocol-relations
+  "Returns the set of protocol values registered for a PHP class tag.
+  Hierarchy-independent: surfaced by every `parents`/`ancestors`/`descendants`
+  call, mirroring PHP class inheritance."
+  [tag]
+  (get @*protocol-type-relations* tag (hash-set)))
+
+(defn register-protocol-implementor!
+  "Records that `type-key` implements `protocol-value`. Called from
+  `extend-type`'s expansion to keep the registry in sync with `derive`."
+  [type-key protocol-value]
+  (swap! *protocol-type-relations*
+         (fn [m]
+           (assoc m type-key
+                  (conj (get m type-key (hash-set)) protocol-value))))
+  nil)
 
 (defn- direct-parents
   "Returns manually-derived parents plus PHP type parents for tag.
 
   Looks up the parents map under both the original tag and the resolved
   tag (constructor function vs PHP class string) so a `derive` call made
-  with a record/type constructor still surfaces in `parents`/`ancestors`."
+  with a record/type constructor still surfaces in `parents`/`ancestors`.
+  Also unions the protocol values registered against the resolved tag so
+  the surfaced ancestors include the protocol map, not only its FQN."
   [parents-map tag]
   (let [resolved-tag (hierarchy-tag tag)]
     (union (get parents-map tag (hash-set))
            (get parents-map resolved-tag (hash-set))
-           (php-class-relations resolved-tag))))
+           (php-class-relations resolved-tag)
+           (protocol-relations resolved-tag))))
 
 (defn- compute-ancestors
   "Computes all transitive ancestors of tag from a parents map."
@@ -432,7 +460,9 @@
                                dsym      (php/:: Symbol
                                                  (create (php/. proto-str "--" mname-str "--dispatch")))]
                            (conj inner `(swap! ~dsym assoc ~type-key (fn ~margs ~@body)))))
-                       (conj acc `(derive ~type-key ~proto-tag))
+                       (conj acc
+                             `(derive ~type-key ~proto-tag)
+                             `(register-protocol-implementor! ~type-key ~proto-name))
                        methods)))
                   []
                   groups)]

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -107,6 +107,33 @@
     (is (contains? anc "Phel\\Lang\\Collections\\Map\\PersistentMapInterface")
         "deftype ancestors include inherited PHP interface")))
 
+(deftest test-defrecord-ancestors-include-protocol-value
+  (let [anc (ancestors AncestorRecord)]
+    (is (contains? anc AncestorRecordProtocol)
+        "defrecord ancestors contain the protocol value (not just its FQN)")))
+
+(deftest test-deftype-ancestors-include-protocol-value
+  (let [anc (ancestors AncestorType)]
+    (is (contains? anc AncestorTypeProtocol)
+        "deftype ancestors contain the protocol value (not just its FQN)")))
+
+(deftest test-ancestors-with-custom-hierarchy-include-protocol-value
+  (let [h   (-> (make-hierarchy)
+                (derive AncestorRecord :hier-test/datatype))
+        anc (ancestors h AncestorRecord)]
+    (is (contains? anc AncestorRecordProtocol)
+        "custom hierarchy ancestors still surface the protocol value via type inheritance")
+    (is (contains? anc :hier-test/datatype)
+        "custom hierarchy ancestors include user-derived parents")))
+
+(defprotocol ParentsProtocolMarker)
+(defrecord ParentsRecordMarker [] ParentsProtocolMarker)
+
+(deftest test-parents-include-protocol-value
+  (let [ps (parents ParentsRecordMarker)]
+    (is (contains? ps ParentsProtocolMarker)
+        "parents contain the protocol value")))
+
 ;; --- descendants ---
 
 (deftest test-descendants


### PR DESCRIPTION
## 🤔 Background

The Clojure test suite expects `(ancestors Record)` and `(ancestors h Record)` to contain the protocol value (the map produced by `defprotocol`), not only its FQN string. Phel previously returned only the FQN, so four `ancestors.cljc` assertions failed even after #1790.

## 💡 Goal

Make `parents`, `ancestors`, and `descendants` surface the protocol value itself when a struct/record/type extends a protocol — across both the global hierarchy and any user-supplied custom hierarchy.

## 🔖 Changes

- New private `*protocol-type-relations*` atom maintained in parallel with the existing class-string `derive` entry written by `extend-type`.
- `direct-parents` unions the registered protocol values into the result, regardless of which hierarchy is passed (mirrors how PHP class inheritance is shared).
- `extend-type` expansion calls a new `register-protocol-implementor!` helper alongside the existing `derive`.
- Tests cover global + custom hierarchy and parents/ancestors paths for both `defrecord` and `deftype`.

Closes #1791