### PR TITLE
fix(core): descendants ignores defrecord/deftype protocol extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - `get-in` traverses into strings by integer index
 - `parents`, `ancestors`, `descendants` find derive entries when the tag is a struct/record constructor function
 - `parents`/`ancestors` of a record/type extended with a protocol include the protocol value itself, not only its FQN string (#1791)
+- `descendants` of a protocol no longer reports records/types extended via `defrecord`/`deftype` (type inheritance is excluded, matching `clojure.core/descendants`)
 - `take` realizes exactly `n` elements from a lazy source (no off-by-one over-realization)
 
 #### String

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -102,13 +102,17 @@
   (get @*protocol-type-relations* tag (hash-set)))
 
 (defn register-protocol-implementor!
-  "Records that `type-key` implements `protocol-value`. Called from
-  `extend-type`'s expansion to keep the registry in sync with `derive`."
-  [type-key protocol-value]
+  "Records that `type-key` implements the protocol identified by both
+  `protocol-value` (the `defprotocol` map) and `protocol-tag` (its FQN
+  string). Called from `extend-type`'s expansion."
+  [type-key protocol-value protocol-tag]
   (swap! *protocol-type-relations*
          (fn [m]
-           (assoc m type-key
-                  (conj (get m type-key (hash-set)) protocol-value))))
+           (let [existing (get m type-key (hash-set))]
+             (assoc m type-key
+                    (-> existing
+                        (conj protocol-value)
+                        (conj protocol-tag))))))
   nil)
 
 (defn- direct-parents
@@ -138,6 +142,27 @@
        (hash-set)
        direct))))
 
+(defn- derive-only-parents
+  "Returns parents recorded by `derive` for tag, ignoring PHP class
+  inheritance and protocol relations. Used by `descendants` to match
+  Clojure's contract that type inheritance is not surfaced."
+  [parents-map tag]
+  (let [resolved-tag (hierarchy-tag tag)]
+    (union (get parents-map tag (hash-set))
+           (get parents-map resolved-tag (hash-set)))))
+
+(defn- compute-derive-ancestors
+  "Like `compute-ancestors` but only follows `derive`-recorded edges."
+  [parents-map tag]
+  (let [direct (derive-only-parents parents-map tag)]
+    (if (empty? direct)
+      (hash-set)
+      (reduce
+       (fn [acc p]
+         (union acc (hash-set p) (compute-derive-ancestors parents-map p)))
+       (hash-set)
+       direct))))
+
 (defn- isa-in?
   "Checks if child is (transitively) a descendant of parent in parents-map.
   Walks up the parent chain without building the full ancestor set."
@@ -164,7 +189,8 @@
    (keys parents-map)))
 
 (defn- compute-descendants-map
-  "Builds the full {tag #{descendants}} map from a parents map."
+  "Builds the full {tag #{descendants}} map from a parents map.
+  Walks only `derive`-recorded edges, mirroring `descendants`'s contract."
   [parents-map]
   (reduce
    (fn [acc child]
@@ -173,7 +199,7 @@
         (let [existing (get inner ancestor (hash-set))]
           (assoc inner ancestor (union existing (hash-set child)))))
       acc
-      (compute-ancestors parents-map child)))
+      (compute-derive-ancestors parents-map child)))
    {}
    (keys parents-map)))
 
@@ -284,7 +310,9 @@
 
 (defn descendants
   "Returns the set of all descendants of tag, or nil.
-  When a hierarchy is provided, consults it; otherwise uses the global hierarchy."
+  Only `derive`-recorded relationships are walked: type inheritance
+  (PHP class hierarchy, protocol extensions) is not surfaced, matching
+  Clojure's contract."
   {:see-also ["parents" "ancestors" "derive" "isa?"]}
   ([tag]
    (descendants @*hierarchy* tag))
@@ -294,7 +322,7 @@
        (let [all-children (keys parents-map)
              result       (reduce
                            (fn [acc child]
-                             (if (contains? (compute-ancestors parents-map child) tag)
+                             (if (contains? (compute-derive-ancestors parents-map child) tag)
                                (union acc (hash-set child))
                                acc))
                            (hash-set)
@@ -461,8 +489,7 @@
                                                  (create (php/. proto-str "--" mname-str "--dispatch")))]
                            (conj inner `(swap! ~dsym assoc ~type-key (fn ~margs ~@body)))))
                        (conj acc
-                             `(derive ~type-key ~proto-tag)
-                             `(register-protocol-implementor! ~type-key ~proto-name))
+                             `(register-protocol-implementor! ~type-key ~proto-name ~proto-tag))
                        methods)))
                   []
                   groups)]

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -115,18 +115,25 @@
                         (conj protocol-tag))))))
   nil)
 
-(defn- direct-parents
-  "Returns manually-derived parents plus PHP type parents for tag.
-
-  Looks up the parents map under both the original tag and the resolved
-  tag (constructor function vs PHP class string) so a `derive` call made
-  with a record/type constructor still surfaces in `parents`/`ancestors`.
-  Also unions the protocol values registered against the resolved tag so
-  the surfaced ancestors include the protocol map, not only its FQN."
+(defn- derive-only-parents
+  "Returns parents recorded by `derive` for tag, ignoring PHP class
+  inheritance and protocol relations. Used by `descendants` to match
+  Clojure's contract that type inheritance is not surfaced."
   [parents-map tag]
   (let [resolved-tag (hierarchy-tag tag)]
     (union (get parents-map tag (hash-set))
-           (get parents-map resolved-tag (hash-set))
+           (get parents-map resolved-tag (hash-set)))))
+
+(defn- direct-parents
+  "Returns manually-derived parents plus PHP type parents for tag.
+
+  Layers `derive`-recorded edges with PHP class inheritance and the
+  protocol-implementor registry so `parents`/`ancestors` surface every
+  relationship. `descendants` (which must ignore type inheritance) uses
+  `derive-only-parents` directly."
+  [parents-map tag]
+  (let [resolved-tag (hierarchy-tag tag)]
+    (union (derive-only-parents parents-map tag)
            (php-class-relations resolved-tag)
            (protocol-relations resolved-tag))))
 
@@ -141,15 +148,6 @@
          (union acc (hash-set p) (compute-ancestors parents-map p)))
        (hash-set)
        direct))))
-
-(defn- derive-only-parents
-  "Returns parents recorded by `derive` for tag, ignoring PHP class
-  inheritance and protocol relations. Used by `descendants` to match
-  Clojure's contract that type inheritance is not surfaced."
-  [parents-map tag]
-  (let [resolved-tag (hierarchy-tag tag)]
-    (union (get parents-map tag (hash-set))
-           (get parents-map resolved-tag (hash-set)))))
 
 (defn- compute-derive-ancestors
   "Like `compute-ancestors` but only follows `derive`-recorded edges."

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -134,6 +134,16 @@
     (is (contains? ps ParentsProtocolMarker)
         "parents contain the protocol value")))
 
+(defprotocol DescendantsLeafProtocol)
+(defrecord DescendantsLeafRecord [] DescendantsLeafProtocol)
+(deftype DescendantsLeafType [] DescendantsLeafProtocol)
+
+(deftest test-descendants-of-protocol-is-nil
+  (is (nil? (descendants DescendantsLeafProtocol))
+      "descendants of a protocol does not list extending records/types")
+  (is (nil? (descendants "phel-test\\test\\core\\hierarchy\\DescendantsLeafProtocol"))
+      "descendants of a protocol's PHP class string does not list extenders either"))
+
 ;; --- descendants ---
 
 (deftest test-descendants


### PR DESCRIPTION
## 🤔 Background

The Clojure test suite (`descendants.cljc`) asserts that `(descendants Proto)` returns nil even after `defrecord`/`deftype` extends the protocol. Phel returned the record/type class strings (and the constructor function) because `extend-type` registered them in the global hierarchy via `derive`.

Reported in https://github.com/phel-lang/phel-lang/issues/1791#issuecomment-4350164255

## 💡 Goal

Match `clojure.core/descendants` semantics: only `derive`-recorded edges are reported, not type inheritance.

## 🔖 Changes

- `extend-type` no longer calls `derive` on the protocol's class string. The relationship now lives only in `*protocol-type-relations*`, which carries both the protocol value and its FQN string so `parents`/`ancestors` continue to surface both.
- New `derive-only-parents` and `compute-derive-ancestors` helpers walk the parents map without consulting PHP class inheritance or the protocol registry. `descendants` and `compute-descendants-map` use them.
- `direct-parents` is rewritten to compose `derive-only-parents` so the layered behavior reads cleanly.
- Tests cover `(descendants Proto)` is nil for both record- and type-extended protocols.

Closes #1791