### PR TITLE
docs(skills): claude gh-issue loads issue comments

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -8,7 +8,9 @@ disable-model-invocation: true
 
 ## Context
 
-!`gh issue view ${ARGUMENTS#\#} --json title,body,labels,assignees,state 2>/dev/null || echo "Provide an issue number"`
+Read both the issue body **and every comment** as requirements input. Maintainer follow-ups frequently add scope, edge cases, or override the original description; when a later comment conflicts with the body, prefer the comment.
+
+!`gh issue view ${ARGUMENTS#\#} --json number,url,title,body,labels,assignees,state,comments 2>/dev/null || echo "Provide an issue number"`
 
 ## Instructions
 


### PR DESCRIPTION
## 🤔 Background

Maintainer follow-up comments on GitHub issues frequently add scope, edge cases, or override the original description. The Claude `/gh-issue` skill currently fetches only `title,body,labels,assignees,state`, so the agent runs blind to comments. We just hit this on issue #1791 where two follow-up comments produced two separate fixes — the skill should expose them automatically.

## 💡 Goal

Make the embedded `gh issue view` call inside the Claude `/gh-issue` skill always include the comment thread, and remind the agent (right under the `## Context` heading) to read every comment and prefer later maintainer comments when they conflict with the body.

## 🔖 Changes

- `.claude/skills/gh-issue/SKILL.md` — extend the embedded `gh issue view --json` field list with `comments` (plus `number`, `url` for completeness) and add a one-paragraph reminder under `## Context` to read body + every comment, preferring later comments on conflict.
- `.claude/skills/gh-issues/SKILL.md` — inspected; it only lists titles to build the queue and delegates the per-issue context fetch back to `/gh-issue`, so it inherits the fix without changes.
- `.codex/skills/...` — intentionally untouched; a parallel agent owns the codex-side mirror.

No code changes, so no `## Unreleased` entry. Verified the new field list against issue #1791 — `comments` resolves to a populated array.