### PR TITLE
feat(core): namespace-string APIs accept dot separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Namespace introspection: `loaded-namespaces`, `find-ns`, `create-ns`, `remove-ns`, `intern`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `load-file` (#1694)
 - `var-get` resolves a symbol to its registry value (#1774)
 - `(rand n)` returns a number in `[0, n)` (#1696)
+- `canonical-ns` returns the canonical (backslash) form of a namespace string (#1795)
 
 #### REPL
 - `require` accepts vector syntax: `(require '[phel\string :as s])` (#1693)
@@ -52,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - `parents`/`ancestors` of a record/type extended with a protocol include the protocol value (#1791, #1792)
 - `descendants` of a protocol returns nil for records/types extended via `defrecord`/`deftype` (#1793)
 - `take` realizes exactly `n` elements from a lazy source
+- Namespace-string APIs (`find-ns`, `create-ns`, `remove-ns`, `ns-interns`, `ns-publics`, `ns-aliases`, `ns-refers`, `intern`, `dir`, `get-symbol-info`) and CLI commands (`phel run`, `phel ns`) accept dot and backslash separators interchangeably (#1795)
 - `seq?` recognizes lists and `seq`/`rseq` over vectors, sorted-maps, sorted-sets (#1700)
 - `special-symbol?` recognizes `&`, `catch`, `finally` (#1701)
 - `binding` rebinds dynamic vars to `nil` (#1702)

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -19,6 +19,17 @@
   ;; Munge is a final readonly class; reuse a single instance to avoid per-call allocation.
   (php/new Munge))
 
+(defn canonical-ns
+  "Returns the canonical form of a namespace string by translating dot
+  separators to backslash. The dot form is the source-level separator
+  introduced for Clojure-aligned syntax; the registry, emitter, and
+  analyzer key off the backslash form. Use this when accepting a
+  namespace string from a user and forwarding it to namespace APIs."
+  {:example "(canonical-ns \"phel.core\") ; => \"phel\\core\""
+   :see-also ["find-ns" "create-ns" "intern"]}
+  [ns-str]
+  (php/:: Munge (canonicalNs ns-str)))
+
 (defn- core-munge-ns
   "Encodes a namespace string for registry lookup."
   [ns-str]
@@ -35,8 +46,9 @@
   {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
-  (when (php/:: Phel (hasNamespace (core-munge-ns ns-str)))
-    ns-str))
+  (let [canonical (canonical-ns ns-str)]
+    (when (php/:: Phel (hasNamespace (core-munge-ns canonical)))
+      canonical)))
 
 (defn create-ns
   "Creates the given namespace if it does not already exist. Returns the
@@ -44,8 +56,9 @@
   {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
-  (php/:: Phel (registerNamespace (core-munge-ns ns-str)))
-  ns-str)
+  (let [canonical (canonical-ns ns-str)]
+    (php/:: Phel (registerNamespace (core-munge-ns canonical)))
+    canonical))
 
 (defn remove-ns
   "Removes the namespace and all of its definitions from the registry.
@@ -81,14 +94,15 @@
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["var-get" "find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
-  (let [encoded-ns   (core-munge-ns ns-str)
+  (let [canonical    (canonical-ns ns-str)
+        encoded-ns   (core-munge-ns canonical)
         encoded-name (core-munge-name name-str)]
     (if (seq rest)
       (php/:: Phel (addDefinition encoded-ns encoded-name (first rest)))
       ;; skip when no value is provided and the definition already exists
       (when-not (php/:: Phel (isDefined encoded-ns encoded-name))
         (php/:: Phel (addDefinition encoded-ns encoded-name nil))))
-    (php/:: Symbol (createForNamespace ns-str name-str))))
+    (php/:: Symbol (createForNamespace canonical name-str))))
 
 (defn var-get
   "Takes a fully-qualified symbol and resolves it from the namespace registry,
@@ -131,7 +145,7 @@
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (php/:: GlobalEnvironmentSingleton (getInstance))
-        aliases (php/-> env (getRequireAliases ns-str))
+        aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
       (assoc! result alias-name (php/-> target-sym (getName))))
@@ -144,7 +158,7 @@
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (php/:: GlobalEnvironmentSingleton (getInstance))
-        refers (php/-> env (getRefers ns-str))
+        refers (php/-> env (getRefers (canonical-ns ns-str)))
         result (transient {})]
     (foreach [refer-name source-sym refers]
       (assoc! result refer-name (php/-> source-sym (getName))))

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -236,7 +236,8 @@
         :deprecated, :min-arity, :max-arity, :is-variadic, :ns, :name"
   {:example "(get-symbol-info \"phel\\core\" \"map\")"}
   [ns-str name-str]
-  (let [encoded-ns   (munge-ns ns-str)
+  (let [canonical    (canonical-ns ns-str)
+        encoded-ns   (munge-ns canonical)
         munge        (php/new Munge)
         encoded-name (php/-> munge (encode name-str))
         meta         (php/:: Phel (getDefinitionMetaData encoded-ns encoded-name))]
@@ -254,7 +255,7 @@
          :min-arity (get meta "min-arity")
          :max-arity (get meta "max-arity")
          :is-variadic (or (get meta "is-variadic") false)
-         :ns ns-str
+         :ns canonical
          :name name-str}))))
 
 (defmacro symbol-info

--- a/src/php/Compiler/Application/Munge.php
+++ b/src/php/Compiler/Application/Munge.php
@@ -57,12 +57,22 @@ final readonly class Munge implements MungeInterface
 
     public function encodeNs(string $str): string
     {
-        return $this->encodeWithMap($str, $this->nsMapping);
+        return $this->encodeWithMap(self::canonicalNs($str), $this->nsMapping);
     }
 
     public function decodeNs(string $str): string
     {
         return $this->encodeWithMap($str, array_flip($this->nsMapping));
+    }
+
+    /**
+     * Canonicalize a namespace string by translating dot separators to
+     * backslash. Dot is the deprecated source-level separator (#1567);
+     * the registry, emitter, and analyzer all key off the backslash form.
+     */
+    public static function canonicalNs(string $str): string
+    {
+        return str_replace('.', '\\', $str);
     }
 
     /**

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -7,6 +7,7 @@ namespace Phel\Run\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Compiler\Application\Munge;
 use Phel\Run\RunFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -16,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function count;
 use function implode;
+use function is_string;
 use function sprintf;
 
 #[ServiceMap(method: 'getFacade', className: RunFacade::class)]
@@ -42,7 +44,9 @@ class NsCommand extends Command
             return $this->listLoadedNamespaces($output, $isSimple);
         }
 
-        return $this->displayNamespaceDependencies($nsToInspect, $output, $isSimple);
+        $namespace = is_string($nsToInspect) ? Munge::canonicalNs($nsToInspect) : $nsToInspect;
+
+        return $this->displayNamespaceDependencies($namespace, $output, $isSimple);
     }
 
     private function listLoadedNamespaces(OutputInterface $output, bool $simple): int

--- a/src/php/Run/Infrastructure/Command/RunCommand.php
+++ b/src/php/Run/Infrastructure/Command/RunCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Compiler\Application\Munge;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\Service\DebugLineTap;
 use Phel\Phel;
@@ -109,11 +110,14 @@ final class RunCommand extends Command
 
             if (file_exists($path)) {
                 $this->getFacade()->runFile($path);
-            } elseif ($this->namespaceExists($path)) {
-                $this->getFacade()->runNamespace($path);
             } else {
-                $output->writeln(sprintf('<error>Namespace "%s" not found in any source directory.</error>', $path));
-                return self::FAILURE;
+                $namespace = Munge::canonicalNs($path);
+                if (!$this->namespaceExists($namespace)) {
+                    $output->writeln(sprintf('<error>Namespace "%s" not found in any source directory.</error>', $path));
+                    return self::FAILURE;
+                }
+
+                $this->getFacade()->runNamespace($namespace);
             }
 
             if ($input->getOption('with-time')) {

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -81,3 +81,47 @@
 (deftest test-ns-aliases-and-refers
   (is (hash-map? (ns-aliases "phel\\core")) "ns-aliases returns a hash-map")
   (is (hash-map? (ns-refers "phel\\core")) "ns-refers returns a hash-map"))
+
+;; ----------------------------------------------------------------------------
+;; Dot-separator parity (#1795)
+;; ----------------------------------------------------------------------------
+
+(deftest test-find-ns-accepts-dot-form
+  (is (= (find-ns "phel\\core") (find-ns "phel.core"))
+      "find-ns resolves dot and backslash forms identically"))
+
+(deftest test-ns-publics-accepts-dot-form
+  (is (= (count (ns-publics "phel\\core"))
+         (count (ns-publics "phel.core")))
+      "ns-publics returns the same map count for dot and backslash forms"))
+
+(deftest test-ns-interns-accepts-dot-form
+  (let [ns "phel-test\\tmp\\dot-interns"]
+    (intern ns "x" 7)
+    (is (= 7 (get (ns-interns "phel-test.tmp.dot-interns") "x"))
+        "ns-interns dot form reaches the same registry bucket")
+    (remove-ns ns)))
+
+(deftest test-create-and-remove-ns-accept-dot-form
+  (let [bs-ns  "phel-test\\tmp\\dot-create"
+        dot-ns "phel-test.tmp.dot-create"]
+    (create-ns dot-ns)
+    (is (not (nil? (find-ns bs-ns))) "create-ns dot form registers the canonical namespace")
+    (remove-ns dot-ns)
+    (is (nil? (find-ns bs-ns)) "remove-ns dot form drops the canonical namespace")))
+
+(deftest test-intern-canonicalizes-namespace-key
+  (let [bs-ns  "phel-test\\tmp\\dot-intern"
+        dot-ns "phel-test.tmp.dot-intern"]
+    (intern dot-ns "x" 99)
+    (is (= 99 (var-get (symbol bs-ns "x")))
+        "intern dot form is reachable via the backslash form")
+    (remove-ns dot-ns)))
+
+(deftest test-ns-aliases-accepts-dot-form
+  (is (= (ns-aliases "phel\\core") (ns-aliases "phel.core"))
+      "ns-aliases dot form parity"))
+
+(deftest test-ns-refers-accepts-dot-form
+  (is (= (ns-refers "phel\\core") (ns-refers "phel.core"))
+      "ns-refers dot form parity"))

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -37,6 +37,17 @@
     (is (s/contains? out "split") "dir keeps string namespace support")
     (is (s/contains? out "trim") "dir keeps string namespace support")))
 
+(deftest test-dir-accepts-dot-form
+  (let [bs-out  (with-output-buffer (dir "phel\\string"))
+        dot-out (with-output-buffer (dir "phel.string"))]
+    (is (= bs-out dot-out)
+        "dir output is identical for dot and backslash forms")))
+
+(deftest test-get-symbol-info-accepts-dot-form
+  (is (= (get-symbol-info "phel\\core" "map")
+         (get-symbol-info "phel.core" "map"))
+      "get-symbol-info returns the same metadata for dot and backslash namespace strings"))
+
 ;; --------
 ;; find-doc
 ;; --------

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -32,6 +32,16 @@ final class RunCommandTest extends AbstractTestCommand
         );
     }
 
+    public function test_run_by_namespace_accepts_dot_form(): void
+    {
+        $this->expectOutputRegex('~hello world~');
+
+        $this->createRunCommand()->run(
+            $this->stubInput('test.test-script'),
+            $this->stubOutput(),
+        );
+    }
+
     public function test_run_by_filename(): void
     {
         $this->expectOutputRegex('~hello world~');

--- a/tests/php/Unit/Compiler/Application/MungeTest.php
+++ b/tests/php/Unit/Compiler/Application/MungeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Application;
+
+use Phel\Compiler\Application\Munge;
+use PHPUnit\Framework\TestCase;
+
+final class MungeTest extends TestCase
+{
+    private Munge $munge;
+
+    protected function setUp(): void
+    {
+        $this->munge = new Munge();
+    }
+
+    public function test_canonical_ns_translates_dot_to_backslash(): void
+    {
+        self::assertSame('phel\\core', Munge::canonicalNs('phel.core'));
+        self::assertSame('a\\b\\c', Munge::canonicalNs('a.b.c'));
+    }
+
+    public function test_canonical_ns_keeps_already_canonical_form(): void
+    {
+        self::assertSame('phel\\core', Munge::canonicalNs('phel\\core'));
+    }
+
+    public function test_canonical_ns_handles_empty_string(): void
+    {
+        self::assertSame('', Munge::canonicalNs(''));
+    }
+
+    public function test_encode_ns_canonicalizes_dot_input(): void
+    {
+        self::assertSame(
+            $this->munge->encodeNs('phel\\core'),
+            $this->munge->encodeNs('phel.core'),
+        );
+    }
+
+    public function test_encode_ns_munges_hyphens_after_canonicalizing(): void
+    {
+        self::assertSame('my_app\\my_module', $this->munge->encodeNs('my-app.my-module'));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

User-facing namespace-string APIs (`find-ns`, `create-ns`, `dir`, `intern`, `phel run`, ...) only matched the backslash form (`phel\core`) when `phel-lang` has been migrating to the dot form (`phel.core`) since #1567. Passing the dot form returned `nil` / "Namespace not found" while `intern` silently fragmented the registry by writing under literal `"user.tmp"` instead of the canonical `"user\\tmp"` key.

Closes #1795.

## 💡 Goal

Accept dot and backslash separators interchangeably across every namespace-string API. Canonicalize input to backslash before registry lookup or write so a single registry bucket is used regardless of which form the caller picked.

## 🔖 Changes

- `Munge::encodeNs` canonicalizes dot to backslash before applying the namespace mapping; new `Munge::canonicalNs(string): string` static helper exposes the translation for callers that bypass `encodeNs`.
- New public `phel.core/canonical-ns` mirrors `Munge::canonicalNs` for Phel callers.
- `find-ns`, `create-ns`, `intern`, `ns-aliases`, `ns-refers`, `get-symbol-info` pass user input through `canonical-ns` and return the canonical form so dot/backslash inputs produce identical results. `ns-interns`, `ns-publics`, `remove-ns` already get the canonicalization for free via `core-munge-ns -> encodeNs`.
- `phel run <namespace>` and `phel ns <namespace>` canonicalize the CLI argument before dispatch.
- Added Phel parity tests in `tests/phel/test/core/ns.phel` and `tests/phel/test/repl.phel`, a PHP unit test for `Munge`, and an integration test for the CLI dot form.

## ✅ Tests

- `composer test-core` (4908) green
- `composer test-compiler` / `./vendor/bin/phpunit --testsuite=unit,integration` (2772, 3 pre-existing skipped) green
- `composer test-quality` green

## 🔁 Final refactor pass

Re-reviewed every touched file. No additional polish surfaced beyond what landed in the feature commit: the `(let [canonical (canonical-ns ns-str)] ...)` pattern repeats across three small functions but each consumes the canonical form differently, so extracting would obscure rather than clarify. CHANGELOG, module docs, naming, and test layout all match surrounding conventions.
