### PR TITLE
feat(lang): namespace APIs return dot-separated display form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `var-get` resolves a symbol to its registry value (#1774)
 - `(rand n)` returns a number in `[0, n)` (#1696)
 - `canonical-ns` returns the canonical (backslash) form of a namespace string (#1795)
+- `display-ns` returns the display (dot) form of a namespace string (#1795)
 
 #### REPL
 - `require` accepts vector syntax: `(require '[phel\string :as s])` (#1693)
@@ -37,6 +38,7 @@ All notable changes to this project will be documented in this file.
 
 #### Lang
 - `(str sym)` and printer output for qualified symbols include the namespace
+- User-facing namespace APIs return strings in dot-separated display form: `loaded-namespaces`, `find-ns`, `create-ns`, `intern`, `ns-aliases`, `ns-refers`, `get-symbol-info`, `apropos`, `find-fn`, REPL prompt, `phel ns` (#1795)
 
 ### Fixed
 

--- a/src/phel/core/ns.phel
+++ b/src/phel/core/ns.phel
@@ -9,26 +9,37 @@
 
 ;; --- Namespace introspection and manipulation ---
 
-(defn loaded-namespaces
-  "Returns all namespaces currently loaded."
-  {:example "(loaded-namespaces) ; => [\"phel\\core\" \"phel\\repl\"]"}
-  []
-  (php/:: Phel (getNamespaces)))
-
 (def ^:private munge-instance
   ;; Munge is a final readonly class; reuse a single instance to avoid per-call allocation.
   (php/new Munge))
 
 (defn canonical-ns
   "Returns the canonical form of a namespace string by translating dot
-  separators to backslash. The dot form is the source-level separator
-  introduced for Clojure-aligned syntax; the registry, emitter, and
-  analyzer key off the backslash form. Use this when accepting a
-  namespace string from a user and forwarding it to namespace APIs."
+  separators to backslash. The registry, emitter, and analyzer key off the
+  backslash form; pass user-supplied namespace strings through this before
+  any registry lookup or write."
   {:example "(canonical-ns \"phel.core\") ; => \"phel\\core\""
-   :see-also ["find-ns" "create-ns" "intern"]}
+   :see-also ["display-ns" "find-ns" "create-ns" "intern"]}
   [ns-str]
   (php/:: Munge (canonicalNs ns-str)))
+
+(defn display-ns
+  "Returns the display form of a namespace string by translating backslash
+  separators to dot. User-facing namespace APIs return strings in this form."
+  {:example "(display-ns \"phel\\core\") ; => \"phel.core\""
+   :see-also ["canonical-ns" "find-ns" "loaded-namespaces"]}
+  [ns-str]
+  (php/:: Munge (displayNs ns-str)))
+
+(defn loaded-namespaces
+  "Returns all namespaces currently loaded, in dot-separated display form."
+  {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
+  []
+  (let [raw    (php/:: Phel (getNamespaces))
+        result (transient [])]
+    (foreach [ns raw]
+      (conj result (display-ns (php/-> munge-instance (decodeNs ns)))))
+    (persistent result)))
 
 (defn- core-munge-ns
   "Encodes a namespace string for registry lookup."
@@ -41,24 +52,24 @@
   (php/-> munge-instance (encode name-str)))
 
 (defn find-ns
-  "Returns the namespace name if it is loaded, or nil if no namespace of
-  that name exists."
-  {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
+  "Returns the namespace name in display form if it is loaded, or nil if no
+  namespace of that name exists. Accepts dot or backslash separators on input."
+  {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
     (when (php/:: Phel (hasNamespace (core-munge-ns canonical)))
-      canonical)))
+      (display-ns canonical))))
 
 (defn create-ns
   "Creates the given namespace if it does not already exist. Returns the
-  namespace name. Existing namespaces are left untouched."
-  {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
+  namespace name in display form. Existing namespaces are left untouched."
+  {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
   (let [canonical (canonical-ns ns-str)]
     (php/:: Phel (registerNamespace (core-munge-ns canonical)))
-    canonical))
+    (display-ns canonical)))
 
 (defn remove-ns
   "Removes the namespace and all of its definitions from the registry.
@@ -90,7 +101,8 @@
   definition unchanged, or creates a new one with nil if none exists.
   Auto-registers the namespace when creating a new definition; the
   arity-2 form is a no-op when the definition already exists.
-  Returns the fully qualified symbol naming the definition."
+  Returns the fully qualified symbol naming the definition (with the
+  namespace in display form)."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["var-get" "find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
@@ -102,7 +114,7 @@
       ;; skip when no value is provided and the definition already exists
       (when-not (php/:: Phel (isDefined encoded-ns encoded-name))
         (php/:: Phel (addDefinition encoded-ns encoded-name nil))))
-    (php/:: Symbol (createForNamespace canonical name-str))))
+    (php/:: Symbol (createForNamespace (display-ns canonical) name-str))))
 
 (defn var-get
   "Takes a fully-qualified symbol and resolves it from the namespace registry,
@@ -140,28 +152,28 @@
 
 (defn ns-aliases
   "Returns a hash-map of {alias => namespace} for all require aliases in the
-  given namespace string."
-  {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel\\repl\" ...}"
+  given namespace string. Target namespaces are returned in display form."
+  {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (php/:: GlobalEnvironmentSingleton (getInstance))
         aliases (php/-> env (getRequireAliases (canonical-ns ns-str)))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
-      (assoc! result alias-name (php/-> target-sym (getName))))
+      (assoc! result alias-name (display-ns (php/-> target-sym (getName)))))
     (persistent result)))
 
 (defn ns-refers
   "Returns a hash-map of {name => source-namespace} for all referred symbols
-  in the given namespace string."
-  {:example "(ns-refers *ns*) ; => {\"doc\" \"phel\\repl\" ...}"
+  in the given namespace string. Source namespaces are returned in display form."
+  {:example "(ns-refers *ns*) ; => {\"doc\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (php/:: GlobalEnvironmentSingleton (getInstance))
         refers (php/-> env (getRefers (canonical-ns ns-str)))
         result (transient {})]
     (foreach [refer-name source-sym refers]
-      (assoc! result refer-name (php/-> source-sym (getName))))
+      (assoc! result refer-name (display-ns (php/-> source-sym (getName)))))
     (persistent result)))
 
 (defn load-file

--- a/src/phel/repl.phel
+++ b/src/phel/repl.phel
@@ -22,20 +22,23 @@
   (php/:: GlobalEnvironmentSingleton (getInstance)))
 
 (defn loaded-namespaces
-  "Returns all namespaces currently loaded in the REPL."
-  {:example "(loaded-namespaces) ; => [\"phel\\core\" \"phel\\repl\"]"}
+  "Returns all namespaces currently loaded in the REPL, in dot-separated
+  display form."
+  {:example "(loaded-namespaces) ; => [\"phel.core\" \"phel.repl\"]"}
   []
-  (php/:: Phel (getNamespaces)))
+  (let [raw    (php/:: Phel (getNamespaces))
+        munge  (php/new Munge)
+        result (transient [])]
+    (foreach [ns raw]
+      (conj result (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))))
+    (persistent result)))
 
 (defn ns-list
-  "Returns a sorted vector of all loaded namespace names, decoded to
-  human-readable form (hyphens restored instead of underscores)."
-  {:example "(ns-list) ; => [\"phel\\core\" \"phel\\repl\" ...]"
+  "Returns a sorted vector of all loaded namespace names in display form."
+  {:example "(ns-list) ; => [\"phel.core\" \"phel.repl\" ...]"
    :see-also ["loaded-namespaces" "dir" "ns-publics"]}
   []
-  (let [munge (php/new Munge)]
-    (sort (for [ns :in (loaded-namespaces)]
-            (php/-> munge (decodeNs ns))))))
+  (sort (loaded-namespaces)))
 
 (defn- eval-file [file]
   (php/-> build-facade (evalFile file)))
@@ -59,7 +62,7 @@
       (throw (php/new \RuntimeException
                       (str "Could not locate namespace '" namespace "' on the source paths."))))
     (foreach [dep dependencies]
-      (when-not (php/in_array (php/-> dep (getNamespace)) (loaded-namespaces))
+      (when-not (php/in_array (php/-> dep (getNamespace)) (php/:: Phel (getNamespaces)))
         (eval-file (php/-> dep (getFile)))))))
 
 (defn- clean-doc [str]
@@ -255,7 +258,7 @@
          :min-arity (get meta "min-arity")
          :max-arity (get meta "max-arity")
          :is-variadic (or (get meta "is-variadic") false)
-         :ns canonical
+         :ns (php/:: Munge (displayNs canonical))
          :name name-str}))))
 
 (defmacro symbol-info
@@ -301,11 +304,11 @@
 (defn apropos
   "Returns a vector of symbols whose name contains the given search string.
   Searches across all loaded namespaces."
-  {:example "(apropos \"map\") ; => [phel\\core/flat-map phel\\core/map ...]"}
+  {:example "(apropos \"map\") ; => [phel.core/flat-map phel.core/map ...]"}
   [search]
   (let [munge   (php/new Munge)
         results (transient [])]
-    (foreach [ns (loaded-namespaces)]
+    (foreach [ns (php/:: Phel (getNamespaces))]
       (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
@@ -313,19 +316,20 @@
                 meta    (php/:: Phel (getDefinitionMetaData ns fn-name))]
             (when (and (not (get meta :private))
                        (php/str_contains decoded search))
-              (conj results (str (php/-> munge (decodeNs ns)) "/" decoded)))))))
+              (conj results (str (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))
+                                 "/" decoded)))))))
     (sort (persistent results))))
 
 (defn find-fn
   "Searches for functions whose name or docstring contains the search string.
   Returns a vector of maps with :ns, :name, :doc, :private, :min-arity, :max-arity, :is-variadic."
-  {:example "(find-fn \"map\") ; => [{:ns \"phel\\core\" :name \"map\" ...} ...]"
+  {:example "(find-fn \"map\") ; => [{:ns \"phel.core\" :name \"map\" ...} ...]"
    :see-also ["apropos" "search-doc" "get-symbol-info"]}
   [search]
   (let [munge        (php/new Munge)
         search-lower (php/strtolower search)
         results      (transient [])]
-    (foreach [ns (loaded-namespaces)]
+    (foreach [ns (php/:: Phel (getNamespaces))]
       (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
@@ -333,7 +337,7 @@
             (when (php/instanceof definition FnInterface)
               (let [meta         (php/:: Phel (getDefinitionMetaData ns fn-name))
                     decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns   (php/-> munge (decodeNs ns))
+                    decoded-ns   (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))
                     doc          (or (get meta :doc) "")
                     name-lower   (php/strtolower decoded-name)
                     doc-lower    (php/strtolower doc)]
@@ -375,27 +379,29 @@
       `(get-source-code ~(namespace resolved-sym) ~(name resolved-sym)))))
 
 (defn find-ns
-  "Returns the namespace name if it is loaded, or nil if no namespace of
-  that name exists."
-  {:example "(find-ns \"phel\\core\") ; => \"phel\\core\""
+  "Returns the namespace name in display form if it is loaded, or nil if no
+  namespace of that name exists. Accepts dot or backslash separators on input."
+  {:example "(find-ns \"phel.core\") ; => \"phel.core\""
    :see-also ["create-ns" "remove-ns" "loaded-namespaces"]}
   [ns-str]
-  (when (php/:: Phel (hasNamespace (munge-ns ns-str)))
-    ns-str))
+  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+    (when (php/:: Phel (hasNamespace (munge-ns canonical)))
+      (php/:: Munge (displayNs canonical)))))
 
 (defn create-ns
   "Creates the given namespace if it does not already exist. Returns the
-  namespace name. Existing namespaces are left untouched."
-  {:example "(create-ns \"my-app\\tmp\") ; => \"my-app\\tmp\""
+  namespace name in display form. Existing namespaces are left untouched."
+  {:example "(create-ns \"my-app.tmp\") ; => \"my-app.tmp\""
    :see-also ["find-ns" "remove-ns" "intern"]}
   [ns-str]
-  (php/:: Phel (registerNamespace (munge-ns ns-str)))
-  ns-str)
+  (let [canonical (php/:: Munge (canonicalNs ns-str))]
+    (php/:: Phel (registerNamespace (munge-ns canonical)))
+    (php/:: Munge (displayNs canonical))))
 
 (defn remove-ns
   "Removes the namespace and all of its definitions from the registry.
   Use with caution. Returns nil."
-  {:example "(remove-ns \"my-app\\tmp\")"
+  {:example "(remove-ns \"my-app.tmp\")"
    :see-also ["find-ns" "create-ns"]}
   [ns-str]
   (php/:: Phel (removeNamespace (munge-ns ns-str)))
@@ -405,15 +411,16 @@
   "Finds or creates a definition named by name-str in namespace ns-str,
   setting its root value to val when supplied (defaults to nil). The
   namespace is auto-registered by the underlying `addDefinition` call.
-  Returns the fully qualified symbol naming the definition."
+  Returns the fully qualified symbol (with the namespace in display form)."
   {:example "(intern \"user\" \"x\" 42) ; => user/x"
    :see-also ["find-ns" "create-ns" "ns-interns"]}
   [ns-str name-str & rest]
-  (let [encoded-ns   (munge-ns ns-str)
+  (let [canonical    (php/:: Munge (canonicalNs ns-str))
+        encoded-ns   (munge-ns canonical)
         encoded-name (php/-> (php/new Munge) (encode name-str))
         value        (first rest)]
     (php/:: Phel (addDefinition encoded-ns encoded-name value))
-    (php/:: Symbol (createForNamespace ns-str name-str))))
+    (php/:: Symbol (createForNamespace (php/:: Munge (displayNs canonical)) name-str))))
 
 (defn ns-interns
   "Returns a hash-map of {name => value} for every definition in the
@@ -447,28 +454,28 @@
 
 (defn ns-aliases
   "Returns a hash-map of {alias => namespace} for all require aliases in the
-  given namespace string."
-  {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel\\repl\" ...}"
+  given namespace string. Target namespaces are returned in display form."
+  {:example "(ns-aliases *ns*) ; => {\"repl\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-refers" "loaded-namespaces"]}
   [ns-str]
   (let [env     (get-global-env)
-        aliases (php/-> env (getRequireAliases ns-str))
+        aliases (php/-> env (getRequireAliases (php/:: Munge (canonicalNs ns-str))))
         result  (transient {})]
     (foreach [alias-name target-sym aliases]
-      (assoc! result alias-name (php/-> target-sym (getName))))
+      (assoc! result alias-name (php/:: Munge (displayNs (php/-> target-sym (getName))))))
     (persistent result)))
 
 (defn ns-refers
   "Returns a hash-map of {name => source-namespace} for all referred symbols
-  in the given namespace string."
-  {:example "(ns-refers *ns*) ; => {\"doc\" \"phel\\repl\" ...}"
+  in the given namespace string. Source namespaces are returned in display form."
+  {:example "(ns-refers *ns*) ; => {\"doc\" \"phel.repl\" ...}"
    :see-also ["ns-publics" "ns-aliases" "loaded-namespaces"]}
   [ns-str]
   (let [env    (get-global-env)
-        refers (php/-> env (getRefers ns-str))
+        refers (php/-> env (getRefers (php/:: Munge (canonicalNs ns-str))))
         result (transient {})]
     (foreach [refer-name source-sym refers]
-      (assoc! result refer-name (php/-> source-sym (getName))))
+      (assoc! result refer-name (php/:: Munge (displayNs (php/-> source-sym (getName))))))
     (persistent result)))
 
 (defn search-doc
@@ -478,7 +485,7 @@
   [search]
   (let [munge        (php/new Munge)
         search-lower (php/strtolower search)]
-    (foreach [ns (loaded-namespaces)]
+    (foreach [ns (php/:: Phel (getNamespaces))]
       (let [defs     (php/:: Phel (getDefinitionInNamespace ns))
             fn-names (php/array_keys defs)]
         (foreach [fn-name fn-names]
@@ -487,7 +494,7 @@
               (let [doc          (or (get meta :doc) "")
                     doc-lower    (php/strtolower doc)
                     decoded-name (php/-> munge (decodeNs fn-name))
-                    decoded-ns   (php/-> munge (decodeNs ns))]
+                    decoded-ns   (php/:: Munge (displayNs (php/-> munge (decodeNs ns))))]
                 (when (and (not (get meta :private))
                            (php/str_contains doc-lower search-lower))
                   (println (str "--- " decoded-ns "/" decoded-name " ---"))

--- a/src/php/Compiler/Application/Munge.php
+++ b/src/php/Compiler/Application/Munge.php
@@ -67,12 +67,23 @@ final readonly class Munge implements MungeInterface
 
     /**
      * Canonicalize a namespace string by translating dot separators to
-     * backslash. Dot is the deprecated source-level separator (#1567);
-     * the registry, emitter, and analyzer all key off the backslash form.
+     * backslash. The registry, emitter, and analyzer key off the backslash
+     * form; pass user-supplied namespace strings through this before any
+     * registry lookup or write.
      */
     public static function canonicalNs(string $str): string
     {
         return str_replace('.', '\\', $str);
+    }
+
+    /**
+     * Convert an internal namespace string to its display form by translating
+     * backslash separators to dot. The dot form is the source-level separator
+     * surfaced by user-facing APIs and printed output.
+     */
+    public static function displayNs(string $str): string
+    {
+        return str_replace('\\', '.', $str);
     }
 
     /**

--- a/src/php/Run/Domain/Repl/ReplPrompt.php
+++ b/src/php/Run/Domain/Repl/ReplPrompt.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Run\Domain\Repl;
 
+use Phel\Compiler\Application\Munge;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 
 use function sprintf;
@@ -30,6 +31,6 @@ final class ReplPrompt
 
         $ns = GlobalEnvironmentSingleton::getInstance()->getNs();
 
-        return $ns !== '' ? $ns : self::DEFAULT_NAMESPACE;
+        return $ns !== '' ? Munge::displayNs($ns) : self::DEFAULT_NAMESPACE;
     }
 }

--- a/src/php/Run/Infrastructure/Command/NsCommand.php
+++ b/src/php/Run/Infrastructure/Command/NsCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_map;
 use function count;
 use function implode;
 use function is_string;
@@ -60,7 +61,7 @@ class NsCommand extends Command
 
         foreach ($loadedNamespaces as $i => $ns) {
             if ($simple) {
-                $output->writeln($ns->getNamespace());
+                $output->writeln(Munge::displayNs($ns->getNamespace()));
                 continue;
             }
 
@@ -76,13 +77,13 @@ class NsCommand extends Command
 
         if ($simple) {
             foreach ($nsInfoList as $info) {
-                $output->writeln($info->getNamespace());
+                $output->writeln(Munge::displayNs($info->getNamespace()));
             }
 
             return self::SUCCESS;
         }
 
-        $output->writeln(sprintf('Dependencies for namespace: %s', $ns));
+        $output->writeln(sprintf('Dependencies for namespace: %s', Munge::displayNs($ns)));
 
         foreach ($nsInfoList as $index => $info) {
             $this->renderNamespaceInfo($output, $index, $info);
@@ -101,11 +102,14 @@ class NsCommand extends Command
 
     private function renderNamespaceInfo(OutputInterface $output, int $index, NamespaceInformation $info): void
     {
-        $dependencies = $info->getDependencies();
+        $dependencies = array_map(
+            Munge::displayNs(...),
+            $info->getDependencies(),
+        );
         $depsCount = count($dependencies);
         $depsString = $depsCount === 0 ? '-' : implode(', ', $dependencies);
 
-        $output->writeln(sprintf('%d) Namespace: %s', $index + 1, $info->getNamespace()));
+        $output->writeln(sprintf('%d) Namespace: %s', $index + 1, Munge::displayNs($info->getNamespace())));
         $output->writeln(sprintf('   File: %s', $info->getFile()));
         $output->writeln(sprintf('   Dependencies (%d): %s', $depsCount, $depsString));
     }

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -2,19 +2,19 @@
   (:require phel\test :refer [deftest is testing]))
 
 (deftest test-loaded-namespaces-includes-core
-  (is (php/in_array "phel\\core" (loaded-namespaces))
-      "loaded-namespaces lists phel\\core"))
+  (is (some #(= "phel.core" %) (loaded-namespaces))
+      "loaded-namespaces lists phel.core in display form"))
 
 (deftest test-find-ns-known
-  (is (= "phel\\core" (find-ns "phel\\core"))
-      "find-ns returns the namespace name when loaded"))
+  (is (= "phel.core" (find-ns "phel.core"))
+      "find-ns returns the namespace name in display form"))
 
 (deftest test-find-ns-unknown
-  (is (nil? (find-ns "no-such-ns\\nope"))
+  (is (nil? (find-ns "no-such-ns.nope"))
       "find-ns returns nil for unknown namespace"))
 
 (deftest test-create-and-remove-ns
-  (let [name "phel-test\\tmp\\ns-roundtrip"]
+  (let [name "phel-test.tmp.ns-roundtrip"]
     (is (nil? (find-ns name)) "namespace does not exist initially")
     (create-ns name)
     (is (= name (find-ns name)) "namespace exists after create-ns")

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -64,7 +64,7 @@
   (let [info (get-symbol-info "phel\\core" "map")]
     (is (hash-map? info) "get-symbol-info returns a map for a known symbol")
     (is (string? (get info :doc)) "info contains :doc as a string")
-    (is (= "phel\\core" (get info :ns)) "info contains :ns")
+    (is (= "phel.core" (get info :ns)) "info contains :ns in display form")
     (is (= "map" (get info :name)) "info contains :name")))
 
 (deftest test-get-symbol-info-has-arity-keys
@@ -133,7 +133,7 @@
 
 (deftest test-ns-aliases-contains-expected-alias
   (let [aliases (ns-aliases "phel-test\\test\\repl")]
-    (is (= "phel\\string" (get aliases "s")) "ns-aliases contains 's' => 'phel\\string'")))
+    (is (= "phel.string" (get aliases "s")) "ns-aliases contains 's' => 'phel.string'")))
 
 ;; ---------
 ;; ns-refers
@@ -145,8 +145,8 @@
 
 (deftest test-ns-refers-contains-expected-refers
   (let [refers (ns-refers "phel-test\\test\\repl")]
-    (is (= "phel\\repl" (get refers "apropos")) "ns-refers contains 'apropos' from phel\\repl")
-    (is (= "phel\\test" (get refers "deftest")) "ns-refers contains 'deftest' from phel\\test")))
+    (is (= "phel.repl" (get refers "apropos")) "ns-refers contains 'apropos' from phel.repl")
+    (is (= "phel.test" (get refers "deftest")) "ns-refers contains 'deftest' from phel.test")))
 
 ;; -------
 ;; find-fn
@@ -439,8 +439,8 @@
 
 (deftest test-ns-list-contains-known-namespaces
   (let [results (ns-list)]
-    (is (some? #(= % "phel\\core") results) "ns-list contains phel\\core")
-    (is (some? #(= % "phel\\repl") results) "ns-list contains phel\\repl")))
+    (is (some #(= % "phel.core") results) "ns-list contains phel.core")
+    (is (some #(= % "phel.repl") results) "ns-list contains phel.repl")))
 
 (deftest test-ns-list-is-sorted
   (let [results (ns-list)]
@@ -528,7 +528,7 @@
   (is (nil? (find-ns "phel-test-repl-unknown-ns"))))
 
 (deftest test-create-ns-registers-empty-namespace
-  (let [ns "phel-test-repl\\create-ns-fixture"]
+  (let [ns "phel-test-repl.create-ns-fixture"]
     (remove-ns ns)
     (is (nil? (find-ns ns)) "pre: namespace not registered")
     (let [created (create-ns ns)]
@@ -537,7 +537,7 @@
     (remove-ns ns)))
 
 (deftest test-create-ns-is-idempotent
-  (let [ns "phel-test-repl\\create-ns-idempotent"]
+  (let [ns "phel-test-repl.create-ns-idempotent"]
     (create-ns ns)
     (intern ns "keeper" 7)
     (create-ns ns)
@@ -546,7 +546,7 @@
     (remove-ns ns)))
 
 (deftest test-intern-stores-value-and-creates-namespace
-  (let [ns "phel-test-repl\\intern-fixture"]
+  (let [ns "phel-test-repl.intern-fixture"]
     (remove-ns ns)
     (intern ns "answer" 42)
     (is (= ns (find-ns ns)) "intern auto-registers the namespace")
@@ -554,7 +554,7 @@
     (remove-ns ns)))
 
 (deftest test-intern-returns-fully-qualified-symbol
-  (let [ns  "phel-test-repl\\intern-return"
+  (let [ns  "phel-test-repl.intern-return"
         sym (intern ns "pointer" 1)]
     (is (= "pointer" (php/-> sym (getName))) "symbol name matches")
     (is (= ns (php/-> sym (getNamespace))) "symbol namespace matches")
@@ -563,7 +563,7 @@
     (remove-ns ns)))
 
 (deftest test-intern-munges-dashes-in-name
-  (let [ns "phel-test-repl\\intern-munge"]
+  (let [ns "phel-test-repl.intern-munge"]
     (remove-ns ns)
     (intern ns "kebab-name" 1)
     (is (= {"kebab-name" 1} (ns-interns ns))
@@ -571,7 +571,7 @@
     (remove-ns ns)))
 
 (deftest test-intern-defaults-to-nil-value
-  (let [ns "phel-test-repl\\intern-nil"]
+  (let [ns "phel-test-repl.intern-nil"]
     (remove-ns ns)
     (intern ns "placeholder")
     (is (= {"placeholder" nil} (ns-interns ns))
@@ -579,7 +579,7 @@
     (remove-ns ns)))
 
 (deftest test-intern-overwrites-existing-value
-  (let [ns "phel-test-repl\\intern-overwrite"]
+  (let [ns "phel-test-repl.intern-overwrite"]
     (remove-ns ns)
     (intern ns "x" 1)
     (intern ns "x" 2)
@@ -591,7 +591,7 @@
       "ns-interns returns an empty map for unknown namespaces"))
 
 (deftest test-ns-interns-includes-private-definitions
-  (let [ns "phel-test-repl\\interns-all"]
+  (let [ns "phel-test-repl.interns-all"]
     (remove-ns ns)
     (intern ns "pub" 1)
     (intern ns "priv" 2)
@@ -600,7 +600,7 @@
     (remove-ns ns)))
 
 (deftest test-remove-ns-drops-all-definitions
-  (let [ns "phel-test-repl\\remove-me"]
+  (let [ns "phel-test-repl.remove-me"]
     (create-ns ns)
     (intern ns "gone" 99)
     (remove-ns ns)

--- a/tests/php/Integration/Run/Command/Ns/NsCommandTest.php
+++ b/tests/php/Integration/Run/Command/Ns/NsCommandTest.php
@@ -40,8 +40,8 @@ final class NsCommandTest extends AbstractTestCommand
             }
         };
 
-        $this->expectOutputRegex('/app\\\\foo/');
-        $this->expectOutputRegex('/app\\\\bar/');
+        $this->expectOutputRegex('/app\.foo/');
+        $this->expectOutputRegex('/app\.bar/');
 
         $command->run(
             self::createStub(InputInterface::class),
@@ -75,11 +75,10 @@ final class NsCommandTest extends AbstractTestCommand
         $input = self::createStub(InputInterface::class);
         $input->method('getArgument')->willReturn('app\\bar');
 
-        $this->expectOutputRegex('/Dependencies for namespace: app\\\\bar/');
-        $this->expectOutputRegex('/1\) Namespace: app\\\\foo/');
-        $this->expectOutputRegex('/Used by: app\\\\bar/');
-        $this->expectOutputRegex('/Dependencies: app\\\\foo \(foo\.phel\)/');
-        $this->expectOutputRegex('/2\) Namespace: app\\\\bar/');
+        $this->expectOutputRegex('/Dependencies for namespace: app\.bar/');
+        $this->expectOutputRegex('/1\) Namespace: app\.foo/');
+        $this->expectOutputRegex('/2\) Namespace: app\.bar/');
+        $this->expectOutputRegex('/Dependencies \(1\): app\.foo/');
         $this->expectOutputRegex('/File: bar\.phel/');
 
         $command->run(

--- a/tests/php/Unit/Compiler/Application/MungeTest.php
+++ b/tests/php/Unit/Compiler/Application/MungeTest.php
@@ -44,4 +44,26 @@ final class MungeTest extends TestCase
     {
         self::assertSame('my_app\\my_module', $this->munge->encodeNs('my-app.my-module'));
     }
+
+    public function test_display_ns_translates_backslash_to_dot(): void
+    {
+        self::assertSame('phel.core', Munge::displayNs('phel\\core'));
+        self::assertSame('a.b.c', Munge::displayNs('a\\b\\c'));
+    }
+
+    public function test_display_ns_keeps_already_display_form(): void
+    {
+        self::assertSame('phel.core', Munge::displayNs('phel.core'));
+    }
+
+    public function test_display_ns_handles_empty_string(): void
+    {
+        self::assertSame('', Munge::displayNs(''));
+    }
+
+    public function test_canonical_and_display_round_trip(): void
+    {
+        self::assertSame('phel.core', Munge::displayNs(Munge::canonicalNs('phel.core')));
+        self::assertSame('phel\\core', Munge::canonicalNs(Munge::displayNs('phel\\core')));
+    }
 }

--- a/tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php
@@ -34,13 +34,13 @@ final class ReplPromptTest extends TestCase
         self::assertSame('....:7> ', $prompt->continuation(7));
     }
 
-    public function test_initial_prompt_reflects_current_namespace(): void
+    public function test_initial_prompt_renders_namespace_in_display_form(): void
     {
         GlobalEnvironmentSingleton::initializeNew();
         GlobalEnvironmentSingleton::getInstance()->setNs('my-app\\core');
 
         $prompt = new ReplPrompt();
 
-        self::assertSame('my-app\\core:3> ', $prompt->initial(3));
+        self::assertSame('my-app.core:3> ', $prompt->initial(3));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Phase 1 (#1796) made user input accept both dot (`phel.core`) and backslash (`phel\core`) namespace separators. Output remained backslash, which is inconsistent with the source-level dot syntax stdlib and docs already use. #1795's Phase 2 plan calls for user-facing output to flip to dot.

## 💡 Goal

Surface dot-separated namespace strings everywhere user code, the REPL, and CLI tooling read them. Keep internal registry keys, PHP namespace declarations, and emitted PHP class FQNs in backslash form so the compiler pipeline and integration fixtures are untouched.

## 🔖 Changes

- New `Munge::displayNs(string): string` is the inverse of `canonicalNs`; new public Phel `phel.core/display-ns` mirrors it.
- `phel.core` namespace APIs return dot form: `loaded-namespaces`, `find-ns`, `create-ns`, `intern`, `ns-aliases`, `ns-refers`.
- `phel.repl` namespace APIs match: `loaded-namespaces`, `ns-list`, `find-ns`, `create-ns`, `intern`, `ns-aliases`, `ns-refers`, `get-symbol-info`, `apropos`, `find-fn`, `search-doc`. `eval-namespace` and the search helpers iterate raw registry keys via `Phel::getNamespaces()` so internal lookups still match the backslash storage form.
- `phel ns` CLI output displays dot via `Munge::displayNs`.
- REPL prompt renders the current namespace in display form.
- Tests updated (`tests/phel/test/core/ns.phel`, `tests/phel/test/repl.phel`, `tests/php/Integration/Run/Command/Ns/NsCommandTest.php`, `tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php`).

## ✅ Tests

- `composer test-core` (4908) green
- `./vendor/bin/phpunit --testsuite=unit,integration` (2777, 3 pre-existing skipped) green
- `composer test-quality` green

## 🔁 Out of scope

The full registry-key flip (changing internal storage and every `tests/php/Integration/Fixtures/**/*.test` from `\Phel::addDefinition("phel\\core", ...)` to `"phel.core"`) is deferred to a Phase 3 issue. PHP `namespace` declarations and `\Phel\Lang\...` class FQNs still require backslash. Splitting the "PHP class name" and "registry key" responsibilities of `Munge::encodeNs` is a meaningful refactor that needs its own PR, fixture sweep, and minor-bump rollout.
