### PR TITLE
feat(api): anchor githubUrl to latest release tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this project will be documented in this file.
 - `(str sym)` and printer output for qualified symbols include the namespace
 - User-facing namespace APIs return strings in dot-separated display form: `loaded-namespaces`, `find-ns`, `create-ns`, `intern`, `ns-aliases`, `ns-refers`, `get-symbol-info`, `apropos`, `find-fn`, REPL prompt, `phel ns` (#1795)
 
+#### API
+- `PhelFunction.githubUrl` anchors to the latest release tag instead of `main`, so doc links remain valid across releases
+
 ### Fixed
 
 #### Core

--- a/src/php/Api/ApiConfig.php
+++ b/src/php/Api/ApiConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Api;
 
 use Gacela\Framework\AbstractConfig;
+use Phel\Console\Application\VersionFinder;
 
 final class ApiConfig extends AbstractConfig
 {
@@ -37,5 +38,10 @@ final class ApiConfig extends AbstractConfig
             'phel\\walk',
             'phel\\watch',
         ];
+    }
+
+    public static function githubRef(): string
+    {
+        return VersionFinder::LATEST_VERSION;
     }
 }

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -52,6 +52,7 @@ final class ApiFactory extends AbstractFactory
             $this->createPhelFnLoader(),
             $this->createPhelFnGroupKeyGenerator(),
             $this->getConfig()->allNamespaces(),
+            $this->getConfig()->githubRef(),
         );
     }
 

--- a/src/php/Api/Application/PhelFnNormalizer.php
+++ b/src/php/Api/Application/PhelFnNormalizer.php
@@ -13,7 +13,7 @@ use Phel\Lang\Keyword;
 
 final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
 {
-    private const string GITHUB_BASE_URL = 'https://github.com/phel-lang/phel-lang/blob/main/';
+    private const string GITHUB_BASE_URL = 'https://github.com/phel-lang/phel-lang/blob/';
 
     private const string DEFAULT_NAMESPACE = 'core';
 
@@ -24,6 +24,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
         private PhelFnLoaderInterface $phelFnLoader,
         private PhelFnGroupKeyGeneratorInterface $phelFnGroupKeyGenerator,
         private array $allNamespaces = [],
+        private string $githubRef = 'main',
     ) {}
 
     /**
@@ -215,7 +216,7 @@ final readonly class PhelFnNormalizer implements PhelFnNormalizerInterface
             return '';
         }
 
-        $url = self::GITHUB_BASE_URL . $file;
+        $url = self::GITHUB_BASE_URL . $this->githubRef . '/' . $file;
         if ($line > 0) {
             $url .= '#L' . $line;
         }

--- a/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
+++ b/tests/php/Unit/Internal/Domain/PhelFnNormalizerTest.php
@@ -397,6 +397,38 @@ final class PhelFnNormalizerTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
+    public function test_returns_source_location_with_custom_github_ref(): void
+    {
+        $meta = Phel::map(
+            Keyword::create('start-location'),
+            Phel::map(
+                Keyword::create('file'),
+                '/var/www/project/src/phel/my-file.phel',
+                Keyword::create('line'),
+                5,
+            ),
+        );
+
+        $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);
+        $phelFnLoader->method('getNormalizedPhelFunctions')->willReturn([
+            'fn-name' => $meta,
+        ]);
+
+        $normalizer = new PhelFnNormalizer(
+            $phelFnLoader,
+            new PhelFnGroupKeyGenerator(),
+            [],
+            'v1.2.3',
+        );
+        $actual = $normalizer->getPhelFunctions();
+
+        self::assertCount(1, $actual);
+        self::assertSame(
+            'https://github.com/phel-lang/phel-lang/blob/v1.2.3/src/phel/my-file.phel#L5',
+            $actual[0]->githubUrl,
+        );
+    }
+
     public function test_normalize_native_symbol_doc_url(): void
     {
         $phelFnLoader = $this->createMock(PhelFnLoaderInterface::class);


### PR DESCRIPTION
## 🤔 Background

`PhelFnNormalizer` builds the `githubUrl` for every documented Phel function from a hard-coded base pointing at `main`:

```php
private const string GITHUB_BASE_URL = 'https://github.com/phel-lang/phel-lang/blob/main/';
```

The value is consumed by `phel doc`, the Nrepl `lookup` op, the LSP hover handler, and the docs site. As soon as a file on `main` shifts after a release, the URL anchor (`#L<line>`) targets the wrong line — or even a deleted file — for anyone browsing the documentation of an older release.

## 💡 Goal

Make the GitHub ref configurable and default it to the latest release tag, so URLs published with a release stay valid against the source for that release.

## 🔖 Changes

- `PhelFnNormalizer` accepts a `string $githubRef` constructor parameter (default `'main'`) and uses it when building `githubUrl`.
- `ApiConfig::githubRef()` returns `VersionFinder::LATEST_VERSION` (e.g. `v0.34.1`); already the source-of-truth used by `Build`.
- `ApiFactory` wires the ref through to the normalizer.
- New unit test verifies a non-default ref (e.g. `v1.2.3`) propagates to `githubUrl`. Existing test continues to assert the `'main'` default.
- CHANGELOG entry under `### Changed` / `#### API`.

### Tradeoff

Dev builds whose code is ahead of the latest tag will get URLs pointing at the tagged commit (file/line may differ). Acceptable: local devs already have the file open, while the common case (released docs anchored to released code) becomes correct.