### PR TITLE
fix(repl): resolve phel.async/delay via FQN without explicit require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to this project will be documented in this file.
 #### REPL
 - Bare namespace symbols in `dir` (#1588)
 - Preserve current namespace across autocompletion and nREPL `completions`/`lookup` (#1692)
+- `phel.async/delay` resolves via fully qualified name without explicit `(require phel.async)` (#1805)
 
 #### Compiler
 - Resolve PHP class aliases consistently regardless of case (#1567)

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -1,4 +1,5 @@
-(ns phel.async)
+(ns phel.async
+  (:require phel.core))
 
 ;; Historical home of Phel's async surface. As of #1548 the
 ;; Clojure-parity primitives (`async`, `await`, `await-all`, `await-any`,

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -5,4 +5,5 @@
                               test-ns eval-capturing eval-str macroexpand-1 macroexpand ns-list])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
-                              prewalk-replace keywordize-keys stringify-keys]))
+                              prewalk-replace keywordize-keys stringify-keys])
+  (:require phel\async))

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -6,4 +6,4 @@
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
                               prewalk-replace keywordize-keys stringify-keys])
-  (:require phel\async))
+  (:require phel.async))

--- a/tests/php/Integration/Run/Command/AbstractTestCommand.php
+++ b/tests/php/Integration/Run/Command/AbstractTestCommand.php
@@ -10,6 +10,7 @@ use Gacela\Framework\Testing\ContainerFixture;
 use Override;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Filesystem\Infrastructure\RealFilesystem;
+use Phel\Run\Application\NamespaceLoader;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -28,6 +29,7 @@ abstract class AbstractTestCommand extends TestCase
         $this->resetContainer();
         GlobalEnvironmentSingleton::initializeNew();
         RealFilesystem::reset();
+        NamespaceLoader::reset();
 
         $reflection = new ReflectionClass($this);
         $childDir = dirname($reflection->getFileName());

--- a/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
@@ -27,6 +27,18 @@ final class EvalCommandTest extends AbstractTestCommand
         );
     }
 
+    public function test_eval_resolves_phel_async_fqn_without_explicit_require(): void
+    {
+        $this->expectOutputRegex('/<function:delay>/');
+
+        $exitCode = $this->createEvalCommand()->run(
+            $this->stubInput('phel.async/delay'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
     public function test_eval_resolves_bare_stdclass(): void
     {
         $this->expectOutputRegex('/Printer cannot print this type: .*stdClass/');


### PR DESCRIPTION
## 🤔 Background

Resolves #1805. In Phel REPL/eval, fully qualified `phel.async/delay` failed with `[PHEL001] Cannot resolve symbol` while `phel.string/split` worked. Cause: `NamespaceLoader::loadPhelNamespaces` seeds dependency resolution with `[startup-ns, phel.core]`. `phel.string` happens to be loaded transitively (`phel.repl` → `phel.test` → `phel.string`); `phel.async` had no transitive path so its definitions were never registered.

## 💡 Goal

Make `phel.async/delay` reachable by FQN at REPL/eval bootstrap, matching the documented intent of `phel.async` (kept separate from `phel.core` only because `delay` semantics diverge from `clojure.core/delay`, but still meant to be available for `.cljc` portability).

## 🔖 Changes

- `src/php/Run/Domain/Repl/startup.phel`: add `(:require phel.async)` so the user namespace pulls it in alongside `phel.repl`, `phel.pprint`, `phel.walk`.
- `src/phel/async.phel`: declare `(:require phel.core)` so the namespace is self-sufficient (matches `phel.string` which already declares it).
- `tests/php/Integration/Run/Command/Eval/EvalCommandTest.php`: regression test asserting `phel.async/delay` resolves via FQN without explicit require.
- `tests/php/Integration/Run/Command/AbstractTestCommand.php`: call `NamespaceLoader::reset()` in `setUp` so the static `$loadedFiles` cache does not leak across tests after `GlobalEnvironmentSingleton::initializeNew()` wipes the registry.
- `CHANGELOG.md`: entry under `## Unreleased` → REPL → Fixed.