### PR TITLE
fix(run): seed bundled phel.* so FQNs resolve without explicit require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,11 +108,12 @@ All notable changes to this project will be documented in this file.
 - Default reporter prints string literals readably in failures (#1601)
 - `phel test --stack-trace` opts into the full PHP stack trace; default omits it (#1695)
 - `phel test` seeds `phel.test` in canonical dot form so `clojure.test :as t` aliases remap correctly in `.cljc` sources (#1807)
+- `phel test` seeds every bundled `phel.*` module so fully qualified references like `phel.async/delay`, `phel.html/escape-html`, `phel.json/encode` compile in test files without an explicit `(:require ...)` (#1805)
 
 #### REPL
 - Bare namespace symbols in `dir` (#1588)
 - Preserve current namespace across autocompletion and nREPL `completions`/`lookup` (#1692)
-- `phel.async/delay` resolves via fully qualified name without explicit `(require phel.async)` (#1805)
+- Every bundled `phel.*` module (`phel.async`, `phel.html`, `phel.json`, ...) resolves via fully qualified name without explicit `(:require ...)` from REPL and `phel eval` (#1805)
 
 #### Compiler
 - Resolve PHP class aliases consistently regardless of case (#1567)

--- a/src/php/Run/Application/BundledNamespaces.php
+++ b/src/php/Run/Application/BundledNamespaces.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+
+use function array_filter;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function str_starts_with;
+
+final readonly class BundledNamespaces
+{
+    /**
+     * Bundled namespaces always live under the reserved `phel.*` prefix —
+     * `phel.core`, `phel.async`, `phel.json`, ... — whether shipped by Phel
+     * itself or by a Phel composer package.
+     */
+    private const string BUNDLED_NAMESPACE_PREFIX = 'phel.';
+
+    public function __construct(
+        private BuildFacadeInterface $buildFacade,
+        private CommandFacadeInterface $commandFacade,
+    ) {}
+
+    /**
+     * Discover every namespace shipped by Phel itself plus any installed Phel
+     * package. The list seeds runtime/test/REPL loaders so fully qualified
+     * references (`phel.async/delay`, `phel.json/encode`, ...) resolve without
+     * forcing user code to spell out a `(:require ...)` for each bundled
+     * module.
+     *
+     * @return list<string>
+     */
+    public function all(): array
+    {
+        $directories = [
+            ...$this->commandFacade->getSourceDirectories(),
+            ...$this->commandFacade->getVendorSourceDirectories(),
+        ];
+
+        if ($directories === []) {
+            return [];
+        }
+
+        $namespaces = array_map(
+            static fn(NamespaceInformation $info): string => $info->getNamespace(),
+            $this->buildFacade->getNamespaceFromDirectories($directories),
+        );
+
+        $bundled = array_filter(
+            $namespaces,
+            static fn(string $ns): bool => str_starts_with($ns, self::BUNDLED_NAMESPACE_PREFIX),
+        );
+
+        return array_values(array_unique($bundled));
+    }
+}

--- a/src/php/Run/Application/BundledNamespaces.php
+++ b/src/php/Run/Application/BundledNamespaces.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Run\Application;
 
-use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
-use function array_filter;
-use function array_map;
-use function array_unique;
-use function array_values;
+use function sort;
 use function str_starts_with;
 
 final readonly class BundledNamespaces
@@ -48,16 +44,17 @@ final readonly class BundledNamespaces
             return [];
         }
 
-        $namespaces = array_map(
-            static fn(NamespaceInformation $info): string => $info->getNamespace(),
-            $this->buildFacade->getNamespaceFromDirectories($directories),
-        );
+        $bundled = [];
+        foreach ($this->buildFacade->getNamespaceFromDirectories($directories) as $info) {
+            $ns = $info->getNamespace();
+            if (str_starts_with($ns, self::BUNDLED_NAMESPACE_PREFIX)) {
+                $bundled[$ns] = true;
+            }
+        }
 
-        $bundled = array_filter(
-            $namespaces,
-            static fn(string $ns): bool => str_starts_with($ns, self::BUNDLED_NAMESPACE_PREFIX),
-        );
+        $namespaces = array_keys($bundled);
+        sort($namespaces);
 
-        return array_values(array_unique($bundled));
+        return $namespaces;
     }
 }

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -57,27 +57,7 @@ final class NamespaceLoader
         // classpath-relative paths against the search roots.
         LoadClasspath::publish($srcDirectories);
 
-        // Seed dependency resolution with both the startup namespace and every
-        // bundled `phel.*` module so fully qualified references like
-        // `phel.async/delay` or `phel.json/encode` work without forcing user
-        // code to spell out a `(:require ...)` for each one.
-        $seeds = [$namespace, CompilerConstants::PHEL_CORE_NAMESPACE];
-        foreach ($this->bundledNamespaces->all() as $bundled) {
-            $seeds[] = $bundled;
-        }
-
-        $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
-            $srcDirectories,
-            array_values(array_unique($seeds)),
-        );
-
-        foreach ($namespaceInformation as $info) {
-            $file = $info->getFile();
-            if (!isset(self::$loadedFiles[$file])) {
-                $this->buildFacade->evalFile($file);
-                self::$loadedFiles[$file] = true;
-            }
-        }
+        $this->evaluateAll($this->resolveSeeds($namespace), $srcDirectories);
 
         // Bundled modules each switch the global namespace as they evaluate;
         // restore the startup namespace so the REPL/eval session lands in the
@@ -87,6 +67,38 @@ final class NamespaceLoader
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, '*file*', '');
 
         $this->loadDataReaders($srcDirectories);
+    }
+
+    /**
+     * Seed dependency resolution with both the startup namespace and every
+     * bundled `phel.*` module so fully qualified references like
+     * `phel.async/delay` or `phel.json/encode` work without forcing user code
+     * to spell out a `(:require ...)` for each one.
+     *
+     * @return list<string>
+     */
+    private function resolveSeeds(string $startupNamespace): array
+    {
+        return array_values(array_unique([
+            $startupNamespace,
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            ...$this->bundledNamespaces->all(),
+        ]));
+    }
+
+    /**
+     * @param list<string> $seeds
+     * @param list<string> $srcDirectories
+     */
+    private function evaluateAll(array $seeds, array $srcDirectories): void
+    {
+        foreach ($this->buildFacade->getDependenciesForNamespace($srcDirectories, $seeds) as $info) {
+            $file = $info->getFile();
+            if (!isset(self::$loadedFiles[$file])) {
+                $this->buildFacade->evalFile($file);
+                self::$loadedFiles[$file] = true;
+            }
+        }
     }
 
     /**

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -6,10 +6,13 @@ namespace Phel\Run\Application;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Resolver\LoadClasspath;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Shared\CompilerConstants;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
+use function array_unique;
+use function array_values;
 use function dirname;
 use function file_exists;
 use function getcwd;
@@ -23,6 +26,7 @@ final class NamespaceLoader
     public function __construct(
         private readonly BuildFacadeInterface $buildFacade,
         private readonly CommandFacadeInterface $commandFacade,
+        private readonly BundledNamespaces $bundledNamespaces,
         private readonly string $defaultReplStartupFile,
     ) {}
 
@@ -53,9 +57,18 @@ final class NamespaceLoader
         // classpath-relative paths against the search roots.
         LoadClasspath::publish($srcDirectories);
 
+        // Seed dependency resolution with both the startup namespace and every
+        // bundled `phel.*` module so fully qualified references like
+        // `phel.async/delay` or `phel.json/encode` work without forcing user
+        // code to spell out a `(:require ...)` for each one.
+        $seeds = [$namespace, CompilerConstants::PHEL_CORE_NAMESPACE];
+        foreach ($this->bundledNamespaces->all() as $bundled) {
+            $seeds[] = $bundled;
+        }
+
         $namespaceInformation = $this->buildFacade->getDependenciesForNamespace(
             $srcDirectories,
-            [$namespace, 'phel.core'],
+            array_values(array_unique($seeds)),
         );
 
         foreach ($namespaceInformation as $info) {
@@ -65,6 +78,11 @@ final class NamespaceLoader
                 self::$loadedFiles[$file] = true;
             }
         }
+
+        // Bundled modules each switch the global namespace as they evaluate;
+        // restore the startup namespace so the REPL/eval session lands in the
+        // expected scope (matching the pre-bundled-seeding behavior).
+        GlobalEnvironmentSingleton::getInstance()->setNs($namespace);
 
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, '*file*', '');
 

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -58,15 +58,21 @@ final class NamespaceLoader
         LoadClasspath::publish($srcDirectories);
 
         $this->evaluateAll($this->resolveSeeds($namespace), $srcDirectories);
-
-        // Bundled modules each switch the global namespace as they evaluate;
-        // restore the startup namespace so the REPL/eval session lands in the
-        // expected scope (matching the pre-bundled-seeding behavior).
-        GlobalEnvironmentSingleton::getInstance()->setNs($namespace);
+        $this->restoreStartupNamespace($namespace);
 
         Phel::addDefinition(CompilerConstants::PHEL_CORE_NAMESPACE, '*file*', '');
 
         $this->loadDataReaders($srcDirectories);
+    }
+
+    /**
+     * Bundled modules each switch the global namespace as they evaluate;
+     * restore the startup namespace so the REPL/eval session lands in the
+     * expected scope (matching the pre-bundled-seeding behavior).
+     */
+    private function restoreStartupNamespace(string $namespace): void
+    {
+        GlobalEnvironmentSingleton::getInstance()->setNs($namespace);
     }
 
     /**

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -48,7 +48,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and al
 
 ```
 Run/
-├── Application/        EntryPointDetector, EvalExecutor, FileRunner, NamespaceLoader, NamespaceRunner, NamespacesLoader, StructuredEvaluator
+├── Application/        BundledNamespaces, EntryPointDetector, EvalExecutor, FileRunner, NamespaceLoader, NamespaceRunner, NamespacesLoader, StructuredEvaluator
 ├── Domain/
 │   ├── Init/           NamespaceNormalizer, ProjectTemplateGenerator
 │   ├── Repl/           EvalResult, EvalError, ReplCommandIoInterface, ReplHistory, ReplPrompt, startup.phel
@@ -70,4 +70,5 @@ Run/
 - `ReplHistory` registers `*1`/`*2`/`*3`/`*e` in `phel\core` after REPL boot; updates on every eval/exception
 - `ReplPrompt` reads `GlobalEnvironmentSingleton::getNs()` to render the current namespace in the prompt
 - `NamespaceRunner` resolves full dependency tree before executing
+- `BundledNamespaces` lists every `phel.*` module shipped by Phel/installed Phel packages; `NamespaceLoader` and `NamespaceCollector` use it as eager seeds so fully qualified references (`phel.async/delay`, `phel.json/encode`) resolve without explicit `(:require ...)`. `NamespaceLoader` restores the startup namespace via `GlobalEnvironmentSingleton::setNs` after seeding so the REPL/eval session lands in the expected scope.
 - This is the **most connected module** — depends on 7 other modules via Provider

--- a/src/php/Run/Domain/Repl/startup.phel
+++ b/src/php/Run/Domain/Repl/startup.phel
@@ -5,5 +5,4 @@
                               test-ns eval-capturing eval-str macroexpand-1 macroexpand ns-list])
   (:require phel\pprint :refer [pprint pprint-str])
   (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
-                              prewalk-replace keywordize-keys stringify-keys])
-  (:require phel.async))
+                              prewalk-replace keywordize-keys stringify-keys]))

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -5,15 +5,20 @@ declare(strict_types=1);
 namespace Phel\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Test\CannotFindAnyTestsException;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
+
+use function array_unique;
+use function array_values;
 
 final readonly class NamespaceCollector
 {
     public function __construct(
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
+        private BundledNamespaces $bundledNamespaces,
     ) {}
 
     /**
@@ -26,7 +31,9 @@ final readonly class NamespaceCollector
             throw CannotFindAnyTestsException::inPaths($paths);
         }
 
-        $namespaces[] = 'phel.test';
+        foreach ($this->bundledNamespaces->all() as $bundled) {
+            $namespaces[] = $bundled;
+        }
 
         return $this->buildFacade->getDependenciesForNamespace(
             [
@@ -34,7 +41,7 @@ final readonly class NamespaceCollector
                 ...$this->commandFacade->getTestDirectories(),
                 ...$this->commandFacade->getVendorSourceDirectories(),
             ],
-            $namespaces,
+            array_values(array_unique($namespaces)),
         );
     }
 

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -31,9 +31,13 @@ final readonly class NamespaceCollector
             throw CannotFindAnyTestsException::inPaths($paths);
         }
 
-        foreach ($this->bundledNamespaces->all() as $bundled) {
-            $namespaces[] = $bundled;
-        }
+        // Seed the bundled `phel.*` modules alongside the user test namespaces
+        // so test files can reach them via FQN (`phel.async/delay`, ...) without
+        // forcing each one to declare a `(:require ...)`.
+        $seeds = array_values(array_unique([
+            ...$namespaces,
+            ...$this->bundledNamespaces->all(),
+        ]));
 
         return $this->buildFacade->getDependenciesForNamespace(
             [
@@ -41,7 +45,7 @@ final readonly class NamespaceCollector
                 ...$this->commandFacade->getTestDirectories(),
                 ...$this->commandFacade->getVendorSourceDirectories(),
             ],
-            array_values(array_unique($namespaces)),
+            $seeds,
         );
     }
 

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractFactory;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Printer\Printer;
 use Phel\Printer\PrinterInterface;
+use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Application\EntryPointDetector;
 use Phel\Run\Application\EvalExecutor;
 use Phel\Run\Application\FileRunner;
@@ -65,6 +66,15 @@ class RunFactory extends AbstractFactory
     public function createNamespaceCollector(): NamespaceCollector
     {
         return new NamespaceCollector(
+            $this->getBuildFacade(),
+            $this->getCommandFacade(),
+            $this->createBundledNamespaces(),
+        );
+    }
+
+    public function createBundledNamespaces(): BundledNamespaces
+    {
+        return new BundledNamespaces(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
         );
@@ -138,6 +148,7 @@ class RunFactory extends AbstractFactory
         return new NamespaceLoader(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
+            $this->createBundledNamespaces(),
             $this->getConfig()->getReplStartupFile(),
         );
     }

--- a/tests/phel/test/phel-async-fqn-regression.phel
+++ b/tests/phel/test/phel-async-fqn-regression.phel
@@ -1,0 +1,11 @@
+(ns phel\test\phel-async-fqn-regression
+  (:require phel.test :refer [deftest is]))
+
+(deftest phel-async-delay-resolves-via-fqn
+  (is (function? phel.async/delay)))
+
+(deftest phel-html-escape-resolves-via-fqn
+  (is (function? phel.html/escape-html)))
+
+(deftest phel-json-encode-resolves-via-fqn
+  (is (function? phel.json/encode)))

--- a/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
@@ -39,6 +39,30 @@ final class EvalCommandTest extends AbstractTestCommand
         self::assertSame(0, $exitCode);
     }
 
+    public function test_eval_resolves_phel_html_fqn_without_explicit_require(): void
+    {
+        $this->expectOutputRegex('/<function:escape-html>/');
+
+        $exitCode = $this->createEvalCommand()->run(
+            $this->stubInput('phel.html/escape-html'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
+    public function test_eval_resolves_phel_json_fqn_without_explicit_require(): void
+    {
+        $this->expectOutputRegex('/<function:encode>/');
+
+        $exitCode = $this->createEvalCommand()->run(
+            $this->stubInput('phel.json/encode'),
+            $this->stubOutput(),
+        );
+
+        self::assertSame(0, $exitCode);
+    }
+
     public function test_eval_resolves_bare_stdclass(): void
     {
         $this->expectOutputRegex('/Printer cannot print this type: .*stdClass/');

--- a/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
+++ b/tests/php/Integration/Run/Command/Eval/EvalCommandTest.php
@@ -8,6 +8,7 @@ use Phel\Phel;
 use Phel\Run\Infrastructure\Command\EvalCommand;
 use Phel\Run\Infrastructure\PhpStdinReader;
 use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\InputInterface;
 
 final class EvalCommandTest extends AbstractTestCommand
@@ -27,36 +28,25 @@ final class EvalCommandTest extends AbstractTestCommand
         );
     }
 
-    public function test_eval_resolves_phel_async_fqn_without_explicit_require(): void
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function bundledNamespaceFqnProvider(): iterable
     {
-        $this->expectOutputRegex('/<function:delay>/');
-
-        $exitCode = $this->createEvalCommand()->run(
-            $this->stubInput('phel.async/delay'),
-            $this->stubOutput(),
-        );
-
-        self::assertSame(0, $exitCode);
+        yield 'phel.async/delay'        => ['phel.async/delay',        '/<function:delay>/'];
+        yield 'phel.html/escape-html'   => ['phel.html/escape-html',   '/<function:escape-html>/'];
+        yield 'phel.json/encode'        => ['phel.json/encode',        '/<function:encode>/'];
     }
 
-    public function test_eval_resolves_phel_html_fqn_without_explicit_require(): void
-    {
-        $this->expectOutputRegex('/<function:escape-html>/');
+    #[DataProvider('bundledNamespaceFqnProvider')]
+    public function test_eval_resolves_bundled_namespace_fqn_without_explicit_require(
+        string $expression,
+        string $expectedOutputRegex,
+    ): void {
+        $this->expectOutputRegex($expectedOutputRegex);
 
         $exitCode = $this->createEvalCommand()->run(
-            $this->stubInput('phel.html/escape-html'),
-            $this->stubOutput(),
-        );
-
-        self::assertSame(0, $exitCode);
-    }
-
-    public function test_eval_resolves_phel_json_fqn_without_explicit_require(): void
-    {
-        $this->expectOutputRegex('/<function:encode>/');
-
-        $exitCode = $this->createEvalCommand()->run(
-            $this->stubInput('phel.json/encode'),
+            $this->stubInput($expression),
             $this->stubOutput(),
         );
 

--- a/tests/php/Integration/Run/Command/Test/BundledNamespaceFqnRegression/BundledNamespaceFqnRegressionTest.php
+++ b/tests/php/Integration/Run/Command/Test/BundledNamespaceFqnRegression/BundledNamespaceFqnRegressionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Test\BundledNamespaceFqnRegression;
+
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function exec;
+use function implode;
+
+final class BundledNamespaceFqnRegressionTest extends TestCase
+{
+    public function test_phel_test_resolves_bundled_namespace_fqns_without_explicit_require(): void
+    {
+        $projectRoot = __DIR__ . '/../../../../../../..';
+        $bin         = $projectRoot . '/bin/phel';
+        $fixture     = $projectRoot . '/tests/phel/test/phel-async-fqn-regression.phel';
+
+        $cmd = 'cd ' . escapeshellarg($projectRoot)
+            . ' && php -d memory_limit=256M ' . escapeshellarg($bin)
+            . ' test ' . escapeshellarg($fixture) . ' 2>&1';
+
+        exec($cmd, $output, $exitCode);
+        $combined = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, 'phel test failed:' . PHP_EOL . $combined);
+        self::assertMatchesRegularExpression('/Passed:\s*3/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Failed:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Error:\s*0/', $combined, $combined);
+        self::assertMatchesRegularExpression('/Total:\s*3/', $combined, $combined);
+    }
+}

--- a/tests/php/Unit/Run/Application/BundledNamespacesTest.php
+++ b/tests/php/Unit/Run/Application/BundledNamespacesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Application\BundledNamespaces;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class BundledNamespacesTest extends TestCase
+{
+    public function test_returns_only_phel_dot_prefixed_namespaces(): void
+    {
+        $namespaces = $this->bundledNamespacesFor(
+            sourceDirs: ['/src'],
+            vendorDirs: ['/vendor'],
+            scanResult: ['phel.async', 'phel.json', 'phel.test', 'app.main', 'lib.helper'],
+        )->all();
+
+        self::assertSame(['phel.async', 'phel.json', 'phel.test'], $namespaces);
+    }
+
+    public function test_deduplicates_duplicates_across_directories(): void
+    {
+        $namespaces = $this->bundledNamespacesFor(
+            sourceDirs: ['/src'],
+            vendorDirs: ['/vendor-a', '/vendor-b'],
+            scanResult: ['phel.async', 'phel.json', 'phel.async', 'phel.json'],
+        )->all();
+
+        self::assertSame(['phel.async', 'phel.json'], $namespaces);
+    }
+
+    public function test_returns_namespaces_in_deterministic_order(): void
+    {
+        $namespaces = $this->bundledNamespacesFor(
+            sourceDirs: ['/src'],
+            vendorDirs: [],
+            scanResult: ['phel.json', 'phel.async', 'phel.html', 'phel.string'],
+        )->all();
+
+        self::assertSame(['phel.async', 'phel.html', 'phel.json', 'phel.string'], $namespaces);
+    }
+
+    public function test_returns_empty_when_no_directories_to_scan(): void
+    {
+        $namespaces = $this->bundledNamespacesFor(
+            sourceDirs: [],
+            vendorDirs: [],
+            scanResult: ['phel.async'],
+            expectScan: false,
+        )->all();
+
+        self::assertSame([], $namespaces);
+    }
+
+    public function test_includes_phel_test_subnamespaces(): void
+    {
+        $namespaces = $this->bundledNamespacesFor(
+            sourceDirs: ['/src'],
+            vendorDirs: [],
+            scanResult: ['phel.test', 'phel.test.gen', 'phel.test.selector'],
+        )->all();
+
+        self::assertSame(['phel.test', 'phel.test.gen', 'phel.test.selector'], $namespaces);
+    }
+
+    /**
+     * @param list<string> $sourceDirs
+     * @param list<string> $vendorDirs
+     * @param list<string> $scanResult
+     */
+    private function bundledNamespacesFor(
+        array $sourceDirs,
+        array $vendorDirs,
+        array $scanResult,
+        bool $expectScan = true,
+    ): BundledNamespaces {
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
+        $commandFacade->method('getSourceDirectories')->willReturn($sourceDirs);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn($vendorDirs);
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade
+            ->expects($expectScan ? self::once() : self::never())
+            ->method('getNamespaceFromDirectories')
+            ->willReturn(array_map(
+                static fn(string $ns): NamespaceInformation => new NamespaceInformation('/' . $ns . '.phel', $ns, []),
+                $scanResult,
+            ));
+
+        return new BundledNamespaces($buildFacade, $commandFacade);
+    }
+}

--- a/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
+++ b/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
@@ -5,34 +5,117 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use PHPUnit\Framework\TestCase;
 
-use function in_array;
-
 final class NamespaceCollectorTest extends TestCase
 {
     public function test_seeds_canonical_dot_form_for_phel_test(): void
     {
+        $captured = [];
+        $collector = $this->createCollector(
+            ['phel.test', 'phel.async', 'phel.json'],
+            new NamespaceInformation('/src/app.phel', 'app.main', []),
+            $captured,
+        );
+
+        $collector->getDependenciesFromPaths(['/src/app.phel']);
+
+        self::assertContains('phel.test', $captured);
+        self::assertNotContains('phel\\test', $captured);
+        self::assertContains('phel.test', $captured);
+    }
+
+    public function test_seeds_every_bundled_namespace(): void
+    {
+        $captured = [];
+        $collector = $this->createCollector(
+            ['phel.async', 'phel.html', 'phel.json', 'phel.test', 'app.helper'],
+            new NamespaceInformation('/src/app.phel', 'app.main', []),
+            $captured,
+        );
+
+        $collector->getDependenciesFromPaths(['/src/app.phel']);
+
+        self::assertContains('app.main', $captured);
+        self::assertContains('phel.async', $captured);
+        self::assertContains('phel.html', $captured);
+        self::assertContains('phel.json', $captured);
+        self::assertContains('phel.test', $captured);
+        self::assertNotContains('app.helper', $captured, 'Non-bundled namespaces must not be seeded.');
+    }
+
+    public function test_deduplicates_seeds(): void
+    {
+        $captured = [];
+        $collector = $this->createCollector(
+            ['phel.test', 'phel.async'],
+            new NamespaceInformation('/src/app.phel', 'phel.async', []),
+            $captured,
+        );
+
+        $collector->getDependenciesFromPaths(['/src/app.phel']);
+
+        $unique = array_values(array_unique($captured));
+        sort($unique);
+
+        self::assertSame(['phel.async', 'phel.test'], $unique);
+    }
+
+    /**
+     * @param list<string>      $bundledNamespaces Namespace strings the BuildFacade should report on its directory scan
+     * @param list<string>|null $captured          Output buffer that captures the seeds passed to getDependenciesForNamespace
+     */
+    private function createCollector(
+        array $bundledNamespaces,
+        NamespaceInformation $extractedFromFile,
+        array &$captured,
+    ): NamespaceCollector {
         $buildFacade = $this->createMock(BuildFacadeInterface::class);
         $commandFacade = $this->createStub(CommandFacadeInterface::class);
 
+        $commandFacade
+            ->method('getSourceDirectories')
+            ->willReturn(['/src']);
+        $commandFacade
+            ->method('getProjectSourceDirectories')
+            ->willReturn(['/src']);
+        $commandFacade
+            ->method('getVendorSourceDirectories')
+            ->willReturn(['/vendor']);
+        $commandFacade
+            ->method('getTestDirectories')
+            ->willReturn(['/tests']);
+
         $buildFacade
             ->method('getNamespaceFromFile')
-            ->willReturn(new NamespaceInformation('/src/app.phel', 'app.main', []));
+            ->willReturn($extractedFromFile);
+
+        $buildFacade
+            ->method('getNamespaceFromDirectories')
+            ->willReturn(array_map(
+                static fn(string $ns): NamespaceInformation => new NamespaceInformation('/vendor/' . $ns . '.phel', $ns, []),
+                $bundledNamespaces,
+            ));
 
         $buildFacade
             ->expects(self::once())
             ->method('getDependenciesForNamespace')
             ->with(self::anything(), self::callback(
-                static fn(array $namespaces): bool => in_array('phel.test', $namespaces, true)
-                    && !in_array('phel\\test', $namespaces, true),
+                static function (array $namespaces) use (&$captured): bool {
+                    $captured = $namespaces;
+                    return true;
+                },
             ))
             ->willReturn([]);
 
-        new NamespaceCollector($buildFacade, $commandFacade)
-            ->getDependenciesFromPaths(['/src/app.phel']);
+        return new NamespaceCollector(
+            $buildFacade,
+            $commandFacade,
+            new BundledNamespaces($buildFacade, $commandFacade),
+        );
     }
 }

--- a/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
+++ b/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
@@ -15,92 +15,71 @@ final class NamespaceCollectorTest extends TestCase
 {
     public function test_seeds_canonical_dot_form_for_phel_test(): void
     {
-        $captured = [];
-        $collector = $this->createCollector(
-            ['phel.test', 'phel.async', 'phel.json'],
-            new NamespaceInformation('/src/app.phel', 'app.main', []),
-            $captured,
-        );
+        $seeds = $this->captureSeedsForBundledScan(['phel.test', 'phel.async', 'phel.json']);
 
-        $collector->getDependenciesFromPaths(['/src/app.phel']);
-
-        self::assertContains('phel.test', $captured);
-        self::assertNotContains('phel\\test', $captured);
-        self::assertContains('phel.test', $captured);
+        self::assertContains('phel.test', $seeds);
+        self::assertNotContains('phel\\test', $seeds);
     }
 
     public function test_seeds_every_bundled_namespace(): void
     {
-        $captured = [];
-        $collector = $this->createCollector(
+        $seeds = $this->captureSeedsForBundledScan(
             ['phel.async', 'phel.html', 'phel.json', 'phel.test', 'app.helper'],
-            new NamespaceInformation('/src/app.phel', 'app.main', []),
-            $captured,
         );
 
-        $collector->getDependenciesFromPaths(['/src/app.phel']);
-
-        self::assertContains('app.main', $captured);
-        self::assertContains('phel.async', $captured);
-        self::assertContains('phel.html', $captured);
-        self::assertContains('phel.json', $captured);
-        self::assertContains('phel.test', $captured);
-        self::assertNotContains('app.helper', $captured, 'Non-bundled namespaces must not be seeded.');
+        self::assertContains('app.main', $seeds);
+        self::assertContains('phel.async', $seeds);
+        self::assertContains('phel.html', $seeds);
+        self::assertContains('phel.json', $seeds);
+        self::assertContains('phel.test', $seeds);
+        self::assertNotContains('app.helper', $seeds, 'Non-bundled namespaces must not be seeded.');
     }
 
     public function test_deduplicates_seeds(): void
     {
-        $captured = [];
-        $collector = $this->createCollector(
+        $seeds = $this->captureSeedsForBundledScan(
             ['phel.test', 'phel.async'],
-            new NamespaceInformation('/src/app.phel', 'phel.async', []),
-            $captured,
+            extractedFromFileNamespace: 'phel.async',
         );
 
-        $collector->getDependenciesFromPaths(['/src/app.phel']);
-
-        $unique = array_values(array_unique($captured));
+        $unique = array_values(array_unique($seeds));
         sort($unique);
 
         self::assertSame(['phel.async', 'phel.test'], $unique);
     }
 
     /**
-     * @param list<string>      $bundledNamespaces Namespace strings the BuildFacade should report on its directory scan
-     * @param list<string>|null $captured          Output buffer that captures the seeds passed to getDependenciesForNamespace
+     * Run the collector against a stubbed bundled-namespace scan and return
+     * the seed list it produces.
+     *
+     * @param list<string> $bundledScanResult Namespace strings the BuildFacade should report on its directory scan
+     *
+     * @return list<string>
      */
-    private function createCollector(
-        array $bundledNamespaces,
-        NamespaceInformation $extractedFromFile,
-        array &$captured,
-    ): NamespaceCollector {
+    private function captureSeedsForBundledScan(
+        array $bundledScanResult,
+        string $extractedFromFileNamespace = 'app.main',
+    ): array {
         $buildFacade = $this->createMock(BuildFacadeInterface::class);
         $commandFacade = $this->createStub(CommandFacadeInterface::class);
 
-        $commandFacade
-            ->method('getSourceDirectories')
-            ->willReturn(['/src']);
-        $commandFacade
-            ->method('getProjectSourceDirectories')
-            ->willReturn(['/src']);
-        $commandFacade
-            ->method('getVendorSourceDirectories')
-            ->willReturn(['/vendor']);
-        $commandFacade
-            ->method('getTestDirectories')
-            ->willReturn(['/tests']);
+        $commandFacade->method('getSourceDirectories')->willReturn(['/src']);
+        $commandFacade->method('getProjectSourceDirectories')->willReturn(['/src']);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn(['/vendor']);
+        $commandFacade->method('getTestDirectories')->willReturn(['/tests']);
 
         $buildFacade
             ->method('getNamespaceFromFile')
-            ->willReturn($extractedFromFile);
+            ->willReturn(new NamespaceInformation('/src/app.phel', $extractedFromFileNamespace, []));
 
         $buildFacade
             ->method('getNamespaceFromDirectories')
             ->willReturn(array_map(
                 static fn(string $ns): NamespaceInformation => new NamespaceInformation('/vendor/' . $ns . '.phel', $ns, []),
-                $bundledNamespaces,
+                $bundledScanResult,
             ));
 
+        $captured = [];
         $buildFacade
             ->expects(self::once())
             ->method('getDependenciesForNamespace')
@@ -112,10 +91,12 @@ final class NamespaceCollectorTest extends TestCase
             ))
             ->willReturn([]);
 
-        return new NamespaceCollector(
+        new NamespaceCollector(
             $buildFacade,
             $commandFacade,
             new BundledNamespaces($buildFacade, $commandFacade),
-        );
+        )->getDependenciesFromPaths(['/src/app.phel']);
+
+        return $captured;
     }
 }


### PR DESCRIPTION
## 🤔 Background

Closes #1805. Follow-up to #1806 (REPL only) and #1807 (clojure.test alias).

Phel only loads namespaces reachable from the user/startup ns dependency graph. Bundled modules with no transitive path (`phel.async`, `phel.html`, `phel.json`, ...) were never registered, so fully qualified references like `phel.async/delay` in a `.cljc` test file failed with `[PHEL001] Cannot resolve symbol 'phel.async/delay'` unless the file added a literal `(:require phel.async)`.

#1806 patched the symptom for REPL via a targeted `(:require phel.async)` in `startup.phel`. As [@jasalt pointed out](https://github.com/phel-lang/phel-lang/issues/1805#issuecomment-4357923343), that hard-codes one bundled module while leaving the rest broken and hides Phel's real namespace-loading semantics. The same comment also flagged that the `phel test` runner still failed even after #1806 (see [the failing CI run](https://github.com/phel-lang/clojure-test-suite/actions/runs/25184635701/job/73838597025#step:7:24) where `phel.async/delay` blocks `portability.cljc`, which then cascades into `p/thrown?` resolution failures across `string_test/*`).

## 💡 Goal

Make every bundled `phel.*` module FQN-resolvable in REPL, `phel eval`, and `phel test` — without forcing user code to spell out a `(:require ...)` for each one — and replace the targeted async-only hack with a single, general mechanism.

## 🔖 Changes

- New `Phel\Run\Application\BundledNamespaces`: scans `phel.*` namespaces across `getSourceDirectories` + `getVendorSourceDirectories` (so it covers Phel's own bundled stdlib and any installed Phel composer package).
- `NamespaceLoader::loadPhelNamespaces` (REPL/eval) seeds dependency resolution with the startup ns + `phel.core` + every bundled `phel.*` module. After the eval loop it restores the startup namespace via `GlobalEnvironmentSingleton::setNs` since each loaded module switches the global ns on evaluation.
- `NamespaceCollector::getDependenciesFromPaths` (test runner) seeds the same bundled set alongside the user test namespaces; deduplicated before passing to `BuildFacade`.
- `RunFactory` wires `BundledNamespaces` into both consumers.
- `src/php/Run/Domain/Repl/startup.phel`: drops the targeted `(:require phel.async)` from #1806; the general seeding subsumes it.
- `src/php/Run/CLAUDE.md`: documents the new class and the ns-restore step.
- Tests:
  - `tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php`: rewritten to cover the bundled-seed behavior (every `phel.*` ns seeded, non-`phel.*` filtered out, deduplication).
  - `tests/php/Integration/Run/Command/Eval/EvalCommandTest.php`: keeps the existing `phel.async/delay` regression and adds `phel.html/escape-html` and `phel.json/encode` FQN cases.
  - New `tests/php/Integration/Run/Command/Test/BundledNamespaceFqnRegression/BundledNamespaceFqnRegressionTest.php` over `tests/phel/test/phel-async-fqn-regression.phel`, which references `phel.async/delay`, `phel.html/escape-html`, `phel.json/encode` via FQN with no explicit require — the exact shape that fails today in `clojure-test-suite`.
- `CHANGELOG.md` under `## Unreleased` REPL + Test sections.