### PR TITLE
chore(tests): pre-clean stale build artefacts in PHPUnit bootstrap

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          backupGlobals="false"
          colors="true"
          defaultTestSuite="unit"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+(static function (): void {
+    $repoRoot = \dirname(__DIR__);
+
+    // Build artefacts a previously killed integration test may have left
+    // behind. While present, NamespaceFileGrouper sees a duplicate primary
+    // definition for `phel.core`, `phel.string`, `phel.pprint`, ... in the
+    // next run and writes a noisy warning to STDERR.
+    $staleDirs = [
+        $repoRoot . '/tests/php/Integration/Build/Command/out-load-e2e',
+    ];
+
+    foreach ($staleDirs as $dir) {
+        if (is_dir($dir)) {
+            removeDirectory($dir);
+        }
+    }
+})();
+
+function removeDirectory(string $target): void
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($target, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $file) {
+        $path = $file->getPathname();
+        is_dir($path) ? rmdir($path) : unlink($path);
+    }
+
+    rmdir($target);
+}


### PR DESCRIPTION
## 🤔 Background

`composer test-compiler` (and direct `phpunit` runs) sometimes prints duplicate-namespace warnings:

```
WARNING: Namespace 'phel.string' is defined in multiple locations:
  - /.../src/phel/string.phel
  - /.../tests/php/Integration/Build/Command/out-load-e2e/phel/string.phel
The last one will be used. Check your phel-config.php srcDirs/testDirs settings.
```

Root cause: `BuildCommandLoadE2ETest` writes its build output to `tests/php/Integration/Build/Command/out-load-e2e/`. The test's `setUp` / `tearDownAfterClass` wipe that directory, but only on a clean exit. After a killed run (Ctrl+C, crashed process, OS sleep), the artefacts stay on disk and the next `NamespaceFileGrouper` scan picks up two primary definitions for `phel.core`, `phel.string`, `phel.pprint`, ... so the warning fires every test run until somebody manually removes the directory.

## 💡 Goal

Make `composer test-compiler` quiet on a fresh clone and after a killed previous run, with no behavior change to the test or to `NamespaceFileGrouper` (real duplicates in user projects still warn).

## 🔖 Changes

- New `tests/bootstrap.php`: requires the Composer autoloader and wipes known stale artefact directories before any test executes.
- `phpunit.xml.dist`: point `bootstrap=` at the new file.

The artefact dir is gitignored (`tests/**/out/`), so wiping it is always safe; nothing committed lives there.

This covers both routes:
- `composer test-compiler` runs phpunit, loads bootstrap, cleans first.
- Direct `./vendor/bin/phpunit ...` follows the same path.

Verified locally:
- `composer test-compiler`: 2793 tests pass, no warnings.
- Manual repro (`mkdir -p .../out-load-e2e/phel && touch .../out-load-e2e/phel/string.phel`): next `phpunit` run wipes the dir before tests start, no warning.