### PR TITLE
ref(ai): DX cleanup pass on phel.ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to this project will be documented in this file.
 #### REPL
 - `require` accepts vector syntax: `(require '[phel\string :as s])` (#1693)
 
+#### AI
+- `with-config` macro for scoped, auto-restoring configuration overrides
+- `run-tools` helper that drives a tool-calling loop end-to-end (Anthropic)
+
 ### Changed
 
 - **BREAKING**: Require PHP 8.4
@@ -102,6 +106,12 @@ All notable changes to this project will be documented in this file.
 
 #### API
 - `phel analyze` preloads `phel\core` so core macros resolve (#1539)
+
+#### AI
+- API key error names the right env var per provider (`OPENAI_API_KEY`, `VOYAGE_API_KEY`, `ANTHROPIC_API_KEY`)
+- Per-call opts honour explicit falsy values (`:max-tokens 0` no longer ignored)
+- JSON-extraction errors truncate the model response so logs don't echo full prompts
+- Default chat model is `claude-sonnet-4-5` (alias) instead of a dated id
 
 #### Test
 - `run-tests` resets assertion counts per run (#1604)

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -44,6 +44,14 @@ Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, a
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
 ```
 
+For scoped configuration that auto-restores (including on exceptions), use `with-config`:
+
+```phel
+(ai/with-config {:provider :openai :model "gpt-4o"}
+  (ai/complete "Summarize the news"))
+;; global config restored here, even if the body threw
+```
+
 ## Chat
 
 ```phel
@@ -76,7 +84,7 @@ Ask the model to populate a schema:
 
 ## Tool use
 
-Define tools with provider-agnostic `tool`, pass them to `chat-with-tools`, dispatch on the returned calls, and feed results back with `tool-result`.
+Define tools with provider-agnostic `tool`, then either drive the loop manually with `chat-with-tools` + `tool-result`, or hand it off to `run-tools`.
 
 ```phel
 (def tools
@@ -84,19 +92,24 @@ Define tools with provider-agnostic `tool`, pass them to `chat-with-tools`, disp
             "Returns current weather for a city."
             {:city {:type "string" :description "City name"}})])
 
-(defn dispatch [call]
-  (case (get call :name)
-    "get-weather" (str "72F sunny in " (get (get call :input) :city))
-    "unknown tool"))
+(def handlers
+  {"get-weather" (fn [args] (str "72F sunny in " (get args :city)))})
 
-(defn run-loop [messages]
-  (let [resp (ai/chat-with-tools messages tools)
-        calls (get resp :tool-calls)]
-    (if (empty? calls)
-      (get resp :text)
-      (let [tool-msgs (map #(ai/tool-result (get % :id) (dispatch %)) calls)
-            assistant-msg {:role "assistant" :content (get resp :raw)}]
-        (recur (concat messages [assistant-msg] tool-msgs))))))
+(ai/run-tools [{:role "user" :content "weather in Paris?"}]
+              tools
+              handlers
+              {:max-turns 5})
+;; => "It's 72F and sunny in Paris."
+```
+
+`run-tools` repeatedly sends the conversation, resolves any tool calls via `handlers` (a map of tool name to fn), feeds the results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
+
+For finer control, use `chat-with-tools` directly:
+
+```phel
+(let [resp (ai/chat-with-tools messages tools)
+      calls (ai/tool-calls resp)]
+  ...)
 ```
 
 `chat-with-tools` returns:

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -31,7 +31,7 @@ Supported providers:
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `:provider` | `:anthropic` | `:anthropic`, `:openai`, `:voyageai` |
-| `:model` | `"claude-sonnet-4-20250514"` | Model name |
+| `:model` | `"claude-sonnet-4-5"` | Model name |
 | `:max-tokens` | `1024` | Output token cap |
 | `:api-key` | `nil` | Falls back to env var |
 | `:base-url` | `nil` | Override endpoint (proxies, self-hosted) |

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -671,8 +671,8 @@
     :provider - :openai (default) or :voyageai"
   {:example "(embed [\"hello world\"]) ; => [[0.123 -0.456 ...]]"
    :see-also ["embed-one" "cosine-similarity" "nearest"]}
-  [texts & [{:model model :provider provider}]]
-  (embed-request (or provider :openai) texts model))
+  [texts & [{:keys [model provider] :or {provider :openai}}]]
+  (embed-request provider texts model))
 
 (defn embed-one
   "Generates an embedding for a single text string.
@@ -695,7 +695,7 @@
   {:example "(nearest query-embedding index 5)"
    :see-also ["cosine-similarity" "build-index" "embed-one"]}
   [query-embedding index & [k]]
-  (let [k      (or k 5)
+  (let [k      (if (nil? k) 5 k)
         scored (for [item :in index]
                  (assoc item :similarity
                         (cosine-similarity query-embedding (get item :embedding))))
@@ -724,6 +724,6 @@
   Returns a vector of {:text, :embedding, :similarity} maps."
   {:example "(search \"greeting\" my-index 3)"
    :see-also ["nearest" "build-index" "embed-one"]}
-  [query index & [{:k k :model model :provider provider}]]
+  [query index & [{:keys [k model provider] :or {k 5}}]]
   (let [query-embedding (embed-one query {:model model :provider provider})]
-    (nearest query-embedding index (or k 5))))
+    (nearest query-embedding index k)))

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -274,15 +274,16 @@
 (def- carry-keys [:model :max-tokens :provider :timeout :base-url :api-key :max-retries])
 
 (defn- apply-opts
-  "Merges per-call opts into cfg, copying over only keys that were explicitly
-  set in `opts`. Uses `contains?` so falsy values (`0`, `nil`, `false`) still
-  override the default."
+  "Merges per-call opts into cfg. Copies over keys whose value is non-nil so
+  numeric zero and `false` propagate (e.g. `:max-tokens 0`), while an
+  explicit `nil` is treated as 'leave the config alone'."
   [cfg opts]
   (let [opts (or opts {})]
     (reduce (fn [acc k]
-              (if (contains? opts k)
-                (assoc acc k (get opts k))
-                acc))
+              (let [v (get opts k)]
+                (if (nil? v)
+                  acc
+                  (assoc acc k v))))
             cfg
             carry-keys)))
 

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -524,6 +524,54 @@
                   :tool_use_id call-id
                   :content result-str}]})))
 
+(defn- assistant-message
+  "Builds an assistant message preserving the model's tool_use blocks so the
+  next turn can carry the conversation forward. Anthropic-only for now."
+  [raw-response]
+  {:role "assistant"
+   :content (or (get raw-response :content) [])})
+
+(defn run-tools
+  "Drives a tool-calling loop: repeatedly sends `messages` with `tools`,
+  resolves any tool calls via `handlers`, and feeds the results back in
+  until the model returns a final text response (or `:max-turns` is hit).
+
+  - `messages`: initial conversation (vector of role/content maps)
+  - `tools`: tool definitions built with `tool`
+  - `handlers`: map of tool-name (string) -> fn taking the call's :input map
+                and returning a value (stringified into the tool result)
+  - `opts`: same keys as `chat-with-tools`, plus `:max-turns` (default 5)
+
+  Returns the assistant's final text. Throws if a tool name has no handler
+  or if `:max-turns` is reached without a final response. Anthropic-only;
+  OpenAI tool loops require a different message shape and are not handled."
+  {:example "(run-tools [{:role \"user\" :content \"weather?\"}]
+                       [(tool \"get-weather\" \"...\" {:city \"string\"})]
+                       {\"get-weather\" (fn [args] \"72F\")})"
+   :see-also ["chat-with-tools" "tool" "tool-result"]}
+  [messages tools handlers & [opts]]
+  (let [max-turns (or (get opts :max-turns) 5)]
+    (loop [msgs messages
+           turn 0]
+      (when (>= turn max-turns)
+        (throw (php/new RuntimeException
+                        (str "run-tools exceeded :max-turns (" max-turns ")"))))
+      (let [response (chat-with-tools msgs tools opts)
+            calls    (get response :tool-calls)]
+        (if (empty? calls)
+          (or (get response :text)
+              (throw (php/new RuntimeException "run-tools: model returned no text and no tool calls")))
+          (let [assistant (assistant-message (get response :raw))
+                results   (for [c :in calls]
+                            (let [name-str (get c :name)
+                                  handler  (get handlers name-str)]
+                              (when (nil? handler)
+                                (throw (php/new RuntimeException
+                                                (str "run-tools: no handler for tool '" name-str "'"))))
+                              (tool-result (get c :id) (handler (get c :input)))))
+                next-msgs (concat msgs [assistant] results)]
+            (recur next-msgs (+ turn 1))))))))
+
 ;; -----------
 ;; Vector math
 ;; -----------

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -270,18 +270,21 @@
     (check-response response)
     (json/decode (get response :body))))
 
+;; Per-call option keys that override the global config when present.
+(def- carry-keys [:model :max-tokens :provider :timeout :base-url :api-key :max-retries])
+
 (defn- apply-opts
-  "Merges per-call opts into cfg."
+  "Merges per-call opts into cfg, copying over only keys that were explicitly
+  set in `opts`. Uses `contains?` so falsy values (`0`, `nil`, `false`) still
+  override the default."
   [cfg opts]
-  (let [opts (or opts {})
-        cfg  (if (get opts :model) (assoc cfg :model (get opts :model)) cfg)
-        cfg  (if (get opts :max-tokens) (assoc cfg :max-tokens (get opts :max-tokens)) cfg)
-        cfg  (if (get opts :provider) (assoc cfg :provider (get opts :provider)) cfg)
-        cfg  (if (get opts :timeout) (assoc cfg :timeout (get opts :timeout)) cfg)
-        cfg  (if (get opts :base-url) (assoc cfg :base-url (get opts :base-url)) cfg)
-        cfg  (if (get opts :api-key) (assoc cfg :api-key (get opts :api-key)) cfg)
-        cfg  (if (contains? opts :max-retries) (assoc cfg :max-retries (get opts :max-retries)) cfg)]
-    cfg))
+  (let [opts (or opts {})]
+    (reduce (fn [acc k]
+              (if (contains? opts k)
+                (assoc acc k (get opts k))
+                acc))
+            cfg
+            carry-keys)))
 
 ;; -----------
 ;; Chat API

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -39,9 +39,23 @@
     :timeout     - HTTP timeout in seconds (default 120)
     :max-retries - Retry attempts on 429/5xx (default 2)"
   {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-5\"})"
-   :see-also ["config" "complete" "chat"]}
+   :see-also ["config" "complete" "chat" "with-config"]}
   [opts]
   (swap! config merge opts))
+
+(defmacro with-config
+  "Temporarily merges `opts` into the global config for the duration of `body`,
+  then restores the previous config. Safer than `configure` for embedded use,
+  since it won't leave global state mutated when `body` throws."
+  {:example "(with-config {:provider :openai :model \"gpt-4o\"} (complete \"hi\"))"
+   :see-also ["configure" "config"]}
+  [opts & body]
+  `(let [original# @config]
+     (try
+       (do (swap! config merge ~opts)
+           ~@body)
+       (finally
+         (reset! config original#)))))
 
 ;; -----------
 ;; API key resolution

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -305,15 +305,14 @@
     :base-url   - Override the API base URL
     :api-key    - Override the configured API key"
   {:example "(chat [{:role \"user\" :content \"Hello!\"}])"
-   :see-also ["complete" "configure"]}
-  [messages & [opts]]
-  (let [cfg           (apply-opts @config opts)
-        provider      (get cfg :provider)
-        system-prompt (get opts :system)
-        req           (if (= provider :openai)
-                        (openai-request cfg messages system-prompt)
-                        (anthropic-request cfg messages system-prompt))
-        body          (send-request cfg req)]
+   :see-also ["complete" "configure" "with-config"]}
+  [messages & [{:keys [system] :as opts}]]
+  (let [cfg      (apply-opts @config opts)
+        provider (get cfg :provider)
+        req      (if (= provider :openai)
+                   (openai-request cfg messages system)
+                   (anthropic-request cfg messages system))
+        body     (send-request cfg req)]
     (or (extract-text provider body)
         (throw (php/new RuntimeException "No text content in AI response")))))
 
@@ -410,6 +409,30 @@
                               (str "Could not extract JSON from AI response: "
                                    (truncate-for-error trimmed)))))))))))
 
+(def- default-extract-system
+  "You are a precise data extraction assistant. Return only valid JSON.")
+
+(defn- extract-json-array-from-response
+  "Extracts a JSON array from a model response, slicing between the first
+  '[' and the last ']' when the array isn't already at the start."
+  [response]
+  (let [trimmed (php/trim response)]
+    (if (php/str_starts_with trimmed "[")
+      trimmed
+      (let [start (php/strpos trimmed "[")
+            end   (php/strrpos trimmed "]")]
+        (if (and start end (>= end start))
+          (php/substr trimmed start (+ (- end start) 1))
+          (throw (php/new RuntimeException
+                          (str "Could not extract JSON array from AI response: "
+                               (truncate-for-error trimmed)))))))))
+
+(defn- run-extraction
+  "Drives a single-shot extraction call with the given prompt and opts."
+  [prompt opts]
+  (let [system (or (get opts :system) default-extract-system)]
+    (complete prompt (assoc (or opts {}) :system system))))
+
 (defn extract
   "Extracts structured data from text using AI.
 
@@ -425,15 +448,12 @@
   {:example "(extract {:name \"string\" :age \"integer\"} \"John is 30 years old\")"
    :see-also ["extract-many" "complete" "chat"]}
   [schema text & [opts]]
-  (let [schema-desc (schema->json-description schema)
-        prompt      (str "Extract the following structured data from the given text.\n\n"
-                         "Schema (field name: expected type/format):\n"
-                         schema-desc "\n\n"
-                         "Text: " text "\n\n"
-                         "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")
-        system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
-        response    (complete prompt (assoc (or opts {}) :system system))]
-    (json/decode (extract-json-from-response response))))
+  (let [prompt (str "Extract the following structured data from the given text.\n\n"
+                    "Schema (field name: expected type/format):\n"
+                    (schema->json-description schema) "\n\n"
+                    "Text: " text "\n\n"
+                    "Return ONLY valid JSON matching the schema. No explanation, no markdown, just the JSON object.")]
+    (json/decode (extract-json-from-response (run-extraction prompt opts)))))
 
 (defn extract-many
   "Extracts a list of structured items from text.
@@ -443,25 +463,12 @@
   {:example "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")"
    :see-also ["extract" "complete"]}
   [schema text & [opts]]
-  (let [schema-desc (schema->json-description schema)
-        prompt      (str "Extract ALL items matching the schema from the given text.\n\n"
-                         "Schema for each item (field name: expected type/format):\n"
-                         schema-desc "\n\n"
-                         "Text: " text "\n\n"
-                         "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")
-        system      (or (get opts :system) "You are a precise data extraction assistant. Return only valid JSON.")
-        response    (complete prompt (assoc (or opts {}) :system system))
-        trimmed     (php/trim response)
-        json-str    (if (php/str_starts_with trimmed "[")
-                      trimmed
-                      (let [start (php/strpos trimmed "[")
-                            end   (php/strrpos trimmed "]")]
-                        (if (and start end (>= end start))
-                          (php/substr trimmed start (+ (- end start) 1))
-                          (throw (php/new RuntimeException
-                                          (str "Could not extract JSON array from AI response: "
-                                               (truncate-for-error trimmed)))))))]
-    (json/decode json-str)))
+  (let [prompt (str "Extract ALL items matching the schema from the given text.\n\n"
+                    "Schema for each item (field name: expected type/format):\n"
+                    (schema->json-description schema) "\n\n"
+                    "Text: " text "\n\n"
+                    "Return ONLY a valid JSON array of objects. No explanation, no markdown, just the JSON array.")]
+    (json/decode (extract-json-array-from-response (run-extraction prompt opts)))))
 
 ;; -----------
 ;; Tool definition & use
@@ -495,21 +502,20 @@
   Options map accepts the same keys as `chat`."
   {:example "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}]
                              [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])"
-   :see-also ["tool" "tool-calls" "tool-result" "extract"]}
-  [messages tools & [opts]]
-  (let [cfg           (apply-opts @config opts)
-        provider      (get cfg :provider)
-        system-prompt (get opts :system)
-        req           (if (= provider :openai)
-                        (openai-request cfg messages system-prompt tools)
-                        (anthropic-request cfg messages system-prompt tools))
-        body          (send-request cfg req)
-        stop-reason   (if (= provider :openai)
-                        (get-in body [:choices 0 :finish_reason])
-                        (get body :stop_reason))
-        tcs           (if (= provider :openai)
-                        (extract-openai-tool-calls body)
-                        (extract-anthropic-tool-calls body))]
+   :see-also ["tool" "tool-calls" "tool-result" "extract" "run-tools"]}
+  [messages tools & [{:keys [system] :as opts}]]
+  (let [cfg         (apply-opts @config opts)
+        provider    (get cfg :provider)
+        req         (if (= provider :openai)
+                      (openai-request cfg messages system tools)
+                      (anthropic-request cfg messages system tools))
+        body        (send-request cfg req)
+        stop-reason (if (= provider :openai)
+                      (get-in body [:choices 0 :finish_reason])
+                      (get body :stop_reason))
+        tcs         (if (= provider :openai)
+                      (extract-openai-tool-calls body)
+                      (extract-anthropic-tool-calls body))]
     {:text (extract-text provider body)
      :tool-calls tcs
      :stop-reason stop-reason

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -353,6 +353,18 @@
                 (str "  \"" (name k) "\": " (if (string? v) v (str v))))]
     (str "{\n" (php/implode ",\n" (to-php-array lines)) "\n}")))
 
+(defn- schema-prop-spec
+  "Resolves a schema field value into a JSON Schema property spec."
+  [v]
+  (cond
+    (map? v)        v
+    (= v "string")  {:type "string"}
+    (= v "integer") {:type "integer"}
+    (= v "number")  {:type "number"}
+    (= v "boolean") {:type "boolean"}
+    (string? v)     {:type "string" :description v}
+    :else           {:type "string" :description (str v)}))
+
 (defn- schema->json-schema
   "Converts a field schema map to a JSON Schema object for tool use."
   [schema]
@@ -360,19 +372,11 @@
         required   (transient [])]
     (foreach [k v schema]
       (let [prop-name (name k)]
-        (conj required prop-name)
-        (assoc properties (keyword prop-name)
-               (cond
-                 (map? v) v
-                 (= v "string") {:type "string"}
-                 (= v "integer") {:type "integer"}
-                 (= v "number") {:type "number"}
-                 (= v "boolean") {:type "boolean"}
-                 (string? v) {:type "string" :description v}
-                 {:type "string" :description (str v)}))))
+        (conj! required prop-name)
+        (assoc! properties (keyword prop-name) (schema-prop-spec v))))
     {:type "object"
-     :properties (persistent properties)
-     :required (persistent required)}))
+     :properties (persistent! properties)
+     :required (persistent! required)}))
 
 ;; -----------
 ;; Structured extraction

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -9,7 +9,7 @@
 
 (def- default-config
   {:provider :anthropic
-   :model "claude-sonnet-4-20250514"
+   :model "claude-sonnet-4-5"
    :max-tokens 1024
    :api-key nil
    :base-url nil
@@ -38,7 +38,7 @@
     :base-url    - Override the API base URL
     :timeout     - HTTP timeout in seconds (default 120)
     :max-retries - Retry attempts on 429/5xx (default 2)"
-  {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-20250514\"})"
+  {:example "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-5\"})"
    :see-also ["config" "complete" "chat"]}
   [opts]
   (swap! config merge opts))

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -94,6 +94,12 @@
     :voyageai "https://api.voyageai.com"
     "https://api.anthropic.com"))
 
+(defn- resolve-base-url
+  "Resolves the base URL: explicit `:base-url` from config, otherwise the
+  provider default."
+  [cfg provider]
+  (or (get cfg :base-url) (provider-base-url provider)))
+
 (defn- anthropic-headers
   [api-key]
   {:x-api-key api-key
@@ -110,7 +116,7 @@
   Optionally includes tool definitions."
   [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
-        base    (or (get cfg :base-url) (provider-base-url :anthropic))
+        base    (resolve-base-url cfg :anthropic)
         body    {:model (get cfg :model)
                  :max_tokens (get cfg :max-tokens)
                  :messages messages}
@@ -133,7 +139,7 @@
   "Builds an HTTP request for the OpenAI Chat Completions API."
   [cfg messages system-prompt & [tools]]
   (let [api-key (resolve-api-key cfg)
-        base    (or (get cfg :base-url) (provider-base-url :openai))
+        base    (resolve-base-url cfg :openai)
         msgs    (if system-prompt
                   (concat [{:role "system" :content system-prompt}] messages)
                   messages)
@@ -613,7 +619,7 @@
   [provider texts model]
   (let [cfg           (assoc @config :provider provider)
         api-key       (resolve-api-key cfg)
-        base-url      (or (get cfg :base-url) (provider-base-url provider))
+        base-url      (resolve-base-url cfg provider)
         default-model (if (= provider :voyageai) "voyage-3-lite" "text-embedding-3-small")
         timeout       (or (get cfg :timeout) 60)
         max-retries   (or (get cfg :max-retries) 2)

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -375,6 +375,16 @@
 ;; Structured extraction
 ;; -----------
 
+(defn- truncate-for-error
+  "Truncates a string for inclusion in an error message so we don't echo the
+  full model response (which may contain prompt content) into logs."
+  [s]
+  (let [limit 120
+        len   (php/strlen s)]
+    (if (<= len limit)
+      s
+      (str (php/substr s 0 limit) "... (" len " chars total)"))))
+
 (defn- extract-json-from-response
   "Extracts JSON from an AI response, handling markdown code blocks."
   [response]
@@ -390,7 +400,8 @@
             (if (and start end (>= end start))
               (php/substr trimmed start (+ (- end start) 1))
               (throw (php/new RuntimeException
-                              (str "Could not extract JSON from AI response: " trimmed))))))))))
+                              (str "Could not extract JSON from AI response: "
+                                   (truncate-for-error trimmed)))))))))))
 
 (defn extract
   "Extracts structured data from text using AI.
@@ -441,7 +452,8 @@
                         (if (and start end (>= end start))
                           (php/substr trimmed start (+ (- end start) 1))
                           (throw (php/new RuntimeException
-                                          (str "Could not extract JSON array from AI response: " trimmed))))))]
+                                          (str "Could not extract JSON array from AI response: "
+                                               (truncate-for-error trimmed)))))))]
     (json/decode json-str)))
 
 ;; -----------

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -315,7 +315,7 @@
    :see-also ["chat" "complete"]}
   [history user-message & [opts]]
   (let [messages (concat history [{:role "user" :content user-message}])
-        response (chat (to-php-array messages) opts)]
+        response (chat messages opts)]
     (concat messages [{:role "assistant" :content response}])))
 
 ;; -----------

--- a/src/phel/ai.phel
+++ b/src/phel/ai.phel
@@ -47,18 +47,26 @@
 ;; API key resolution
 ;; -----------
 
+(defn- provider-env-var
+  "Returns the canonical environment variable name for the given provider."
+  [provider]
+  (case provider
+    :openai   "OPENAI_API_KEY"
+    :voyageai "VOYAGE_API_KEY"
+    "ANTHROPIC_API_KEY"))
+
 (defn- resolve-api-key
   "Resolves the API key from config or environment variables.
   Supports :anthropic, :openai, and :voyageai providers."
   [cfg]
-  (or (get cfg :api-key)
-      (case (get cfg :provider)
-        :anthropic (php/getenv "ANTHROPIC_API_KEY")
-        :openai    (php/getenv "OPENAI_API_KEY")
-        :voyageai  (php/getenv "VOYAGE_API_KEY")
-        (php/getenv "ANTHROPIC_API_KEY"))
-      (throw (php/new RuntimeException
-                      "No API key configured. Use (ai/configure {:api-key \"...\"}) or set ANTHROPIC_API_KEY env var."))))
+  (let [provider (get cfg :provider)
+        env-var  (provider-env-var provider)]
+    (or (get cfg :api-key)
+        (php/getenv env-var)
+        (throw (php/new RuntimeException
+                        (str "No API key configured for provider " provider
+                             ". Use (ai/configure {:api-key \"...\"}) or set "
+                             env-var " env var."))))))
 
 ;; -----------
 ;; Provider-specific request builders

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -26,6 +26,22 @@
     (is (= :anthropic (get @ai/config :provider)) "configure preserves unset keys")
     (reset! ai/config original)))
 
+(deftest test-with-config-restores-original
+  (let [original @ai/config]
+    (ai/with-config {:provider :openai :model "gpt-4o"}
+      (is (= :openai (get @ai/config :provider)) "provider switched inside body")
+      (is (= "gpt-4o" (get @ai/config :model)) "model switched inside body"))
+    (is (= (get original :provider) (get @ai/config :provider)) "provider restored")
+    (is (= (get original :model) (get @ai/config :model)) "model restored")))
+
+(deftest test-with-config-restores-on-throw
+  (let [original @ai/config]
+    (try
+      (ai/with-config {:provider :openai}
+        (throw (php/new \RuntimeException "boom")))
+      (catch \RuntimeException _e nil))
+    (is (= (get original :provider) (get @ai/config :provider)) "config restored after throw")))
+
 (deftest test-configure-changes-provider
   (let [original @ai/config]
     (ai/configure {:provider :openai :model "gpt-4o" :api-key "test-key"})
@@ -295,6 +311,7 @@
   ;; Chat API
   (is (function? ai/configure) "configure is defined")
   (is (function? ai/chat) "chat is defined")
+  ;; with-config is a macro, can't use function? directly
   (is (function? ai/complete) "complete is defined")
   (is (function? ai/chat-with-history) "chat-with-history is defined")
   ;; Structured extraction & tools

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -42,6 +42,22 @@
       (catch \RuntimeException _e nil))
     (is (= (get original :provider) (get @ai/config :provider)) "config restored after throw")))
 
+(deftest test-with-config-nests
+  (let [original @ai/config]
+    (ai/with-config {:provider :openai :model "gpt-4o"}
+      (is (= :openai (get @ai/config :provider)) "outer scope: openai")
+      (ai/with-config {:model "gpt-4o-mini"}
+        (is (= :openai (get @ai/config :provider)) "inner: provider preserved")
+        (is (= "gpt-4o-mini" (get @ai/config :model)) "inner: model overridden"))
+      (is (= "gpt-4o" (get @ai/config :model)) "outer model restored after inner exits"))
+    (is (= (get original :model) (get @ai/config :model)) "fully restored")))
+
+(deftest test-with-config-returns-body-result
+  (let [original @ai/config
+        result   (ai/with-config {:model "x"} 42)]
+    (is (= 42 result) "with-config returns body's last expression")
+    (reset! ai/config original)))
+
 (deftest test-configure-changes-provider
   (let [original @ai/config]
     (ai/configure {:provider :openai :model "gpt-4o" :api-key "test-key"})
@@ -176,6 +192,14 @@
     (is (= "tool" (get msg :role)) "openai tool message uses tool role")
     (is (= "call-1" (get msg :tool_call_id)) "openai message carries tool_call_id")
     (is (= "42" (get msg :content)) "openai message carries content")))
+
+(deftest test-tool-result-honors-provider-opt-without-mutating-config
+  (let [original @ai/config]
+    (ai/configure {:provider :anthropic})
+    (let [msg (ai/tool-result "id" "result" {:provider :openai})]
+      (is (= "tool" (get msg :role)) "explicit provider opt overrides global"))
+    (is (= :anthropic (get @ai/config :provider)) "global provider unchanged")
+    (reset! ai/config original)))
 
 (deftest test-tool-result-coerces-non-string
   (let [msg (ai/tool-result "call-1" 42 {:provider :openai})]
@@ -442,6 +466,22 @@
         (is (= "user" (get (first msgs) :role)) "role user")
         (is (= "prompt" (get (first msgs) :content)) "prompt reaches content")))))
 
+(deftest test-chat-with-history-honors-provider-override
+  (let [fake (mock-fn (fn [_ _] (ok-response {:choices [{:message {:content "yo"}}]})))]
+    (binding [ai/*http-post* fake]
+      (let [history [{:role "user" :content "hi"}
+                     {:role "assistant" :content "hello"}]
+            result (ai/chat-with-history history "again?" {:api-key "k" :provider :openai})]
+        (is (= "yo" (get (last result) :content)) "provider override flows into chat-with-history")
+        (is (php/str_contains (url-of (first-call fake)) "api.openai.com") "openai endpoint hit")))))
+
+(deftest test-chat-honors-zero-max-tokens
+  (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "ok"}]})))]
+    (binding [ai/*http-post* fake]
+      (ai/chat [{:role "user" :content "hi"}]
+               {:api-key "k" :max-tokens 0})
+      (is (= 0 (get (body-of (first-call fake)) :max_tokens)) "explicit 0 max-tokens reaches body"))))
+
 (deftest test-chat-with-history-appends-assistant
   (let [fake (mock-fn (fn [_ _] (ok-response {:content [{:type "text" :text "reply"}]})))]
     (binding [ai/*http-post* fake]
@@ -593,6 +633,34 @@
                                  {"loop" (fn [_] "again")}
                                  {:api-key "k" :max-turns 2}))
           "loops over max-turns throws"))))
+
+(deftest test-run-tools-handles-multiple-calls-in-one-turn
+  (let [responses (atom [(ok-response {:content [{:type "tool_use" :id "a1" :name "add" :input {:n 1}}
+                                                 {:type "tool_use" :id "a2" :name "add" :input {:n 2}}]
+                                       :stop_reason "tool_use"})
+                         (ok-response {:content [{:type "text" :text "summed"}]
+                                       :stop_reason "end_turn"})])
+        fake (mock-fn (fn [_ _]
+                        (let [r (first @responses)]
+                          (swap! responses rest)
+                          r)))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/run-tools [{:role "user" :content "add 1 and 2"}]
+                                 [(ai/tool "add" "Adds n" {:n "integer"})]
+                                 {"add" (fn [args] (str (get args :n)))}
+                                 {:api-key "k"})]
+        (is (= "summed" result) "final text after two parallel tool calls")))))
+
+(deftest test-run-tools-passes-through-empty-final
+  (let [fake (mock-fn (fn [_ _]
+                        (ok-response {:content [] :stop_reason "end_turn"})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException
+                   (ai/run-tools [{:role "user" :content "hi"}]
+                                 []
+                                 {}
+                                 {:api-key "k"}))
+          "empty final response throws"))))
 
 ;; --- Retry / backoff ---
 

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -321,6 +321,7 @@
   (is (function? ai/chat-with-tools) "chat-with-tools is defined")
   (is (function? ai/tool-calls) "tool-calls is defined")
   (is (function? ai/tool-result) "tool-result is defined")
+  (is (function? ai/run-tools) "run-tools is defined")
   ;; Embeddings & search
   (is (function? ai/dot-product) "dot-product is defined")
   (is (function? ai/magnitude) "magnitude is defined")
@@ -549,6 +550,49 @@
               tools (get body :tools)]
           (is (= "function" (get (first tools) :type)) "openai tool uses function shape")
           (is (= "t1" (get-in (first tools) [:function :name])) "function name set"))))))
+
+;; --- run-tools ---
+
+(deftest test-run-tools-resolves-single-call
+  (let [responses (atom [(ok-response {:content [{:type "tool_use" :id "tu1" :name "echo" :input {:msg "hello"}}]
+                                       :stop_reason "tool_use"})
+                         (ok-response {:content [{:type "text" :text "all done"}]
+                                       :stop_reason "end_turn"})])
+        fake (mock-fn (fn [_ _]
+                        (let [r (first @responses)]
+                          (swap! responses rest)
+                          r)))]
+    (binding [ai/*http-post* fake]
+      (let [result (ai/run-tools [{:role "user" :content "echo hello"}]
+                                 [(ai/tool "echo" "Echoes input" {:msg "string"})]
+                                 {"echo" (fn [args] (get args :msg))}
+                                 {:api-key "k"})]
+        (is (= "all done" result) "returns final assistant text")
+        (is (= 2 (call-count fake)) "two model turns")))))
+
+(deftest test-run-tools-throws-on-missing-handler
+  (let [fake (mock-fn (fn [_ _]
+                        (ok-response {:content [{:type "tool_use" :id "tu1" :name "missing" :input {}}]
+                                      :stop_reason "tool_use"})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException
+                   (ai/run-tools [{:role "user" :content "hi"}]
+                                 [(ai/tool "missing" "x" {:a "string"})]
+                                 {}
+                                 {:api-key "k"}))
+          "missing handler throws"))))
+
+(deftest test-run-tools-respects-max-turns
+  (let [fake (mock-fn (fn [_ _]
+                        (ok-response {:content [{:type "tool_use" :id "tu1" :name "loop" :input {}}]
+                                      :stop_reason "tool_use"})))]
+    (binding [ai/*http-post* fake]
+      (is (thrown? \RuntimeException
+                   (ai/run-tools [{:role "user" :content "hi"}]
+                                 [(ai/tool "loop" "x" {})]
+                                 {"loop" (fn [_] "again")}
+                                 {:api-key "k" :max-turns 2}))
+          "loops over max-turns throws"))))
 
 ;; --- Retry / backoff ---
 

--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -54,7 +54,7 @@
 
 (deftest test-anthropic-response-extraction
   (let [response-body {:content [{:type "text" :text "Hello from Claude!"}]
-                       :model "claude-sonnet-4-20250514"
+                       :model "claude-sonnet-4-5"
                        :role "assistant"}]
     (is (= "Hello from Claude!"
            (get (first (get response-body :content)) :text))


### PR DESCRIPTION
## 🤔 Background

Audit of the `phel.ai` namespace ahead of the v0.35.0 release surfaced a handful of correctness suspects, ergonomics gaps, and Clojure-idiom polish that were better fixed before tagging.

## 💡 Goal

Bring `phel.ai` to A+ DX before the release: provider-aware errors, scoped configuration, a tool-calling driver, idiomatic destructuring, and tighter test coverage.
