### PR TITLE
fix(phar): repair stdlib pre-compile + leak audit

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -31,6 +31,7 @@ final class PharBuilder
         'tests', 'Tests', 'test', 'Test',
         'docker', 'benchmarks', 'bench',
         'local', 'build', 'tools', 'resources', 'examples', 'fixtures', 'out',
+        'data', 'node_modules', 'var',
         '.phel-cache', '.phpunit.cache',
     ];
 
@@ -444,19 +445,26 @@ final class PharBuilder
             $basename = $current->getBasename();
 
             if ($current->isDir()) {
-                if (!isset($excludeDirMap[$basename])) {
-                    return true;
-                }
-
-                // Directories under /src/ are first-party source trees and must
-                // never be filtered out by generic excludes like 'test'/'Test'.
-                // Examples: src/phel/test/ (stdlib), src/php/Run/Domain/Test/ (PHP classes).
                 $relative = str_replace('\\', '/', substr($current->getPathname(), $rootLen));
-                if (str_starts_with($relative, '/src/')) {
-                    return true;
+
+                if (isset($excludeDirMap[$basename])) {
+                    // Directories under /src/ are first-party source trees and must
+                    // never be filtered out by generic excludes like 'test'/'Test'.
+                    // Examples: src/phel/test/ (stdlib), src/php/Run/Domain/Test/ (PHP classes).
+                    return str_starts_with($relative, '/src/');
                 }
 
-                return false;
+                // Default-deny unknown hidden directories anywhere outside /src/
+                // and /vendor/ to stop tooling caches (e.g. /.foo, /var/folders/.../T)
+                // from leaking into the PHAR.
+                if ($basename !== '' && $basename[0] === '.'
+                    && !str_starts_with($relative, '/src/')
+                    && !str_starts_with($relative, '/vendor/')
+                ) {
+                    return false;
+                }
+
+                return true;
             }
 
             if (isset($excludeFiles[$basename])) {

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -203,9 +203,15 @@ final class PharBuilder
             mkdir($compiledDir, 0755, true);
         }
 
-        // Copy only stdlib compiled files (phel_* prefix)
-        $compiledFiles = glob($tempCacheDir . '/compiled/phel_*');
-        if ($compiledFiles === false) {
+        // Copy only stdlib compiled files. Cache filenames use the canonical
+        // dot-separated namespace prefix since #1798 (e.g. `phel.core__abc.php`),
+        // so match both the legacy underscore prefix and the current dotted one.
+        $compiledFiles = array_merge(
+            glob($tempCacheDir . '/compiled/phel.*') ?: [],
+            glob($tempCacheDir . '/compiled/phel_*') ?: [],
+        );
+        if ($compiledFiles === []) {
+            echo "⚠️  No compiled phel.* / phel_* files found in {$tempCacheDir}/compiled\n";
             return;
         }
 
@@ -224,7 +230,7 @@ final class PharBuilder
             if (\is_array($indexData) && isset($indexData['entries'])) {
                 $stdlibEntries = [];
                 foreach ($indexData['entries'] as $namespace => $entry) {
-                    if (str_starts_with($namespace, 'phel\\')) {
+                    if (str_starts_with($namespace, 'phel.') || str_starts_with($namespace, 'phel\\')) {
                         // Rewrite compiled_path to be relative to phar cache dir
                         $entry['compiled_path'] = $compiledDir . '/' . basename($entry['compiled_path']);
                         // Drop wall-clock timestamps so the index is deterministic

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -360,12 +360,14 @@ final class PharBuilder
             return false;
         }
 
-        if (!is_dir($compiledDir) && !mkdir($compiledDir, 0o755, true) && !is_dir($compiledDir)) {
+        $cached = glob($bucket . '/compiled/*') ?: [];
+        if ($cached === []) {
+            // Empty bucket means an earlier build wrote the index without any
+            // compiled files. Treat it as a miss and force a rebuild.
             return false;
         }
 
-        $cached = glob($bucket . '/compiled/*');
-        if ($cached === false) {
+        if (!is_dir($compiledDir) && !mkdir($compiledDir, 0o755, true) && !is_dir($compiledDir)) {
             return false;
         }
 
@@ -388,13 +390,19 @@ final class PharBuilder
             return;
         }
 
+        $files = glob($compiledDir . '/*') ?: [];
+        if ($files === []) {
+            // Refuse to persist an empty bucket — a future restore would think
+            // it succeeded and ship a PHAR without any compiled stdlib.
+            return;
+        }
+
         $bucket = $this->stdlibCacheDir . '/' . $hash;
         $bucketCompiled = $bucket . '/compiled';
         if (!is_dir($bucketCompiled) && !mkdir($bucketCompiled, 0o755, true) && !is_dir($bucketCompiled)) {
             return;
         }
 
-        $files = glob($compiledDir . '/*') ?: [];
         foreach ($files as $file) {
             @copy($file, $bucketCompiled . '/' . basename($file));
         }

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -531,14 +531,16 @@ EOF;
     }
 
     /**
-     * Compress the PHAR archive
+     * Compress the PHAR archive. Compression is optional, but record the
+     * failure in stats.errors so the build report surfaces the warning
+     * instead of silently shipping an uncompressed PHAR.
      */
     private function compressPhar(Phar $phar): void
     {
         try {
             $phar->compressFiles(Phar::GZ);
         } catch (Exception $e) {
-            // Compression is optional, silently skip if not available
+            $this->stats['errors'][] = "compressFiles failed: {$e->getMessage()}";
         }
     }
 

--- a/build/phar.sh
+++ b/build/phar.sh
@@ -119,6 +119,7 @@ rsync -a "$REPO_ROOT/" "$WORK_DIR/" \
   --exclude='out' \
   --exclude='local' \
   --exclude='node_modules' \
+  --exclude='var' \
   --delete
 
 # ============================================================================


### PR DESCRIPTION
## 🤔 Background

Auditing the PHAR build before tagging v0.35.0 surfaced four bugs: the most important one was that the shipped PHAR has been booting without any pre-compiled stdlib since the dot-canonical namespace rename merged on main, plus a stale `var/folders/.../T/phel-gacela/` directory was leaking into the archive.

## 💡 Goal

Make the release-time PHAR contain only what users need (no caches, no temp files), and make sure stdlib pre-compilation actually populates `cache/compiled/`.

## 🔖 Changes

One commit per finding so they can be reviewed independently.

- `fix(phar): match dot-canonical phel.* cache filenames in pre-compile` — `glob('phel_*')` matched 0 files since #1798 renamed the cache layout to dotted namespaces. Glob both `phel.*` and `phel_*` and warn when neither matches.
- `fix(phar): treat empty stdlib cache bucket as miss` — a bucket with a valid `compiled-index.php` but an empty `compiled/` directory used to short-circuit the rebuild. Skip restore when the bucket has zero files, and refuse to persist an empty bucket in the first place.
- `fix(phar): exclude var/data/node_modules and default-deny hidden dirs` — added `var`, `data`, `node_modules` to the exclude list and made the directory filter default-deny any unknown dot-prefixed dir outside `/src` and `/vendor` so future tooling caches don't leak in.
- `ref(phar): surface compressFiles errors in build report` — silent catch replaced with a `stats.errors` entry.

## ✅ Verification

Local build before fix:

```
Files Added: 1410
cache/: 1
var/folders/.../T/phel-gacela/: 3   ← leak
```

Local build after fix:

```
Files Added: 1528
cache/: 121   ← stdlib pre-compiled
var/: gone
```

PHAR smoke tests:

```
$ ./build/out/phel.phar --version
Phel v0.34.1

$ echo "(println (map inc [1 2 3]))" | ./build/out/phel.phar repl
@[2 3 4]
```

`composer test-compiler`: 2793 / 0 / 0 (3 skipped).