### PR TITLE
fix(phar): polish + correctness pass on build script

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -550,7 +550,10 @@ EOF;
     {
         try {
             $phar->compressFiles(Phar::GZ);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
+            // Catch Throwable, not just Exception, because PHP 8.x can raise
+            // BadMethodCallException, ValueError, or PharException variants
+            // depending on the underlying gzip support.
             $this->stats['errors'][] = "compressFiles failed: {$e->getMessage()}";
         }
     }

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -319,6 +319,9 @@ final class PharBuilder
 
         if (!empty($this->stats['errors'])) {
             $report .= '⚠️  Warnings:           ' . \count($this->stats['errors']) . "\n";
+            foreach ($this->stats['errors'] as $message) {
+                $report .= "   • {$message}\n";
+            }
         }
 
         return $report;

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -156,7 +156,10 @@ final class PharBuilder
         $compiledDir = $cacheDir . '/compiled';
         $outDir = $this->root . '/out';
 
-        // Clean previous compiled cache to avoid stale entries
+        // Clean previous compiled cache to avoid stale entries. Wipe both the
+        // compiled/ files and the sibling compiled-index.php — leaving the
+        // index in place can fool the next run into seeing a populated cache
+        // that no longer points at real files.
         if (is_dir($compiledDir)) {
             $files = glob($compiledDir . '/*');
             if ($files !== false) {
@@ -164,6 +167,11 @@ final class PharBuilder
                     @unlink($file);
                 }
             }
+        }
+
+        $staleIndex = $cacheDir . '/compiled-index.php';
+        if (is_file($staleIndex)) {
+            @unlink($staleIndex);
         }
 
         $hash = $this->stdlibSourceHash();

--- a/build/phar.sh
+++ b/build/phar.sh
@@ -78,10 +78,10 @@ check_command "rsync"
 check_file "$BUILD_SCRIPT"
 check_dir "$REPO_ROOT"
 
-# Validate PHP version (minimum 7.4)
-php_version=$(php -r 'echo version_compare(PHP_VERSION, "7.4", ">=") ? "OK" : "FAIL";')
+# Validate PHP version against the project minimum declared in composer.json
+php_version=$(php -r 'echo version_compare(PHP_VERSION, "8.4", ">=") ? "OK" : "FAIL";')
 if [[ "$php_version" != "OK" ]]; then
-    error "PHP 7.4 or higher is required"
+    error "PHP 8.4 or higher is required"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## 🤔 Background

Second pass over `build/build-phar.php` and `build/phar.sh` after #1811 surfaced four smaller issues. Worth landing before tagging v0.35.0 so the release has a clean build.

## 💡 Goal

Tighten cache hygiene, match the documented PHP minimum, and surface warnings instead of silently swallowing them.

## 🔖 Changes

- `fix(phar): clean stale compiled-index.php during pre-compile reset` — `preCompileStdlib()` wiped `cache/compiled/*` but left `cache/compiled-index.php` in place, so a later run could see a populated index pointing at vanished files.
- `fix(phar): bump PHP minimum check from 7.4 to 8.4` — `composer.json` already requires `>=8.4`; the PHAR script's runtime guard still allowed 7.4 and would only fail later with confusing errors.
- `ref(phar): print collected warning messages in build report` — the report counted warnings but never echoed them, hiding silent `compressFiles` / `buildFromIterator` failures.
- `ref(phar): catch Throwable around compressFiles for PHP 8 errors` — PHP 8 raises `BadMethodCallException` / `ValueError` for some PHAR ops; switching from `Exception` to `Throwable` keeps the catch effective.

## ✅ Verification

```
$ OFFICIAL_RELEASE=true ./build/phar.sh
Files Added: 1528 | cache/: 121 | PHAR Size: 1.797 MB

$ echo "(println (apply + (range 1 11)))" | ./build/out/phel.phar repl
55
```