### PR TITLE
fix(phar): scope data/var/node_modules excludes to repo root only

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -31,8 +31,16 @@ final class PharBuilder
         'tests', 'Tests', 'test', 'Test',
         'docker', 'benchmarks', 'bench',
         'local', 'build', 'tools', 'resources', 'examples', 'fixtures', 'out',
-        'data', 'node_modules', 'var',
         '.phel-cache', '.phpunit.cache',
+    ];
+
+    /**
+     * Directories excluded only when they sit at the workdir root. Used for
+     * names that legitimately appear inside vendor packages — `data` (e.g.
+     * symfony/string/Resources/data) is the canonical example.
+     */
+    private array $excludeDirsAtRoot = [
+        'data', 'node_modules', 'var',
     ];
 
     private array $excludeFiles = [
@@ -441,6 +449,7 @@ final class PharBuilder
     private function addFiles(Phar $phar): void
     {
         $excludeDirMap = array_fill_keys($this->excludeDirs, true);
+        $excludeRootDirMap = array_fill_keys($this->excludeDirsAtRoot, true);
         $excludeFiles = $this->excludeFiles;
         $excludeExtensions = $this->excludeExtensions;
         $versionedDocPattern = $this->versionedDocPattern;
@@ -448,6 +457,7 @@ final class PharBuilder
 
         $filter = static function ($current) use (
             $excludeDirMap,
+            $excludeRootDirMap,
             $excludeFiles,
             $excludeExtensions,
             $versionedDocPattern,
@@ -457,6 +467,13 @@ final class PharBuilder
 
             if ($current->isDir()) {
                 $relative = str_replace('\\', '/', substr($current->getPathname(), $rootLen));
+
+                // Root-only excludes — match `data` at the workdir top level
+                // without breaking nested vendor dirs like
+                // vendor/symfony/string/Resources/data.
+                if (isset($excludeRootDirMap[$basename]) && $relative === '/' . $basename) {
+                    return false;
+                }
 
                 if (isset($excludeDirMap[$basename])) {
                     // Directories under /src/ are first-party source trees and must


### PR DESCRIPTION
## 🤔 Background

The release-time QA suite caught a regression introduced in #1811: `phel doc <symbol>` exits with `phar error: "vendor/symfony/string/Resources/data/wcswidth_table_zero.php" is not a file in phar`. The bundled PHAR was missing Symfony's wide/zero-width Unicode tables.

## 💡 Goal

Keep the new `data` / `var` / `node_modules` excludes (which were added to stop the top-level `data/` log dir and the macOS TMPDIR `var/` from leaking into the PHAR), without dropping legitimate vendor subdirectories that share those names.

## 🔖 Changes

- New `excludeDirsAtRoot` list for basenames that should only match the workdir root, not nested vendor packages.
- `addFiles` filter consults the root-only list before the generic basename map, so `vendor/symfony/string/Resources/data/` survives while `/data/log-junit.xml` is still pruned.

## ✅ Verification

```
$ OFFICIAL_RELEASE=true ./build/phar.sh
Files Added: 1674 (+146)
PHAR Size: 2.57 MB
Compression: 84.2%

$ ./build/out/phel.phar doc map        # was failing pre-fix
… renders the docs table cleanly …
```