### PR TITLE
feat!: enforce dynamic-only binding, add var-set/with-redefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this project will be documented in this file.
 - `find-var` returns the `Var` named by a fully-qualified symbol (#1717)
 - `var-get` accepts a `Var` instance in addition to a fully-qualified symbol (#1717)
 - `var?` predicate returns true on `Var` values (#1717)
+- `with-redefs` macro temporarily replaces the root values of vars (any var, dynamic or not) and restores them on exit, including on exceptions
+- `with-bindings` macro takes a map of `Var -> value` and rebinds dynamic vars for the body
+- `bound?` returns true when a var has a current root binding in the registry
+- `thread-bound?` returns true when a fiber-local frame currently overrides the var
+- `var-set` mutates the topmost active fiber-local binding frame for a var
 
 ### Changed
 
@@ -23,6 +28,12 @@ All notable changes to this project will be documented in this file.
 - `type` returns `:atom` for `atom` values; `:var` is now reserved for `Var` handles (#1717)
 - `alter-var-root` mutates the root binding of a `Var`; rejects atoms with a clear error pointing at `swap!` (#1717)
 - `deref` works on both atoms and `Var` instances (#1717)
+- `phel\mock`'s `with-mocks` and `with-mock-wrapper` now expand to `with-redefs` so they keep working when the target functions are not tagged `^:dynamic`
+
+### Breaking
+
+#### Core
+- `binding` throws `InvalidArgumentException` when any var in the bindings vector is not tagged `^:dynamic`. Previously it silently fell back to `with-redefs` semantics. Switch test mocks and other non-dynamic rebindings to `with-redefs`.
 
 ### Removed
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -90,11 +90,15 @@ final class Phel extends InternalPhel
 
     /**
      * Runtime target for the `set-var` special form. Routes by whether a
-     * `binding` macro is currently recording on the current fiber:
+     * `binding` / `with-redefs` macro is currently recording on the
+     * current fiber:
      *
-     *  - Recording + `:dynamic` var → stage into the pending fiber frame.
-     *  - Recording + non-dynamic var → record old value for with-redefs
-     *    restore, then mutate the registry.
+     *  - Recording in `binding` mode + `:dynamic` var → stage into the
+     *    pending fiber frame.
+     *  - Recording in `binding` mode + non-dynamic var → throw, pointing
+     *    callers at `with-redefs` for tests.
+     *  - Recording in `redefs` mode → record old value for restore, then
+     *    mutate the registry. Allowed for any var.
      *  - Not recording → plain registry mutation, as `set-var` always did.
      */
     public static function setVar(string $ns, string $name, mixed $value): mixed
@@ -103,11 +107,22 @@ final class Phel extends InternalPhel
         $scope = DynamicScope::getInstance();
 
         if ($scope->isRecording()) {
-            if (self::isDynamicVar($ns, $name)) {
+            $mode = $scope->currentRecordingMode();
+
+            if ($mode === DynamicScope::MODE_BINDING) {
+                if (!self::isDynamicVar($ns, $name)) {
+                    throw new InvalidArgumentException(\sprintf(
+                        "Can't dynamically bind non-dynamic var: %s/%s. Tag the def with ^:dynamic, or use `with-redefs` to rebind for tests.",
+                        $ns,
+                        $name,
+                    ));
+                }
+
                 $scope->recordDynamic($ns, $name, $value);
                 return $value;
             }
 
+            // MODE_REDEFS: capture previous value and fall through to mutate.
             $scope->recordRedef($ns, $name, $registry->getDefinition($ns, $name));
         }
 
@@ -116,13 +131,43 @@ final class Phel extends InternalPhel
     }
 
     /**
+     * Mutate the topmost active dynamic frame slot for the named var.
+     * Backing call for `var-set`. Throws when the var is not currently
+     * bound on the calling fiber's stack.
+     */
+    public static function varSet(string $ns, string $name, mixed $value): mixed
+    {
+        $scope = DynamicScope::getInstance();
+        if (!$scope->setBinding($ns, $name, $value)) {
+            throw new InvalidArgumentException(\sprintf(
+                "Can't change/establish root binding of %s/%s with var-set; no thread-local binding is active.",
+                $ns,
+                $name,
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
      * Open a pending fiber-local binding recording. The subsequent
      * `set-var` calls emitted by the `binding` macro feed into it, and
-     * {@see self::commitAndRunBindingFrame()} consumes it.
+     * {@see self::commitAndRunBindingFrame()} consumes it. Use
+     * {@see self::openRedefsFrame()} for `with-redefs`-style mutation.
      */
     public static function openBindingFrame(): void
     {
-        DynamicScope::getInstance()->startRecording();
+        DynamicScope::getInstance()->startRecording(DynamicScope::MODE_BINDING);
+    }
+
+    /**
+     * Open a pending fiber-local recording in `with-redefs` mode: any
+     * var (dynamic or not) may be re-bound, with the previous root
+     * captured for restore on exit.
+     */
+    public static function openRedefsFrame(): void
+    {
+        DynamicScope::getInstance()->startRecording(DynamicScope::MODE_REDEFS);
     }
 
     /**

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -3,6 +3,7 @@
 (use InvalidArgumentException)
 (use Phel)
 (use Phel.Lang.Collections.LazySeq.ChunkedSeq)
+(use Phel.Lang.DynamicScope)
 (use Phel.Lang.Equalizer)
 (use Phel.Lang.Hasher)
 (use Phel.Lang.PhelVar)
@@ -117,6 +118,45 @@
     (throw (php/new \InvalidArgumentException
                     "alter-var-root expects a Var as first argument; use swap! for atoms")))
   (php/-> v (alterRoot (fn [current] (apply f current args)))))
+
+(defn bound?
+  "Returns true when `v` has a current root binding in the namespace
+  registry. `v` must be a `Var`."
+  {:example "(bound? #'phel.core/map) ; => true"
+   :see-also ["thread-bound?" "var-get" "find-var"]}
+  [v]
+  (when-not (var? v)
+    (throw (php/new \InvalidArgumentException
+                    "bound? expects a Var as its argument")))
+  (php/:: Phel (isDefined (php/-> v (getNamespace))
+                          (php/-> v (getName)))))
+
+(defn thread-bound?
+  "Returns true when a fiber-local `binding` (or `with-bindings`) frame
+  currently overrides the value of `v` on the calling fiber."
+  {:example "(binding [*foo* 1] (thread-bound? #'*foo*)) ; => true"
+   :see-also ["bound?" "binding" "var-set"]}
+  [v]
+  (when-not (var? v)
+    (throw (php/new \InvalidArgumentException
+                    "thread-bound? expects a Var as its argument")))
+  (let [scope (php/:: DynamicScope (getInstance))]
+    (php/-> scope (hasBinding (php/-> v (getNamespace))
+                              (php/-> v (getName))))))
+
+(defn var-set
+  "Sets the value of the topmost active fiber-local binding frame for
+  `v` to `val`. Throws when no `binding` (or `with-bindings`) frame is
+  currently overriding `v`. Returns `val`."
+  {:example "(def ^:dynamic *x* 0)\n(binding [*x* 1] (var-set #'*x* 2) *x*) ; => 2"
+   :see-also ["binding" "thread-bound?" "alter-var-root"]}
+  [v val]
+  (when-not (var? v)
+    (throw (php/new \InvalidArgumentException
+                    "var-set expects a Var as its first argument")))
+  (php/:: Phel (varSet (php/-> v (getNamespace))
+                       (php/-> v (getName))
+                       val)))
 
 (defn remove-watch
   "Removes a watch function from a variable by key."

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -379,6 +379,29 @@
 ;; Binding
 ;; -------
 
+(defn- emit-set-vars
+  "Expands a `[v1 e1 v2 e2 ...]` binding vector into the sequence of
+  `(set-var v e)` forms consumed by an open binding/with-redefs frame."
+  [bindings]
+  (map (fn [pair]
+         (list 'set-var (php/aget pair 0) (php/aget pair 1)))
+       (php/array_chunk (apply php/array bindings) 2)))
+
+(defn- emit-binding-form
+  "Builds the open/try/commit/finally skeleton shared by `binding` and
+  `with-redefs`. `open-method` is the `\\Phel` static used to start the
+  fiber-local recording (`openBindingFrame` for dynamic-only,
+  `openRedefsFrame` for any var)."
+  [open-method bindings body]
+  `(do
+     (php/:: \Phel (~open-method))
+     (try
+       (do
+         ~@(emit-set-vars bindings)
+         (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
+       (finally
+         (php/:: \Phel (abortBindingFrameIfOpen))))))
+
 (defmacro binding
   "Temporarily rebinds dynamic vars while executing `body`.
 
@@ -391,18 +414,7 @@
   `:dynamic`. To swap a non-dynamic var for the duration of an
   expression (e.g. mocking in tests), use `with-redefs`."
   [bindings & body]
-  (let [pairs    (php/array_chunk (apply php/array bindings) 2)
-        set-vars (map (fn [pair]
-                        (list 'set-var (php/aget pair 0) (php/aget pair 1)))
-                      pairs)]
-    `(do
-       (php/:: \Phel (openBindingFrame))
-       (try
-         (do
-           ~@set-vars
-           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
-         (finally
-           (php/:: \Phel (abortBindingFrameIfOpen)))))))
+  (emit-binding-form 'openBindingFrame bindings body))
 
 (defmacro with-redefs
   "Temporarily replaces the root values of vars while executing `body`.
@@ -415,18 +427,7 @@
   production code. Use `binding` for fiber-local rebinding of
   `^:dynamic` vars."
   [bindings & body]
-  (let [pairs    (php/array_chunk (apply php/array bindings) 2)
-        set-vars (map (fn [pair]
-                        (list 'set-var (php/aget pair 0) (php/aget pair 1)))
-                      pairs)]
-    `(do
-       (php/:: \Phel (openRedefsFrame))
-       (try
-         (do
-           ~@set-vars
-           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
-         (finally
-           (php/:: \Phel (abortBindingFrameIfOpen)))))))
+  (emit-binding-form 'openRedefsFrame bindings body))
 
 (defmacro with-bindings
   "Like `binding` but takes a map of `Var -> value` instead of a binding

--- a/src/phel/core/io.phel
+++ b/src/phel/core/io.phel
@@ -380,15 +380,16 @@
 ;; -------
 
 (defmacro binding
-  "Temporarily rebinds vars while executing `body`.
+  "Temporarily rebinds dynamic vars while executing `body`.
 
-  Vars tagged `^:dynamic` use fiber-local storage: concurrent fibers
-  observe independent values and child futures (`future`, `async`,
-  `future-fiber`) inherit the bindings active at their creation.
+  Each var in `bindings` must be tagged `^:dynamic` at its `def`. The
+  rebinding is fiber-local: concurrent fibers observe independent
+  values, and child futures (`future`, `async`, `future-fiber`)
+  inherit the bindings active at their creation.
 
-  Non-dynamic vars fall back to `with-redefs`-style registry
-  mutation restored on exit — convenient for tests but shared
-  across fibers."
+  Throws at runtime if any var in the bindings vector is not
+  `:dynamic`. To swap a non-dynamic var for the duration of an
+  expression (e.g. mocking in tests), use `with-redefs`."
   [bindings & body]
   (let [pairs    (php/array_chunk (apply php/array bindings) 2)
         set-vars (map (fn [pair]
@@ -399,6 +400,51 @@
        (try
          (do
            ~@set-vars
+           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
+         (finally
+           (php/:: \Phel (abortBindingFrameIfOpen)))))))
+
+(defmacro with-redefs
+  "Temporarily replaces the root values of vars while executing `body`.
+
+  Accepts any var, dynamic or not. The previous root values are
+  captured before `body` runs and restored on exit, including when
+  `body` throws. The replacement is process-global: every fiber sees
+  the new root for the duration of the body, which makes this a
+  convenient mocking primitive for tests but unsafe for concurrent
+  production code. Use `binding` for fiber-local rebinding of
+  `^:dynamic` vars."
+  [bindings & body]
+  (let [pairs    (php/array_chunk (apply php/array bindings) 2)
+        set-vars (map (fn [pair]
+                        (list 'set-var (php/aget pair 0) (php/aget pair 1)))
+                      pairs)]
+    `(do
+       (php/:: \Phel (openRedefsFrame))
+       (try
+         (do
+           ~@set-vars
+           (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
+         (finally
+           (php/:: \Phel (abortBindingFrameIfOpen)))))))
+
+(defmacro with-bindings
+  "Like `binding` but takes a map of `Var -> value` instead of a binding
+  vector. Same dynamic-only enforcement: throws when any key resolves
+  to a non-dynamic var."
+  [m & body]
+  (let [m-sym (gensym "m__")
+        v-sym (gensym "v__")
+        x-sym (gensym "x__")]
+    `(let [~m-sym ~m]
+       (php/:: \Phel (openBindingFrame))
+       (try
+         (do
+           (foreach [~v-sym ~x-sym ~m-sym]
+             (php/:: \Phel
+                    (setVar (php/-> ~v-sym (getNamespace))
+                            (php/-> ~v-sym (getName))
+                            ~x-sym)))
            (php/:: \Phel (commitAndRunBindingFrame (fn [] ~@body))))
          (finally
            (php/:: \Phel (abortBindingFrameIfOpen)))))))

--- a/src/phel/mock.phel
+++ b/src/phel/mock.phel
@@ -177,7 +177,7 @@
 ;; -----------
 
 (defmacro with-mocks
-  "Temporarily replaces functions with mocks using binding.
+  "Temporarily replaces functions with mocks using `with-redefs`.
   Automatically resets mocks after the body executes.
 
   Works with inline mock creation:
@@ -206,7 +206,7 @@
         values    (take-nth 2 (drop 1 bindings))
         mock-syms (map (fn [_] (gensym "mock")) values)]
     `(let [~@(interleave mock-syms values)]
-       (binding [~@(interleave symbols mock-syms)]
+       (with-redefs [~@(interleave symbols mock-syms)]
          (try
            (do ~@body)
            (finally
@@ -239,7 +239,7 @@
         reset-forms  (map (fn [m] `(reset-mock! ~m)) mock-syms)]
     `(let [~@(interleave mock-syms mocks)
            ~@(interleave wrapper-syms wrappers)]
-       (binding [~@(interleave symbols wrapper-syms)]
+       (with-redefs [~@(interleave symbols wrapper-syms)]
          (try
            (do ~@body)
            (finally

--- a/src/php/Lang/DynamicScope.php
+++ b/src/php/Lang/DynamicScope.php
@@ -11,18 +11,23 @@ use WeakMap;
 use function array_key_exists;
 use function array_pop;
 use function array_reverse;
+use function count;
 
 /**
  * Fiber-local stack of dynamic bindings.
  *
- * Clojure's `binding` establishes thread-local values for vars tagged
- * `:dynamic`. In Phel we model that per-PHP-fiber: each fiber owns its
- * own LIFO stack of frames, and the main (non-fiber) context has its
- * own stack. This is the backing store for both the `binding` macro
- * and "binding conveyance" into `future`/`async` bodies.
+ * `binding` establishes thread-local values for vars tagged `:dynamic`.
+ * In Phel we model that per-PHP-fiber: each fiber owns its own LIFO
+ * stack of frames, and the main (non-fiber) context has its own stack.
+ * This is the backing store for both the `binding` macro and "binding
+ * conveyance" into `future`/`async` bodies.
  */
 final class DynamicScope
 {
+    public const string MODE_BINDING = 'binding';
+
+    public const string MODE_REDEFS = 'redefs';
+
     private static ?DynamicScope $instance = null;
 
     /**
@@ -37,14 +42,16 @@ final class DynamicScope
 
     /**
      * Per-fiber stack of "binding recordings" — a recording is opened
-     * when a `binding` macro starts and closed when it commits. Each
-     * entry: `['dynamic' => array<string,mixed>, 'redefs' => list<array{string,string,mixed}>]`.
+     * when a `binding` or `with-redefs` macro starts and closed when
+     * it commits. Each entry: `['mode' => 'binding'|'redefs',
+     * 'dynamic' => array<string,mixed>,
+     * 'redefs' => list<array{string,string,mixed}>]`.
      *
-     * @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     * @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
      */
     private array $mainRecordings = [];
 
-    /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> */
+    /** @var WeakMap<Fiber, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> */
     private WeakMap $fiberRecordings;
 
     private function __construct()
@@ -52,7 +59,7 @@ final class DynamicScope
         /** @var WeakMap<Fiber, list<array<string, mixed>>> $map */
         $map = new WeakMap();
         $this->fiberStacks = $map;
-        /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        /** @var WeakMap<Fiber, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
         $recMap = new WeakMap();
         $this->fiberRecordings = $recMap;
     }
@@ -69,7 +76,7 @@ final class DynamicScope
         /** @var WeakMap<Fiber, list<array<string, mixed>>> $map */
         $map = new WeakMap();
         $this->fiberStacks = $map;
-        /** @var WeakMap<Fiber, list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
+        /** @var WeakMap<Fiber, list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>> $recMap */
         $recMap = new WeakMap();
         $this->fiberRecordings = $recMap;
     }
@@ -77,16 +84,32 @@ final class DynamicScope
     /**
      * Open a new binding recording on the current fiber's stack.
      * Subsequent `recordDynamic` / `recordRedef` calls append to it
-     * until `popRecording` is called.
+     * until `popRecording` is called. The mode controls which kind of
+     * mutation is allowed: `binding` enforces `:dynamic`-only vars at
+     * the call site, `redefs` accepts any var.
      */
-    public function startRecording(): void
+    public function startRecording(string $mode = self::MODE_BINDING): void
     {
-        $this->pushRecording(['dynamic' => [], 'redefs' => []]);
+        $this->pushRecording(['mode' => $mode, 'dynamic' => [], 'redefs' => []]);
     }
 
     public function isRecording(): bool
     {
         return $this->currentRecordings() !== [];
+    }
+
+    /**
+     * Returns the mode of the topmost open recording, or null when
+     * nothing is being recorded on the current fiber.
+     */
+    public function currentRecordingMode(): ?string
+    {
+        $recordings = $this->currentRecordings();
+        if ($recordings === []) {
+            return null;
+        }
+
+        return $recordings[count($recordings) - 1]['mode'];
     }
 
     public function recordDynamic(string $ns, string $name, mixed $value): void
@@ -112,11 +135,11 @@ final class DynamicScope
     }
 
     /**
-     * @return array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}
+     * @return array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}
      */
     public function popRecording(): array
     {
-        return $this->popTopRecording() ?? ['dynamic' => [], 'redefs' => []];
+        return $this->popTopRecording() ?? ['mode' => self::MODE_BINDING, 'dynamic' => [], 'redefs' => []];
     }
 
     /**
@@ -202,6 +225,42 @@ final class DynamicScope
     }
 
     /**
+     * Mutate the topmost active frame slot for the given var. Returns
+     * true when a frame holding the slot was found and updated, false
+     * when no fiber-local frame currently overrides the var. Backing
+     * store for `var-set`.
+     */
+    public function setBinding(string $ns, string $name, mixed $value): bool
+    {
+        $fiber = Fiber::getCurrent();
+        $key = $ns . '/' . $name;
+
+        if (!$fiber instanceof Fiber) {
+            $updated = $this->writeTopmostFrame($this->mainStack, $key, $value);
+            if ($updated === null) {
+                return false;
+            }
+
+            $this->mainStack = $updated;
+            return true;
+        }
+
+        if (!isset($this->fiberStacks[$fiber])) {
+            return false;
+        }
+
+        /** @var list<array<string, mixed>> $stack */
+        $stack = $this->fiberStacks[$fiber];
+        $updated = $this->writeTopmostFrame($stack, $key, $value);
+        if ($updated === null) {
+            return false;
+        }
+
+        $this->fiberStacks[$fiber] = $updated;
+        return true;
+    }
+
+    /**
      * Flatten the current stack into a single map (innermost value wins).
      * Used for binding conveyance into futures.
      *
@@ -235,7 +294,7 @@ final class DynamicScope
     }
 
     /**
-     * @param array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>} $entry
+     * @param array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>} $entry
      */
     private function pushRecording(array $entry): void
     {
@@ -247,14 +306,14 @@ final class DynamicScope
             return;
         }
 
-        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
         $stack = $this->fiberRecordings[$fiber] ?? [];
         $stack[] = $entry;
         $this->fiberRecordings[$fiber] = $stack;
     }
 
     /**
-     * @return array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}|null
+     * @return array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}|null
      */
     private function popTopRecording(): ?array
     {
@@ -267,7 +326,7 @@ final class DynamicScope
             return null;
         }
 
-        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
         $stack = $this->fiberRecordings[$fiber];
         $entry = array_pop($stack);
         if ($stack === []) {
@@ -280,7 +339,7 @@ final class DynamicScope
     }
 
     /**
-     * @return list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
+     * @return list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}>
      */
     private function currentRecordings(): array
     {
@@ -289,7 +348,7 @@ final class DynamicScope
             return $this->mainRecordings;
         }
 
-        /** @var list<array{dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
+        /** @var list<array{mode: string, dynamic: array<string, mixed>, redefs: list<array{0: string, 1: string, 2: mixed}>}> $stack */
         $stack = $this->fiberRecordings[$fiber] ?? [];
         return $stack;
     }
@@ -307,5 +366,26 @@ final class DynamicScope
         /** @var list<array<string, mixed>> $stack */
         $stack = $this->fiberStacks[$fiber] ?? [];
         return $stack;
+    }
+
+    /**
+     * Walk the stack from top to bottom and return a new stack with the
+     * first frame holding `$key` mutated to `$value`. Returns null when
+     * no frame holds the key.
+     *
+     * @param list<array<string, mixed>> $stack
+     *
+     * @return list<array<string, mixed>>|null
+     */
+    private function writeTopmostFrame(array $stack, string $key, mixed $value): ?array
+    {
+        for ($i = count($stack) - 1; $i >= 0; --$i) {
+            if (array_key_exists($key, $stack[$i])) {
+                $stack[$i][$key] = $value;
+                return $stack;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -53,13 +53,21 @@
       (is (= :outer (deref ff))
           "future-fiber captures the caller's dynamic bindings"))))
 
-;; --- binding on a non-dynamic var still uses with-redefs semantics ---
+;; --- with-redefs handles non-dynamic vars; binding throws ---
 (def *not-dynamic* :root)
 
-(deftest test-binding-non-dynamic-var-legacy-redef
-  (binding [*not-dynamic* :rebound]
-    (is (= :rebound *not-dynamic*) "non-dynamic var is mutated in-place"))
-  (is (= :root *not-dynamic*) "non-dynamic var is restored on exit"))
+(deftest test-with-redefs-on-non-dynamic-var
+  (with-redefs [*not-dynamic* :rebound]
+    (is (= :rebound *not-dynamic*) "with-redefs mutates the root in-place"))
+  (is (= :root *not-dynamic*) "with-redefs restores the root on exit"))
+
+(deftest test-binding-on-non-dynamic-var-throws
+  (let [thrown? (try
+                  (binding [*not-dynamic* :rebound] :unreached)
+                  false
+                  (catch \Throwable _ true))]
+    (is thrown? "binding on a non-dynamic var raises an exception"))
+  (is (= :root *not-dynamic*) "non-dynamic var is left untouched after the failed bind"))
 
 ;; --- nil values in dynamic bindings ---
 (deftest test-binding-with-nil-value

--- a/tests/phel/test/core/binding-regression-1363.phel
+++ b/tests/phel/test/core/binding-regression-1363.phel
@@ -12,7 +12,7 @@
 ;;      parse cleanly because the selected branch wins and unselected branches
 ;;      are discarded.
 
-(def *x* :unset)
+(def ^:dynamic *x* :unset)
 
 (deftest binding-inside-is-compiles
   (is (binding [*x* :set] (= *x* :set))

--- a/tests/phel/test/core/binding.phel
+++ b/tests/phel/test/core/binding.phel
@@ -1,15 +1,40 @@
 (ns phel-test\test\core\binding
   (:require phel\test :refer [deftest is]))
 
-(def *my-binding-var* 1)
+(def ^:dynamic *my-binding-var* 1)
 
 (deftest test-binding
   (is (= 3 (binding [*my-binding-var* 2] (inc *my-binding-var*))) "binding inc")
   (is (= 1 *my-binding-var*) "binding is not changing the value"))
 
 (deftest test-binding-atom-body
-  (let [form (read-string "(do (def *my-binding-var* 1) (binding [*my-binding-var* 2] *my-binding-var*))")]
+  (let [form (read-string "(do (def ^:dynamic *my-binding-var* 1) (binding [*my-binding-var* 2] *my-binding-var*))")]
     (is (= 2 (eval form)) "binding atom")))
+
+(def *my-redef-target* 10)
+
+(deftest test-binding-on-non-dynamic-throws
+  (is (php/instanceof
+       (try
+         (binding [*my-redef-target* 99] :unreached)
+         nil
+         (catch \Throwable e e))
+       \InvalidArgumentException)
+      "binding rejects non-dynamic vars at runtime"))
+
+(deftest test-with-redefs-on-any-var
+  (with-redefs [*my-redef-target* 99]
+    (is (= 99 *my-redef-target*) "with-redefs swaps the root for any var"))
+  (is (= 10 *my-redef-target*) "with-redefs restores the root on exit"))
+
+(deftest test-with-redefs-restores-on-throw
+  (let [threw? (try
+                 (with-redefs [*my-redef-target* 42]
+                   (throw (php/new \RuntimeException "boom")))
+                 false
+                 (catch \Throwable _ true))]
+    (is threw? "with-redefs lets the body's exception propagate")
+    (is (= 10 *my-redef-target*) "with-redefs still restores after a thrown body")))
 
 (deftest test-atom
   (is (= :atom (type (atom 10))) "type of atom is :atom")

--- a/tests/phel/test/core/var-introspection.phel
+++ b/tests/phel/test/core/var-introspection.phel
@@ -1,0 +1,95 @@
+(ns phel-test\test\core\var-introspection
+  (:require phel\test :refer [deftest is]))
+
+;; Coverage for `bound?`, `thread-bound?`, `var-set`, `with-bindings`,
+;; and `with-redefs` introspection / mutation primitives.
+
+(def ^:dynamic *intro-dyn* :root)
+(def *intro-static* :static-root)
+
+;; ---- bound? -------------------------------------------------------------
+
+(deftest test-bound-true-on-defined-var
+  (is (true? (bound? #'*intro-dyn*)) "bound? true for a defined var")
+  (is (true? (bound? #'*intro-static*)) "bound? true for a static def")
+  (is (true? (bound? #'phel.core/map)) "bound? true on core defs"))
+
+(deftest test-bound-rejects-non-var
+  (is (php/instanceof
+       (try (bound? 42) nil (catch \Throwable e e))
+       \InvalidArgumentException)
+      "bound? throws on non-var input"))
+
+;; ---- thread-bound? -------------------------------------------------------
+
+(deftest test-thread-bound-false-outside-binding
+  (is (false? (thread-bound? #'*intro-dyn*))
+      "no thread-local frame outside binding"))
+
+(deftest test-thread-bound-true-inside-binding
+  (binding [*intro-dyn* :inside]
+    (is (true? (thread-bound? #'*intro-dyn*))
+        "thread-bound? true inside binding")))
+
+(deftest test-thread-bound-rejects-non-var
+  (is (php/instanceof
+       (try (thread-bound? :not-a-var) nil (catch \Throwable e e))
+       \InvalidArgumentException)
+      "thread-bound? throws on non-var input"))
+
+;; ---- var-set -------------------------------------------------------------
+
+(deftest test-var-set-mutates-active-binding
+  (binding [*intro-dyn* :first]
+    (is (= :first *intro-dyn*) "binding seeds the value")
+    (var-set #'*intro-dyn* :second)
+    (is (= :second *intro-dyn*) "var-set updates the active frame"))
+  (is (= :root *intro-dyn*) "root value is restored on exit"))
+
+(deftest test-var-set-returns-new-value
+  (binding [*intro-dyn* :a]
+    (is (= :b (var-set #'*intro-dyn* :b))
+        "var-set returns the value it stored")))
+
+(deftest test-var-set-without-binding-throws
+  (is (php/instanceof
+       (try (var-set #'*intro-dyn* :nope) nil (catch \Throwable e e))
+       \InvalidArgumentException)
+      "var-set outside any binding frame throws"))
+
+(deftest test-var-set-rejects-non-var
+  (is (php/instanceof
+       (try (var-set "string" 1) nil (catch \Throwable e e))
+       \InvalidArgumentException)
+      "var-set rejects non-var first arg"))
+
+;; ---- with-bindings -------------------------------------------------------
+
+(def ^:dynamic *intro-dyn-2* :root-2)
+
+(deftest test-with-bindings-rebinds-from-map
+  (with-bindings {#'*intro-dyn* :wb-a #'*intro-dyn-2* :wb-b}
+    (is (= :wb-a *intro-dyn*) "first var rebound")
+    (is (= :wb-b *intro-dyn-2*) "second var rebound"))
+  (is (= :root *intro-dyn*) "first var restored")
+  (is (= :root-2 *intro-dyn-2*) "second var restored"))
+
+(deftest test-with-bindings-throws-on-non-dynamic
+  (is (php/instanceof
+       (try
+         (with-bindings {#'*intro-static* :nope} :unreached)
+         nil
+         (catch \Throwable e e))
+       \InvalidArgumentException)
+      "with-bindings rejects non-dynamic vars")
+  (is (= :static-root *intro-static*)
+      "non-dynamic var left untouched after the failed with-bindings"))
+
+;; ---- with-redefs ---------------------------------------------------------
+
+(deftest test-with-redefs-rebinds-any-var
+  (with-redefs [*intro-static* :swapped *intro-dyn* :also-swapped]
+    (is (= :swapped *intro-static*) "with-redefs accepts non-dynamic vars")
+    (is (= :also-swapped *intro-dyn*) "with-redefs accepts dynamic vars too"))
+  (is (= :static-root *intro-static*) "static restored on exit")
+  (is (= :root *intro-dyn*) "dynamic restored on exit"))

--- a/tests/phel/test/mock.phel
+++ b/tests/phel/test/mock.phel
@@ -166,12 +166,12 @@
   "Simulates saving a user to database"
   (db user))
 
-(deftest test-mocking-with-binding
+(deftest test-mocking-with-redefs
   (let [mock-http (mock {:id 1 :name "Alice"})]
-    (binding [fetch-user (fn [_ id] (mock-http id))]
-             (let [result (fetch-user nil 123)]
-               (is (= {:id 1 :name "Alice"} result) "uses mocked response")
-               (is (called-with? mock-http 123) "verifies call arguments")))))
+    (with-redefs [fetch-user (fn [_ id] (mock-http id))]
+                 (let [result (fetch-user nil 123)]
+                   (is (= {:id 1 :name "Alice"} result) "uses mocked response")
+                   (is (called-with? mock-http 123) "verifies call arguments")))))
 
 (deftest test-with-mocks-macro
   (let [mock-http (mock {:status 200})
@@ -285,8 +285,8 @@
 
 (deftest test-email-sending-mock
   (let [mock-email (mock :sent)]
-    (binding [send-email (fn [_ to subject body] (mock-email to subject body))]
-             (register-user nil {:email "user@example.com"})
+    (with-redefs [send-email (fn [_ to subject body] (mock-email to subject body))]
+                 (register-user nil {:email "user@example.com"})
              (is (called-once? mock-email) "sends exactly one email")
              (is (called-with? mock-email "user@example.com" "Welcome!" "Thanks for signing up")
                  "sends correct email"))))
@@ -297,7 +297,7 @@
 
 (deftest test-api-failure-with-mock-throwing
   (let [mock-api (mock-throwing (php/new \RuntimeException "API unavailable"))]
-    (binding [fetch-from-api (fn [url] (mock-api url))]
+    (with-redefs [fetch-from-api (fn [url] (mock-api url))]
              (is (thrown? \RuntimeException (fetch-from-api "http://api.example.com"))
                  "throws when API fails")
              (is (called-with? mock-api "http://api.example.com") "attempted call with URL"))))
@@ -313,7 +313,7 @@
 
 (deftest test-retry-logic-with-mock-returning
   (let [mock-api (mock-returning [nil nil {:status 200}])]
-    (binding [fetch-from-api (fn [url]
+    (with-redefs [fetch-from-api (fn [url]
                                (let [result (mock-api url)]
                                  (when (nil? result)
                                    (throw (php/new \Exception "Failed")))
@@ -333,7 +333,7 @@
 (deftest test-mock-external-interop-function
   (let [mock-external (mock {:success true :data "mocked response"})]
     ;; Mock an external/foreign function by wrapping it
-    (binding [call-external-service (fn [_ endpoint] (mock-external endpoint))]
+    (with-redefs [call-external-service (fn [_ endpoint] (mock-external endpoint))]
              (let [result (call-external-service nil "/api/data")]
                (is (= {:success true :data "mocked response"} result) "returns mocked response")
                (is (called-with? mock-external "/api/data") "verifies external call was made")))))

--- a/tests/php/Unit/Lang/DynamicScopeTest.php
+++ b/tests/php/Unit/Lang/DynamicScopeTest.php
@@ -170,7 +170,58 @@ final class DynamicScopeTest extends TestCase
 
         $entry = $scope->popRecording();
 
-        self::assertSame(['dynamic' => [], 'redefs' => []], $entry);
+        self::assertSame(
+            ['mode' => DynamicScope::MODE_BINDING, 'dynamic' => [], 'redefs' => []],
+            $entry,
+        );
+    }
+
+    public function test_recording_mode_defaults_to_binding(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->startRecording();
+
+        self::assertSame(DynamicScope::MODE_BINDING, $scope->currentRecordingMode());
+
+        $scope->popRecording();
+        self::assertNull($scope->currentRecordingMode());
+    }
+
+    public function test_redefs_recording_mode_is_distinguishable(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->startRecording(DynamicScope::MODE_REDEFS);
+
+        self::assertSame(DynamicScope::MODE_REDEFS, $scope->currentRecordingMode());
+
+        $entry = $scope->popRecording();
+        self::assertSame(DynamicScope::MODE_REDEFS, $entry['mode']);
+    }
+
+    public function test_set_binding_updates_topmost_frame(): void
+    {
+        $scope = DynamicScope::getInstance();
+        $scope->pushFrame(['ns/x' => 'outer']);
+        $scope->pushFrame(['ns/x' => 'inner']);
+
+        self::assertTrue($scope->setBinding('ns', 'x', 'inner-edited'));
+        self::assertSame('inner-edited', $scope->getBinding('ns', 'x'));
+
+        $scope->popFrame();
+        self::assertSame('outer', $scope->getBinding('ns', 'x'), 'lower frame remains untouched');
+
+        $scope->popFrame();
+    }
+
+    public function test_set_binding_returns_false_when_no_frame_holds_key(): void
+    {
+        $scope = DynamicScope::getInstance();
+
+        self::assertFalse($scope->setBinding('ns', 'unbound', 1));
+
+        $scope->pushFrame(['ns/other' => 1]);
+        self::assertFalse($scope->setBinding('ns', 'unbound', 1));
+        $scope->popFrame();
     }
 
     public function test_recording_stacks_are_isolated_per_fiber(): void


### PR DESCRIPTION
## 🤔 Background

PR #1817 introduced first-class vars and a fiber-local `DynamicScope` for the `binding` macro. To match how every other Lisp/Var-based language behaves, `binding` should refuse vars that were not opted into dynamic rebinding. Currently it silently falls back to a `with-redefs`-style root mutation, which works for tests but hides bugs in production code that assumes fiber isolation.

## 💡 Goal

Make `binding` strict (dynamic-only), pull the test-mocking path into its own `with-redefs` macro, and ship the introspection / mutation helpers (`bound?`, `thread-bound?`, `var-set`, `with-bindings`) that pair naturally with the new var surface.

## 🔖 Changes

**Behavior**
- `binding` throws `InvalidArgumentException` when any var in its bindings vector is not tagged `^:dynamic`. The error message points users at `with-redefs`.
- `with-redefs` is now its own macro, accepting any var (dynamic or not), restoring the previous root values on exit, including on exceptions.
- `with-bindings` accepts a `Var -> value` map with the same dynamic-only enforcement as `binding`.
- `bound?` / `thread-bound?` / `var-set` round out the var introspection surface.
- `phel.mock`'s `with-mocks` and `with-mock-wrapper` now expand to `with-redefs` so they keep working when target functions are not tagged `^:dynamic`.

**Runtime**
- `DynamicScope` records carry a `mode` tag (`MODE_BINDING` / `MODE_REDEFS`); `\Phel::setVar` enforces the dynamic-only invariant in binding mode.
- `DynamicScope::setBinding` mutates the topmost active frame slot for a var; backing call for `var-set`.
- New `\Phel::openRedefsFrame` and `\Phel::varSet` runtime entry points; the existing `commit/abort` helpers are reused for both modes.

**Tests**
- New `tests/phel/test/core/var-introspection.phel` covering `bound?`, `thread-bound?`, `var-set`, `with-bindings`, and `with-redefs` paths (23 tests).
- Existing `binding-conveyance.phel` split into a `with-redefs` case and a `binding` case asserting the new throw.
- `binding.phel` and `binding-regression-1363.phel` tag their target vars `^:dynamic` and add three new cases for the strict path.
- Mock test fixtures use `with-redefs` for non-dynamic targets.
- `DynamicScopeTest` covers the new `MODE_*` constants, `currentRecordingMode`, and `setBinding`.