### PR TITLE
feat: extend PhelVar with callable, watchers, per-var meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
 - `bound?` returns true when a var has a current root binding in the registry
 - `thread-bound?` returns true when a fiber-local frame currently overrides the var
 - `var-set` mutates the topmost active fiber-local binding frame for a var
+- `Var` handles are callable: `((var f) ...args)` invokes the var's current root value and forwards the arguments
+- `add-watch` and `remove-watch` accept a `Var` as the target; watch fns fire on `alter-var-root`
+- `alter-meta!` and `reset-meta!` mutate per-var metadata on `Var` handles and atoms; per-var metadata survives subsequent `def` redefinitions
+
+#### Lang
+- `PhelVar` implements `FnInterface` and exposes `__invoke`, `addWatch`, `removeWatch`, `alterMeta`, `resetMeta`, and a cached `isDynamic()` lookup
+- `PhelVarStateRegistry` singleton holds per-var watch fns, metadata overrides, and dynamic-flag cache keyed by `(ns, name)` so all handles to the same slot share state
 
 ### Changed
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -8,6 +8,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\DynamicScope;
 use Phel\Lang\Keyword;
+use Phel\Lang\PhelVarStateRegistry;
 use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
@@ -76,16 +77,12 @@ final class Phel extends InternalPhel
     }
 
     /**
-     * Returns true if the given var was defined with `^:dynamic` metadata.
+     * Returns true if the given var carries `^:dynamic` metadata. Honors
+     * per-var meta overrides installed via `alter-meta!` / `reset-meta!`.
      */
     public static function isDynamicVar(string $ns, string $name): bool
     {
-        $meta = Registry::getInstance()->getDefinitionMetaData($ns, $name);
-        if ($meta === null) {
-            return false;
-        }
-
-        return ($meta[Keyword::create('dynamic')] ?? false) === true;
+        return PhelVarStateRegistry::getInstance()->isDynamic($ns, $name);
     }
 
     /**

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -158,6 +158,34 @@
                        (php/-> v (getName))
                        val)))
 
+(defn alter-meta!
+  "Replaces the metadata on `r` with `(apply f current-meta args)`.
+  Works on `Var` handles (mutates per-var metadata, surviving subsequent
+  `def` redefinitions) and on atoms (mutates the atom's own meta map).
+  Returns the new metadata map."
+  {:example "(alter-meta! #'my-var assoc :tag :int)"
+   :see-also ["reset-meta!" "meta" "with-meta"]}
+  [r f & args]
+  (cond
+    (var? r) (php/-> r (alterMeta (fn [current] (apply f current args))))
+    (atom? r) (let [next (apply f (php/-> r (getMeta)) args)]
+                (php/-> r (withMeta next))
+                next)
+    :else (throw (php/new \InvalidArgumentException
+                          "alter-meta! expects a Var or atom as first argument"))))
+
+(defn reset-meta!
+  "Installs `meta-map` as the metadata on `r`, replacing any prior metadata.
+  Works on `Var` handles and on atoms. Returns the installed map."
+  {:example "(reset-meta! #'my-var {:tag :int})"
+   :see-also ["alter-meta!" "meta" "with-meta"]}
+  [r meta-map]
+  (cond
+    (var? r) (php/-> r (resetMeta meta-map))
+    (atom? r) (do (php/-> r (withMeta meta-map)) meta-map)
+    :else (throw (php/new \InvalidArgumentException
+                          "reset-meta! expects a Var or atom as first argument"))))
+
 (defn remove-watch
   "Removes a watch function from a variable by key."
   {:see-also ["add-watch"]}

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -11,7 +11,8 @@ This is a **foundational module** with no Facade, Factory, or DependencyProvider
 - **Symbol** — names with optional namespace; special constants for language forms (`def`, `fn`, `if`, etc.)
 - **Keyword** — interned with pool; callable as functions to access map values (implements `FnInterface`)
 - **Variable** — mutable box (atom) with watches, validators, deref
-- **PhelVar** — first-class handle to a global definition (`def`); produced by `Registry::addDefinition`/`getVar` and the `(var sym)` / `#'sym` forms; offers `deref`, `meta`, `alterRoot`
+- **PhelVar** — first-class handle to a global definition (`def`); produced by `Registry::addDefinition`/`getVar` and the `(var sym)` / `#'sym` forms; offers `deref`, `meta`, `alterRoot`, `addWatch`/`removeWatch`, `alterMeta`/`resetMeta`, and cached `isDynamic`; implements `FnInterface` so handles are callable (`__invoke` forwards to the current root value)
+- **PhelVarStateRegistry** — singleton side table for per-var watches, metadata overrides, and dynamic-flag cache keyed by `(ns, name)`; lets `PhelVar` stay `readonly` while `alter-meta!` / `add-watch` mutate canonical state
 - **Delay** — lazy evaluation with caching
 - **Volatile** — lightweight mutable container for transducer state
 - **Reduced** — signals early termination from reduce/transduce

--- a/src/php/Lang/PhelVar.php
+++ b/src/php/Lang/PhelVar.php
@@ -132,7 +132,6 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
     {
         $next = $f($this->meta(), ...$args);
         PhelVarStateRegistry::getInstance()->setMetaOverride($this->namespace, $this->name, $next);
-        $this->refreshDynamicCache($next);
 
         return $next;
     }
@@ -144,7 +143,6 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
     public function resetMeta(?PersistentMapInterface $meta): ?PersistentMapInterface
     {
         PhelVarStateRegistry::getInstance()->setMetaOverride($this->namespace, $this->name, $meta);
-        $this->refreshDynamicCache($meta);
 
         return $meta;
     }
@@ -194,22 +192,13 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
     }
 
     /**
-     * True when this var was defined with `^:dynamic` metadata. The lookup
-     * is cached on first call and refreshed when `alter-meta!` /
-     * `reset-meta!` mutate the per-var metadata.
+     * True when this var carries `^:dynamic` metadata. The lookup is cached
+     * by {@see PhelVarStateRegistry} and invalidated automatically when
+     * `alter-meta!` / `reset-meta!` mutate the per-var metadata.
      */
     public function isDynamic(): bool
     {
-        $state = PhelVarStateRegistry::getInstance();
-        $cached = $state->getCachedDynamic($this->namespace, $this->name);
-        if ($cached !== null) {
-            return $cached;
-        }
-
-        $value = $this->computeIsDynamic($this->meta());
-        $state->rememberDynamic($this->namespace, $this->name, $value);
-
-        return $value;
+        return PhelVarStateRegistry::getInstance()->isDynamic($this->namespace, $this->name);
     }
 
     public function equals(mixed $other): bool
@@ -234,23 +223,5 @@ final readonly class PhelVar implements EqualsInterface, FnInterface, HashableIn
         foreach ($watches as $key => $callback) {
             $callback(Keyword::create($key), $this, $oldValue, $newValue);
         }
-    }
-
-    private function refreshDynamicCache(?PersistentMapInterface $meta): void
-    {
-        PhelVarStateRegistry::getInstance()->rememberDynamic(
-            $this->namespace,
-            $this->name,
-            $this->computeIsDynamic($meta),
-        );
-    }
-
-    private function computeIsDynamic(?PersistentMapInterface $meta): bool
-    {
-        if (!$meta instanceof PersistentMapInterface) {
-            return false;
-        }
-
-        return ($meta[Keyword::create('dynamic')] ?? false) === true;
     }
 }

--- a/src/php/Lang/PhelVar.php
+++ b/src/php/Lang/PhelVar.php
@@ -7,6 +7,8 @@ namespace Phel\Lang;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use RuntimeException;
 
+use function get_debug_type;
+use function is_callable;
 use function sprintf;
 
 /**
@@ -15,18 +17,46 @@ use function sprintf;
  * Each `PhelVar` is a stable handle to a single registry slot identified by
  * namespace and name. The handle stays valid as the slot's value changes;
  * `deref()` always reads the current value, `alterRoot()` replaces it,
- * `meta()` returns the metadata attached at definition time.
+ * `meta()` returns the metadata attached at definition time (or the
+ * override installed by `alter-meta!` / `reset-meta!`).
+ *
+ * `PhelVar` is also callable: invoking the handle (`(#'+ 1 2)`) forwards
+ * the arguments to its current root value when that value is itself
+ * callable.
  *
  * Equality is structural over `(ns, name)` so two handles to the same slot
  * compare equal; identity-style equality is provided by the same operator
- * since `PhelVar` has no further state.
+ * since `PhelVar` has no further state. Per-var mutable state (meta
+ * override, watches, dynamic-flag cache) lives in
+ * {@see PhelVarStateRegistry}, keyed by `ns/name`, so all handles to the
+ * same slot observe the same state.
  */
-final readonly class PhelVar implements EqualsInterface, HashableInterface, MetaInterface
+final readonly class PhelVar implements EqualsInterface, FnInterface, HashableInterface, MetaInterface
 {
     public function __construct(
         private string $namespace,
         private string $name,
     ) {}
+
+    /**
+     * Invokes the var's current root value with the supplied arguments.
+     * Throws when the root value is not callable so the failure surfaces
+     * at the call site instead of being swallowed by PHP's "uncallable"
+     * error path.
+     */
+    public function __invoke(mixed ...$args): mixed
+    {
+        $value = $this->deref();
+        if (!is_callable($value)) {
+            throw new RuntimeException(sprintf(
+                "Cannot invoke #'%s: root value is not callable (got %s)",
+                $this->getFullName(),
+                get_debug_type($value),
+            ));
+        }
+
+        return $value(...$args);
+    }
 
     public function getNamespace(): string
     {
@@ -50,9 +80,10 @@ final readonly class PhelVar implements EqualsInterface, HashableInterface, Meta
 
     /**
      * Vars are global handles to a single registry slot, so attaching
-     * different metadata per handle is meaningless. The call returns the
-     * receiver unchanged. To rotate metadata on the underlying definition,
-     * redefine it with `def`.
+     * different metadata per handle is meaningless: the call returns the
+     * receiver unchanged. Use `alter-meta!` / `reset-meta!` to mutate the
+     * canonical per-var metadata, or redefine the var to rotate the
+     * metadata attached to the underlying definition.
      */
     public function withMeta(?PersistentMapInterface $meta): static
     {
@@ -83,12 +114,46 @@ final readonly class PhelVar implements EqualsInterface, HashableInterface, Meta
 
     public function meta(): ?PersistentMapInterface
     {
+        $state = PhelVarStateRegistry::getInstance();
+        if ($state->hasMetaOverride($this->namespace, $this->name)) {
+            return $state->getMetaOverride($this->namespace, $this->name);
+        }
+
         return Registry::getInstance()->getDefinitionMetaData($this->namespace, $this->name);
     }
 
     /**
+     * Replaces this var's per-var metadata with `$f($currentMeta, ...$args)`
+     * and returns the new metadata map. The previous override (or the
+     * definition meta when no override was set) is fed in as the first
+     * argument.
+     */
+    public function alterMeta(callable $f, mixed ...$args): ?PersistentMapInterface
+    {
+        $next = $f($this->meta(), ...$args);
+        PhelVarStateRegistry::getInstance()->setMetaOverride($this->namespace, $this->name, $next);
+        $this->refreshDynamicCache($next);
+
+        return $next;
+    }
+
+    /**
+     * Installs `$meta` as this var's per-var metadata, replacing any prior
+     * override. Returns the installed map.
+     */
+    public function resetMeta(?PersistentMapInterface $meta): ?PersistentMapInterface
+    {
+        PhelVarStateRegistry::getInstance()->setMetaOverride($this->namespace, $this->name, $meta);
+        $this->refreshDynamicCache($meta);
+
+        return $meta;
+    }
+
+    /**
      * Sets the registry slot to `$f($current, ...$args)` and returns the
-     * new value. Metadata attached to the definition is preserved.
+     * new value. Metadata attached to the definition is preserved. Watch
+     * functions registered via {@see self::addWatch()} are notified after
+     * the slot has been updated.
      */
     public function alterRoot(callable $f, mixed ...$args): mixed
     {
@@ -105,7 +170,46 @@ final readonly class PhelVar implements EqualsInterface, HashableInterface, Meta
         $meta = $registry->getDefinitionMetaData($this->namespace, $this->name);
         $registry->addDefinition($this->namespace, $this->name, $next, $meta);
 
+        $this->notifyWatches($current, $next);
+
         return $next;
+    }
+
+    /**
+     * Registers a watch function under `$key`. The function is called with
+     * `($keyword, $var, $oldValue, $newValue)` after a successful
+     * `alterRoot()`. Re-adding the same key replaces the previous fn.
+     */
+    public function addWatch(string $key, callable $fn): void
+    {
+        PhelVarStateRegistry::getInstance()->addWatch($this->namespace, $this->name, $key, $fn);
+    }
+
+    /**
+     * Removes the watch function registered under `$key`, if any.
+     */
+    public function removeWatch(string $key): void
+    {
+        PhelVarStateRegistry::getInstance()->removeWatch($this->namespace, $this->name, $key);
+    }
+
+    /**
+     * True when this var was defined with `^:dynamic` metadata. The lookup
+     * is cached on first call and refreshed when `alter-meta!` /
+     * `reset-meta!` mutate the per-var metadata.
+     */
+    public function isDynamic(): bool
+    {
+        $state = PhelVarStateRegistry::getInstance();
+        $cached = $state->getCachedDynamic($this->namespace, $this->name);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $value = $this->computeIsDynamic($this->meta());
+        $state->rememberDynamic($this->namespace, $this->name, $value);
+
+        return $value;
     }
 
     public function equals(mixed $other): bool
@@ -118,5 +222,35 @@ final readonly class PhelVar implements EqualsInterface, HashableInterface, Meta
     public function hash(): int
     {
         return crc32($this->getFullName());
+    }
+
+    private function notifyWatches(mixed $oldValue, mixed $newValue): void
+    {
+        $watches = PhelVarStateRegistry::getInstance()->getWatches($this->namespace, $this->name);
+        if ($watches === []) {
+            return;
+        }
+
+        foreach ($watches as $key => $callback) {
+            $callback(Keyword::create($key), $this, $oldValue, $newValue);
+        }
+    }
+
+    private function refreshDynamicCache(?PersistentMapInterface $meta): void
+    {
+        PhelVarStateRegistry::getInstance()->rememberDynamic(
+            $this->namespace,
+            $this->name,
+            $this->computeIsDynamic($meta),
+        );
+    }
+
+    private function computeIsDynamic(?PersistentMapInterface $meta): bool
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return false;
+        }
+
+        return ($meta[Keyword::create('dynamic')] ?? false) === true;
     }
 }

--- a/src/php/Lang/PhelVarStateRegistry.php
+++ b/src/php/Lang/PhelVarStateRegistry.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+
+use function array_key_exists;
+
+/**
+ * Singleton side table for {@see PhelVar} per-var state that lives outside
+ * the value/meta slots managed by {@see Registry}.
+ *
+ * Vars are global handles to a single registry slot; equality and hashing
+ * are based on `(ns, name)`. Because every `PhelVar` instance for the same
+ * slot is interchangeable, mutable per-var state (an override metadata map,
+ * the watch fn table, and a cached dynamic-flag lookup) cannot live on the
+ * handle without surprising semantics. Storing it here, keyed by
+ * `ns/name`, keeps `PhelVar` immutable while still letting `alter-meta!`,
+ * `reset-meta!`, `add-watch`, and `remove-watch` mutate the canonical
+ * state for a definition.
+ */
+final class PhelVarStateRegistry
+{
+    private static ?self $instance = null;
+
+    /** @var array<string, ?PersistentMapInterface> */
+    private array $metaOverrides = [];
+
+    /** @var array<string, array<string, callable>> */
+    private array $watches = [];
+
+    /** @var array<string, bool> */
+    private array $dynamicCache = [];
+
+    public static function getInstance(): self
+    {
+        if (!self::$instance instanceof self) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function clear(): void
+    {
+        $this->metaOverrides = [];
+        $this->watches = [];
+        $this->dynamicCache = [];
+    }
+
+    public function hasMetaOverride(string $ns, string $name): bool
+    {
+        return array_key_exists($this->key($ns, $name), $this->metaOverrides);
+    }
+
+    public function getMetaOverride(string $ns, string $name): ?PersistentMapInterface
+    {
+        return $this->metaOverrides[$this->key($ns, $name)] ?? null;
+    }
+
+    public function setMetaOverride(string $ns, string $name, ?PersistentMapInterface $meta): void
+    {
+        $this->metaOverrides[$this->key($ns, $name)] = $meta;
+    }
+
+    public function clearMetaOverride(string $ns, string $name): void
+    {
+        unset($this->metaOverrides[$this->key($ns, $name)]);
+    }
+
+    public function addWatch(string $ns, string $name, string $watchKey, callable $fn): void
+    {
+        $this->watches[$this->key($ns, $name)][$watchKey] = $fn;
+    }
+
+    public function removeWatch(string $ns, string $name, string $watchKey): void
+    {
+        $key = $this->key($ns, $name);
+        unset($this->watches[$key][$watchKey]);
+        if (isset($this->watches[$key]) && $this->watches[$key] === []) {
+            unset($this->watches[$key]);
+        }
+    }
+
+    /**
+     * @return array<string, callable>
+     */
+    public function getWatches(string $ns, string $name): array
+    {
+        return $this->watches[$this->key($ns, $name)] ?? [];
+    }
+
+    public function rememberDynamic(string $ns, string $name, bool $isDynamic): void
+    {
+        $this->dynamicCache[$this->key($ns, $name)] = $isDynamic;
+    }
+
+    public function getCachedDynamic(string $ns, string $name): ?bool
+    {
+        return $this->dynamicCache[$this->key($ns, $name)] ?? null;
+    }
+
+    public function invalidateDynamicCache(string $ns, string $name): void
+    {
+        unset($this->dynamicCache[$this->key($ns, $name)]);
+    }
+
+    private function key(string $ns, string $name): string
+    {
+        return $ns . '/' . $name;
+    }
+}

--- a/src/php/Lang/PhelVarStateRegistry.php
+++ b/src/php/Lang/PhelVarStateRegistry.php
@@ -63,11 +63,7 @@ final class PhelVarStateRegistry
     public function setMetaOverride(string $ns, string $name, ?PersistentMapInterface $meta): void
     {
         $this->metaOverrides[$this->key($ns, $name)] = $meta;
-    }
-
-    public function clearMetaOverride(string $ns, string $name): void
-    {
-        unset($this->metaOverrides[$this->key($ns, $name)]);
+        $this->invalidateDynamicCache($ns, $name);
     }
 
     public function addWatch(string $ns, string $name, string $watchKey, callable $fn): void
@@ -92,19 +88,39 @@ final class PhelVarStateRegistry
         return $this->watches[$this->key($ns, $name)] ?? [];
     }
 
-    public function rememberDynamic(string $ns, string $name, bool $isDynamic): void
+    /**
+     * Returns true when the var carries `^:dynamic` metadata, consulting
+     * any per-var override installed via `alter-meta!` / `reset-meta!`
+     * before falling back to the definition meta. Result is memoized;
+     * {@see self::invalidateDynamicCache()} clears the cache.
+     */
+    public function isDynamic(string $ns, string $name): bool
     {
-        $this->dynamicCache[$this->key($ns, $name)] = $isDynamic;
-    }
+        $cacheKey = $this->key($ns, $name);
+        if (array_key_exists($cacheKey, $this->dynamicCache)) {
+            return $this->dynamicCache[$cacheKey];
+        }
 
-    public function getCachedDynamic(string $ns, string $name): ?bool
-    {
-        return $this->dynamicCache[$this->key($ns, $name)] ?? null;
+        $meta = $this->effectiveMeta($ns, $name);
+        $value = $meta instanceof PersistentMapInterface
+            && ($meta[Keyword::create('dynamic')] ?? false) === true;
+        $this->dynamicCache[$cacheKey] = $value;
+
+        return $value;
     }
 
     public function invalidateDynamicCache(string $ns, string $name): void
     {
         unset($this->dynamicCache[$this->key($ns, $name)]);
+    }
+
+    private function effectiveMeta(string $ns, string $name): ?PersistentMapInterface
+    {
+        if ($this->hasMetaOverride($ns, $name)) {
+            return $this->getMetaOverride($ns, $name);
+        }
+
+        return Registry::getInstance()->getDefinitionMetaData($ns, $name);
     }
 
     private function key(string $ns, string $name): string

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -39,6 +39,7 @@ final class Registry
     {
         $this->definitions = [];
         $this->definitionsMetaData = [];
+        PhelVarStateRegistry::getInstance()->clear();
     }
 
     /**
@@ -65,6 +66,7 @@ final class Registry
     {
         $this->definitions[$ns][$name] = $value;
         $this->definitionsMetaData[$ns][$name] = $metaData;
+        PhelVarStateRegistry::getInstance()->invalidateDynamicCache($ns, $name);
 
         return new PhelVar($ns, $name);
     }

--- a/tests/phel/test/core/vars-callable.phel
+++ b/tests/phel/test/core/vars-callable.phel
@@ -1,0 +1,33 @@
+(ns phel-test\test\core\vars-callable
+  (:require phel\test :refer [deftest is thrown?]))
+
+;; Var handles forward calls to their current root value when that value
+;; is callable. Throws a clear error when the root value cannot be invoked.
+
+(defn callable-target [a b] (+ a b))
+
+(deftest test-invoke-var-with-args
+  (is (= 5 (#'callable-target 2 3)) "calling a var fns its root value"))
+
+(deftest test-invoke-var-no-args
+  (defn pi [] 3.14)
+  (is (= 3.14 (#'pi)) "zero-arg var call works"))
+
+(deftest test-invoke-var-variadic
+  (defn vsum [& xs] (apply + xs))
+  (is (= 10 (#'vsum 1 2 3 4)) "variadic var call forwards all args"))
+
+(deftest test-invoke-var-tracks-root-changes
+  (defn rebound-fn [] :first)
+  (is (= :first (#'rebound-fn)) "initial root value")
+  (alter-var-root #'rebound-fn (fn [_] (fn [] :second)))
+  (is (= :second (#'rebound-fn)) "invocation reflects new root"))
+
+(def non-callable-data 42)
+
+(deftest test-invoke-var-non-callable-throws
+  (is (thrown? \RuntimeException (#'non-callable-data))
+      "invoking a var whose root is not callable raises RuntimeException"))
+
+(deftest test-invoke-core-var
+  (is (= 6 ((var +) 1 2 3)) "(var +) is callable like the underlying fn"))

--- a/tests/phel/test/core/vars-meta.phel
+++ b/tests/phel/test/core/vars-meta.phel
@@ -1,0 +1,57 @@
+(ns phel-test\test\core\vars-meta
+  (:require phel\test :refer [deftest is thrown?]))
+
+;; Per-var metadata mutation: `alter-meta!` updates a var's metadata in
+;; place; `reset-meta!` replaces it wholesale. Both work on atoms too.
+
+(def docless 1)
+
+(deftest test-reset-meta-on-var
+  (reset-meta! #'docless {:tag :int})
+  (is (= :int (get (meta #'docless) :tag))
+      "reset-meta! installs a fresh metadata map on the var"))
+
+(def alter-meta-target
+  "initial doc"
+  :value)
+
+(deftest test-alter-meta-on-var
+  (alter-meta! #'alter-meta-target assoc :tag :keyword)
+  (let [m (meta #'alter-meta-target)]
+    (is (= :keyword (get m :tag)) "alter-meta! adds keys to existing meta")
+    (is (= "initial doc" (get m :doc))
+        "alter-meta! preserves keys present in the prior metadata")))
+
+(def alter-meta-args 0)
+
+(deftest test-alter-meta-passes-extra-args
+  (alter-meta! #'alter-meta-args assoc :a 1 :b 2)
+  (let [m (meta #'alter-meta-args)]
+    (is (= 1 (get m :a)) "extra args route through to the fn")
+    (is (= 2 (get m :b)) "extra args route through to the fn")))
+
+(def shared-handle 1)
+
+(deftest test-meta-changes-visible-to-other-handles
+  (reset-meta! #'shared-handle {:shared true})
+  (is (= true (get (meta (var shared-handle)) :shared))
+      "meta changes via #'sym are visible through (var sym)"))
+
+(deftest test-alter-meta-on-atom
+  (let [a (atom 1 :meta {:tag :counter})]
+    (alter-meta! a assoc :unit :ms)
+    (let [m (meta a)]
+      (is (= :counter (get m :tag)) "atom meta preserved")
+      (is (= :ms (get m :unit)) "atom meta updated"))))
+
+(deftest test-reset-meta-on-atom
+  (let [a (atom 1 :meta {:tag :counter})]
+    (reset-meta! a {:tag :other})
+    (is (= :other (get (meta a) :tag)) "atom meta replaced")
+    (is (nil? (get (meta a) :unit)) "previous keys gone")))
+
+(deftest test-alter-meta-rejects-non-ref
+  (is (thrown? \InvalidArgumentException (alter-meta! 42 assoc :a 1))
+      "alter-meta! refuses non-ref arguments")
+  (is (thrown? \InvalidArgumentException (reset-meta! :kw {:a 1}))
+      "reset-meta! refuses non-ref arguments"))

--- a/tests/phel/test/core/vars-watchers.phel
+++ b/tests/phel/test/core/vars-watchers.phel
@@ -1,0 +1,70 @@
+(ns phel-test\test\core\vars-watchers
+  (:require phel\test :refer [deftest is]))
+
+;; `add-watch` / `remove-watch` work on `Var` handles. Watch fns are called
+;; with `[key var old-value new-value]` after `alter-var-root` succeeds.
+
+(def watched-counter 0)
+
+(deftest test-add-watch-fires-on-alter-var-root
+  (let [log (atom [])]
+    (add-watch #'watched-counter :log
+      (fn [k r o n] (swap! log (fn [xs] (push xs [o n])))))
+    (alter-var-root #'watched-counter inc)
+    (alter-var-root #'watched-counter inc)
+    (is (= [[0 1] [1 2]] (deref log))
+        "watch fires once per alter-var-root with old/new values")
+    (remove-watch #'watched-counter :log)))
+
+(def receives-key-target 0)
+
+(deftest test-watch-receives-keyword-key
+  (let [received-key (atom nil)]
+    (add-watch #'receives-key-target :my-key
+      (fn [k r o n] (reset! received-key k)))
+    (alter-var-root #'receives-key-target inc)
+    (is (= :my-key (deref received-key)) "watch receives keyword key")
+    (remove-watch #'receives-key-target :my-key)))
+
+(def receives-ref-target 0)
+
+(deftest test-watch-receives-var-handle
+  (let [ref-is-var (atom false)]
+    (add-watch #'receives-ref-target :ref-check
+      (fn [k r o n] (reset! ref-is-var (var? r))))
+    (alter-var-root #'receives-ref-target inc)
+    (is (true? (deref ref-is-var)) "watch receives a Var as the ref arg")
+    (remove-watch #'receives-ref-target :ref-check)))
+
+(def remove-target 0)
+
+(deftest test-remove-watch-on-var
+  (let [count (atom 0)]
+    (add-watch #'remove-target :counter (fn [k r o n] (swap! count inc)))
+    (alter-var-root #'remove-target inc)
+    (is (= 1 (deref count)) "watch fires once")
+    (remove-watch #'remove-target :counter)
+    (alter-var-root #'remove-target inc)
+    (is (= 1 (deref count)) "watch no longer fires after remove")))
+
+(def shared-state-target 0)
+
+(deftest test-watches-shared-across-handles
+  (let [hits (atom 0)]
+    (add-watch #'shared-state-target :h (fn [k r o n] (swap! hits inc)))
+    (alter-var-root (var shared-state-target) inc)
+    (is (= 1 (deref hits))
+        "watch fires when alter-var-root targets a different handle to the same slot")
+    (remove-watch #'shared-state-target :h)))
+
+(def multi-watch-target 0)
+
+(deftest test-multiple-watches-on-var
+  (let [a (atom 0) b (atom 0)]
+    (add-watch #'multi-watch-target :a (fn [k r o n] (swap! a inc)))
+    (add-watch #'multi-watch-target :b (fn [k r o n] (swap! b inc)))
+    (alter-var-root #'multi-watch-target inc)
+    (is (= 1 (deref a)) "first watch fires")
+    (is (= 1 (deref b)) "second watch fires")
+    (remove-watch #'multi-watch-target :a)
+    (remove-watch #'multi-watch-target :b)))

--- a/tests/php/Unit/Lang/PhelVarTest.php
+++ b/tests/php/Unit/Lang/PhelVarTest.php
@@ -145,4 +145,135 @@ final class PhelVarTest extends TestCase
         self::assertFalse($a->equals('user/x'));
         self::assertFalse($a->equals(null));
     }
+
+    public function test_invoke_calls_root_value(): void
+    {
+        $var = $this->registry->addDefinition('user', 'add', static fn(int $a, int $b): int => $a + $b);
+
+        self::assertSame(5, $var(2, 3));
+    }
+
+    public function test_invoke_forwards_zero_args(): void
+    {
+        $var = $this->registry->addDefinition('user', 'pi', static fn(): float => 3.14);
+
+        self::assertSame(3.14, $var());
+    }
+
+    public function test_invoke_throws_when_root_value_not_callable(): void
+    {
+        $var = $this->registry->addDefinition('user', 'data', 42);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Cannot invoke #'user/data: root value is not callable (got int)");
+        $var(1);
+    }
+
+    public function test_invoke_throws_when_definition_removed(): void
+    {
+        $var = $this->registry->addDefinition('user', 'x', static fn(): int => 1);
+        $this->registry->removeNamespace('user');
+
+        $this->expectException(RuntimeException::class);
+        $var();
+    }
+
+    public function test_alter_root_notifies_watches_with_old_and_new(): void
+    {
+        $var = $this->registry->addDefinition('user', 'counter', 1);
+        $events = [];
+        $var->addWatch('log', static function (mixed $key, PhelVar $ref, mixed $old, mixed $new) use (&$events): void {
+            $events[] = [$key->getName(), $ref->getFullName(), $old, $new];
+        });
+
+        $var->alterRoot(static fn(int $n): int => $n + 1);
+
+        self::assertSame([['log', 'user/counter', 1, 2]], $events);
+    }
+
+    public function test_remove_watch_stops_notifications(): void
+    {
+        $var = $this->registry->addDefinition('user', 'x', 0);
+        $count = 0;
+        $var->addWatch('w', static function () use (&$count): void {
+            ++$count;
+        });
+        $var->alterRoot(static fn(int $n): int => $n + 1);
+        $var->removeWatch('w');
+        $var->alterRoot(static fn(int $n): int => $n + 1);
+
+        self::assertSame(1, $count);
+    }
+
+    public function test_watch_state_is_shared_across_handles(): void
+    {
+        $a = $this->registry->addDefinition('user', 'x', 0);
+        $b = new PhelVar('user', 'x');
+        $count = 0;
+        $a->addWatch('w', static function () use (&$count): void {
+            ++$count;
+        });
+
+        $b->alterRoot(static fn(int $n): int => $n + 1);
+
+        self::assertSame(1, $count);
+    }
+
+    public function test_reset_meta_replaces_meta_returned_by_meta(): void
+    {
+        $var = $this->registry->addDefinition('user', 'x', 1, Phel::map(Phel::keyword('doc'), 'orig'));
+        $next = Phel::map(Phel::keyword('doc'), 'updated');
+
+        $var->resetMeta($next);
+
+        self::assertSame($next, $var->meta());
+    }
+
+    public function test_alter_meta_passes_current_meta_to_fn(): void
+    {
+        $original = Phel::map(Phel::keyword('a'), 1);
+        $var = $this->registry->addDefinition('user', 'x', 1, $original);
+
+        $result = $var->alterMeta(static fn($current) => $current->put(Phel::keyword('b'), 2));
+
+        self::assertSame(1, $result[Phel::keyword('a')]);
+        self::assertSame(2, $result[Phel::keyword('b')]);
+        self::assertSame($result, $var->meta());
+    }
+
+    public function test_meta_override_is_shared_across_handles(): void
+    {
+        $a = $this->registry->addDefinition('user', 'x', 1);
+        $b = new PhelVar('user', 'x');
+        $next = Phel::map(Phel::keyword('tag'), 'shared');
+
+        $a->resetMeta($next);
+
+        self::assertSame($next, $b->meta());
+    }
+
+    public function test_is_dynamic_true_when_meta_has_dynamic_keyword(): void
+    {
+        $meta = Phel::map(Phel::keyword('dynamic'), true);
+        $var = $this->registry->addDefinition('user', '*x*', null, $meta);
+
+        self::assertTrue($var->isDynamic());
+    }
+
+    public function test_is_dynamic_false_for_plain_var(): void
+    {
+        $var = $this->registry->addDefinition('user', 'x', 1);
+
+        self::assertFalse($var->isDynamic());
+    }
+
+    public function test_is_dynamic_refreshes_after_reset_meta(): void
+    {
+        $var = $this->registry->addDefinition('user', 'x', 1);
+        self::assertFalse($var->isDynamic());
+
+        $var->resetMeta(Phel::map(Phel::keyword('dynamic'), true));
+
+        self::assertTrue($var->isDynamic());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

PR #1817 introduced `PhelVar`, a first-class handle to a global definition produced by `def`, `(var sym)`, and `#'sym`. The handle currently supports `deref`, `meta`, `alterRoot` and structural `(ns, name)` equality. PR #1818 then made `binding` strict and added the missing dynamic-scope primitives.

What's still missing to round out the Var surface: calling a var like a function, attaching watches, and rotating per-var metadata independently of root redefinition.

## 💡 Goal

Extend `PhelVar` with the operations that make var handles useful as a programming primitive, not just a deref target.

## 🔖 Changes

### Lang

- `PhelVar` implements `Phel\Lang\FnInterface`; `__invoke(...$args)` derefs the current root value and forwards the call. Throws `RuntimeException` with the var's full name when the root value is not callable.
- `PhelVar::addWatch`, `removeWatch`, `notifyWatchers` mirror the watcher API on `Variable`. Watch fns fire on `alterRoot` with `(key, var, old, new)`.
- `PhelVar::alterMeta`, `resetMeta` mutate per-var metadata stored side-band so the handle stays `readonly` and equality is unchanged. `meta()` reads the per-var override first, then falls back to the underlying definition meta.
- `PhelVar::isDynamic()` caches the `^:dynamic` lookup keyed by `(ns, name)`.
- New `PhelVarStateRegistry` singleton holds the per-var watch fns, metadata overrides, and dynamic-flag cache. All handles to the same `(ns, name)` slot share state.

### Core

- `add-watch` and `remove-watch` accept a `Var` as the target.
- `alter-meta!` and `reset-meta!` work on `Var` handles and atoms; on vars the meta lives in `PhelVarStateRegistry` so it survives subsequent `def` redefinitions.

### Tests

- `tests/phel/test/core/vars-callable.phel` covers `((var f) ...)` invocation, error on non-callable root, and arg forwarding.
- `tests/phel/test/core/vars-meta.phel` covers per-var meta, `alter-meta!`, `reset-meta!`, and the fallback to definition meta.
- `tests/phel/test/core/vars-watchers.phel` covers `add-watch` / `remove-watch` on vars, including notification on `alter-var-root`.
- `tests/php/Unit/Lang/PhelVarTest.php` extended with unit coverage for the new methods.

## 📝 Notes

Marked draft until full CI confirms green, then a polish/refactor pass and merge.