### PR TITLE
ref(core): use dot form for *ns* bootstrap value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - `alter-var-root` mutates the root binding of a `Var`; rejects atoms with a clear error pointing at `swap!` (#1717)
 - `deref` works on both atoms and `Var` instances (#1717)
 - `phel\mock`'s `with-mocks` and `with-mock-wrapper` now expand to `with-redefs` so they keep working when the target functions are not tagged `^:dynamic`
+- `*ns*` bootstrap value in `phel.core` is now `"phel.core"` (dot form) to match the value emitted for every other namespace by `(ns ...)`
 
 ### Breaking
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -9,7 +9,7 @@
 
 (def *ns*
   {:doc "Returns the namespace in the current scope."}
-  "\\phel\\core")
+  "phel.core")
 
 (def *file*
   {:doc "Returns the path of the current source file."}

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -30,7 +30,7 @@ Returns the path of the current source file.',
 Returns the namespace in the current scope.',
             'signatures' => ['*ns*'],
             'desc' => 'Returns the namespace in the current scope.',
-            'example' => '(println *ns*) ; => "my-app\\core"',
+            'example' => '(println *ns*) ; => "my-app.core"',
         ],
         Symbol::NAME_APPLY => [
             'doc' => '```phel


### PR DESCRIPTION
## 🤔 Background

`*ns*` returns the namespace of the current scope. For every namespace except `phel.core` itself, the value is set by `NsEmitter::emitCurrentNamespace()` using `Munge::displayNs()` — the canonical **dot form** (e.g. `phel.string`, `my-app.core`).

`phel.core` was the odd one out. The static `(def *ns* "\\phel\\core")` in `src/phel/core.phel` immediately overrode the dot value the `(ns phel.core …)` form had just emitted, so code running inside `phel.core` saw `\phel\core` while every other namespace saw the dot form.

## 💡 Goal

Make `*ns*` return the same form everywhere.

## 🔖 Changes

- `src/phel/core.phel` — change the bootstrap value of `*ns*` from `"\\phel\\core"` to `"phel.core"` so it matches what `NsEmitter` emits for every other namespace.
- `src/php/Api/Infrastructure/PhelFnLoader.php` — update the inline doc example for `*ns*` (`"my-app\\core"` → `"my-app.core"`) to match.
- `CHANGELOG.md` — note under Unreleased › Changed › Stdlib.

### Test impact

- No test asserts `*ns*` equals `"\\phel\\core"`.
- `tests/phel/test/repl.phel` and `tests/phel/test/core/ns.phel` pass `"phel\\core"` as input to functions like `find-ns` / `ns-publics` / `ns-aliases` to verify both forms are accepted; those still hold.
- `tests/phel/test/core/ns.phel:90` actively asserts `(= (find-ns "phel\\core") (find-ns "phel.core"))` — unaffected.
- `composer test-compiler`: 2812 tests pass.
- `composer test-core`: 4984 tests pass.