### PR TITLE
docs(readme): update namespace syntax in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ All notable changes to this project will be documented in this file.
 - Deprecated `var?` alias for `atom?` (#1717)
 - Deprecated `set!` alias for `reset!` (#1717)
 
+#### Documentation
+- Update README with new namespace syntax using dot separator
+
 ## [0.35.0](https://github.com/phel-lang/phel-lang/compare/v0.34.1...v0.35.0) - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ using "clojure" here is just for the md coloring
 we should use "phel" once GitHub accept phel coloring too
 -->
 ```clojure
-(ns my\example)
+(ns my.example)
 
 (defn greet [name] (str "Hello, " name "!"))
 
@@ -82,7 +82,7 @@ we should use "phel" once GitHub accept phel coloring too
 **HTTP response**
 
 ```clojure
-(ns app (:require phel\http :as h))
+(ns app (:require phel.http :as h))
 
 (def req (h/request-from-globals))
 


### PR DESCRIPTION
Backslash to dot format.