### PR TITLE
fix(core): `symbol` accepts PhelVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `Var` handles are callable: `((var f) ...args)` invokes the var's current root value and forwards the arguments
 - `add-watch` and `remove-watch` accept a `Var` as the target; watch fns fire on `alter-var-root`
 - `alter-meta!` and `reset-meta!` mutate per-var metadata on `Var` handles and atoms; per-var metadata survives subsequent `def` redefinitions
+- `symbol` accepts a `Var` and returns its fully qualified name as a symbol (#1821)
 
 #### Lang
 - `PhelVar` implements `FnInterface` and exposes `__invoke`, `addWatch`, `removeWatch`, `alterMeta`, `resetMeta`, and a cached `isDynamic()` lookup

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -1,6 +1,13 @@
 (in-ns phel.core)
 
+(use Phel.Compiler.Application.Munge)
+(use Phel.Lang.PhelVar)
 (use Phel.Lang.Symbol)
+
+(def ^:private symbol-munge
+  ;; Munge is a final readonly class; reuse one instance to decode var
+  ;; namespaces back to their display form when constructing symbols.
+  (php/new Munge))
 
 ;; Two families of primitive value constructors grouped together:
 ;;   - Symbol constructors: `symbol` (a runtime symbol from a string or
@@ -25,9 +32,10 @@
   "Returns a new symbol for the given name with an optional namespace.
 
   With one argument, creates a symbol without namespace. Accepts a
-  string, a keyword, or another symbol. With two arguments, creates a
-  symbol in the given namespace."
-  {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc"}
+  string, a keyword, another symbol, or a `Var` (in which case the
+  result is a fully qualified symbol naming the var). With two
+  arguments, creates a symbol in the given namespace."
+  {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc\n(symbol #'phel.core/+) ; => phel.core/+"}
   [name-or-ns & [name]]
   (if name
     (php/:: Symbol (createForNamespace
@@ -35,7 +43,11 @@
                     (to-symbol-part name)))
     (if (php/instanceof name-or-ns Symbol)
       name-or-ns
-      (php/:: Symbol (create (to-symbol-part name-or-ns))))))
+      (if (php/instanceof name-or-ns PhelVar)
+        (php/:: Symbol (createForNamespace
+                        (php/-> symbol-munge (decodeNs (php/-> name-or-ns (getNamespace))))
+                        (php/-> name-or-ns (getName))))
+        (php/:: Symbol (create (to-symbol-part name-or-ns)))))))
 
 (defn gensym
   "Generates a new unique symbol."

--- a/tests/phel/test/core/vars.phel
+++ b/tests/phel/test/core/vars.phel
@@ -69,3 +69,9 @@
 (deftest test-var-get-on-core
   (is (= map (var-get 'phel.core/map))
       "var-get reads phel.core function values"))
+
+(deftest test-symbol-on-var
+  (is (= 'phel-test.test.core.vars/var-target-value (symbol #'var-target-value))
+      "symbol on a var returns its fully qualified name as a symbol")
+  (is (= 'phel.core/+ (symbol #'phel.core/+))
+      "symbol on a core var returns its namespaced symbol"))


### PR DESCRIPTION
## 🤔 Background

`(symbol some-var)` previously raised `TypeError` because `Symbol::create` rejects non-string input. After PR #1817 introduced `PhelVar`, the `symbol` core fn never grew a branch for it.

## 💡 Goal

Make `symbol` accept a `Var` and return a fully qualified symbol naming it (`#'phel.core/+ -> phel.core/+`).

## 🔖 Changes

- `symbol` dispatches on `PhelVar`, decoding the registry-encoded namespace via `Munge::decodeNs` before constructing `Symbol::createForNamespace(ns, name)`.
- Phel test `tests/phel/test/core/vars.phel` covers `(symbol #'sym)` for both a user var and a `phel.core` var.
- CHANGELOG entry under Unreleased > Core.

No follow-up `ref` commit: the diff is small enough that a polish pass found nothing actionable (nested `if` matches the surrounding load-order constraints since `cond` is not yet bound when `strings.phel` loads).

Closes #1821