### PR TITLE
feat(core): special-symbol? recognizes var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - `add-watch` and `remove-watch` accept a `Var` as the target; watch fns fire on `alter-var-root`
 - `alter-meta!` and `reset-meta!` mutate per-var metadata on `Var` handles and atoms; per-var metadata survives subsequent `def` redefinitions
 - `symbol` accepts a `Var` and returns its fully qualified name as a symbol (#1821)
+- `special-symbol?` recognizes `var` (#1822)
 
 #### Lang
 - `PhelVar` implements `FnInterface` and exposes `__invoke`, `addWatch`, `removeWatch`, `alterMeta`, `resetMeta`, and a cached `isDynamic()` lookup

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -195,7 +195,7 @@
   "The set of symbols that name Phel special forms, including the
   syntactic markers `&`, `catch`, and `finally` recognised by `fn`,
   `let`, and `try`."
-  (hash-set 'def 'ns 'in-ns 'load 'fn 'quote 'do 'if 'apply
+  (hash-set 'def 'ns 'in-ns 'load 'fn 'quote 'var 'do 'if 'apply
             'let 'recur 'try 'throw 'loop 'foreach 'set-var
             'defstruct* 'definterface* 'defexception* 'reify*
             'php/new 'php/-> 'php/:: 'php/aget 'php/aget-in

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -159,6 +159,7 @@
   (is (true? (special-symbol? 'do)) "special-symbol? on do")
   (is (true? (special-symbol? 'let)) "special-symbol? on let")
   (is (true? (special-symbol? 'quote)) "special-symbol? on quote")
+  (is (true? (special-symbol? 'var)) "special-symbol? on var")
   (is (true? (special-symbol? 'try)) "special-symbol? on try")
   (is (true? (special-symbol? 'throw)) "special-symbol? on throw")
   (is (true? (special-symbol? 'recur)) "special-symbol? on recur")


### PR DESCRIPTION
## 🤔 Background

`var` is a special form in Phel since #1717, but `(special-symbol? 'var)` returned `false` because the predicate's hardcoded set in `src/phel/core/predicates.phel` was not updated when the special form was added.

## 💡 Goal

Make `(special-symbol? 'var)` return `true` so it stays in sync with the analyzer's special-form dispatch table.

## 🔖 Changes

- Add `'var` to the `special-symbols` set in `src/phel/core/predicates.phel`.
- Cover it with a Phel test in `tests/phel/test/core/type-operation.phel`.
- CHANGELOG entry under Unreleased > Added > Core.

No polish commit was needed: only the three lines above changed.

Closes #1822