### PR TITLE
feat(lang): add BigInteger and Rational value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 #### Lang
 - `PhelVar` implements `FnInterface` and exposes `__invoke`, `addWatch`, `removeWatch`, `alterMeta`, `resetMeta`, and a cached `isDynamic()` lookup
 - `PhelVarStateRegistry` singleton holds per-var watch fns, metadata overrides, and dynamic-flag cache keyed by `(ns, name)` so all handles to the same slot share state
+- `BigInteger` arbitrary-precision integer and `Rational` value types in `Phel\Lang`, with printer support that renders rationals as `n/d` (#1825)
 
 ### Changed
 

--- a/src/php/Lang/BigInteger.php
+++ b/src/php/Lang/BigInteger.php
@@ -1,0 +1,593 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use DivisionByZeroError;
+use InvalidArgumentException;
+use OverflowException;
+use Stringable;
+
+use function array_pop;
+use function count;
+use function intdiv;
+use function preg_match;
+use function sprintf;
+use function str_pad;
+use function str_split;
+use function strrev;
+use function substr;
+
+/**
+ * Arbitrary-precision signed integer.
+ *
+ * Internal representation: sign (-1, 0, or 1) plus a magnitude expressed as
+ * an array of base-1_000_000_000 digits, least-significant first. Choosing
+ * 10^9 keeps any single multiplication of two digits inside 64-bit signed
+ * integer range with margin (10^18 < 9.22e18 = PHP_INT_MAX).
+ */
+final readonly class BigInteger implements Stringable
+{
+    private const int BASE = 1_000_000_000;
+
+    private const int BASE_DIGITS = 9;
+
+    /**
+     * @param int       $sign      -1, 0, or 1; must be 0 iff magnitude is empty
+     * @param list<int> $magnitude base-10^9 digits, least-significant first; no trailing zeros
+     */
+    private function __construct(
+        private int $sign,
+        private array $magnitude,
+    ) {}
+
+    public function __toString(): string
+    {
+        if ($this->sign === 0) {
+            return '0';
+        }
+
+        $count = count($this->magnitude);
+        $highest = $this->magnitude[$count - 1];
+        $out = (string) $highest;
+        for ($i = $count - 2; $i >= 0; --$i) {
+            $out .= str_pad((string) $this->magnitude[$i], self::BASE_DIGITS, '0', STR_PAD_LEFT);
+        }
+
+        return $this->sign < 0 ? '-' . $out : $out;
+    }
+
+    public static function zero(): self
+    {
+        return new self(0, []);
+    }
+
+    public static function one(): self
+    {
+        return new self(1, [1]);
+    }
+
+    public static function fromInt(int $value): self
+    {
+        if ($value === 0) {
+            return self::zero();
+        }
+
+        if ($value > 0) {
+            return new self(1, self::splitNonNegative($value));
+        }
+
+        // Handle PHP_INT_MIN specially: negation overflows in PHP int.
+        if ($value === PHP_INT_MIN) {
+            // |PHP_INT_MIN| = PHP_INT_MAX + 1; build it digit-piecewise.
+            $magnitude = self::splitNonNegative(PHP_INT_MAX);
+            return new self(-1, self::trim(self::addMagnitudes($magnitude, [1])));
+        }
+
+        return new self(-1, self::splitNonNegative(-$value));
+    }
+
+    public static function fromString(string $value): self
+    {
+        if (preg_match('/^-?(0|[1-9]\d*)$/', $value) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf("Invalid BigInteger string: '%s'", $value),
+            );
+        }
+
+        $isNegative = $value[0] === '-';
+        $digits = $isNegative ? substr($value, 1) : $value;
+
+        if ($digits === '0') {
+            return self::zero();
+        }
+
+        $magnitude = self::digitsToMagnitude($digits);
+
+        return new self($isNegative ? -1 : 1, $magnitude);
+    }
+
+    public function add(self $other): self
+    {
+        if ($this->sign === 0) {
+            return $other;
+        }
+
+        if ($other->sign === 0) {
+            return $this;
+        }
+
+        if ($this->sign === $other->sign) {
+            return new self(
+                $this->sign,
+                self::addMagnitudes($this->magnitude, $other->magnitude),
+            );
+        }
+
+        $cmp = $this->compareMagnitudes($this->magnitude, $other->magnitude);
+        if ($cmp === 0) {
+            return self::zero();
+        }
+
+        if ($cmp > 0) {
+            return new self(
+                $this->sign,
+                $this->subtractMagnitudes($this->magnitude, $other->magnitude),
+            );
+        }
+
+        return new self(
+            $other->sign,
+            $this->subtractMagnitudes($other->magnitude, $this->magnitude),
+        );
+    }
+
+    public function subtract(self $other): self
+    {
+        return $this->add($other->negate());
+    }
+
+    public function multiply(self $other): self
+    {
+        if ($this->sign === 0 || $other->sign === 0) {
+            return self::zero();
+        }
+
+        return new self(
+            $this->sign * $other->sign,
+            $this->multiplyMagnitudes($this->magnitude, $other->magnitude),
+        );
+    }
+
+    public function divide(self $other): self
+    {
+        if ($other->sign === 0) {
+            throw new DivisionByZeroError('Division by zero');
+        }
+
+        if ($this->sign === 0) {
+            return self::zero();
+        }
+
+        [$quotient] = $this->divModMagnitudes($this->magnitude, $other->magnitude);
+        if ($quotient === []) {
+            return self::zero();
+        }
+
+        return new self($this->sign * $other->sign, $quotient);
+    }
+
+    public function mod(self $other): self
+    {
+        if ($other->sign === 0) {
+            throw new DivisionByZeroError('Modulo by zero');
+        }
+
+        if ($this->sign === 0) {
+            return self::zero();
+        }
+
+        [, $remainder] = $this->divModMagnitudes($this->magnitude, $other->magnitude);
+        if ($remainder === []) {
+            return self::zero();
+        }
+
+        return new self($this->sign, $remainder);
+    }
+
+    public function gcd(self $other): self
+    {
+        $a = $this->abs();
+        $b = $other->abs();
+
+        while (!$b->isZero()) {
+            $temp = $b;
+            $b = $a->mod($b);
+            $a = $temp;
+        }
+
+        return $a;
+    }
+
+    public function negate(): self
+    {
+        if ($this->sign === 0) {
+            return $this;
+        }
+
+        return new self(-$this->sign, $this->magnitude);
+    }
+
+    public function abs(): self
+    {
+        if ($this->sign >= 0) {
+            return $this;
+        }
+
+        return new self(1, $this->magnitude);
+    }
+
+    public function pow(int $exp): self
+    {
+        if ($exp < 0) {
+            throw new InvalidArgumentException('Exponent must be non-negative');
+        }
+
+        if ($exp === 0) {
+            return self::one();
+        }
+
+        $base = $this;
+        $result = self::one();
+        while ($exp > 0) {
+            if (($exp & 1) === 1) {
+                $result = $result->multiply($base);
+            }
+
+            $exp >>= 1;
+            if ($exp > 0) {
+                $base = $base->multiply($base);
+            }
+        }
+
+        return $result;
+    }
+
+    public function compareTo(self $other): int
+    {
+        if ($this->sign !== $other->sign) {
+            return $this->sign <=> $other->sign;
+        }
+
+        if ($this->sign === 0) {
+            return 0;
+        }
+
+        $magCmp = $this->compareMagnitudes($this->magnitude, $other->magnitude);
+
+        return $this->sign > 0 ? $magCmp : -$magCmp;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->compareTo($other) === 0;
+    }
+
+    public function signum(): int
+    {
+        return $this->sign;
+    }
+
+    public function isZero(): bool
+    {
+        return $this->sign === 0;
+    }
+
+    public function isOne(): bool
+    {
+        return $this->sign === 1
+            && count($this->magnitude) === 1
+            && $this->magnitude[0] === 1;
+    }
+
+    public function fitsInPhpInt(): bool
+    {
+        if ($this->sign === 0) {
+            return true;
+        }
+
+        if ($this->sign > 0) {
+            return $this->compareMagnitudes($this->magnitude, $this->phpIntMaxMagnitude()) <= 0;
+        }
+
+        return $this->compareMagnitudes($this->magnitude, $this->phpIntMinAbsMagnitude()) <= 0;
+    }
+
+    public function toInt(): int
+    {
+        if (!$this->fitsInPhpInt()) {
+            throw new OverflowException(
+                sprintf("BigInteger value '%s' exceeds PHP int range", $this),
+            );
+        }
+
+        if ($this->sign === 0) {
+            return 0;
+        }
+
+        // Materialise from base-10^9 digits without overflow.
+        if ($this->sign < 0
+            && $this->compareMagnitudes($this->magnitude, $this->phpIntMinAbsMagnitude()) === 0
+        ) {
+            return PHP_INT_MIN;
+        }
+
+        $value = 0;
+        for ($i = count($this->magnitude) - 1; $i >= 0; --$i) {
+            $value = $value * self::BASE + $this->magnitude[$i];
+        }
+
+        return $this->sign > 0 ? $value : -$value;
+    }
+
+    /**
+     * @param int<0, max> $value
+     *
+     * @return list<int>
+     */
+    private static function splitNonNegative(int $value): array
+    {
+        $magnitude = [];
+        while ($value > 0) {
+            $magnitude[] = $value % self::BASE;
+            $value = intdiv($value, self::BASE);
+        }
+
+        return $magnitude;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private static function digitsToMagnitude(string $digits): array
+    {
+        // Process digits in chunks of BASE_DIGITS from the right.
+        $magnitude = [];
+        $reversed = strrev($digits);
+        $chunks = str_split($reversed, self::BASE_DIGITS);
+        foreach ($chunks as $chunk) {
+            $magnitude[] = (int) strrev($chunk);
+        }
+
+        return self::trim($magnitude);
+    }
+
+    /**
+     * @param list<int> $a
+     * @param list<int> $b
+     */
+    private function compareMagnitudes(array $a, array $b): int
+    {
+        $countA = count($a);
+        $countB = count($b);
+        if ($countA !== $countB) {
+            return $countA <=> $countB;
+        }
+
+        for ($i = $countA - 1; $i >= 0; --$i) {
+            if ($a[$i] !== $b[$i]) {
+                return $a[$i] <=> $b[$i];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param list<int> $a
+     * @param list<int> $b
+     *
+     * @return list<int>
+     */
+    private static function addMagnitudes(array $a, array $b): array
+    {
+        $result = [];
+        $carry = 0;
+        $max = max(count($a), count($b));
+        for ($i = 0; $i < $max; ++$i) {
+            $sum = ($a[$i] ?? 0) + ($b[$i] ?? 0) + $carry;
+            $result[] = $sum % self::BASE;
+            $carry = intdiv($sum, self::BASE);
+        }
+
+        if ($carry > 0) {
+            $result[] = $carry;
+        }
+
+        return self::trim($result);
+    }
+
+    /**
+     * Subtracts $b from $a; requires |a| >= |b|.
+     *
+     * @param list<int> $a
+     * @param list<int> $b
+     *
+     * @return list<int>
+     */
+    private function subtractMagnitudes(array $a, array $b): array
+    {
+        $result = [];
+        $borrow = 0;
+        $countA = count($a);
+        for ($i = 0; $i < $countA; ++$i) {
+            $diff = $a[$i] - ($b[$i] ?? 0) - $borrow;
+            if ($diff < 0) {
+                $diff += self::BASE;
+                $borrow = 1;
+            } else {
+                $borrow = 0;
+            }
+
+            $result[] = $diff;
+        }
+
+        return self::trim($result);
+    }
+
+    /**
+     * @param list<int> $a
+     * @param list<int> $b
+     *
+     * @return list<int>
+     */
+    private function multiplyMagnitudes(array $a, array $b): array
+    {
+        $countA = count($a);
+        $countB = count($b);
+        $result = array_fill(0, $countA + $countB, 0);
+        for ($i = 0; $i < $countA; ++$i) {
+            $carry = 0;
+            for ($j = 0; $j < $countB; ++$j) {
+                $product = $result[$i + $j] + $a[$i] * $b[$j] + $carry;
+                $result[$i + $j] = $product % self::BASE;
+                $carry = intdiv($product, self::BASE);
+            }
+
+            if ($carry > 0) {
+                $result[$i + $countB] += $carry;
+            }
+        }
+
+        /** @var list<int> $result */
+        return self::trim($result);
+    }
+
+    /**
+     * Long division of magnitudes; returns [$quotient, $remainder].
+     *
+     * @param list<int> $a
+     * @param list<int> $b
+     *
+     * @return array{0: list<int>, 1: list<int>}
+     */
+    private function divModMagnitudes(array $a, array $b): array
+    {
+        if ($this->compareMagnitudes($a, $b) < 0) {
+            return [[], $a];
+        }
+
+        // Single-digit divisor — fast path.
+        if (count($b) === 1) {
+            return $this->divModSingle($a, $b[0]);
+        }
+
+        $countA = count($a);
+        $remainder = [];
+        $quotient = array_fill(0, $countA, 0);
+
+        for ($i = $countA - 1; $i >= 0; --$i) {
+            // Prepend a[i] to remainder (least-significant first means index 0).
+            array_unshift($remainder, $a[$i]);
+            $remainder = self::trim($remainder);
+
+            if ($this->compareMagnitudes($remainder, $b) < 0) {
+                $quotient[$i] = 0;
+                continue;
+            }
+
+            $digit = $this->trialQuotientDigit($remainder, $b);
+            $product = $this->multiplyMagnitudes($b, [$digit]);
+            $remainder = $this->subtractMagnitudes($remainder, $product);
+            $quotient[$i] = $digit;
+        }
+
+        /** @var list<int> $quotient */
+        return [self::trim($quotient), $remainder];
+    }
+
+    /**
+     * Returns the largest base-digit q in [0, BASE) such that b*q <= remainder,
+     * via binary search. The remainder is guaranteed >= b at call time so
+     * q >= 1.
+     *
+     * @param list<int> $remainder
+     * @param list<int> $b
+     */
+    private function trialQuotientDigit(array $remainder, array $b): int
+    {
+        $lo = 1;
+        $hi = self::BASE - 1;
+        $best = 1;
+        while ($lo <= $hi) {
+            $mid = intdiv($lo + $hi, 2);
+            $product = $this->multiplyMagnitudes($b, [$mid]);
+            $cmp = $this->compareMagnitudes($product, $remainder);
+            if ($cmp <= 0) {
+                $best = $mid;
+                $lo = $mid + 1;
+            } else {
+                $hi = $mid - 1;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * @param list<int> $a
+     *
+     * @return array{0: list<int>, 1: list<int>}
+     */
+    private function divModSingle(array $a, int $divisor): array
+    {
+        $quotient = array_fill(0, count($a), 0);
+        $remainder = 0;
+        for ($i = count($a) - 1; $i >= 0; --$i) {
+            $current = $remainder * self::BASE + $a[$i];
+            $quotient[$i] = intdiv($current, $divisor);
+            $remainder = $current % $divisor;
+        }
+
+        /** @var list<int> $quotient */
+        return [
+            self::trim($quotient),
+            $remainder === 0 ? [] : [$remainder],
+        ];
+    }
+
+    /**
+     * @param list<int> $magnitude
+     *
+     * @return list<int>
+     */
+    private static function trim(array $magnitude): array
+    {
+        while ($magnitude !== [] && $magnitude[count($magnitude) - 1] === 0) {
+            array_pop($magnitude);
+        }
+
+        return $magnitude;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function phpIntMaxMagnitude(): array
+    {
+        /** @var list<int>|null $cached */
+        static $cached = null;
+        return $cached ??= self::splitNonNegative(PHP_INT_MAX);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function phpIntMinAbsMagnitude(): array
+    {
+        /** @var list<int>|null $cached */
+        static $cached = null;
+        return $cached ??= self::trim(self::addMagnitudes($this->phpIntMaxMagnitude(), [1]));
+    }
+}

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -13,6 +13,8 @@ This is a **foundational module** with no Facade, Factory, or DependencyProvider
 - **Variable** — mutable box (atom) with watches, validators, deref
 - **PhelVar** — first-class handle to a global definition (`def`); produced by `Registry::addDefinition`/`getVar` and the `(var sym)` / `#'sym` forms; offers `deref`, `meta`, `alterRoot`, `addWatch`/`removeWatch`, `alterMeta`/`resetMeta`, and cached `isDynamic`; implements `FnInterface` so handles are callable (`__invoke` forwards to the current root value)
 - **PhelVarStateRegistry** — singleton side table for per-var watches, metadata overrides, and dynamic-flag cache keyed by `(ns, name)`; lets `PhelVar` stay `readonly` while `alter-meta!` / `add-watch` mutate canonical state
+- **BigInteger** — pure-PHP arbitrary-precision signed integer (`final readonly`); base-10^9 magnitude with sign; `fromInt`, `fromString`, `add/subtract/multiply/divide/mod/gcd/pow/negate/abs`, `compareTo/equals`, `toInt`/`fitsInPhpInt`. No I/O, no static state.
+- **Rational** — exact rational `n/d` (`final readonly`, implements `TypeInterface`); always normalised (denominator > 0, `gcd(|num|, denom) = 1`). `Rational::create($num, $den)` auto-collapses to `int` or `BigInteger` when the result is integral, so `create(4, 2)` returns `int 2`, not a `Rational`. Arithmetic accepts `Rational | BigInteger | int` and stays `Rational` only while the result is non-integral.
 - **Delay** — lazy evaluation with caching
 - **Volatile** — lightweight mutable container for transducer state
 - **Reduced** — signals early termination from reduce/transduce

--- a/src/php/Lang/Rational.php
+++ b/src/php/Lang/Rational.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use DivisionByZeroError;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Stringable;
+
+use function is_int;
+use function sprintf;
+
+/**
+ * Rational number n/d held in canonical form: denominator > 0 and
+ * gcd(|numerator|, denominator) = 1.
+ *
+ * Construction goes through {@see self::create()}, which auto-collapses
+ * integral results to native PHP int (or {@see BigInteger} if outside the
+ * PHP int range). As a consequence `Rational::create(4, 2)` returns
+ * `int 2`, never a `Rational`.
+ */
+final readonly class Rational implements Stringable, TypeInterface
+{
+    private function __construct(
+        private BigInteger $numerator,
+        private BigInteger $denominator,
+        private ?PersistentMapInterface $meta = null,
+        private ?SourceLocation $startLocation = null,
+        private ?SourceLocation $endLocation = null,
+    ) {}
+
+    public function __toString(): string
+    {
+        return sprintf('%s/%s', $this->numerator, $this->denominator);
+    }
+
+    /**
+     * Builds a normalised rational. Returns native int / BigInteger when
+     * the result is an integer (denominator collapses to 1), otherwise a
+     * Rational. Throws on a zero denominator.
+     */
+    public static function create(
+        BigInteger|int $numerator,
+        BigInteger|int $denominator,
+    ): self|BigInteger|int {
+        $num = is_int($numerator) ? BigInteger::fromInt($numerator) : $numerator;
+        $den = is_int($denominator) ? BigInteger::fromInt($denominator) : $denominator;
+
+        if ($den->isZero()) {
+            throw new DivisionByZeroError('Rational denominator must be non-zero');
+        }
+
+        if ($num->isZero()) {
+            return 0;
+        }
+
+        // Force denominator positive.
+        if ($den->signum() < 0) {
+            $num = $num->negate();
+            $den = $den->negate();
+        }
+
+        $gcd = $num->abs()->gcd($den);
+        if (!$gcd->isOne()) {
+            $num = $num->divide($gcd);
+            $den = $den->divide($gcd);
+        }
+
+        if ($den->isOne()) {
+            return $num->fitsInPhpInt() ? $num->toInt() : $num;
+        }
+
+        return new self($num, $den);
+    }
+
+    public function numerator(): BigInteger
+    {
+        return $this->numerator;
+    }
+
+    public function denominator(): BigInteger
+    {
+        return $this->denominator;
+    }
+
+    public function add(self|BigInteger|int $other): self|BigInteger|int
+    {
+        [$num, $den] = $this->extractNumDen($other);
+        // a/b + c/d = (a*d + c*b) / (b*d)
+        $resultNum = $this->numerator->multiply($den)->add($num->multiply($this->denominator));
+        $resultDen = $this->denominator->multiply($den);
+        return self::create($resultNum, $resultDen);
+    }
+
+    public function subtract(self|BigInteger|int $other): self|BigInteger|int
+    {
+        [$num, $den] = $this->extractNumDen($other);
+        $resultNum = $this->numerator->multiply($den)->subtract($num->multiply($this->denominator));
+        $resultDen = $this->denominator->multiply($den);
+        return self::create($resultNum, $resultDen);
+    }
+
+    public function multiply(self|BigInteger|int $other): self|BigInteger|int
+    {
+        [$num, $den] = $this->extractNumDen($other);
+        return self::create(
+            $this->numerator->multiply($num),
+            $this->denominator->multiply($den),
+        );
+    }
+
+    public function divide(self|BigInteger|int $other): self|BigInteger|int
+    {
+        [$num, $den] = $this->extractNumDen($other);
+        if ($num->isZero()) {
+            throw new DivisionByZeroError('Division by zero');
+        }
+
+        return self::create(
+            $this->numerator->multiply($den),
+            $this->denominator->multiply($num),
+        );
+    }
+
+    public function negate(): self
+    {
+        return new self($this->numerator->negate(), $this->denominator);
+    }
+
+    public function abs(): self
+    {
+        if ($this->numerator->signum() >= 0) {
+            return $this;
+        }
+
+        return new self($this->numerator->negate(), $this->denominator);
+    }
+
+    public function compareTo(self|BigInteger|int $other): int
+    {
+        [$num, $den] = $this->extractNumDen($other);
+        // a/b vs c/d  →  sign(a*d - c*b) since b,d > 0
+        $left = $this->numerator->multiply($den);
+        $right = $num->multiply($this->denominator);
+        return $left->compareTo($right);
+    }
+
+    public function equals(mixed $other): bool
+    {
+        if ($other instanceof self) {
+            return $this->numerator->equals($other->numerator)
+                && $this->denominator->equals($other->denominator);
+        }
+
+        if ($other instanceof BigInteger) {
+            return $this->denominator->isOne() && $this->numerator->equals($other);
+        }
+
+        if (is_int($other)) {
+            return $this->denominator->isOne() && $this->numerator->equals(BigInteger::fromInt($other));
+        }
+
+        return false;
+    }
+
+    public function hash(): int
+    {
+        return crc32(sprintf('%s/%s', $this->numerator, $this->denominator));
+    }
+
+    public function toFloat(): float
+    {
+        return (float) ((string) $this->numerator) / (float) ((string) $this->denominator);
+    }
+
+    public function getMeta(): ?PersistentMapInterface
+    {
+        return $this->meta;
+    }
+
+    public function withMeta(?PersistentMapInterface $meta): static
+    {
+        return new self(
+            $this->numerator,
+            $this->denominator,
+            $meta,
+            $this->startLocation,
+            $this->endLocation,
+        );
+    }
+
+    public function setStartLocation(?SourceLocation $startLocation): static
+    {
+        return new self(
+            $this->numerator,
+            $this->denominator,
+            $this->meta,
+            $startLocation,
+            $this->endLocation,
+        );
+    }
+
+    public function setEndLocation(?SourceLocation $endLocation): static
+    {
+        return new self(
+            $this->numerator,
+            $this->denominator,
+            $this->meta,
+            $this->startLocation,
+            $endLocation,
+        );
+    }
+
+    public function getStartLocation(): ?SourceLocation
+    {
+        return $this->startLocation;
+    }
+
+    public function getEndLocation(): ?SourceLocation
+    {
+        return $this->endLocation;
+    }
+
+    public function copyLocationFrom(mixed $other): static
+    {
+        if ($other instanceof SourceLocationInterface) {
+            return $this
+                ->setStartLocation($other->getStartLocation())
+                ->setEndLocation($other->getEndLocation());
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array{0: BigInteger, 1: BigInteger}
+     */
+    private function extractNumDen(self|BigInteger|int $value): array
+    {
+        if ($value instanceof self) {
+            return [$value->numerator, $value->denominator];
+        }
+
+        if ($value instanceof BigInteger) {
+            return [$value, BigInteger::one()];
+        }
+
+        return [BigInteger::fromInt($value), BigInteger::one()];
+    }
+}

--- a/src/php/Printer/CLAUDE.md
+++ b/src/php/Printer/CLAUDE.md
@@ -28,6 +28,7 @@ Each implements `TypePrinterInterface`. Selected at runtime based on value type:
 | `NullPrinter` | null |
 | `KeywordPrinter` | Keyword objects |
 | `SymbolPrinter` | Symbol objects |
+| `RationalPrinter` | Rational numbers (`n/d`) |
 | `VariablePrinter` | Variable objects (recursive) |
 | `PersistentListPrinter` | Lists (recursive) |
 | `PersistentVectorPrinter` | Vectors (recursive) |

--- a/src/php/Printer/Printer.php
+++ b/src/php/Printer/Printer.php
@@ -13,6 +13,7 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\PhelVar;
+use Phel\Lang\Rational;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use Phel\Lang\TypeStringifier;
@@ -31,6 +32,7 @@ use Phel\Printer\TypePrinter\PersistentHashSetPrinter;
 use Phel\Printer\TypePrinter\PersistentListPrinter;
 use Phel\Printer\TypePrinter\PersistentMapPrinter;
 use Phel\Printer\TypePrinter\PersistentVectorPrinter;
+use Phel\Printer\TypePrinter\RationalPrinter;
 use Phel\Printer\TypePrinter\ResourcePrinter;
 use Phel\Printer\TypePrinter\StringPrinter;
 use Phel\Printer\TypePrinter\StructPrinter;
@@ -131,6 +133,10 @@ final readonly class Printer implements PrinterInterface
 
         if ($form instanceof PhelVar) {
             return new VarPrinter($this->withColor);
+        }
+
+        if ($form instanceof Rational) {
+            return new RationalPrinter($this->withColor);
         }
 
         if ($form instanceof FnInterface) {

--- a/src/php/Printer/TypePrinter/RationalPrinter.php
+++ b/src/php/Printer/TypePrinter/RationalPrinter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Printer\TypePrinter;
+
+use Phel\Lang\Rational;
+
+use function sprintf;
+
+/**
+ * @implements TypePrinterInterface<Rational>
+ */
+final class RationalPrinter implements TypePrinterInterface
+{
+    use WithColorTrait;
+
+    /**
+     * @param Rational $form
+     */
+    public function print(mixed $form): string
+    {
+        return $this->color($form->__toString());
+    }
+
+    private function color(string $str): string
+    {
+        if ($this->withColor) {
+            return sprintf("\033[0;92m%s\033[0m", $str);
+        }
+
+        return $str;
+    }
+}

--- a/tests/php/Unit/Lang/BigIntegerTest.php
+++ b/tests/php/Unit/Lang/BigIntegerTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use DivisionByZeroError;
+use InvalidArgumentException;
+use OverflowException;
+use Phel\Lang\BigInteger;
+use PHPUnit\Framework\TestCase;
+
+final class BigIntegerTest extends TestCase
+{
+    public function test_zero_factory(): void
+    {
+        $zero = BigInteger::zero();
+
+        self::assertSame('0', (string) $zero);
+        self::assertTrue($zero->isZero());
+        self::assertSame(0, $zero->signum());
+    }
+
+    public function test_one_factory(): void
+    {
+        $one = BigInteger::one();
+
+        self::assertSame('1', (string) $one);
+        self::assertTrue($one->isOne());
+        self::assertSame(1, $one->signum());
+    }
+
+    public function test_from_int_small(): void
+    {
+        self::assertSame('42', (string) BigInteger::fromInt(42));
+        self::assertSame('-42', (string) BigInteger::fromInt(-42));
+        self::assertSame('0', (string) BigInteger::fromInt(0));
+    }
+
+    public function test_from_int_php_int_max(): void
+    {
+        self::assertSame((string) PHP_INT_MAX, (string) BigInteger::fromInt(PHP_INT_MAX));
+        self::assertSame((string) PHP_INT_MIN, (string) BigInteger::fromInt(PHP_INT_MIN));
+    }
+
+    public function test_from_string_decimal(): void
+    {
+        self::assertSame('123456789012345678901234567890', (string) BigInteger::fromString('123456789012345678901234567890'));
+        self::assertSame('-987654321098765432109876543210', (string) BigInteger::fromString('-987654321098765432109876543210'));
+    }
+
+    public function test_from_string_zero(): void
+    {
+        self::assertSame('0', (string) BigInteger::fromString('0'));
+        self::assertTrue(BigInteger::fromString('0')->isZero());
+    }
+
+    public function test_from_string_negative_zero_is_zero(): void
+    {
+        self::assertSame('0', (string) BigInteger::fromString('-0'));
+        self::assertTrue(BigInteger::fromString('-0')->isZero());
+    }
+
+    public function test_from_string_rejects_empty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('');
+    }
+
+    public function test_from_string_rejects_only_minus(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('-');
+    }
+
+    public function test_from_string_rejects_leading_zero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('012');
+    }
+
+    public function test_from_string_rejects_negative_leading_zero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('-012');
+    }
+
+    public function test_from_string_rejects_letters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('12a3');
+    }
+
+    public function test_from_string_rejects_plus_sign(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromString('+12');
+    }
+
+    public function test_add_small(): void
+    {
+        $result = BigInteger::fromInt(2)->add(BigInteger::fromInt(3));
+
+        self::assertSame('5', (string) $result);
+    }
+
+    public function test_add_carry_across_digits(): void
+    {
+        $a = BigInteger::fromString('999999999');
+        $b = BigInteger::fromString('1');
+
+        self::assertSame('1000000000', (string) $a->add($b));
+    }
+
+    public function test_add_large(): void
+    {
+        $a = BigInteger::fromString('123456789012345678901234567890');
+        $b = BigInteger::fromString('987654321098765432109876543210');
+
+        self::assertSame('1111111110111111111011111111100', (string) $a->add($b));
+    }
+
+    public function test_add_commutative(): void
+    {
+        $a = BigInteger::fromString('1234567890');
+        $b = BigInteger::fromString('9876543210');
+
+        self::assertSame((string) $a->add($b), (string) $b->add($a));
+    }
+
+    public function test_add_negative_negative(): void
+    {
+        self::assertSame('-12', (string) BigInteger::fromInt(-5)->add(BigInteger::fromInt(-7)));
+    }
+
+    public function test_add_positive_negative_yields_difference(): void
+    {
+        self::assertSame('3', (string) BigInteger::fromInt(10)->add(BigInteger::fromInt(-7)));
+        self::assertSame('-3', (string) BigInteger::fromInt(7)->add(BigInteger::fromInt(-10)));
+        self::assertSame('0', (string) BigInteger::fromInt(7)->add(BigInteger::fromInt(-7)));
+    }
+
+    public function test_subtract_small(): void
+    {
+        self::assertSame('-1', (string) BigInteger::fromInt(2)->subtract(BigInteger::fromInt(3)));
+        self::assertSame('1', (string) BigInteger::fromInt(3)->subtract(BigInteger::fromInt(2)));
+    }
+
+    public function test_subtract_large(): void
+    {
+        $a = BigInteger::fromString('1000000000000000000000');
+        $b = BigInteger::fromString('1');
+
+        self::assertSame('999999999999999999999', (string) $a->subtract($b));
+    }
+
+    public function test_subtract_negatives(): void
+    {
+        self::assertSame('2', (string) BigInteger::fromInt(-5)->subtract(BigInteger::fromInt(-7)));
+        self::assertSame('-2', (string) BigInteger::fromInt(-7)->subtract(BigInteger::fromInt(-5)));
+    }
+
+    public function test_multiply_small(): void
+    {
+        self::assertSame('6', (string) BigInteger::fromInt(2)->multiply(BigInteger::fromInt(3)));
+        self::assertSame('0', (string) BigInteger::fromInt(0)->multiply(BigInteger::fromInt(123)));
+    }
+
+    public function test_multiply_signs(): void
+    {
+        self::assertSame('-6', (string) BigInteger::fromInt(-2)->multiply(BigInteger::fromInt(3)));
+        self::assertSame('-6', (string) BigInteger::fromInt(2)->multiply(BigInteger::fromInt(-3)));
+        self::assertSame('6', (string) BigInteger::fromInt(-2)->multiply(BigInteger::fromInt(-3)));
+    }
+
+    public function test_multiply_large(): void
+    {
+        $a = BigInteger::fromString('1000000000000000000');
+        $b = BigInteger::fromString('1000000000000000000');
+
+        self::assertSame('1000000000000000000000000000000000000', (string) $a->multiply($b));
+    }
+
+    public function test_multiply_carry(): void
+    {
+        $a = BigInteger::fromString('999999999');
+        $b = BigInteger::fromString('999999999');
+
+        self::assertSame('999999998000000001', (string) $a->multiply($b));
+    }
+
+    public function test_divide_small(): void
+    {
+        self::assertSame('3', (string) BigInteger::fromInt(10)->divide(BigInteger::fromInt(3)));
+        self::assertSame('5', (string) BigInteger::fromInt(20)->divide(BigInteger::fromInt(4)));
+    }
+
+    public function test_divide_truncates_toward_zero(): void
+    {
+        self::assertSame('-3', (string) BigInteger::fromInt(-10)->divide(BigInteger::fromInt(3)));
+        self::assertSame('-3', (string) BigInteger::fromInt(10)->divide(BigInteger::fromInt(-3)));
+        self::assertSame('3', (string) BigInteger::fromInt(-10)->divide(BigInteger::fromInt(-3)));
+    }
+
+    public function test_divide_zero_dividend(): void
+    {
+        self::assertSame('0', (string) BigInteger::fromInt(0)->divide(BigInteger::fromInt(5)));
+    }
+
+    public function test_divide_by_zero_throws(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+        BigInteger::fromInt(10)->divide(BigInteger::zero());
+    }
+
+    public function test_divide_large(): void
+    {
+        $a = BigInteger::fromString('1000000000000000000000000000000');
+        $b = BigInteger::fromString('1000000000');
+
+        self::assertSame('1000000000000000000000', (string) $a->divide($b));
+    }
+
+    public function test_divide_multi_digit_divisor(): void
+    {
+        $a = BigInteger::fromString('123456789012345678901234567890');
+        $b = BigInteger::fromString('987654321');
+
+        self::assertSame('124999998873437499901', (string) $a->divide($b));
+    }
+
+    public function test_mod_small(): void
+    {
+        self::assertSame('1', (string) BigInteger::fromInt(10)->mod(BigInteger::fromInt(3)));
+        self::assertSame('0', (string) BigInteger::fromInt(20)->mod(BigInteger::fromInt(4)));
+    }
+
+    public function test_mod_sign_follows_dividend(): void
+    {
+        self::assertSame('-1', (string) BigInteger::fromInt(-10)->mod(BigInteger::fromInt(3)));
+        self::assertSame('1', (string) BigInteger::fromInt(10)->mod(BigInteger::fromInt(-3)));
+        self::assertSame('-1', (string) BigInteger::fromInt(-10)->mod(BigInteger::fromInt(-3)));
+    }
+
+    public function test_mod_by_zero_throws(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+        BigInteger::fromInt(10)->mod(BigInteger::zero());
+    }
+
+    public function test_gcd_coprimes(): void
+    {
+        self::assertSame('1', (string) BigInteger::fromInt(7)->gcd(BigInteger::fromInt(13)));
+    }
+
+    public function test_gcd_common(): void
+    {
+        self::assertSame('6', (string) BigInteger::fromInt(12)->gcd(BigInteger::fromInt(18)));
+        self::assertSame('21', (string) BigInteger::fromInt(1071)->gcd(BigInteger::fromInt(462)));
+    }
+
+    public function test_gcd_zero_zero(): void
+    {
+        self::assertSame('0', (string) BigInteger::zero()->gcd(BigInteger::zero()));
+    }
+
+    public function test_gcd_with_zero(): void
+    {
+        self::assertSame('5', (string) BigInteger::fromInt(5)->gcd(BigInteger::zero()));
+        self::assertSame('5', (string) BigInteger::zero()->gcd(BigInteger::fromInt(5)));
+    }
+
+    public function test_gcd_negative_signs_normalized(): void
+    {
+        self::assertSame('6', (string) BigInteger::fromInt(-12)->gcd(BigInteger::fromInt(18)));
+        self::assertSame('6', (string) BigInteger::fromInt(12)->gcd(BigInteger::fromInt(-18)));
+        self::assertSame('6', (string) BigInteger::fromInt(-12)->gcd(BigInteger::fromInt(-18)));
+    }
+
+    public function test_negate(): void
+    {
+        self::assertSame('-5', (string) BigInteger::fromInt(5)->negate());
+        self::assertSame('5', (string) BigInteger::fromInt(-5)->negate());
+        self::assertSame('0', (string) BigInteger::zero()->negate());
+    }
+
+    public function test_abs(): void
+    {
+        self::assertSame('5', (string) BigInteger::fromInt(-5)->abs());
+        self::assertSame('5', (string) BigInteger::fromInt(5)->abs());
+        self::assertSame('0', (string) BigInteger::zero()->abs());
+    }
+
+    public function test_pow_basic(): void
+    {
+        self::assertSame('1', (string) BigInteger::fromInt(2)->pow(0));
+        self::assertSame('2', (string) BigInteger::fromInt(2)->pow(1));
+        self::assertSame('1024', (string) BigInteger::fromInt(2)->pow(10));
+    }
+
+    public function test_pow_large(): void
+    {
+        self::assertSame(
+            '100000000000000000000',
+            (string) BigInteger::fromInt(10)->pow(20),
+        );
+    }
+
+    public function test_pow_negative_base_signs(): void
+    {
+        self::assertSame('-8', (string) BigInteger::fromInt(-2)->pow(3));
+        self::assertSame('16', (string) BigInteger::fromInt(-2)->pow(4));
+    }
+
+    public function test_pow_zero_to_zero_is_one(): void
+    {
+        self::assertSame('1', (string) BigInteger::zero()->pow(0));
+    }
+
+    public function test_pow_negative_exponent_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromInt(2)->pow(-1);
+    }
+
+    public function test_compare_to(): void
+    {
+        self::assertSame(-1, BigInteger::fromInt(1)->compareTo(BigInteger::fromInt(2)));
+        self::assertSame(0, BigInteger::fromInt(2)->compareTo(BigInteger::fromInt(2)));
+        self::assertSame(1, BigInteger::fromInt(3)->compareTo(BigInteger::fromInt(2)));
+    }
+
+    public function test_compare_to_signs(): void
+    {
+        self::assertSame(1, BigInteger::fromInt(1)->compareTo(BigInteger::fromInt(-1)));
+        self::assertSame(-1, BigInteger::fromInt(-1)->compareTo(BigInteger::fromInt(1)));
+        self::assertSame(0, BigInteger::zero()->compareTo(BigInteger::zero()));
+    }
+
+    public function test_compare_to_large(): void
+    {
+        $a = BigInteger::fromString('123456789012345678901234567890');
+        $b = BigInteger::fromString('123456789012345678901234567891');
+
+        self::assertSame(-1, $a->compareTo($b));
+        self::assertSame(1, $b->compareTo($a));
+        self::assertSame(0, $a->compareTo($a));
+    }
+
+    public function test_equals(): void
+    {
+        self::assertTrue(BigInteger::fromInt(7)->equals(BigInteger::fromInt(7)));
+        self::assertFalse(BigInteger::fromInt(7)->equals(BigInteger::fromInt(-7)));
+        self::assertTrue(BigInteger::zero()->equals(BigInteger::fromString('-0')));
+    }
+
+    public function test_signum(): void
+    {
+        self::assertSame(1, BigInteger::fromInt(42)->signum());
+        self::assertSame(-1, BigInteger::fromInt(-42)->signum());
+        self::assertSame(0, BigInteger::zero()->signum());
+    }
+
+    public function test_to_int_within_range(): void
+    {
+        self::assertSame(42, BigInteger::fromInt(42)->toInt());
+        self::assertSame(-42, BigInteger::fromInt(-42)->toInt());
+        self::assertSame(PHP_INT_MAX, BigInteger::fromInt(PHP_INT_MAX)->toInt());
+        self::assertSame(PHP_INT_MIN, BigInteger::fromInt(PHP_INT_MIN)->toInt());
+    }
+
+    public function test_to_int_overflow_throws(): void
+    {
+        $this->expectException(OverflowException::class);
+        BigInteger::fromString('99999999999999999999999999')->toInt();
+    }
+
+    public function test_to_int_underflow_throws(): void
+    {
+        $this->expectException(OverflowException::class);
+        BigInteger::fromString('-99999999999999999999999999')->toInt();
+    }
+
+    public function test_fits_in_php_int_boundaries(): void
+    {
+        self::assertTrue(BigInteger::fromInt(PHP_INT_MAX)->fitsInPhpInt());
+        self::assertTrue(BigInteger::fromInt(PHP_INT_MIN)->fitsInPhpInt());
+        self::assertFalse(BigInteger::fromString((string) PHP_INT_MAX)->add(BigInteger::one())->fitsInPhpInt());
+        self::assertFalse(BigInteger::fromString((string) PHP_INT_MIN)->subtract(BigInteger::one())->fitsInPhpInt());
+    }
+
+    public function test_to_string_roundtrip_via_from_string(): void
+    {
+        $samples = [
+            '0',
+            '1',
+            '-1',
+            '999999999',
+            '1000000000',
+            '999999999999999999',
+            '-123456789012345678901234567890',
+            '999999999999999999999999999999',
+        ];
+
+        foreach ($samples as $sample) {
+            self::assertSame($sample, (string) BigInteger::fromString($sample));
+        }
+    }
+
+    public function test_to_string_no_leading_zeros(): void
+    {
+        $value = BigInteger::fromString('1000000000')->subtract(BigInteger::fromString('1'));
+
+        self::assertSame('999999999', (string) $value);
+    }
+
+    public function test_subtract_zero_yields_self(): void
+    {
+        self::assertSame('42', (string) BigInteger::fromInt(42)->subtract(BigInteger::zero()));
+        self::assertSame('-42', (string) BigInteger::zero()->subtract(BigInteger::fromInt(42)));
+    }
+}

--- a/tests/php/Unit/Lang/RationalTest.php
+++ b/tests/php/Unit/Lang/RationalTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use DivisionByZeroError;
+use Phel\Lang\BigInteger;
+use Phel\Lang\Rational;
+use PHPUnit\Framework\TestCase;
+
+final class RationalTest extends TestCase
+{
+    public function test_create_simple(): void
+    {
+        $r = Rational::create(1, 2);
+
+        self::assertInstanceOf(Rational::class, $r);
+        self::assertSame('1', (string) $r->numerator());
+        self::assertSame('2', (string) $r->denominator());
+        self::assertSame('1/2', (string) $r);
+    }
+
+    public function test_create_normalises_negative_denominator(): void
+    {
+        $r = Rational::create(1, -2);
+
+        self::assertInstanceOf(Rational::class, $r);
+        self::assertSame('-1', (string) $r->numerator());
+        self::assertSame('2', (string) $r->denominator());
+    }
+
+    public function test_create_normalises_double_negative(): void
+    {
+        $r = Rational::create(-1, -2);
+
+        self::assertInstanceOf(Rational::class, $r);
+        self::assertSame('1', (string) $r->numerator());
+        self::assertSame('2', (string) $r->denominator());
+    }
+
+    public function test_create_reduces_via_gcd(): void
+    {
+        $r = Rational::create(6, 4);
+
+        self::assertInstanceOf(Rational::class, $r);
+        self::assertSame('3', (string) $r->numerator());
+        self::assertSame('2', (string) $r->denominator());
+    }
+
+    public function test_create_zero_numerator_collapses_to_int_zero(): void
+    {
+        self::assertSame(0, Rational::create(0, 5));
+        self::assertSame(0, Rational::create(0, -5));
+    }
+
+    public function test_create_collapses_when_denominator_one(): void
+    {
+        self::assertSame(2, Rational::create(4, 2));
+        self::assertSame(8, Rational::create(8, 1));
+        self::assertSame(-3, Rational::create(-6, 2));
+    }
+
+    public function test_create_collapses_to_big_integer_when_too_large(): void
+    {
+        $big = BigInteger::fromString('123456789012345678901234567890');
+        $result = Rational::create($big, 1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame('123456789012345678901234567890', (string) $result);
+    }
+
+    public function test_create_zero_denominator_throws(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+        Rational::create(1, 0);
+    }
+
+    public function test_create_accepts_big_integers(): void
+    {
+        $num = BigInteger::fromString('1000000000000');
+        $den = BigInteger::fromString('500000000000');
+
+        self::assertSame(2, Rational::create($num, $den));
+    }
+
+    public function test_add_rational_to_rational(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(1, 3);
+        $sum = $a->add($b);
+
+        self::assertInstanceOf(Rational::class, $sum);
+        self::assertSame('5/6', (string) $sum);
+    }
+
+    public function test_add_collapses_when_result_integer(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(1, 2);
+
+        self::assertSame(1, $a->add($b));
+    }
+
+    public function test_add_with_int(): void
+    {
+        $a = Rational::create(1, 2);
+
+        $result = $a->add(2);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertSame('5/2', (string) $result);
+    }
+
+    public function test_add_with_big_integer(): void
+    {
+        $a = Rational::create(1, 2);
+        $big = BigInteger::fromInt(3);
+
+        $result = $a->add($big);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertSame('7/2', (string) $result);
+    }
+
+    public function test_subtract(): void
+    {
+        $a = Rational::create(3, 4);
+        $b = Rational::create(1, 4);
+        $expected = Rational::create(1, 2);
+
+        $result = $a->subtract($b);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertTrue($expected->equals($result));
+    }
+
+    public function test_subtract_collapses_to_zero(): void
+    {
+        $a = Rational::create(1, 2);
+
+        self::assertSame(0, $a->subtract($a));
+    }
+
+    public function test_multiply(): void
+    {
+        $a = Rational::create(2, 3);
+        $b = Rational::create(3, 4);
+
+        $result = $a->multiply($b);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertSame('1/2', (string) $result);
+    }
+
+    public function test_multiply_collapses_to_int(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(2, 1);
+
+        self::assertSame(1, $a->multiply($b));
+    }
+
+    public function test_divide(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(1, 4);
+
+        self::assertSame(2, $a->divide($b));
+    }
+
+    public function test_divide_with_int(): void
+    {
+        $a = Rational::create(1, 2);
+
+        $result = $a->divide(3);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertSame('1/6', (string) $result);
+    }
+
+    public function test_divide_by_zero_throws(): void
+    {
+        $a = Rational::create(1, 2);
+
+        $this->expectException(DivisionByZeroError::class);
+        $a->divide(0);
+    }
+
+    public function test_negate(): void
+    {
+        $a = Rational::create(2, 3);
+
+        self::assertSame('-2/3', (string) $a->negate());
+        self::assertSame('2/3', (string) $a->negate()->negate());
+    }
+
+    public function test_abs(): void
+    {
+        self::assertSame('2/3', (string) Rational::create(-2, 3)->abs());
+        self::assertSame('2/3', (string) Rational::create(2, 3)->abs());
+    }
+
+    public function test_compare_to_rational(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(2, 3);
+
+        self::assertSame(-1, $a->compareTo($b));
+        self::assertSame(1, $b->compareTo($a));
+        self::assertSame(0, $a->compareTo(Rational::create(1, 2)));
+    }
+
+    public function test_compare_to_int(): void
+    {
+        $a = Rational::create(3, 2);
+
+        self::assertSame(1, $a->compareTo(1));
+        self::assertSame(-1, $a->compareTo(2));
+    }
+
+    public function test_compare_to_big_integer(): void
+    {
+        $a = Rational::create(3, 2);
+
+        self::assertSame(1, $a->compareTo(BigInteger::fromInt(1)));
+        self::assertSame(-1, $a->compareTo(BigInteger::fromInt(2)));
+    }
+
+    public function test_equals_canonical_form(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(2, 4);
+
+        self::assertTrue($a->equals($b));
+    }
+
+    public function test_equals_distinct_canonical_forms_not_equal(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(1, 3);
+
+        self::assertFalse($a->equals($b));
+    }
+
+    public function test_equals_non_rational(): void
+    {
+        $a = Rational::create(1, 2);
+
+        self::assertFalse($a->equals('1/2'));
+        self::assertFalse($a->equals(null));
+        self::assertFalse($a->equals(0.5));
+    }
+
+    public function test_hash_equal_for_equal_canonical_forms(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(2, 4);
+
+        self::assertSame($a->hash(), $b->hash());
+    }
+
+    public function test_hash_distinct_for_distinct_forms(): void
+    {
+        $a = Rational::create(1, 2);
+        $b = Rational::create(1, 3);
+
+        self::assertNotSame($a->hash(), $b->hash());
+    }
+
+    public function test_to_float(): void
+    {
+        self::assertSame(0.5, Rational::create(1, 2)->toFloat());
+        self::assertSame(-0.25, Rational::create(-1, 4)->toFloat());
+        self::assertEqualsWithDelta(1.0 / 3.0, Rational::create(1, 3)->toFloat(), 1e-15);
+    }
+
+    public function test_to_string_format(): void
+    {
+        self::assertSame('1/2', (string) Rational::create(1, 2));
+        self::assertSame('-1/2', (string) Rational::create(-1, 2));
+        self::assertSame('22/7', (string) Rational::create(22, 7));
+    }
+
+    public function test_arithmetic_with_big_integer_arguments(): void
+    {
+        $a = Rational::create(1, 3);
+        $bigOther = BigInteger::fromString('1000000000000000000');
+
+        $result = $a->multiply($bigOther);
+        self::assertInstanceOf(Rational::class, $result);
+        self::assertSame('1000000000000000000/3', (string) $result);
+    }
+
+    public function test_arithmetic_no_overflow_with_large_values(): void
+    {
+        $big = BigInteger::fromString('100000000000000000');
+        $a = Rational::create($big, 3);
+        $b = Rational::create($big, 7);
+
+        $result = $a->add($b);
+        self::assertInstanceOf(Rational::class, $result);
+        // (100e15/3) + (100e15/7) = 100e15 * 10 / 21 = 1e18 / 21
+        self::assertSame('1000000000000000000/21', (string) $result);
+    }
+}

--- a/tests/php/Unit/Printer/TypePrinter/RationalPrinterTest.php
+++ b/tests/php/Unit/Printer/TypePrinter/RationalPrinterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Printer\TypePrinter;
+
+use Generator;
+use Phel\Lang\Rational;
+use Phel\Printer\Printer;
+use Phel\Printer\TypePrinter\RationalPrinter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RationalPrinterTest extends TestCase
+{
+    #[DataProvider('printerDataProvider')]
+    public function test_print(string $expected, Rational $rational): void
+    {
+        self::assertSame(
+            $expected,
+            new RationalPrinter()->print($rational),
+        );
+    }
+
+    public static function printerDataProvider(): Generator
+    {
+        $half = Rational::create(1, 2);
+        self::assertInstanceOf(Rational::class, $half);
+        yield 'one half' => ['1/2', $half];
+
+        $negativeThirteenths = Rational::create(-3, 13);
+        self::assertInstanceOf(Rational::class, $negativeThirteenths);
+        yield 'negative' => ['-3/13', $negativeThirteenths];
+
+        $reduced = Rational::create(6, 4);
+        self::assertInstanceOf(Rational::class, $reduced);
+        yield 'reduced form' => ['3/2', $reduced];
+    }
+
+    public function test_printer_dispatch_readable(): void
+    {
+        $rational = Rational::create(7, 9);
+
+        self::assertSame('7/9', Printer::readable()->print($rational));
+    }
+
+    public function test_printer_dispatch_non_readable(): void
+    {
+        $rational = Rational::create(7, 9);
+
+        self::assertSame('7/9', Printer::nonReadable()->print($rational));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Foundation work for #1825 (rational numbers). This PR ships only the value-object layer; lexer, emitter, and Phel-side arithmetic land in follow-up PRs.

## 💡 Goal

Add the underlying types so subsequent slices can build on a stable, fully tested foundation.

## 🔖 Changes

- `Phel\Lang\BigInteger`: pure-PHP arbitrary-precision integer (sign + base-10^9 digits). `add/sub/mul/div/mod/gcd/pow/compareTo/equals/abs/negate`, `fromInt/fromString/zero/one`, overflow-aware `toInt`.
- `Phel\Lang\Rational`: `final readonly` value object using `BigInteger`. `Rational::create` normalizes via gcd, lifts the sign onto the numerator, and auto-collapses to `int` (or `BigInteger`) when the result is integral.
- Printer dispatch renders `Rational` as `n/d`.
- 98 new unit tests; full PHPUnit suite green.

Related to #1825