### PR TITLE
fix(lang): symmetric =, int-overflow promotion, float div-by-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+#### Lang
+- `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)
+- `+`, `-`, `*`, `**` on native PHP ints auto-promote to `BigInteger` on overflow instead of silently widening to a float (#1830)
+- `(/ 1.0 0.0)` returns `##Inf`, `(/ -1.0 0.0)` returns `##-Inf`, `(/ 0.0 0.0)` returns `##NaN`; finite integer division by zero still throws (#1830)
+
 ### Added
 
 #### Compiler

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -3,7 +3,6 @@
 (use Countable)
 (use InvalidArgumentException)
 (use Phel)
-(use Phel.Lang.AbstractType)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
 (use Phel.Lang.Collections.Map.PersistentMapInterface)
 (use Phel.Lang.ConsInterface)
@@ -21,15 +20,14 @@
 ;; ------------------------
 
 (defn- equals1 [a b]
-  (if (php/instanceof a AbstractType)
+  ;; Symmetric dispatch: prefer the side that carries equality semantics.
+  ;; `AbstractType` already implements `EqualsInterface` via `TypeInterface`,
+  ;; so a single instanceof check per side is enough.
+  (if (php/instanceof a \Phel\Lang\EqualsInterface)
     (php/-> a (equals b))
-    (if (php/instanceof a \Phel\Lang\EqualsInterface)
-      (php/-> a (equals b))
-      (if (php/instanceof b AbstractType)
-        (php/-> b (equals a))
-        (if (php/instanceof b \Phel\Lang\EqualsInterface)
-          (php/-> b (equals a))
-          (php/=== a b))))))
+    (if (php/instanceof b \Phel\Lang\EqualsInterface)
+      (php/-> b (equals a))
+      (php/=== a b))))
 
 (defn- cons-string [x coll]
   (let [result (php/array x)]

--- a/src/phel/core/seq-basics.phel
+++ b/src/phel/core/seq-basics.phel
@@ -25,7 +25,11 @@
     (php/-> a (equals b))
     (if (php/instanceof a \Phel\Lang\EqualsInterface)
       (php/-> a (equals b))
-      (php/=== a b))))
+      (if (php/instanceof b AbstractType)
+        (php/-> b (equals a))
+        (if (php/instanceof b \Phel\Lang\EqualsInterface)
+          (php/-> b (equals a))
+          (php/=== a b))))))
 
 (defn- cons-string [x coll]
   (let [result (php/array x)]

--- a/src/php/Lang/Equalizer.php
+++ b/src/php/Lang/Equalizer.php
@@ -6,6 +6,8 @@ namespace Phel\Lang;
 
 use Gacela\Container\Attribute\Singleton;
 
+use function is_int;
+
 #[Singleton]
 final class Equalizer implements EqualizerInterface
 {
@@ -21,10 +23,38 @@ final class Equalizer implements EqualizerInterface
             return true;
         }
 
+        // Symmetric numeric-tower equality across {int, BigInteger}.
+        // Floats are a separate category and never equal an int/BigInteger
+        // under `=` (use `==` for cross-category comparison).
+        if ($this->isIntegralNumber($a) && $this->isIntegralNumber($b)) {
+            return $this->integralEquals($a, $b);
+        }
+
         if ($a instanceof EqualsInterface) {
             return $a->equals($b);
         }
 
+        // Dispatch on $b when only the right side carries equality semantics.
+        if ($b instanceof EqualsInterface) {
+            return $b->equals($a);
+        }
+
         return false;
+    }
+
+    private function isIntegralNumber(mixed $value): bool
+    {
+        return is_int($value) || $value instanceof BigInteger;
+    }
+
+    private function integralEquals(int|BigInteger $a, int|BigInteger $b): bool
+    {
+        if ($a instanceof BigInteger) {
+            return $a->equals($b);
+        }
+
+        // $a is int; $b must be BigInteger here (the int === int case is
+        // handled by the strict-equality fast path).
+        return $b instanceof BigInteger && $b->equals($a);
     }
 }

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -10,7 +10,6 @@ use InvalidArgumentException;
 use function abs;
 use function fdiv;
 use function intdiv;
-use function is_finite;
 use function is_float;
 use function is_int;
 use function sprintf;
@@ -53,6 +52,10 @@ final class NumericOperations
             return self::collapseBigInt(self::toBigInt($a)->add(self::toBigInt($b)));
         }
 
+        if (self::addOverflows($a, $b)) {
+            return self::collapseBigInt(BigInteger::fromInt($a)->add(BigInteger::fromInt($b)));
+        }
+
         return $a + $b;
     }
 
@@ -76,6 +79,10 @@ final class NumericOperations
 
         if ($a instanceof BigInteger || $b instanceof BigInteger) {
             return self::collapseBigInt(self::toBigInt($a)->subtract(self::toBigInt($b)));
+        }
+
+        if (self::subtractOverflows($a, $b)) {
+            return self::collapseBigInt(BigInteger::fromInt($a)->subtract(BigInteger::fromInt($b)));
         }
 
         return $a - $b;
@@ -102,6 +109,10 @@ final class NumericOperations
             return self::collapseBigInt(self::toBigInt($a)->multiply(self::toBigInt($b)));
         }
 
+        if (self::multiplyOverflows($a, $b)) {
+            return self::collapseBigInt(BigInteger::fromInt($a)->multiply(BigInteger::fromInt($b)));
+        }
+
         return $a * $b;
     }
 
@@ -117,9 +128,10 @@ final class NumericOperations
         if (is_float($a) || is_float($b)) {
             $left = self::toFloat($a);
             $right = self::toFloat($b);
-            // Preserve PHP's `fdiv` semantics for Inf/NaN over zero so that
-            // `(/ ##Inf 0) => Inf` and `(/ ##NaN 0) => NaN` keep working.
-            if ($right === 0.0 && !is_finite($left)) {
+            // Route any float-over-zero division through `fdiv` so
+            // `(/ 1.0 0)` => `INF`, `(/ -1.0 0)` => `-INF`, `(/ 0.0 0)` => `NAN`,
+            // and `(/ ##Inf 0)` / `(/ ##NaN 0)` keep their IEEE-754 results.
+            if ($right === 0.0) {
                 return fdiv($left, $right);
             }
 
@@ -272,7 +284,9 @@ final class NumericOperations
             return Rational::create(1, BigInteger::fromInt($base)->pow(-$exponent));
         }
 
-        return $base ** $exponent;
+        // Always route int^int through BigInteger so overflow auto-promotes.
+        // Cheap exponents collapse straight back to int.
+        return self::collapseBigInt(BigInteger::fromInt($base)->pow($exponent));
     }
 
     /**
@@ -363,6 +377,48 @@ final class NumericOperations
         }
 
         return $rem;
+    }
+
+    private static function addOverflows(int $a, int $b): bool
+    {
+        if ($a > 0 && $b > 0) {
+            return $a > PHP_INT_MAX - $b;
+        }
+
+        if ($a < 0 && $b < 0) {
+            return $a < PHP_INT_MIN - $b;
+        }
+
+        return false;
+    }
+
+    private static function subtractOverflows(int $a, int $b): bool
+    {
+        if ($a >= 0 && $b < 0) {
+            // a - b > PHP_INT_MAX when b < a - PHP_INT_MAX.
+            return $a > PHP_INT_MAX + $b;
+        }
+
+        if ($a < 0 && $b > 0) {
+            return $a < PHP_INT_MIN + $b;
+        }
+
+        return false;
+    }
+
+    private static function multiplyOverflows(int $a, int $b): bool
+    {
+        if ($a === 0 || $b === 0) {
+            return false;
+        }
+
+        // PHP_INT_MIN * -1 overflows to PHP_INT_MAX + 1.
+        if (($a === PHP_INT_MIN && $b === -1) || ($b === PHP_INT_MIN && $a === -1)) {
+            return true;
+        }
+
+        // Compare against PHP_INT_MAX magnitude using truncating intdiv.
+        return intdiv(PHP_INT_MAX, abs($a)) < abs($b);
     }
 
     private static function ensureNumeric(mixed $value): void

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -272,21 +272,15 @@ final class NumericOperations
             return self::rationalPower($base, $exponent);
         }
 
-        if ($base instanceof BigInteger) {
-            if ($exponent < 0) {
-                return Rational::create(BigInteger::one(), $base->pow(-$exponent));
-            }
-
-            return self::collapseBigInt($base->pow($exponent));
-        }
+        // Route int^int and BigInteger^int through BigInteger so overflow
+        // auto-promotes; cheap exponents collapse back to int.
+        $baseBig = self::toBigInt($base);
 
         if ($exponent < 0) {
-            return Rational::create(1, BigInteger::fromInt($base)->pow(-$exponent));
+            return Rational::create(BigInteger::one(), $baseBig->pow(-$exponent));
         }
 
-        // Always route int^int through BigInteger so overflow auto-promotes.
-        // Cheap exponents collapse straight back to int.
-        return self::collapseBigInt(BigInteger::fromInt($base)->pow($exponent));
+        return self::collapseBigInt($baseBig->pow($exponent));
     }
 
     /**
@@ -408,16 +402,18 @@ final class NumericOperations
 
     private static function multiplyOverflows(int $a, int $b): bool
     {
-        if ($a === 0 || $b === 0) {
+        if ($a === 0 || $b === 0 || $a === 1 || $b === 1) {
             return false;
         }
 
-        // PHP_INT_MIN * -1 overflows to PHP_INT_MAX + 1.
-        if (($a === PHP_INT_MIN && $b === -1) || ($b === PHP_INT_MIN && $a === -1)) {
+        // PHP_INT_MIN cannot be negated within int range, so any multiply of
+        // PHP_INT_MIN by anything other than 0 or 1 leaves the int range.
+        if ($a === PHP_INT_MIN || $b === PHP_INT_MIN) {
             return true;
         }
 
         // Compare against PHP_INT_MAX magnitude using truncating intdiv.
+        // Both operands are now safe to negate within int range.
         return intdiv(PHP_INT_MAX, abs($a)) < abs($b);
     }
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -36,6 +36,9 @@
   (is (= ##Inf (/ ##Inf 0)) "##Inf divided by zero remains ##Inf")
   (is (= ##-Inf (/ ##-Inf 0)) "##-Inf divided by zero remains ##-Inf")
   (is (NaN? (/ ##NaN 0)) "##NaN divided by zero remains ##NaN")
+  (is (= ##Inf (/ 1.0 0.0)) "finite positive float divided by zero is ##Inf")
+  (is (= ##-Inf (/ -1.0 0.0)) "finite negative float divided by zero is ##-Inf")
+  (is (NaN? (/ 0.0 0.0)) "0.0 divided by 0.0 is ##NaN")
   (is (thrown? \DivisionByZeroError (/ 1 0)) "finite division by zero still throws"))
 
 (deftest test-%
@@ -374,6 +377,29 @@
   (is (= 1000000 1_000_000N) "(= 1000000 1_000_000N)")
   (is (int? 1N) "(int? 1N)")
   (is (int? -1N) "(int? -1N)"))
+
+(deftest test-equality-bigint-int-symmetric
+  (let [b (php/:: \Phel\Lang\BigInteger (fromString "5"))]
+    (is (= b 5) "(= bigint int) is true when values match")
+    (is (= 5 b) "(= int bigint) is true when values match")
+    (is (false? (= b 6)) "(= bigint int) is false on mismatch")
+    (is (false? (= 6 b)) "(= int bigint) is false on mismatch")))
+
+(deftest test-equality-bigint-large-symmetric
+  (let [big (php/:: \Phel\Lang\BigInteger (fromString "1000000000000000000000000"))
+        product (* 100000000 100000000 100000000)]
+    (is (= big product) "(= bigint product) is true when values match")
+    (is (= product big) "(= product bigint) is true when values match")))
+
+(deftest test-multiply-int-overflow-promotes-to-bigint
+  (let [r (* 100000000 100000000 100000000)]
+    (is (bigint? r) "int multiplication overflow promotes to BigInteger")
+    (is (= "1000000000000000000000000" (str r)) "value is preserved exactly")))
+
+(deftest test-power-int-overflow-promotes-to-bigint
+  (let [r (** 2 64)]
+    (is (bigint? r) "int power overflow promotes to BigInteger")
+    (is (= "18446744073709551616" (str r)) "value is preserved exactly")))
 
 (deftest test-bigdec-literals
   (is (= 1.0 1M) "(= 1.0 1M)")

--- a/tests/php/Unit/Lang/EqualizerTest.php
+++ b/tests/php/Unit/Lang/EqualizerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Lang;
+
+use Phel\Lang\BigInteger;
+use Phel\Lang\Equalizer;
+use Phel\Lang\Rational;
+use PHPUnit\Framework\TestCase;
+
+final class EqualizerTest extends TestCase
+{
+    private Equalizer $equalizer;
+
+    protected function setUp(): void
+    {
+        $this->equalizer = new Equalizer();
+    }
+
+    public function test_it_returns_true_for_identical_values(): void
+    {
+        self::assertTrue($this->equalizer->equals(1, 1));
+        self::assertTrue($this->equalizer->equals('hello', 'hello'));
+        self::assertTrue($this->equalizer->equals(null, null));
+    }
+
+    public function test_it_returns_false_for_different_native_values(): void
+    {
+        self::assertFalse($this->equalizer->equals(1, 2));
+        self::assertFalse($this->equalizer->equals(1, '1'));
+    }
+
+    public function test_it_compares_bigint_and_int_symmetrically(): void
+    {
+        $big = BigInteger::fromInt(5);
+
+        self::assertTrue($this->equalizer->equals($big, 5));
+        self::assertTrue($this->equalizer->equals(5, $big));
+    }
+
+    public function test_it_returns_false_for_bigint_and_unequal_int(): void
+    {
+        $big = BigInteger::fromInt(5);
+
+        self::assertFalse($this->equalizer->equals($big, 6));
+        self::assertFalse($this->equalizer->equals(6, $big));
+    }
+
+    public function test_it_compares_two_bigints(): void
+    {
+        $a = BigInteger::fromString('12345678901234567890');
+        $b = BigInteger::fromString('12345678901234567890');
+        $c = BigInteger::fromString('12345678901234567891');
+
+        self::assertTrue($this->equalizer->equals($a, $b));
+        self::assertFalse($this->equalizer->equals($a, $c));
+    }
+
+    public function test_it_returns_false_for_int_and_float_with_same_value(): void
+    {
+        // Different categories: integers and floats are not equal under `=`.
+        self::assertFalse($this->equalizer->equals(1, 1.0));
+        self::assertFalse($this->equalizer->equals(1.0, 1));
+    }
+
+    public function test_it_returns_false_for_bigint_and_float(): void
+    {
+        $big = BigInteger::fromInt(5);
+
+        self::assertFalse($this->equalizer->equals($big, 5.0));
+        self::assertFalse($this->equalizer->equals(5.0, $big));
+    }
+
+    public function test_it_returns_false_for_rational_and_int(): void
+    {
+        // Rational instances are by construction non-integral.
+        $half = Rational::create(1, 2);
+
+        self::assertFalse($this->equalizer->equals($half, 1));
+        self::assertFalse($this->equalizer->equals(1, $half));
+    }
+
+    public function test_it_returns_false_for_rational_and_bigint(): void
+    {
+        $half = Rational::create(1, 2);
+        $big = BigInteger::fromInt(1);
+
+        self::assertFalse($this->equalizer->equals($half, $big));
+        self::assertFalse($this->equalizer->equals($big, $half));
+    }
+
+    public function test_it_compares_two_rationals(): void
+    {
+        $half = Rational::create(1, 2);
+        $sameHalf = Rational::create(2, 4);
+        $third = Rational::create(1, 3);
+
+        self::assertTrue($this->equalizer->equals($half, $sameHalf));
+        self::assertTrue($this->equalizer->equals($sameHalf, $half));
+        self::assertFalse($this->equalizer->equals($half, $third));
+    }
+}

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -348,6 +348,16 @@ final class NumericOperationsTest extends TestCase
     {
         self::assertSame(6, NumericOperations::multiply(2, 3));
         self::assertSame(0, NumericOperations::multiply(0, PHP_INT_MAX));
+        self::assertSame(PHP_INT_MIN, NumericOperations::multiply(PHP_INT_MIN, 1));
+        self::assertSame(PHP_INT_MIN, NumericOperations::multiply(1, PHP_INT_MIN));
+    }
+
+    public function test_multiply_int_min_by_two_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::multiply(PHP_INT_MIN, 2);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcmul((string) PHP_INT_MIN, '2'), (string) $result);
     }
 
     public function test_power_int_int_overflow_promotes_to_bigint(): void

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -135,6 +135,23 @@ final class NumericOperationsTest extends TestCase
         self::assertSame(INF, NumericOperations::divide(INF, 0));
     }
 
+    public function test_divide_finite_float_by_zero_returns_inf(): void
+    {
+        $result = NumericOperations::divide(1.0, 0.0);
+        self::assertTrue(is_infinite($result) && $result > 0);
+    }
+
+    public function test_divide_negative_finite_float_by_zero_returns_negative_inf(): void
+    {
+        $result = NumericOperations::divide(-1.0, 0.0);
+        self::assertTrue(is_infinite($result) && $result < 0);
+    }
+
+    public function test_divide_zero_float_by_zero_returns_nan(): void
+    {
+        self::assertNan(NumericOperations::divide(0.0, 0.0));
+    }
+
     public function test_divide_int_rational(): void
     {
         $half = Rational::create(1, 2);
@@ -276,5 +293,74 @@ final class NumericOperationsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         NumericOperations::add('not a number', 1);
+    }
+
+    public function test_add_int_int_overflow_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::add(PHP_INT_MAX, 1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcadd((string) PHP_INT_MAX, '1'), (string) $result);
+    }
+
+    public function test_add_int_int_negative_overflow_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::add(PHP_INT_MIN, -1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcadd((string) PHP_INT_MIN, '-1'), (string) $result);
+    }
+
+    public function test_subtract_int_int_overflow_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::subtract(PHP_INT_MIN, 1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcsub((string) PHP_INT_MIN, '1'), (string) $result);
+    }
+
+    public function test_subtract_int_int_positive_overflow_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::subtract(PHP_INT_MAX, -1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcsub((string) PHP_INT_MAX, '-1'), (string) $result);
+    }
+
+    public function test_multiply_int_int_overflow_promotes_to_bigint(): void
+    {
+        // 100000000 ^ 3 = 1e24, well outside PHP int range.
+        $result = NumericOperations::multiply(NumericOperations::multiply(100000000, 100000000), 100000000);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame('1000000000000000000000000', (string) $result);
+    }
+
+    public function test_multiply_int_min_by_negative_one_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::multiply(PHP_INT_MIN, -1);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcmul((string) PHP_INT_MIN, '-1'), (string) $result);
+    }
+
+    public function test_multiply_int_int_within_range_stays_int(): void
+    {
+        self::assertSame(6, NumericOperations::multiply(2, 3));
+        self::assertSame(0, NumericOperations::multiply(0, PHP_INT_MAX));
+    }
+
+    public function test_power_int_int_overflow_promotes_to_bigint(): void
+    {
+        $result = NumericOperations::power(2, 64);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame('18446744073709551616', (string) $result);
+    }
+
+    public function test_power_int_int_within_range_stays_int(): void
+    {
+        self::assertSame(8, NumericOperations::power(2, 3));
+        self::assertSame(1, NumericOperations::power(1, 100));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Three numeric runtime bugs surfaced after the BigInteger and Rational types landed.

1. `=` between `int` and `BigInteger` was asymmetric: `(= big5 5)` returned `true` but `(= 5 big5)` returned `false`.
2. Native int arithmetic (`+ - * **`) silently widened to float on overflow instead of promoting to `BigInteger`.
3. Finite float division by zero (`(/ 1.0 0.0)`) raised `DivisionByZeroError` even though `(/ ##Inf 0)` and `(/ ##NaN 0)` flowed through `fdiv`.

## 💡 Goal

Make `=` symmetric across the integer tower, auto-promote native int arithmetic on overflow, and route every float-over-zero division through `fdiv` so finite floats produce `INF`/`-INF`/`NAN` instead of throwing.

## 🔖 Changes

- `Phel\Lang\Equalizer::equals` dispatches on either side that implements `EqualsInterface` and treats `{int, BigInteger}` as a single integer category. Floats stay a separate category, matching `=` semantics in the rest of the runtime; `==` keeps cross-category comparison.
- `Phel\Lang\NumericOperations::add/subtract/multiply` detect int-int overflow and route through `BigInteger`, then collapse back to int when the result fits.
- `Phel\Lang\NumericOperations::power` lifts native ints to `BigInteger` up front so int^int and BigInteger^int share one overflow-aware path.
- `Phel\Lang\NumericOperations::divide` routes any float-over-zero division through `fdiv`. Integer division by zero still throws `DivisionByZeroError`.
- The compiled-Phel `equals1` helper now dispatches on either side carrying equality semantics so the symmetry is visible to `=` everywhere, not just to direct `Equalizer` callers.
- Tests: new `tests/php/Unit/Lang/EqualizerTest.php`, expanded `NumericOperationsTest` for overflow promotion and float-zero division, plus integration tests in `tests/phel/test/core/math-operation.phel` for `(= 5 big5)` symmetry, `(* 100000000 100000000 100000000)` overflow, `(** 2 64)` overflow, and `(/ 1.0 0.0)` => `##Inf`.
- CHANGELOG entries under `## Unreleased` -> `Fixed` -> `Lang`.

Closes #1830