### PR TITLE
feat(core): expose quot, rem, mod, floor, ceil, round, sqrt, bigint, *' +' -' inc' dec'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `ratio?`, `bigint?`, `numerator`, `denominator`, and `rationalize` core fns (#1825)
+- `quot`, `rem`, `mod` integer division fns; `%` becomes an alias for `rem` (#1831)
+- `floor`, `ceil`, `round`, `sqrt` float math fns (#1831)
+- `+'`, `-'`, `*'`, `inc'`, `dec'` auto-promoting arithmetic variants that return `BigInteger` for integer results (#1831)
+- `bigint` and `biginteger` constructors that coerce ints, numeric strings, and `BigInteger` values (#1831)
 
 #### Lang
 - `Phel\Lang\NumericOperations` runtime dispatch helper for arithmetic and comparison on `Rational`, `BigInteger`, and native PHP numbers (#1825)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -147,12 +147,42 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     2 (php/:: NumericOperations (divide (first xs) (second xs)))
     (reduce #(php/:: NumericOperations (divide %1 %2)) xs)))
 
-(defn %
-  "Return the remainder of `dividend` / `divisor`. Result has the same sign
-  as `dividend` (truncated remainder, matching PHP's `%`)."
+(defn quot
+  "Returns the truncated integer quotient of `dividend` / `divisor`.
+  Truncates toward zero. Throws `\\DivisionByZeroError` when `divisor`
+  is zero."
+  {:example "(quot 7 3) ; => 2\n(quot -7 3) ; => -2"
+   :see-also ["rem" "mod" "/"]}
+  [dividend divisor]
+  (assert-non-nil dividend divisor)
+  (php/:: NumericOperations (quot dividend divisor)))
+
+(defn rem
+  "Returns the truncated remainder of `dividend` / `divisor`. The result
+  has the same sign as `dividend` (matches PHP's `%`)."
+  {:example "(rem 7 3) ; => 1\n(rem -7 3) ; => -1"
+   :see-also ["quot" "mod" "%"]}
   [dividend divisor]
   (assert-non-nil dividend divisor)
   (php/:: NumericOperations (rem dividend divisor)))
+
+(defn mod
+  "Returns the floor remainder of `dividend` / `divisor`. The result has
+  the same sign as `divisor`. Differs from `rem` on mixed-sign operands:
+  `(mod -7 3) => 2` while `(rem -7 3) => -1`."
+  {:example "(mod 7 3) ; => 1\n(mod -7 3) ; => 2"
+   :see-also ["quot" "rem" "%"]}
+  [dividend divisor]
+  (assert-non-nil dividend divisor)
+  (php/:: NumericOperations (mod dividend divisor)))
+
+(defn %
+  "Alias for `rem`. Returns the truncated remainder of `dividend` /
+  `divisor`. Result has the same sign as `dividend`."
+  {:example "(% 11 2) ; => 1"
+   :see-also ["rem" "quot" "mod"]}
+  [dividend divisor]
+  (rem dividend divisor))
 
 (defn **
   "Return `a` to the power of `x`."
@@ -171,6 +201,55 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   [x]
   (assert-non-nil x)
   (php/:: NumericOperations (subtract x 1)))
+
+(defn- promote-int->bigint
+  [x]
+  (if (php/is_int x)
+    (php/:: BigInteger (fromInt x))
+    x))
+
+(defn +'
+  "Auto-promoting variant of `+`. Integer results are returned as
+  `BigInteger` so callers get explicit promotion semantics; floats and
+  rationals pass through unchanged. Equivalent to `+` for overflow
+  protection (Phel's `+` already auto-promotes on overflow), kept for
+  `.cljc` interop."
+  {:example "(+' 1 2) ; => 3N"
+   :see-also ["+" "*'" "-'"]}
+  [& xs]
+  (promote-int->bigint (apply + xs)))
+
+(defn -'
+  "Auto-promoting variant of `-`. Integer results are returned as
+  `BigInteger`; floats and rationals pass through unchanged."
+  {:example "(-' 5 2) ; => 3N"
+   :see-also ["-" "+'" "*'"]}
+  [& xs]
+  (promote-int->bigint (apply - xs)))
+
+(defn *'
+  "Auto-promoting variant of `*`. Integer results are returned as
+  `BigInteger`; floats and rationals pass through unchanged."
+  {:example "(*' 2 3) ; => 6N"
+   :see-also ["*" "+'" "-'"]}
+  [& xs]
+  (promote-int->bigint (apply * xs)))
+
+(defn inc'
+  "Auto-promoting variant of `inc`. Integer results are returned as
+  `BigInteger`; floats and rationals pass through unchanged."
+  {:example "(inc' 1) ; => 2N"
+   :see-also ["inc" "dec'"]}
+  [x]
+  (promote-int->bigint (inc x)))
+
+(defn dec'
+  "Auto-promoting variant of `dec`. Integer results are returned as
+  `BigInteger`; floats and rationals pass through unchanged."
+  {:example "(dec' 1) ; => 0N"
+   :see-also ["dec" "inc'"]}
+  [x]
+  (promote-int->bigint (dec x)))
 
 (defn even?
   "Checks if `x` is even."
@@ -533,3 +612,108 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     :else
     (throw (php/new InvalidArgumentException
                     (str "rationalize expects a number, got " (type x))))))
+
+(defn bigint
+  "Coerces `x` to a `Phel\\Lang\\BigInteger`. Accepts ints, numeric
+  strings, and `BigInteger` values."
+  {:example "(bigint 42) ; => 42N\n(bigint \"123\") ; => 123N"
+   :see-also ["bigint?" "int" "rationalize"]}
+  [x]
+  (cond
+    (php/instanceof x BigInteger) x
+    (php/is_int x)                (php/:: BigInteger (fromInt x))
+    (string? x)                   (php/:: BigInteger (fromString x))
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "bigint expects an int, numeric string, or BigInteger, got " (type x))))))
+
+(defn biginteger
+  "Alias for `bigint`. Coerces `x` to a `Phel\\Lang\\BigInteger`."
+  {:example "(biginteger 42) ; => 42N"
+   :see-also ["bigint" "bigint?"]}
+  [x]
+  (bigint x))
+
+;; -----------
+;; Float math
+;; -----------
+
+(defn- number->float
+  [x]
+  (cond
+    (php/is_int x)                (php/floatval x)
+    (php/is_float x)              x
+    (php/instanceof x BigInteger) (php/floatval (str x))
+    (php/instanceof x Rational)   (php/-> x (toFloat))
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "expected a number, got " (type x))))))
+
+(defn- rational-floor
+  ;; floor(n/d) = (n - mod(n, d)) / d. Rational denominators are always
+  ;; positive, so `mod` (floor-modulo) yields a non-negative remainder
+  ;; whose subtraction lands the dividend on a clean multiple of `d`.
+  [r]
+  (let [n (php/-> r (numerator))
+        d (php/-> r (denominator))]
+    (php/:: NumericOperations
+            (quot (php/:: NumericOperations (subtract n
+                                                      (php/:: NumericOperations (mod n d))))
+                  d))))
+
+(defn floor
+  "Returns the largest integer not greater than `x`. Ints and `BigInteger`
+  values are returned unchanged. Rationals collapse via floor division.
+  Floats route through PHP's `floor`."
+  {:example "(floor 1.7) ; => 1.0\n(floor -1.2) ; => -2.0\n(floor 7/3) ; => 2"
+   :see-also ["ceil" "round" "quot"]}
+  [x]
+  (assert-non-nil x)
+  (cond
+    (php/is_int x)                x
+    (php/instanceof x BigInteger) x
+    (php/instanceof x Rational)   (rational-floor x)
+    (php/is_float x)              (php/floor x)
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "floor expects a number, got " (type x))))))
+
+(defn ceil
+  "Returns the smallest integer not less than `x`. Ints and `BigInteger`
+  values are returned unchanged. Rationals collapse via ceiling division.
+  Floats route through PHP's `ceil`."
+  {:example "(ceil 1.2) ; => 2.0\n(ceil -1.7) ; => -1.0\n(ceil 7/3) ; => 3"
+   :see-also ["floor" "round" "quot"]}
+  [x]
+  (assert-non-nil x)
+  (cond
+    (php/is_int x)                x
+    (php/instanceof x BigInteger) x
+    (php/instanceof x Rational)
+    (php/:: NumericOperations (negate (rational-floor (php/:: NumericOperations (negate x)))))
+    (php/is_float x)              (php/ceil x)
+    :else
+    (throw (php/new InvalidArgumentException
+                    (str "ceil expects a number, got " (type x))))))
+
+(defn round
+  "Rounds `x` to the nearest integer using PHP's `round` (half away from
+  zero). Ints and `BigInteger` values are returned unchanged. Rationals
+  and floats return floats."
+  {:example "(round 1.5) ; => 2.0\n(round -1.5) ; => -2.0\n(round 5) ; => 5"
+   :see-also ["floor" "ceil"]}
+  [x]
+  (assert-non-nil x)
+  (cond
+    (php/is_int x)                x
+    (php/instanceof x BigInteger) x
+    :else                         (php/round (number->float x))))
+
+(defn sqrt
+  "Returns the square root of `x` as a float. Negative inputs return
+  `##NaN` (matches PHP's `sqrt`)."
+  {:example "(sqrt 9) ; => 3.0\n(sqrt 2) ; => 1.4142135623730951"
+   :see-also ["**" "abs"]}
+  [x]
+  (assert-non-nil x)
+  (php/sqrt (number->float x)))

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -650,16 +650,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "expected a number, got " (type x))))))
 
 (defn- rational-floor
-  ;; floor(n/d) = (n - mod(n, d)) / d. Rational denominators are always
-  ;; positive, so `mod` (floor-modulo) yields a non-negative remainder
-  ;; whose subtraction lands the dividend on a clean multiple of `d`.
+  ;; floor(n/d) = (n - mod(n,d)) / d; Rational denominators are positive.
   [r]
-  (let [n (php/-> r (numerator))
-        d (php/-> r (denominator))]
-    (php/:: NumericOperations
-            (quot (php/:: NumericOperations (subtract n
-                                                      (php/:: NumericOperations (mod n d))))
-                  d))))
+  (let [n (numerator r)
+        d (denominator r)]
+    (quot (- n (mod n d)) d)))
 
 (defn floor
   "Returns the largest integer not greater than `x`. Ints and `BigInteger`
@@ -689,8 +684,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   (cond
     (php/is_int x)                x
     (php/instanceof x BigInteger) x
-    (php/instanceof x Rational)
-    (php/:: NumericOperations (negate (rational-floor (php/:: NumericOperations (negate x)))))
+    (php/instanceof x Rational)   (- (rational-floor (- x)))
     (php/is_float x)              (php/ceil x)
     :else
     (throw (php/new InvalidArgumentException

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -43,7 +43,39 @@
 
 (deftest test-%
   (is (= 0 (% 10 2)) "10 % 2")
-  (is (= 1 (% 11 2)) "11 % 2"))
+  (is (= 1 (% 11 2)) "11 % 2")
+  (is (= -1 (% -7 3)) "% follows dividend sign"))
+
+(deftest test-quot
+  (is (= 2 (quot 7 3)) "(quot 7 3)")
+  (is (= -2 (quot -7 3)) "(quot -7 3) truncates toward zero")
+  (is (= -2 (quot 7 -3)) "(quot 7 -3) truncates toward zero")
+  (is (= 0 (quot 1 3)) "(quot 1 3)")
+  (is (= 2 (quot 7/2 3/2)) "quot on rationals truncates")
+  (is (thrown? \DivisionByZeroError (quot 1 0)) "quot by zero throws"))
+
+(deftest test-rem
+  (is (= 1 (rem 7 3)) "(rem 7 3)")
+  (is (= -1 (rem -7 3)) "(rem -7 3) follows dividend sign")
+  (is (= 1 (rem 7 -3)) "(rem 7 -3) follows dividend sign")
+  (is (= 0 (rem 6 3)) "(rem 6 3)")
+  (is (thrown? \DivisionByZeroError (rem 1 0)) "rem by zero throws"))
+
+(deftest test-mod
+  (is (= 1 (mod 7 3)) "(mod 7 3)")
+  (is (= 2 (mod -7 3)) "(mod -7 3) follows divisor sign (Clojure reference)")
+  (is (= -2 (mod 7 -3)) "(mod 7 -3) follows divisor sign")
+  (is (= -1 (mod -7 -3)) "(mod -7 -3)")
+  (is (= 0 (mod 6 3)) "(mod 6 3)")
+  (is (thrown? \DivisionByZeroError (mod 1 0)) "mod by zero throws"))
+
+(deftest test-quot-rem-mod-bigint
+  (let [big (php/:: \Phel\Lang\BigInteger (fromString "1000000000000000000"))]
+    (is (= 333333333333333333 (quot big 3)) "quot on BigInteger collapses to int when fits")
+    (is (= 1 (rem big 3)) "rem on BigInteger collapses to int when fits")
+    (is (= 1 (mod big 3)) "mod on BigInteger collapses to int when fits"))
+  (let [huge (php/:: \Phel\Lang\BigInteger (fromString "100000000000000000000"))]
+    (is (bigint? (quot huge 3)) "quot stays BigInteger when result overflows int")))
 
 (deftest test-**
   (is (= 8 (** 2 3)) "2 ** 3"))
@@ -409,3 +441,69 @@
   (is (= 1500.0 1.5e3M) "(= 1500.0 1.5e3M)")
   (is (float? 1M) "(float? 1M)")
   (is (float? -1.1M) "(float? -1.1M)"))
+
+(deftest test-floor
+  (is (= 1.0 (floor 1.7)) "(floor 1.7)")
+  (is (= -2.0 (floor -1.2)) "(floor -1.2) toward negative infinity")
+  (is (= 5 (floor 5)) "(floor 5) on int")
+  (is (= 2 (floor 7/3)) "(floor 7/3)")
+  (is (= -3 (floor -7/3)) "(floor -7/3)")
+  (is (= 2 (floor 6/3)) "(floor 6/3) collapses to int"))
+
+(deftest test-ceil
+  (is (= 2.0 (ceil 1.2)) "(ceil 1.2)")
+  (is (= -1.0 (ceil -1.7)) "(ceil -1.7)")
+  (is (= 5 (ceil 5)) "(ceil 5) on int")
+  (is (= 3 (ceil 7/3)) "(ceil 7/3)")
+  (is (= -2 (ceil -7/3)) "(ceil -7/3)")
+  (is (= 2 (ceil 6/3)) "(ceil 6/3) collapses to int"))
+
+(deftest test-round
+  (is (= 2.0 (round 1.5)) "(round 1.5) half away from zero")
+  (is (= -2.0 (round -1.5)) "(round -1.5) half away from zero")
+  (is (= 5 (round 5)) "(round 5) on int")
+  (is (= 1.0 (round 1.4)) "(round 1.4)")
+  (is (= 2.0 (round 1.6)) "(round 1.6)")
+  (is (= 0.0 (round 1/3)) "(round 1/3)")
+  (is (= 1.0 (round 2/3)) "(round 2/3)"))
+
+(deftest test-sqrt
+  (is (= 3.0 (sqrt 9)) "(sqrt 9)")
+  (is (= 2.0 (sqrt 4)) "(sqrt 4)")
+  (is (= 0.0 (sqrt 0)) "(sqrt 0)")
+  (is (NaN? (sqrt -1)) "(sqrt -1) returns NaN"))
+
+(deftest test-bigint
+  (is (= 42 (bigint 42)) "(bigint 42)")
+  (is (bigint? (bigint 42)) "(bigint 42) is BigInteger")
+  (is (bigint? (bigint "1000000000000000000000000")) "(bigint string) parses")
+  (is (= "1000000000000000000000000" (str (bigint "1000000000000000000000000"))) "(bigint big-string)")
+  (let [b (php/:: \Phel\Lang\BigInteger (fromInt 5))]
+    (is (= b (bigint b)) "(bigint BigInteger) is identity"))
+  (is (thrown? \InvalidArgumentException (bigint 1.5)) "(bigint 1.5) rejects floats")
+  (is (thrown? \InvalidArgumentException (bigint nil)) "(bigint nil) rejects nil"))
+
+(deftest test-biginteger-alias
+  (is (= 42 (biginteger 42)) "(biginteger 42)")
+  (is (bigint? (biginteger 42)) "(biginteger 42) is BigInteger"))
+
+(deftest test-promotion-arithmetic
+  (is (bigint? (+' 2 3)) "(+' 2 3) returns BigInteger")
+  (is (= 5 (+' 2 3)) "(+' 2 3) value")
+  (is (bigint? (-' 5 2)) "(-' 5 2) returns BigInteger")
+  (is (= 3 (-' 5 2)) "(-' 5 2) value")
+  (is (bigint? (*' 2 3)) "(*' 2 3) returns BigInteger")
+  (is (= 6 (*' 2 3)) "(*' 2 3) value")
+  (is (bigint? (inc' 1)) "(inc' 1) returns BigInteger")
+  (is (= 2 (inc' 1)) "(inc' 1) value")
+  (is (bigint? (dec' 5)) "(dec' 5) returns BigInteger")
+  (is (= 4 (dec' 5)) "(dec' 5) value"))
+
+(deftest test-promotion-arithmetic-floats-pass-through
+  (is (float? (+' 1.5 2.5)) "(+' 1.5 2.5) stays float")
+  (is (= 4.0 (+' 1.5 2.5)) "(+' 1.5 2.5) value")
+  (is (float? (*' 2.0 3)) "(*' 2.0 3) stays float"))
+
+(deftest test-promotion-arithmetic-rationals
+  (is (true? (ratio? (+' 1/2 1/3))) "(+' 1/2 1/3) stays rational")
+  (is (= 5/6 (+' 1/2 1/3)) "(+' 1/2 1/3) value"))


### PR DESCRIPTION
## 🤔 Background

After #1825/#1827/#1829 landed `BigInteger`, `Rational`, and the `NumericOperations` dispatch helper, several Clojure-aligned numeric core fns were still missing. Most are thin wrappers over the existing `NumericOperations` API or PHP math.

Closes #1831.

## 💡 Goal

Expose the standard integer division family, float math fns, auto-promoting arithmetic variants, and a `BigInteger` constructor as Phel core fns with full doc/example/see-also metadata.

## 🔖 Changes

- `quot`, `rem`, `mod` integer division fns; `%` becomes an alias for `rem`. `mod` returns floor-modulo (`(mod -7 3) ; => 2`) while `rem` returns truncated remainder (`(rem -7 3) ; => -1`).
- `floor`, `ceil`, `round`, `sqrt` float math fns. Ints and `BigInteger` pass through `floor`/`ceil`/`round` unchanged; rationals collapse via floor/ceiling division; `sqrt` always returns a float.
- `+'`, `-'`, `*'`, `inc'`, `dec'` auto-promoting arithmetic variants. Integer results are returned as `BigInteger`; floats and rationals pass through unchanged. Equivalent to `+`, `-`, `*`, `inc`, `dec` for overflow protection (already auto-promoting since #1830), kept for `.cljc` interop and explicit promotion intent.
- `bigint` and `biginteger` constructors that coerce ints, numeric strings, and `BigInteger` values to `BigInteger`.
- New tests in `tests/phel/test/core/math-operation.phel` covering positive, negative, `Rational`, and `BigInteger` operands; `mod` floor-semantic verified against the Clojure reference cases.
- `CHANGELOG.md` updated under `## Unreleased > Added > Core`.

### Final refactor pass

`floor`/`ceil` initially used direct `NumericOperations` method calls; the refactor commit replaces them with the higher-level Phel core fns (`numerator`, `denominator`, `quot`, `mod`, `-`), keeping the same dispatch behavior with shorter call sites.