### PR TITLE
fix(core): rationalize canonicalizes floats; add docs/numeric-tower.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+#### Core
+- `rationalize` uses the shortest round-trip decimal so `(rationalize 0.1)` is `1/10` and small floats in scientific notation no longer error (#1832)
+
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)
 - `+`, `-`, `*`, `**` on native PHP ints auto-promote to `BigInteger` on overflow instead of silently widening to a float (#1830)
@@ -27,6 +30,9 @@ All notable changes to this project will be documented in this file.
 
 #### Lang
 - `Phel\Lang\NumericOperations` runtime dispatch helper for arithmetic and comparison on `Rational`, `BigInteger`, and native PHP numbers (#1825)
+
+#### Documentation
+- `docs/numeric-tower.md` covers the `int` / `BigInteger` / `Rational` / `float` tower: no `BigDecimal`, no `1N`/`1M` literal suffixes, oversize int literals lex as `float`, arithmetic `bit-shift-right`, single-argument `==` asserts numeric (#1832)
 
 ### Changed
 

--- a/docs/numeric-tower.md
+++ b/docs/numeric-tower.md
@@ -1,0 +1,69 @@
+# Numeric tower
+
+Phel has a numeric tower built around four scalar shapes:
+
+| Type | Where it comes from | Notes |
+|------|---------------------|-------|
+| `int` | Native PHP `int` | 64-bit signed on common platforms |
+| `Phel\Lang\BigInteger` | `bigint`, `+'`, `*'`, etc. | Arbitrary-precision signed integer |
+| `Phel\Lang\Rational` | `1/2` literals, `/`, `rationalize` | Always normalised; collapses to `int`/`BigInteger` when integral |
+| `float` | Native PHP `float` (IEEE-754 double) | Inexact |
+
+`+`, `-`, `*`, `/`, comparisons, and the predicates dispatch on these types via `Phel\Lang\NumericOperations`. PHP's native operators do not dispatch on objects, so the runtime helper does.
+
+## Differences from Clojure
+
+Phel diverges from Clojure's numeric tower in deliberate ways. Map your mental model:
+
+### No `BigDecimal`
+
+Phel does not have a base-10 floating-point type. For exact non-integer values use `Rational` (`1/3`, `(/ 1 3)`, `(rationalize 0.1)`). For inexact use `float`.
+
+### No `1N` / `1M` literal suffixes
+
+Clojure writes `1N` for `BigInt` and `1M` for `BigDecimal`. Phel has neither suffix. Promote with the explicit constructors:
+
+```phel
+(bigint 42)         ; => 42N (a BigInteger)
+(bigint "1000000000000000000000")
+(rationalize 0.1)   ; => 1/10
+```
+
+The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) return `BigInteger`.
+
+### Large integer literals lex as `float`
+
+```phel
+12345678901234567890   ; => float (PHP int range overflow)
+```
+
+PHP's lexer parses oversize integer literals as `float`, so the same happens in Phel source. Wrap with `bigint` to keep precision:
+
+```phel
+(bigint "12345678901234567890")
+```
+
+### `bit-shift-right` is arithmetic
+
+`bit-shift-right` performs an arithmetic (sign-preserving) shift, matching PHP's `>>`. There is currently no `unsigned-bit-shift-right`; use `(bit-and (bit-shift-right x n) mask)` if you need a logical shift.
+
+### `==` arity-1 asserts numeric
+
+Clojure's `(==)` and `(== x)` return `true` for any single argument. Phel's `==` requires its argument to be numeric and otherwise throws — single-argument `==` is treated as a numeric assertion, not an identity.
+
+### `rationalize` uses shortest round-trip decimal
+
+`(rationalize 0.1) ; => 1/10`, not `10000000000000001/100000000000000000`. The conversion picks the shortest decimal expansion that round-trips back to the same `float`, so binary-noise digits do not leak into the result. Floats whose exact value has no short decimal representation (e.g. `(/ 1.0 3.0)`) keep that round-trip representation as a `Rational`.
+
+`(rationalize ##Inf)`, `(rationalize ##-Inf)`, and `(rationalize ##NaN)` throw `InvalidArgumentException`.
+
+## Quick reference
+
+| Need | Use |
+|------|-----|
+| Exact integer beyond PHP `int` | `(bigint "...")` or promoting ops `+'`, `*'` |
+| Exact non-integer | `Rational` literal `1/2`, `(/ a b)`, `(rationalize x)` |
+| Inexact decimal | native `float` |
+| Predicate | `int?`, `bigint?`, `ratio?`, `float?`, `number?` |
+| Numerator / denominator | `numerator`, `denominator` |
+| Float to exact | `rationalize` |

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -606,8 +606,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
         eff-exp    (php/- exponent (php/strlen frac-part))]
     (if (php/>= eff-exp 0)
       (let [scale (php/-> (php/:: BigInteger (fromInt 10)) (pow eff-exp))]
-        (php/:: Rational (create (php/-> num (multiply scale))
-                                 (php/:: BigInteger (fromInt 1)))))
+        (php/:: Rational (create (php/-> num (multiply scale)) 1)))
       (let [denom (php/-> (php/:: BigInteger (fromInt 10)) (pow (php/- 0 eff-exp)))]
         (php/:: Rational (create num denom))))))
 

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -572,35 +572,59 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "denominator expects a rational, integer, or BigInteger, got "
                          (type r))))))
 
+(defn- float-shortest-decimal
+  "Shortest %g-formatted decimal that round-trips back to `x`. Tries
+  increasing precision so 0.1 becomes \"0.1\", not \"0.10000000000000001\"."
+  [x]
+  (loop [p 1]
+    (let [s (php/sprintf (str "%." p "g") x)]
+      (if (or (php/=== (php/floatval s) x) (php/>= p 17))
+        s
+        (recur (php/+ p 1))))))
+
+(defn- decimal-string->rational
+  "Parses a decimal or scientific-notation string into a Rational
+  (auto-collapsed to int / BigInteger when integral)."
+  [s]
+  (let [lower      (php/strtolower s)
+        e-pos      (php/strpos lower "e")
+        mantissa   (if (php/=== false e-pos) lower (php/substr lower 0 e-pos))
+        exponent   (if (php/=== false e-pos) 0 (php/intval (php/substr lower (php/+ e-pos 1))))
+        first-char (php/substr mantissa 0 1)
+        negative?  (php/=== "-" first-char)
+        unsigned   (if (or negative? (php/=== "+" first-char))
+                     (php/substr mantissa 1)
+                     mantissa)
+        dot-pos    (php/strpos unsigned ".")
+        int-part   (if (php/=== false dot-pos) unsigned (php/substr unsigned 0 dot-pos))
+        frac-part  (if (php/=== false dot-pos) "" (php/substr unsigned (php/+ dot-pos 1)))
+        joined     (php/. (if (php/=== "" int-part) "0" int-part) frac-part)
+        stripped   (php/ltrim joined "0")
+        digits     (if (php/=== "" stripped) "0" stripped)
+        signed     (if negative? (php/. "-" digits) digits)
+        num        (php/:: BigInteger (fromString signed))
+        eff-exp    (php/- exponent (php/strlen frac-part))]
+    (if (php/>= eff-exp 0)
+      (let [scale (php/-> (php/:: BigInteger (fromInt 10)) (pow eff-exp))]
+        (php/:: Rational (create (php/-> num (multiply scale))
+                                 (php/:: BigInteger (fromInt 1)))))
+      (let [denom (php/-> (php/:: BigInteger (fromInt 10)) (pow (php/- 0 eff-exp)))]
+        (php/:: Rational (create num denom))))))
+
 (defn- float->rational
-  "Converts a finite float to a Rational by parsing its decimal expansion.
-  Non-finite floats are rejected."
+  "Converts a finite float to a Rational using its shortest round-trip
+  decimal expansion. Non-finite floats are rejected."
   [x]
   (when (or (php/is_infinite x) (php/is_nan x))
     (throw (php/new InvalidArgumentException
                     "rationalize cannot convert ##Inf, ##-Inf, or ##NaN")))
-  (let [s   (php/sprintf "%.17g" x)
-        dot (php/strpos s ".")]
-    (if (php/=== false dot)
-      (php/:: Rational (create (php/:: BigInteger (fromString s))
-                               (php/:: BigInteger (fromInt 1))))
-      (let [negative?  (php/=== "-" (php/substr s 0 1))
-            body       (if negative? (php/substr s 1) s)
-            body-dot   (php/strpos body ".")
-            int-part   (php/substr body 0 body-dot)
-            frac-part  (php/substr body (php/+ body-dot 1))
-            digits     (php/strlen frac-part)
-            normalised (php/. (if (php/=== "" int-part) "0" int-part) frac-part)
-            stripped   (php/ltrim normalised "0")
-            num-string (if (php/=== "" stripped) "0" stripped)
-            num        (php/:: BigInteger (fromString (if negative? (php/. "-" num-string) num-string)))
-            den        (php/-> (php/:: BigInteger (fromInt 10)) (pow digits))]
-        (php/:: Rational (create num den))))))
+  (decimal-string->rational (float-shortest-decimal x)))
 
 (defn rationalize
-  "Converts `x` to a `Rational`. Floats use a decimal-expansion best-effort
-  conversion; ints and `BigInteger` values become `n/1` and auto-collapse,
-  so they are returned unchanged."
+  "Converts `x` to a `Rational`. Floats use the shortest decimal expansion
+  that round-trips back to the same float, so `(rationalize 0.1)` is `1/10`
+  rather than the float-noise denominator. Ints and `BigInteger` values
+  become `n/1` and auto-collapse, so they are returned unchanged."
   {:example "(rationalize 0.5) ; => 1/2\n(rationalize 3) ; => 3"
    :see-also ["numerator" "denominator" "ratio?"]}
   [x]

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -507,3 +507,41 @@
 (deftest test-promotion-arithmetic-rationals
   (is (true? (ratio? (+' 1/2 1/3))) "(+' 1/2 1/3) stays rational")
   (is (= 5/6 (+' 1/2 1/3)) "(+' 1/2 1/3) value"))
+
+(deftest test-rationalize-canonicalizes-floats
+  (is (= 1/10 (rationalize 0.1)) "(rationalize 0.1) is 1/10")
+  (is (= 1/2 (rationalize 0.5)) "(rationalize 0.5) is 1/2")
+  (is (= -1/4 (rationalize -0.25)) "(rationalize -0.25) is -1/4")
+  (is (= 3/10 (rationalize 0.3)) "(rationalize 0.3) is 3/10")
+  (is (= 1/4 (rationalize 0.25)) "(rationalize 0.25) is 1/4")
+  (is (= 7/100 (rationalize 0.07)) "(rationalize 0.07) is 7/100")
+  (is (= 1/100000 (rationalize 1e-5)) "(rationalize 1e-5) is 1/100000")
+  (is (= -3/2 (rationalize -1.5)) "(rationalize -1.5) is -3/2"))
+
+(deftest test-rationalize-integer-valued-floats
+  (is (= 0 (rationalize 0.0)) "(rationalize 0.0) collapses to 0")
+  (is (= 0 (rationalize -0.0)) "(rationalize -0.0) collapses to 0")
+  (is (= 3 (rationalize 3.0)) "(rationalize 3.0) collapses to 3")
+  (is (= -42 (rationalize -42.0)) "(rationalize -42.0) collapses to -42")
+  (is (php/=== false (ratio? (rationalize 7.0))) "integer-valued floats do not produce a Rational"))
+
+(deftest test-rationalize-passes-through-exact
+  (is (= 1/3 (rationalize 1/3)) "(rationalize 1/3) is identity")
+  (is (= 7 (rationalize 7)) "(rationalize 7) is identity for ints")
+  (let [b (php/:: \Phel\Lang\BigInteger (fromString "100000000000000000000"))]
+    (is (= b (rationalize b)) "(rationalize BigInteger) is identity")))
+
+(deftest test-rationalize-rejects-non-finite
+  (is (thrown? \InvalidArgumentException (rationalize ##Inf)) "(rationalize ##Inf) throws")
+  (is (thrown? \InvalidArgumentException (rationalize ##-Inf)) "(rationalize ##-Inf) throws")
+  (is (thrown? \InvalidArgumentException (rationalize ##NaN)) "(rationalize ##NaN) throws")
+  (is (thrown? \InvalidArgumentException (rationalize "1.0")) "(rationalize string) throws")
+  (is (thrown? \InvalidArgumentException (rationalize nil)) "(rationalize nil) throws"))
+
+(deftest test-rationalize-repeating-decimal
+  ;; Floats without an exact short decimal use the shortest decimal that
+  ;; round-trips back to the same float value.
+  (let [x (/ 1.0 3.0)
+        r (rationalize x)]
+    (is (true? (ratio? r)) "rationalize on 1/3-as-double yields a Rational")
+    (is (= x (php/-> r (toFloat))) "rationalize round-trips back to the same float")))


### PR DESCRIPTION
## 🤔 Background

`(rationalize 0.1)` returned `10000000000000001/100000000000000000` because the previous implementation parsed `sprintf("%.17g", x)` raw, so binary float noise leaked straight into the numerator/denominator. Small floats (`1e-5`) errored entirely because the scientific-notation output was passed to `BigInteger::fromString`. There was also no docs page enumerating the int / `BigInteger` / `Rational` / `float` types and how Phel's numeric tower differs from Clojure's, so devs migrating across had to read source to find out.

Closes #1832.

## 💡 Goal

- Make `rationalize` produce canonical results for finite floats: `0.1 → 1/10`, `0.5 → 1/2`, `-0.25 → -1/4`, integer-valued floats collapse to native ints.
- Stop erroring on small floats whose `%.17g` output is in scientific notation.
- Document the numeric tower so the deliberate divergences from Clojure (no `BigDecimal`, no `1N` / `1M` literal suffixes, oversize int literals lex as `float`, arithmetic `bit-shift-right`, single-arg `==` asserts numeric) are written down.

## 🔖 Changes

- `src/phel/core/math.phel`
  - New private helper `float-shortest-decimal` finds the shortest `%.{p}g` precision (1 → 17) that round-trips back to the same `float`.
  - New private helper `decimal-string->rational` parses both decimal and scientific-notation strings via mantissa + exponent into `Rational::create`, so `1e-5` becomes `1/100000`.
  - `float->rational` composes the two; non-finite floats still throw.
  - `rationalize` docstring updated to describe the round-trip behaviour.
- `tests/phel/test/core/math-operation.phel` — five new `deftest` blocks covering canonicalisation, integer-valued floats, identity passes (`1/3`, ints, `BigInteger`), rejection of `##Inf` / `##-Inf` / `##NaN` / non-numeric inputs, and the round-trip property for floats without an exact short decimal (`(/ 1.0 3.0)`).
- `docs/numeric-tower.md` — new doc covering the four numeric types, the differences from Clojure, and a quick-reference table.
- `CHANGELOG.md` — entries under `## Unreleased` for the fix and the new doc.

## Test plan

- [x] `./bin/phel test tests/phel/test/core/math-operation.phel` — 341 / 341 pass
- [x] `./vendor/bin/phpunit --testsuite=unit,integration` — 2993 pass, 3 skipped (env)
- [x] `./vendor/bin/phpstan analyse --memory-limit=512M` — no errors
- [x] `./vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] `./vendor/bin/rector --dry-run` — clean