### PR TITLE
fix(core): float/double collapse Rational and BigInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `rationalize` uses the shortest round-trip decimal so `(rationalize 0.1)` is `1/10` and small floats in scientific notation no longer error (#1832)
+- `float` and `double` collapse `Rational` and `BigInteger` values, so `phel.async/delay` (and other PHP-typed-float interop) accepts results of `/` (#1836)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/phel/async.phel
+++ b/src/phel/async.phel
@@ -17,13 +17,13 @@
 ;; See `docs/async-guide.md` for the full decision guide and examples.
 
 (defn delay
-  "Suspends execution for `seconds` (a float; supports sub-second
-  precision such as `0.05`).
+  "Suspends execution for `seconds`. Accepts any number (int, float, or
+  `Rational`); sub-second precision such as `0.05` is supported.
 
   At the top level this behaves like `php/sleep` / `php/usleep`: it
   blocks the script for the given duration. Inside an `async`/`future`
-  body — or any AMPHP fiber context — it suspends the *fiber* (not the
-  whole process), so other concurrent fibers keep running and the
+  body (or any AMPHP fiber context) it suspends the *fiber*, not the
+  whole process, so other concurrent fibers keep running and the
   delay is cancellable via `future-cancel`.
 
   `phel.async/delay` is **not** the Clojure `clojure.core/delay`. The
@@ -33,7 +33,8 @@
   out, or compose with `future` / `pmap`; reach for `php/sleep` when you
   just want a blocking pause and don't care about fiber semantics."
   {:example "(delay 0.5) ; suspends current fiber for 500ms
-  (async (delay 1.0) :done) ; => future that resolves after 1s"
+  (async (delay 1.0) :done) ; => future that resolves after 1s
+  (delay (/ 1 1000)) ; ratio collapses to a float"
    :see-also ["async" "await" "future" "future-cancel"]}
   [seconds]
-  (php/amp\delay seconds))
+  (php/amp\delay (float seconds)))

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -320,12 +320,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and
-   double; both map to the same native PHP float type. Delegates to PHP's
-   `floatval`, so non-numeric strings return `0.0` and `nil` returns `0.0`."
-  {:example "(float 1) ; => 1.0"
+   double; both map to the same native PHP float type. `Rational` and
+   `BigInteger` values collapse to their float value; everything else
+   delegates to PHP's `floatval`, so non-numeric strings return `0.0` and
+   `nil` returns `0.0`."
+  {:example "(float 1) ; => 1.0\n(float 1/2) ; => 0.5"
    :see-also ["double" "int?" "number?"]}
   [x]
-  (php/floatval x))
+  (cond
+    (php/instanceof x Rational)   (php/-> x (toFloat))
+    (php/instanceof x BigInteger) (php/floatval (str x))
+    :else                         (php/floatval x)))
 
 (defn double
   "Coerces `x` to a double. In PHP there is no distinction between float and
@@ -333,7 +338,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(double 1) ; => 1.0"
    :see-also ["float" "int?" "number?"]}
   [x]
-  (php/floatval x))
+  (float x))
 
 (defn long
   "Coerces `x` to a long integer. In PHP there is no distinction between int
@@ -663,12 +668,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn- number->float
   [x]
-  (cond
-    (php/is_int x)                (php/floatval x)
-    (php/is_float x)              x
-    (php/instanceof x BigInteger) (php/floatval (str x))
-    (php/instanceof x Rational)   (php/-> x (toFloat))
-    :else
+  (if (number? x)
+    (float x)
     (throw (php/new InvalidArgumentException
                     (str "expected a number, got " (type x))))))
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -269,7 +269,11 @@
   (is (= -3.0 (float -3)) "(float -3)")
   (is (= 0.0 (float 0)) "(float 0)")
   (is (= 3.14 (float "3.14")) "(float \"3.14\")")
-  (is (= 0.0 (float nil)) "(float nil)"))
+  (is (= 0.0 (float nil)) "(float nil)")
+  (is (= 0.5 (float 1/2)) "(float 1/2) collapses Rational")
+  (is (true? (float? (float 1/2))) "(float 1/2) returns float")
+  (is (= 0.001 (float (/ 1 1000))) "(float (/ 1 1000)) survives Rational division")
+  (is (= 1.0 (float (bigint 1))) "(float (bigint 1)) collapses BigInteger"))
 
 (deftest test-double
   (is (= 1.0 (double 1)) "(double 1)")
@@ -278,7 +282,9 @@
   (is (= -3.0 (double -3)) "(double -3)")
   (is (= 0.0 (double 0)) "(double 0)")
   (is (= 3.14 (double "3.14")) "(double \"3.14\")")
-  (is (= 0.0 (double nil)) "(double nil)"))
+  (is (= 0.0 (double nil)) "(double nil)")
+  (is (= 0.5 (double 1/2)) "(double 1/2) collapses Rational")
+  (is (= 1.0 (double (bigint 1))) "(double (bigint 1)) collapses BigInteger"))
 
 (deftest test-long
   (is (= 1 (long 1.9)) "(long 1.9) truncates toward zero")


### PR DESCRIPTION
## 🤔 Background

`(/ 1 1000)` returns a `Rational` after #1828/#1829. Passing the result to a PHP function with a `float` parameter type (e.g. `Amp\delay`) raised:

```
TypeError: Amp\delay(): Argument #1 ($timeout) must be of type float, Phel\Lang\Rational given
```

The `realized?` test in `clojure-test-suite` triggered this via `(phel.async/delay (/ ms 1000))`. Closes #1836.

## 💡 Goal

Make `(float x)` (and its alias `(double x)`) work on the full numeric tower so `Rational` and `BigInteger` values collapse cleanly into PHP floats wherever interop demands a native float.

## 🔖 Changes

- `phel.core/float`: dispatch on `Rational` (via `toFloat`) and `BigInteger` (via `floatval(str x)`); keep PHP `floatval` semantics for ints, floats, strings, and `nil`.
- `phel.core/double`: now a real alias for `float` (was a duplicate `floatval` call).
- `phel.async/delay`: routes `seconds` through `float` so ratios from `/` reach `Amp\delay` as a native float.
- Tests cover `(float 1/2)`, `(float (/ 1 1000))`, `(float (bigint 1))`, and the matching `double` cases.
- `CHANGELOG.md` Unreleased entry under `Fixed > Core`.

No final `ref(...)` polish commit: re-review of the four touched files surfaced no duplication, dead code, or naming drift to clean up.