### PR TITLE
ref(tests): migrate Phel test namespaces from backslash to dot form

### DIFF
--- a/tests/phel/test/ai.phel
+++ b/tests/phel/test/ai.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\ai
-  (:require phel\test :refer [deftest is])
-  (:require phel\ai :as ai)
-  (:require phel\json)
-  (:require phel\mock :refer [mock-fn calls call-count first-call]))
+(ns phel-test.test.ai
+  (:require phel.test :refer [deftest is])
+  (:require phel.ai :as ai)
+  (:require phel.json)
+  (:require phel.mock :refer [mock-fn calls call-count first-call]))
 
 ;; --- Mock HTTP helpers ---
 
@@ -711,7 +711,7 @@
           (is (php/str_contains (php/-> e (getMessage)) "400") "error includes status code"))))))
 
 ;; --- Embeddings ---
-;; Note: responses use raw JSON strings because phel\json stringifies floats
+;; Note: responses use raw JSON strings because phel.json stringifies floats
 ;; during encode (e.g. 0.1 → "0.1"), which would corrupt embedding vectors.
 
 (defn- raw-ok [json-str] {:status 200 :body json-str})

--- a/tests/phel/test/are.phel
+++ b/tests/phel/test/are.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\are
-  (:require phel\test :refer [deftest is are testing get-stats reset-stats restore-stats]))
+(ns phel-test.test.are
+  (:require phel.test :refer [deftest is are testing get-stats reset-stats restore-stats]))
 
 ;; ---------------------------------------------------------------------------
 ;; Basic 2-variable usage — the canonical use case

--- a/tests/phel/test/assert-expr-extensibility.phel
+++ b/tests/phel/test/assert-expr-extensibility.phel
@@ -1,10 +1,10 @@
-(ns phel-test\test\assert-expr-extensibility
-  (:require phel\test :refer [deftest is get-stats reset-stats restore-stats]))
+(ns phel-test.test.assert-expr-extensibility
+  (:require phel.test :refer [deftest is get-stats reset-stats restore-stats]))
 
-;; Issue #1188: `phel\test/assert-expr` is a public multimethod, so users
+;; Issue #1188: `phel.test/assert-expr` is a public multimethod, so users
 ;; can register custom assertion forms for the `is` macro from any
 ;; namespace via `defmethod`. Cross-namespace defmethod must fully
-;; qualify the multi-name so the methods table is resolved in phel\test,
+;; qualify the multi-name so the methods table is resolved in phel.test,
 ;; not the local namespace.
 ;;
 ;; These tests cover the multimethod behavior end-to-end:
@@ -19,7 +19,7 @@
 ;; Custom binary assertion: approx= for near-equal floats
 ;; ---------------------------------------------------------------------------
 
-(defmethod phel\test/assert-expr 'approx= [form message]
+(defmethod phel.test/assert-expr 'approx= [form message]
   (let [a (second form)
         b (second (next form))
         epsilon 0.001]
@@ -41,7 +41,7 @@
 ;; Second custom method: divisible? — proves multiple methods coexist
 ;; ---------------------------------------------------------------------------
 
-(defmethod phel\test/assert-expr 'divisible? [form message]
+(defmethod phel.test/assert-expr 'divisible? [form message]
   (let [n (second form)
         d (second (next form))]
     `(is (zero? (php/% ~n ~d)) ~message)))
@@ -63,7 +63,7 @@
 ;; Custom unary assertion: even-positive? — single-arg form
 ;; ---------------------------------------------------------------------------
 
-(defmethod phel\test/assert-expr 'even-positive? [form message]
+(defmethod phel.test/assert-expr 'even-positive? [form message]
   (let [n (second form)]
     `(is (and (pos? ~n) (even? ~n)) ~message)))
 
@@ -87,7 +87,7 @@
 ;; as :error rather than :failed.
 ;; ---------------------------------------------------------------------------
 
-(defmethod phel\test/assert-expr 'always-throws [_form _message]
+(defmethod phel.test/assert-expr 'always-throws [_form _message]
   `(throw (php/new \RuntimeException "boom from custom assertion")))
 
 (deftest test-custom-method-exception-is-reported-as-error
@@ -120,7 +120,7 @@
 ;; method (not through :default), proving dispatch precedence.
 ;; ---------------------------------------------------------------------------
 
-(defmethod phel\test/assert-expr 'tagged= [form message]
+(defmethod phel.test/assert-expr 'tagged= [form message]
   `(is (= ~(second form) ~(second (next form))) ~message))
 
 (deftest test-custom-dispatch-routes-through-new-method

--- a/tests/phel/test/async-fiber.phel
+++ b/tests/phel/test/async-fiber.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\async-fiber
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.async-fiber
+  (:require phel.test :refer [deftest is]))
 
 ;; --- promise / deliver ---
 

--- a/tests/phel/test/async.phel
+++ b/tests/phel/test/async.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\async
-  (:require phel\test :refer [deftest is])
-  (:require phel\async :refer [delay]))
+(ns phel-test.test.async
+  (:require phel.test :refer [deftest is])
+  (:require phel.async :refer [delay]))
 
 ;; --- Pure function tests ---
 

--- a/tests/phel/test/base64.phel
+++ b/tests/phel/test/base64.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\base64
-  (:require phel\base64 :as b64)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.base64
+  (:require phel.base64 :as b64)
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-encode
   (is (= "aGVsbG8=" (b64/encode "hello"))))

--- a/tests/phel/test/cli.phel
+++ b/tests/phel/test/cli.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\cli
-  (:require phel\cli :as cli)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.cli
+  (:require phel.cli :as cli)
+  (:require phel.test :refer [deftest is]))
 
 (defn- run-app [app args]
   (let [input  (cli/argv args)

--- a/tests/phel/test/clojure-test-alias-regression.phel
+++ b/tests/phel/test/clojure-test-alias-regression.phel
@@ -1,4 +1,4 @@
-(ns phel\test\clojure-test-alias-regression
+(ns phel.test.clojure-test-alias-regression
   (:require clojure.test :as t))
 
 (t/deftest clojure-test-alias-resolves-via-remap

--- a/tests/phel/test/core/are-regression-1364.phel
+++ b/tests/phel/test/core/are-regression-1364.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\are-regression-1364
-  (:require phel\test :refer [deftest testing are is]))
+(ns phel-test.test.core.are-regression-1364
+  (:require phel.test :refer [deftest testing are is]))
 
 ;; Regression coverage for https://github.com/phel-lang/phel-lang/issues/1364
 ;;

--- a/tests/phel/test/core/assert.phel
+++ b/tests/phel/test/core/assert.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\assert
-  (:require phel\test :refer [deftest is thrown? thrown-with-msg?]))
+(ns phel-test.test.core.assert
+  (:require phel.test :refer [deftest is thrown? thrown-with-msg?]))
 
 (deftest test-assert-passes
   (assert true)
@@ -19,7 +19,7 @@
 (deftest test-assert-var-default
   (is (= true *assert*) "*assert* defaults to true"))
 
-;; Toggle phel\core/*assert* at file load time so the forms below are
+;; Toggle phel.core/*assert* at file load time so the forms below are
 ;; macroexpanded while the flag is false. The macro must read the current
 ;; value of *assert* from the core namespace on each expansion.
 (php/:: \Phel (addDefinition "phel.core" "*assert*" false))

--- a/tests/phel/test/core/async-in-core.phel
+++ b/tests/phel/test/core/async-in-core.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\async-in-core
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.async-in-core
+  (:require phel.test :refer [deftest is]))
 
 ;; Regression test for https://github.com/phel-lang/phel-lang/issues/1548
 ;; The Clojure-parity async surface (and Phel's fiber combinators that

--- a/tests/phel/test/core/atom-options.phel
+++ b/tests/phel/test/core/atom-options.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\atom-options
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.atom-options
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-atom-meta-empty
   (is (= {} (meta (atom nil :meta {}))) "atom :meta {} preserves empty map"))

--- a/tests/phel/test/core/basic-constructors.phel
+++ b/tests/phel/test/core/basic-constructors.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\basic-constructors
-  (:require phel\test :refer [deftest is are]))
+(ns phel-test.test.core.basic-constructors
+  (:require phel.test :refer [deftest is are]))
 
 (deftest create-list
   (is (= '(1 2 3) (list '1 '2 '3)) "construct list"))

--- a/tests/phel/test/core/basic-sequence-operation.phel
+++ b/tests/phel/test/core/basic-sequence-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\basic-sequence-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.basic-sequence-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-cons
   (is (= (php/array 1 2) (cons 1 (php/array 2))) "cons php array")

--- a/tests/phel/test/core/binding-conveyance.phel
+++ b/tests/phel/test/core/binding-conveyance.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\binding-conveyance
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.binding-conveyance
+  (:require phel.test :refer [deftest is]))
 
 ;; Regression tests for https://github.com/phel-lang/phel-lang/issues/1536
 ;;

--- a/tests/phel/test/core/binding-regression-1363.phel
+++ b/tests/phel/test/core/binding-regression-1363.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\binding-regression-1363
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.binding-regression-1363
+  (:require phel.test :refer [deftest is]))
 
 ;; Regression coverage for https://github.com/phel-lang/phel-lang/issues/1363
 ;;

--- a/tests/phel/test/core/binding.phel
+++ b/tests/phel/test/core/binding.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\binding
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.binding
+  (:require phel.test :refer [deftest is]))
 
 (def ^:dynamic *my-binding-var* 1)
 

--- a/tests/phel/test/core/bitwise-operation.phel
+++ b/tests/phel/test/core/bitwise-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\bitwise-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.bitwise-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-bit-and
   (is (= 0b1000 (bit-and 0b1100 0b1001)) "bit-and of two number")

--- a/tests/phel/test/core/boolean-operation.phel
+++ b/tests/phel/test/core/boolean-operation.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\core\boolean-operation
-  (:require phel\test :refer [deftest is thrown?])
-  (:require phel\string :as s))
+(ns phel-test.test.core.boolean-operation
+  (:require phel.test :refer [deftest is thrown?])
+  (:require phel.string :as s))
 
 (deftest test-or
   (is (nil? (or)) "or zero args")

--- a/tests/phel/test/core/char-literals.phel
+++ b/tests/phel/test/core/char-literals.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\char-literals
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.char-literals
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-char-literal-alpha
   (is (= "a" \a) "lowercase alpha char")

--- a/tests/phel/test/core/clojure-aliases.phel
+++ b/tests/phel/test/core/clojure-aliases.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\clojure-aliases
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.clojure-aliases
+  (:require phel.test :refer [deftest is]))
 
 ;; --- atom basics ---
 

--- a/tests/phel/test/core/comments.phel
+++ b/tests/phel/test/core/comments.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\comments
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.comments
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-line-comment
   ;; line comments compile away cleanly

--- a/tests/phel/test/core/control-structures.phel
+++ b/tests/phel/test/core/control-structures.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\control-structures
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.control-structures
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-if-not
   (is (= 2 (if-not true 1 2)) "if-not true")

--- a/tests/phel/test/core/def-in-def.phel
+++ b/tests/phel/test/core/def-in-def.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\def-in-def
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.def-in-def
+  (:require phel.test :refer [deftest is]))
 
 ;; `def` inside `def` is permitted, matching Clojure's semantics:
 ;;   (defn a [] (def x 1) x) => 1

--- a/tests/phel/test/core/defmacro-env.phel
+++ b/tests/phel/test/core/defmacro-env.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\defmacro-env
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.defmacro-env
+  (:require phel.test :refer [deftest is]))
 
 ;; `&form` and `&env` are implicit leading params that every `defmacro`
 ;; receives. `&form` holds the call form (the list written at the call

--- a/tests/phel/test/core/delay.phel
+++ b/tests/phel/test/core/delay.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\delay
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.delay
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-delay-caches-result
   (let [counter (atom 0)

--- a/tests/phel/test/core/destructuring.phel
+++ b/tests/phel/test/core/destructuring.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\destructuring
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.destructuring
+  (:require phel.test :refer [deftest is]))
 
 (deftest destructure-vector
   (is (= 3 (let [[a b] [1 2]] (+ a b))) "from vector")

--- a/tests/phel/test/core/doseq.phel
+++ b/tests/phel/test/core/doseq.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\doseq
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.doseq
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-doseq-range-side-effects
   (let [sum (atom 0)

--- a/tests/phel/test/core/ex-info.phel
+++ b/tests/phel/test/core/ex-info.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\ex-info
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.ex-info
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-ex-info-creates-exception
   (let [ex (ex-info "bad input" {:field :email})]

--- a/tests/phel/test/core/file-operation.phel
+++ b/tests/phel/test/core/file-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\file-operation
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.file-operation
+  (:require phel.test :refer [deftest is thrown?]))
 
 (deftest test-slurp
   (is (string? (slurp php/__FILE__)) "reads current file successfully")

--- a/tests/phel/test/core/fn-map-body.phel
+++ b/tests/phel/test/core/fn-map-body.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\fn-map-body
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.fn-map-body
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-fn-map-body
   (let [xfun (fn [x] {:value x})]

--- a/tests/phel/test/core/for-loop.phel
+++ b/tests/phel/test/core/for-loop.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\for-loop
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.for-loop
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-range
   (is (= [0 1 2 3 4] (take 5 (range))) "(range) infinite")

--- a/tests/phel/test/core/function-operation.phel
+++ b/tests/phel/test/core/function-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\function-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.function-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-identity
   (is (= "a" (identity "a")) "identity returns itself"))

--- a/tests/phel/test/core/future-in-core.phel
+++ b/tests/phel/test/core/future-in-core.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\core\future-in-core
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.future-in-core
+  (:require phel.test :refer [deftest is]))
 
 ;; Regression test for https://github.com/phel-lang/phel-lang/issues/1537
-;; `future` must be available from core without requiring `phel\async`,
+;; `future` must be available from core without requiring `phel.async`,
 ;; matching Clojure's out-of-the-box availability.
 
 (deftest test-future-macro-is-available-without-require

--- a/tests/phel/test/core/hash-gensym.phel
+++ b/tests/phel/test/core/hash-gensym.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\hash-gensym
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.hash-gensym
+  (:require phel.test :refer [deftest is]))
 
 ;; Phel accepts Clojure-style `name#` as an auto-gensym suffix inside
 ;; syntax-quote (alongside the deprecated Phel-specific `name$`). These

--- a/tests/phel/test/core/hierarchy.phel
+++ b/tests/phel/test/core/hierarchy.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\hierarchy
-  (:require phel\test :refer [deftest is])
+(ns phel-test.test.core.hierarchy
+  (:require phel.test :refer [deftest is])
   (:use RecursiveArrayIterator)
   (:use ArrayIterator)
   (:use RecursiveIterator)

--- a/tests/phel/test/core/infinite-seqs.phel
+++ b/tests/phel/test/core/infinite-seqs.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\infinite-seqs
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.infinite-seqs
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-repeat-infinite
   (is (= [:a :a :a] (take 3 (repeat :a)))

--- a/tests/phel/test/core/iteration.phel
+++ b/tests/phel/test/core/iteration.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\iteration
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.iteration
+  (:require phel.test :refer [deftest is]))
 
 (defn- mock-paginated-api
   "Simulates a paginated API with 3 pages."

--- a/tests/phel/test/core/letfn.phel
+++ b/tests/phel/test/core/letfn.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\letfn
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.letfn
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-letfn-mutual-recursion
   (is (true? (letfn [(my-even? [n] (if (zero? n) true (my-odd? (dec n))))

--- a/tests/phel/test/core/macroexpand.phel
+++ b/tests/phel/test/core/macroexpand.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\macroexpand
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.macroexpand
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-macroexpand-1-when
   (is (= '(if true (do 1 2))

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\math-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.math-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-+
   (is (= 0 (+)) "+ zero arguments")

--- a/tests/phel/test/core/meta.phel
+++ b/tests/phel/test/core/meta.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\meta
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.meta
+  (:require phel.test :refer [deftest is]))
 
 (def secret {:private true} 1)
 

--- a/tests/phel/test/core/more-sequence-operation.phel
+++ b/tests/phel/test/core/more-sequence-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\more-sequence-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.more-sequence-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-tree-seq
   (is (= [[[1 2 [3]] [4]]

--- a/tests/phel/test/core/multi-arity-fn.phel
+++ b/tests/phel/test/core/multi-arity-fn.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\multi-arity-fn
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.multi-arity-fn
+  (:require phel.test :refer [deftest is thrown?]))
 
 (defn- greet
   ([] "hi")

--- a/tests/phel/test/core/multimethods.phel
+++ b/tests/phel/test/core/multimethods.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\multimethods
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.multimethods
+  (:require phel.test :refer [deftest is]))
 
 ;; --------
 ;; defmulti

--- a/tests/phel/test/core/ns.phel
+++ b/tests/phel/test/core/ns.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\ns
-  (:require phel\test :refer [deftest is testing]))
+(ns phel-test.test.core.ns
+  (:require phel.test :refer [deftest is testing]))
 
 (deftest test-loaded-namespaces-includes-core
   (is (some #(= "phel.core" %) (loaded-namespaces))

--- a/tests/phel/test/core/pre-post-conditions.phel
+++ b/tests/phel/test/core/pre-post-conditions.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\pre-post-conditions
-  (:require phel\test :refer [deftest is thrown? thrown-with-msg?])
+(ns phel-test.test.core.pre-post-conditions
+  (:require phel.test :refer [deftest is thrown? thrown-with-msg?])
   (:use RuntimeException))
 
 (deftest test-pre-condition

--- a/tests/phel/test/core/print-operation.phel
+++ b/tests/phel/test/core/print-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\print-operation
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.print-operation
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-str
   (is (= "" (str)) "str with no arg")

--- a/tests/phel/test/core/protocols.phel
+++ b/tests/phel/test/core/protocols.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\protocols
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.protocols
+  (:require phel.test :refer [deftest is]))
 
 ;; --- Protocol definition and basic dispatch ---
 

--- a/tests/phel/test/core/records.phel
+++ b/tests/phel/test/core/records.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\records
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.records
+  (:require phel.test :refer [deftest is]))
 
 ;; --- defrecord: basic shape and constructors ---
 

--- a/tests/phel/test/core/regex-functions.phel
+++ b/tests/phel/test/core/regex-functions.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\regex-functions
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.regex-functions
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-re-seq
   (let [input "Hello, 1 regex 2 test"]

--- a/tests/phel/test/core/reify.phel
+++ b/tests/phel/test/core/reify.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\reify
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.reify
+  (:require phel.test :refer [deftest is]))
 
 ;; --- Protocol definitions ---
 

--- a/tests/phel/test/core/sequence-functions.phel
+++ b/tests/phel/test/core/sequence-functions.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\sequence-functions
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.sequence-functions
+  (:require phel.test :refer [deftest is thrown?]))
 
 (defn naturals []
   (loop [i 0]

--- a/tests/phel/test/core/sequence-operation.phel
+++ b/tests/phel/test/core/sequence-operation.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\core\sequence-operation
+(ns phel-test.test.core.sequence-operation
   (:use OutOfBoundsException)
-  (:require phel\test :refer [deftest is]))
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-fnext
   (is (= 2 (fnext [1 2 3])) "fnext on vector")

--- a/tests/phel/test/core/set-operation.phel
+++ b/tests/phel/test/core/set-operation.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\set-operation
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.set-operation
+  (:require phel.test :refer [deftest is thrown?]))
 
 (deftest test-set-union
   (is (= (hash-set) (union)) "set 0-ary union")

--- a/tests/phel/test/core/sorted-collections.phel
+++ b/tests/phel/test/core/sorted-collections.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\sorted-collections
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.sorted-collections
+  (:require phel.test :refer [deftest is]))
 
 ;; ---- sorted-map ----
 

--- a/tests/phel/test/core/special-forms.phel
+++ b/tests/phel/test/core/special-forms.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\special-forms
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.special-forms
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-set-object-property
   (is (= "foo" (php/-> (php/oset (php/-> (php/new \stdClass) name) "foo") name)) "set value to stdClass"))

--- a/tests/phel/test/core/tap.phel
+++ b/tests/phel/test/core/tap.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\tap
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.tap
+  (:require phel.test :refer [deftest is]))
 
 (deftest tap-single-listener
   (let [seen (atom [])

--- a/tests/phel/test/core/threading-macros.phel
+++ b/tests/phel/test/core/threading-macros.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\core\threading-macros
+(ns phel-test.test.core.threading-macros
   (:use DateTime)
-  (:require phel\test :refer [deftest is]))
+  (:require phel.test :refer [deftest is]))
 
 (deftest test->
   (is (= 1 (-> 1)))

--- a/tests/phel/test/core/tilde-unquote.phel
+++ b/tests/phel/test/core/tilde-unquote.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\tilde-unquote
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.tilde-unquote
+  (:require phel.test :refer [deftest is]))
 
 ;; Phel accepts Clojure-style `~` / `~@` as aliases for `,` / `,@` inside
 ;; syntax-quote (`). These tests drive the full pipeline — lex, parse,

--- a/tests/phel/test/core/transducers.phel
+++ b/tests/phel/test/core/transducers.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\transducers
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.transducers
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-reduced-and-reduced?
   (let [r (reduced 42)]

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\core\type-operation
+(ns phel-test.test.core.type-operation
   (:use DateTime)
   (:use RuntimeException)
   (:use Phel\Lang\Symbol)
-  (:require phel\test :refer [deftest is are]))
+  (:require phel.test :refer [deftest is are]))
 
 (deftest test-type
   (is (= :vector (type [])) "type of vector")

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\core\utility-functions
-  (:require phel\test :refer [deftest is])
-  (:require phel\string :as s))
+(ns phel-test.test.core.utility-functions
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as s))
 
 ;; --- Math predicates & functions ---
 

--- a/tests/phel/test/core/var-introspection.phel
+++ b/tests/phel/test/core/var-introspection.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\var-introspection
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.var-introspection
+  (:require phel.test :refer [deftest is]))
 
 ;; Coverage for `bound?`, `thread-bound?`, `var-set`, `with-bindings`,
 ;; and `with-redefs` introspection / mutation primitives.

--- a/tests/phel/test/core/var-quote.phel
+++ b/tests/phel/test/core/var-quote.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\var-quote
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.var-quote
+  (:require phel.test :refer [deftest is]))
 
 ;; `#'foo` expands to `(var foo)` and yields a `Var` handle to the named
 ;; definition. Calling the var derefs to the current root.

--- a/tests/phel/test/core/vars-callable.phel
+++ b/tests/phel/test/core/vars-callable.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\vars-callable
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.vars-callable
+  (:require phel.test :refer [deftest is thrown?]))
 
 ;; Var handles forward calls to their current root value when that value
 ;; is callable. Throws a clear error when the root value cannot be invoked.

--- a/tests/phel/test/core/vars-meta.phel
+++ b/tests/phel/test/core/vars-meta.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\vars-meta
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.vars-meta
+  (:require phel.test :refer [deftest is thrown?]))
 
 ;; Per-var metadata mutation: `alter-meta!` updates a var's metadata in
 ;; place; `reset-meta!` replaces it wholesale. Both work on atoms too.

--- a/tests/phel/test/core/vars-watchers.phel
+++ b/tests/phel/test/core/vars-watchers.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\vars-watchers
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.vars-watchers
+  (:require phel.test :refer [deftest is]))
 
 ;; `add-watch` / `remove-watch` work on `Var` handles. Watch fns are called
 ;; with `[key var old-value new-value]` after `alter-var-root` succeeds.

--- a/tests/phel/test/core/vars.phel
+++ b/tests/phel/test/core/vars.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\vars
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.core.vars
+  (:require phel.test :refer [deftest is]))
 
 ;; First-class `Var` handles: produced by `(var sym)` / `#'sym`, manipulated
 ;; by `deref`, `alter-var-root`, `meta`, `find-var`, `var-get`, and tested by
@@ -45,9 +45,9 @@
       "two #'sym handles to the same slot compare equal"))
 
 (deftest test-find-var
-  (is (var? (find-var 'phel-test\test\core\vars/var-target-value))
+  (is (var? (find-var 'phel-test.test.core.vars/var-target-value))
       "find-var on a defined symbol returns a Var")
-  (is (nil? (find-var 'phel-test\test\core\vars/missing-symbol))
+  (is (nil? (find-var 'phel-test.test.core.vars/missing-symbol))
       "find-var on a missing symbol returns nil")
   (is (nil? (find-var 'unqualified))
       "find-var on an unqualified symbol returns nil")
@@ -59,11 +59,11 @@
   (is (= var-target-fn (var-get #'var-target-fn)) "var-get on Var fn returns fn"))
 
 (deftest test-var-get-on-symbol
-  (is (= 1 (var-get 'phel-test\test\core\vars/var-target-value))
+  (is (= 1 (var-get 'phel-test.test.core.vars/var-target-value))
       "var-get on a fully-qualified symbol returns the value")
-  (is (nil? (var-get 'phel-test\test\core\vars/missing))
+  (is (nil? (var-get 'phel-test.test.core.vars/missing))
       "var-get on a missing symbol returns nil")
-  (is (= ::none (var-get 'phel-test\test\core\vars/missing ::none))
+  (is (= ::none (var-get 'phel-test.test.core.vars/missing ::none))
       "var-get with not-found arg returns it"))
 
 (deftest test-var-get-on-core

--- a/tests/phel/test/core/watches-validators.phel
+++ b/tests/phel/test/core/watches-validators.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\core\watches-validators
-  (:require phel\test :refer [deftest is thrown?]))
+(ns phel-test.test.core.watches-validators
+  (:require phel.test :refer [deftest is thrown?]))
 
 ;; --- Return values ---
 

--- a/tests/phel/test/defspec-shrink.phel
+++ b/tests/phel/test/defspec-shrink.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\defspec-shrink
-  (:require phel\test :as t :refer [deftest is testing])
-  (:require phel\test\gen :as g))
+(ns phel-test.test.defspec-shrink
+  (:require phel.test :as t :refer [deftest is testing])
+  (:require phel.test.gen :as g))
 
 ;; End-to-end coverage for the `defspec` + shrinker integration. The
 ;; specs used for the tests below are declared with a mock name so they

--- a/tests/phel/test/fixtures/tagged-tests.phel
+++ b/tests/phel/test/fixtures/tagged-tests.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\fixtures\tagged-tests
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.fixtures.tagged-tests
+  (:require phel.test :refer [deftest is]))
 
 ;; Fixture namespace consumed by `tests/phel/test/selectors-runtime.phel`.
 ;;

--- a/tests/phel/test/gen.phel
+++ b/tests/phel/test/gen.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\gen
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\test\gen :as g))
+(ns phel-test.test.gen
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.test.gen :as g))
 
 (def- fixed-seed 1729)
 

--- a/tests/phel/test/html.phel
+++ b/tests/phel/test/html.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\html
-  (:require phel\html :refer [html raw-string doctype])
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.html
+  (:require phel.html :refer [html raw-string doctype])
+  (:require phel.test :refer [deftest is]))
 
 (deftest basic-tags
   (is (= "<div></div>" (html [:div])))

--- a/tests/phel/test/http-client.phel
+++ b/tests/phel/test/http-client.phel
@@ -1,7 +1,7 @@
-(ns phel-test\test\http-client
-  (:require phel\test :refer [deftest is])
-  (:require phel\http-client :as hc)
-  (:require phel\http :as http))
+(ns phel-test.test.http-client
+  (:require phel.test :refer [deftest is])
+  (:require phel.http-client :as hc)
+  (:require phel.http :as http))
 
 ;; --- Response parser integration (via PHP static call) ---
 

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\http
-  (:require phel\http :as h)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.http
+  (:require phel.http :as h)
+  (:require phel.test :refer [deftest is]))
 
 ;; Tests adopted from nyholm/psr7-server
 

--- a/tests/phel/test/json/decode/flags.phel
+++ b/tests/phel/test/json/decode/flags.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\decode\flags
-  (:require phel\json)
-  (:require phel\test :refer [deftest is])
+(ns phel-test.test.json.decode.flags
+  (:require phel.json)
+  (:require phel.test :refer [deftest is])
   (:use \JSON_INVALID_UTF8_IGNORE)
   (:use \JSON_INVALID_UTF8_SUBSTITUTE))
 

--- a/tests/phel/test/json/decode/value.phel
+++ b/tests/phel/test/json/decode/value.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\decode\value
-  (:require phel\json)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.json.decode.value
+  (:require phel.json)
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-json-decode-sample-value
   (let [sample-data (php/file_get_contents (str __DIR__ "/sample-value.json"))]

--- a/tests/phel/test/json/encode/depth.phel
+++ b/tests/phel/test/json/encode/depth.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\encode\depth
-  (:require phel\json)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.json.encode.depth
+  (:require phel.json)
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-json-encode-encode-depth
   (let [sample-data [1 [2] [[3]]]]

--- a/tests/phel/test/json/encode/flags.phel
+++ b/tests/phel/test/json/encode/flags.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\encode\flags
-  (:require phel\json)
-  (:require phel\test :refer [deftest is])
+(ns phel-test.test.json.encode.flags
+  (:require phel.json)
+  (:require phel.test :refer [deftest is])
   (:use \JSON_HEX_TAG)
   (:use \JSON_HEX_AMP))
 

--- a/tests/phel/test/json/encode/keys.phel
+++ b/tests/phel/test/json/encode/keys.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\encode\keys
-  (:require phel\json)
-  (:require phel\test :refer [deftest is])
+(ns phel-test.test.json.encode.keys
+  (:require phel.json)
+  (:require phel.test :refer [deftest is])
   (:use \Exception))
 
 (deftest test-json-encode-valid-keys

--- a/tests/phel/test/json/encode/value.phel
+++ b/tests/phel/test/json/encode/value.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\json\encode\value
-  (:require phel\json)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.json.encode.value
+  (:require phel.json)
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-json-encode-nil
   (is (= "null" (json/encode nil))))

--- a/tests/phel/test/match.phel
+++ b/tests/phel/test/match.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\match
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\match :refer [match]))
+(ns phel-test.test.match
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.match :refer [match]))
 
 (deftest test-literal-patterns
   (testing "integers"
@@ -148,15 +148,15 @@
   ;; expression under test itself would fail to expand. Verify the
   ;; error via `macroexpand-1` instead.
   (is (thrown? \InvalidArgumentException
-               (macroexpand-1 '(phel\match/match [1 2] [1 2 3] :x :else :y)))
+               (macroexpand-1 '(phel.match/match [1 2] [1 2 3] :x :else :y)))
       "mismatched target/pattern count raises at expansion"))
 
 (deftest test-invalid-pattern-shapes-throw-at-expand
   (is (thrown? \InvalidArgumentException
-               (macroexpand-1 '(phel\match/match "not-a-vector" [1] :x :else :y)))
+               (macroexpand-1 '(phel.match/match "not-a-vector" [1] :x :else :y)))
       "non-vector target list raises")
   (is (thrown? \InvalidArgumentException
-               (macroexpand-1 '(phel\match/match [1] :not-a-vector-pattern :x :else :y)))
+               (macroexpand-1 '(phel.match/match [1] :not-a-vector-pattern :x :else :y)))
       "non-vector pattern raises"))
 
 (deftest test-target-evaluated-once
@@ -245,12 +245,12 @@
         "no alternative matches"))
   (testing ":or requires at least one alternative"
     (is (thrown? \InvalidArgumentException
-                 (macroexpand-1 '(phel\match/match [1] [(:or)] :x :else :y)))
+                 (macroexpand-1 '(phel.match/match [1] [(:or)] :x :else :y)))
         "empty :or raises at expansion")))
 
 (deftest test-or-pattern-rejects-binding-alternatives
   (is (thrown? \InvalidArgumentException
-               (macroexpand-1 '(phel\match/match [1] [(:or x 2)] x :else :none)))
+               (macroexpand-1 '(phel.match/match [1] [(:or x 2)] x :else :none)))
       ":or alternatives may not introduce bindings"))
 
 (deftest test-as-pattern-bindings-accumulate
@@ -273,10 +273,10 @@
            (match [[1 2 3]] [[_ & tail]] [:ok tail] :else :else))))
   (testing "rest position must be symbol"
     (is (thrown? \InvalidArgumentException
-                 (macroexpand-1 '(phel\match/match [[1 2]] [[a & 3]] :x :else :y)))
+                 (macroexpand-1 '(phel.match/match [[1 2]] [[a & 3]] :x :else :y)))
         "non-symbol rest binding raises")
     (is (thrown? \InvalidArgumentException
-                 (macroexpand-1 '(phel\match/match [[1 2]] [[a & b c]] :x :else :y)))
+                 (macroexpand-1 '(phel.match/match [[1 2]] [[a & b c]] :x :else :y)))
         "multiple items after & raises")))
 
 (deftest test-map-pattern-with-string-keys

--- a/tests/phel/test/mock.phel
+++ b/tests/phel/test/mock.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\mock
-  (:require phel\test :refer [deftest is])
-  (:require phel\mock :refer [mock mock-fn spy mock-returning mock-throwing
+(ns phel-test.test.mock
+  (:require phel.test :refer [deftest is])
+  (:require phel.mock :refer [mock mock-fn spy mock-returning mock-throwing
                               calls call-count called? called-with? called-once?
                               called-times? never-called? last-call first-call
                               reset-mock! clear-all-mocks! mock? with-mocks

--- a/tests/phel/test/phel-async-fqn-regression.phel
+++ b/tests/phel/test/phel-async-fqn-regression.phel
@@ -1,4 +1,4 @@
-(ns phel\test\phel-async-fqn-regression
+(ns phel.test.phel-async-fqn-regression
   (:require phel.test :refer [deftest is]))
 
 (deftest phel-async-delay-resolves-via-fqn

--- a/tests/phel/test/pprint.phel
+++ b/tests/phel/test/pprint.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\pprint
-  (:require phel\test :refer [deftest is])
-  (:require phel\pprint :refer [pprint-str]))
+(ns phel-test.test.pprint
+  (:require phel.test :refer [deftest is])
+  (:require phel.pprint :refer [pprint-str]))
 
 ;; ---------------------------
 ;; Scalar values (no wrapping)

--- a/tests/phel/test/reader.phel
+++ b/tests/phel/test/reader.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\reader
-  (:require phel\reader :as reader)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.reader
+  (:require phel.reader :as reader)
+  (:require phel.test :refer [deftest is]))
 
 (defn- datetime? [x]
   (php/instanceof x \DateTimeImmutable))

--- a/tests/phel/test/repl.phel
+++ b/tests/phel/test/repl.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\repl
-  (:require phel\repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers ns-interns find-fn test-ns eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns find-ns create-ns remove-ns intern])
-  (:require phel\ai :as ai)
-  (:require phel\string :as s)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.repl
+  (:require phel.repl :refer [apropos dir search-doc get-symbol-info get-source-code ns-publics ns-aliases ns-refers ns-interns find-fn test-ns eval-capturing eval-str macroexpand-1-form macroexpand-form macroexpand-1 macroexpand ns-list loaded-namespaces explain suggest fix review embed-ns search-ns find-ns create-ns remove-ns intern])
+  (:require phel.ai :as ai)
+  (:require phel.string :as s)
+  (:require phel.test :refer [deftest is]))
 
 ;; -------
 ;; apropos
@@ -28,7 +28,7 @@
     (is (s/contains? out "filter") "dir lists 'filter'")))
 
 (deftest test-dir-accepts-bare-namespace-symbol
-  (let [out (with-output-buffer (dir phel\string))]
+  (let [out (with-output-buffer (dir phel.string))]
     (is (s/contains? out "split") "dir lists phel\\string definitions")
     (is (s/contains? out "trim") "dir lists phel\\string definitions")))
 
@@ -128,11 +128,11 @@
 ;; ----------
 
 (deftest test-ns-aliases-returns-map
-  (let [aliases (ns-aliases "phel-test\\test\\repl")]
+  (let [aliases (ns-aliases "phel-test.test.repl")]
     (is (hash-map? aliases) "ns-aliases returns a hash-map")))
 
 (deftest test-ns-aliases-contains-expected-alias
-  (let [aliases (ns-aliases "phel-test\\test\\repl")]
+  (let [aliases (ns-aliases "phel-test.test.repl")]
     (is (= "phel.string" (get aliases "s")) "ns-aliases contains 's' => 'phel.string'")))
 
 ;; ---------
@@ -140,11 +140,11 @@
 ;; ---------
 
 (deftest test-ns-refers-returns-map
-  (let [refers (ns-refers "phel-test\\test\\repl")]
+  (let [refers (ns-refers "phel-test.test.repl")]
     (is (hash-map? refers) "ns-refers returns a hash-map")))
 
 (deftest test-ns-refers-contains-expected-refers
-  (let [refers (ns-refers "phel-test\\test\\repl")]
+  (let [refers (ns-refers "phel-test.test.repl")]
     (is (= "phel.repl" (get refers "apropos")) "ns-refers contains 'apropos' from phel.repl")
     (is (= "phel.test" (get refers "deftest")) "ns-refers contains 'deftest' from phel.test")))
 
@@ -180,13 +180,13 @@
 ;; -------
 
 (deftest test-test-ns-returns-result-map
-  (let [result (with-output-buffer (test-ns "phel-test\\test\\test-framework"))]
+  (let [result (with-output-buffer (test-ns "phel-test.test.test-framework"))]
     (is (s/contains? result "Passed:") "test-ns output contains Passed summary")
     (is (s/contains? result "Failed:") "test-ns output contains Failed summary")))
 
 (deftest test-test-ns-result-has-expected-keys
   (let [result (let [r (atom nil)]
-                 (with-output-buffer (reset! r (test-ns "phel-test\\test\\test-framework")))
+                 (with-output-buffer (reset! r (test-ns "phel-test.test.test-framework")))
                  (deref r))]
     (is (hash-map? result) "test-ns returns a hash-map")
     (is (not (nil? (get result :pass))) "result contains :pass key")

--- a/tests/phel/test/reporters.phel
+++ b/tests/phel/test/reporters.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\reporters
-  (:require phel\test :as t :refer [deftest is]))
+(ns phel-test.test.reporters
+  (:require phel.test :as t :refer [deftest is]))
 
 ;; Coverage for the pluggable `report` multimethod and the built-in
-;; reporter implementations shipped with `phel\test`.
+;; reporter implementations shipped with `phel.test`.
 ;;
 ;; Each test resolves a built-in reporter, feeds it a scripted event
 ;; sequence by binding `*reporters*` locally via `set-reporters!`, and

--- a/tests/phel/test/rose.phel
+++ b/tests/phel/test/rose.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\rose
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\test\rose :as r))
+(ns phel-test.test.rose
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.test.rose :as r))
 
-;; Coverage for the `phel\test\rose` namespace: rose-tree constructors,
+;; Coverage for the `phel.test.rose` namespace: rose-tree constructors,
 ;; monadic helpers (`rose-fmap`, `rose-bind`), and the lazy-evaluation
 ;; invariant that keeps the shrink tree cheap to build.
 

--- a/tests/phel/test/router.phel
+++ b/tests/phel/test/router.phel
@@ -1,7 +1,7 @@
-(ns phel-test\test\router
-  (:require phel\http :as h)
-  (:require phel\test :refer [deftest is])
-  (:require phel\router :as r :refer [routes match-by-path match-by-name generate])
+(ns phel-test.test.router
+  (:require phel.http :as h)
+  (:require phel.test :refer [deftest is])
+  (:require phel.router :as r :refer [routes match-by-path match-by-name generate])
   (:use Symfony\Component\Routing\Exception\RouteNotFoundException)
   (:use Symfony\Component\Routing\Exception\MissingMandatoryParametersException))
 

--- a/tests/phel/test/router/flatten.phel
+++ b/tests/phel/test/router/flatten.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\router\flatten
-  (:require phel\test :refer [deftest is])
-  (:require phel\router :refer [flatten-routes]))
+(ns phel-test.test.router.flatten
+  (:require phel.test :refer [deftest is])
+  (:require phel.router :refer [flatten-routes]))
 
 (deftest flatten-routes-test
   (is (=

--- a/tests/phel/test/router/match-by-path.phel
+++ b/tests/phel/test/router/match-by-path.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\router\match-by-path
-  (:require phel\router :as r)
-  (:require phel\test :refer [deftest is]))
+(ns phel-test.test.router.match-by-path
+  (:require phel.router :as r)
+  (:require phel.test :refer [deftest is]))
 
 (def- routes
   (apply

--- a/tests/phel/test/schema/coerce.phel
+++ b/tests/phel/test/schema/coerce.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\schema\coerce
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s))
+(ns phel-test.test.schema.coerce
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s))
 
 ;; Type coercion — converting HTTP-style string input to schema-required types.
 

--- a/tests/phel/test/schema/explain.phel
+++ b/tests/phel/test/schema/explain.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\schema\explain
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s))
+(ns phel-test.test.schema.explain
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s))
 
 ;; Structured error output from `explain`.
 

--- a/tests/phel/test/schema/generate.phel
+++ b/tests/phel/test/schema/generate.phel
@@ -1,7 +1,7 @@
-(ns phel-test\test\schema\generate
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s)
-  (:require phel\test\gen :as g))
+(ns phel-test.test.schema.generate
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s)
+  (:require phel.test.gen :as g))
 
 ;; Generated values must conform to their source schema.
 

--- a/tests/phel/test/schema/instrument.phel
+++ b/tests/phel/test/schema/instrument.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\schema\instrument
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s))
+(ns phel-test.test.schema.instrument
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s))
 
 ;; Function-level instrumentation wrappers: a wrapped fn validates its
 ;; arguments and return value against the declared schema, throwing

--- a/tests/phel/test/schema/registry.phel
+++ b/tests/phel/test/schema/registry.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\schema\registry
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s))
+(ns phel-test.test.schema.registry
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s))
 
 ;; Named-schema registry behaviour and recursive references.
 

--- a/tests/phel/test/schema/validate.phel
+++ b/tests/phel/test/schema/validate.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\schema\validate
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\schema :as s))
+(ns phel-test.test.schema.validate
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.schema :as s))
 
 ;; Positive and negative coverage for every built-in schema form.
 

--- a/tests/phel/test/selectors-runtime.phel
+++ b/tests/phel/test/selectors-runtime.phel
@@ -1,16 +1,16 @@
-(ns phel-test\test\selectors-runtime
-  (:require phel\test :as t :refer [deftest is testing])
-  (:require phel-test\test\fixtures\tagged-tests))
+(ns phel-test.test.selectors-runtime
+  (:require phel.test :as t :refer [deftest is testing])
+  (:require phel-test.test.fixtures.tagged-tests))
 
 ;; End-to-end coverage for selectors in `run-tests`.
 ;;
-;; The fixture namespace `phel-test\test\fixtures\tagged-tests` defines
+;; The fixture namespace `phel-test.test.fixtures.tagged-tests` defines
 ;; three tests with distinct metadata shapes. Each scenario runs that
 ;; namespace with a scripted option map, captures every emitted event
 ;; (via a temporary reporter), then restores the outer suite's stats
 ;; and reporter set.
 
-(def- fixture-ns 'phel-test\test\fixtures\tagged-tests)
+(def- fixture-ns 'phel-test.test.fixtures.tagged-tests)
 
 (defn- snapshot-run [options]
   (let [saved-reporters (t/get-reporters)

--- a/tests/phel/test/selectors.phel
+++ b/tests/phel/test/selectors.phel
@@ -1,8 +1,8 @@
-(ns phel-test\test\selectors
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\test\selector :as selector))
+(ns phel-test.test.selectors
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.test.selector :as selector))
 
-;; Coverage for the pure test-selection helpers in `phel\test\selector`.
+;; Coverage for the pure test-selection helpers in `phel.test.selector`.
 ;;
 ;; Every predicate is exercised in isolation using hand-rolled metadata
 ;; maps (no macro expansion), so the tests are independent of the

--- a/tests/phel/test/shrink.phel
+++ b/tests/phel/test/shrink.phel
@@ -1,9 +1,9 @@
-(ns phel-test\test\shrink
-  (:require phel\test :refer [deftest is testing])
-  (:require phel\test\shrink :as shrink)
-  (:require phel\test\rose :as r))
+(ns phel-test.test.shrink
+  (:require phel.test :refer [deftest is testing])
+  (:require phel.test.shrink :as shrink)
+  (:require phel.test.rose :as r))
 
-;; Coverage for the value-based shrink driver in `phel\test\shrink`.
+;; Coverage for the value-based shrink driver in `phel.test.shrink`.
 ;; Each test constructs a failing property and verifies that the
 ;; driver reaches the expected minimal counterexample.
 

--- a/tests/phel/test/string.phel
+++ b/tests/phel/test/string.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\string
-  (:require phel\test :refer [deftest is thrown?])
-  (:require phel\string :as s))
+(ns phel-test.test.string
+  (:require phel.test :refer [deftest is thrown?])
+  (:require phel.string :as s))
 
 (deftest test-chars
   (is (= ["h" "e" "l" "l" "o"] (s/chars "hello")) "chars basic")

--- a/tests/phel/test/test-framework.phel
+++ b/tests/phel/test/test-framework.phel
@@ -1,9 +1,9 @@
-(ns phel-test\test\test-framework
-  (:require phel\test :refer [deftest is testing get-stats reset-stats restore-stats do-report]))
+(ns phel-test.test.test-framework
+  (:require phel.test :refer [deftest is testing get-stats reset-stats restore-stats do-report]))
 
 ;; Behavior coverage for the `is` macro and its built-in dispatch arms.
 ;;
-;; These tests exercise the public surface of `phel\test/is` end-to-end:
+;; These tests exercise the public surface of `phel.test/is` end-to-end:
 ;; pass paths run as ordinary `is` assertions, while fail/error paths use
 ;; the `get-stats`/`reset-stats`/`restore-stats` snapshot pattern so the
 ;; failure is observed in isolation without polluting the outer suite.

--- a/tests/phel/test/use-fixtures.phel
+++ b/tests/phel/test/use-fixtures.phel
@@ -1,5 +1,5 @@
-(ns phel-test\test\use-fixtures
-  (:require phel\test :refer [deftest is use-fixtures]))
+(ns phel-test.test.use-fixtures
+  (:require phel.test :refer [deftest is use-fixtures]))
 
 ;; Behaviour coverage for `use-fixtures`. The fixtures registered below
 ;; wrap tests in this namespace, so we observe their effect by recording

--- a/tests/phel/test/walk.phel
+++ b/tests/phel/test/walk.phel
@@ -1,6 +1,6 @@
-(ns phel-test\test\walk
-  (:require phel\test :refer [deftest is])
-  (:require phel\walk :refer [walk postwalk prewalk postwalk-replace
+(ns phel-test.test.walk
+  (:require phel.test :refer [deftest is])
+  (:require phel.walk :refer [walk postwalk prewalk postwalk-replace
                                prewalk-replace keywordize-keys stringify-keys]))
 
 (defstruct point [x y])


### PR DESCRIPTION
## 🤔 Background

Phel namespaces accept both `phel\core` (backslash) and `phel.core` (dot) form. Source under `src/phel/` already uses dot form exclusively; 106 files under `tests/phel/` still used the legacy backslash form for `(ns ...)` declarations and `(:require ...)` clauses.

## 💡 Goal

Use the canonical dot form in all test code so the codebase has a single style. Backslash form remains supported by the parser; this is purely a stylistic refactor.

## 🔖 Changes

- `(ns phel-test\test\X ...)` → `(ns phel-test.test.X ...)`
- `(:require phel\Y ...)` / `(:use phel\Y ...)` → dot form
- `(ns-aliases "phel-test\\test\\repl")` and similar lookups in `tests/phel/test/repl.phel` updated to dot form
- Deliberate exceptions kept on backslash form:
  - PHP class string in `tests/phel/test/core/hierarchy.phel` (PHP FQNs use `\`)
  - Parity assertions in `tests/phel/test/core/ns.phel` that exercise both forms
  - Cache fixtures under `tests/php/Integration/Nrepl/cache/` (auto-generated)

## ✅ Verification

- `composer test-core` (5156 passed)
- `phpunit --testsuite=integration` (575 passed)
- `phpunit --testsuite=unit` (2418 passed)

No CHANGELOG entry: internal test-style refactor, no user-facing change.