### PR TITLE
fix(compiler): integer? accepts BigInteger; oversize int literals lex as float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+#### Compiler
+- Decimal integer literals that overflow `PHP_INT_MAX` now lex as `float` instead of silently clamping to the platform integer bound (#1837)
+
 #### Core
 - `rationalize` uses the shortest round-trip decimal so `(rationalize 0.1)` is `1/10` and small floats in scientific notation no longer error (#1832)
 - `float` and `double` collapse `Rational` and `BigInteger` values, so `phel.async/delay` (and other PHP-typed-float interop) accepts results of `/` (#1836)
+- `integer?` accepts `BigInteger` values (mathematical integers); `int?` stays restricted to fixed-precision PHP `int` (#1837)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -396,7 +396,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["byte" "int?" "string?"]}
   [x]
   (cond
-    (integer? x)
+    (int? x)
     (if (php/< x 0)
       (throw (php/new InvalidArgumentException
                       (php/. "Value out of range for char: " (php/strval x))))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -83,42 +83,40 @@
   (php/is_float x))
 
 (defn integer?
-  "Returns true if `x` is an integer number, false otherwise."
-  {:see-also ["int?"]}
+  "Returns true if `x` is a mathematical integer: a fixed-precision PHP
+   `int` or a `BigInteger`."
+  {:see-also ["int?" "bigint?"]}
+  [x]
+  (or (php/is_int x)
+      (php/instanceof x BigInteger)))
+
+(defn int?
+  "Returns true if `x` is a fixed-precision PHP integer. `BigInteger`
+   values return false; use `integer?` to accept either."
+  {:see-also ["integer?" "bigint?"]}
   [x]
   (php/is_int x))
 
-(defn int?
-  "Returns true if `x` is an integer number, false otherwise.
-   Alias for `integer?`.
-
-   Note that, unlike Clojure, Phel uses PHP integers and there is no
-   distinction between standard and fixed-precision integers.
-   Integer sizes are also limited by platform (see php/PHP_INT_MAX constant)."
-  {:see-also ["integer?"]}
-  [x]
-  (integer? x))
-
 (defn neg-int?
-  "Returns true if `x` is a negative integer."
+  "Returns true if `x` is a negative fixed-precision integer."
   {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? 1) ; => false"
    :see-also ["int?" "pos-int?" "nat-int?"]}
   [x]
-  (and (integer? x) (php/< x 0)))
+  (and (int? x) (php/< x 0)))
 
 (defn pos-int?
-  "Returns true if `x` is a positive integer (greater than zero)."
+  "Returns true if `x` is a positive fixed-precision integer (greater than zero)."
   {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? -1) ; => false"
    :see-also ["int?" "neg-int?" "nat-int?"]}
   [x]
-  (and (integer? x) (php/> x 0)))
+  (and (int? x) (php/> x 0)))
 
 (defn nat-int?
-  "Returns true if `x` is a non-negative integer (zero or positive)."
+  "Returns true if `x` is a non-negative fixed-precision integer (zero or positive)."
   {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? -1) ; => false"
    :see-also ["int?" "pos-int?" "neg-int?"]}
   [x]
-  (and (integer? x) (php/>= x 0)))
+  (and (int? x) (php/>= x 0)))
 
 (defn number?
   "Returns true if `x` is a number — int, float, `Rational`, or `BigInteger`."

--- a/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
+++ b/src/php/Compiler/Domain/Parser/ExpressionParser/AtomParser.php
@@ -115,7 +115,9 @@ final readonly class AtomParser
         }
 
         if (is_numeric($word)) {
-            $value = strpbrk($word, '.eE') !== false ? (float) $word : (int) $word;
+            $value = strpbrk($word, '.eE') !== false
+                ? (float) $word
+                : $this->parseIntegerWithOverflowFallback($word);
 
             return new NumberNode($word, $token->getStartLocation(), $token->getEndLocation(), $value);
         }
@@ -272,6 +274,22 @@ final readonly class AtomParser
         }
 
         return $value;
+    }
+
+    /**
+     * Casts a numeric integer literal to PHP `int`, falling back to `float`
+     * when the literal exceeds `PHP_INT_MAX` / `PHP_INT_MIN`. Without this
+     * fallback PHP's `(int)` cast silently clamps oversize literals to the
+     * platform integer bound, so a literal like `99999999999999999999` would
+     * compare equal to `PHP_INT_MAX` instead of preserving its magnitude.
+     */
+    private function parseIntegerWithOverflowFallback(string $word): float|int
+    {
+        $intValue = (int) $word;
+        $magnitude = ltrim($word, '+-0') ?: '0';
+        $canonical = ($word[0] === '-' && $magnitude !== '0' ? '-' : '') . $magnitude;
+
+        return ((string) $intValue === $canonical) ? $intValue : (float) $word;
     }
 
     private function parseDecimalNumber(array $matches, string $word, Token $token): NumberNode

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -52,13 +52,17 @@
   (is (false? (int? 10.0)) "int? on 10.0")
   (is (false? (int? 0.0)) "int? on 0.0")
   (is (true? (int? 10)) "int? on 10")
-  (is (true? (int? 0)) "int? on 10"))
+  (is (true? (int? 0)) "int? on 10")
+  (is (false? (int? (bigint "9999999999999999999999999")))
+      "int? on BigInteger is false: only fixed-precision PHP int qualifies"))
 
 (deftest test-integer?
   (is (false? (integer? 10.0)) "integer? on 10.0")
   (is (false? (integer? 0.0)) "integer? on 0.0")
   (is (true? (integer? 10)) "integer? on 10")
-  (is (true? (integer? 0)) "integer? on 10"))
+  (is (true? (integer? 0)) "integer? on 10")
+  (is (true? (integer? (bigint "9999999999999999999999999")))
+      "integer? on BigInteger is true: any mathematical integer qualifies"))
 
 (deftest test-neg-int?
   (is (true? (neg-int? -1)) "neg-int? on -1")

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -21,6 +21,8 @@ use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
+use function strlen;
+
 final class AtomParserTest extends TestCase
 {
     public function test_parse_true(): void
@@ -836,5 +838,47 @@ final class AtomParserTest extends TestCase
         $start = new SourceLocation('string', 0, 0);
         $end = new SourceLocation('string', 0, 3);
         $parser->parse(new Token(Token::T_ATOM, '0/0', $start, $end));
+    }
+
+    public function test_parse_oversize_decimal_int_literal_returns_float(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 20);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '99999999999999999999', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        $value = $node->getValue();
+        self::assertIsFloat($value);
+        self::assertSame((float) '99999999999999999999', $value);
+    }
+
+    public function test_parse_oversize_negative_decimal_int_literal_returns_float(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 21);
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, '-99999999999999999999', $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertIsFloat($node->getValue());
+    }
+
+    public function test_parse_php_int_max_decimal_literal_stays_int(): void
+    {
+        $parser = new AtomParser(new GlobalEnvironment());
+        $word = (string) PHP_INT_MAX;
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, strlen($word));
+        $node = $parser->parse(
+            new Token(Token::T_ATOM, $word, $start, $end),
+        );
+
+        self::assertInstanceOf(NumberNode::class, $node);
+        self::assertSame(PHP_INT_MAX, $node->getValue());
     }
 }


### PR DESCRIPTION
## 🤔 Background

Two related defects surfaced via the issue's repro:

```clojure
(int? 9999999999999999999999999999999999999999999999999999999999999999999)
;; was: true   ;; expected: false
```

1. The lexer was casting oversize decimal literals through `(int) $word`, which silently clamps to `PHP_INT_MAX`. The numeric-tower docs already promised these literals would lex as `float`, but the implementation was clamping to the platform integer bound.
2. `integer?` was a thin wrapper around `is_int`, so it returned `false` for `BigInteger`. Per Clojure's `int?` / `integer?` distinction, `integer?` should accept any mathematical integer (incl. `BigInteger`); `int?` should be the fixed-precision predicate.

Closes #1837.

## 💡 Goal

Restore the documented numeric-tower behaviour and align `int?` / `integer?` with their Clojure-equivalent contracts.

## 🔖 Changes

**Compiler**
- `AtomParser::parseIntegerWithOverflowFallback`: detects when `(int) $word` clamped (canonicalised compare against the literal's magnitude) and falls back to `(float) $word`. Tested for overflow, `PHP_INT_MAX`, and signed forms.

**Core**
- `integer?` matches PHP `int` or `BigInteger`.
- `int?` is now `is_int` directly (not an alias for `integer?`); docstring spells out the difference.
- `neg-int?`, `pos-int?`, `nat-int?`, and `char` (math.phel) switch from `integer?` to `int?` so they keep their PHP-int-only dispatch.

**Tests**
- `tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php`: oversize positive/negative literals lex as float; `PHP_INT_MAX` literal still lexes as int.
- `tests/phel/test/core/type-operation.phel`: `(int? bigint)` is false; `(integer? bigint)` is true.
