### PR TITLE
fix(compiler): resolve clojure.lang.X class FQNs to Phel\Lang\X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - Decimal integer literals that overflow `PHP_INT_MAX` now lex as `float` instead of silently clamping to the platform integer bound (#1837)
+- `clojure.lang.X` class FQNs resolve to `\Phel\Lang\X` (with renames `BigInt` -> `BigInteger`, `Ratio` -> `Rational`) (#1840)
 
 #### Core
 - `rationalize` uses the shortest round-trip decimal so `(rationalize 0.1)` is `1/10` and small floats in scientific notation no longer error (#1832)

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -19,10 +19,25 @@ use RuntimeException;
 use function class_exists;
 use function interface_exists;
 use function ltrim;
+use function strlen;
 use function trait_exists;
 
 final readonly class SymbolResolver
 {
+    /**
+     * Renames where the Phel class name diverges from its `clojure.lang.X`
+     * counterpart. Names that match 1:1 (e.g. `Symbol`, `Keyword`) are picked
+     * up by the auto-resolution fallback below and need no entry here.
+     */
+    private const array CLOJURE_CLASS_RENAMES = [
+        'BigInt' => 'BigInteger',
+        'Ratio' => 'Rational',
+    ];
+
+    private const string CLOJURE_LANG_PREFIX = 'clojure.lang.';
+
+    private const string PHEL_LANG_NAMESPACE = '\\Phel\\Lang\\';
+
     public function __construct(
         private GlobalEnvironment $globalEnv,
         private MagicConstantResolver $magicConstantResolver,
@@ -50,6 +65,16 @@ final readonly class SymbolResolver
 
         if ($strName[0] === '\\') {
             return new PhpClassNameNode($env, $name, $name->getStartLocation());
+        }
+
+        if ($name->getNamespace() === null) {
+            $clojureClassFqn = $this->remapClojureClassFqn($strName);
+            if ($clojureClassFqn !== null) {
+                $fqn = Symbol::create($clojureClassFqn);
+                $fqn->copyLocationFrom($name);
+
+                return new PhpClassNameNode($env, $fqn, $name->getStartLocation());
+            }
         }
 
         if ($name->getNamespace() === null && $this->looksLikeDotSeparatedClassFqn($strName)) {
@@ -171,6 +196,34 @@ final readonly class SymbolResolver
     private function looksLikePhpConstantName(string $name): bool
     {
         return preg_match('/^[A-Z_][A-Z0-9_]*$/', $name) === 1;
+    }
+
+    /**
+     * Maps `clojure.lang.X` references to the matching Phel runtime class.
+     * Auto-resolves when `\Phel\Lang\X` exists (covers `Symbol`, `Keyword`,
+     * `Variable`, etc.); a small rename table handles cases where Phel
+     * diverged from the Clojure name (`BigInt` vs `BigInteger`, `Ratio` vs
+     * `Rational`). Returns null when no Phel counterpart exists.
+     */
+    private function remapClojureClassFqn(string $name): ?string
+    {
+        if (!str_starts_with($name, self::CLOJURE_LANG_PREFIX)) {
+            return null;
+        }
+
+        $shortName = substr($name, strlen(self::CLOJURE_LANG_PREFIX));
+        if ($shortName === '' || str_contains($shortName, '.')) {
+            return null;
+        }
+
+        $phelShortName = self::CLOJURE_CLASS_RENAMES[$shortName] ?? $shortName;
+        $fqn = self::PHEL_LANG_NAMESPACE . $phelShortName;
+
+        if (!class_exists($fqn) && !interface_exists($fqn) && !trait_exists($fqn)) {
+            return null;
+        }
+
+        return $fqn;
     }
 
     private function remapClojureAlias(string $alias): string

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -289,6 +289,18 @@
       \DateTime "not-a-date"
       \DateTime nil)))
 
+(deftest test-instance-clojure-lang-aliases
+  (is (true? (instance? clojure.lang.BigInt (bigint 0)))
+      "clojure.lang.BigInt resolves to Phel\\Lang\\BigInteger")
+  (is (false? (instance? clojure.lang.BigInt 0))
+      "clojure.lang.BigInt does not match a native int")
+  (is (true? (instance? clojure.lang.Ratio 1/2))
+      "clojure.lang.Ratio resolves to Phel\\Lang\\Rational")
+  (is (true? (instance? clojure.lang.Keyword :foo))
+      "clojure.lang.Keyword auto-aliases to Phel\\Lang\\Keyword")
+  (is (true? (instance? clojure.lang.Symbol 'foo))
+      "clojure.lang.Symbol auto-aliases to Phel\\Lang\\Symbol"))
+
 (deftest test-php-array?
   (is (true? (php-array? (php/array))) "php-array? on php array")
   (is (false? (php-array? [])) "php-array? on vector"))

--- a/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php
@@ -14,7 +14,9 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\MagicConstantResolver;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\SymbolResolver;
+use Phel\Lang\BigInteger;
 use Phel\Lang\Keyword;
+use Phel\Lang\Rational;
 use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -371,6 +373,59 @@ final class SymbolResolverTest extends TestCase
         self::assertEquals(
             new GlobalVarNode($nodeEnv, 'user', Symbol::create('Foo'), Phel::map()),
             $this->resolver->resolve(Symbol::create('Foo'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_lang_bigint_remaps_to_phel_biginteger(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\' . BigInteger::class)),
+            $this->resolver->resolve(Symbol::create('clojure.lang.BigInt'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_lang_ratio_remaps_to_phel_rational(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\' . Rational::class)),
+            $this->resolver->resolve(Symbol::create('clojure.lang.Ratio'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_lang_auto_aliases_matching_phel_class(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\' . Symbol::class)),
+            $this->resolver->resolve(Symbol::create('clojure.lang.Symbol'), $nodeEnv),
+        );
+
+        self::assertEquals(
+            new PhpClassNameNode($nodeEnv, Symbol::create('\\' . Keyword::class)),
+            $this->resolver->resolve(Symbol::create('clojure.lang.Keyword'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_lang_unknown_class_falls_through(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertNull(
+            $this->resolver->resolve(Symbol::create('clojure.lang.DoesNotExist'), $nodeEnv),
+        );
+    }
+
+    public function test_resolve_clojure_lang_nested_segment_falls_through(): void
+    {
+        $nodeEnv = NodeEnvironment::empty();
+
+        self::assertNull(
+            $this->resolver->resolve(Symbol::create('clojure.lang.foo.Bar'), $nodeEnv),
         );
     }
 


### PR DESCRIPTION
## 🤔 Background

Closes #1840.

The Clojure cross-test suite (`bigint.cljc`, `plus_squote.cljc`, `star_squote.cljc`) writes things like:

```clojure
(instance? clojure.lang.BigInt (bigint 0))
```

Phel's symbol resolver rejected `clojure.lang.BigInt` because the dot-FQN path requires an uppercase first segment (`Phel.Lang.X`), and the lowercase `clojure.lang.X` form has no Phel counterpart registered. The result was `[PHEL001] Cannot resolve symbol 'clojure.lang.BigInt'`.

## 💡 Goal

Make `clojure.lang.X` symbols resolve to the matching `\Phel\Lang\X` runtime class so cross-port code, REPL pastes, and the shared test suite work without Phel-specific rewrites — without renaming Phel's existing PHP classes or pushing per-class shims into the test suite.

## 🔖 Changes

- `SymbolResolver` now remaps `clojure.lang.X` references inside `resolve()`:
  - Auto-resolves when `\Phel\Lang\X` exists (`Symbol`, `Keyword`, `Variable`, `Volatile`, `Delay`, ...).
  - A two-entry rename table covers names where Phel diverged from Clojure (`BigInt` -> `BigInteger`, `Ratio` -> `Rational`).
  - Returns `null` for unknown or nested-segment names so existing fall-through paths are unchanged.
- Unit coverage in `SymbolResolverTest`: rename mappings, auto-alias for matching names, unknown-class fall-through, nested-segment fall-through.
- Phel coverage in `tests/phel/test/core/type-operation.phel`: `instance?` against `clojure.lang.BigInt`, `clojure.lang.Ratio`, `clojure.lang.Keyword`, `clojure.lang.Symbol`.
- Existing `\Phel\Lang\BigInteger` / `\Phel\Lang\Rational` FQNs still work — no public API break.
- `CHANGELOG.md` updated under `## Unreleased` -> `### Fixed` -> `#### Compiler`.

### Why option B (alias) over A (rename) or C (test-suite exception)

- **A** (rename `BigInteger` -> `BigInt`, `Rational` -> `Ratio`) breaks existing `(php/:: \Phel\Lang\BigInteger ...)` callers, loses PHP-idiomatic naming (`BigInteger` parallels `java.math.BigInteger`), and **still** needs a lowercase-FQN remap because `clojure.lang.X` starts with `c` and bypasses the dot-FQN regex.
- **C** pushes Phel internals into a shared test suite — every cross-port consumer would re-implement the same shim. Root cause untouched.
- **B** (this PR) is localised, extensible, and serves both audiences: PHP users keep the idiomatic class names; Clojure-flavoured snippets resolve transparently.

### Refactor pass

Re-reviewed all touched files for duplication, dead code, naming, em dashes in docblocks, and `.claude/rules/php.md` adherence — no follow-up changes needed, so no separate `ref(...)` commit was added.

## ✅ Test plan

- [x] `./vendor/bin/phpunit tests/php/Unit/Compiler/Analyzer/Environment/SymbolResolverTest.php` — 34 / 34 pass
- [x] `./vendor/bin/phpunit --testsuite=unit,integration` — 3001 / 3001 pass
- [x] `./bin/phel test tests/phel/test/core/type-operation.phel` — 352 / 352 pass
- [x] `composer test-core` — 4816 / 4816 pass
- [x] `php-cs-fixer` clean on touched files; `phpstan` clean