### PR TITLE
fix(core): int/long/short/byte coerce Rational and BigInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `rationalize` uses the shortest round-trip decimal so `(rationalize 0.1)` is `1/10` and small floats in scientific notation no longer error (#1832)
 - `float` and `double` collapse `Rational` and `BigInteger` values, so `phel.async/delay` (and other PHP-typed-float interop) accepts results of `/` (#1836)
 - `integer?` accepts `BigInteger` values (mathematical integers); `int?` stays restricted to fixed-precision PHP `int` (#1837)
+- `int`, `long`, `short`, `byte` accept `Rational` and `BigInteger` inputs and truncate toward zero, replacing the prior `Object of class Rational could not be converted to int` PHP warning (#1842)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -319,10 +319,9 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42\n(int 1/10) ; => 0"
    :see-also ["float" "double" "int?" "number?"]}
   [x]
-  (cond
-    (php/instanceof x Rational)   (php/-> x (toInt))
-    (php/instanceof x BigInteger) (php/-> x (toInt))
-    :else                         (php/intval x)))
+  (if (or (php/instanceof x Rational) (php/instanceof x BigInteger))
+    (php/-> x (toInt))
+    (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -311,12 +311,18 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "abs expects a number, got " (type x))))))
 
 (defn int
-  "Coerces `x` to an integer. Delegates to PHP's `intval`, so floats are
-   truncated toward zero, numeric strings are parsed, and `nil` returns `0`."
-  {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42"
+  "Coerces `x` to an integer. `Rational` values truncate toward zero
+   (`(int 1/10)` is `0`); `BigInteger` values collapse to their PHP int
+   value or throw `OverflowException` when outside the PHP int range.
+   Other inputs delegate to PHP's `intval`, so floats are truncated toward
+   zero, numeric strings are parsed, and `nil` returns `0`."
+  {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42\n(int 1/10) ; => 0"
    :see-also ["float" "double" "int?" "number?"]}
   [x]
-  (php/intval x))
+  (cond
+    (php/instanceof x Rational)   (php/-> x (toInt))
+    (php/instanceof x BigInteger) (php/-> x (toInt))
+    :else                         (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and
@@ -346,40 +352,39 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
   {:example "(long 1.9) ; => 1"
    :see-also ["int" "float" "double"]}
   [x]
-  (php/intval x))
+  (int x))
 
 (defn short
   "Coerces `x` to a signed 16-bit integer in the range `-32768..32767`.
-   Decimal values are truncated toward zero (as in Clojure on the JVM).
-   Values outside the range or non-numeric inputs raise
-   `InvalidArgumentException`. Phel has no dedicated short type, so the
-   result is a plain PHP int."
+   Decimal values are truncated toward zero. `Rational` and `BigInteger`
+   values are accepted (truncate toward zero, then range-check). Values
+   outside the range or non-numeric inputs raise `InvalidArgumentException`.
+   Phel has no dedicated short type, so the result is a plain PHP int."
   {:example "(short 32767) ; => 32767\n(short 1.9) ; => 1\n(short -32768) ; => -32768"
    :see-also ["int" "byte" "long"]}
   [x]
   (if (number? x)
-    (let [truncated (php/intval x)]
+    (let [truncated (int x)]
       (if (or (php/< truncated -32768) (php/> truncated 32767))
         (throw (php/new InvalidArgumentException
-                        (php/. "Value out of range for short: " (php/strval x))))
+                        (php/. "Value out of range for short: " (php/strval truncated))))
         truncated))
     (throw (php/new InvalidArgumentException "short expects a numeric value"))))
 
 (defn byte
   "Coerces `x` to a signed 8-bit integer in the range `-128..127`.
-   Decimal values are truncated toward zero (as in Clojure on the JVM).
-   Values outside the range or non-numeric inputs raise
-   `InvalidArgumentException`. Phel has no dedicated byte type, so the
-   result is a plain PHP int — `byte` exists for `.cljc` interop with
-   Clojure sources."
+   Decimal values are truncated toward zero. `Rational` and `BigInteger`
+   values are accepted (truncate toward zero, then range-check). Values
+   outside the range or non-numeric inputs raise `InvalidArgumentException`.
+   Phel has no dedicated byte type, so the result is a plain PHP int."
   {:example "(byte 127) ; => 127\n(byte 1.9) ; => 1\n(byte -128) ; => -128"
    :see-also ["int?" "float" "double"]}
   [x]
   (if (number? x)
-    (let [truncated (php/intval x)]
+    (let [truncated (int x)]
       (if (or (php/< truncated -128) (php/> truncated 127))
         (throw (php/new InvalidArgumentException
-                        (php/. "Value out of range for byte: " (php/strval x))))
+                        (php/. "Value out of range for byte: " (php/strval truncated))))
         truncated))
     (throw (php/new InvalidArgumentException "byte expects a numeric value"))))
 

--- a/src/php/Lang/Rational.php
+++ b/src/php/Lang/Rational.php
@@ -174,6 +174,15 @@ final readonly class Rational implements Stringable, TypeInterface
         return (float) ((string) $this->numerator) / (float) ((string) $this->denominator);
     }
 
+    /**
+     * Truncates toward zero. Throws {@see OverflowException} if the integer
+     * quotient does not fit in a native PHP int.
+     */
+    public function toInt(): int
+    {
+        return $this->numerator->divide($this->denominator)->toInt();
+    }
+
     public function getMeta(): ?PersistentMapInterface
     {
         return $this->meta;

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -260,7 +260,14 @@
   (is (= 42 (int "42")) "(int \"42\") parses string")
   (is (= 0 (int nil)) "(int nil) returns 0")
   (is (= 0 (int 0)) "(int 0)")
-  (is (= -3 (int -3)) "(int -3)"))
+  (is (= -3 (int -3)) "(int -3)")
+  (is (= 0 (int 1/10)) "(int 1/10) truncates Rational toward zero")
+  (is (= 0 (int -1/10)) "(int -1/10) truncates Rational toward zero")
+  (is (= 1 (int 11/10)) "(int 11/10) truncates Rational toward zero")
+  (is (= -1 (int -11/10)) "(int -11/10) truncates Rational toward zero")
+  (is (true? (int? (int 1/10))) "(int 1/10) returns a PHP int")
+  (is (= 7 (int (bigint 7))) "(int (bigint 7)) collapses BigInteger")
+  (is (true? (int? (int (bigint 7)))) "(int (bigint 7)) returns a PHP int"))
 
 (deftest test-float
   (is (= 1.0 (float 1)) "(float 1)")
@@ -291,7 +298,9 @@
   (is (= -1 (long -1.9)) "(long -1.9) truncates toward zero")
   (is (true? (int? (long 1.5))) "(long 1.5) returns an int")
   (is (= 42 (long "42")) "(long \"42\") parses string")
-  (is (= 0 (long nil)) "(long nil) returns 0"))
+  (is (= 0 (long nil)) "(long nil) returns 0")
+  (is (= 0 (long 1/10)) "(long 1/10) truncates Rational toward zero")
+  (is (= 7 (long (bigint 7))) "(long (bigint 7)) collapses BigInteger"))
 
 (deftest test-short
   (is (= 0 (short 0)) "(short 0)")
@@ -301,7 +310,10 @@
   (is (= -32768 (short -32768)) "(short -32768) is min")
   (is (int? (short 0)) "(short 0) returns an int")
   (is (= 1 (short 1.9)) "(short 1.9) truncates toward zero")
-  (is (= -1 (short -1.9)) "(short -1.9) truncates toward zero"))
+  (is (= -1 (short -1.9)) "(short -1.9) truncates toward zero")
+  (is (= 0 (short 1/10)) "(short 1/10) truncates Rational toward zero")
+  (is (= 0 (short -1/10)) "(short -1/10) truncates Rational toward zero")
+  (is (= 7 (short (bigint 7))) "(short (bigint 7)) collapses BigInteger"))
 
 (deftest test-short-out-of-range
   (is (thrown? \InvalidArgumentException (short 32768))
@@ -330,6 +342,19 @@
   (is (= -1 (byte -1.9)) "(byte -1.9) truncates toward zero")
   (is (= 0 (byte 0.5)) "(byte 0.5) truncates to 0")
   (is (= 0 (byte -0.5)) "(byte -0.5) truncates to 0"))
+
+(deftest test-byte-truncates-rationals
+  (is (= 0 (byte 1/10)) "(byte 1/10) truncates Rational toward zero")
+  (is (= 0 (byte -1/10)) "(byte -1/10) truncates Rational toward zero")
+  (is (= 1 (byte 11/10)) "(byte 11/10) truncates Rational toward zero")
+  (is (= -1 (byte -11/10)) "(byte -11/10) truncates Rational toward zero")
+  (is (int? (byte 1/10)) "(byte 1/10) returns a PHP int"))
+
+(deftest test-byte-bigint
+  (is (= 7 (byte (bigint 7))) "(byte (bigint 7)) collapses BigInteger")
+  (is (int? (byte (bigint 7))) "(byte (bigint 7)) returns a PHP int")
+  (is (thrown? \InvalidArgumentException (byte (bigint 200)))
+      "(byte (bigint 200)) raises out-of-range"))
 
 (deftest test-byte-out-of-range
   (is (thrown? \InvalidArgumentException (byte 128))

--- a/tests/php/Unit/Lang/RationalTest.php
+++ b/tests/php/Unit/Lang/RationalTest.php
@@ -270,6 +270,18 @@ final class RationalTest extends TestCase
         self::assertEqualsWithDelta(1.0 / 3.0, Rational::create(1, 3)->toFloat(), 1e-15);
     }
 
+    public function test_to_int_truncates_toward_zero(): void
+    {
+        self::assertSame(0, Rational::create(1, 10)->toInt());
+        self::assertSame(0, Rational::create(-1, 10)->toInt());
+        self::assertSame(0, Rational::create(9, 10)->toInt());
+        self::assertSame(0, Rational::create(-9, 10)->toInt());
+        self::assertSame(1, Rational::create(11, 10)->toInt());
+        self::assertSame(-1, Rational::create(-11, 10)->toInt());
+        self::assertSame(3, Rational::create(22, 7)->toInt());
+        self::assertSame(-3, Rational::create(-22, 7)->toInt());
+    }
+
     public function test_to_string_format(): void
     {
         self::assertSame('1/2', (string) Rational::create(1, 2));


### PR DESCRIPTION
## 🤔 Background

`(byte 1/10)` and similar coercions raised PHP warning `Object of class Phel\Lang\Rational could not be converted to int` and returned the wrong value (1 instead of 0), surfaced by the clojure-test-suite CI run linked in #1842. `int`, `long`, `short`, `byte` all routed through `php/intval`, which does not know about `Rational` or `BigInteger`.

## 💡 Goal

Fix #1842: make `int`, `long`, `short`, `byte` accept `Rational` and `BigInteger` inputs and truncate toward zero, mirroring the recently fixed `float`/`double` coercions (#1838).

## 🔖 Changes

- `Phel\Lang\Rational::toInt()` — exact integer quotient via `BigInteger.divide`, truncates toward zero, throws `OverflowException` outside PHP int range.
- `int` dispatches `Rational`/`BigInteger` through `toInt()`, falls back to `intval` for everything else.
- `long` is a thin alias for `int`; `short`/`byte` route through `int` so the range-check sees the correctly truncated value.
- Phel tests cover `(int 1/10)`, `(byte 1/10)`, `(short ...)`, `(long ...)`, BigInteger inputs, and `(byte (bigint 200))` raising `InvalidArgumentException`.
- Unit test for `Rational::toInt()` covering positive/negative truncation toward zero.
- Changelog entry under `## Unreleased > Fixed > Core`.

Related to #1842