### PR TITLE
fix(core): quot keeps float type; abs(PHP_INT_MIN) promotes to BigInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - `float` and `double` collapse `Rational` and `BigInteger` values, so `phel.async/delay` (and other PHP-typed-float interop) accepts results of `/` (#1836)
 - `integer?` accepts `BigInteger` values (mathematical integers); `int?` stays restricted to fixed-precision PHP `int` (#1837)
 - `int`, `long`, `short`, `byte` accept `Rational` and `BigInteger` inputs and truncate toward zero, replacing the prior `Object of class Rational could not be converted to int` PHP warning (#1842)
+- `quot` keeps the float type when any operand is a float, so `(quot 10.0 3.0)` returns `3.0` instead of `3` (#1844)
+- `abs` of `PHP_INT_MIN` promotes to `BigInteger` (`9223372036854775808`) instead of dropping to a float (#1844)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -8,7 +8,9 @@ use DivisionByZeroError;
 use InvalidArgumentException;
 
 use function abs;
+use function ceil;
 use function fdiv;
+use function floor;
 use function intdiv;
 use function is_float;
 use function is_int;
@@ -252,6 +254,12 @@ final class NumericOperations
             return self::collapseBigInt($a->abs());
         }
 
+        // |PHP_INT_MIN| overflows the PHP int range; native abs() drops
+        // to float, so promote to BigInteger to preserve exactness.
+        if ($a === PHP_INT_MIN) {
+            return BigInteger::fromInt($a)->abs();
+        }
+
         return abs($a);
     }
 
@@ -297,7 +305,8 @@ final class NumericOperations
 
         if (is_float($a) || is_float($b)) {
             $ratio = self::toFloat($a) / self::toFloat($b);
-            return (int) $ratio;
+            // Float operands keep float result; truncate toward zero.
+            return $ratio < 0 ? ceil($ratio) : floor($ratio);
         }
 
         if ($a instanceof Rational || $b instanceof Rational) {

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -54,6 +54,15 @@
   (is (= 2 (quot 7/2 3/2)) "quot on rationals truncates")
   (is (thrown? \DivisionByZeroError (quot 1 0)) "quot by zero throws"))
 
+(deftest test-quot-float
+  (is (= 3.0 (quot 10.0 3.0)) "(quot 10.0 3.0) keeps float and truncates toward zero")
+  (is (= -3.0 (quot -10.0 3.0)) "(quot -10.0 3.0) truncates toward zero")
+  (is (= 3.0 (quot -10.0 -3.0)) "(quot -10.0 -3.0) truncates toward zero")
+  (is (= -3.0 (quot 10.0 -3.0)) "(quot 10.0 -3.0) truncates toward zero")
+  (is (double? (quot 10.0 3.0)) "(quot 10.0 3.0) returns a float")
+  (is (double? (quot 10 3.0)) "(quot 10 3.0) promotes to float")
+  (is (double? (quot 10.0 3)) "(quot 10.0 3) promotes to float"))
+
 (deftest test-rem
   (is (= 1 (rem 7 3)) "(rem 7 3)")
   (is (= -1 (rem -7 3)) "(rem -7 3) follows dividend sign")

--- a/tests/phel/test/core/utility-functions.phel
+++ b/tests/phel/test/core/utility-functions.phel
@@ -16,11 +16,16 @@
   (is (= 5 (abs 5)) "(abs 5)")
   (is (= 0 (abs 0)) "(abs 0)")
   (is (= 3.14 (abs -3.14)) "(abs -3.14)")
-  ;; Clojure-compat: reject non-numbers instead of PHP's permissive coercion
+  ;; Reject non-numbers instead of PHP's permissive coercion
   ;; (which would silently return 0 for nil and throw a raw TypeError for strings).
   (is (thrown? \InvalidArgumentException (abs nil)) "(abs nil) throws")
   (is (thrown? \InvalidArgumentException (abs "abc")) "(abs string) throws")
   (is (thrown? \InvalidArgumentException (abs :k)) "(abs keyword) throws"))
+
+(deftest test-abs-php-int-min-promotes
+  (let [r (abs php/PHP_INT_MIN)]
+    (is (bigint? r) "(abs PHP_INT_MIN) promotes to BigInteger to keep exactness")
+    (is (= (bigint "9223372036854775808") r) "(abs PHP_INT_MIN) equals 2^63")))
 
 ;; --- Map utilities ---
 

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -276,6 +276,24 @@ final class NumericOperationsTest extends TestCase
         self::assertSame(3, NumericOperations::quot($half, 1));
     }
 
+    public function test_quot_float_preserves_float_type(): void
+    {
+        self::assertSame(3.0, NumericOperations::quot(10.0, 3.0));
+        self::assertSame(-3.0, NumericOperations::quot(-10.0, 3.0));
+        self::assertSame(3.0, NumericOperations::quot(-10.0, -3.0));
+        self::assertSame(-3.0, NumericOperations::quot(10.0, -3.0));
+        self::assertSame(3.0, NumericOperations::quot(10, 3.0));
+        self::assertSame(3.0, NumericOperations::quot(10.0, 3));
+    }
+
+    public function test_abs_php_int_min_promotes_to_big_integer(): void
+    {
+        $result = NumericOperations::abs(PHP_INT_MIN);
+
+        self::assertInstanceOf(BigInteger::class, $result);
+        self::assertSame(bcmul((string) PHP_INT_MIN, '-1'), (string) $result);
+    }
+
     public function test_rem_int(): void
     {
         self::assertSame(1, NumericOperations::rem(10, 3));


### PR DESCRIPTION
## 🤔 Background

Two regressions surfaced by the clojure-test-suite CI run linked in #1844:

1. `quot` with any float operand returned a PHP `int`, so `(quot 10.0 3.0)` was `3` instead of `3.0`. The float family of clojure-test-suite `quot` rows asserts that `r` satisfies `double?`, so every float-quot case failed.
2. `(abs PHP_INT_MIN)` evaluated to `9.2233720368548E+18` (float) because PHP's native `abs(PHP_INT_MIN)` cannot fit `|PHP_INT_MIN|` in a PHP int and silently widens to float, losing exactness against the matching `(* -1 PHP_INT_MIN)` BigInteger value (`#1830` auto-promotion).

The remaining `int`/`long`/`short`/`byte` rows from #1844 were already fixed by #1842 / #1847.

## 💡 Goal

Restore exact result types for both operations:

- `quot` with any float operand stays `float`, truncating toward zero.
- `abs(PHP_INT_MIN)` returns `BigInteger 9223372036854775808`, matching `(* -1 PHP_INT_MIN)`.

## 🔖 Changes

- `NumericOperations::quot` truncates the float quotient via `floor`/`ceil` based on sign instead of casting to PHP int.
- `NumericOperations::abs` short-circuits `PHP_INT_MIN` through `BigInteger::fromInt(...)->abs()` before falling back to the native `abs()`.
- Phel tests for `(quot 10.0 3.0)` and friends, and `(abs PHP_INT_MIN)` returning `BigInteger 9223372036854775808`.
- Unit tests on `NumericOperations` covering both branches.
- Changelog entries under `## Unreleased > Fixed > Core`.

Refactor pass on touched files surfaced no further changes (single-call-site truncation, simple guard for `PHP_INT_MIN`).

Related to #1844