### PR TITLE
fix(core): bigint accepts floats (truncate toward zero)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - `int`, `long`, `short`, `byte` accept `Rational` and `BigInteger` inputs and truncate toward zero, replacing the prior `Object of class Rational could not be converted to int` PHP warning (#1842)
 - `quot` keeps the float type when any operand is a float, so `(quot 10.0 3.0)` returns `3.0` instead of `3` (#1844)
 - `abs` of `PHP_INT_MIN` promotes to `BigInteger` (`9223372036854775808`) instead of dropping to a float (#1844)
+- `bigint` accepts floats (truncates toward zero, rejects `NaN`/`Inf`), so `(bigint 0.0)` is `0N` and `(bigint php/PHP_FLOAT_MAX)` returns the exact integer (#1845)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -646,18 +646,20 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "rationalize expects a number, got " (type x))))))
 
 (defn bigint
-  "Coerces `x` to a `Phel\\Lang\\BigInteger`. Accepts ints, numeric
-  strings, and `BigInteger` values."
-  {:example "(bigint 42) ; => 42N\n(bigint \"123\") ; => 123N"
+  "Coerces `x` to a `Phel\\Lang\\BigInteger`. Accepts ints, floats
+  (truncated toward zero, rejecting `NaN`/`Inf`), numeric strings, and
+  `BigInteger` values."
+  {:example "(bigint 42) ; => 42N\n(bigint 1.9) ; => 1N\n(bigint \"123\") ; => 123N"
    :see-also ["bigint?" "int" "rationalize"]}
   [x]
   (cond
     (php/instanceof x BigInteger) x
     (php/is_int x)                (php/:: BigInteger (fromInt x))
+    (php/is_float x)              (php/:: BigInteger (fromFloat x))
     (string? x)                   (php/:: BigInteger (fromString x))
     :else
     (throw (php/new InvalidArgumentException
-                    (str "bigint expects an int, numeric string, or BigInteger, got " (type x))))))
+                    (str "bigint expects an int, float, numeric string, or BigInteger, got " (type x))))))
 
 (defn biginteger
   "Alias for `bigint`. Coerces `x` to a `Phel\\Lang\\BigInteger`."

--- a/src/php/Lang/BigInteger.php
+++ b/src/php/Lang/BigInteger.php
@@ -89,6 +89,23 @@ final readonly class BigInteger implements EqualsInterface, HashableInterface, S
         return new self(-1, self::splitNonNegative(-$value));
     }
 
+    /**
+     * Truncates `$value` toward zero and converts the integer part to a
+     * BigInteger. Throws on NaN or infinity.
+     */
+    public static function fromFloat(float $value): self
+    {
+        if (!is_finite($value)) {
+            throw new InvalidArgumentException(
+                sprintf("Cannot convert non-finite float '%s' to BigInteger", $value),
+            );
+        }
+
+        $truncated = $value < 0.0 ? ceil($value) : floor($value);
+
+        return self::fromString(sprintf('%.0F', $truncated));
+    }
+
     public static function fromString(string $value): self
     {
         if (preg_match('/^-?(0|[1-9]\d*)$/', $value) !== 1) {

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -520,8 +520,18 @@
   (is (= "1000000000000000000000000" (str (bigint "1000000000000000000000000"))) "(bigint big-string)")
   (let [b (php/:: \Phel\Lang\BigInteger (fromInt 5))]
     (is (= b (bigint b)) "(bigint BigInteger) is identity"))
-  (is (thrown? \InvalidArgumentException (bigint 1.5)) "(bigint 1.5) rejects floats")
   (is (thrown? \InvalidArgumentException (bigint nil)) "(bigint nil) rejects nil"))
+
+(deftest test-bigint-from-float
+  (is (= 0 (bigint 0.0)) "(bigint 0.0) is 0")
+  (is (bigint? (bigint 0.0)) "(bigint 0.0) is BigInteger")
+  (is (= 1 (bigint 1.9)) "(bigint 1.9) truncates toward zero")
+  (is (= -1 (bigint -1.9)) "(bigint -1.9) truncates toward zero")
+  (is (= 42 (bigint 42.5)) "(bigint 42.5) truncates toward zero")
+  (is (bigint? (bigint php/PHP_FLOAT_MAX)) "(bigint PHP_FLOAT_MAX) returns BigInteger")
+  (is (thrown? \InvalidArgumentException (bigint php/NAN)) "(bigint NaN) rejects NaN")
+  (is (thrown? \InvalidArgumentException (bigint php/INF)) "(bigint Inf) rejects Inf")
+  (is (thrown? \InvalidArgumentException (bigint (- php/INF))) "(bigint -Inf) rejects -Inf"))
 
 (deftest test-biginteger-alias
   (is (= 42 (biginteger 42)) "(biginteger 42)")

--- a/tests/php/Unit/Lang/BigIntegerTest.php
+++ b/tests/php/Unit/Lang/BigIntegerTest.php
@@ -10,6 +10,8 @@ use OverflowException;
 use Phel\Lang\BigInteger;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 final class BigIntegerTest extends TestCase
 {
     public function test_zero_factory(): void
@@ -65,6 +67,42 @@ final class BigIntegerTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         BigInteger::fromString('');
+    }
+
+    public function test_from_float_truncates_toward_zero(): void
+    {
+        self::assertSame('0', (string) BigInteger::fromFloat(0.0));
+        self::assertSame('0', (string) BigInteger::fromFloat(0.9));
+        self::assertSame('0', (string) BigInteger::fromFloat(-0.9));
+        self::assertSame('1', (string) BigInteger::fromFloat(1.9));
+        self::assertSame('-1', (string) BigInteger::fromFloat(-1.9));
+        self::assertSame('42', (string) BigInteger::fromFloat(42.5));
+        self::assertSame('-42', (string) BigInteger::fromFloat(-42.5));
+    }
+
+    public function test_from_float_handles_php_float_max(): void
+    {
+        $result = BigInteger::fromFloat(PHP_FLOAT_MAX);
+
+        self::assertSame(sprintf('%.0F', PHP_FLOAT_MAX), (string) $result);
+    }
+
+    public function test_from_float_rejects_nan(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromFloat(NAN);
+    }
+
+    public function test_from_float_rejects_positive_infinity(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromFloat(INF);
+    }
+
+    public function test_from_float_rejects_negative_infinity(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BigInteger::fromFloat(-INF);
     }
 
     public function test_from_string_rejects_only_minus(): void


### PR DESCRIPTION
## 🤔 Background

Reported in #1845 from the clojure-test-suite \`bigint\` cases:

\`\`\`
(bigint 0.0)
;; expected: 0N
;; actual:   InvalidArgumentException: bigint expects an int, numeric string, or BigInteger, got :float

(bigint php/PHP_FLOAT_MAX)
;; expected: a BigInteger holding the exact integer value of PHP_FLOAT_MAX
;; actual:   InvalidArgumentException
\`\`\`

\`bigint\` accepted ints, numeric strings, and \`BigInteger\` values but fell through to a throw on floats.

## 💡 Goal

Fix #1845: let \`bigint\` accept floats. Truncate toward zero so \`(bigint 1.9) = 1N\` and \`(bigint -1.9) = -1N\`. Reject \`NaN\`/\`Inf\` since neither is representable as a finite integer.

## 🔖 Changes

- \`BigInteger::fromFloat(float \$value): self\` truncates toward zero (\`floor\` for non-negative, \`ceil\` for negative) and routes through \`fromString(sprintf('%.0F', ...))\`. Throws \`InvalidArgumentException\` on \`NaN\`/\`Inf\`.
- \`bigint\` Phel fn dispatches on \`(php/is_float x)\` before falling back to the rejection branch; the error message now mentions \`float\` as an accepted type.
- Unit tests for \`fromFloat\`: truncation toward zero (positive/negative), \`PHP_FLOAT_MAX\` round-trip, and \`NaN\`/\`Inf\` rejection.
- Phel tests covering \`(bigint 0.0)\`, \`(bigint 1.9)\`, \`(bigint -1.9)\`, \`(bigint 42.5)\`, \`(bigint php/PHP_FLOAT_MAX)\`, and \`NaN\`/\`Inf\` rejection.
- Changelog entry under \`## Unreleased > Fixed > Core\`.

Refactor pass on touched files surfaced no further changes.

Related to #1845