### PR TITLE
fix(compiler): emit scientific-notation floats; int rejects out-of-range floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - `quot` keeps the float type when any operand is a float, so `(quot 10.0 3.0)` returns `3.0` instead of `3` (#1844)
 - `abs` of `PHP_INT_MIN` promotes to `BigInteger` (`9223372036854775808`) instead of dropping to a float (#1844)
 - `bigint` accepts floats (truncates toward zero, rejects `NaN`/`Inf`), so `(bigint 0.0)` is `0N` and `(bigint php/PHP_FLOAT_MAX)` returns the exact integer (#1845)
+- Float literals in scientific notation no longer emit invalid PHP like `-9.22E+18.0`; the emitter only appends `.0` when the rendered float lacks a decimal point or exponent (#1846)
+- `int`, `long`, `short`, `byte` route float operands through `BigInteger::fromFloat`, so out-of-range values such as `(long -9223372036854775809)` raise `OverflowException` instead of silently wrapping; `NaN`/`Inf` raise `InvalidArgumentException` (#1846)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -320,10 +320,10 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
    :see-also ["float" "double" "int?" "number?"]}
   [x]
   (cond
-    (php/instanceof x Rational)   (php/-> x (toInt))
-    (php/instanceof x BigInteger) (php/-> x (toInt))
-    (php/is_float x)              (php/-> (php/:: BigInteger (fromFloat x)) (toInt))
-    :else                         (php/intval x)))
+    (or (php/instanceof x Rational) (php/instanceof x BigInteger))
+                     (php/-> x (toInt))
+    (php/is_float x) (php/-> (php/:: BigInteger (fromFloat x)) (toInt))
+    :else            (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -312,16 +312,18 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn int
   "Coerces `x` to an integer. `Rational` values truncate toward zero
-   (`(int 1/10)` is `0`); `BigInteger` values collapse to their PHP int
-   value or throw `OverflowException` when outside the PHP int range.
-   Other inputs delegate to PHP's `intval`, so floats are truncated toward
-   zero, numeric strings are parsed, and `nil` returns `0`."
+   (`(int 1/10)` is `0`); `BigInteger` and `float` values collapse to
+   their PHP int value or throw `OverflowException` when outside the PHP
+   int range (`NaN`/`Inf` floats raise `InvalidArgumentException`).
+   Numeric strings are parsed via PHP's `intval`, and `nil` returns `0`."
   {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42\n(int 1/10) ; => 0"
    :see-also ["float" "double" "int?" "number?"]}
   [x]
-  (if (or (php/instanceof x Rational) (php/instanceof x BigInteger))
-    (php/-> x (toInt))
-    (php/intval x)))
+  (cond
+    (php/instanceof x Rational)   (php/-> x (toInt))
+    (php/instanceof x BigInteger) (php/-> x (toInt))
+    (php/is_float x)              (php/-> (php/:: BigInteger (fromFloat x)) (toInt))
+    :else                         (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -24,6 +24,7 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
+use function preg_match;
 
 final readonly class LiteralEmitter
 {
@@ -99,14 +100,16 @@ final readonly class LiteralEmitter
 
     private function emitFloat(float $x): void
     {
-        /** @psalm-suppress InvalidCast */
-        $float = ((int) $x == $x)
-            // (string) 10.0 will return 10 and not 10.0
-            // so, we just add a .0 at the end
-            ? ($x) . '.0'
-            : ((string) $x);
+        $str = (string) $x;
+        // (string) 10.0 renders as "10"; append .0 so the literal stays
+        // a float in PHP. Skip when the string already carries a decimal
+        // point or scientific notation (e.g. -9.22E+18) — appending .0
+        // would yield invalid PHP like "-9.22E+18.0".
+        if (preg_match('/^-?\d+$/', $str) === 1) {
+            $str .= '.0';
+        }
 
-        $this->outputEmitter->emitStr($float);
+        $this->outputEmitter->emitStr($str);
     }
 
     private function emitInt(int $x): void

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -278,6 +278,22 @@
   (is (= 7 (int (bigint 7))) "(int (bigint 7)) collapses BigInteger")
   (is (true? (int? (int (bigint 7)))) "(int (bigint 7)) returns a PHP int"))
 
+(deftest test-int-float-out-of-range
+  (is (thrown? \OverflowException (int -9.223372036854776E+18))
+      "(int oversize-negative-float) throws OverflowException")
+  (is (thrown? \OverflowException (int 9.223372036854776E+18))
+      "(int oversize-positive-float) throws OverflowException")
+  (is (thrown? \InvalidArgumentException (int php/NAN))
+      "(int NaN) throws InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (int php/INF))
+      "(int Inf) throws InvalidArgumentException"))
+
+(deftest test-long-float-out-of-range
+  (is (thrown? \OverflowException (long -9223372036854775809))
+      "(long oversize-negative-literal) throws OverflowException after lexing as float")
+  (is (thrown? \OverflowException (long 9223372036854775808))
+      "(long oversize-positive-literal) throws OverflowException after lexing as float"))
+
 (deftest test-float
   (is (= 1.0 (float 1)) "(float 1)")
   (is (true? (float? (float 1))) "(float 1) is float")

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/LiteralEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/LiteralEmitterTest.php
@@ -69,4 +69,18 @@ final class LiteralEmitterTest extends TestCase
             . ')',
         );
     }
+
+    public function test_emit_integer_valued_float_appends_decimal(): void
+    {
+        $this->literalEmitter->emitLiteral(10.0);
+
+        $this->expectOutputString('10.0');
+    }
+
+    public function test_emit_scientific_float_does_not_append_decimal(): void
+    {
+        $this->literalEmitter->emitLiteral(-9.223372036854776E+18);
+
+        $this->expectOutputString('-9.2233720368548E+18');
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Reported in #1846:

\`\`\`
(long -9223372036854775809)
;; ParseError: syntax error, unexpected floating-point number ".0", expecting ")"
\`\`\`

The lexer promotes oversize int literals to floats (#1837), so \`9223372036854775809\` becomes \`9.22E+18\`. The float emitter unconditionally appended \`.0\` when \`(int) \$x == \$x\`, producing the invalid PHP literal \`-9.22E+18.0\` for any scientific-notation float that lands on an integer value.

The reporter also noted that throwing on out-of-range \`long\` (matching the clojure-test-suite \`p/thrown?\` cases) would be the least surprising behavior.

## 💡 Goal

Fix #1846 in two parts:

1. The emitter should produce valid PHP for every \`float\` value, including scientific notation.
2. \`int\`/\`long\`/\`short\`/\`byte\` should signal out-of-range floats explicitly instead of silently wrapping or returning a saturated PHP int.

## 🔖 Changes

- \`LiteralEmitter::emitFloat\` checks the rendered string with \`/^-?\d+\$/\` and only appends \`.0\` when the float renders as a plain integer; scientific notation passes through unchanged.
- \`int\` (and \`long\`/\`short\`/\`byte\` via the chained call) routes float operands through \`BigInteger::fromFloat\`, so out-of-range values raise \`OverflowException\` and \`NaN\`/\`Inf\` raise \`InvalidArgumentException\`.
- Unit tests for \`LiteralEmitter\` covering the integer-valued float and scientific-notation float cases.
- Phel tests covering \`(int oversize-float)\`, \`(long -9223372036854775809)\`, \`(int php/NAN)\`, \`(int php/INF)\`.
- Changelog entries under \`## Unreleased > Fixed\` (Compiler + Core).

Refactor pass surfaced one cleanup (\`int\` cond now guards \`Rational|BigInteger\` with a single \`or\`), shipped as a separate \`ref(...)\` commit.

Related to #1846