### PR TITLE
fix(core): bigint of float uses shortest round-trip decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Float literals in scientific notation no longer emit invalid PHP like `-9.22E+18.0`; the emitter only appends `.0` when the rendered float lacks a decimal point or exponent (#1846)
 - `int`, `long`, `short`, `byte` route float operands through `BigInteger::fromFloat`, so out-of-range values such as `(long -9223372036854775809)` raise `OverflowException` instead of silently wrapping; `NaN`/`Inf` raise `InvalidArgumentException` (#1846)
 - `N`-suffix integer literals beyond `PHP_INT_MAX` parse as `BigInteger` (e.g. `9223372036854775808N`), so equality between `(inc (bigint php/PHP_INT_MAX))`, `(inc' php/PHP_INT_MAX)`, and the matching `N` literal now holds (#1850)
+- `(bigint <float>)` rounds through the shortest round-trip decimal of the float (so `(bigint php/PHP_FLOAT_MAX)` is the 17-significant-digit value plus trailing zeros) instead of materialising the exact bit-level integer, matching the integer literal printed by the same float (#1852)
 
 #### Lang
 - `=` between an integer and a `BigInteger` is now symmetric in both directions (#1830)

--- a/src/php/Lang/BigInteger.php
+++ b/src/php/Lang/BigInteger.php
@@ -18,6 +18,7 @@ use function preg_match;
 use function sprintf;
 use function str_pad;
 use function str_split;
+use function strlen;
 use function strrev;
 use function substr;
 
@@ -135,8 +136,12 @@ final readonly class BigInteger implements TypeInterface, Stringable
     }
 
     /**
-     * Truncates `$value` toward zero and converts the integer part to a
-     * BigInteger. Throws on NaN or infinity.
+     * Converts a finite float to a BigInteger via its shortest round-trip
+     * decimal representation, truncating fractional digits toward zero.
+     * Floats too large to represent every digit (e.g. `PHP_FLOAT_MAX`)
+     * round-trip through ~17 significant digits and pad with trailing
+     * zeros, so equality with the literal printed by the same float
+     * holds. Throws on `NaN`/`Inf`.
      */
     public static function fromFloat(float $value): self
     {
@@ -146,9 +151,11 @@ final readonly class BigInteger implements TypeInterface, Stringable
             );
         }
 
-        $truncated = $value < 0.0 ? ceil($value) : floor($value);
+        if ($value == 0.0) {
+            return self::zero();
+        }
 
-        return self::fromString(sprintf('%.0F', $truncated));
+        return self::fromString(self::floatToIntegerString($value));
     }
 
     public static function fromString(string $value): self
@@ -669,5 +676,56 @@ final readonly class BigInteger implements TypeInterface, Stringable
         /** @var list<int>|null $cached */
         static $cached = null;
         return $cached ??= self::trim(self::addMagnitudes($this->phpIntMaxMagnitude(), [1]));
+    }
+
+    /**
+     * Renders `$value` as the shortest %g-formatted decimal that round-trips
+     * back to the same float, then expands scientific notation and truncates
+     * the fractional digits toward zero so the result is a plain integer
+     * string suitable for {@see self::fromString()}.
+     */
+    private static function floatToIntegerString(float $value): string
+    {
+        $repr = self::shortestRoundTripDecimal($value);
+        if (preg_match('/^(-?)(\d+)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/', $repr, $matches) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf("Unrecognised float string: '%s'", $repr),
+            );
+        }
+
+        $sign = $matches[1];
+        $intPart = $matches[2];
+        $fracPart = $matches[3] ?? '';
+        $exponent = (int) ($matches[4] ?? '0');
+
+        $digits = $intPart . $fracPart;
+        $pointPosition = strlen($intPart) + $exponent;
+
+        if ($pointPosition <= 0) {
+            return '0';
+        }
+
+        $intStr = $pointPosition >= strlen($digits)
+            ? $digits . str_repeat('0', $pointPosition - strlen($digits))
+            : substr($digits, 0, $pointPosition);
+
+        $intStr = ltrim($intStr, '0');
+        if ($intStr === '') {
+            return '0';
+        }
+
+        return $sign . $intStr;
+    }
+
+    private static function shortestRoundTripDecimal(float $value): string
+    {
+        for ($precision = 1; $precision < 17; ++$precision) {
+            $repr = sprintf('%.' . $precision . 'g', $value);
+            if ((float) $repr === $value) {
+                return $repr;
+            }
+        }
+
+        return sprintf('%.17g', $value);
     }
 }

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -558,6 +558,13 @@
   (is (thrown? \InvalidArgumentException (bigint php/INF)) "(bigint Inf) rejects Inf")
   (is (thrown? \InvalidArgumentException (bigint (- php/INF))) "(bigint -Inf) rejects -Inf"))
 
+(deftest test-bigint-float-uses-shortest-round-trip
+  ;; PHP_FLOAT_MAX renders as 1.7976931348623157e+308, so (bigint ...) must
+  ;; expand to 17 significant digits + trailing zeros, matching the printed
+  ;; literal of the same float.
+  (let [expected (bigint (str "17976931348623157" (php/str_repeat "0" 292)))]
+    (is (= expected (bigint php/PHP_FLOAT_MAX)) "(bigint PHP_FLOAT_MAX) round-trips through shortest decimal")))
+
 (deftest test-biginteger-alias
   (is (= 42 (biginteger 42)) "(biginteger 42)")
   (is (bigint? (biginteger 42)) "(biginteger 42) is BigInteger"))

--- a/tests/php/Unit/Lang/BigIntegerTest.php
+++ b/tests/php/Unit/Lang/BigIntegerTest.php
@@ -10,8 +10,6 @@ use OverflowException;
 use Phel\Lang\BigInteger;
 use PHPUnit\Framework\TestCase;
 
-use function sprintf;
-
 final class BigIntegerTest extends TestCase
 {
     public function test_zero_factory(): void
@@ -80,11 +78,14 @@ final class BigIntegerTest extends TestCase
         self::assertSame('-42', (string) BigInteger::fromFloat(-42.5));
     }
 
-    public function test_from_float_handles_php_float_max(): void
+    public function test_from_float_uses_shortest_round_trip_decimal(): void
     {
+        // PHP_FLOAT_MAX renders as 1.7976931348623157e+308 (17 sig digits),
+        // so the resulting integer has those 17 digits followed by 292 zeros.
         $result = BigInteger::fromFloat(PHP_FLOAT_MAX);
+        $expected = '17976931348623157' . str_repeat('0', 292);
 
-        self::assertSame(sprintf('%.0F', PHP_FLOAT_MAX), (string) $result);
+        self::assertSame($expected, (string) $result);
     }
 
     public function test_from_float_rejects_nan(): void


### PR DESCRIPTION
## 🤔 Background

Reported in #1852 from \`bigint.cljc\` in the clojure-test-suite:

\`\`\`clojure
(= (bigint php/PHP_FLOAT_MAX) 1797693134862315700...000N)
;; expected: true
;; actual:   false
\`\`\`

\`BigInteger::fromFloat\` used \`sprintf('%.0F', ...)\` which materialised the exact 308-digit integer for \`PHP_FLOAT_MAX\` (\`...858368\`), but the integer literal printed by the same float keeps only the 17 significant digits and pads with trailing zeros. The two integer values are different, so equality with the literal fails.

## 💡 Goal

Match the literal-form value: \`(bigint <float>)\` should expand the shortest round-trip decimal of the float, not the exact bit-level integer. \`(bigint php/PHP_FLOAT_MAX)\` ends up with 17 significant digits plus 292 trailing zeros.

## 🔖 Changes

- \`BigInteger::fromFloat\` now routes through two new private helpers:
  - \`shortestRoundTripDecimal\` finds the shortest \`%g\` precision (1..17) whose string round-trips back to the same double.
  - \`floatToIntegerString\` parses sign / int / fractional / exponent, shifts the decimal point by the exponent, pads or truncates so the result is a plain integer string suitable for \`fromString\`. Truncation is toward zero (subbing instead of rounding), keeping the existing \`(bigint 1.5) = 1\` / \`(bigint -1.5) = -1\` semantics.
- \`(bigint 0.0)\` short-circuits to \`zero()\`.
- Updated unit test for \`PHP_FLOAT_MAX\` to assert \`'17976931348623157' . str_repeat('0', 292)\`.
- New Phel test \`test-bigint-float-uses-shortest-round-trip\` cross-checks the result against \`(bigint "17976931348623157000...")\`.
- Changelog entry under \`## Unreleased > Fixed > Core\`.

Refactor pass on touched files surfaced no further changes.

Related to #1852