### PR TITLE
fix(lang): rector strict-equality on BigInteger::fromFloat zero check

### DIFF
--- a/src/php/Lang/BigInteger.php
+++ b/src/php/Lang/BigInteger.php
@@ -151,7 +151,7 @@ final readonly class BigInteger implements TypeInterface, Stringable
             );
         }
 
-        if ($value == 0.0) {
+        if ($value === 0.0) {
             return self::zero();
         }
 


### PR DESCRIPTION
## 🤔 Background

Main CI flagged \`==\` between \`\$value\` (float) and \`0.0\` in \`BigInteger::fromFloat\` (PR #1854 fallout). Rector wants \`===\`.

\`\`\`
1) src/php/Lang/BigInteger.php:151
-        if (\$value == 0.0) {
+        if (\$value === 0.0) {
\`\`\`

## 🔖 Changes

- Switch to \`===\` against \`0.0\`.