### PR TITLE
fix(lang): post-merge CI followups for Uuid type

### DIFF
--- a/src/php/Lang/Uuid.php
+++ b/src/php/Lang/Uuid.php
@@ -102,12 +102,15 @@ final readonly class Uuid implements TypeInterface, Stringable
         if (($nibble & 0x8) === 0) {
             return 'ncs';
         }
+
         if (($nibble & 0x4) === 0) {
             return 'rfc-4122';
         }
+
         if (($nibble & 0x2) === 0) {
             return 'microsoft';
         }
+
         return 'reserved';
     }
 

--- a/src/php/Lang/Uuid.php
+++ b/src/php/Lang/Uuid.php
@@ -99,19 +99,13 @@ final readonly class Uuid implements TypeInterface, Stringable
     public function variant(): string
     {
         $nibble = (int) hexdec($this->value[19]);
-        if (($nibble & 0x8) === 0) {
-            return 'ncs';
-        }
 
-        if (($nibble & 0x4) === 0) {
-            return 'rfc-4122';
-        }
-
-        if (($nibble & 0x2) === 0) {
-            return 'microsoft';
-        }
-
-        return 'reserved';
+        return match (true) {
+            ($nibble & 0x8) === 0 => 'ncs',
+            ($nibble & 0x4) === 0 => 'rfc-4122',
+            ($nibble & 0x2) === 0 => 'microsoft',
+            default => 'reserved',
+        };
     }
 
     public function isNil(): bool

--- a/tests/php/Integration/Compiler/Reader/ReaderTest.php
+++ b/tests/php/Integration/Compiler/Reader/ReaderTest.php
@@ -22,6 +22,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\TagHandlers\BuiltinTagHandlers;
 use Phel\Lang\TagRegistry;
 use Phel\Lang\TypeInterface;
+use Phel\Lang\Uuid;
 use Phel\Shared\Facade\CompilerFacadeInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -1333,20 +1334,20 @@ final class ReaderTest extends TestCase
         );
     }
 
-    public function test_uuid_tagged_literal_reads_as_string(): void
+    public function test_uuid_tagged_literal_reads_as_uuid_value(): void
     {
-        self::assertSame(
-            '00000000-0000-0000-0000-000000000000',
-            $this->read('#uuid "00000000-0000-0000-0000-000000000000"'),
-        );
+        $value = $this->read('#uuid "00000000-0000-0000-0000-000000000000"');
+
+        self::assertInstanceOf(Uuid::class, $value);
+        self::assertSame('00000000-0000-0000-0000-000000000000', (string) $value);
     }
 
     public function test_uuid_tagged_literal_lowercases_input(): void
     {
-        self::assertSame(
-            '550e8400-e29b-41d4-a716-446655440000',
-            $this->read('#uuid "550E8400-E29B-41D4-A716-446655440000"'),
-        );
+        $value = $this->read('#uuid "550E8400-E29B-41D4-A716-446655440000"');
+
+        self::assertInstanceOf(Uuid::class, $value);
+        self::assertSame('550e8400-e29b-41d4-a716-446655440000', (string) $value);
     }
 
     public function test_uuid_tagged_literal_rejects_invalid_format(): void


### PR DESCRIPTION
## 🤔 Background

Main CI on commit 6aff1a0e (PR #1856) flagged two real failures and one transient:

1. **Coding Guidelines** — \`NewlineAfterStatementRector\` wants blank lines between consecutive \`if/return\` arms in \`Uuid::variant\`.
2. **Compiler tests on PHP 8.4 / 8.5** — \`ReaderTest::test_uuid_tagged_literal_*\` still asserted raw lower-cased strings; the literal now reads as a \`Uuid\` value.
3. **\`ApiFacadeTest::test_can_load_phel_functions_from_all_namespaces\`** — async namespace not loaded; flaky on the same commit before and passed on rerun. Not addressed here.

## 🔖 Changes

- \`Uuid::variant\` gets blank lines between the four short-circuit arms.
- \`ReaderTest::test_uuid_tagged_literal_reads_as_uuid_value\` (renamed from \`reads_as_string\`) and \`test_uuid_tagged_literal_lowercases_input\` assert \`Uuid::class\` and compare via \`(string) \$value\`.
- \`use Phel\Lang\Uuid;\` added to the test imports.