### PR TITLE
feat(core): quick wins from clojure-test-suite PR #873 feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 - `abs(PHP_INT_MIN)` returns `BigInteger 9223372036854775808` (#1844)
 - `bigint` accepts floats; truncates toward zero, rejects `NaN`/`Inf` (#1845)
 - `bigint` of a float uses the shortest round-trip decimal (#1852)
+- `pos-int?` / `neg-int?` / `nat-int?` accept `BigInteger` values
+- `symbol` rejects non-name input (`nil`, fns, numbers, collections) with `InvalidArgumentException`
 
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)
@@ -45,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - `floor`, `ceil`, `round`, `sqrt` (#1831)
 - `+'`, `-'`, `*'`, `inc'`, `dec'` auto-promoting variants (#1831)
 - `bigint`, `biginteger` constructors (#1831)
+- `map-entry?` predicate; true for any 2-element vector
 
 #### Documentation
 - `docs/numeric-tower.md` documents the `int`/`BigInteger`/`Rational`/`float` tower (#1832)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -12,6 +12,7 @@
 (use Phel.Lang.Collections.Vector.PersistentVectorInterface)
 (use Phel.Lang.BigInteger)
 (use Phel.Lang.FnInterface)
+(use Phel.Lang.NumericOperations)
 (use Phel.Lang.Keyword)
 (use Phel.Lang.MetaInterface)
 (use Phel.Lang.PhelVar)
@@ -98,25 +99,28 @@
   (php/is_int x))
 
 (defn neg-int?
-  "Returns true if `x` is a negative fixed-precision integer."
-  {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? 1) ; => false"
-   :see-also ["int?" "pos-int?" "nat-int?"]}
+  "Returns true if `x` is a negative integer. Accepts both fixed-precision
+  PHP `int` and arbitrary-precision `BigInteger` values."
+  {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? (bigint -5)) ; => true"
+   :see-also ["int?" "integer?" "pos-int?" "nat-int?"]}
   [x]
-  (and (int? x) (php/< x 0)))
+  (and (integer? x) (php/< (php/:: NumericOperations (compare x 0)) 0)))
 
 (defn pos-int?
-  "Returns true if `x` is a positive fixed-precision integer (greater than zero)."
-  {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? -1) ; => false"
-   :see-also ["int?" "neg-int?" "nat-int?"]}
+  "Returns true if `x` is a positive integer (greater than zero). Accepts both
+  fixed-precision PHP `int` and arbitrary-precision `BigInteger` values."
+  {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? (bigint 5)) ; => true"
+   :see-also ["int?" "integer?" "neg-int?" "nat-int?"]}
   [x]
-  (and (int? x) (php/> x 0)))
+  (and (integer? x) (php/> (php/:: NumericOperations (compare x 0)) 0)))
 
 (defn nat-int?
-  "Returns true if `x` is a non-negative fixed-precision integer (zero or positive)."
-  {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? -1) ; => false"
-   :see-also ["int?" "pos-int?" "neg-int?"]}
+  "Returns true if `x` is a non-negative integer (zero or positive). Accepts
+  both fixed-precision PHP `int` and arbitrary-precision `BigInteger` values."
+  {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? (bigint 5)) ; => true"
+   :see-also ["int?" "integer?" "pos-int?" "neg-int?"]}
   [x]
-  (and (int? x) (php/>= x 0)))
+  (and (integer? x) (php/>= (php/:: NumericOperations (compare x 0)) 0)))
 
 (defn number?
   "Returns true if `x` is a number — int, float, `Rational`, or `BigInteger`."
@@ -259,6 +263,15 @@
   "Returns true if `x` is a vector, false otherwise."
   [x]
   (php/instanceof x PersistentVectorInterface))
+
+(defn map-entry?
+  "Returns true if `x` is a map entry. Phel represents map entries as
+  two-element vectors, so this predicate accepts any vector of length
+  exactly 2."
+  {:example "(map-entry? [:a 1]) ; => true\n(map-entry? [1 2 3]) ; => false"
+   :see-also ["vector?" "map?" "key" "val"]}
+  [x]
+  (and (vector? x) (php/=== 2 (php/count x))))
 
 (defn list?
   "Returns true if `x` is a list, false otherwise.

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -98,13 +98,20 @@
   [x]
   (php/is_int x))
 
+(defn- compare-to-zero
+  "Returns the sign comparison of `x` against zero across the numeric tower
+  (PHP int, BigInteger, Rational, float). Negative for x<0, 0 for x=0,
+  positive for x>0."
+  [x]
+  (php/:: NumericOperations (compare x 0)))
+
 (defn neg-int?
   "Returns true if `x` is a negative integer. Accepts both fixed-precision
   PHP `int` and arbitrary-precision `BigInteger` values."
   {:example "(neg-int? -1) ; => true\n(neg-int? 0) ; => false\n(neg-int? (bigint -5)) ; => true"
    :see-also ["int?" "integer?" "pos-int?" "nat-int?"]}
   [x]
-  (and (integer? x) (php/< (php/:: NumericOperations (compare x 0)) 0)))
+  (and (integer? x) (php/< (compare-to-zero x) 0)))
 
 (defn pos-int?
   "Returns true if `x` is a positive integer (greater than zero). Accepts both
@@ -112,7 +119,7 @@
   {:example "(pos-int? 1) ; => true\n(pos-int? 0) ; => false\n(pos-int? (bigint 5)) ; => true"
    :see-also ["int?" "integer?" "neg-int?" "nat-int?"]}
   [x]
-  (and (integer? x) (php/> (php/:: NumericOperations (compare x 0)) 0)))
+  (and (integer? x) (php/> (compare-to-zero x) 0)))
 
 (defn nat-int?
   "Returns true if `x` is a non-negative integer (zero or positive). Accepts
@@ -120,7 +127,7 @@
   {:example "(nat-int? 0) ; => true\n(nat-int? 1) ; => true\n(nat-int? (bigint 5)) ; => true"
    :see-also ["int?" "integer?" "pos-int?" "neg-int?"]}
   [x]
-  (and (integer? x) (php/>= (php/:: NumericOperations (compare x 0)) 0)))
+  (and (integer? x) (php/>= (compare-to-zero x) 0)))
 
 (defn number?
   "Returns true if `x` is a number — int, float, `Rational`, or `BigInteger`."

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -28,26 +28,50 @@
       (php/-> x (getName))
       x)))
 
+(defn- valid-symbol-name? [x]
+  (if (php/is_string x)
+    true
+    (if (php/instanceof x \Phel\Lang\Keyword)
+      true
+      (php/instanceof x \Phel\Lang\Symbol))))
+
+(defn- assert-symbol-name [arg-name x]
+  (if (valid-symbol-name? x)
+    nil
+    (throw (php/new \InvalidArgumentException
+                    (php/. "symbol expects a string, keyword, or symbol for "
+                           arg-name
+                           ", got "
+                           (php/get_debug_type x))))))
+
 (defn symbol
   "Returns a new symbol for the given name with an optional namespace.
 
   With one argument, creates a symbol without namespace. Accepts a
   string, a keyword, another symbol, or a `Var` (in which case the
   result is a fully qualified symbol naming the var). With two
-  arguments, creates a symbol in the given namespace."
+  arguments, creates a symbol in the given namespace.
+
+  Throws `InvalidArgumentException` for any other input (including
+  `nil`, functions, numbers, and collections)."
   {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc\n(symbol #'phel.core/+) ; => phel.core/+"}
   [name-or-ns & [name]]
   (if name
-    (php/:: Symbol (createForNamespace
-                    (to-symbol-part name-or-ns)
-                    (to-symbol-part name)))
+    (do
+      (assert-symbol-name "namespace" name-or-ns)
+      (assert-symbol-name "name" name)
+      (php/:: Symbol (createForNamespace
+                      (to-symbol-part name-or-ns)
+                      (to-symbol-part name))))
     (if (php/instanceof name-or-ns Symbol)
       name-or-ns
       (if (php/instanceof name-or-ns PhelVar)
         (php/:: Symbol (createForNamespace
                         (php/-> symbol-munge (decodeNs (php/-> name-or-ns (getNamespace))))
                         (php/-> name-or-ns (getName))))
-        (php/:: Symbol (create (to-symbol-part name-or-ns)))))))
+        (do
+          (assert-symbol-name "name-or-ns" name-or-ns)
+          (php/:: Symbol (create (to-symbol-part name-or-ns))))))))
 
 (defn gensym
   "Generates a new unique symbol."

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -89,6 +89,40 @@
   (is (false? (nat-int? 0.0)) "nat-int? on 0.0")
   (is (false? (nat-int? nil)) "nat-int? on nil"))
 
+(deftest test-int-predicates-bigint
+  (is (true? (pos-int? (bigint 5))) "pos-int? on BigInteger 5")
+  (is (false? (pos-int? (bigint -5))) "pos-int? on BigInteger -5")
+  (is (false? (pos-int? (bigint 0))) "pos-int? on BigInteger 0")
+  (is (true? (neg-int? (bigint -5))) "neg-int? on BigInteger -5")
+  (is (false? (neg-int? (bigint 5))) "neg-int? on BigInteger 5")
+  (is (true? (nat-int? (bigint 0))) "nat-int? on BigInteger 0")
+  (is (true? (nat-int? (bigint 5))) "nat-int? on BigInteger 5")
+  (is (false? (nat-int? (bigint -5))) "nat-int? on BigInteger -5")
+  (is (true? (pos-int? (bigint "100000000000000000000")))
+      "pos-int? on huge BigInteger")
+  (is (true? (neg-int? (bigint "-100000000000000000000")))
+      "neg-int? on huge negative BigInteger"))
+
+(deftest test-map-entry?
+  (is (true? (map-entry? [:a 1])) "map-entry? on 2-element vector")
+  (is (true? (map-entry? ["k" "v"])) "map-entry? on string pair vector")
+  (is (false? (map-entry? [1 2 3])) "map-entry? rejects 3-element vector")
+  (is (false? (map-entry? [:a])) "map-entry? rejects 1-element vector")
+  (is (false? (map-entry? [])) "map-entry? rejects empty vector")
+  (is (false? (map-entry? '(:a 1))) "map-entry? rejects list")
+  (is (false? (map-entry? {:a 1})) "map-entry? rejects map")
+  (is (false? (map-entry? nil)) "map-entry? rejects nil"))
+
+(deftest test-symbol-rejects-non-name-input
+  (is (thrown? \InvalidArgumentException (symbol nil))
+      "(symbol nil) throws InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (symbol map))
+      "(symbol fn) throws InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (symbol 42))
+      "(symbol int) throws InvalidArgumentException")
+  (is (thrown? \InvalidArgumentException (symbol [:a]))
+      "(symbol vector) throws InvalidArgumentException"))
+
 (deftest test-number?
   (is (true? (number? 10.0)) "number? on 10.0")
   (is (true? (number? 0.0)) "number? on 0.0")


### PR DESCRIPTION
## 🤔 Background

While reviewing jank-lang/clojure-test-suite#873 against current Phel I found a handful of small gaps that bundle naturally:

1. \`pos-int?\` / \`neg-int?\` / \`nat-int?\` returned false for any \`BigInteger\` because they were hard-wired to \`int?\` (PHP-int only). After the recent \`integer?\` widening (#1837) the sign predicates were the odd one out.
2. \`map-entry?\` predicate did not exist. Phel maps yield 2-element vectors as entries, but consumers had no built-in way to detect them without re-implementing the check.
3. \`symbol\` happily accepted anything, so \`(symbol +)\` produced a symbol whose \`getName\` was the printed form (\`"<function:+>"\`), and \`(symbol nil)\` raised a raw PHP \`TypeError\` instead of \`InvalidArgumentException\`.

## 💡 Goal

Tighten the three predicates and the constructor so they behave sensibly across the Phel numeric tower and reject obviously-wrong inputs.

## 🔖 Changes

- \`neg-int?\` / \`pos-int?\` / \`nat-int?\` now route through \`integer?\` and \`Phel\Lang\NumericOperations::compare\`, so they answer correctly for both \`int\` and \`BigInteger\` (including values outside the PHP int range).
- New \`map-entry?\` predicate returning true for any 2-element vector.
- New private \`assert-symbol-name\` / \`valid-symbol-name?\` helpers in \`phel.core/symbol\`. \`symbol\` rejects anything that is not a string, keyword, symbol, or \`Var\` with \`InvalidArgumentException\`, matching the docstring.
- Phel tests under \`test-int-predicates-bigint\`, \`test-map-entry?\`, and \`test-symbol-rejects-non-name-input\`.
- Changelog entries under \`## Unreleased\` (Fixed/Added).