### PR TITLE
fix(core): symbol accepts nil namespace (#1859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - `bigint` of a float uses the shortest round-trip decimal (#1852)
 - `pos-int?` / `neg-int?` / `nat-int?` accept `BigInteger` values
 - `symbol` rejects non-name input (`nil`, fns, numbers, collections) with `InvalidArgumentException`
+- `(symbol nil name)` returns an unqualified symbol instead of throwing (#1859)
 
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)

--- a/src/phel/core/strings.phel
+++ b/src/phel/core/strings.phel
@@ -50,19 +50,23 @@
   With one argument, creates a symbol without namespace. Accepts a
   string, a keyword, another symbol, or a `Var` (in which case the
   result is a fully qualified symbol naming the var). With two
-  arguments, creates a symbol in the given namespace.
+  arguments, creates a symbol in the given namespace; a `nil`
+  namespace yields a symbol without a namespace.
 
   Throws `InvalidArgumentException` for any other input (including
-  `nil`, functions, numbers, and collections)."
-  {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc\n(symbol #'phel.core/+) ; => phel.core/+"}
+  functions, numbers, and collections)."
+  {:example "(symbol \"foo\") ; => foo\n(symbol :abc) ; => abc\n(symbol nil \"foo\") ; => foo\n(symbol #'phel.core/+) ; => phel.core/+"}
   [name-or-ns & [name]]
   (if name
     (do
-      (assert-symbol-name "namespace" name-or-ns)
       (assert-symbol-name "name" name)
-      (php/:: Symbol (createForNamespace
-                      (to-symbol-part name-or-ns)
-                      (to-symbol-part name))))
+      (if (php/=== nil name-or-ns)
+        (php/:: Symbol (create (to-symbol-part name)))
+        (do
+          (assert-symbol-name "namespace" name-or-ns)
+          (php/:: Symbol (createForNamespace
+                          (to-symbol-part name-or-ns)
+                          (to-symbol-part name))))))
     (if (php/instanceof name-or-ns Symbol)
       name-or-ns
       (if (php/instanceof name-or-ns PhelVar)

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -535,7 +535,9 @@
   (is (= 'abc (symbol :abc)) "symbol on a keyword extracts the name")
   (is (= '+ (symbol :+)) "symbol on a single-character keyword")
   (is (= 'a/b (symbol :a :b)) "symbol with keyword namespace and keyword name")
-  (is (identical? 'foo (symbol 'foo)) "symbol on a symbol returns it unchanged"))
+  (is (identical? 'foo (symbol 'foo)) "symbol on a symbol returns it unchanged")
+  (is (= 'abc (symbol nil "abc")) "symbol with nil namespace yields unqualified symbol")
+  (is (nil? (namespace (symbol nil "hi"))) "symbol with nil namespace has no namespace"))
 
 (deftest test-namespace
   (is (= nil (namespace 'symbol)) "namespace on symbol without ns")


### PR DESCRIPTION
## 🤔 Background

Closes #1859. The clojure-test-suite job hits two forms that should succeed:

```
(= (quote abc) (symbol nil "abc"))
(nil? (namespace (symbol nil "hi")))
```

Both raise `InvalidArgumentException: symbol expects a string, keyword, or symbol for namespace, got null`. The single-argument `symbol` already returns an unqualified symbol; the two-argument variant should accept a `nil` namespace as the same intent.

## 💡 Goal

Treat `(symbol nil name)` as equivalent to `(symbol name)` and continue to validate `name`.

## 🔖 Changes

- `phel.core/symbol`: when called with two arguments, a `nil` namespace short-circuits to `Symbol::create` after asserting `name`. Non-nil namespaces still go through `assert-symbol-name`.
- Docstring and `:example` updated to mention the `nil`-namespace form.
- `test-symbol`: two new assertions cover `(symbol nil "abc")` and `(namespace (symbol nil "hi"))`.
- CHANGELOG entry under `Fixed › Core`.