### PR TITLE
fix(core): BigDecimal flows through numeric tower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - `pos-int?` / `neg-int?` / `nat-int?` accept `BigInteger` values
 - `symbol` rejects non-name input (`nil`, fns, numbers, collections) with `InvalidArgumentException`
 - `(symbol nil name)` returns an unqualified symbol instead of throwing (#1859)
+- `int`/`long`/`float`/`double` accept `BigDecimal`; `zero?`/`pos?`/`neg?`, `<`/`<=`/`>`/`>=`, `==`, `number?` route `BigDecimal` through the numeric tower (#1867)
 
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)

--- a/src/phel/core/booleans.phel
+++ b/src/phel/core/booleans.phel
@@ -1,6 +1,7 @@
 (in-ns phel.core)
 
 (use InvalidArgumentException)
+(use Phel.Lang.BigDecimal)
 (use Phel.Lang.BigInteger)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
 (use Phel.Lang.Collections.LinkedList.PersistentListInterface)
@@ -115,7 +116,8 @@
   (or (php/is_int x)
       (php/is_float x)
       (php/instanceof x Rational)
-      (php/instanceof x BigInteger)))
+      (php/instanceof x BigInteger)
+      (php/instanceof x BigDecimal)))
 
 (defn- num-equals1 [a b]
   (when-not (num? a)
@@ -157,7 +159,9 @@
 
 (defn- numeric-object?
   [x]
-  (or (php/instanceof x Rational) (php/instanceof x BigInteger)))
+  (or (php/instanceof x Rational)
+      (php/instanceof x BigInteger)
+      (php/instanceof x BigDecimal)))
 
 (defn- lt2 [a b]
   (if (or (numeric-object? a) (numeric-object? b))

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -312,32 +312,35 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
                     (str "abs expects a number, got " (type x))))))
 
 (defn int
-  "Coerces `x` to an integer. `Rational` values truncate toward zero
-   (`(int 1/10)` is `0`); `BigInteger` and `float` values collapse to
-   their PHP int value or throw `OverflowException` when outside the PHP
-   int range (`NaN`/`Inf` floats raise `InvalidArgumentException`).
-   Numeric strings are parsed via PHP's `intval`, and `nil` returns `0`."
+  "Coerces `x` to an integer. `Rational` and `BigDecimal` values truncate
+   toward zero (`(int 1/10)` is `0`, `(int -1.1M)` is `-1`); `BigInteger`
+   and `float` values collapse to their PHP int value or throw
+   `OverflowException` when outside the PHP int range (`NaN`/`Inf` floats
+   raise `InvalidArgumentException`). Numeric strings are parsed via PHP's
+   `intval`, and `nil` returns `0`."
   {:example "(int 1.9) ; => 1\n(int \"42\") ; => 42\n(int 1/10) ; => 0"
    :see-also ["float" "double" "int?" "number?"]}
   [x]
   (cond
-    (or (php/instanceof x Rational) (php/instanceof x BigInteger))
-                     (php/-> x (toInt))
-    (php/is_float x) (php/-> (php/:: BigInteger (fromFloat x)) (toInt))
-    :else            (php/intval x)))
+    (or (php/instanceof x Rational)
+        (php/instanceof x BigInteger)
+        (php/instanceof x BigDecimal)) (php/-> x (toInt))
+    (php/is_float x)                   (php/-> (php/:: BigInteger (fromFloat x)) (toInt))
+    :else                              (php/intval x)))
 
 (defn float
   "Coerces `x` to a float. In PHP there is no distinction between float and
-   double; both map to the same native PHP float type. `Rational` and
-   `BigInteger` values collapse to their float value; everything else
-   delegates to PHP's `floatval`, so non-numeric strings return `0.0` and
-   `nil` returns `0.0`."
+   double; both map to the same native PHP float type. `Rational`,
+   `BigInteger`, and `BigDecimal` values collapse to their float value;
+   everything else delegates to PHP's `floatval`, so non-numeric strings
+   return `0.0` and `nil` returns `0.0`."
   {:example "(float 1) ; => 1.0\n(float 1/2) ; => 0.5"
    :see-also ["double" "int?" "number?"]}
   [x]
   (cond
     (php/instanceof x Rational)   (php/-> x (toFloat))
     (php/instanceof x BigInteger) (php/floatval (str x))
+    (php/instanceof x BigDecimal) (php/-> x (toFloat))
     :else                         (php/floatval x)))
 
 (defn double

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -178,12 +178,13 @@
   (and (integer? x) (php/>= (compare-to-zero x) 0)))
 
 (defn number?
-  "Returns true if `x` is a number — int, float, `Rational`, or `BigInteger`."
+  "Returns true if `x` is a number: int, float, `Rational`, `BigInteger`, or `BigDecimal`."
   [x]
   (or (php/is_int x)
       (php/is_float x)
       (php/instanceof x Rational)
-      (php/instanceof x BigInteger)))
+      (php/instanceof x BigInteger)
+      (php/instanceof x BigDecimal)))
 
 (defn ratio?
   "Returns true if `x` is a `Rational` value. Integer-valued rationals

--- a/src/php/Lang/BigDecimal.php
+++ b/src/php/Lang/BigDecimal.php
@@ -6,7 +6,9 @@ namespace Phel\Lang;
 
 use ArithmeticError;
 use InvalidArgumentException;
+use OverflowException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+
 use Stringable;
 
 use function crc32;
@@ -206,6 +208,46 @@ final readonly class BigDecimal implements TypeInterface, Stringable
     public function isZero(): bool
     {
         return $this->mantissa->isZero();
+    }
+
+    /**
+     * Sign of this value: -1, 0, or 1.
+     */
+    public function signum(): int
+    {
+        if ($this->mantissa->isZero()) {
+            return 0;
+        }
+
+        return $this->mantissa->compareTo(BigInteger::fromInt(0));
+    }
+
+    /**
+     * Truncates toward zero and returns a PHP int. Throws when the
+     * truncated integer part does not fit in `PHP_INT_MIN..PHP_INT_MAX`.
+     */
+    public function toInt(): int
+    {
+        $integerPart = $this->scale === 0
+            ? $this->mantissa
+            : $this->mantissa->divide(BigInteger::fromInt(10)->pow($this->scale));
+
+        if (!$integerPart->fitsInPhpInt()) {
+            throw new OverflowException(
+                sprintf('BigDecimal value %s does not fit in PHP int range', $this),
+            );
+        }
+
+        return $integerPart->toInt();
+    }
+
+    /**
+     * Returns the closest IEEE-754 double to this value. Subject to the
+     * usual float precision limits for very large or very small magnitudes.
+     */
+    public function toFloat(): float
+    {
+        return (float) $this->renderDigits();
     }
 
     public function equals(mixed $other): bool

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -184,6 +184,10 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->compareTo(self::toBigDecimal($b));
+        }
+
         if (is_float($a) || is_float($b)) {
             return self::toFloat($a) <=> self::toFloat($b);
         }
@@ -207,6 +211,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::compare($a, $b) === 0;
+        }
 
         if (is_float($a) || is_float($b)) {
             return self::toFloat($a) === self::toFloat($b);
@@ -236,6 +244,10 @@ final class NumericOperations
         }
 
         if ($a instanceof BigInteger) {
+            return $a->isZero();
+        }
+
+        if ($a instanceof BigDecimal) {
             return $a->isZero();
         }
 
@@ -432,12 +444,40 @@ final class NumericOperations
             return;
         }
 
-        if ($value instanceof BigInteger || $value instanceof Rational) {
+        if ($value instanceof BigInteger || $value instanceof Rational || $value instanceof BigDecimal) {
             return;
         }
 
         throw new InvalidArgumentException(
             sprintf('Expected a number, got %s', get_debug_type($value)),
+        );
+    }
+
+    private static function toBigDecimal(mixed $value): BigDecimal
+    {
+        if ($value instanceof BigDecimal) {
+            return $value;
+        }
+
+        if ($value instanceof BigInteger) {
+            return BigDecimal::fromBigInteger($value);
+        }
+
+        if (is_int($value)) {
+            return BigDecimal::fromInt($value);
+        }
+
+        if (is_float($value)) {
+            return BigDecimal::fromFloat($value);
+        }
+
+        if ($value instanceof Rational) {
+            return BigDecimal::fromBigInteger($value->numerator())
+                ->divideExact(BigDecimal::fromBigInteger($value->denominator()));
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot lift %s to BigDecimal', get_debug_type($value)),
         );
     }
 

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -501,6 +501,41 @@
   (is (= 1.5M (bigdec "1.5")) "literal equals constructor")
   (is (= "1500M" (str 1.5e3M)) "(str 1.5e3M)"))
 
+(deftest test-bigdec-coercions
+  (is (= 0 (int 0M)) "(int 0M)")
+  (is (= -1 (int -1M)) "(int -1M)")
+  (is (= -1 (int -1.1M)) "(int -1.1M) truncates toward zero")
+  (is (= 2 (int 2.7M)) "(int 2.7M) truncates toward zero")
+  (is (= 0 (long 0M)) "(long 0M)")
+  (is (= -1 (long -1M)) "(long -1M)")
+  (is (= 0.0 (float 0M)) "(float 0M)")
+  (is (= -1.0 (float -1M)) "(float -1M)")
+  (is (= -1.1 (float -1.1M)) "(float -1.1M)")
+  (is (= 0.0 (double 0M)) "(double 0M)")
+  (is (= -1.0 (double -1M)) "(double -1M)"))
+
+(deftest test-bigdec-sign-predicates
+  (is (zero? 0M) "(zero? 0M)")
+  (is (not (zero? 1M)) "(zero? 1M)")
+  (is (not (zero? -1M)) "(zero? -1M)")
+  (is (pos? 1M) "(pos? 1M)")
+  (is (not (pos? 0M)) "(pos? 0M)")
+  (is (not (pos? -1M)) "(pos? -1M)")
+  (is (neg? -1M) "(neg? -1M)")
+  (is (neg? -1.1M) "(neg? -1.1M)")
+  (is (not (neg? 0M)) "(neg? 0M)")
+  (is (not (neg? 1M)) "(neg? 1M)"))
+
+(deftest test-bigdec-numeric-equality
+  (is (== 0 0M) "(== 0 0M)")
+  (is (== 1 1M) "(== 1 1M)")
+  (is (== 1.5 1.5M) "(== 1.5 1.5M)")
+  (is (not (== 1M 2M)) "(== 1M 2M)")
+  (is (number? 0M) "(number? 0M)")
+  (is (< -1M 0M) "(< -1M 0M)")
+  (is (< 0M 1M) "(< 0M 1M)")
+  (is (> 1M 0M) "(> 1M 0M)"))
+
 (deftest test-floor
   (is (= 1.0 (floor 1.7)) "(floor 1.7)")
   (is (= -2.0 (floor -1.2)) "(floor -1.2) toward negative infinity")

--- a/tests/php/Unit/Lang/BigDecimalTest.php
+++ b/tests/php/Unit/Lang/BigDecimalTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Lang;
 
 use ArithmeticError;
 use InvalidArgumentException;
+use OverflowException;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInteger;
 use PHPUnit\Framework\TestCase;
@@ -141,5 +142,39 @@ final class BigDecimalTest extends TestCase
     public function test_to_plain_string_keeps_trailing_zeros(): void
     {
         self::assertSame('1.20', BigDecimal::fromString('1.20')->toPlainString());
+    }
+
+    public function test_signum_reports_sign(): void
+    {
+        self::assertSame(0, BigDecimal::fromString('0')->signum());
+        self::assertSame(0, BigDecimal::fromString('0.000')->signum());
+        self::assertSame(1, BigDecimal::fromString('0.0001')->signum());
+        self::assertSame(-1, BigDecimal::fromString('-0.0001')->signum());
+        self::assertSame(1, BigDecimal::fromString('42')->signum());
+        self::assertSame(-1, BigDecimal::fromString('-42.5')->signum());
+    }
+
+    public function test_to_int_truncates_toward_zero(): void
+    {
+        self::assertSame(0, BigDecimal::fromString('0')->toInt());
+        self::assertSame(1, BigDecimal::fromString('1')->toInt());
+        self::assertSame(-1, BigDecimal::fromString('-1')->toInt());
+        self::assertSame(2, BigDecimal::fromString('2.7')->toInt());
+        self::assertSame(-1, BigDecimal::fromString('-1.9')->toInt());
+        self::assertSame(0, BigDecimal::fromString('-0.5')->toInt());
+    }
+
+    public function test_to_int_throws_when_out_of_range(): void
+    {
+        $this->expectException(OverflowException::class);
+        BigDecimal::fromString('99999999999999999999999')->toInt();
+    }
+
+    public function test_to_float_returns_native_double(): void
+    {
+        self::assertSame(0.0, BigDecimal::fromString('0')->toFloat());
+        self::assertSame(1.5, BigDecimal::fromString('1.5')->toFloat());
+        self::assertSame(-1.1, BigDecimal::fromString('-1.1')->toFloat());
+        self::assertSame(1500.0, BigDecimal::fromString('1.5e3')->toFloat());
     }
 }


### PR DESCRIPTION
## 🤔 Background

Closes #1867. The clojure-test-suite run flagged a batch of `BigDecimal` failures: `(int 0M)` returned `1`, `(neg? -1M)` returned `false`, `(pos? 0M)` returned `true`, `(zero? 0M)` returned `false`, `(float -1.1M)` returned `1`, etc. Root cause: `BigDecimal` was a typed value but never plumbed through `Phel\Lang\NumericOperations` or the `numeric-object?` / `num?` predicates that gate numeric dispatch. Comparisons fell back to PHP's object-vs-int coercion (object always > int) and coercion fns hit `php/intval` / `php/floatval` on an object (always `1`).

## 💡 Goal

Make `BigDecimal` a first-class citizen of the numeric tower for sign/order/equality/coercion, so every test in #1867 that represents a real bug now passes. Keep the surface narrow: arithmetic mixing `BigDecimal` with other numeric types is intentionally **not** in scope (that needs a separate design pass on contagion rules).

## 🔖 Changes

### Lang
- `BigDecimal::toInt()` truncates toward zero; throws `OverflowException` outside the PHP int range.
- `BigDecimal::toFloat()` renders to the closest IEEE-754 double via canonical decimal form.
- `BigDecimal::signum()` returns `-1`/`0`/`1` for negative/zero/positive values.
- `NumericOperations::ensureNumeric` accepts `BigDecimal`.
- `NumericOperations::compare` and `isEqual` route through a private `toBigDecimal` lift; `isZero` recognises `BigDecimal`.

### Core
- `int`, `long`, `float`, `double` dispatch `BigDecimal` to the new accessors (truncate toward zero for `int`/`long`).
- `number?` includes `BigDecimal`.
- `num?` (used by `==`) and `numeric-object?` (used by `<`/`<=`/`>`/`>=`) both include `BigDecimal`.

### Tests
- `tests/phel/test/core/math-operation.phel` adds `test-bigdec-coercions`, `test-bigdec-sign-predicates`, and `test-bigdec-numeric-equality` mirroring the failures in #1867.
- `tests/php/Unit/Lang/BigDecimalTest.php` covers `signum`, `toInt`, `toInt` overflow, and `toFloat`.

## 🚧 Intentional non-changes

`(str 0M) => "0M"` and `(double? 0M) => false` remain. The clojure-test-suite expected `"0.0"` and `true`, but those are deliberate Phel design choices: the `M` suffix matches the literal form (#1862), and `double?` is reserved for native `float` per Clojure's own `clojure.core/double?` semantics. No code change here.