### PR TITLE
fix(core): bigdec accepts Rational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - `symbol` rejects non-name input (`nil`, fns, numbers, collections) with `InvalidArgumentException`
 - `(symbol nil name)` returns an unqualified symbol instead of throwing (#1859)
 - `int`/`long`/`float`/`double` accept `BigDecimal`; `zero?`/`pos?`/`neg?`, `<`/`<=`/`>`/`>=`, `==`, `number?` route `BigDecimal` through the numeric tower (#1867)
+- `bigdec` accepts `Rational`; non-terminating expansions raise `ArithmeticError` (#1873)
 
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -560,9 +560,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 
 (defn bigdec
   "Coerces `x` to a `Phel\\Lang\\BigDecimal`. Accepts `BigDecimal` (returned
-  as-is), ints, floats (truncated through the shortest round-trip
-  decimal of the float), `BigInteger`, and numeric strings."
-  {:example "(bigdec 1.5) ; => 1.5M\n(bigdec \"3.14\") ; => 3.14M"
+  as-is), ints, floats (via the shortest round-trip decimal of the
+  float), `BigInteger`, `Rational` (computed via exact decimal division;
+  throws `ArithmeticError` when the expansion does not terminate,
+  matching `(bigdec 1/3)`), and numeric strings."
+  {:example "(bigdec 1.5) ; => 1.5M\n(bigdec 1/2) ; => 0.5M\n(bigdec \"3.14\") ; => 3.14M"
    :see-also ["bigdec?" "decimal?" "rationalize"]}
   [x]
   (cond
@@ -570,10 +572,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (php/is_int x)                 (php/:: BigDecimal (fromInt x))
     (php/is_float x)               (php/:: BigDecimal (fromFloat x))
     (php/instanceof x BigInteger)  (php/:: BigDecimal (fromBigInteger x))
+    (php/instanceof x Rational)    (php/-> (php/:: BigDecimal (fromBigInteger (php/-> x (numerator))))
+                                           (divideExact (php/:: BigDecimal (fromBigInteger (php/-> x (denominator))))))
     (string? x)                    (php/:: BigDecimal (fromString x))
     :else
     (throw (php/new \InvalidArgumentException
-                    (php/. "bigdec expects a BigDecimal, int, float, BigInteger, or numeric string, got "
+                    (php/. "bigdec expects a BigDecimal, int, float, BigInteger, Rational, or numeric string, got "
                            (php/get_debug_type x))))))
 
 (defn numerator

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -536,6 +536,14 @@
   (is (< 0M 1M) "(< 0M 1M)")
   (is (> 1M 0M) "(> 1M 0M)"))
 
+(deftest test-bigdec-from-rational
+  (is (= 0.5M (bigdec 1/2)) "(bigdec 1/2)")
+  (is (= 0.25M (bigdec 1/4)) "(bigdec 1/4)")
+  (is (= -0.5M (bigdec -1/2)) "(bigdec -1/2)")
+  (is (= 2M (bigdec 4/2)) "(bigdec 4/2) collapses to int via Rational, returns 2M")
+  (is (thrown? \ArithmeticError (bigdec 1/3))
+      "(bigdec 1/3) throws on non-terminating decimal expansion"))
+
 (deftest test-floor
   (is (= 1.0 (floor 1.7)) "(floor 1.7)")
   (is (= -2.0 (floor -1.2)) "(floor -1.2) toward negative infinity")


### PR DESCRIPTION
## 🤔 Background

Closes #1873. Reported via clojure-test-suite: `(= 0.5M (bigdec 1/2))` raised `InvalidArgumentException: bigdec expects a BigDecimal, int, float, BigInteger, or numeric string, got Phel\\Lang\\Rational`. Clojure returns `true` here.

## 💡 Goal

Let `bigdec` accept `Rational` values, computing the exact decimal expansion when terminating, and matching Clojure's `(bigdec 1/3) -> ArithmeticError` for non-terminating expansions.

## 🔖 Changes

### Core
- `bigdec` adds a `Rational` arm: builds `BigDecimal` instances from numerator and denominator and uses `divideExact`. Terminating expansions return the exact value (`(bigdec 1/2) -> 0.5M`, `(bigdec 1/4) -> 0.25M`). Non-terminating expansions (`1/3`, `2/7`) raise `ArithmeticError`.
- Updated docstring and `:else` error message to mention `Rational`.

### Tests
- `test-bigdec-from-rational` covers `1/2`, `1/4`, `-1/2`, `4/2` (which collapses to `Rational -> int 2 -> bigdec 2M`), and asserts `(bigdec 1/3)` throws.