### PR TITLE
fix(core): plumb BigDecimal through arithmetic and rationalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - `(symbol nil name)` returns an unqualified symbol instead of throwing (#1859)
 - `int`/`long`/`float`/`double` accept `BigDecimal`; `zero?`/`pos?`/`neg?`, `<`/`<=`/`>`/`>=`, `==`, `number?` route `BigDecimal` through the numeric tower (#1867)
 - `bigdec` accepts `Rational`; non-terminating expansions raise `ArithmeticError` (#1873)
+- `+`, `-`, `*`, `/`, `abs`, `quot`, `rem`, `mod`, `rationalize` accept `BigDecimal` operands; `/` raises `ArithmeticError` on non-terminating expansions (#1875)
 
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)

--- a/src/phel/core/math.phel
+++ b/src/phel/core/math.phel
@@ -673,9 +673,11 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 (defn rationalize
   "Converts `x` to a `Rational`. Floats use the shortest decimal expansion
   that round-trips back to the same float, so `(rationalize 0.1)` is `1/10`
-  rather than the float-noise denominator. Ints and `BigInteger` values
-  become `n/1` and auto-collapse, so they are returned unchanged."
-  {:example "(rationalize 0.5) ; => 1/2\n(rationalize 3) ; => 3"
+  rather than the float-noise denominator. Ints, `BigInteger`, and
+  integer-valued `BigDecimal` values become `n/1` and auto-collapse, so
+  they are returned as the integer value. `BigDecimal` with a fractional
+  part rationalizes through its canonical decimal form."
+  {:example "(rationalize 0.5) ; => 1/2\n(rationalize 3) ; => 3\n(rationalize 1M) ; => 1"
    :see-also ["numerator" "denominator" "ratio?"]}
   [x]
   (cond
@@ -683,6 +685,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
     (php/instanceof x BigInteger) x
     (php/is_int x)                x
     (php/is_float x)              (float->rational x)
+    (php/instanceof x BigDecimal) (decimal-string->rational (php/-> x (toPlainString)))
     :else
     (throw (php/new InvalidArgumentException
                     (str "rationalize expects a number, got " (type x))))))

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -38,6 +38,10 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->add(self::toBigDecimal($b));
+        }
+
         if (is_float($a) || is_float($b)) {
             return self::toFloat($a) + self::toFloat($b);
         }
@@ -65,6 +69,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->subtract(self::toBigDecimal($b));
+        }
 
         if (is_float($a) || is_float($b)) {
             return self::toFloat($a) - self::toFloat($b);
@@ -94,6 +102,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->multiply(self::toBigDecimal($b));
+        }
 
         if (is_float($a) || is_float($b)) {
             return self::toFloat($a) * self::toFloat($b);
@@ -126,6 +138,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->divideExact(self::toBigDecimal($b));
+        }
 
         if (is_float($a) || is_float($b)) {
             $left = self::toFloat($a);
@@ -174,6 +190,10 @@ final class NumericOperations
 
         if ($a instanceof BigInteger) {
             return self::collapseBigInt($a->negate());
+        }
+
+        if ($a instanceof BigDecimal) {
+            return $a->negate();
         }
 
         return -$a;
@@ -266,6 +286,10 @@ final class NumericOperations
             return self::collapseBigInt($a->abs());
         }
 
+        if ($a instanceof BigDecimal) {
+            return $a->abs();
+        }
+
         // |PHP_INT_MIN| overflows the PHP int range; native abs() drops
         // to float, so promote to BigInteger to preserve exactness.
         if ($a === PHP_INT_MIN) {
@@ -315,6 +339,13 @@ final class NumericOperations
             throw new DivisionByZeroError('Division by zero');
         }
 
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::truncateBigDecimalQuot(
+                self::toBigDecimal($a),
+                self::toBigDecimal($b),
+            );
+        }
+
         if (is_float($a) || is_float($b)) {
             $ratio = self::toFloat($a) / self::toFloat($b);
             // Float operands keep float result; truncate toward zero.
@@ -343,6 +374,13 @@ final class NumericOperations
 
         if (self::isZero($b)) {
             throw new DivisionByZeroError('Division by zero');
+        }
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            $aBig = self::toBigDecimal($a);
+            $bBig = self::toBigDecimal($b);
+            $q = self::truncateBigDecimalQuot($aBig, $bBig);
+            return $aBig->subtract($bBig->multiply($q));
         }
 
         if (is_float($a) || is_float($b)) {
@@ -451,6 +489,19 @@ final class NumericOperations
         throw new InvalidArgumentException(
             sprintf('Expected a number, got %s', get_debug_type($value)),
         );
+    }
+
+    /**
+     * Truncates `a / b` toward zero and returns the result as a scale-0
+     * `BigDecimal`. Used by `quot` and `rem` for BigDecimal operands.
+     */
+    private static function truncateBigDecimalQuot(BigDecimal $a, BigDecimal $b): BigDecimal
+    {
+        $scale = max($a->scale(), $b->scale());
+        $aLifted = $a->mantissa()->multiply(BigInteger::fromInt(10)->pow($scale - $a->scale()));
+        $bLifted = $b->mantissa()->multiply(BigInteger::fromInt(10)->pow($scale - $b->scale()));
+
+        return BigDecimal::fromBigInteger($aLifted->divide($bLifted));
     }
 
     private static function toBigDecimal(mixed $value): BigDecimal

--- a/tests/phel/test/core/math-operation.phel
+++ b/tests/phel/test/core/math-operation.phel
@@ -544,6 +544,38 @@
   (is (thrown? \ArithmeticError (bigdec 1/3))
       "(bigdec 1/3) throws on non-terminating decimal expansion"))
 
+(deftest test-bigdec-arithmetic
+  (is (= 3M (+ 1M 2M)) "(+ 1M 2M)")
+  (is (= 3M (+ 1 2M)) "mixed (+ 1 2M)")
+  (is (= 3M (+ 1M 2)) "mixed (+ 1M 2)")
+  (is (= 1M (- 2M 1M)) "(- 2M 1M)")
+  (is (= -1M (- 1M 2M)) "(- 1M 2M)")
+  (is (= -2M (- 2M)) "unary (- 2M)")
+  (is (= 6M (* 2M 3M)) "(* 2M 3M)")
+  (is (= 6M (* 2M 3)) "mixed (* 2M 3)")
+  (is (= 2M (/ 2M 1M)) "(/ 2M 1M)")
+  (is (= 2.5M (/ 5M 2M)) "(/ 5M 2M) terminating")
+  (is (thrown? \ArithmeticError (/ 1M 3M))
+      "(/ 1M 3M) raises on non-terminating expansion"))
+
+(deftest test-bigdec-abs
+  (is (= 123.456M (abs -123.456M)) "(abs -123.456M)")
+  (is (= 0M (abs 0M)) "(abs 0M)")
+  (is (= 5M (abs 5M)) "(abs 5M) on positive")
+  (is (= 1.5M (abs -1.5M)) "(abs -1.5M)"))
+
+(deftest test-bigdec-quot-rem-mod
+  (is (= -3M (quot -10M 3)) "(quot -10M 3)")
+  (is (= -1M (rem -10 3M)) "(rem -10 3M)")
+  (is (= 1M (mod 10 3M)) "(mod 10 3M)"))
+
+(deftest test-bigdec-rationalize
+  (let [r (rationalize 1M)]
+    (is (= 1 r) "(rationalize 1M) value")
+    (is (or (integer? r) (ratio? r)) "(rationalize 1M) is integer or ratio"))
+  (let [r (rationalize 0.5M)]
+    (is (= 1/2 r) "(rationalize 0.5M)")))
+
 (deftest test-floor
   (is (= 1.0 (floor 1.7)) "(floor 1.7)")
   (is (= -2.0 (floor -1.2)) "(floor -1.2) toward negative infinity")


### PR DESCRIPTION
## 🤔 Background

Closes #1875. Reported via clojure-test-suite: `(+ 1M 2M)`, `(- 2M 1M)`, `(* 2M 3M)`, `(/ 2M 1M)`, `(abs -123.456M)`, `(quot -10M 3)`, `(rem -10 3M)`, `(mod 10 3M)`, and `(rationalize 1M)` either threw `TypeError` or produced wrong values because BigDecimal was not plumbed through `NumericOperations`.

## 💡 Goal

Treat `BigDecimal` as a first-class arithmetic operand. Mixed-type ops promote everything to `BigDecimal` because it's the highest-precision type in the tower; the result is always `BigDecimal` when at least one operand is.

## 🔖 Changes

### Lang
- `NumericOperations` add/subtract/multiply/negate/abs gain a `BigDecimal` arm. Each lifts the other operand via the existing `toBigDecimal` helper and delegates to the corresponding `BigDecimal` method.
- `divide` lifts to `BigDecimal` and uses `divideExact`. Non-terminating expansions raise `ArithmeticError`.
- `quot` and `rem` lift to `BigDecimal` and use a new `truncateBigDecimalQuot` helper that aligns scales and divides the lifted mantissas. `mod` derives from `rem` so it inherits the new behavior.

### Core
- `rationalize` accepts `BigDecimal` and routes through `decimal-string->rational` on the value's canonical decimal form. `(rationalize 1M)` returns `1`; `(rationalize 0.5M)` returns `1/2`.

### Tests
Added under `tests/phel/test/core/math-operation.phel`:
- `test-bigdec-arithmetic` covers `+ - * /` across pure `BigDecimal` and mixed `BigDecimal/int` operands, plus `(/ 1M 3M)` raising `ArithmeticError`.
- `test-bigdec-abs` covers `abs` on positive, negative, zero, and fractional `BigDecimal`.
- `test-bigdec-quot-rem-mod` covers the exact failures reported in #1875.
- `test-bigdec-rationalize` covers `(rationalize 1M)` and `(rationalize 0.5M)`.