### PR TITLE
feat(core): assoc and conj accept MapEntry, degrade to vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 
 #### Lang
 - `(first m)` and `(next m)` yield `MapEntry` instances; equality between `MapEntry` and a 2-vector is symmetric in both directions (#1868)
+- `assoc` and `conj` accept `MapEntry` and degrade to a `PersistentVector` (the result is no longer an entry); `(nth entry idx)` and `(count entry)` work directly (#1871)
 - `BigDecimal::__toString` (and therefore `(str 0M)`, `(str 1.5M)`, etc.) returns the canonical decimal form without the `M` suffix and preserves trailing zeros, matching `java.math.BigDecimal.toString` and Clojure's `str`. The readable form via the printer (`pr`/`prn`) keeps the `M` suffix (#1877)
 
 ### Added

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -193,6 +193,10 @@
     (vector-target? coll)                          (php/-> coll (append value))
     (set-target? coll)                             (php/-> coll (add value))
     (map-target? coll)                             (conj-map-entry coll value)
+    ;; MapEntry degrades to a 3-vector when grown; the result is no longer
+    ;; an entry. Matches Clojure's MapEntry under conj.
+    (php/instanceof coll MapEntry)
+    (php/-> [(php/-> coll (key)) (php/-> coll (value))] (append value))
     (php/instanceof coll PushInterface)            (php/-> coll (push value))
     :else
     (throw (php/new InvalidArgumentException

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -5,6 +5,7 @@
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
 (use Phel.Lang.Collections.HashSet.TransientHashSetInterface)
 (use Phel.Lang.Collections.LazySeq.LazySeqInterface)
+(use Phel.Lang.Collections.Map.MapEntry)
 (use Phel.Lang.Collections.Map.PersistentMapInterface)
 (use Phel.Lang.Collections.Map.TransientMapInterface)
 (use Phel.Lang.Collections.Vector.PersistentVectorInterface)
@@ -224,6 +225,12 @@
 
     (vector-target? ds)
     (php/-> ds (update key value))
+
+    ;; MapEntry degrades to a 2-vector once mutated, since the result no
+    ;; longer represents a real map entry. Matches Clojure's MapEntry
+    ;; behavior under assoc.
+    (php/instanceof ds MapEntry)
+    (php/-> [(php/-> ds (key)) (php/-> ds (value))] (update key value))
 
     ;; Explicit rejection for any other shape (string, list, set, sorted set,
     ;; number, …). Without this the old fall-through silently mutated strings

--- a/tests/phel/test/core/type-operation.phel
+++ b/tests/phel/test/core/type-operation.phel
@@ -183,6 +183,19 @@
   (let [pairs (next {:a 1 :b 2})]
     (is (true? (every? map-entry? pairs)) "next over a map yields MapEntry instances")))
 
+(deftest test-map-entry-indexed-access
+  (let [e (first {:a 1})]
+    (is (= 2 (count e)) "(count entry) is 2")
+    (is (= :a (nth e 0)) "(nth entry 0) is the key")
+    (is (= 1 (nth e 1)) "(nth entry 1) is the value"))
+  (let [e (map-entry :k 42)]
+    (is (= [:b 42] (assoc e 0 :b)) "(assoc entry 0 :b) degrades to a vector")
+    (is (= :vector (type (assoc e 0 :b))) "assoc result is a vector, not a MapEntry instance")
+    (is (true? (vector? (assoc e 0 :b))) "assoc result is a vector")
+    (is (= [:k 42 :extra] (conj e :extra)) "(conj entry x) degrades to a 3-vector")
+    (is (= :vector (type (conj e :extra))) "conj result is a vector, not a MapEntry instance")
+    (is (true? (vector? (conj e :extra))) "conj result is a vector")))
+
 (deftest test-number?
   (is (true? (number? 10.0)) "number? on 10.0")
   (is (true? (number? 0.0)) "number? on 0.0")


### PR DESCRIPTION
## 🤔 Background

Closes #1871. Tracks the richer accessors discussion split out of #1868. After #1868 made \`MapEntry\` the canonical map iteration type, callers that wanted to mutate an entry hit \"assoc expects a map, vector, struct, or nil; got :map-entry\" or \"Cannot conj on type :map-entry\" because neither code path knew about the new type.

## 💡 Goal

Treat \`MapEntry\` the way Clojure treats \`clojure.lang.MapEntry\`: it iterates and indexes like a 2-vector, but mutating it produces a plain vector (the result is no longer an entry).

## 🔖 Changes

### Core
- \`assoc\` accepts \`MapEntry\`: \`(assoc (map-entry :k 42) 0 :b)\` returns \`[:b 42]\` as a \`PersistentVector\`. The result is a vector, not a \`MapEntry\` instance.
- \`conj\` accepts \`MapEntry\`: \`(conj (map-entry :k 42) :extra)\` returns \`[:k 42 :extra]\` as a 3-vector.

### Already worked (via existing interfaces)
- \`(nth entry 0)\` returns the key, \`(nth entry 1)\` returns the value (via \`FirstInterface\` / \`CdrInterface\` from #1868).
- \`(count entry)\` returns 2 via \`Countable\`.

### Tests
- \`tests/phel/test/core/type-operation.phel\` adds \`test-map-entry-indexed-access\` covering \`count\`, \`nth\`, \`assoc\`, \`conj\`, and the type assertions for the degraded result.

## 🚧 Out of scope

Making \`MapEntry\` implement \`PersistentVectorInterface\` so \`(vector? entry)\` becomes true. The current design intentionally keeps the type distinction: \`(map-entry? e)\` and \`(vector? e)\` distinguish the two roles for diagnostics and dispatch. Indexed access is the 90% interop value at 20% of the type-system cost, matching the recommendation in #1871.