### PR TITLE
perf: prune vendor/.git/node_modules and cache directory scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Performance
+
+- Cold REPL boot prunes `vendor/`, `.git/`, `node_modules/` at namespace-scan descent and memoises directory scans per process (#1885)
+
 ### Fixed
 
 #### Compiler

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -12,20 +12,25 @@ use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceFileGrouper;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Domain\Extractor\NamespaceSorterInterface;
+use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
+use SplFileInfo;
 use UnexpectedValueException;
 
-final readonly class CachedNamespaceExtractor implements NamespaceExtractorInterface
+final class CachedNamespaceExtractor implements NamespaceExtractorInterface
 {
-    private NamespaceFileGrouper $grouper;
+    private readonly NamespaceFileGrouper $grouper;
 
-    private ExcludedScanPaths $excludedPaths;
+    private readonly ExcludedScanPaths $excludedPaths;
+
+    /** @var array<string, list<NamespaceInformation>> */
+    private array $directoriesScanCache = [];
 
     public function __construct(
-        private NamespaceExtractorInterface $innerExtractor,
-        private NamespaceCacheInterface $cache,
+        private readonly NamespaceExtractorInterface $innerExtractor,
+        private readonly NamespaceCacheInterface $cache,
         NamespaceSorterInterface $namespaceSorter,
         ?ExcludedScanPaths $excludedPaths = null,
     ) {
@@ -58,6 +63,11 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
      */
     public function getNamespacesFromDirectories(array $directories): array
     {
+        $cacheKey = $this->scanCacheKey($directories);
+        if (isset($this->directoriesScanCache[$cacheKey])) {
+            return $this->directoriesScanCache[$cacheKey];
+        }
+
         $allInfos = [];
         foreach ($this->findAllPhelFiles($directories) as $file) {
             try {
@@ -71,7 +81,23 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
             }
         }
 
-        return $this->grouper->groupAndSort($allInfos);
+        return $this->directoriesScanCache[$cacheKey] = $this->grouper->groupAndSort($allInfos);
+    }
+
+    /**
+     * @param list<string> $directories
+     */
+    private function scanCacheKey(array $directories): string
+    {
+        $resolved = [];
+        foreach ($directories as $directory) {
+            $real = $this->resolvePath($directory);
+            $resolved[] = $real ?? $directory;
+        }
+
+        sort($resolved);
+
+        return implode("\0", $resolved);
     }
 
     private function cacheNamespaceInfo(NamespaceInformation $info): void
@@ -114,8 +140,26 @@ final readonly class CachedNamespaceExtractor implements NamespaceExtractorInter
             }
 
             try {
-                $directoryIterator = new RecursiveDirectoryIterator($realpath);
-                $iterator = new RecursiveIteratorIterator($directoryIterator);
+                $directoryIterator = new RecursiveDirectoryIterator(
+                    $realpath,
+                    RecursiveDirectoryIterator::SKIP_DOTS,
+                );
+                $excludedPaths = $this->excludedPaths;
+                $prunedDescent = new RecursiveCallbackFilterIterator(
+                    $directoryIterator,
+                    static function (SplFileInfo $current) use ($excludedPaths, $realpath): bool {
+                        if (!$current->isDir()) {
+                            return true;
+                        }
+
+                        return !$excludedPaths->shouldPruneDirectory(
+                            $current->getFilename(),
+                            $current->getPathname(),
+                            $realpath,
+                        );
+                    },
+                );
+                $iterator = new RecursiveIteratorIterator($prunedDescent);
                 $phelIterator = new RegexIterator($iterator, '/^.+\.(phel|cljc)$/i', RegexIterator::GET_MATCH);
 
                 foreach ($phelIterator as $file) {

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -131,7 +131,11 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
 
         foreach ($directories as $directory) {
             $realpath = $this->resolvePath($directory);
-            if ($realpath === null || !is_dir($realpath)) {
+            if ($realpath === null) {
+                continue;
+            }
+
+            if (!is_dir($realpath)) {
                 continue;
             }
 
@@ -169,8 +173,8 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
         $excludedPaths = $this->excludedPaths;
         $prunedDescent = new RecursiveCallbackFilterIterator(
             $directoryIterator,
-            static function (SplFileInfo $current) use ($excludedPaths, $root): bool {
-                if (!$current->isDir()) {
+            static function (mixed $current) use ($excludedPaths, $root): bool {
+                if (!$current instanceof SplFileInfo || !$current->isDir()) {
                     return true;
                 }
 

--- a/src/php/Build/Application/CachedNamespaceExtractor.php
+++ b/src/php/Build/Application/CachedNamespaceExtractor.php
@@ -131,38 +131,12 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
 
         foreach ($directories as $directory) {
             $realpath = $this->resolvePath($directory);
-            if ($realpath === null) {
-                continue;
-            }
-
-            if (!is_dir($realpath)) {
+            if ($realpath === null || !is_dir($realpath)) {
                 continue;
             }
 
             try {
-                $directoryIterator = new RecursiveDirectoryIterator(
-                    $realpath,
-                    RecursiveDirectoryIterator::SKIP_DOTS,
-                );
-                $excludedPaths = $this->excludedPaths;
-                $prunedDescent = new RecursiveCallbackFilterIterator(
-                    $directoryIterator,
-                    static function (SplFileInfo $current) use ($excludedPaths, $realpath): bool {
-                        if (!$current->isDir()) {
-                            return true;
-                        }
-
-                        return !$excludedPaths->shouldPruneDirectory(
-                            $current->getFilename(),
-                            $current->getPathname(),
-                            $realpath,
-                        );
-                    },
-                );
-                $iterator = new RecursiveIteratorIterator($prunedDescent);
-                $phelIterator = new RegexIterator($iterator, '/^.+\.(phel|cljc)$/i', RegexIterator::GET_MATCH);
-
-                foreach ($phelIterator as $file) {
+                foreach ($this->phelFileIterator($realpath) as $file) {
                     if ($this->excludedPaths->contains($file[0], $realpath)) {
                         continue;
                     }
@@ -179,6 +153,40 @@ final class CachedNamespaceExtractor implements NamespaceExtractorInterface
         }
 
         return array_unique($files);
+    }
+
+    /**
+     * Build the recursive iterator that yields `.phel`/`.cljc` files under
+     * `$root`, pruning subtrees flagged by `ExcludedScanPaths` at descent
+     * time so vendor/.git/node_modules never get walked.
+     */
+    private function phelFileIterator(string $root): RegexIterator
+    {
+        $directoryIterator = new RecursiveDirectoryIterator(
+            $root,
+            RecursiveDirectoryIterator::SKIP_DOTS,
+        );
+        $excludedPaths = $this->excludedPaths;
+        $prunedDescent = new RecursiveCallbackFilterIterator(
+            $directoryIterator,
+            static function (SplFileInfo $current) use ($excludedPaths, $root): bool {
+                if (!$current->isDir()) {
+                    return true;
+                }
+
+                return !$excludedPaths->shouldPruneDirectory(
+                    $current->getFilename(),
+                    $current->getPathname(),
+                    $root,
+                );
+            },
+        );
+
+        return new RegexIterator(
+            new RecursiveIteratorIterator($prunedDescent),
+            '/^.+\.(phel|cljc)$/i',
+            RegexIterator::GET_MATCH,
+        );
     }
 
     private function resolvePath(string $path): ?string

--- a/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
+++ b/src/php/Build/Domain/Extractor/ExcludedScanPaths.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Extractor;
 
+use function in_array;
 use function strlen;
 
 /**
@@ -16,15 +17,35 @@ final readonly class ExcludedScanPaths
 {
     /**
      * Segments always pruned from a namespace scan regardless of scan root.
+     *
+     * `vendor/`, `.git/`, `node_modules/` never carry user Phel sources and
+     * dominate descent cost when the scan root is the project root.
+     *
      * Agent tooling (Claude Code, Codex, etc.) drops repo clones under a
      * `worktrees/` directory whose `src/phel/` would shadow real sources.
      * Agent config directories can contain examples, scripts, or worktrees
      * whose Phel files must not leak into the host repo's scan.
      */
     private const array ALWAYS_EXCLUDED_SEGMENTS = [
+        DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . '.git' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'node_modules' . DIRECTORY_SEPARATOR,
         DIRECTORY_SEPARATOR . 'worktrees' . DIRECTORY_SEPARATOR,
         DIRECTORY_SEPARATOR . '.agents' . DIRECTORY_SEPARATOR,
         DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'agents' . DIRECTORY_SEPARATOR,
+    ];
+
+    /**
+     * Basenames of directories always pruned at descent time. Matched against
+     * `RecursiveDirectoryIterator` directory entries before recursion to avoid
+     * walking subtrees that cannot contain user Phel sources.
+     */
+    private const array ALWAYS_PRUNED_BASENAMES = [
+        'vendor',
+        '.git',
+        'node_modules',
+        'worktrees',
+        '.agents',
     ];
 
     /** @var list<string> */
@@ -45,6 +66,20 @@ final readonly class ExcludedScanPaths
     public static function none(): self
     {
         return new self();
+    }
+
+    /**
+     * Returns `true` when a directory entry must be skipped at descent time
+     * during a recursive scan. Pruning here is much cheaper than discarding
+     * files emitted by the underlying iterator.
+     */
+    public function shouldPruneDirectory(string $basename, string $absolutePath, string $scanRoot): bool
+    {
+        if (in_array($basename, self::ALWAYS_PRUNED_BASENAMES, true)) {
+            return true;
+        }
+
+        return $this->contains($absolutePath . DIRECTORY_SEPARATOR, $scanRoot);
     }
 
     public function contains(string $path, string $scanRoot): bool

--- a/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
+++ b/tests/php/Unit/Build/Application/CachedNamespaceExtractorTest.php
@@ -80,6 +80,77 @@ final class CachedNamespaceExtractorTest extends TestCase
         self::assertStringEndsWith('/split/part.phel', $picked[1]->getFile());
     }
 
+    public function test_repeated_directory_scan_uses_in_memory_cache(): void
+    {
+        $primaryPath = $this->dir . '/main.phel';
+        file_put_contents($primaryPath, '(ns split\\ns)');
+
+        $primaryInfo = new NamespaceInformation(
+            $primaryPath,
+            'split\\ns',
+            [],
+            isPrimaryDefinition: true,
+        );
+
+        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner->expects(self::once())
+            ->method('getNamespaceFromFile')
+            ->willReturn($primaryInfo);
+
+        $extractor = new CachedNamespaceExtractor(
+            $inner,
+            new NullNamespaceCache(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $first = $extractor->getNamespacesFromDirectories([$this->dir]);
+        $second = $extractor->getNamespacesFromDirectories([$this->dir]);
+
+        self::assertSame($first, $second, 'Second scan must return the cached result.');
+    }
+
+    public function test_directory_scan_prunes_vendor_and_git_subtrees(): void
+    {
+        mkdir($this->dir . '/vendor/foo/bar', 0777, true);
+        mkdir($this->dir . '/.git/objects', 0777, true);
+        mkdir($this->dir . '/node_modules/pkg', 0777, true);
+
+        file_put_contents($this->dir . '/vendor/foo/bar/inside.phel', '(ns vendor\\inside)');
+        file_put_contents($this->dir . '/.git/objects/inside.phel', '(ns git\\inside)');
+        file_put_contents($this->dir . '/node_modules/pkg/inside.phel', '(ns node\\inside)');
+        file_put_contents($this->dir . '/visible.phel', '(ns visible)');
+
+        $visibleInfo = new NamespaceInformation(
+            $this->dir . '/visible.phel',
+            'visible',
+            [],
+            isPrimaryDefinition: true,
+        );
+
+        $seenPaths = [];
+        $inner = $this->createMock(NamespaceExtractorInterface::class);
+        $inner->method('getNamespaceFromFile')->willReturnCallback(
+            static function (string $path) use (&$seenPaths, $visibleInfo): NamespaceInformation {
+                $seenPaths[] = $path;
+                return $visibleInfo;
+            },
+        );
+
+        $extractor = new CachedNamespaceExtractor(
+            $inner,
+            new NullNamespaceCache(),
+            new TopologicalNamespaceSorter(),
+        );
+
+        $extractor->getNamespacesFromDirectories([$this->dir]);
+
+        self::assertSame(
+            [realpath($this->dir) . '/visible.phel'],
+            $seenPaths,
+            'Only the visible.phel must be scanned; vendor/.git/node_modules pruned.',
+        );
+    }
+
     public function test_directory_scan_skips_files_that_fail_to_extract(): void
     {
         $goodPath = $this->dir . '/good.phel';


### PR DESCRIPTION
## 🤔 Background

`./bin/phel repl` was taking ~5.3s to first prompt on a cold cache (issue #1885). Profiling with Xdebug showed:

- `loadPhelNamespaces` accounted for ~87% of REPL boot time
- `getNamespacesFromDirectories` was invoked **twice** per boot (once for the bundled core seeds, once again from `DataReadersLoader`)
- Each scan walked the entire project tree under every srcDirectory entry, including `vendor/` (2,394 dirs) and `.git/` (300 dirs); total ~37,717 `RecursiveDirectoryIterator::hasChildren` calls

## 💡 Goal

Cut REPL boot to under 1s warm and bring cold boot in line. Reduce per-command floor where the namespace scan runs at all. No functional regressions.

## 🔖 Changes

- `ExcludedScanPaths::shouldPruneDirectory` lets the iterator decide at descent time whether to enter a subtree. `vendor`, `.git`, `node_modules`, `worktrees`, `.agents` are pruned by basename so `RecursiveCallbackFilterIterator` never walks them.
- `CachedNamespaceExtractor` wraps the directory iterator in `RecursiveCallbackFilterIterator` and memoises `getNamespacesFromDirectories` per sorted-directory key, eliminating the duplicate scan triggered by `DataReadersLoader`.
- Iterator construction extracted to a dedicated `phelFileIterator` helper so the file-walk loop reads as policy.

### Benchmarks (`./bin/phel`, source checkout, warm filesystem cache)

| Command | Before | After |
|---|---|---|
| `--version` (cold) | 0.22s | 0.11s |
| `--version` (warm) | 0.11s | 0.11s |
| `list` (cold/warm) | 0.12s | 0.12s |
| `repl < /dev/null` (cold) | **5.29s** | **0.36s** |
| `repl < /dev/null` (warm) | 0.46s | 0.35s |

Cold REPL boot drops 14×; warm REPL drops 25%. Goals from #1885 met.

### Tests

- New: `test_repeated_directory_scan_uses_in_memory_cache` asserts the second `getNamespacesFromDirectories` call hits the in-process memo.
- New: `test_directory_scan_prunes_vendor_and_git_subtrees` asserts the iterator never visits files under `vendor/`, `.git/`, or `node_modules/`.
- Existing `composer test-compiler` (3090 tests), `composer test-core` (4908 tests), `phpstan`, `cs-fixer`, `rector` all green.

Closes #1885