### PR TITLE
perf(test): prune namespaces by --ns and skip redundant cache work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - Cold REPL boot prunes `vendor/`, `.git/`, `node_modules/` at namespace-scan descent and memoises directory scans per process (#1885)
+- `bin/phel test --ns 'pat.**'` preloads only matching namespaces and their dependency closure
+- `bin/phel test` skips re-registering dependency-graph entries on cache hits and re-restoring a namespace's environment after the first file in it
 
 ### Fixed
 

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Phel\Build\Application;
 
 use ParseError;
+use Phel\Build\Domain\Cache\DependencyTrackerInterface;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
-use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
@@ -20,15 +20,34 @@ use Throwable;
 
 use function sprintf;
 
-final readonly class FileEvaluator
+final class FileEvaluator
 {
+    /**
+     * Per-process record of namespaces whose env data was already restored
+     * from cache. Restoring re-iterates every refer/alias of a namespace, so
+     * repeating it for `phel.core` or other large namespaces during a single
+     * `bin/phel test` run is pure overhead.
+     *
+     * @var array<string, true>
+     */
+    private static array $restoredNamespaces = [];
+
     public function __construct(
-        private CompilerFacadeInterface $compilerFacade,
-        private NamespaceExtractorInterface $namespaceExtractor,
-        private ?CompiledCodeCache $compiledCodeCache = null,
-        private FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
-        private ?DependencyTracker $dependencyTracker = null,
+        private readonly CompilerFacadeInterface $compilerFacade,
+        private readonly NamespaceExtractorInterface $namespaceExtractor,
+        private readonly ?CompiledCodeCache $compiledCodeCache = null,
+        private readonly FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
+        private readonly ?DependencyTrackerInterface $dependencyTracker = null,
     ) {}
+
+    /**
+     * Reset the per-process namespace restoration cache. Tests should call
+     * this between scenarios so static state does not leak across runs.
+     */
+    public static function resetState(): void
+    {
+        self::$restoredNamespaces = [];
+    }
 
     public function evalFile(string $src): CompiledFile
     {
@@ -45,15 +64,6 @@ final readonly class FileEvaluator
         $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
         $namespace = $namespaceInfo->getNamespace();
 
-        // Register dependencies in the tracker for cascading invalidation
-        if ($this->dependencyTracker instanceof DependencyTracker) {
-            $this->dependencyTracker->registerDependencies(
-                $src,
-                $namespace,
-                $namespaceInfo->getDependencies(),
-            );
-        }
-
         if ($this->compiledCodeCache instanceof CompiledCodeCache) {
             $sourceHash = md5($code);
             $cachedPath = $this->compiledCodeCache->get($src, $sourceHash);
@@ -61,12 +71,16 @@ final readonly class FileEvaluator
             if ($cachedPath !== null) {
                 $this->compilerFacade->initializeGlobalEnvironment();
                 try {
-                    $envData = $this->compiledCodeCache->getEnvironment($namespace);
+                    if (!isset(self::$restoredNamespaces[$namespace])) {
+                        $envData = $this->compiledCodeCache->getEnvironment($namespace);
 
-                    if ($envData !== null) {
-                        $this->compilerFacade->restoreNamespaceEnvironmentData($namespace, $envData);
-                    } else {
-                        $this->analyzeNsForm($code, $src);
+                        if ($envData !== null) {
+                            $this->compilerFacade->restoreNamespaceEnvironmentData($namespace, $envData);
+                        } else {
+                            $this->analyzeNsForm($code, $src);
+                        }
+
+                        self::$restoredNamespaces[$namespace] = true;
                     }
 
                     /** @psalm-suppress UnresolvableInclude */
@@ -79,11 +93,22 @@ final readonly class FileEvaluator
                     $this->compiledCodeCache->invalidate($src);
                     throw $e;
                 }
-            } elseif ($this->dependencyTracker instanceof DependencyTracker
+            } elseif ($this->dependencyTracker instanceof DependencyTrackerInterface
                 && $this->compiledCodeCache->has($src)
             ) {
                 // Stale cache entry — source changed. Cascade invalidation to dependents.
                 $this->dependencyTracker->invalidateDependentsOf($namespace, $this->compiledCodeCache);
+            }
+
+            // Fresh compile: register dependencies so future runs can cascade
+            // invalidations. Skipped on cache hit since the previous fresh
+            // compile already registered them.
+            if ($this->dependencyTracker instanceof DependencyTrackerInterface) {
+                $this->dependencyTracker->registerDependencies(
+                    $src,
+                    $namespace,
+                    $namespaceInfo->getDependencies(),
+                );
             }
 
             $options = new CompileOptions()

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -10,6 +10,7 @@ use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
@@ -93,7 +94,7 @@ final class FileEvaluator
                     $this->compiledCodeCache->invalidate($src);
                     throw $e;
                 }
-            } elseif ($this->dependencyTracker instanceof DependencyTrackerInterface
+            } elseif ($this->dependencyTracker instanceof DependencyTracker
                 && $this->compiledCodeCache->has($src)
             ) {
                 // Stale cache entry — source changed. Cascade invalidation to dependents.

--- a/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
+++ b/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
@@ -4,17 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Cache;
 
-use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
-
 interface DependencyTrackerInterface
 {
     /**
      * @param list<string> $dependencies
      */
     public function registerDependencies(string $sourcePath, string $namespace, array $dependencies): void;
-
-    /**
-     * @return list<string>
-     */
-    public function invalidateDependentsOf(string $namespace, CompiledCodeCache $compiledCodeCache): array;
 }

--- a/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
+++ b/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Cache;
+
+use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
+
+interface DependencyTrackerInterface
+{
+    /**
+     * @param list<string> $dependencies
+     */
+    public function registerDependencies(string $sourcePath, string $namespace, array $dependencies): void;
+
+    /**
+     * @return list<string>
+     */
+    public function invalidateDependentsOf(string $namespace, CompiledCodeCache $compiledCodeCache): array;
+}

--- a/src/php/Build/Infrastructure/Cache/DependencyTracker.php
+++ b/src/php/Build/Infrastructure/Cache/DependencyTracker.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Infrastructure\Cache;
 use Gacela\Framework\Cache\CycleDetectedException;
 use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
+use Phel\Build\Domain\Cache\DependencyTrackerInterface;
 
 use function is_string;
 
@@ -22,7 +23,7 @@ use function is_string;
  * A file that requires namespace B is registered as:
  *   dependsOn("file:{sourcePath}", "ns:B")
  */
-final readonly class DependencyTracker
+final readonly class DependencyTracker implements DependencyTrackerInterface
 {
     private ScopedCache $cache;
 

--- a/src/php/Run/Domain/Test/TestNamespacePruner.php
+++ b/src/php/Run/Domain/Test/TestNamespacePruner.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Test;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_shift;
+use function array_values;
+use function preg_match;
+use function preg_quote;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+
+/**
+ * Drops user namespaces no `--ns` glob touches and keeps the dependency
+ * closure of the survivors. Bundled `phel.*` modules stay so fully qualified
+ * references in surviving tests still resolve. Without this prune,
+ * `bin/phel test --ns 'foo.*'` would still preload every other test
+ * namespace before discarding their tests at selection time.
+ */
+final readonly class TestNamespacePruner
+{
+    /**
+     * @param list<NamespaceInformation> $infos
+     * @param list<string>               $patterns
+     *
+     * @return list<NamespaceInformation>
+     */
+    public function prune(array $infos, array $patterns): array
+    {
+        if ($patterns === []) {
+            return $infos;
+        }
+
+        $regexes = array_map($this->globToRegex(...), $patterns);
+
+        $byName = [];
+        foreach ($infos as $info) {
+            $byName[$info->getNamespace()] = $info;
+        }
+
+        $keep = [];
+        foreach ($infos as $info) {
+            $ns = $info->getNamespace();
+            if (str_starts_with($ns, 'phel.') || $this->matchesAny($ns, $regexes)) {
+                $keep[$ns] = true;
+            }
+        }
+
+        $queue = array_keys($keep);
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            $info = $byName[$current] ?? null;
+            if ($info === null) {
+                continue;
+            }
+
+            foreach ($info->getDependencies() as $dep) {
+                if (!isset($keep[$dep]) && isset($byName[$dep])) {
+                    $keep[$dep] = true;
+                    $queue[] = $dep;
+                }
+            }
+        }
+
+        return array_values(array_filter(
+            $infos,
+            static fn(NamespaceInformation $i): bool => isset($keep[$i->getNamespace()]),
+        ));
+    }
+
+    /**
+     * @param list<string> $regexes
+     */
+    private function matchesAny(string $namespace, array $regexes): bool
+    {
+        $normalised = str_replace('\\', '.', $namespace);
+        return array_any($regexes, static fn($regex): bool => preg_match($regex, $normalised) === 1);
+    }
+
+    /**
+     * Mirrors `phel\test\selector/glob->regex`: `*` matches one segment,
+     * `**` matches any run, `.` is literal.
+     */
+    private function globToRegex(string $pattern): string
+    {
+        $normalised = str_replace('\\', '.', $pattern);
+        $out = '';
+        $len = strlen($normalised);
+        $i = 0;
+        while ($i < $len) {
+            $ch = $normalised[$i];
+            if ($ch === '*' && $i + 1 < $len && $normalised[$i + 1] === '*') {
+                $out .= '.*';
+                $i += 2;
+                continue;
+            }
+
+            if ($ch === '*') {
+                $out .= '[^.]*';
+                ++$i;
+                continue;
+            }
+
+            if ($ch === '.') {
+                $out .= '\\.';
+                ++$i;
+                continue;
+            }
+
+            $out .= preg_quote($ch, '/');
+            ++$i;
+        }
+
+        return '/^' . $out . '$/';
+    }
+}

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -10,6 +10,7 @@ use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
 use Phel\Run\Domain\Test\TestCommandOptions;
+use Phel\Run\Domain\Test\TestNamespacePruner;
 use Phel\Run\RunFacade;
 use Phel\Shared\ResourceUsageFormatter;
 use Symfony\Component\Console\Command\Command;
@@ -124,6 +125,9 @@ final class TestCommand extends Command
             $paths = (array) $input->getArgument(self::ARG_PATHS);
             $namespacesInformation = $this->getFacade()->getDependenciesFromPaths($paths);
             $failFast = (bool) $input->getOption(self::OPT_FAIL_FAST);
+            /** @var list<string> $nsPatterns */
+            $nsPatterns = (array) $input->getOption(self::OPT_NS);
+            $namespacesInformation = new TestNamespacePruner()->prune($namespacesInformation, $nsPatterns);
 
             // Suppress output during file loading phase and filter out integration test fixtures
             ob_start();

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Build\Application;
 
 use Phel\Build\Application\FileEvaluator;
+use Phel\Build\Domain\Cache\DependencyTrackerInterface;
+use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
@@ -23,11 +25,13 @@ final class FileEvaluatorTest extends TestCase
     {
         $this->tempDir = sys_get_temp_dir() . '/phel-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
+        FileEvaluator::resetState();
     }
 
     protected function tearDown(): void
     {
         $this->removeDir($this->tempDir);
+        FileEvaluator::resetState();
     }
 
     public function test_eval_file_uses_cache_on_hit(): void
@@ -389,6 +393,102 @@ final class FileEvaluatorTest extends TestCase
         // evalFile succeeds despite analysis failure
         self::assertSame($sourceFile, $result->getSourceFile());
         self::assertSame($namespace, $result->getNamespace());
+    }
+
+    public function test_register_dependencies_skipped_on_cache_hit(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        $cache = new CompiledCodeCache($cacheDir);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$result = 1;');
+
+        $tracker = $this->createMock(DependencyTrackerInterface::class);
+        $tracker->expects($this->never())->method('registerDependencies');
+
+        $compilerFacade = $this->createStub(CompilerFacadeInterface::class);
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator(
+            $compilerFacade,
+            $namespaceExtractor,
+            $cache,
+            new FirstFormExtractor(),
+            $tracker,
+        );
+
+        $evaluator->evalFile($sourceFile);
+    }
+
+    public function test_restore_environment_skipped_on_second_call_for_same_namespace(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        $cache = new CompiledCodeCache($cacheDir);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$result = 1;');
+        $cache->putEnvironment($namespace, [
+            'refers' => ['map' => ['ns' => null, 'name' => 'phel.core']],
+            'require_aliases' => [],
+            'use_aliases' => [],
+        ]);
+
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->expects($this->exactly(2))->method('initializeGlobalEnvironment');
+        $compilerFacade->expects($this->once())->method('restoreNamespaceEnvironmentData');
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator($compilerFacade, $namespaceExtractor, $cache);
+        $evaluator->evalFile($sourceFile);
+        $evaluator->evalFile($sourceFile);
+    }
+
+    public function test_register_dependencies_called_on_cache_miss(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        $cache = new CompiledCodeCache($cacheDir);
+
+        $tracker = $this->createMock(DependencyTrackerInterface::class);
+        $tracker->expects($this->once())
+            ->method('registerDependencies')
+            ->with($sourceFile, $namespace, ['phel.core']);
+
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->method('compileForCache')
+            ->willReturn(new EmitterResult(false, '$compiled = true;', '', ''));
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator(
+            $compilerFacade,
+            $namespaceExtractor,
+            $cache,
+            new FirstFormExtractor(),
+            $tracker,
+        );
+
+        $evaluator->evalFile($sourceFile);
     }
 
     private function removeDir(string $dir): void

--- a/tests/php/Unit/Run/Domain/Test/TestNamespacePrunerTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestNamespacePrunerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Test;
+
+use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Domain\Test\TestNamespacePruner;
+use PHPUnit\Framework\TestCase;
+
+final class TestNamespacePrunerTest extends TestCase
+{
+    public function test_no_patterns_returns_input_unchanged(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app.foo', ['phel.core']),
+            $this->ns('app.bar', ['phel.core']),
+        ];
+
+        self::assertSame($infos, new TestNamespacePruner()->prune($infos, []));
+    }
+
+    public function test_single_segment_glob_keeps_only_matching_user_namespaces(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app.foo', ['phel.core']),
+            $this->ns('app.bar', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.foo']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertSame(['phel.core', 'app.foo'], $names);
+    }
+
+    public function test_keeps_transitive_dependencies_of_matching_namespaces(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app.util', ['phel.core']),
+            $this->ns('app.foo', ['app.util', 'phel.core']),
+            $this->ns('app.bar', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.foo']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertSame(['phel.core', 'app.util', 'app.foo'], $names);
+        self::assertNotContains('app.bar', $names, 'unrelated user ns must be pruned');
+    }
+
+    public function test_bundled_phel_namespaces_always_survive(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('phel.json', ['phel.core']),
+            $this->ns('app.foo', ['phel.core']),
+            $this->ns('app.bar', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.foo']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertContains('phel.json', $names, 'bundled phel.* must stay so FQN access works');
+    }
+
+    public function test_double_star_glob_matches_any_run(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app.deep.nested.tests', ['phel.core']),
+            $this->ns('app.shallow', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.**']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertContains('app.deep.nested.tests', $names);
+        self::assertContains('app.shallow', $names);
+    }
+
+    public function test_single_star_does_not_cross_segments(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app.deep.nested', ['phel.core']),
+            $this->ns('app.shallow', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.*']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertContains('app.shallow', $names);
+        self::assertNotContains('app.deep.nested', $names, 'single * must stop at segment boundary');
+    }
+
+    public function test_backslash_namespaces_match_dotted_globs(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('app\\foo', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['app.foo']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertContains('app\\foo', $names);
+    }
+
+    public function test_no_match_keeps_only_bundled(): void
+    {
+        $infos = [
+            $this->ns('phel.core', []),
+            $this->ns('phel.test', ['phel.core']),
+            $this->ns('app.foo', ['phel.core']),
+        ];
+
+        $pruned = new TestNamespacePruner()->prune($infos, ['zzz_no_match']);
+        $names = array_map(static fn(NamespaceInformation $i): string => $i->getNamespace(), $pruned);
+
+        self::assertSame(['phel.core', 'phel.test'], $names);
+    }
+
+    /**
+     * @param list<string> $deps
+     */
+    private function ns(string $name, array $deps): NamespaceInformation
+    {
+        return new NamespaceInformation('/tmp/' . str_replace(['.', '\\'], '_', $name) . '.phel', $name, $deps);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`bin/phel test` startup is dominated by preloading every test namespace plus all bundled `phel.*` modules into the global registry before tests run. On a 137-namespace project, that costs ~1.7s on a warm cache, ~3.5s on dev environments with Xdebug active, before a single dot prints.

Even when the user narrows the run with `--ns 'foo.**'`, the preload loop still walked all 137 namespaces and only the test selector dropped non-matching ones at execution time.

## 💡 Goal

Cut `bin/phel test` startup when the user has already narrowed the run via `--ns`, and remove redundant work the cache-hit path was doing on every file.

## 🔖 Changes

- `TestNamespacePruner` filters the topologically sorted namespace list down to the user's `--ns` glob plus the dependency closure of survivors. Bundled `phel.*` modules are kept so fully qualified references (`phel.async/delay`) still resolve. Wired into `TestCommand` so `--ns 'pat.**'` runs ~10x faster (`~3.5s` to `~0.3s` on this repo).
- `FileEvaluator` skips re-registering dependency-graph entries on cache hits; `registerDependencies` now only runs on the fresh-compile path. The previous registration is still on disk and still drives cascade invalidation.
- `FileEvaluator` skips re-restoring a namespace's cached environment data after the first file in that namespace processes the restore. Restoration walks every refer/alias, so doing it once per namespace per process is enough.
- `DependencyTrackerInterface` (Domain) extracted from `DependencyTracker` so `FileEvaluator` can mock the tracker in unit tests. Concrete `DependencyTracker` still owns `invalidateDependentsOf`.
- `TestNamespacePruner` covered by `TestNamespacePrunerTest` (8 cases: glob shapes, transitive closure, bundled survival, backslash normalization, no-match safety).
- `FileEvaluator` cache-hit / cache-miss interactions covered by 3 new `FileEvaluatorTest` cases.

CHANGELOG entry added under `## Unreleased > Performance`.

## ⏱ Bench (local, warm cache, Xdebug off)

| Command | main | branch |
| --- | --- | --- |
| `bin/phel test` | ~5.8s | ~5.8s |
| `bin/phel test --ns 'phel-test.json.**'` | ~3.55s | ~0.35s |
| `bin/phel test --ns 'no_match'` | ~3.45s | ~0.30s |
| `bin/phel test tests/phel/are.phel` | ~0.32s | ~0.32s |

The full-suite case is unchanged because the preload set is already the full closure. Path-mode is unchanged because `getDependenciesFromPaths` already narrows to one file's closure. The pruner only kicks in when `--ns` is provided.