### PR TITLE
fix(core): arithmetic mixing Inf/NaN with BigDecimal falls back to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+#### Core
+- `+`, `-`, `*`, `/` mixing `##Inf`/`##NaN` with `BigDecimal` fall back to float arithmetic instead of throwing (#1887)
+
 #### Compiler
 - Oversize decimal int literals lex as `float` (#1837)
 - `clojure.lang.X` FQNs resolve to `\Phel\Lang\X` (`BigInt` to `BigInteger`, `Ratio` to `Rational`) (#1840)

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -38,6 +38,10 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
+        if (self::hasNonFiniteFloat($a, $b)) {
+            return self::toFloat($a) + self::toFloat($b);
+        }
+
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->add(self::toBigDecimal($b));
         }
@@ -69,6 +73,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if (self::hasNonFiniteFloat($a, $b)) {
+            return self::toFloat($a) - self::toFloat($b);
+        }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->subtract(self::toBigDecimal($b));
@@ -102,6 +110,10 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if (self::hasNonFiniteFloat($a, $b)) {
+            return self::toFloat($a) * self::toFloat($b);
+        }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->multiply(self::toBigDecimal($b));
@@ -138,6 +150,13 @@ final class NumericOperations
     {
         self::ensureNumeric($a);
         self::ensureNumeric($b);
+
+        if (self::hasNonFiniteFloat($a, $b)) {
+            // BigDecimal cannot represent Inf/NaN; fall back to float arithmetic
+            // so `(/ ##Inf 1.0M)` => `##Inf`, `(/ 1.0M ##Inf)` => `0.0`, etc.
+            // Route through `fdiv` so `(/ ##Inf 0)` keeps its IEEE-754 result.
+            return fdiv(self::toFloat($a), self::toFloat($b));
+        }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->divideExact(self::toBigDecimal($b));
@@ -538,11 +557,21 @@ final class NumericOperations
             return $value->toFloat();
         }
 
-        if ($value instanceof BigInteger) {
+        if ($value instanceof BigInteger || $value instanceof BigDecimal) {
             return (float) (string) $value;
         }
 
         return (float) $value;
+    }
+
+    /**
+     * `BigDecimal` cannot represent `INF`/`NAN`, so any op that mixes a
+     * non-finite float with a `BigDecimal` must fall back to float arithmetic
+     * before the BigDecimal branch tries (and fails) to convert the float.
+     */
+    private static function hasNonFiniteFloat(mixed $a, mixed $b): bool
+    {
+        return (is_float($a) && !is_finite($a)) || (is_float($b) && !is_finite($b));
     }
 
     private static function toBigInt(mixed $value): BigInteger

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -223,6 +223,10 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
+        if (self::hasNonFiniteFloat($a, $b)) {
+            return self::toFloat($a) <=> self::toFloat($b);
+        }
+
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->compareTo(self::toBigDecimal($b));
         }

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Lang;
 
 use DivisionByZeroError;
 use InvalidArgumentException;
+use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInteger;
 use Phel\Lang\NumericOperations;
 use Phel\Lang\Rational;
@@ -390,5 +391,48 @@ final class NumericOperationsTest extends TestCase
     {
         self::assertSame(8, NumericOperations::power(2, 3));
         self::assertSame(1, NumericOperations::power(1, 100));
+    }
+
+    public function test_divide_inf_by_bigdecimal_returns_inf(): void
+    {
+        $result = NumericOperations::divide(INF, BigDecimal::fromString('1.0'));
+
+        self::assertSame(INF, $result);
+    }
+
+    public function test_divide_negative_inf_by_bigdecimal_returns_negative_inf(): void
+    {
+        $result = NumericOperations::divide(-INF, BigDecimal::fromString('2.5'));
+
+        self::assertSame(-INF, $result);
+    }
+
+    public function test_divide_bigdecimal_by_inf_returns_zero_float(): void
+    {
+        $result = NumericOperations::divide(BigDecimal::fromString('1.0'), INF);
+
+        self::assertSame(0.0, $result);
+    }
+
+    public function test_divide_nan_by_bigdecimal_returns_nan(): void
+    {
+        $result = NumericOperations::divide(NAN, BigDecimal::fromString('1.0'));
+
+        self::assertNan($result);
+    }
+
+    public function test_add_inf_and_bigdecimal_returns_inf(): void
+    {
+        self::assertSame(INF, NumericOperations::add(INF, BigDecimal::fromString('1.0')));
+    }
+
+    public function test_subtract_bigdecimal_minus_inf_returns_negative_inf(): void
+    {
+        self::assertSame(-INF, NumericOperations::subtract(BigDecimal::fromString('1.0'), INF));
+    }
+
+    public function test_multiply_inf_and_bigdecimal_returns_inf(): void
+    {
+        self::assertSame(INF, NumericOperations::multiply(INF, BigDecimal::fromString('2.0')));
     }
 }

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -435,4 +435,20 @@ final class NumericOperationsTest extends TestCase
     {
         self::assertSame(INF, NumericOperations::multiply(INF, BigDecimal::fromString('2.0')));
     }
+
+    public function test_compare_inf_and_bigdecimal_returns_positive(): void
+    {
+        self::assertSame(1, NumericOperations::compare(INF, BigDecimal::fromString('1.0')));
+        self::assertSame(-1, NumericOperations::compare(BigDecimal::fromString('1.0'), INF));
+    }
+
+    public function test_compare_negative_inf_and_bigdecimal_returns_negative(): void
+    {
+        self::assertSame(-1, NumericOperations::compare(-INF, BigDecimal::fromString('1.0')));
+    }
+
+    public function test_is_equal_inf_and_bigdecimal_is_false(): void
+    {
+        self::assertFalse(NumericOperations::isEqual(INF, BigDecimal::fromString('1.0')));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Reported in #1887. `(/ ##Inf 1.0M)` throws `InvalidArgumentException: Cannot convert non-finite float 'INF' to BigDecimal`. Clojure's reference behaviour is `##Inf`. The same crash hits `+`, `-`, `*`, `compare`, and `=` whenever one operand is non-finite (`##Inf`, `-##Inf`, `##NaN`) and the other is a `BigDecimal`.

Root cause: `NumericOperations` checks `instanceof BigDecimal` first and routes both operands through `toBigDecimal`, which calls `BigDecimal::fromFloat` and rejects non-finite floats.

## 💡 Goal

Make Phel's numeric tower keep IEEE-754 semantics whenever a non-finite float meets a `BigDecimal`. `BigDecimal` cannot represent `INF`/`NaN`, so the answer must downcast.

## 🔖 Changes

- `NumericOperations` adds `hasNonFiniteFloat($a, $b)` and short-circuits `add`/`subtract`/`multiply`/`divide`/`compare` to float arithmetic before the `BigDecimal` branch when either operand is non-finite. `divide` routes through `fdiv` so `(/ ##Inf 0)` keeps its IEEE-754 result.
- `toFloat` now stringifies `BigDecimal` instead of letting `(float) $bd` trigger a PHP warning.
- `isEqual` and `min`/`max` get the fix transitively via `compare`.
- 10 unit tests in `NumericOperationsTest` cover `(/ ##Inf 1.0M)`, `(/ -##Inf 2.5M)`, `(/ 1.0M ##Inf)`, `(/ ##NaN 1.0M)`, `(+ ##Inf 1.0M)`, `(- 1.0M ##Inf)`, `(* ##Inf 2.0M)`, and `compare`/`isEqual` cases.

CHANGELOG entry under `## Unreleased > Fixed > Core`.

Closes #1887