### PR TITLE
fix(core): vector? returns true for MapEntry from map iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `+`, `-`, `*`, `/` mixing `##Inf`/`##NaN` with `BigDecimal` fall back to float arithmetic instead of throwing (#1887)
+- `vector?` returns `true` for `MapEntry` produced by iterating a hash map (#1889)
 
 #### Compiler
 - Oversize decimal int literals lex as `float` (#1837)

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -319,9 +319,12 @@
   (map? x))
 
 (defn vector?
-  "Returns true if `x` is a vector, false otherwise."
+  "Returns true if `x` is a vector. Map entries returned by iterating a
+  hash map (`(first {:a 1})`) are vector-shaped two-element values, so
+  this predicate also accepts the typed `MapEntry`."
   [x]
-  (php/instanceof x PersistentVectorInterface))
+  (or (php/instanceof x PersistentVectorInterface)
+      (php/instanceof x MapEntry)))
 
 (defn map-entry?
   "Returns true if `x` is a map entry. Accepts both the typed

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -113,7 +113,11 @@
 
 (defn- indexed-vector?
   [coll]
-  (or (vector? coll) (transient-vector? coll)))
+  ;; Strict: persistent or transient `PersistentVectorInterface`. `MapEntry`
+  ;; is a vector to `vector?` callers but does not support `php/aget`, so
+  ;; `nth`/`get` must keep walking to their seq fallbacks for it.
+  (or (php/instanceof coll PersistentVectorInterface)
+      (transient-vector? coll)))
 
 (defn- in-bounds?
   [index size]

--- a/tests/phel/core/type-operation.phel
+++ b/tests/phel/core/type-operation.phel
@@ -172,7 +172,7 @@
   (let [e (first {:a 1})]
     (is (= :map-entry (type e)) "first of a map yields MapEntry")
     (is (true? (map-entry? e)) "map-entry? on iteration product")
-    (is (false? (vector? e)) "vector? on MapEntry is false")
+    (is (true? (vector? e)) "vector? on MapEntry is true")
     (is (= :a (key e)) "key on iteration product")
     (is (= 1 (val e)) "val on iteration product")
     (is (= [:a 1] e) "iteration product equals a 2-vector"))


### PR DESCRIPTION
## 🤔 Background

Reported in #1889. `(vector? (first {:a 1}))` returns `false` in Phel, but should return `true`. After #1868, iterating a hash map yields `MapEntry` instances (a typed two-element value), and the predicate `vector?` only accepted `PersistentVectorInterface`.

## 💡 Goal

Make `vector?` recognise `MapEntry` as vector-shaped, matching how the equality machinery already treats it (`(= [:a 1] entry)` is true), without breaking `nth`/`get` which call `php/aget` under the hood.

## 🔖 Changes

- `vector?` (`src/phel/core/predicates.phel`) accepts `MapEntry` as well as `PersistentVectorInterface`. The existing `(false? (vector? e))` assertion in `type-operation.phel` flipped to `(true? ...)` to lock the new behaviour.
- `indexed-vector?` (`src/phel/core/sequences.phel`) keeps a strict instance check against `PersistentVectorInterface`/`TransientVectorInterface`. `nth`/`get` therefore still walk the seq fallback for `MapEntry`, since `php/aget` does not work on that type. Comment explains the asymmetry.

CHANGELOG entry under `## Unreleased > Fixed > Core`.

Final-review note: re-read every touched file before opening this PR; the fix already has no duplication, dead branches, or em-dash drift, so the refactor pass surfaced zero further changes.

Closes #1889