### PR TITLE
fix(core): float wins over BigDecimal in arithmetic and comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `+`, `-`, `*`, `/` mixing `##Inf`/`##NaN` with `BigDecimal` fall back to float arithmetic instead of throwing (#1887)
 - `vector?` returns `true` for `MapEntry` produced by iterating a hash map (#1889)
+- Mixing `BigDecimal` with a float in `+`, `-`, `*`, `/`, `quot`, `rem`, `mod`, `compare` returns a float instead of a `BigDecimal` (#1891)
 
 #### Compiler
 - Oversize decimal int literals lex as `float` (#1837)

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -24,12 +24,12 @@ use function sprintf;
  *
  * Contagion rules (left to right yields the result type):
  *
+ *  - any op float                        -> float (highest priority; BigDecimal
+ *                                                  cannot represent Inf/NaN)
+ *  - BigDecimal op BigDecimal/int        -> BigDecimal
  *  - Rational op Rational/int/BigInteger -> Rational (auto-collapsed)
- *  - Rational op float                   -> float
  *  - BigInteger op BigInteger/int        -> BigInteger (auto-collapsed)
- *  - BigInteger op float                 -> float
  *  - int op int                          -> int (or Rational for non-integer divisions)
- *  - any op float                        -> float
  */
 final class NumericOperations
 {

--- a/src/php/Lang/NumericOperations.php
+++ b/src/php/Lang/NumericOperations.php
@@ -38,16 +38,15 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
-        if (self::hasNonFiniteFloat($a, $b)) {
+        if (is_float($a) || is_float($b)) {
+            // Float wins over BigDecimal: `(+ 1.0M 2.0)` returns a float, not a
+            // BigDecimal. BigDecimal also cannot represent `##Inf`/`##NaN`, so a
+            // non-finite float operand still routes here.
             return self::toFloat($a) + self::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->add(self::toBigDecimal($b));
-        }
-
-        if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) + self::toFloat($b);
         }
 
         if ($a instanceof Rational) {
@@ -74,16 +73,12 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
-        if (self::hasNonFiniteFloat($a, $b)) {
+        if (is_float($a) || is_float($b)) {
             return self::toFloat($a) - self::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->subtract(self::toBigDecimal($b));
-        }
-
-        if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) - self::toFloat($b);
         }
 
         if ($a instanceof Rational) {
@@ -111,16 +106,12 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
-        if (self::hasNonFiniteFloat($a, $b)) {
+        if (is_float($a) || is_float($b)) {
             return self::toFloat($a) * self::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->multiply(self::toBigDecimal($b));
-        }
-
-        if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) * self::toFloat($b);
         }
 
         if ($a instanceof Rational) {
@@ -151,28 +142,22 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
-        if (self::hasNonFiniteFloat($a, $b)) {
-            // BigDecimal cannot represent Inf/NaN; fall back to float arithmetic
-            // so `(/ ##Inf 1.0M)` => `##Inf`, `(/ 1.0M ##Inf)` => `0.0`, etc.
-            // Route through `fdiv` so `(/ ##Inf 0)` keeps its IEEE-754 result.
-            return fdiv(self::toFloat($a), self::toFloat($b));
-        }
-
-        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
-            return self::toBigDecimal($a)->divideExact(self::toBigDecimal($b));
-        }
-
         if (is_float($a) || is_float($b)) {
             $left = self::toFloat($a);
             $right = self::toFloat($b);
             // Route any float-over-zero division through `fdiv` so
             // `(/ 1.0 0)` => `INF`, `(/ -1.0 0)` => `-INF`, `(/ 0.0 0)` => `NAN`,
             // and `(/ ##Inf 0)` / `(/ ##NaN 0)` keep their IEEE-754 results.
+            // Float wins over BigDecimal (`(/ 1.0M 2.0)` returns a float).
             if ($right === 0.0) {
                 return fdiv($left, $right);
             }
 
             return $left / $right;
+        }
+
+        if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
+            return self::toBigDecimal($a)->divideExact(self::toBigDecimal($b));
         }
 
         if ($a instanceof Rational) {
@@ -223,16 +208,12 @@ final class NumericOperations
         self::ensureNumeric($a);
         self::ensureNumeric($b);
 
-        if (self::hasNonFiniteFloat($a, $b)) {
+        if (is_float($a) || is_float($b)) {
             return self::toFloat($a) <=> self::toFloat($b);
         }
 
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::toBigDecimal($a)->compareTo(self::toBigDecimal($b));
-        }
-
-        if (is_float($a) || is_float($b)) {
-            return self::toFloat($a) <=> self::toFloat($b);
         }
 
         if ($a instanceof Rational) {
@@ -362,17 +343,18 @@ final class NumericOperations
             throw new DivisionByZeroError('Division by zero');
         }
 
+        if (is_float($a) || is_float($b)) {
+            $ratio = self::toFloat($a) / self::toFloat($b);
+            // Float operands keep float result; truncate toward zero.
+            // Float wins over BigDecimal (`(quot 1.0M 1.0)` returns a float).
+            return $ratio < 0 ? ceil($ratio) : floor($ratio);
+        }
+
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             return self::truncateBigDecimalQuot(
                 self::toBigDecimal($a),
                 self::toBigDecimal($b),
             );
-        }
-
-        if (is_float($a) || is_float($b)) {
-            $ratio = self::toFloat($a) / self::toFloat($b);
-            // Float operands keep float result; truncate toward zero.
-            return $ratio < 0 ? ceil($ratio) : floor($ratio);
         }
 
         if ($a instanceof Rational || $b instanceof Rational) {
@@ -399,16 +381,17 @@ final class NumericOperations
             throw new DivisionByZeroError('Division by zero');
         }
 
+        if (is_float($a) || is_float($b)) {
+            // Float wins over BigDecimal (`(rem 1.0M 1.0)` returns a float).
+            $q = (float) self::quot($a, $b);
+            return self::toFloat($a) - (self::toFloat($b) * $q);
+        }
+
         if ($a instanceof BigDecimal || $b instanceof BigDecimal) {
             $aBig = self::toBigDecimal($a);
             $bBig = self::toBigDecimal($b);
             $q = self::truncateBigDecimalQuot($aBig, $bBig);
             return $aBig->subtract($bBig->multiply($q));
-        }
-
-        if (is_float($a) || is_float($b)) {
-            $q = (float) self::quot($a, $b);
-            return self::toFloat($a) - (self::toFloat($b) * $q);
         }
 
         if ($a instanceof Rational || $b instanceof Rational) {
@@ -566,16 +549,6 @@ final class NumericOperations
         }
 
         return (float) $value;
-    }
-
-    /**
-     * `BigDecimal` cannot represent `INF`/`NAN`, so any op that mixes a
-     * non-finite float with a `BigDecimal` must fall back to float arithmetic
-     * before the BigDecimal branch tries (and fails) to convert the float.
-     */
-    private static function hasNonFiniteFloat(mixed $a, mixed $b): bool
-    {
-        return (is_float($a) && !is_finite($a)) || (is_float($b) && !is_finite($b));
     }
 
     private static function toBigInt(mixed $value): BigInteger

--- a/tests/php/Unit/Lang/NumericOperationsTest.php
+++ b/tests/php/Unit/Lang/NumericOperationsTest.php
@@ -451,4 +451,74 @@ final class NumericOperationsTest extends TestCase
     {
         self::assertFalse(NumericOperations::isEqual(INF, BigDecimal::fromString('1.0')));
     }
+
+    public function test_divide_bigdecimal_by_float_returns_float(): void
+    {
+        $result = NumericOperations::divide(BigDecimal::fromString('2.0'), 1.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(2.0, $result);
+    }
+
+    public function test_divide_float_by_bigdecimal_returns_float(): void
+    {
+        $result = NumericOperations::divide(2.0, BigDecimal::fromString('1.0'));
+
+        self::assertIsFloat($result);
+        self::assertSame(2.0, $result);
+    }
+
+    public function test_add_bigdecimal_and_float_returns_float(): void
+    {
+        $result = NumericOperations::add(BigDecimal::fromString('1.5'), 2.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(3.5, $result);
+    }
+
+    public function test_subtract_float_and_bigdecimal_returns_float(): void
+    {
+        $result = NumericOperations::subtract(2.5, BigDecimal::fromString('1.0'));
+
+        self::assertIsFloat($result);
+        self::assertSame(1.5, $result);
+    }
+
+    public function test_multiply_bigdecimal_and_float_returns_float(): void
+    {
+        $result = NumericOperations::multiply(BigDecimal::fromString('2.0'), 3.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(6.0, $result);
+    }
+
+    public function test_quot_bigdecimal_by_float_returns_float(): void
+    {
+        $result = NumericOperations::quot(BigDecimal::fromString('5.5'), 2.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(2.0, $result);
+    }
+
+    public function test_rem_bigdecimal_by_float_returns_float(): void
+    {
+        $result = NumericOperations::rem(BigDecimal::fromString('5.5'), 2.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(1.5, $result);
+    }
+
+    public function test_mod_bigdecimal_by_float_returns_float(): void
+    {
+        $result = NumericOperations::mod(BigDecimal::fromString('5.5'), 2.0);
+
+        self::assertIsFloat($result);
+        self::assertSame(1.5, $result);
+    }
+
+    public function test_compare_bigdecimal_and_float_routes_through_floats(): void
+    {
+        self::assertSame(0, NumericOperations::compare(BigDecimal::fromString('1.0'), 1.0));
+        self::assertSame(-1, NumericOperations::compare(BigDecimal::fromString('1.0'), 2.0));
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Reported in #1891. `(/ 2.0M 1.0)` returned a `BigDecimal`; the reference behaviour is `Double`. The same dispatch order also caused:

```
(/ 2.0  1.0M)  ;; Phel: :bigdec  -> should be :float
(/ 2.0M 1.0)   ;; Phel: :bigdec  -> should be :float
(quot 1.0M 1.0) (rem 1.0M 1.0) (mod 1.0M 1.0) (compare 1.0M 1.0)
```

`NumericOperations` checked `BigDecimal` before `is_float`, so any mix of the two routed through `BigDecimal::divideExact`/`multiply`/etc. and stuck with the BigDecimal type.

## 💡 Goal

Match the reference contagion order: any float operand wins, even when the other side is a `BigDecimal`. `BigDecimal` priority remains for pure BigDecimal/int combinations.

## 🔖 Changes

- `NumericOperations` swaps the order in `add`/`subtract`/`multiply`/`divide`/`quot`/`rem`/`compare` so the `is_float` branch runs before the `BigDecimal` branch. `mod`, `isEqual`, `min`, `max` get the change transitively.
- The dedicated `hasNonFiniteFloat` guard introduced in #1893 becomes redundant once float runs first; remove it.
- Class-level docblock header reordered to match the implemented contagion priority.
- 9 new unit tests in `NumericOperationsTest`: `(/ 2.0M 1.0)`, `(/ 2.0 1.0M)`, `(+ 1.5M 2.0)`, `(- 2.5 1.0M)`, `(* 2.0M 3.0)`, `(quot 5.5M 2.0)`, `(rem 5.5M 2.0)`, `(mod 5.5M 2.0)`, `(compare 1.0M 1.0)`.

CHANGELOG entry under `## Unreleased > Fixed > Core`.

Closes #1891