### PR TITLE
fix(test): --filter silently drops non-matching tests instead of skipping (#1888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to this project will be documented in this file.
 - `bigdec` accepts `Rational`; non-terminating expansions raise `ArithmeticError` (#1873)
 - `+`, `-`, `*`, `/`, `abs`, `quot`, `rem`, `mod`, `rationalize` accept `BigDecimal` operands; `/` raises `ArithmeticError` on non-terminating expansions (#1875)
 
+#### Testing
+- `--filter` (and `:filters`) now acts as a discovery filter: non-matching tests are silently dropped instead of emitting `S` (skipped) markers and inflating the `Skipped:` counter (#1888)
+
 #### Lang
 - `=` between `int` and `BigInteger` is symmetric (#1830)
 - `+`, `-`, `*`, `**` on PHP ints auto-promote to `BigInteger` on overflow (#1830)

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1017,27 +1017,22 @@
             :meta meta}))))
 
 (defn- selector-options
-  "Extracts the selector subset from the full options map."
+  "Extracts the tag/namespace selector subset from the full options map.
+  Name-based filters (`:filter` / `:filters`) are handled separately as
+  discovery filters and are intentionally excluded here."
   [options]
   {:include     (:include options)
    :exclude     (:exclude options)
-   :ns-patterns (:ns-patterns options)
-   :filters     (:filters options)})
+   :ns-patterns (:ns-patterns options)})
 
 (defn- skip-reason
-  "Returns the reason the test should be skipped — `:filtered` for the
-  legacy `--filter` gate, `:selector` for any other selector miss, or
-  `nil` when the test should run."
-  [options sel-opts ns-name m]
-  (cond
-    (not (legacy-filter-matches? (:filter options) (:test-name m)))
-    :filtered
-
-    (not (selector/keep-test? sel-opts ns-name m))
-    :selector
-
-    :else
-    nil))
+  "Returns `:selector` when the test is excluded by a tag or namespace
+  selector, or `nil` when it should run. Name-based filters
+  (`:filter` / `:filters`) are applied upstream as discovery filters and
+  never reach this function."
+  [sel-opts ns-name m]
+  (when (not (selector/keep-test? sel-opts ns-name m))
+    :selector))
 
 (defn- partition-tests
   "Splits the discovered tests into a `{:keep [...] :skip [...]}` map
@@ -1048,7 +1043,7 @@
   (let [sel-opts (selector-options options)]
     (reduce
      (fn [acc {:fn f :meta m}]
-       (if-let [reason (skip-reason options sel-opts ns-name m)]
+       (if-let [reason (skip-reason sel-opts ns-name m)]
          (update acc :skip conj {:fn f :meta m :reason reason})
          (update acc :keep conj {:fn f :meta m})))
      {:keep [] :skip []}
@@ -1063,8 +1058,17 @@
              :tags (:tags m)})))
 
 (defn- run-test [options ns]
-  (let [all-tests (find-test-vars ns)
-        parts     (partition-tests options ns all-tests)
+  (let [filter-value    (:filter options)
+        filter-patterns (:filters options)
+        all-tests       (find-test-vars ns)
+        ;; Name filters act as discovery: silently drop non-matching tests.
+        ;; Only tag/ns selectors (include/exclude/ns-patterns) surface as :skipped events.
+        visible-tests   (vec (filter
+                               (fn [{:meta m}]
+                                 (and (legacy-filter-matches? filter-value (:test-name m))
+                                      (selector/matches-filter? filter-patterns (:test-name m))))
+                               all-tests))
+        parts     (partition-tests options ns visible-tests)
         keeps     (:keep parts)
         skips     (:skip parts)
         each-wrap (join-fixtures (fixtures-for ns :each-fixtures))

--- a/tests/phel/selectors-runtime.phel
+++ b/tests/phel/selectors-runtime.phel
@@ -123,16 +123,41 @@
 ;; Filter by test name — regex/substring OR semantics
 ;; ---------------------------------------------------------------------------
 
-(deftest test-filter-by-name-substring
+(deftest test-filter-by-name-excludes-silently
   (let [{:events events} (snapshot-run {:reporters []
                                         :filters ["slow"]})
+        summary          (first (events-of events :summary))]
+    (is (= 0 (count (skipped-names events)))
+        ":filters miss produces no :skipped events")
+    (is (= 0 (:skipped summary))
+        ":filters miss is not counted in the summary :skipped field")
+    (is (= 1 (passing-count events))
+        "only the one matching fixture runs")))
+
+(deftest test-legacy-filter-key-excludes-silently
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :filter "slow"})
+        summary          (first (events-of events :summary))]
+    (is (= 0 (count (skipped-names events)))
+        "legacy :filter miss produces no :skipped events")
+    (is (= 0 (:skipped summary))
+        "legacy :filter miss is not counted in the summary :skipped field")
+    (is (= 1 (passing-count events))
+        "only the one matching fixture runs")))
+
+(deftest test-filter-and-tag-selector-combined
+  (let [{:events events} (snapshot-run {:reporters []
+                                        :filters ["fixture"]
+                                        :include [:unit]})
         skipped          (names-skipped-set events)]
-    (is (contains? skipped "fixture-unit-passes")
-        "unit fixture skipped (name doesn't match)")
+    (is (= 2 (count (skipped-names events)))
+        "tag-excluded tests emit :skipped events; name-filtered tests do not")
     (is (contains? skipped "fixture-integration-passes")
-        "integration fixture skipped (name doesn't match)")
-    (is (not (contains? skipped "fixture-slow-integration-passes"))
-        "slow integration fixture runs (name contains 'slow')")))
+        "integration fixture skipped by :include selector")
+    (is (contains? skipped "fixture-slow-integration-passes")
+        "slow fixture skipped by :include selector")
+    (is (= 1 (passing-count events))
+        "only unit fixture runs")))
 
 ;; ---------------------------------------------------------------------------
 ;; Backwards compat — no selectors behave identical to pre-feature run


### PR DESCRIPTION
## 🤔 Background

`vendor/bin/phel test --filter <name>` currently emits a `:skipped` event for every test whose name does not contain the filter substring. Reporters render each skip as `S`, so running with a narrow filter produces a long `SSSS...` prefix and inflates the `Skipped:` counter — even when only one test matches.

Closes #1888.

## 💡 Goal

Make `--filter` (and the underlying `:filters` option) act as a **discovery filter**: non-matching tests are silently dropped before they reach the reporter layer, matching PHPUnit's `--filter` behaviour. Tag/namespace selectors (`--include`, `--exclude`, `--ns`) continue to emit `:skipped` events, where surfacing the skip is informative.

## 🔖 Changes

- **`src/phel/test.phel` — two-phase filter design**
  - `run-test` now pre-filters `all-tests` by name (`:filter` + `:filters`) before passing to `partition-tests`. Non-matching tests are silently dropped; no events emitted.
  - `selector-options` no longer forwards `:filters` — tag/namespace selectors only. This removes the hidden coupling and the need for the `tag-options` workaround.
  - `skip-reason` simplified: the dead `:filtered` branch removed; `options` parameter dropped (was unused after the above change).
  - `partition-tests` updated to match the new `skip-reason` arity.

- **`tests/phel/selectors-runtime.phel` — updated and new tests**
  - `test-filter-by-name-substring` replaced by `test-filter-by-name-excludes-silently` (verifies 0 skip events and `Skipped: 0` in summary).
  - `test-legacy-filter-key-excludes-silently` added for the legacy `:filter` (singular) path.
  - `test-filter-and-tag-selector-combined` added to verify the two-phase design: name filter drops tests silently while a tag selector on the remaining tests still emits `:skipped` events correctly.

- **`CHANGELOG.md`** — entry added under `## Unreleased → ### Fixed → #### Testing`.