### PR TITLE
fix(emitter): emit NAN/INF as constants to avoid PHP 8.5 coercion warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `clojure.lang.X` FQNs resolve to `\Phel\Lang\X` (`BigInt` to `BigInteger`, `Ratio` to `Rational`) (#1840)
 - `LiteralEmitter::emitFloat` skips `.0` when the rendered float carries `.` or an exponent (#1846)
 - `N`-suffix int literals beyond `PHP_INT_MAX` parse as `BigInteger` (#1850)
+- `LiteralEmitter::emitFloat` emits `NAN`/`INF`/`-INF` as constants, avoiding the PHP 8.5 string-coercion warning (#1898)
 
 #### Core
 - `rationalize` uses the shortest round-trip decimal (#1832)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -24,7 +24,9 @@ use function count;
 use function is_array;
 use function is_bool;
 use function is_float;
+use function is_infinite;
 use function is_int;
+use function is_nan;
 use function is_string;
 use function preg_match;
 
@@ -122,6 +124,20 @@ final readonly class LiteralEmitter
 
     private function emitFloat(float $x): void
     {
+        // NAN and INF have no PHP literal form, and (string) coercion of NAN
+        // emits an E_WARNING on PHP 8.5+. Emit constant expressions instead.
+        if (is_nan($x)) {
+            $this->outputEmitter->emitStr('NAN');
+
+            return;
+        }
+
+        if (is_infinite($x)) {
+            $this->outputEmitter->emitStr($x > 0 ? 'INF' : '-INF');
+
+            return;
+        }
+
         $str = (string) $x;
         // (string) 10.0 renders as "10"; append .0 so the literal stays
         // a float in PHP. Skip when the string already carries a decimal

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -124,18 +124,19 @@ final readonly class LiteralEmitter
 
     private function emitFloat(float $x): void
     {
+        $this->outputEmitter->emitStr($this->formatFloatLiteral($x));
+    }
+
+    private function formatFloatLiteral(float $x): string
+    {
         // NAN and INF have no PHP literal form, and (string) coercion of NAN
         // emits an E_WARNING on PHP 8.5+. Emit constant expressions instead.
         if (is_nan($x)) {
-            $this->outputEmitter->emitStr('NAN');
-
-            return;
+            return 'NAN';
         }
 
         if (is_infinite($x)) {
-            $this->outputEmitter->emitStr($x > 0 ? 'INF' : '-INF');
-
-            return;
+            return $x > 0 ? 'INF' : '-INF';
         }
 
         $str = (string) $x;
@@ -147,7 +148,7 @@ final readonly class LiteralEmitter
             $str .= '.0';
         }
 
-        $this->outputEmitter->emitStr($str);
+        return $str;
     }
 
     private function emitInt(int $x): void

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/LiteralEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/LiteralEmitterTest.php
@@ -83,4 +83,25 @@ final class LiteralEmitterTest extends TestCase
 
         $this->expectOutputString('-9.2233720368548E+18');
     }
+
+    public function test_emit_nan_uses_constant(): void
+    {
+        $this->literalEmitter->emitLiteral(NAN);
+
+        $this->expectOutputString('NAN');
+    }
+
+    public function test_emit_positive_infinity_uses_constant(): void
+    {
+        $this->literalEmitter->emitLiteral(INF);
+
+        $this->expectOutputString('INF');
+    }
+
+    public function test_emit_negative_infinity_uses_constant(): void
+    {
+        $this->literalEmitter->emitLiteral(-INF);
+
+        $this->expectOutputString('-INF');
+    }
 }


### PR DESCRIPTION
Fixes #1897.

`emitFloat` casts to string with `(string) $x`, which on PHP 8.5 raises `unexpected NAN value was coerced to string` for `NAN` and produces invalid PHP literals (`INF`/`-INF`) for infinite values. Detect both up front and emit the matching PHP constants instead.