### PR TITLE
fix(compiler): symbol names ending in apostrophe resolve cross-namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Mixing `BigDecimal` with a float in `+`, `-`, `*`, `/`, `quot`, `rem`, `mod`, `compare` returns a float instead of a `BigDecimal` (#1891)
 
 #### Compiler
+- Symbol/keyword names ending in `'` (`inc'`, `dec'`, `+'`, `-'`, `*'`) now resolve cross-namespace; emitter no longer escapes the apostrophe with a backslash inside double-quoted PHP literals
 - Oversize decimal int literals lex as `float` (#1837)
 - `clojure.lang.X` FQNs resolve to `\Phel\Lang\X` (`BigInt` to `BigInteger`, `Ratio` to `Rational`) (#1840)
 - `LiteralEmitter::emitFloat` skips `.0` when the rendered float carries `.` or an exponent (#1846)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -168,12 +168,12 @@ final readonly class LiteralEmitter
     {
         if ($x->getNamespace() !== null) {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . $this->escapeForDoubleQuotedString($x->getName()) . '", "' . $this->escapeForDoubleQuotedString($x->getNamespace()) . '")',
+                '\Phel::keyword("' . PhpStringEscape::doubleQuoted($x->getName()) . '", "' . PhpStringEscape::doubleQuoted($x->getNamespace()) . '")',
                 $x->getStartLocation(),
             );
         } else {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . $this->escapeForDoubleQuotedString($x->getName()) . '")',
+                '\Phel::keyword("' . PhpStringEscape::doubleQuoted($x->getName()) . '")',
                 $x->getStartLocation(),
             );
         }
@@ -182,24 +182,9 @@ final readonly class LiteralEmitter
     private function emitSymbol(Symbol $x): void
     {
         $this->outputEmitter->emitStr(
-            '(\Phel\Lang\Symbol::create("' . $this->escapeForDoubleQuotedString($x->getFullName()) . '"))',
+            '(\Phel\Lang\Symbol::create("' . PhpStringEscape::doubleQuoted($x->getFullName()) . '"))',
             $x->getStartLocation(),
         );
-    }
-
-    /**
-     * Escape a string so it can be embedded inside a PHP double-quoted
-     * literal without losing characters. `addslashes` is wrong here
-     * because it escapes the apostrophe with a backslash that PHP keeps
-     * verbatim inside `"..."`, polluting symbol/keyword names.
-     */
-    private function escapeForDoubleQuotedString(string $value): string
-    {
-        return strtr($value, [
-            '\\' => '\\\\',
-            '"' => '\\"',
-            '$' => '\\$',
-        ]);
     }
 
     private function emitMap(PersistentMapInterface $x): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Lang\Symbol;
 
@@ -23,8 +24,8 @@ final class DefEmitter implements NodeEmitterInterface
         // In cache mode, also register the definition in GlobalEnvironment
         // so the analyzer can resolve symbols when other files have cache misses
         if ($this->outputEmitter->getOptions()->isCacheEmitMode()) {
-            $ns = addslashes($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace()));
-            $name = addslashes($node->getName()->getName());
+            $ns = PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace()));
+            $name = PhpStringEscape::doubleQuoted($node->getName()->getName());
             $this->outputEmitter->emitLine('if (!\\' . GlobalEnvironmentSingleton::class . '::getInstance()->hasDefinition("' . $ns . '", \\' . Symbol::class . '::create("' . $name . '"))) {');
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine('\\' . GlobalEnvironmentSingleton::class . '::getInstance()->addDefinition(');
@@ -43,10 +44,10 @@ final class DefEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('\\Phel::addDefinition(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(addslashes($node->getName()->getName()));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($node->getName()->getName()));
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitNode($node->getInit());
         if ($node->getMeta()->getKeyValues() !== []) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/GlobalVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/GlobalVarEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 
 use function assert;
 
@@ -25,9 +26,9 @@ final class GlobalVarEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitStr('\\Phel::getDefinition("');
         }
 
-        $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
         $this->outputEmitter->emitStr('", "');
-        $this->outputEmitter->emitStr(addslashes($node->getName()->getName()));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($node->getName()->getName()));
         $this->outputEmitter->emitStr('")');
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetVarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetVarEmitter.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 
 use function assert;
 
@@ -28,10 +29,10 @@ final class SetVarEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine('\\Phel::setVar(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey($symbolNode->getNamespace())));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($symbolNode->getNamespace())));
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(addslashes($symbolNode->getName()->getName()));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($symbolNode->getName()->getName()));
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitNode($node->getValueExpr());
         $this->outputEmitter->emitLine();

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VarEmitter.php
@@ -7,9 +7,9 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Lang\Registry;
 
-use function addslashes;
 use function assert;
 
 final class VarEmitter implements NodeEmitterInterface
@@ -22,9 +22,9 @@ final class VarEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
         $this->outputEmitter->emitStr(Registry::class . '::getInstance()->getVar("');
-        $this->outputEmitter->emitStr(addslashes($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
         $this->outputEmitter->emitStr('", "');
-        $this->outputEmitter->emitStr(addslashes($node->getName()));
+        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($node->getName()));
         $this->outputEmitter->emitStr('")');
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpStringEscape.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/PhpStringEscape.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use function strtr;
+
+/**
+ * String-escape helpers for emitting Phel symbol/keyword names into
+ * generated PHP source.
+ */
+final class PhpStringEscape
+{
+    /**
+     * Escape `$value` so it can be embedded inside a PHP double-quoted
+     * literal (`"..."`) without losing characters.
+     *
+     * `addslashes` is wrong for double-quoted output because it escapes
+     * the apostrophe with a backslash that PHP keeps verbatim inside
+     * `"..."`, which silently mangles symbol/keyword names ending in
+     * `'` (`inc'`, `dec'`, `+'`, `-'`, `*'`).
+     */
+    public static function doubleQuoted(string $value): string
+    {
+        return strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            '$' => '\\$',
+        ]);
+    }
+}

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -3,7 +3,7 @@
 --PHP--
 \Phel::addDefinition(
   "user",
-  "a\'",
+  "a'",
   42,
   \Phel::map(
     \Phel::keyword("start-location"), \Phel::map(

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/PhpStringEscapeTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/PhpStringEscapeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+final class PhpStringEscapeTest extends TestCase
+{
+    public function test_apostrophe_passes_through_unchanged(): void
+    {
+        // `addslashes` would escape `'` to `\'`, which a PHP double-quoted
+        // literal keeps verbatim and would silently mangle `inc'`/`dec'`/etc.
+        self::assertSame("inc'", PhpStringEscape::doubleQuoted("inc'"));
+        self::assertSame("+'", PhpStringEscape::doubleQuoted("+'"));
+        self::assertSame("foo''", PhpStringEscape::doubleQuoted("foo''"));
+    }
+
+    public function test_backslash_is_doubled(): void
+    {
+        self::assertSame('a\\\\b', PhpStringEscape::doubleQuoted('a\\b'));
+    }
+
+    public function test_double_quote_is_escaped(): void
+    {
+        self::assertSame('a\\"b', PhpStringEscape::doubleQuoted('a"b'));
+    }
+
+    public function test_dollar_is_escaped_to_block_interpolation(): void
+    {
+        self::assertSame('a\\$var', PhpStringEscape::doubleQuoted('a$var'));
+    }
+
+    public function test_round_trips_into_a_double_quoted_php_literal(): void
+    {
+        $names = ["inc'", "dec'", "+'", "-'", "*'", "foo''", 'plain', 'with"quote', 'with$dollar', 'with\\backslash'];
+
+        foreach ($names as $name) {
+            $literal = '"' . PhpStringEscape::doubleQuoted($name) . '"';
+            /** @var mixed $value */
+            $value = eval('return ' . $literal . ';');
+            self::assertSame($name, $value, sprintf('round-trip for %s', $name));
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`(inc' 1)`, `(dec' 5)`, `(+' 1 2)`, `(-' 5 2)`, `(*' 2 3)` and any other call into a `phel.core` symbol whose name ends in `'` failed at compile time:

```
[PHEL001] Cannot resolve symbol 'inc''. Did you mean 'inc', 'inc\'', or 'int?'?
```

The "Did you mean 'inc\''" suggestion was the smoking gun: the registry was storing the symbol under the literally-backslashed name `inc\'`, while lookups asked for `inc'`. They never matched, so every cross-namespace call (`(inc' x)` from a user file referring `phel.core`) blew up. Same story for `dec'`, `+'`, `-'`, `*'` (added in #1834), and `tests/phel/core/math-operation.phel` had been silently skipping its 455 tests because of this every run.

Root cause: the emitters write symbol/keyword names through PHP's `addslashes()` and embed the result inside `"..."` PHP literals. `addslashes()` escapes `'` to `\'`, but `\'` is **not** a recognised escape inside a PHP double-quoted string — PHP keeps both characters verbatim. So `addDefinition("phel.core", "inc\'", ...)` registered `inc\'` (with the literal backslash), and the call site emitted `getDefinition("phel.core", "inc\'")` looking for the same backslashed key — except `getDefinition` and `addDefinition` are the same code path on different files, and the cross-file registry in #1885's preload made the lookup land on the strings that were assembled the same wrong way.

`LiteralEmitter` already had a private `escapeForDoubleQuotedString` helper with a comment explaining that `addslashes` was wrong here, but the helper was never used outside `LiteralEmitter`.

## 💡 Goal

Pull the escape into a shared `PhpStringEscape::doubleQuoted` helper and route every emit-into-double-quoted-PHP site for symbol / keyword / var names through it.

## 🔖 Changes

- New `Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape` (single static `doubleQuoted` that escapes only `\`, `"`, `$`).
- `DefEmitter`, `GlobalVarEmitter`, `VarEmitter`, `SetVarEmitter`, `LiteralEmitter` (`Symbol::create` + `Phel::keyword`) all swap `addslashes` → `PhpStringEscape::doubleQuoted` for symbol/keyword/var names.
- `LiteralEmitter`'s private `escapeForDoubleQuotedString` is removed (now redundant).
- 5 unit tests for `PhpStringEscape` covering apostrophe pass-through, backslash doubling, double-quote escape, dollar-sign escape, and a round-trip `eval`-based check across `inc'`/`dec'`/`+'`/`-'`/`*'`/`foo''`/etc.
- Integration fixture `Def/def-trailing-quote-in-name.test` flipped from the buggy `"a\'"` expectation to the correct `"a'"` output.
- 455 tests in `tests/phel/core/math-operation.phel` start running again (the file used to compile-error out at line 626 and skip wholesale).

CHANGELOG entry added under `## Unreleased > Fixed > Compiler`.

## ⏱ Verification

- `composer test-quality` (cs-fixer + rector + phpstan) green.
- `php -d xdebug.mode=off ./vendor/bin/phpunit --testsuite=unit` → 2549 / 2549 (2 skipped pre-existing).
- `php -d xdebug.mode=off ./vendor/bin/phpunit --testsuite=integration` → 576 / 576 (1 skipped pre-existing).
- `./bin/phel test` → 5363 / 5363 with `tests/phel/core/math-operation.phel` no longer silently skipped.

Final-review note: re-read every touched file before opening this PR; the helper is single-purpose, no duplication or dead branches surfaced, so the refactor pass produced zero further changes.