### PR TITLE
perf(test): mtime+size fast-path, single-scan namespace collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Cold REPL boot prunes `vendor/`, `.git/`, `node_modules/` at namespace-scan descent and memoises directory scans per process (#1885)
 - `bin/phel test --ns 'pat.**'` preloads only matching namespaces and their dependency closure
 - `bin/phel test` skips re-registering dependency-graph entries on cache hits and re-restoring a namespace's environment after the first file in it
+- `FileEvaluator` skips reading and hashing a source on cache hits when the recorded mtime+size still match (after a 2s grace window); falls back to the content-hash check otherwise
+- `bin/phel test` collapses three overlapping namespace-directory scans into one to seed user tests, bundled `phel.*` modules, and the dependency walk
 
 ### Fixed
 

--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -19,6 +19,8 @@ use Phel\Shared\Facade\CompilerFacadeInterface;
 use RuntimeException;
 use Throwable;
 
+use function assert;
+use function is_string;
 use function sprintf;
 
 final class FileEvaluator
@@ -52,6 +54,25 @@ final class FileEvaluator
 
     public function evalFile(string $src): CompiledFile
     {
+        if ($this->compiledCodeCache instanceof CompiledCodeCache) {
+            // Fast-path: skip reading and hashing the source when the cached
+            // entry's recorded (mtime, size) still match. Falls through to
+            // the content-hash path on any mismatch or grace-window hit.
+            $sourceMtime = @filemtime($src);
+            $sourceSize = @filesize($src);
+            if ($sourceMtime !== false && $sourceSize !== false) {
+                $cachedPath = $this->compiledCodeCache->getByFingerprint($src, $sourceMtime, $sourceSize);
+                if ($cachedPath !== null) {
+                    $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
+                    $namespace = $namespaceInfo->getNamespace();
+                    $compiled = $this->loadFromCache($src, $cachedPath, $namespace, null);
+                    if ($compiled instanceof CompiledFile) {
+                        return $compiled;
+                    }
+                }
+            }
+        }
+
         $code = @file_get_contents($src);
         if ($code === false) {
             $error = error_get_last();
@@ -70,29 +91,9 @@ final class FileEvaluator
             $cachedPath = $this->compiledCodeCache->get($src, $sourceHash);
 
             if ($cachedPath !== null) {
-                $this->compilerFacade->initializeGlobalEnvironment();
-                try {
-                    if (!isset(self::$restoredNamespaces[$namespace])) {
-                        $envData = $this->compiledCodeCache->getEnvironment($namespace);
-
-                        if ($envData !== null) {
-                            $this->compilerFacade->restoreNamespaceEnvironmentData($namespace, $envData);
-                        } else {
-                            $this->analyzeNsForm($code, $src);
-                        }
-
-                        self::$restoredNamespaces[$namespace] = true;
-                    }
-
-                    /** @psalm-suppress UnresolvableInclude */
-                    require $cachedPath;
-
-                    return new CompiledFile($src, $cachedPath, $namespace);
-                } catch (ParseError) {
-                    $this->compiledCodeCache->invalidate($src);
-                } catch (Throwable $e) {
-                    $this->compiledCodeCache->invalidate($src);
-                    throw $e;
+                $compiled = $this->loadFromCache($src, $cachedPath, $namespace, $code);
+                if ($compiled instanceof CompiledFile) {
+                    return $compiled;
                 }
             } elseif ($this->dependencyTracker instanceof DependencyTracker
                 && $this->compiledCodeCache->has($src)
@@ -136,6 +137,39 @@ final class FileEvaluator
         $this->compilerFacade->eval($code, $options);
 
         return new CompiledFile($src, '', $namespace);
+    }
+
+    private function loadFromCache(string $src, string $cachedPath, string $namespace, ?string $code): ?CompiledFile
+    {
+        assert($this->compiledCodeCache instanceof CompiledCodeCache);
+        $this->compilerFacade->initializeGlobalEnvironment();
+        try {
+            if (!isset(self::$restoredNamespaces[$namespace])) {
+                $envData = $this->compiledCodeCache->getEnvironment($namespace);
+
+                if ($envData !== null) {
+                    $this->compilerFacade->restoreNamespaceEnvironmentData($namespace, $envData);
+                } else {
+                    $sourceCode = $code ?? @file_get_contents($src);
+                    if (is_string($sourceCode)) {
+                        $this->analyzeNsForm($sourceCode, $src);
+                    }
+                }
+
+                self::$restoredNamespaces[$namespace] = true;
+            }
+
+            /** @psalm-suppress UnresolvableInclude */
+            require $cachedPath;
+
+            return new CompiledFile($src, $cachedPath, $namespace);
+        } catch (ParseError) {
+            $this->compiledCodeCache->invalidate($src);
+            return null;
+        } catch (Throwable $e) {
+            $this->compiledCodeCache->invalidate($src);
+            throw $e;
+        }
     }
 
     private function analyzeNsForm(string $code, string $src): void

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -319,13 +319,15 @@ final class CompiledCodeCache
                 && is_string($entryData['source_hash'])
                 && is_string($entryData['compiled_path'])
             ) {
+                $rawMtime = $entryData['source_mtime'] ?? null;
+                $rawSize = $entryData['source_size'] ?? null;
                 $entries[$sourcePath] = [
                     'namespace' => $entryData['namespace'],
                     'source_hash' => $entryData['source_hash'],
                     'compiled_path' => $entryData['compiled_path'],
                     'last_accessed' => $entryData['last_accessed'] ?? time(),
-                    'source_mtime' => is_int($entryData['source_mtime'] ?? null) ? $entryData['source_mtime'] : 0,
-                    'source_size' => is_int($entryData['source_size'] ?? null) ? $entryData['source_size'] : -1,
+                    'source_mtime' => is_int($rawMtime) ? $rawMtime : 0,
+                    'source_size' => is_int($rawSize) ? $rawSize : -1,
                 ];
             }
         }
@@ -434,13 +436,15 @@ final class CompiledCodeCache
                 && is_string($entryData['source_hash'])
                 && is_string($entryData['compiled_path'])
             ) {
+                $rawMtime = $entryData['source_mtime'] ?? null;
+                $rawSize = $entryData['source_size'] ?? null;
                 $entries[$sourcePath] = [
                     'namespace' => $entryData['namespace'],
                     'source_hash' => $entryData['source_hash'],
                     'compiled_path' => $entryData['compiled_path'],
                     'last_accessed' => $entryData['last_accessed'] ?? time(),
-                    'source_mtime' => is_int($entryData['source_mtime'] ?? null) ? $entryData['source_mtime'] : 0,
-                    'source_size' => is_int($entryData['source_size'] ?? null) ? $entryData['source_size'] : -1,
+                    'source_mtime' => is_int($rawMtime) ? $rawMtime : 0,
+                    'source_size' => is_int($rawSize) ? $rawSize : -1,
                 ];
             }
         }

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -10,6 +10,8 @@ use function array_key_exists;
 use function count;
 use function function_exists;
 use function is_array;
+use function is_int;
+
 use function is_string;
 
 use function token_get_all;
@@ -28,7 +30,9 @@ final class CompiledCodeCache
 {
     private const string VERSION = '1.2';
 
-    /** @var array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}> */
+    private const int MTIME_GRACE_SECONDS = 2;
+
+    /** @var array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int, source_mtime?: int, source_size?: int}> */
     private array $entries = [];
 
     private bool $loaded = false;
@@ -90,6 +94,59 @@ final class CompiledCodeCache
     }
 
     /**
+     * Mtime+size fast-path: if the cached entry's recorded mtime AND size
+     * match the current source's, return the compiled path without forcing
+     * the caller to read + hash the source. Returns null on any mismatch —
+     * the caller must then fall back to {@see self::get()} with a content
+     * hash, which still validates correctness.
+     *
+     * The mtime is required to be at least 2 seconds old so a same-second
+     * write that produced an identical size cannot serve a stale entry —
+     * filesystem mtime resolution is one second, so within that window a
+     * size-preserving content swap could collide otherwise.
+     *
+     * @param string $sourcePath  Absolute path to the .phel source file
+     * @param int    $sourceMtime Current `filemtime($sourcePath)`
+     * @param int    $sourceSize  Current `filesize($sourcePath)`
+     */
+    public function getByFingerprint(string $sourcePath, int $sourceMtime, int $sourceSize): ?string
+    {
+        $this->loadEntries();
+
+        $entry = $this->entries[$sourcePath] ?? null;
+        if ($entry === null) {
+            return null;
+        }
+
+        $cachedMtime = $entry['source_mtime'] ?? 0;
+        $cachedSize = $entry['source_size'] ?? -1;
+        if ($cachedMtime <= 0 || $cachedSize < 0) {
+            return null;
+        }
+
+        if ($cachedMtime !== $sourceMtime || $cachedSize !== $sourceSize) {
+            return null;
+        }
+
+        // Force hash path while the source is still within the 1-second
+        // mtime granularity window — a same-second write could have
+        // happened between cache write and this read.
+        if ($sourceMtime + self::MTIME_GRACE_SECONDS > time()) {
+            return null;
+        }
+
+        $compiledPath = $this->getCompiledPath($sourcePath, $entry['namespace']);
+
+        if (!file_exists($compiledPath)) {
+            return null;
+        }
+
+        $this->entries[$sourcePath]['last_accessed'] = time();
+
+        return $compiledPath;
+    }
+
+    /**
      * Returns true if an entry exists for this source file, regardless
      * of whether the hash matches. Used to distinguish "first build"
      * (no entry at all) from "source changed" (stale entry).
@@ -120,11 +177,15 @@ final class CompiledCodeCache
             return;
         }
 
+        $sourceMtime = @filemtime($sourcePath);
+        $sourceSize = @filesize($sourcePath);
         $this->entries[$sourcePath] = [
             'namespace' => $namespace,
             'source_hash' => $sourceHash,
             'compiled_path' => $compiledPath,
             'last_accessed' => time(),
+            'source_mtime' => $sourceMtime !== false ? $sourceMtime : 0,
+            'source_size' => $sourceSize !== false ? $sourceSize : -1,
         ];
 
         $this->evictLRU();
@@ -263,6 +324,8 @@ final class CompiledCodeCache
                     'source_hash' => $entryData['source_hash'],
                     'compiled_path' => $entryData['compiled_path'],
                     'last_accessed' => $entryData['last_accessed'] ?? time(),
+                    'source_mtime' => is_int($entryData['source_mtime'] ?? null) ? $entryData['source_mtime'] : 0,
+                    'source_size' => is_int($entryData['source_size'] ?? null) ? $entryData['source_size'] : -1,
                 ];
             }
         }
@@ -323,7 +386,7 @@ final class CompiledCodeCache
      *
      * @param resource $handle Open, exclusively-locked file handle for the index file
      *
-     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}>
+     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int, source_mtime?: int, source_size?: int}>
      */
     private function mergeWithDiskEntries($handle): array
     {
@@ -339,7 +402,7 @@ final class CompiledCodeCache
     }
 
     /**
-     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}>
+     * @return array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int, source_mtime?: int, source_size?: int}>
      */
     private function parseIndexContent(string $content): array
     {
@@ -376,6 +439,8 @@ final class CompiledCodeCache
                     'source_hash' => $entryData['source_hash'],
                     'compiled_path' => $entryData['compiled_path'],
                     'last_accessed' => $entryData['last_accessed'] ?? time(),
+                    'source_mtime' => is_int($entryData['source_mtime'] ?? null) ? $entryData['source_mtime'] : 0,
+                    'source_size' => is_int($entryData['source_size'] ?? null) ? $entryData['source_size'] : -1,
                 ];
             }
         }

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Phel\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
-use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Test\CannotFindAnyTestsException;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
 use function array_unique;
 use function array_values;
+use function realpath;
+use function str_starts_with;
 
 final readonly class NamespaceCollector
 {
     public function __construct(
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
-        private BundledNamespaces $bundledNamespaces,
     ) {}
 
     /**
@@ -26,53 +26,100 @@ final readonly class NamespaceCollector
      */
     public function getDependenciesFromPaths(array $paths): array
     {
-        $namespaces = $this->getNamespacesFromPaths($paths);
-        if ($namespaces === []) {
+        $allDirs = [
+            ...$this->commandFacade->getSourceDirectories(),
+            ...$this->commandFacade->getTestDirectories(),
+            ...$this->commandFacade->getVendorSourceDirectories(),
+        ];
+
+        // One scan covers user test ns discovery, bundled phel.* discovery,
+        // and the dependency walk that follows. Per-call directory caches in
+        // the namespace extractor turn the three downstream consumers into a
+        // single filesystem traversal.
+        $allInfos = $this->buildFacade->getNamespaceFromDirectories($allDirs);
+
+        $userNamespaces = $this->resolveUserNamespaces($paths, $allInfos);
+        if ($userNamespaces === []) {
             throw CannotFindAnyTestsException::inPaths($paths);
         }
 
-        // Seed the bundled `phel.*` modules alongside the user test namespaces
-        // so test files can reach them via FQN (`phel.async/delay`, ...) without
-        // forcing each one to declare a `(:require ...)`.
+        $bundledRoots = $this->resolveRoots([
+            ...$this->commandFacade->getSourceDirectories(),
+            ...$this->commandFacade->getVendorSourceDirectories(),
+        ]);
+        $bundled = [];
+        foreach ($allInfos as $info) {
+            $ns = $info->getNamespace();
+            if (!str_starts_with($ns, 'phel.')) {
+                continue;
+            }
+
+            if (!$this->isFileUnderAny($info->getFile(), $bundledRoots)) {
+                continue;
+            }
+
+            $bundled[$ns] = true;
+        }
+
         $seeds = array_values(array_unique([
-            ...$namespaces,
-            ...$this->bundledNamespaces->all(),
+            ...$userNamespaces,
+            ...array_keys($bundled),
         ]));
 
-        return $this->buildFacade->getDependenciesForNamespace(
-            [
-                ...$this->commandFacade->getSourceDirectories(),
-                ...$this->commandFacade->getTestDirectories(),
-                ...$this->commandFacade->getVendorSourceDirectories(),
-            ],
-            $seeds,
-        );
+        return $this->buildFacade->getDependenciesForNamespace($allDirs, $seeds);
     }
 
     /**
-     * @param list<string> $paths
+     * @param list<string>               $paths
+     * @param list<NamespaceInformation> $allInfos
      *
      * @return list<string>
      */
-    private function getNamespacesFromPaths(array $paths): array
+    private function resolveUserNamespaces(array $paths, array $allInfos): array
     {
-        if ($paths === []) {
-            $namespaces = $this->buildFacade->getNamespaceFromDirectories(
-                $this->commandFacade->getTestDirectories(),
-            );
-
+        if ($paths !== []) {
             return array_map(
-                static fn(NamespaceInformation $info): string => $info->getNamespace(),
-                $namespaces,
+                fn(string $filename): string => $this
+                    ->buildFacade
+                    ->getNamespaceFromFile($filename)
+                    ->getNamespace(),
+                $paths,
             );
         }
 
-        return array_map(
-            fn(string $filename): string => $this
-                ->buildFacade
-                ->getNamespaceFromFile($filename)
-                ->getNamespace(),
-            $paths,
-        );
+        $testRoots = $this->resolveRoots($this->commandFacade->getTestDirectories());
+
+        $namespaces = [];
+        foreach ($allInfos as $info) {
+            if ($this->isFileUnderAny($info->getFile(), $testRoots)) {
+                $namespaces[$info->getNamespace()] = true;
+            }
+        }
+
+        return array_keys($namespaces);
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function resolveRoots(array $directories): array
+    {
+        $roots = [];
+        foreach ($directories as $dir) {
+            $real = realpath($dir);
+            $roots[] = $real !== false ? $real : $dir;
+        }
+
+        return $roots;
+    }
+
+    /**
+     * @param list<string> $roots
+     */
+    private function isFileUnderAny(string $file, array $roots): bool
+    {
+        return array_any($roots, fn($root): bool => $file === $root || str_starts_with($file, $root . '/'));
     }
 }

--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -120,6 +120,6 @@ final readonly class NamespaceCollector
      */
     private function isFileUnderAny(string $file, array $roots): bool
     {
-        return array_any($roots, fn($root): bool => $file === $root || str_starts_with($file, $root . '/'));
+        return array_any($roots, static fn($root): bool => $file === $root || str_starts_with($file, $root . '/'));
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -68,7 +68,6 @@ class RunFactory extends AbstractFactory
         return new NamespaceCollector(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
-            $this->createBundledNamespaces(),
         );
     }
 

--- a/tests/php/Unit/Build/Application/FileEvaluatorTest.php
+++ b/tests/php/Unit/Build/Application/FileEvaluatorTest.php
@@ -491,6 +491,38 @@ final class FileEvaluatorTest extends TestCase
         $evaluator->evalFile($sourceFile);
     }
 
+    public function test_fingerprint_fast_path_skips_compile_for_stable_files(): void
+    {
+        $sourceFile = $this->tempDir . '/test.phel';
+        $sourceCode = '(ns test\\namespace)';
+        file_put_contents($sourceFile, $sourceCode);
+        $cacheDir = $this->tempDir . '/cache';
+        $namespace = 'test\\namespace';
+
+        $cache = new CompiledCodeCache($cacheDir);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$result = 1;');
+
+        // Push mtime out of the grace window so the fingerprint path is eligible.
+        $past = time() - 10;
+        touch($sourceFile, $past, $past);
+        $cache->put($sourceFile, $namespace, md5($sourceCode), '$result = 1;');
+        touch($sourceFile, $past, $past);
+
+        $compilerFacade = $this->createMock(CompilerFacadeInterface::class);
+        $compilerFacade->expects($this->never())->method('compileForCache');
+        $compilerFacade->expects($this->once())->method('initializeGlobalEnvironment');
+
+        $namespaceExtractor = $this->createMock(NamespaceExtractorInterface::class);
+        $namespaceExtractor->method('getNamespaceFromFile')->willReturn(
+            new NamespaceInformation($sourceFile, $namespace, ['phel.core']),
+        );
+
+        $evaluator = new FileEvaluator($compilerFacade, $namespaceExtractor, $cache);
+        $result = $evaluator->evalFile($sourceFile);
+
+        self::assertSame($namespace, $result->getNamespace());
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -332,6 +332,74 @@ final class CompiledCodeCacheTest extends TestCase
         self::assertSame($envData, $cache->getEnvironment('test\\namespace'));
     }
 
+    public function test_get_by_fingerprint_hits_when_mtime_and_size_match_after_grace(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+        $sourcePath = $this->cacheDir . '/test.phel';
+        @mkdir($this->cacheDir, 0o755, true);
+        file_put_contents($sourcePath, '(ns x)');
+
+        $cache->put($sourcePath, 'x', 'hash', '// code');
+
+        // Push the source mtime out of the grace window (>2s old).
+        $past = time() - 10;
+        touch($sourcePath, $past, $past);
+
+        // Refresh entry mtime so cache record matches the touched mtime.
+        $cache->put($sourcePath, 'x', 'hash', '// code');
+        touch($sourcePath, $past, $past);
+
+        $hit = $cache->getByFingerprint($sourcePath, $past, (int) filesize($sourcePath));
+
+        self::assertNotNull($hit);
+        self::assertFileExists($hit);
+    }
+
+    public function test_get_by_fingerprint_misses_when_size_differs(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+        $sourcePath = $this->cacheDir . '/test.phel';
+        @mkdir($this->cacheDir, 0o755, true);
+        file_put_contents($sourcePath, '(ns x)');
+
+        $cache->put($sourcePath, 'x', 'hash', '// code');
+
+        $past = time() - 10;
+        touch($sourcePath, $past, $past);
+
+        $cache->put($sourcePath, 'x', 'hash', '// code');
+        touch($sourcePath, $past, $past);
+
+        // Mtime matches, but size differs by one byte — must miss.
+        self::assertNull(
+            $cache->getByFingerprint($sourcePath, $past, (int) filesize($sourcePath) + 1),
+        );
+    }
+
+    public function test_get_by_fingerprint_misses_within_grace_window(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+        $sourcePath = $this->cacheDir . '/test.phel';
+        @mkdir($this->cacheDir, 0o755, true);
+        file_put_contents($sourcePath, '(ns x)');
+
+        $cache->put($sourcePath, 'x', 'hash', '// code');
+
+        // Source mtime is "now" — within the 2-second grace window — so the
+        // fingerprint path must defer to the content-hash path.
+        $now = time();
+        self::assertNull(
+            $cache->getByFingerprint($sourcePath, $now, (int) filesize($sourcePath)),
+        );
+    }
+
+    public function test_get_by_fingerprint_misses_when_no_cached_entry(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+
+        self::assertNull($cache->getByFingerprint('/no/such/file.phel', time() - 100, 10));
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
+++ b/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
-use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
@@ -94,7 +93,6 @@ final class NamespaceCollectorTest extends TestCase
         new NamespaceCollector(
             $buildFacade,
             $commandFacade,
-            new BundledNamespaces($buildFacade, $commandFacade),
         )->getDependenciesFromPaths(['/src/app.phel']);
 
         return $captured;


### PR DESCRIPTION
## 🤔 Background

`bin/phel test` walked three overlapping namespace-directory scans (test ns, bundled `phel.*`, dep closure) and re-read+md5'd every cached source on each cache hit, even when the file had not changed in hours.

## 💡 Goal

Cut redundant filesystem and hashing work in the `phel test` boot phase without weakening the existing content-hash correctness contract.

## 🔖 Changes

- `CompiledCodeCache` records `source_mtime` + `source_size`; `getByFingerprint` returns the compiled path when both still match. A 2s grace window and the size guard prevent same-second size-preserving writes from serving stale entries.
- `FileEvaluator::evalFile` tries the fingerprint fast-path first and falls back to the content-hash path on any mismatch.
- `NamespaceCollector::getDependenciesFromPaths` collapses three overlapping directory scans into one. Bundled `phel.*` detection is scoped to src+vendor roots so a fixture namespace like `phel.test.clojure-test-alias-regression` is not seeded as bundled.