### PR TITLE
ref(test): collapse three namespace scans in test command into one

### DIFF
--- a/src/php/Run/Domain/Runner/NamespaceCollector.php
+++ b/src/php/Run/Domain/Runner/NamespaceCollector.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Phel\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
-use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Test\CannotFindAnyTestsException;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 
 use function array_unique;
 use function array_values;
+use function realpath;
+use function str_starts_with;
 
 final readonly class NamespaceCollector
 {
     public function __construct(
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
-        private BundledNamespaces $bundledNamespaces,
     ) {}
 
     /**
@@ -26,53 +26,100 @@ final readonly class NamespaceCollector
      */
     public function getDependenciesFromPaths(array $paths): array
     {
-        $namespaces = $this->getNamespacesFromPaths($paths);
-        if ($namespaces === []) {
+        $allDirs = [
+            ...$this->commandFacade->getSourceDirectories(),
+            ...$this->commandFacade->getTestDirectories(),
+            ...$this->commandFacade->getVendorSourceDirectories(),
+        ];
+
+        // One scan covers user test ns discovery, bundled phel.* discovery,
+        // and the dependency walk that follows. Per-call directory caches in
+        // the namespace extractor turn the three downstream consumers into a
+        // single filesystem traversal.
+        $allInfos = $this->buildFacade->getNamespaceFromDirectories($allDirs);
+
+        $userNamespaces = $this->resolveUserNamespaces($paths, $allInfos);
+        if ($userNamespaces === []) {
             throw CannotFindAnyTestsException::inPaths($paths);
         }
 
-        // Seed the bundled `phel.*` modules alongside the user test namespaces
-        // so test files can reach them via FQN (`phel.async/delay`, ...) without
-        // forcing each one to declare a `(:require ...)`.
+        $bundledRoots = $this->resolveRoots([
+            ...$this->commandFacade->getSourceDirectories(),
+            ...$this->commandFacade->getVendorSourceDirectories(),
+        ]);
+        $bundled = [];
+        foreach ($allInfos as $info) {
+            $ns = $info->getNamespace();
+            if (!str_starts_with($ns, 'phel.')) {
+                continue;
+            }
+
+            if (!$this->isFileUnderAny($info->getFile(), $bundledRoots)) {
+                continue;
+            }
+
+            $bundled[$ns] = true;
+        }
+
         $seeds = array_values(array_unique([
-            ...$namespaces,
-            ...$this->bundledNamespaces->all(),
+            ...$userNamespaces,
+            ...array_keys($bundled),
         ]));
 
-        return $this->buildFacade->getDependenciesForNamespace(
-            [
-                ...$this->commandFacade->getSourceDirectories(),
-                ...$this->commandFacade->getTestDirectories(),
-                ...$this->commandFacade->getVendorSourceDirectories(),
-            ],
-            $seeds,
-        );
+        return $this->buildFacade->getDependenciesForNamespace($allDirs, $seeds);
     }
 
     /**
-     * @param list<string> $paths
+     * @param list<string>               $paths
+     * @param list<NamespaceInformation> $allInfos
      *
      * @return list<string>
      */
-    private function getNamespacesFromPaths(array $paths): array
+    private function resolveUserNamespaces(array $paths, array $allInfos): array
     {
-        if ($paths === []) {
-            $namespaces = $this->buildFacade->getNamespaceFromDirectories(
-                $this->commandFacade->getTestDirectories(),
-            );
-
+        if ($paths !== []) {
             return array_map(
-                static fn(NamespaceInformation $info): string => $info->getNamespace(),
-                $namespaces,
+                fn(string $filename): string => $this
+                    ->buildFacade
+                    ->getNamespaceFromFile($filename)
+                    ->getNamespace(),
+                $paths,
             );
         }
 
-        return array_map(
-            fn(string $filename): string => $this
-                ->buildFacade
-                ->getNamespaceFromFile($filename)
-                ->getNamespace(),
-            $paths,
-        );
+        $testRoots = $this->resolveRoots($this->commandFacade->getTestDirectories());
+
+        $namespaces = [];
+        foreach ($allInfos as $info) {
+            if ($this->isFileUnderAny($info->getFile(), $testRoots)) {
+                $namespaces[$info->getNamespace()] = true;
+            }
+        }
+
+        return array_keys($namespaces);
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function resolveRoots(array $directories): array
+    {
+        $roots = [];
+        foreach ($directories as $dir) {
+            $real = realpath($dir);
+            $roots[] = $real !== false ? $real : $dir;
+        }
+
+        return $roots;
+    }
+
+    /**
+     * @param list<string> $roots
+     */
+    private function isFileUnderAny(string $file, array $roots): bool
+    {
+        return array_any($roots, static fn($root): bool => $file === $root || str_starts_with($file, $root . '/'));
     }
 }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -68,7 +68,6 @@ class RunFactory extends AbstractFactory
         return new NamespaceCollector(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
-            $this->createBundledNamespaces(),
         );
     }
 

--- a/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
+++ b/tests/php/Unit/Run/Domain/Runner/NamespaceCollectorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Run\Domain\Runner;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
-use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Domain\Runner\NamespaceCollector;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
@@ -94,7 +93,6 @@ final class NamespaceCollectorTest extends TestCase
         new NamespaceCollector(
             $buildFacade,
             $commandFacade,
-            new BundledNamespaces($buildFacade, $commandFacade),
         )->getDependenciesFromPaths(['/src/app.phel']);
 
         return $captured;


### PR DESCRIPTION
## 🤔 Background

`NamespaceCollector::getDependenciesFromPaths` invoked the namespace extractor with three different directory sets — test ns discovery (`testDirs`), bundled `phel.*` seeding (`src+vendor`), and the dependency walk (`src+test+vendor`). Each call produced a distinct `directoriesScanCache` key inside `CachedNamespaceExtractor`, so the call graph was duplicated even though per-file extraction was already mtime-cached.

A larger experiment in #1900 added an mtime+size fast-path on top of this; benches showed the fast-path savings were within run-to-run noise (boot-only median main 399 ms vs branch 421 ms; full warm 8524 ms vs 8721 ms) because the wall time of `bin/phel test` is dominated by ~7 s of test execution. Closing that PR and shipping only the pure refactor here.

## 💡 Goal

One traversal in the test command's namespace collection, with the existing bundled-namespace seeding behaviour preserved.

## 🔖 Changes

- `NamespaceCollector` scans `src+test+vendor` once and derives user test namespaces (entries under test roots) and bundled `phel.*` (entries under `src+vendor`) from that single result.
- Bundled detection is scoped to `src+vendor` roots so a fixture namespace like `phel.test.clojure-test-alias-regression` cannot be seeded as bundled.
- `BundledNamespaces` dependency removed from `NamespaceCollector` (still used by `NamespaceLoader`).