### PR TITLE
feat(test): add --list, --last-failed, and --slowest=N flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tests/**/out/
 .php-cs-fixer.php
 .phel-repl-history
 *.phel-repl-history
+.phel/
 phel-debug.log
 phel-error.log
 local.phel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ All notable changes to this project will be documented in this file.
 - `(queue & xs)` constructor and `queue?` predicate (#1869)
 - `type` returns `:uuid`, `:php/class`, `:map-entry`, `:queue`, `:bigdec`, `:atom`, `:var`, `:ratio`, `:bigint`
 
+#### Testing
+- `phel test --list` prints discovered tests after applying filters/selectors and skips execution
+- `phel test --last-failed` re-runs only tests that failed on the previous run; failures persist to `.phel/last-failed.txt`
+- `phel test --slowest=N` prints the N slowest tests after the summary
+
 #### Documentation
 - `docs/numeric-tower.md` covers `int`/`BigInteger`/`Rational`/`float` (#1832)
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -13,6 +13,8 @@
 
 (def- fail-fast? (atom false))
 (def- print-stack-trace? (atom false))
+(def- timings (atom []))
+(def- failed-tests (atom []))
 
 (def- ^:dynamic *current-test-name* nil)
 
@@ -1057,17 +1059,40 @@
              :reason reason
              :tags (:tags m)})))
 
-(defn- run-test [options ns]
+(defn- only-tests-matches?
+  "Returns true when `only-tests` is empty (no restriction) or when
+  `ns/test-name` matches one of the entries verbatim."
+  [only-tests ns test-name]
+  (or (nil? only-tests)
+      (empty? only-tests)
+      (some (fn [t] (= t (str ns "/" test-name))) only-tests)))
+
+(defn- visible-test-pred
+  "Returns the predicate that decides whether a discovered test passes
+  the discovery filters (`:filter`, `:filters`, `:only-tests`)."
+  [options ns]
   (let [filter-value    (:filter options)
         filter-patterns (:filters options)
-        all-tests       (find-test-vars ns)
+        only-tests      (:only-tests options)]
+    (fn [{:meta m}]
+      (let [tname (:test-name m)]
+        (and (legacy-filter-matches? filter-value tname)
+             (selector/matches-filter? filter-patterns tname)
+             (only-tests-matches? only-tests ns tname))))))
+
+(defn- failure-count []
+  (let [{:failed f :error e} (get (deref stats) :counts)]
+    (+ f e)))
+
+(defn- record-test-time! [ns test-name duration-ms]
+  (swap! timings conj {:ns ns :test-name test-name :duration-ms duration-ms}))
+
+(defn- run-test [options ns]
+  (let [track-slowest? (pos? (or (:slowest options) 0))
+        all-tests      (find-test-vars ns)
         ;; Name filters act as discovery: silently drop non-matching tests.
         ;; Only tag/ns selectors (include/exclude/ns-patterns) surface as :skipped events.
-        visible-tests   (vec (filter
-                               (fn [{:meta m}]
-                                 (and (legacy-filter-matches? filter-value (:test-name m))
-                                      (selector/matches-filter? filter-patterns (:test-name m))))
-                               all-tests))
+        visible-tests  (vec (filter (visible-test-pred options ns) all-tests))
         parts     (partition-tests options ns visible-tests)
         keeps     (:keep parts)
         skips     (:skip parts)
@@ -1077,9 +1102,16 @@
     (when-not (empty? keeps)
       (once-wrap
        (fn []
-         (dofor [{:fn f} :in keeps
+         (dofor [{:fn f :meta m} :in keeps
                  :when (not (should-stop?))]
-           (each-wrap f)))))))
+           (let [test-name (:test-name m)
+                 t0        (when track-slowest? (php/microtime true))
+                 c0        (failure-count)]
+             (each-wrap f)
+             (when track-slowest?
+               (record-test-time! ns test-name (* 1000.0 (- (php/microtime true) t0))))
+             (when (> (failure-count) c0)
+               (swap! failed-tests conj (str ns "/" test-name))))))))))
 
 (defn- coerce-reporter
   "Turns a single `:reporters` entry (function, keyword, or string) into
@@ -1126,17 +1158,78 @@
     (run-test options ns-name)
     (fan-out! {:type :end-test-ns :ns ns-name})))
 
+(defn- list-tests-for-ns! [options ns-name]
+  (let [sel-opts  (selector-options options)
+        all-tests (find-test-vars ns-name)
+        visible   (filter (visible-test-pred options ns-name) all-tests)]
+    (reduce
+     (fn [count {:meta m}]
+       (let [test-name (:test-name m)
+             skip      (skip-reason sel-opts ns-name m)
+             tags      (or (:tags m) [])
+             tag-str   (if (empty? tags) "" (str " [" (s/join "," (map name tags)) "]"))]
+         (if skip
+           (println (str "- " ns-name "/" test-name tag-str " (skipped: " (name skip) ")"))
+           (println (str "+ " ns-name "/" test-name tag-str)))
+         (if skip count (inc count))))
+     0
+     visible)))
+
+(defn- list-tests! [options namespaces]
+  (println "Discovered tests:")
+  (let [total (reduce
+               (fn [acc namespace]
+                 (+ acc (list-tests-for-ns! options (name namespace))))
+               0
+               namespaces)]
+    (println (str "Total runnable: " total))))
+
+(defn- write-last-failed!
+  "Persists the failed-test list to `path` so a subsequent
+  `--last-failed` run can replay it. Always overwrites; an empty list
+  produces an empty file."
+  [path]
+  (let [dir (php/dirname path)]
+    (when (and dir (not= dir "") (not (php/is_dir dir)))
+      (php/mkdir dir 0755 true)))
+  (php/file_put_contents path (s/join "\n" (deref failed-tests))))
+
+(defn- format-duration [ms]
+  (if (>= ms 1000)
+    (php/sprintf "%.2f s"  (/ ms 1000.0))
+    (php/sprintf "%.2f ms" ms)))
+
+(defn- print-slowest! [options]
+  (let [n (or (:slowest options) 0)]
+    (when (pos? n)
+      (let [sorted (take n (sort-by (fn [t] (- 0 (:duration-ms t))) (deref timings)))]
+        (when-not (empty? sorted)
+          (println)
+          (println (str "Slowest " (count sorted) " test(s):"))
+          (dofor [t :in sorted]
+            (println (str "  " (format-duration (:duration-ms t))
+                          "  " (:ns t) "/" (:test-name t)))))))))
+
 (defn run-tests
-  "Runs all tests in the given namespaces."
+  "Runs all tests in the given namespaces. When `:list-only` is true,
+  prints the discovered tests and skips execution."
   {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
   (configure-run! options)
   (reset! stats initial-stats)
-  (fan-out! {:type :begin-test-run})
-  (dofor [namespace :in namespaces
-          :when (not (should-stop?))]
-    (run-one-ns! options namespace))
-  (print-summary))
+  (reset! timings [])
+  (reset! failed-tests [])
+  (if (:list-only options)
+    (list-tests! options namespaces)
+    (do
+      (fan-out! {:type :begin-test-run})
+      (dofor [namespace :in namespaces
+              :when (not (should-stop?))]
+        (run-one-ns! options namespace))
+      (print-summary)
+      (print-slowest! options)
+      (when-let [path (:last-failed-file options)]
+        (write-last-failed! path)))))
 
 (defn reset-stats
   "Resets the test statistics to their initial state.

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -32,12 +32,21 @@ final readonly class TestCommandOptions
 
     public const string FILTERS = 'filters';
 
+    public const string LIST_ONLY = 'list-only';
+
+    public const string ONLY_TESTS = 'only-tests';
+
+    public const string LAST_FAILED_FILE = 'last-failed-file';
+
+    public const string SLOWEST = 'slowest';
+
     /**
      * @param list<string> $reporters
      * @param list<string> $filters
      * @param list<string> $includes
      * @param list<string> $excludes
      * @param list<string> $nsPatterns
+     * @param list<string> $onlyTests
      */
     private function __construct(
         private ?string $filter,
@@ -50,6 +59,10 @@ final readonly class TestCommandOptions
         private array $excludes,
         private array $nsPatterns,
         private array $filters,
+        private bool $listOnly,
+        private array $onlyTests,
+        private ?string $lastFailedFile,
+        private int $slowest,
     ) {}
 
     public static function empty(): self
@@ -67,6 +80,16 @@ final readonly class TestCommandOptions
             $junitOutput = null;
         }
 
+        $lastFailedFile = $options[self::LAST_FAILED_FILE] ?? null;
+        if ($lastFailedFile === '') {
+            $lastFailedFile = null;
+        }
+
+        $slowest = (int) ($options[self::SLOWEST] ?? 0);
+        if ($slowest < 0) {
+            $slowest = 0;
+        }
+
         return new self(
             $options[self::FILTER] ?? null,
             !empty($options[self::TESTDOX]),
@@ -78,6 +101,10 @@ final readonly class TestCommandOptions
             self::normalizeStringList($options[self::EXCLUDE] ?? null),
             self::normalizeStringList($options[self::NS_PATTERNS] ?? null),
             self::normalizeStringList($options[self::FILTERS] ?? null),
+            !empty($options[self::LIST_ONLY]),
+            self::normalizeStringList($options[self::ONLY_TESTS] ?? null),
+            is_string($lastFailedFile) ? $lastFailedFile : null,
+            $slowest,
         );
     }
 
@@ -86,7 +113,7 @@ final readonly class TestCommandOptions
         $printer = Printer::readable();
 
         return sprintf(
-            '{:filter %s :testdox %s :fail-fast %s :stack-trace %s%s%s%s%s%s%s}',
+            '{:filter %s :testdox %s :fail-fast %s :stack-trace %s%s%s%s%s%s%s%s%s%s%s}',
             $this->filter === null ? 'nil' : $printer->print($this->filter),
             $printer->print($this->testdox),
             $printer->print($this->failFast),
@@ -97,6 +124,10 @@ final readonly class TestCommandOptions
             $this->keywordVector(':exclude', $this->excludes),
             $this->stringVector(':ns-patterns', $this->nsPatterns),
             $this->stringVector(':filters', $this->filters),
+            $this->listOnly ? ' :list-only true' : '',
+            $this->stringVector(':only-tests', $this->onlyTests),
+            $this->optionalString(':last-failed-file', $this->lastFailedFile, $printer),
+            $this->slowest > 0 ? ' :slowest ' . $this->slowest : '',
         );
     }
 

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -54,6 +54,14 @@ final class TestCommand extends Command
 
     private const string OPT_NS = 'ns';
 
+    private const string OPT_LIST = 'list';
+
+    private const string OPT_LAST_FAILED = 'last-failed';
+
+    private const string OPT_SLOWEST = 'slowest';
+
+    private const string LAST_FAILED_FILE = '.phel/last-failed.txt';
+
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
@@ -115,6 +123,22 @@ final class TestCommand extends Command
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 "Namespace glob (e.g. phel.http.*). Repeatable; globs are OR'd. `*` matches one segment, `**` any.",
                 [],
+            )->addOption(
+                self::OPT_LIST,
+                null,
+                InputOption::VALUE_NONE,
+                'List discovered tests after applying filters/selectors. Does not run them.',
+            )->addOption(
+                self::OPT_LAST_FAILED,
+                null,
+                InputOption::VALUE_NONE,
+                'Re-run only tests that failed on the previous run. Reads ' . self::LAST_FAILED_FILE . ' from the current directory.',
+            )->addOption(
+                self::OPT_SLOWEST,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Print the N slowest tests after the summary. 0 disables.',
+                0,
             );
     }
 
@@ -223,6 +247,11 @@ final class TestCommand extends Command
         /** @var list<string> $nsPatterns */
         $nsPatterns = (array) $input->getOption(self::OPT_NS);
 
+        $listOnly = (bool) $input->getOption(self::OPT_LIST);
+        $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
+        $onlyTests = $lastFailed ? $this->readLastFailed() : [];
+        $slowest = (int) $input->getOption(self::OPT_SLOWEST);
+
         return sprintf(
             '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
             TestCommandOptions::fromArray([
@@ -236,9 +265,38 @@ final class TestCommand extends Command
                 TestCommandOptions::EXCLUDE => $excludes,
                 TestCommandOptions::NS_PATTERNS => $nsPatterns,
                 TestCommandOptions::FILTERS => $filters,
+                TestCommandOptions::LIST_ONLY => $listOnly,
+                TestCommandOptions::ONLY_TESTS => $onlyTests,
+                TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : self::LAST_FAILED_FILE,
+                TestCommandOptions::SLOWEST => $slowest,
             ])->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readLastFailed(): array
+    {
+        if (!is_file(self::LAST_FAILED_FILE)) {
+            return [];
+        }
+
+        $contents = @file_get_contents(self::LAST_FAILED_FILE);
+        if (!is_string($contents) || $contents === '') {
+            return [];
+        }
+
+        $entries = [];
+        foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+            $line = trim($line);
+            if ($line !== '') {
+                $entries[] = $line;
+            }
+        }
+
+        return $entries;
     }
 
     /**

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -338,6 +338,103 @@ final class TestCommandOptionsTest extends TestCase
         self::assertStringNotContainsString(':junit-output', $options->asPhelHashMap());
     }
 
+    public function test_list_only_flag_emits_keyword(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::LIST_ONLY => true,
+        ]);
+
+        self::assertStringContainsString(':list-only true', $options->asPhelHashMap());
+    }
+
+    public function test_list_only_default_false_is_omitted(): void
+    {
+        $options = TestCommandOptions::fromArray([]);
+
+        self::assertStringNotContainsString(':list-only', $options->asPhelHashMap());
+    }
+
+    public function test_only_tests_emits_string_vector(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::ONLY_TESTS => ['phel.core/foo', 'phel.core/bar'],
+        ]);
+
+        self::assertStringContainsString(
+            ':only-tests ["phel.core/foo" "phel.core/bar"]',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_only_tests_drops_empty_entries(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::ONLY_TESTS => ['', 'phel.core/foo', ''],
+        ]);
+
+        self::assertStringContainsString(
+            ':only-tests ["phel.core/foo"]',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_last_failed_file_emits_string(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::LAST_FAILED_FILE => '.phel/last-failed.txt',
+        ]);
+
+        self::assertStringContainsString(
+            ':last-failed-file ".phel/last-failed.txt"',
+            $options->asPhelHashMap(),
+        );
+    }
+
+    public function test_last_failed_file_empty_string_is_dropped(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::LAST_FAILED_FILE => '',
+        ]);
+
+        self::assertStringNotContainsString(':last-failed-file', $options->asPhelHashMap());
+    }
+
+    public function test_slowest_emits_int_when_positive(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SLOWEST => 5,
+        ]);
+
+        self::assertStringContainsString(':slowest 5', $options->asPhelHashMap());
+    }
+
+    public function test_slowest_zero_is_omitted(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SLOWEST => 0,
+        ]);
+
+        self::assertStringNotContainsString(':slowest', $options->asPhelHashMap());
+    }
+
+    public function test_slowest_negative_is_clamped_to_zero(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SLOWEST => -3,
+        ]);
+
+        self::assertStringNotContainsString(':slowest', $options->asPhelHashMap());
+    }
+
+    public function test_slowest_string_is_coerced_to_int(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SLOWEST => '7',
+        ]);
+
+        self::assertStringContainsString(':slowest 7', $options->asPhelHashMap());
+    }
+
     public function test_selector_order_in_output_is_stable_across_inputs(): void
     {
         // Regardless of input order, the output always emits selector keys

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -62,6 +62,33 @@ final class TestCommandOptionsWiringTest extends TestCase
         self::assertStringContainsString('stack trace', strtolower($option->getDescription()));
     }
 
+    public function test_it_declares_list_flag(): void
+    {
+        $option = $this->optionFor('list');
+
+        self::assertFalse($option->isValueRequired(), 'list is a flag');
+        self::assertFalse($option->getDefault(), 'list defaults to false');
+        self::assertStringContainsString('list', strtolower($option->getDescription()));
+    }
+
+    public function test_it_declares_last_failed_flag(): void
+    {
+        $option = $this->optionFor('last-failed');
+
+        self::assertFalse($option->isValueRequired(), 'last-failed is a flag');
+        self::assertFalse($option->getDefault(), 'last-failed defaults to false');
+        self::assertStringContainsString('failed', strtolower($option->getDescription()));
+    }
+
+    public function test_it_declares_slowest_option(): void
+    {
+        $option = $this->optionFor('slowest');
+
+        self::assertTrue($option->isValueRequired(), 'slowest takes a value');
+        self::assertSame(0, $option->getDefault(), 'slowest defaults to 0');
+        self::assertStringContainsString('slowest', strtolower($option->getDescription()));
+    }
+
     public function test_description_mentions_selector_semantics(): void
     {
         $include = $this->optionFor('include');


### PR DESCRIPTION
## 🤔 Background

`phel test` had no way to inspect what would run, no way to focus on the failures from the previous run, and no built-in profiling. Three frequent DX gaps that small additions cover.

## 💡 Goal

Three flags, one PR:

- `phel test --list` lists discovered tests (post filters/selectors), skips execution.
- `phel test --last-failed` re-runs only tests that failed on the previous run.
- `phel test --slowest=N` prints the N slowest tests after the summary.

## 🔖 Changes

### CLI

- `TestCommand` adds `--list`, `--last-failed`, `--slowest=N`.
- On a normal run, the failed-test list is persisted to `.phel/last-failed.txt` (one `ns/test-name` per line, overwritten each run; empty file when everything passed).
- `--last-failed` reads that file and passes it as `:only-tests` to the Phel runner.

### `TestCommandOptions`

- Four new fields: `LIST_ONLY`, `ONLY_TESTS`, `LAST_FAILED_FILE`, `SLOWEST`.
- New keys are emitted into the Phel hash-map only when active so the existing wire format stays unchanged for callers that don't use them.

### `phel.test`

- `run-tests` branches on `:list-only` and prints `+ ns/test-name [tags]` (or `- ... (skipped: ...)`) without executing.
- Per-test wall time is captured when `:slowest > 0` and rendered after `print-summary`.
- Failed tests (`:failed`/`:error` delta around each test fn) are collected and written to `:last-failed-file` after the summary.
- `:only-tests` is applied as a discovery filter alongside `:filter` / `:filters`.

### Tests

- `TestCommandOptionsTest`: 9 new cases covering each option's hash-map projection.
- `TestCommandOptionsWiringTest`: 3 new cases for the CLI definition (flag types, defaults).

### Misc

- `.phel/` added to `.gitignore` so the generated last-failed file doesn't leak into commits.
- `CHANGELOG.md` Unreleased -> Added -> Testing entry.

## Test plan

- [x] `composer test-compiler` (3141 tests, 8594 assertions)
- [x] `composer test-core` (5370 tests)
- [x] PHPStan, Rector, php-cs-fixer clean (Psalm crashes locally on missing `Amp\Cache\LocalCache`; CI runs it from a clean install)
- [x] Manual smoke for each flag against a temp project with two passing and two failing tests