### PR TITLE
fix(emitter): prefix Registry FQN in VarEmitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - `LiteralEmitter::emitFloat` skips `.0` when the rendered float carries `.` or an exponent (#1846)
 - `N`-suffix int literals beyond `PHP_INT_MAX` parse as `BigInteger` (#1850)
 - `LiteralEmitter::emitFloat` emits `NAN`/`INF`/`-INF` as constants on PHP 8.5 (#1898)
+- `VarEmitter` prefixes `\Phel\Lang\Registry` with leading backslash so `(var sym)` resolves outside `phel\\` namespaces
 
 #### Core
 - `+`, `-`, `*`, `/` mixing `##Inf`/`##NaN` with `BigDecimal` fall back to float arithmetic (#1887)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VarEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VarEmitter.php
@@ -21,7 +21,7 @@ final class VarEmitter implements NodeEmitterInterface
         assert($node instanceof VarNode);
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr(Registry::class . '::getInstance()->getVar("');
+        $this->outputEmitter->emitStr('\\' . Registry::class . '::getInstance()->getVar("');
         $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
         $this->outputEmitter->emitStr('", "');
         $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($node->getName()));

--- a/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
@@ -19,4 +19,4 @@
     )
   )
 );
-Phel\Lang\Registry::getInstance()->getVar("user", "x");
+\Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
@@ -19,4 +19,4 @@
     )
   )
 );
-Phel\Lang\Registry::getInstance()->getVar("user", "x");
+\Phel\Lang\Registry::getInstance()->getVar("user", "x");


### PR DESCRIPTION
## 🤔 Background

`bin/phel test --last-failed` (and any test using `(var sym)` or `#'sym`) crashed with:

```
Class "phel_test\core\vars_callable\Phel\Lang\Registry" not found
```

## 💡 Goal

Make `(var sym)` resolve `Phel\Lang\Registry` correctly inside compiled namespaces other than `phel\...`.

## 🔖 Changes

- `VarEmitter` now emits `'\\' . Registry::class . '::getInstance()->getVar(...)'`, matching every other `NodeEmitter` (`SetEmitter`, `DefEmitter`, `InNsEmitter`, `LoadEmitter`, `ForeachEmitter`, `ApplyEmitter`).
- Without the leading backslash, PHP resolved `Phel\Lang\Registry` relative to the file's `namespace ...;` declaration. Files compiled under e.g. `phel_test\core\vars_callable` looked up `phel_test\core\vars_callable\Phel\Lang\Registry` and failed.
- Updated the two `VarQuote` integration fixtures to match the new emitter output.
- `CHANGELOG.md` Fixed/Compiler section gets a one-liner.

Verified locally: `bin/phel test`, `bin/phel test --last-failed`, `bin/phel test --list`, `bin/phel test --slowest=5` all pass on the project; `composer test-compiler` and `phpstan` clean.