### PR TITLE
feat(test): unified diff output for = failures on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+#### Test
+- `(is (= a b))` failures on collections render a `+`/`-`/`~` diff block under the existing summary
+
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 
 ### Added

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -497,6 +497,128 @@
   (print-label label-form form)
   (print-label label-eval result))
 
+;; --------------------------
+;; Collection diff (= failures)
+;; --------------------------
+
+(def- diff-min-count
+  ;; Render a collection diff only when at least one side has more than this
+  ;; many entries, so small literals keep the original single-line summary.
+  3)
+
+(def- diff-min-readable-length
+  ;; Or when either side prints longer than this many characters; small
+  ;; collections of long values still benefit from a stacked diff.
+  80)
+
+(defn- sequential?
+  "Returns true when `v` is a vector or a list: the two ordered shapes
+  the diff renderer aligns by index."
+  [v]
+  (or (vector? v) (list? v)))
+
+(defn- same-shape?
+  "Returns true when `a` and `b` are both maps, both sets, or both
+  sequential. Mixed-shape pairs fall back to the summary printer."
+  [a b]
+  (or (and (map? a) (map? b))
+      (and (set? a) (set? b))
+      (and (sequential? a) (sequential? b))))
+
+(defn- diff-worth-rendering?
+  "Decides whether `expected` and `actual` are large enough to justify a
+  block-style diff. Below the thresholds the existing summary line is
+  more readable than the diff."
+  [expected actual]
+  (or (> (count expected) diff-min-count)
+      (> (count actual) diff-min-count)
+      (> (php/strlen (readable-str expected)) diff-min-readable-length)
+      (> (php/strlen (readable-str actual)) diff-min-readable-length)))
+
+(defn- print-diff-line [marker text]
+  (println (str "    " marker " " text)))
+
+(defn- sort-by-readable
+  "Sorts `coll` by the readable representation of each entry. Used to
+  give the diff a deterministic order even when keys or values mix
+  types that Phel's default comparator rejects."
+  [coll]
+  (sort-by readable-str coll))
+
+(defn- print-map-diff [expected actual]
+  (let [expected-keys (into (hash-set) (keys expected))
+        actual-keys   (into (hash-set) (keys actual))
+        removed       (sort-by-readable (vec (difference expected-keys actual-keys)))
+        added         (sort-by-readable (vec (difference actual-keys expected-keys)))
+        shared        (sort-by-readable (vec (intersection expected-keys actual-keys)))]
+    (dofor [k :in removed]
+      (print-diff-line "-" (str (readable-str k) " " (readable-str (get expected k)))))
+    (dofor [k :in added]
+      (print-diff-line "+" (str (readable-str k) " " (readable-str (get actual k)))))
+    (dofor [k :in shared
+            :when (not= (get expected k) (get actual k))]
+      (print-diff-line "~" (str (readable-str k) " "
+                                (readable-str (get expected k))
+                                " -> "
+                                (readable-str (get actual k)))))))
+
+(defn- print-sequential-diff [expected actual]
+  (let [exp-vec (vec expected)
+        act-vec (vec actual)
+        n       (max (count exp-vec) (count act-vec))]
+    (dofor [i :range [0 n]]
+      (let [in-exp? (< i (count exp-vec))
+            in-act? (< i (count act-vec))
+            exp-v   (when in-exp? (nth exp-vec i))
+            act-v   (when in-act? (nth act-vec i))]
+        (cond
+          (and in-exp? (not in-act?))
+          (print-diff-line "-" (str "[" i "] " (readable-str exp-v)))
+
+          (and (not in-exp?) in-act?)
+          (print-diff-line "+" (str "[" i "] " (readable-str act-v)))
+
+          (not= exp-v act-v)
+          (do
+            (print-diff-line "-" (str "[" i "] " (readable-str exp-v)))
+            (print-diff-line "+" (str "[" i "] " (readable-str act-v))))
+
+          :else
+          (print-diff-line " " (str "[" i "] " (readable-str exp-v))))))))
+
+(defn- print-set-diff [expected actual]
+  (let [removed (sort-by-readable (vec (difference expected actual)))
+        added   (sort-by-readable (vec (difference actual expected)))]
+    (dofor [v :in removed]
+      (print-diff-line "-" (readable-str v)))
+    (dofor [v :in added]
+      (print-diff-line "+" (readable-str v)))))
+
+(defn- print-collection-diff
+  "Prints a unified-diff-like block comparing the `expected` and `actual`
+  collections. Maps show added/removed/changed keys with `+`, `-`, `~`;
+  vectors and lists show index-aligned `+`, `-`, ` ` rows; sets show the
+  symmetric difference. Callers should invoke this only after checking
+  `same-shape?` and `diff-worth-rendering?`."
+  [expected actual]
+  (println "  Diff:")
+  (cond
+    (and (map? expected) (map? actual))
+    (print-map-diff expected actual)
+
+    (and (set? expected) (set? actual))
+    (print-set-diff expected actual)
+
+    :else
+    (print-sequential-diff expected actual)))
+
+(defn- collection-diff-applicable?
+  "Returns true when a `=`/`not=` failure carries two same-shape
+  collections big enough to benefit from a stacked diff."
+  [expected actual]
+  (and (same-shape? expected actual)
+       (diff-worth-rendering? expected actual)))
+
 (defn- print-error [data]
   (print-error-headline data)
   (let [{:exception exception :form form} data
@@ -522,12 +644,18 @@
 (defn- print-binary-failure [{:pred pred :expected expected :actual actual :result result}]
   (print-form-evaluated "          Form" actual
                         "  evaluated to" result)
-  (print-label "    but is not" pred "to" (readable-str expected)))
+  (print-label "    but is not" pred "to" (readable-str expected))
+  (when (and (= pred '=)
+             (collection-diff-applicable? expected result))
+    (print-collection-diff expected result)))
 
 (defn- print-binary-not-failure [{:pred pred :expected expected :actual actual :result result}]
   (print-form-evaluated "          Form" actual
                         "  evaluated to" result)
-  (print-label "        but is" pred "to" (readable-str expected) "(it shouldn't be)"))
+  (print-label "        but is" pred "to" (readable-str expected) "(it shouldn't be)")
+  (when (and (= pred 'not=)
+             (collection-diff-applicable? expected result))
+    (print-collection-diff expected result)))
 
 (defn- print-thrown-failure [{:form form :exception-symbol exception-symbol}]
   (print-label "    expected" form)

--- a/tests/phel/reporter-diff.phel
+++ b/tests/phel/reporter-diff.phel
@@ -1,0 +1,157 @@
+(ns phel-test.reporter-diff
+  (:require phel.test :as t :refer [deftest is]))
+
+;; Coverage for the unified-diff block emitted by the default reporter
+;; when an `=` failure compares two large collections of the same
+;; shape. The diff supplements the existing "Form / evaluated to / but
+;; is not" summary; small primitives keep the legacy single-line view.
+
+(defn- failure-event
+  "Builds the synthetic `:failed` event a `=` assertion would produce
+  with `expected` on the left and `actual` on the right."
+  [expected actual]
+  {:type :binary
+   :state :failed
+   :pred '=
+   :expected expected
+   :actual 'actual-form
+   :result actual
+   :form '(= expected actual)
+   :location {:file "diff.phel" :line 1}})
+
+(defn- run-default-reporter
+  "Captures the default reporter's stdout when fed a single failure
+  event for the given pair."
+  [expected actual]
+  (let [rep (t/resolve-reporter :default)]
+    (with-output-buffer
+      (rep {:type :begin-test-run})
+      (rep (failure-event expected actual))
+      (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+            :failures [(failure-event expected actual)]}))))
+
+;; ---------------------------------------------------------------------------
+;; Threshold: small primitive failures keep the legacy single-line summary
+;; ---------------------------------------------------------------------------
+
+(deftest test-small-primitive-failure-skips-diff-block
+  (let [out (run-default-reporter 1 2)]
+    (is (php/preg_match "/but is not: = to 1/" out)
+        "summary line still rendered for primitive `=` failure")
+    (is (= 0 (php/preg_match "/Diff:/" out))
+        "no Diff block for non-collection values")))
+
+(deftest test-tiny-vector-failure-skips-diff-block
+  (let [out (run-default-reporter [1 2] [3 4])]
+    (is (= 0 (php/preg_match "/Diff:/" out))
+        "vectors with 2 entries fall under the diff threshold")))
+
+;; ---------------------------------------------------------------------------
+;; Map diff: + added, - removed, ~ changed (sorted by key)
+;; ---------------------------------------------------------------------------
+
+(deftest test-map-diff-marks-added-removed-and-changed-keys
+  (let [out (run-default-reporter
+              {:a 1 :b 2 :c 3 :d 4}
+              {:a 1 :b 99 :c 3 :e 5})]
+    (is (php/preg_match "/Diff:/" out) "Diff block is rendered")
+    (is (php/preg_match "/- :d 4/" out) "removed key is prefixed with -")
+    (is (php/preg_match "/\\+ :e 5/" out) "added key is prefixed with +")
+    (is (php/preg_match "/~ :b 2 -> 99/" out)
+        "changed key is prefixed with ~ and shows old -> new")))
+
+;; ---------------------------------------------------------------------------
+;; Vector diff: index-aligned, with - / + for differing rows and a leading
+;; space for matching ones
+;; ---------------------------------------------------------------------------
+
+(deftest test-vector-diff-shows-index-aligned-rows
+  (let [out (run-default-reporter [1 2 3 4 5] [1 2 99 4 5 6])]
+    (is (php/preg_match "/Diff:/" out) "Diff block is rendered")
+    (is (php/preg_match "/- \\[2\\] 3/" out) "differing index marked with -")
+    (is (php/preg_match "/\\+ \\[2\\] 99/" out) "differing index marked with +")
+    (is (php/preg_match "/\\+ \\[5\\] 6/" out) "extra trailing entry marked with +")
+    (is (php/preg_match "/  \\[0\\] 1/" out) "matching row keeps a leading space")))
+
+;; ---------------------------------------------------------------------------
+;; Set diff: items only on each side, no order alignment
+;; ---------------------------------------------------------------------------
+
+(deftest test-set-diff-shows-symmetric-difference
+  (let [out (run-default-reporter
+              (hash-set 1 2 3 4 5)
+              (hash-set 2 3 4 5 6))]
+    (is (php/preg_match "/Diff:/" out) "Diff block is rendered")
+    (is (php/preg_match "/- 1/" out) "item only in expected is prefixed with -")
+    (is (php/preg_match "/\\+ 6/" out) "item only in actual is prefixed with +")))
+
+;; ---------------------------------------------------------------------------
+;; Mixed shapes (vector vs map) fall back to the summary printer
+;; ---------------------------------------------------------------------------
+
+(deftest test-mixed-shape-skips-diff-block
+  (let [out (run-default-reporter [1 2 3 4] {:a 1 :b 2 :c 3 :d 4})]
+    (is (= 0 (php/preg_match "/Diff:/" out))
+        "no diff when expected is a vector and actual is a map")))
+
+;; ---------------------------------------------------------------------------
+;; Nested collections render values with their readable form
+;; ---------------------------------------------------------------------------
+
+(deftest test-nested-map-diff-prints-inner-readable-form
+  (let [out (run-default-reporter
+              {:a {:x 1 :y 2 :z 3} :b 2 :c [1 2 3 4] :d "kept"}
+              {:a {:x 1 :y 99 :z 3} :b 2 :c [1 2 9 4] :d "kept"})]
+    (is (php/preg_match "/Diff:/" out)
+        "outer Diff block is rendered for the top-level map")
+    (is (php/preg_match "/~ :a/" out)
+        "differing nested map shows up as a changed key")
+    (is (php/preg_match "/~ :c/" out)
+        "differing nested vector shows up as a changed key")))
+
+;; ---------------------------------------------------------------------------
+;; not=: the diff trigger only fires when the failure proves inequality
+;; ---------------------------------------------------------------------------
+
+(deftest test-not=-failure-skips-diff-block
+  ;; A `(is (not= a b))` failure means a and b were equal; a diff would
+  ;; be empty, so the reporter should keep the original summary only.
+  (let [rep   (t/resolve-reporter :default)
+        equal (vec (range 5))
+        out   (with-output-buffer
+                (rep {:type :begin-test-run})
+                (rep {:type :binary :state :failed
+                      :pred 'not= :expected equal :actual 'actual-form
+                      :result equal
+                      :form '(not= expected actual)
+                      :location {:file "diff.phel" :line 1}})
+                (rep {:type :summary :total 1 :pass 0 :failed 1 :error 0
+                      :failures []}))]
+    (is (= 0 (php/preg_match "/Diff:/" out))
+        "no diff block for not= failures: the values are equal")))
+
+;; ---------------------------------------------------------------------------
+;; Long-printed-but-small collections still trigger the diff
+;; ---------------------------------------------------------------------------
+
+(deftest test-long-printed-vector-triggers-diff-even-with-few-entries
+  (let [long-a "this is a fairly long string that pushes the readable length over the threshold"
+        long-b "another fairly long string that also pushes the readable length over the threshold"
+        out    (run-default-reporter [long-a] [long-b])]
+    (is (php/preg_match "/Diff:/" out)
+        "vector with one long element still renders as a diff block")))
+
+;; ---------------------------------------------------------------------------
+;; Mixed-type keys do not break the diff sort
+;; ---------------------------------------------------------------------------
+
+(deftest test-map-diff-handles-mixed-type-keys-without-throwing
+  ;; Phel's default comparator refuses to sort across keyword/string/int
+  ;; together. The diff sorts on the readable form so it stays robust.
+  (let [out (run-default-reporter
+              {:a 1 "b" 2 3 :three :extra 9}
+              {:a 1 "b" 99 3 :three :other 7})]
+    (is (php/preg_match "/Diff:/" out)
+        "diff renders for maps with mixed-type keys")
+    (is (php/preg_match "/~ \"b\" 2 -> 99/" out)
+        "string-keyed change is reported")))


### PR DESCRIPTION
## 🤔 Background

A failing `(is (= big-map other-big-map))` currently prints two long single-line readable representations:

```
          Form: {:a 1, :b 99, :c 3, :e 5}
  evaluated to: {:a 1, :b 99, :c 3, :e 5}
    but is not: = to {:a 1, :b 2, :c 3, :d 4}
```

Spotting which keys actually differ takes a careful side-by-side scan, and the line wraps once collections grow.

## 💡 Goal

When an `=` failure compares two same-shape collections big enough to wrap, render a unified-diff-like block under the existing summary so the differing entries jump out:

```
          Form: {:a 1, :b 99, :c 3, :e 5}
  evaluated to: {:a 1, :b 99, :c 3, :e 5}
    but is not: = to {:a 1, :b 2, :c 3, :d 4}
  Diff:
    - :d 4
    + :e 5
    ~ :b 2 -> 99
```

Other binary preds (`<`, `>`, `not=` when values are equal, etc.) and small primitives keep the original single-line format.

## 🔖 Changes

- `print-collection-diff` helper plus three shape-specific renderers in `src/phel/test.phel`:
  - maps mark added/removed/changed keys with `+`, `-`, `~`
  - vectors and lists render index-aligned `+`, `-`, leading-space rows
  - sets show the symmetric difference
- `collection-diff-applicable?` gates the new block on:
  - both sides being the same shape (map+map, set+set, or sequential+sequential)
  - either side having more than 3 entries OR a readable form longer than 80 chars
- `print-binary-failure` delegates when pred is `=`; `print-binary-not-failure` delegates when pred is `not=` (the `(not (not= a b))` path proving inequality)
- `sort-by-readable` keeps the diff order stable across mixed-type keys (keyword/string/int) without crashing Phel's default comparator
- New `tests/phel/reporter-diff.phel` covers: tiny primitives skip the diff, map diff, vector diff, set diff, mixed shapes skip, nested collections, `not=` failure stays summary-only, long-printed-but-small triggers, mixed-type keys stay safe
- `CHANGELOG.md` Unreleased entry added