### PR TITLE
ref(test): make test options builder extensible

### DIFF
--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1229,31 +1229,36 @@
 (defn- record-test-time! [ns test-name duration-ms]
   (swap! timings conj {:ns ns :test-name test-name :duration-ms duration-ms}))
 
+(defn- visible-tests-for-ns
+  "Returns the discovered tests in `ns` that survive the discovery filters
+  (`:filter`, `:filters`, `:only-tests`). Tag and namespace selectors are
+  applied later by `partition-tests` so they can surface as skip events."
+  [options ns]
+  (vec (filter (visible-test-pred options ns) (find-test-vars ns))))
+
+(defn- run-one-test! [options ns each-wrap {:fn f :meta m}]
+  (let [test-name      (:test-name m)
+        track-slowest? (pos? (or (:slowest options) 0))
+        t0             (when track-slowest? (php/microtime true))
+        c0             (failure-count)]
+    (each-wrap f)
+    (when track-slowest?
+      (record-test-time! ns test-name (* 1000.0 (- (php/microtime true) t0))))
+    (when (> (failure-count) c0)
+      (swap! failed-tests conj (str ns "/" test-name)))))
+
 (defn- run-test [options ns]
-  (let [track-slowest? (pos? (or (:slowest options) 0))
-        all-tests      (find-test-vars ns)
-        ;; Name filters act as discovery: silently drop non-matching tests.
-        ;; Only tag/ns selectors (include/exclude/ns-patterns) surface as :skipped events.
-        visible-tests  (vec (filter (visible-test-pred options ns) all-tests))
-        parts     (partition-tests options ns visible-tests)
+  (let [parts     (partition-tests options ns (visible-tests-for-ns options ns))
         keeps     (:keep parts)
-        skips     (:skip parts)
         each-wrap (join-fixtures (fixtures-for ns :each-fixtures))
         once-wrap (join-fixtures (fixtures-for ns :once-fixtures))]
-    (emit-skip-events! ns skips)
+    (emit-skip-events! ns (:skip parts))
     (when-not (empty? keeps)
       (once-wrap
        (fn []
-         (dofor [{:fn f :meta m} :in keeps
+         (dofor [test :in keeps
                  :when (not (should-stop?))]
-           (let [test-name (:test-name m)
-                 t0        (when track-slowest? (php/microtime true))
-                 c0        (failure-count)]
-             (each-wrap f)
-             (when track-slowest?
-               (record-test-time! ns test-name (* 1000.0 (- (php/microtime true) t0))))
-             (when (> (failure-count) c0)
-               (swap! failed-tests conj (str ns "/" test-name))))))))))
+           (run-one-test! options ns each-wrap test)))))))
 
 (defn- coerce-reporter
   "Turns a single `:reporters` entry (function, keyword, or string) into
@@ -1301,9 +1306,7 @@
     (fan-out! {:type :end-test-ns :ns ns-name})))
 
 (defn- list-tests-for-ns! [options ns-name]
-  (let [sel-opts  (selector-options options)
-        all-tests (find-test-vars ns-name)
-        visible   (filter (visible-test-pred options ns-name) all-tests)]
+  (let [sel-opts (selector-options options)]
     (reduce
      (fn [count {:meta m}]
        (let [test-name (:test-name m)
@@ -1315,7 +1318,7 @@
            (println (str "+ " ns-name "/" test-name tag-str)))
          (if skip count (inc count))))
      0
-     visible)))
+     (visible-tests-for-ns options ns-name))))
 
 (defn- list-tests! [options namespaces]
   (println "Discovered tests:")
@@ -1352,26 +1355,31 @@
             (println (str "  " (format-duration (:duration-ms t))
                           "  " (:ns t) "/" (:test-name t)))))))))
 
+(defn- reset-run-state! []
+  (reset! stats initial-stats)
+  (reset! timings [])
+  (reset! failed-tests []))
+
+(defn- execute-run! [options namespaces]
+  (fan-out! {:type :begin-test-run})
+  (dofor [namespace :in namespaces
+          :when (not (should-stop?))]
+    (run-one-ns! options namespace))
+  (print-summary)
+  (print-slowest! options)
+  (when-let [path (:last-failed-file options)]
+    (write-last-failed! path)))
+
 (defn run-tests
   "Runs all tests in the given namespaces. When `:list-only` is true,
   prints the discovered tests and skips execution."
   {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
   (configure-run! options)
-  (reset! stats initial-stats)
-  (reset! timings [])
-  (reset! failed-tests [])
+  (reset-run-state!)
   (if (:list-only options)
     (list-tests! options namespaces)
-    (do
-      (fan-out! {:type :begin-test-run})
-      (dofor [namespace :in namespaces
-              :when (not (should-stop?))]
-        (run-one-ns! options namespace))
-      (print-summary)
-      (print-slowest! options)
-      (when-let [path (:last-failed-file options)]
-        (write-last-failed! path)))))
+    (execute-run! options namespaces)))
 
 (defn reset-stats
   "Resets the test statistics to their initial state.

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -8,7 +8,6 @@ use Phel\Printer\Printer;
 
 use function is_array;
 use function is_string;
-use function sprintf;
 
 final readonly class TestCommandOptions
 {
@@ -111,29 +110,68 @@ final readonly class TestCommandOptions
     public function asPhelHashMap(): string
     {
         $printer = Printer::readable();
+        $entries = [];
 
-        return sprintf(
-            '{:filter %s :testdox %s :fail-fast %s :stack-trace %s%s%s%s%s%s%s%s%s%s%s}',
-            $this->filter === null ? 'nil' : $printer->print($this->filter),
-            $printer->print($this->testdox),
-            $printer->print($this->failFast),
-            $printer->print($this->stackTrace),
-            $this->keywordVector(':reporters', $this->reporters),
-            $this->optionalString(':junit-output', $this->junitOutput, $printer),
-            $this->keywordVector(':include', $this->includes),
-            $this->keywordVector(':exclude', $this->excludes),
-            $this->stringVector(':ns-patterns', $this->nsPatterns),
-            $this->stringVector(':filters', $this->filters),
-            $this->listOnly ? ' :list-only true' : '',
-            $this->stringVector(':only-tests', $this->onlyTests),
-            $this->optionalString(':last-failed-file', $this->lastFailedFile, $printer),
-            $this->slowest > 0 ? ' :slowest ' . $this->slowest : '',
-        );
+        $entries[] = ':filter ' . ($this->filter === null ? 'nil' : $printer->print($this->filter));
+        $entries[] = ':testdox ' . $printer->print($this->testdox);
+        $entries[] = ':fail-fast ' . $printer->print($this->failFast);
+        $entries[] = ':stack-trace ' . $printer->print($this->stackTrace);
+
+        $this->appendKeywordVector($entries, ':reporters', $this->reporters);
+        $this->appendOptionalString($entries, ':junit-output', $this->junitOutput, $printer);
+        $this->appendKeywordVector($entries, ':include', $this->includes);
+        $this->appendKeywordVector($entries, ':exclude', $this->excludes);
+        $this->appendStringVector($entries, ':ns-patterns', $this->nsPatterns, $printer);
+        $this->appendStringVector($entries, ':filters', $this->filters, $printer);
+        if ($this->listOnly) {
+            $entries[] = ':list-only true';
+        }
+
+        $this->appendStringVector($entries, ':only-tests', $this->onlyTests, $printer);
+        $this->appendOptionalString($entries, ':last-failed-file', $this->lastFailedFile, $printer);
+        if ($this->slowest > 0) {
+            $entries[] = ':slowest ' . $this->slowest;
+        }
+
+        return '{' . implode(' ', $entries) . '}';
     }
 
-    private function optionalString(string $key, ?string $value, Printer $printer): string
+    /**
+     * @param list<string> $entries
+     */
+    private function appendOptionalString(array &$entries, string $key, ?string $value, Printer $printer): void
     {
-        return $value === null ? '' : ' ' . $key . ' ' . $printer->print($value);
+        if ($value === null) {
+            return;
+        }
+
+        $entries[] = $key . ' ' . $printer->print($value);
+    }
+
+    /**
+     * @param list<string> $entries
+     * @param list<string> $values
+     */
+    private function appendKeywordVector(array &$entries, string $key, array $values): void
+    {
+        if ($values === []) {
+            return;
+        }
+
+        $entries[] = $key . ' [' . implode(' ', array_map(static fn(string $name): string => ':' . $name, $values)) . ']';
+    }
+
+    /**
+     * @param list<string> $entries
+     * @param list<string> $values
+     */
+    private function appendStringVector(array &$entries, string $key, array $values, Printer $printer): void
+    {
+        if ($values === []) {
+            return;
+        }
+
+        $entries[] = $key . ' [' . implode(' ', array_map($printer->print(...), $values)) . ']';
     }
 
     /**
@@ -153,38 +191,5 @@ final readonly class TestCommandOptions
         }
 
         return $result;
-    }
-
-    /**
-     * @param list<string> $values
-     */
-    private function keywordVector(string $key, array $values): string
-    {
-        return $this->renderVector(
-            $key,
-            $values,
-            static fn(string $name): string => ':' . $name,
-        );
-    }
-
-    /**
-     * @param list<string> $values
-     */
-    private function stringVector(string $key, array $values): string
-    {
-        return $this->renderVector($key, $values, Printer::readable()->print(...));
-    }
-
-    /**
-     * @param list<string>             $values
-     * @param callable(string): string $mapper
-     */
-    private function renderVector(string $key, array $values, callable $mapper): string
-    {
-        if ($values === []) {
-            return '';
-        }
-
-        return ' ' . $key . ' [' . implode(' ', array_map($mapper, $values)) . ']';
     }
 }

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -235,43 +235,38 @@ final class TestCommand extends Command
 
     private function generatePhelTestCode(InputInterface $input, array $namespacesInformation): string
     {
-        /** @var list<string> $reporters */
-        $reporters = (array) $input->getOption(self::OPT_REPORTER);
-        $output = $input->getOption(self::OPT_OUTPUT);
-        /** @var list<string> $filters */
-        $filters = (array) $input->getOption(self::OPT_FILTER);
-        /** @var list<string> $includes */
-        $includes = (array) $input->getOption(self::OPT_INCLUDE);
-        /** @var list<string> $excludes */
-        $excludes = (array) $input->getOption(self::OPT_EXCLUDE);
-        /** @var list<string> $nsPatterns */
-        $nsPatterns = (array) $input->getOption(self::OPT_NS);
-
-        $listOnly = (bool) $input->getOption(self::OPT_LIST);
-        $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
-        $onlyTests = $lastFailed ? $this->readLastFailed() : [];
-        $slowest = (int) $input->getOption(self::OPT_SLOWEST);
-
         return sprintf(
             '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
-            TestCommandOptions::fromArray([
-                TestCommandOptions::FILTER => null,
-                TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
-                TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
-                TestCommandOptions::STACK_TRACE => (bool) $input->getOption(self::OPT_STACK_TRACE),
-                TestCommandOptions::REPORTERS => $reporters,
-                TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
-                TestCommandOptions::INCLUDE => $includes,
-                TestCommandOptions::EXCLUDE => $excludes,
-                TestCommandOptions::NS_PATTERNS => $nsPatterns,
-                TestCommandOptions::FILTERS => $filters,
-                TestCommandOptions::LIST_ONLY => $listOnly,
-                TestCommandOptions::ONLY_TESTS => $onlyTests,
-                TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : self::LAST_FAILED_FILE,
-                TestCommandOptions::SLOWEST => $slowest,
-            ])->asPhelHashMap(),
+            TestCommandOptions::fromArray($this->collectOptions($input))->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectOptions(InputInterface $input): array
+    {
+        $output = $input->getOption(self::OPT_OUTPUT);
+        $listOnly = (bool) $input->getOption(self::OPT_LIST);
+        $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
+
+        return [
+            TestCommandOptions::FILTER => null,
+            TestCommandOptions::TESTDOX => (bool) $input->getOption(self::OPT_TESTDOX),
+            TestCommandOptions::FAIL_FAST => (bool) $input->getOption(self::OPT_FAIL_FAST),
+            TestCommandOptions::STACK_TRACE => (bool) $input->getOption(self::OPT_STACK_TRACE),
+            TestCommandOptions::REPORTERS => (array) $input->getOption(self::OPT_REPORTER),
+            TestCommandOptions::JUNIT_OUTPUT => is_string($output) ? $output : null,
+            TestCommandOptions::INCLUDE => (array) $input->getOption(self::OPT_INCLUDE),
+            TestCommandOptions::EXCLUDE => (array) $input->getOption(self::OPT_EXCLUDE),
+            TestCommandOptions::NS_PATTERNS => (array) $input->getOption(self::OPT_NS),
+            TestCommandOptions::FILTERS => (array) $input->getOption(self::OPT_FILTER),
+            TestCommandOptions::LIST_ONLY => $listOnly,
+            TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
+            TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : self::LAST_FAILED_FILE,
+            TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
+        ];
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

`TestCommandOptions::asPhelHashMap` used a 14-slot positional `sprintf`. Adding any new option meant changing three places (format string, slot, expression). `TestCommand::generatePhelTestCode` had grown into a 35-line method mixing input parsing with code generation. In `test.phel`, `run-test` and `list-tests-for-ns!` repeated the same `find-test-vars` plus `(filter (visible-test-pred ...))` discovery pipeline.

## 💡 Goal

Reshape the layer the upcoming `--repeat` / `--seed` / `--random-order` flags will modify, so the feature diff stays small. Zero behavior change.

## 🔖 Changes

- `TestCommandOptions::asPhelHashMap`: replace positional `sprintf` with a fluent entries-array builder. Adding an option is now one `appendKeywordVector` / `appendStringVector` / direct `$entries[]` line.
- `TestCommand::generatePhelTestCode`: extract the option collection into a private `collectOptions(InputInterface)` helper.
- `src/phel/test.phel`:
  - `visible-tests-for-ns` now centralises the discovery pipeline shared by `run-test` and `list-tests-for-ns!`.
  - `run-one-test!` extracted from the inner `run-test` loop, isolating the per-test timing and failure-tracking logic.
  - `run-tests` split into `reset-run-state!` and `execute-run!` so the entry point reads as a four-line dispatch.

Public APIs, output shape, and event ordering are unchanged. All 50 `TestCommandOptions` unit tests, the full PHPUnit suite, and the Phel core suite stay green.