### PR TITLE
feat(test): add --repeat, --seed and --random-order flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Test
 - `(is (= a b))` failures on collections render a `+`/`-`/`~` diff block under the existing summary
+- `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
 
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1229,12 +1229,27 @@
 (defn- record-test-time! [ns test-name duration-ms]
   (swap! timings conj {:ns ns :test-name test-name :duration-ms duration-ms}))
 
+(defn- maybe-shuffle-tests
+  "Returns `tests` shuffled when `:random-order` is set in `options`, or
+  unchanged otherwise. The active seed (`:seed-resolved`) reseeds PHP's
+  Mersenne Twister so the resulting order is reproducible."
+  [options tests]
+  (if (:random-order options)
+    (do
+      (when-let [seed (:seed-resolved options)]
+        (php/mt_srand seed))
+      (shuffle tests))
+    tests))
+
 (defn- visible-tests-for-ns
   "Returns the discovered tests in `ns` that survive the discovery filters
   (`:filter`, `:filters`, `:only-tests`). Tag and namespace selectors are
-  applied later by `partition-tests` so they can surface as skip events."
+  applied later by `partition-tests` so they can surface as skip events.
+  Honours `:random-order` to shuffle the result deterministically."
   [options ns]
-  (vec (filter (visible-test-pred options ns) (find-test-vars ns))))
+  (maybe-shuffle-tests
+   options
+   (vec (filter (visible-test-pred options ns) (find-test-vars ns)))))
 
 (defn- run-one-test! [options ns each-wrap {:fn f :meta m}]
   (let [test-name      (:test-name m)
@@ -1247,18 +1262,27 @@
     (when (> (failure-count) c0)
       (swap! failed-tests conj (str ns "/" test-name)))))
 
+(defn- repeat-count
+  "Returns the validated `:repeat` count from `options`, defaulting to 1."
+  [options]
+  (let [n (or (:repeat options) 1)]
+    (if (pos? n) n 1)))
+
 (defn- run-test [options ns]
   (let [parts     (partition-tests options ns (visible-tests-for-ns options ns))
         keeps     (:keep parts)
         each-wrap (join-fixtures (fixtures-for ns :each-fixtures))
-        once-wrap (join-fixtures (fixtures-for ns :once-fixtures))]
+        once-wrap (join-fixtures (fixtures-for ns :once-fixtures))
+        rounds    (repeat-count options)]
     (emit-skip-events! ns (:skip parts))
     (when-not (empty? keeps)
       (once-wrap
        (fn []
-         (dofor [test :in keeps
+         (dofor [_ :range [0 rounds]
                  :when (not (should-stop?))]
-           (run-one-test! options ns each-wrap test)))))))
+           (dofor [test :in keeps
+                   :when (not (should-stop?))]
+             (run-one-test! options ns each-wrap test))))))))
 
 (defn- coerce-reporter
   "Turns a single `:reporters` entry (function, keyword, or string) into
@@ -1291,6 +1315,21 @@
   sequence of functions, or a mix. Defaults to `[:default]`."
   [options]
   (vec (map coerce-reporter (requested-reporters options))))
+
+(defn- generate-seed
+  "Returns a fresh non-negative integer seed suitable for PHP's RNG."
+  []
+  (php/random_int 0 php/PHP_INT_MAX))
+
+(defn- resolve-seed
+  "Returns the seed `run-tests` should use, or `nil` when ordering is
+  deterministic and no seed was requested. An explicit `:seed` always
+  wins; `:random-order` without a seed gets a freshly generated one."
+  [options]
+  (cond
+    (:seed options)         (:seed options)
+    (:random-order options) (generate-seed)
+    :else                   nil))
 
 (defn- configure-run! [options]
   (reset! fail-fast? (:fail-fast options))
@@ -1360,7 +1399,15 @@
   (reset! timings [])
   (reset! failed-tests []))
 
+(defn- announce-seed!
+  "Prints `Seed: <n>` once at the start of a randomized run so failures
+  can be reproduced with `--seed=<n>`."
+  [options]
+  (when-let [seed (:seed-resolved options)]
+    (println (str "Seed: " seed))))
+
 (defn- execute-run! [options namespaces]
+  (announce-seed! options)
   (fan-out! {:type :begin-test-run})
   (dofor [namespace :in namespaces
           :when (not (should-stop?))]
@@ -1372,14 +1419,22 @@
 
 (defn run-tests
   "Runs all tests in the given namespaces. When `:list-only` is true,
-  prints the discovered tests and skips execution."
+  prints the discovered tests and skips execution.
+
+  Recognized option keys include `:filter`, `:filters`, `:include`,
+  `:exclude`, `:ns-patterns`, `:fail-fast`, `:stack-trace`, `:reporters`,
+  `:junit-output`, `:list-only`, `:only-tests`, `:last-failed-file`,
+  `:slowest`, `:repeat` (run the selected tests N times), `:seed`
+  (integer seed for the order RNG), and `:random-order` (shuffle tests
+  per namespace)."
   {:example "(run-tests {} 'my-app\\test)"}
   [options & namespaces]
-  (configure-run! options)
-  (reset-run-state!)
-  (if (:list-only options)
-    (list-tests! options namespaces)
-    (execute-run! options namespaces)))
+  (let [options (assoc options :seed-resolved (resolve-seed options))]
+    (configure-run! options)
+    (reset-run-state!)
+    (if (:list-only options)
+      (list-tests! options namespaces)
+      (execute-run! options namespaces))))
 
 (defn reset-stats
   "Resets the test statistics to their initial state.

--- a/src/php/Run/Domain/Test/TestCommandOptions.php
+++ b/src/php/Run/Domain/Test/TestCommandOptions.php
@@ -7,6 +7,7 @@ namespace Phel\Run\Domain\Test;
 use Phel\Printer\Printer;
 
 use function is_array;
+use function is_int;
 use function is_string;
 
 final readonly class TestCommandOptions
@@ -39,6 +40,12 @@ final readonly class TestCommandOptions
 
     public const string SLOWEST = 'slowest';
 
+    public const string REPEAT = 'repeat';
+
+    public const string SEED = 'seed';
+
+    public const string RANDOM_ORDER = 'random-order';
+
     /**
      * @param list<string> $reporters
      * @param list<string> $filters
@@ -62,6 +69,9 @@ final readonly class TestCommandOptions
         private array $onlyTests,
         private ?string $lastFailedFile,
         private int $slowest,
+        private int $repeat,
+        private ?int $seed,
+        private bool $randomOrder,
     ) {}
 
     public static function empty(): self
@@ -89,6 +99,14 @@ final readonly class TestCommandOptions
             $slowest = 0;
         }
 
+        $repeat = (int) ($options[self::REPEAT] ?? 1);
+        if ($repeat < 1) {
+            $repeat = 1;
+        }
+
+        $seedRaw = $options[self::SEED] ?? null;
+        $seed = is_int($seedRaw) ? $seedRaw : null;
+
         return new self(
             $options[self::FILTER] ?? null,
             !empty($options[self::TESTDOX]),
@@ -104,6 +122,9 @@ final readonly class TestCommandOptions
             self::normalizeStringList($options[self::ONLY_TESTS] ?? null),
             is_string($lastFailedFile) ? $lastFailedFile : null,
             $slowest,
+            $repeat,
+            $seed,
+            !empty($options[self::RANDOM_ORDER]),
         );
     }
 
@@ -131,6 +152,18 @@ final readonly class TestCommandOptions
         $this->appendOptionalString($entries, ':last-failed-file', $this->lastFailedFile, $printer);
         if ($this->slowest > 0) {
             $entries[] = ':slowest ' . $this->slowest;
+        }
+
+        if ($this->repeat > 1) {
+            $entries[] = ':repeat ' . $this->repeat;
+        }
+
+        if ($this->seed !== null) {
+            $entries[] = ':seed ' . $this->seed;
+        }
+
+        if ($this->randomOrder) {
+            $entries[] = ':random-order true';
         }
 
         return '{' . implode(' ', $entries) . '}';

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use InvalidArgumentException;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
@@ -21,6 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
+use function is_numeric;
 use function is_string;
 use function sprintf;
 
@@ -59,6 +61,12 @@ final class TestCommand extends Command
     private const string OPT_LAST_FAILED = 'last-failed';
 
     private const string OPT_SLOWEST = 'slowest';
+
+    private const string OPT_REPEAT = 'repeat';
+
+    private const string OPT_SEED = 'seed';
+
+    private const string OPT_RANDOM_ORDER = 'random-order';
 
     private const string LAST_FAILED_FILE = '.phel/last-failed.txt';
 
@@ -132,13 +140,29 @@ final class TestCommand extends Command
                 self::OPT_LAST_FAILED,
                 null,
                 InputOption::VALUE_NONE,
-                'Re-run only tests that failed on the previous run. Reads ' . self::LAST_FAILED_FILE . ' from the current directory.',
+                'Re-run only tests that failed on the previous run. Reads ' . self::LAST_FAILED_FILE . ' from the current directory. Combine with --repeat to hammer flaky tests.',
             )->addOption(
                 self::OPT_SLOWEST,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Print the N slowest tests after the summary. 0 disables.',
                 0,
+            )->addOption(
+                self::OPT_REPEAT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Run the selected tests N times in a row. Useful for catching flaky tests. Must be >= 1.',
+                1,
+            )->addOption(
+                self::OPT_SEED,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Integer seed for the test-order RNG. Printed at the start of every randomized run so failures can be reproduced.',
+            )->addOption(
+                self::OPT_RANDOM_ORDER,
+                null,
+                InputOption::VALUE_NONE,
+                'Shuffle the order of tests within each namespace. Uses --seed when provided, otherwise picks a fresh random seed.',
             );
     }
 
@@ -266,7 +290,38 @@ final class TestCommand extends Command
             TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
             TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : self::LAST_FAILED_FILE,
             TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
+            TestCommandOptions::REPEAT => $this->parseRepeat($input),
+            TestCommandOptions::SEED => $this->parseSeed($input),
+            TestCommandOptions::RANDOM_ORDER => (bool) $input->getOption(self::OPT_RANDOM_ORDER),
         ];
+    }
+
+    private function parseRepeat(InputInterface $input): int
+    {
+        $raw = $input->getOption(self::OPT_REPEAT);
+        $value = is_numeric($raw) ? (int) $raw : 1;
+        if ($value < 1) {
+            throw new InvalidArgumentException(sprintf(
+                '--repeat must be a positive integer, got %s.',
+                is_string($raw) ? $raw : (string) $value,
+            ));
+        }
+
+        return $value;
+    }
+
+    private function parseSeed(InputInterface $input): ?int
+    {
+        $raw = $input->getOption(self::OPT_SEED);
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        if (!is_numeric($raw)) {
+            throw new InvalidArgumentException(sprintf('--seed must be an integer, got %s.', (string) $raw));
+        }
+
+        return (int) $raw;
     }
 
     /**

--- a/tests/phel/repeat-seed.phel
+++ b/tests/phel/repeat-seed.phel
@@ -1,0 +1,113 @@
+(ns phel-test.repeat-seed
+  (:require phel.test :as t :refer [deftest is])
+  (:require phel-test.fixtures.tagged-tests))
+
+;; Behavior coverage for `phel.test/run-tests` `:repeat`, `:seed`, and
+;; `:random-order` options.
+;;
+;; Each scenario uses the snapshot-and-restore pattern: the outer
+;; suite's stats and reporter set are saved, the inner run executes
+;; against a tiny fixture namespace, then everything is restored. The
+;; inner run's output is captured with `with-output-buffer` so it does
+;; not pollute the outer suite's reporter output.
+
+(def- fixture-ns 'phel-test.fixtures.tagged-tests)
+
+(defn- snapshot-run [options]
+  (let [saved-reporters (t/get-reporters)
+        saved-stats     (t/get-stats)
+        events          (atom [])
+        capture         (fn [e] (swap! events conj e))
+        run-options     (assoc options :reporters
+                               (conj (vec (:reporters options)) capture))]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests run-options fixture-ns))
+    (let [snapshot (t/get-stats)]
+      (t/set-reporters! saved-reporters)
+      (t/restore-stats saved-stats)
+      {:events (deref events)
+       :stats  snapshot})))
+
+(defn- pass-count [events]
+  (count (for [e :in events
+               :when (and (= :pass (:state e))
+                          (not= :skipped (:type e)))])))
+
+(defn- begin-test-run-events [events]
+  (vec (for [e :in events :when (= :begin-test-run (:type e))])))
+
+;; ---------------------------------------------------------------------------
+;; :repeat — selected tests run N times, stats accumulate
+;; ---------------------------------------------------------------------------
+
+(deftest test-repeat-default-runs-each-test-once
+  (let [{:events events} (snapshot-run {:reporters []})]
+    ;; The fixture namespace exposes 3 deftests; each emits 1 assertion.
+    (is (= 3 (pass-count events)) "with default repeat each fixture runs once")))
+
+(deftest test-repeat-greater-than-one-multiplies-assertion-count
+  (let [{:events events} (snapshot-run {:reporters [] :repeat 3})]
+    (is (= 9 (pass-count events))
+        "repeat=3 yields 3x the assertions across the fixture namespace")))
+
+(deftest test-repeat-counter-increments-once-per-iteration
+  (let [counter         (atom 0)
+        bump-reporter   (fn [e]
+                          (when (and (= :pass (:state e))
+                                     (not= :skipped (:type e)))
+                            (swap! counter inc)))
+        saved-reporters (t/get-reporters)
+        saved-stats     (t/get-stats)]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests {:reporters [bump-reporter] :repeat 4} fixture-ns))
+    (t/set-reporters! saved-reporters)
+    (t/restore-stats saved-stats)
+    ;; 3 fixtures × 4 iterations = 12 pass events.
+    (is (= 12 (deref counter))
+        "the per-iteration counter sees every assertion in every iteration")))
+
+;; ---------------------------------------------------------------------------
+;; :seed — fixed seed yields reproducible test order under :random-order
+;; ---------------------------------------------------------------------------
+
+(defn- ordered-test-names [seed]
+  (let [order (atom [])
+        capture (fn [e]
+                  (when (= :pass (:state e))
+                    (swap! order conj (:test-name e))))
+        saved-reporters (t/get-reporters)
+        saved-stats     (t/get-stats)]
+    (t/reset-stats)
+    (with-output-buffer
+      (t/run-tests {:reporters [capture]
+                    :random-order true
+                    :seed seed}
+                   fixture-ns))
+    (t/set-reporters! saved-reporters)
+    (t/restore-stats saved-stats)
+    (deref order)))
+
+(deftest test-fixed-seed-yields-deterministic-order
+  (let [first-run  (ordered-test-names 12345)
+        second-run (ordered-test-names 12345)]
+    (is (= first-run second-run)
+        "the same seed produces the same test order across runs")
+    (is (= 3 (count first-run))
+        "every fixture test appears in the captured order")))
+
+(deftest test-fixed-seed-produces-permutation-of-fixture-tests
+  (let [order (into (hash-set) (ordered-test-names 99))]
+    (is (contains? order "fixture-unit-passes") "unit fixture present")
+    (is (contains? order "fixture-integration-passes") "integration fixture present")
+    (is (contains? order "fixture-slow-integration-passes") "slow integration fixture present")))
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle: :begin-test-run still fires exactly once even with repeat > 1
+;; ---------------------------------------------------------------------------
+
+(deftest test-repeat-emits-single-begin-test-run
+  (let [{:events events} (snapshot-run {:reporters [] :repeat 5})]
+    (is (= 1 (count (begin-test-run-events events)))
+        ":begin-test-run is still fired exactly once per run-tests call")))

--- a/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
+++ b/tests/php/Unit/Run/Domain/Test/TestCommandOptionsTest.php
@@ -435,6 +435,87 @@ final class TestCommandOptionsTest extends TestCase
         self::assertStringContainsString(':slowest 7', $options->asPhelHashMap());
     }
 
+    public function test_repeat_emits_when_greater_than_one(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::REPEAT => 3,
+        ]);
+
+        self::assertStringContainsString(':repeat 3', $options->asPhelHashMap());
+    }
+
+    public function test_repeat_default_is_omitted(): void
+    {
+        $options = TestCommandOptions::fromArray([]);
+
+        self::assertStringNotContainsString(':repeat', $options->asPhelHashMap());
+    }
+
+    public function test_repeat_zero_or_negative_falls_back_to_one(): void
+    {
+        $zero = TestCommandOptions::fromArray([TestCommandOptions::REPEAT => 0]);
+        $negative = TestCommandOptions::fromArray([TestCommandOptions::REPEAT => -5]);
+
+        self::assertStringNotContainsString(':repeat', $zero->asPhelHashMap());
+        self::assertStringNotContainsString(':repeat', $negative->asPhelHashMap());
+    }
+
+    public function test_seed_emits_when_set(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SEED => 42,
+        ]);
+
+        self::assertStringContainsString(':seed 42', $options->asPhelHashMap());
+    }
+
+    public function test_seed_default_is_omitted(): void
+    {
+        $options = TestCommandOptions::fromArray([]);
+
+        self::assertStringNotContainsString(':seed', $options->asPhelHashMap());
+    }
+
+    public function test_seed_non_int_is_dropped(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::SEED => 'not-a-number',
+        ]);
+
+        self::assertStringNotContainsString(':seed', $options->asPhelHashMap());
+    }
+
+    public function test_random_order_emits_keyword(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::RANDOM_ORDER => true,
+        ]);
+
+        self::assertStringContainsString(':random-order true', $options->asPhelHashMap());
+    }
+
+    public function test_random_order_default_is_omitted(): void
+    {
+        $options = TestCommandOptions::fromArray([]);
+
+        self::assertStringNotContainsString(':random-order', $options->asPhelHashMap());
+    }
+
+    public function test_repeat_seed_random_order_combined(): void
+    {
+        $options = TestCommandOptions::fromArray([
+            TestCommandOptions::REPEAT => 5,
+            TestCommandOptions::SEED => 1234,
+            TestCommandOptions::RANDOM_ORDER => true,
+        ]);
+
+        $printed = $options->asPhelHashMap();
+
+        self::assertStringContainsString(':repeat 5', $printed);
+        self::assertStringContainsString(':seed 1234', $printed);
+        self::assertStringContainsString(':random-order true', $printed);
+    }
+
     public function test_selector_order_in_output_is_stable_across_inputs(): void
     {
         // Regardless of input order, the output always emits selector keys

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandOptionsWiringTest.php
@@ -89,6 +89,33 @@ final class TestCommandOptionsWiringTest extends TestCase
         self::assertStringContainsString('slowest', strtolower($option->getDescription()));
     }
 
+    public function test_it_declares_repeat_option(): void
+    {
+        $option = $this->optionFor('repeat');
+
+        self::assertTrue($option->isValueRequired(), 'repeat takes a value');
+        self::assertSame(1, $option->getDefault(), 'repeat defaults to 1');
+        self::assertStringContainsString('flaky', strtolower($option->getDescription()));
+    }
+
+    public function test_it_declares_seed_option(): void
+    {
+        $option = $this->optionFor('seed');
+
+        self::assertTrue($option->isValueRequired(), 'seed takes a value');
+        self::assertNull($option->getDefault(), 'seed defaults to null');
+        self::assertStringContainsString('seed', strtolower($option->getDescription()));
+    }
+
+    public function test_it_declares_random_order_flag(): void
+    {
+        $option = $this->optionFor('random-order');
+
+        self::assertFalse($option->isValueRequired(), 'random-order is a flag');
+        self::assertFalse($option->getDefault(), 'random-order defaults to false');
+        self::assertStringContainsString('shuffle', strtolower($option->getDescription()));
+    }
+
     public function test_description_mentions_selector_semantics(): void
     {
         $include = $this->optionFor('include');

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure\Command;
+
+use InvalidArgumentException;
+use Phel\Run\Domain\Test\TestCommandOptions;
+use Phel\Run\Infrastructure\Command\TestCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\ArrayInput;
+
+final class TestCommandRepeatSeedTest extends TestCase
+{
+    public function test_repeat_flag_appears_in_phel_hash_map(): void
+    {
+        $printed = $this->collectAndPrint(['--repeat' => '4']);
+
+        self::assertStringContainsString(':repeat 4', $printed);
+    }
+
+    public function test_repeat_default_does_not_appear(): void
+    {
+        $printed = $this->collectAndPrint([]);
+
+        self::assertStringNotContainsString(':repeat', $printed);
+    }
+
+    public function test_repeat_zero_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('--repeat must be a positive integer');
+
+        $this->collectAndPrint(['--repeat' => '0']);
+    }
+
+    public function test_repeat_negative_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->collectAndPrint(['--repeat' => '-2']);
+    }
+
+    public function test_seed_flag_appears_in_phel_hash_map(): void
+    {
+        $printed = $this->collectAndPrint(['--seed' => '777']);
+
+        self::assertStringContainsString(':seed 777', $printed);
+    }
+
+    public function test_seed_default_does_not_appear(): void
+    {
+        $printed = $this->collectAndPrint([]);
+
+        self::assertStringNotContainsString(':seed', $printed);
+    }
+
+    public function test_seed_non_numeric_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('--seed must be an integer');
+
+        $this->collectAndPrint(['--seed' => 'abc']);
+    }
+
+    public function test_random_order_flag_appears_in_phel_hash_map(): void
+    {
+        $printed = $this->collectAndPrint(['--random-order' => true]);
+
+        self::assertStringContainsString(':random-order true', $printed);
+    }
+
+    public function test_random_order_default_does_not_appear(): void
+    {
+        $printed = $this->collectAndPrint([]);
+
+        self::assertStringNotContainsString(':random-order', $printed);
+    }
+
+    public function test_combined_flags_round_trip(): void
+    {
+        $printed = $this->collectAndPrint([
+            '--repeat' => '3',
+            '--seed' => '42',
+            '--random-order' => true,
+        ]);
+
+        self::assertStringContainsString(':repeat 3', $printed);
+        self::assertStringContainsString(':seed 42', $printed);
+        self::assertStringContainsString(':random-order true', $printed);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function collectAndPrint(array $arguments): string
+    {
+        $command = new TestCommand();
+        $input = new ArrayInput($arguments, $command->getDefinition());
+
+        $method = new ReflectionMethod(TestCommand::class, 'collectOptions');
+
+        /** @var array<string, mixed> $collected */
+        $collected = $method->invoke($command, $input);
+
+        return TestCommandOptions::fromArray($collected)->asPhelHashMap();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Hunting flaky tests today means re-running the whole suite by hand. Knowing which order a failure first appeared in is also tricky because deftest order is implicit in source position. The runner had no built-in way to repeat or randomize.

## 💡 Goal

Three flags on `phel test` that cover both needs:

- `--repeat=N` runs the selected tests N times in a row (default 1, must be >= 1).
- `--seed=<int>` sets the RNG seed used for ordering.
- `--random-order` shuffles deftest order within each namespace, using `--seed` when given or generating a fresh seed otherwise.

The active seed is printed (`Seed: <n>`) at the start of every randomized run so failures can be reproduced verbatim.

## 🔖 Changes

- `TestCommand`: new flags wired through `collectOptions`, with `parseRepeat` (rejects `0` / negative) and `parseSeed` (rejects non-numeric).
- `TestCommandOptions`: new `REPEAT`, `SEED`, `RANDOM_ORDER` constants. `asPhelHashMap` emits `:repeat`, `:seed`, `:random-order` only when non-default.
- `src/phel/test.phel`:
  - `maybe-shuffle-tests` reseeds PHP's Mersenne Twister and shuffles when `:random-order` is set.
  - `run-test` wraps the keep-loop in an N-iteration outer `dofor`; both layers honour `should-stop?` so `--fail-fast` still cuts the run on the first failure across all iterations.
  - `resolve-seed` picks the explicit `:seed`, falls back to a generated seed when only `:random-order` is set, returns `nil` for fully deterministic runs.
  - `announce-seed!` prints `Seed: <n>` at the start of `execute-run!`.
- `--last-failed` help text now mentions the `--repeat` combo for hammering flaky tests.
- `CHANGELOG.md` Unreleased entry under Test.

## ✅ Tests

- `TestCommandOptionsTest`: 9 new cases covering `:repeat`, `:seed`, `:random-order` shape and edge cases.
- `TestCommandOptionsWiringTest`: 3 new cases asserting the CLI flags are declared with the expected defaults and help text.
- `TestCommandRepeatSeedTest`: 9 cases that round-trip the CLI flags through `collectOptions` and `TestCommandOptions::asPhelHashMap`, including the validation throws.
- `tests/phel/repeat-seed.phel`: 7 deftests verifying that `:repeat` multiplies assertion counts, that an iteration counter increments per round, that a fixed seed produces deterministic order, and that the seed permutation contains every fixture test.