### PR TITLE
fix(test): default reporter wraps at 80 cols under with-output-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 - `(is (= a b))` failures on collections render a `+`/`-`/`~` diff block under the existing summary
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
 
+### Fixed
+
+#### Test
+- Default reporter dot output wraps uniformly at 80 columns when tests use `with-output-buffer`
+
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 
 ### Added

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -719,30 +719,40 @@
   (println)
   (print-counts-summary event))
 
+(defn- emit-marker!
+  "Prints a single progress marker and wraps the line every 80 markers."
+  [ch]
+  (let [n (swap! default-line-count inc)]
+    (print ch)
+    (when (= 0 (% n 80)) (println))))
+
+(defn- assertion-marker [state]
+  (case state :failed "F" :error "E" "."))
+
 (defn- default-reporter
   "Human-readable dot output. Preserves the legacy behavior: `.` for
   pass, `F` for fail, `E` for error, plus periodic newlines so long
   runs wrap at 80 columns. `S` marks a skipped test."
   [event]
+  ;; Dot/wrap branches are skipped when an outer `with-output-buffer`
+  ;; silences this reporter: counting invisible dots and resetting the
+  ;; shared counter would break the 80-column wrap of the surrounding run.
   (let [type (:type event)]
     (cond
+      (= type :summary)
+      (print-summary-block event)
+
+      (pos? (php/ob_get_level))
+      nil
+
       (= type :begin-test-run)
       (reset! default-line-count 0)
 
       (assertion-event? event)
-      (let [state (:state event)
-            ch    (case state :failed "F" :error "E" ".")
-            n     (swap! default-line-count inc)]
-        (print ch)
-        (when (= 0 (% n 80)) (println)))
+      (emit-marker! (assertion-marker (:state event)))
 
       (= type :skipped)
-      (let [n (swap! default-line-count inc)]
-        (print "S")
-        (when (= 0 (% n 80)) (println)))
-
-      (= type :summary)
-      (print-summary-block event))))
+      (emit-marker! "S"))))
 
 (defn- testdox-reporter
   "Per-assertion single-line description used by the `--reporter=testdox`


### PR DESCRIPTION
## 🤔 Background

`./bin/phel test` produced jagged dot output: most lines wrapped at 80 chars, but some ran 170+ and others stopped at 73-91. Counter increments and wrap newlines drifted out of sync with the visible column.

## 💡 Goal

Restore uniform 80-column wrap for the default reporter regardless of nested output buffering.

## 🔖 Changes

- `default-reporter` no longer counts assertion events whose output is captured by an outer `with-output-buffer` (e.g. self-tests in `tests/phel/reporters.phel` and `tests/phel/test-framework.phel`). Counting invisible dots desynchronised the `(% n 80)` wrap from the visible column.
- `:begin-test-run` events fired synthetically from inside `with-output-buffer` no longer reset the shared counter mid-run.
- `:summary` stays ungated so `(with-output-buffer (test-ns ...))` still captures the summary block.
- Extracted `emit-marker!` and `assertion-marker` helpers; removed three repeated `(and visible? ...)` cond branches.
- CHANGELOG entry under `Unreleased > Fixed > Test`.

Before: lines vary 73 to 175 chars. After: every dot line is 80 chars except the final partial line.