### PR TITLE
Friendlier REPL error output with hints and filtered traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - `(is (= a b))` failures on collections render a `+`/`-`/`~` diff block under the existing summary
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
 
+#### REPL
+- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command frames
+
 ### Fixed
 
 #### Test

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -51,7 +51,7 @@ Run/
 ├── Application/        BundledNamespaces, EntryPointDetector, EvalExecutor, FileRunner, NamespaceLoader, NamespaceRunner, NamespacesLoader, StructuredEvaluator
 ├── Domain/
 │   ├── Init/           NamespaceNormalizer, ProjectTemplateGenerator
-│   ├── Repl/           EvalResult, EvalError, ReplCommandIoInterface, ReplHistory, ReplPrompt, startup.phel
+│   ├── Repl/           EvalResult, EvalError, ReplCommandIoInterface, ReplErrorFormatter, ReplFormattedError, ReplHistory, ReplPrompt, startup.phel, Hint/
 │   ├── Runner/         NamespaceCollector, NamespaceRunnerInterface
 │   ├── Test/           TestCommandOptions, CannotFindAnyTestsException
 │   └── StdinReaderInterface
@@ -69,6 +69,7 @@ Run/
 - `ReplCommandSystemIo` requires PHP `readline` extension; falls back to `ReplCommandFallbackIo`
 - `ReplHistory` registers `*1`/`*2`/`*3`/`*e` in `phel\core` after REPL boot; updates on every eval/exception
 - `ReplPrompt` reads `GlobalEnvironmentSingleton::getNs()` to render the current namespace in the prompt
+- `ReplErrorFormatter` renders eval-time `Throwable`s for REPL output: short headline, optional hint, trace with internal compiler/run/build/command frames hidden. `Hint/` holds `ReplHintInterface` implementations (`NotCallableHint`, `ArgumentCountHint`, `UndefinedSymbolHint`); register new hints via `RunFactory::createReplHints`
 - `NamespaceRunner` resolves full dependency tree before executing
 - `BundledNamespaces` lists every `phel.*` module shipped by Phel/installed Phel packages; `NamespaceLoader` and `NamespaceCollector` use it as eager seeds so fully qualified references (`phel.async/delay`, `phel.json/encode`) resolve without explicit `(:require ...)`. `NamespaceLoader` restores the startup namespace via `GlobalEnvironmentSingleton::setNs` after seeding so the REPL/eval session lands in the expected scope.
 - This is the **most connected module** — depends on 7 other modules via Provider

--- a/src/php/Run/Domain/Repl/Hint/ArgumentCountHint.php
+++ b/src/php/Run/Domain/Repl/Hint/ArgumentCountHint.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl\Hint;
+
+use ArgumentCountError;
+use Throwable;
+
+use function preg_match;
+use function sprintf;
+
+final class ArgumentCountHint implements ReplHintInterface
+{
+    public function appliesTo(Throwable $e): bool
+    {
+        return $e instanceof ArgumentCountError;
+    }
+
+    public function hint(Throwable $e): string
+    {
+        $message = $e->getMessage();
+
+        if (preg_match('/(\d+) passed.*?and (?:exactly |at least )?(\d+).*?expected/', $message, $m) === 1) {
+            $given = (int) $m[1];
+            $expected = (int) $m[2];
+
+            return sprintf(
+                'wrong arity: expected %d argument%s, got %d.',
+                $expected,
+                $expected === 1 ? '' : 's',
+                $given,
+            );
+        }
+
+        return 'wrong number of arguments passed.';
+    }
+}

--- a/src/php/Run/Domain/Repl/Hint/NotCallableHint.php
+++ b/src/php/Run/Domain/Repl/Hint/NotCallableHint.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl\Hint;
+
+use Throwable;
+
+use function preg_match;
+use function sprintf;
+
+final class NotCallableHint implements ReplHintInterface
+{
+    private const array PHEL_TYPE_LABELS = [
+        '/^Phel\\\\Lang\\\\Collections\\\\LazySeq\\\\/' => 'sequence',
+        '/^Phel\\\\Lang\\\\Collections\\\\Vector\\\\/' => 'vector',
+        '/^Phel\\\\Lang\\\\Collections\\\\Map\\\\/' => 'map',
+        '/^Phel\\\\Lang\\\\Collections\\\\SortedMap\\\\/' => 'sorted map',
+        '/^Phel\\\\Lang\\\\Collections\\\\HashSet\\\\/' => 'set',
+        '/^Phel\\\\Lang\\\\Collections\\\\SortedSet\\\\/' => 'sorted set',
+        '/^Phel\\\\Lang\\\\Collections\\\\LinkedList\\\\/' => 'list',
+        '/^Phel\\\\Lang\\\\Collections\\\\Queue\\\\/' => 'queue',
+        '/^Phel\\\\Lang\\\\Collections\\\\Struct\\\\/' => 'struct',
+        '/^Phel\\\\Lang\\\\Keyword$/' => 'keyword',
+        '/^Phel\\\\Lang\\\\Symbol$/' => 'symbol',
+    ];
+
+    public function appliesTo(Throwable $e): bool
+    {
+        return $this->extractType($e->getMessage()) !== null;
+    }
+
+    public function hint(Throwable $e): string
+    {
+        $type = $this->extractType($e->getMessage()) ?? 'value';
+        $label = $this->phelLabel($type) ?? $type;
+
+        return sprintf(
+            "value of type '%s' is not a function. Drop the parens, or use an accessor like (first), (nth), or (get).",
+            $label,
+        );
+    }
+
+    private function extractType(string $message): ?string
+    {
+        if (preg_match('/Object of type ([\\w\\\\]+) is not callable/', $message, $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
+    }
+
+    private function phelLabel(string $fqcn): ?string
+    {
+        foreach (self::PHEL_TYPE_LABELS as $pattern => $label) {
+            if (preg_match($pattern, $fqcn) === 1) {
+                return $label;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/php/Run/Domain/Repl/Hint/ReplHintInterface.php
+++ b/src/php/Run/Domain/Repl/Hint/ReplHintInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl\Hint;
+
+use Throwable;
+
+interface ReplHintInterface
+{
+    public function appliesTo(Throwable $e): bool;
+
+    public function hint(Throwable $e): string;
+}

--- a/src/php/Run/Domain/Repl/Hint/UndefinedSymbolHint.php
+++ b/src/php/Run/Domain/Repl/Hint/UndefinedSymbolHint.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl\Hint;
+
+use Throwable;
+
+use function preg_match;
+use function sprintf;
+
+final class UndefinedSymbolHint implements ReplHintInterface
+{
+    public function appliesTo(Throwable $e): bool
+    {
+        return $this->extract($e->getMessage()) !== null;
+    }
+
+    public function hint(Throwable $e): string
+    {
+        $name = $this->extract($e->getMessage()) ?? 'symbol';
+
+        return sprintf(
+            "'%s' is not defined. Check the spelling, or add (:require ...) for the namespace it lives in.",
+            $name,
+        );
+    }
+
+    private function extract(string $message): ?string
+    {
+        $patterns = [
+            '/Cannot resolve symbol \'?([^\']+?)\'?(?:\s|$)/',
+            '/Undefined (?:variable|constant|function) [\'"$]?([^\'"]+?)[\'"]?(?:\s|$|\.)/',
+            '/Call to undefined function ([\\w\\\\]+)\\(\\)/',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $message, $m) === 1) {
+                return $m[1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/php/Run/Domain/Repl/ReplCommandFallbackIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandFallbackIo.php
@@ -19,6 +19,7 @@ final readonly class ReplCommandFallbackIo implements ReplCommandIoInterface
 {
     public function __construct(
         private CommandFacadeInterface $commandFacade,
+        private ReplErrorFormatter $errorFormatter,
     ) {}
 
     public function readHistory(): void {}
@@ -43,6 +44,11 @@ final readonly class ReplCommandFallbackIo implements ReplCommandIoInterface
     public function writeStackTrace(Throwable $e): void
     {
         $this->writeln($this->commandFacade->getStackTraceString($e));
+    }
+
+    public function writeReplError(Throwable $e): void
+    {
+        $this->writeln($this->errorFormatter->render($e));
     }
 
     public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void

--- a/src/php/Run/Domain/Repl/ReplCommandIoInterface.php
+++ b/src/php/Run/Domain/Repl/ReplCommandIoInterface.php
@@ -18,6 +18,8 @@ interface ReplCommandIoInterface
 
     public function writeStackTrace(Throwable $e): void;
 
+    public function writeReplError(Throwable $e): void;
+
     public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void;
 
     /**

--- a/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
+++ b/src/php/Run/Domain/Repl/ReplCommandSystemIo.php
@@ -16,6 +16,7 @@ final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
         private string $historyFile,
         private CommandFacadeInterface $commandFacade,
         private ApiFacadeInterface $apiFacade,
+        private ReplErrorFormatter $errorFormatter,
     ) {
         readline_completion_function(
             $this->apiFacade->replComplete(...),
@@ -48,6 +49,11 @@ final readonly class ReplCommandSystemIo implements ReplCommandIoInterface
     public function writeStackTrace(Throwable $e): void
     {
         $this->writeln($this->commandFacade->getStackTraceString($e));
+    }
+
+    public function writeReplError(Throwable $e): void
+    {
+        $this->writeln($this->errorFormatter->render($e));
     }
 
     public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl;
+
+use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Run\Domain\Repl\Hint\ReplHintInterface;
+use Phel\Shared\ColorStyleInterface;
+use Throwable;
+
+use function explode;
+use function implode;
+use function preg_match;
+use function sprintf;
+use function str_contains;
+
+use const PHP_EOL;
+
+final readonly class ReplErrorFormatter
+{
+    /**
+     * @param list<ReplHintInterface> $hints
+     */
+    public function __construct(
+        private array $hints,
+        private ExceptionPrinterInterface $exceptionPrinter,
+        private ColorStyleInterface $style,
+    ) {}
+
+    public function format(Throwable $e): ReplFormattedError
+    {
+        $fullTrace = $this->exceptionPrinter->getStackTraceString($e);
+
+        return new ReplFormattedError(
+            $this->buildHeadline($e),
+            $this->lookupHint($e),
+            $this->filterTrace($fullTrace),
+            $fullTrace,
+        );
+    }
+
+    public function render(Throwable $e): string
+    {
+        $formatted = $this->format($e);
+        $parts = [$formatted->headline];
+
+        if ($formatted->hint !== null) {
+            $parts[] = $this->style->yellow('hint: ' . $formatted->hint);
+        }
+
+        if ($formatted->trace !== '') {
+            $parts[] = '';
+            $parts[] = $formatted->trace;
+        }
+
+        return implode(PHP_EOL, $parts);
+    }
+
+    private function buildHeadline(Throwable $e): string
+    {
+        $type = $this->shortClassName($e::class);
+        $message = $e->getMessage() !== '' ? $e->getMessage() : '*no message*';
+
+        return $this->style->red(sprintf('%s: %s', $type, $message));
+    }
+
+    private function lookupHint(Throwable $e): ?string
+    {
+        foreach ($this->hints as $hint) {
+            if ($hint->appliesTo($e)) {
+                return $hint->hint($e);
+            }
+        }
+
+        return null;
+    }
+
+    private function filterTrace(string $trace): string
+    {
+        $lines = explode(PHP_EOL, $trace);
+        $kept = [];
+        $dropped = 0;
+
+        foreach ($lines as $line) {
+            if ($this->isInternalFrame($line)) {
+                ++$dropped;
+                continue;
+            }
+
+            $kept[] = $line;
+        }
+
+        if ($dropped > 0) {
+            $kept[] = sprintf('  ... %d internal frame%s hidden', $dropped, $dropped === 1 ? '' : 's');
+        }
+
+        return implode(PHP_EOL, $kept);
+    }
+
+    private function isInternalFrame(string $line): bool
+    {
+        if (preg_match('/^#\d+\s/', $line) !== 1) {
+            return false;
+        }
+
+        return str_contains($line, '/phel-lang/src/php/Compiler/')
+            || str_contains($line, '/phel-lang/src/php/Run/')
+            || str_contains($line, '/phel-lang/src/php/Build/')
+            || str_contains($line, '/phel-lang/src/php/Command/');
+    }
+
+    private function shortClassName(string $fqcn): string
+    {
+        $pos = strrpos($fqcn, '\\');
+
+        return $pos === false ? $fqcn : substr($fqcn, $pos + 1);
+    }
+}

--- a/src/php/Run/Domain/Repl/ReplFormattedError.php
+++ b/src/php/Run/Domain/Repl/ReplFormattedError.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Repl;
+
+final readonly class ReplFormattedError
+{
+    public function __construct(
+        public string $headline,
+        public ?string $hint,
+        public string $trace,
+        public string $fullTrace,
+    ) {}
+}

--- a/src/php/Run/Infrastructure/Command/ReplCommand.php
+++ b/src/php/Run/Infrastructure/Command/ReplCommand.php
@@ -144,7 +144,7 @@ final class ReplCommand extends Command
                 break;
             } catch (Throwable $e) {
                 $this->inputBuffer = [];
-                $this->io->writeStackTrace($e);
+                $this->io->writeReplError($e);
             }
         }
 
@@ -244,7 +244,7 @@ final class ReplCommand extends Command
             $this->inputBuffer = [];
         } catch (Throwable $e) {
             $this->history?->recordException($e);
-            $this->io->writeStackTrace($e);
+            $this->io->writeReplError($e);
             $this->addHistory($fullInput);
             $this->inputBuffer = [];
         }

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -16,9 +16,14 @@ use Phel\Run\Application\NamespaceLoader;
 use Phel\Run\Application\NamespaceRunner;
 use Phel\Run\Application\NamespacesLoader;
 use Phel\Run\Application\StructuredEvaluator;
+use Phel\Run\Domain\Repl\Hint\ArgumentCountHint;
+use Phel\Run\Domain\Repl\Hint\NotCallableHint;
+use Phel\Run\Domain\Repl\Hint\ReplHintInterface;
+use Phel\Run\Domain\Repl\Hint\UndefinedSymbolHint;
 use Phel\Run\Domain\Repl\ReplCommandFallbackIo;
 use Phel\Run\Domain\Repl\ReplCommandIoInterface;
 use Phel\Run\Domain\Repl\ReplCommandSystemIo;
+use Phel\Run\Domain\Repl\ReplErrorFormatter;
 use Phel\Run\Domain\Repl\ReplHistory;
 use Phel\Run\Domain\Repl\ReplPrompt;
 use Phel\Run\Domain\Runner\NamespaceCollector;
@@ -96,12 +101,35 @@ class RunFactory extends AbstractFactory
                 $this->getConfig()->getPhelReplHistory(),
                 $this->getCommandFacade(),
                 $this->getApiFacade(),
+                $this->createReplErrorFormatter(),
             );
         }
 
         return new ReplCommandFallbackIo(
             $this->getCommandFacade(),
+            $this->createReplErrorFormatter(),
         );
+    }
+
+    public function createReplErrorFormatter(): ReplErrorFormatter
+    {
+        return new ReplErrorFormatter(
+            $this->createReplHints(),
+            $this->getCommandFacade()->getExceptionPrinter(),
+            $this->createColorStyle(),
+        );
+    }
+
+    /**
+     * @return list<ReplHintInterface>
+     */
+    public function createReplHints(): array
+    {
+        return [
+            new NotCallableHint(),
+            new ArgumentCountHint(),
+            new UndefinedSymbolHint(),
+        ];
     }
 
     public function createReplHistory(): ReplHistory

--- a/src/php/Shared/Facade/CommandFacadeInterface.php
+++ b/src/php/Shared/Facade/CommandFacadeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Facade;
 
+use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,6 +23,8 @@ interface CommandFacadeInterface
     public function getExceptionString(AbstractLocatedException $e, CodeSnippet $codeSnippet): string;
 
     public function getStackTraceString(Throwable $e): string;
+
+    public function getExceptionPrinter(): ExceptionPrinterInterface;
 
     /**
      * All src, tests, and vendor directories.

--- a/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplTestIo.php
@@ -7,7 +7,12 @@ namespace PhelTest\Integration\Run\Command\Repl;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
+use Phel\Run\Domain\Repl\Hint\ArgumentCountHint;
+use Phel\Run\Domain\Repl\Hint\NotCallableHint;
+use Phel\Run\Domain\Repl\Hint\UndefinedSymbolHint;
 use Phel\Run\Domain\Repl\ReplCommandIoInterface;
+use Phel\Run\Domain\Repl\ReplErrorFormatter;
+use Phel\Shared\ColorStyle;
 use Throwable;
 
 use function array_slice;
@@ -23,9 +28,22 @@ final class ReplTestIo implements ReplCommandIoInterface
 
     private int $currentIndex = 0;
 
+    private readonly ReplErrorFormatter $errorFormatter;
+
     public function __construct(
         private readonly ExceptionPrinterInterface $exceptionPrinter,
-    ) {}
+        ?ReplErrorFormatter $errorFormatter = null,
+    ) {
+        $this->errorFormatter = $errorFormatter ?? new ReplErrorFormatter(
+            [
+                new NotCallableHint(),
+                new ArgumentCountHint(),
+                new UndefinedSymbolHint(),
+            ],
+            $exceptionPrinter,
+            ColorStyle::noStyles(),
+        );
+    }
 
     public function readHistory(): void {}
 
@@ -51,6 +69,11 @@ final class ReplTestIo implements ReplCommandIoInterface
     public function writeStackTrace(Throwable $e): void
     {
         $this->write($this->exceptionPrinter->getStackTraceString($e));
+    }
+
+    public function writeReplError(Throwable $e): void
+    {
+        $this->write($this->errorFormatter->render($e));
     }
 
     public function writeLocatedException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void

--- a/tests/php/Unit/Run/Domain/Repl/Hint/ArgumentCountHintTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/Hint/ArgumentCountHintTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Repl\Hint;
+
+use ArgumentCountError;
+use Phel\Run\Domain\Repl\Hint\ArgumentCountHint;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ArgumentCountHintTest extends TestCase
+{
+    public function test_does_not_apply_to_other_throwables(): void
+    {
+        self::assertFalse(new ArgumentCountHint()->appliesTo(new RuntimeException('boom')));
+    }
+
+    public function test_applies_to_argument_count_error(): void
+    {
+        $e = new ArgumentCountError(
+            'foo() expects 1 passed exactly 2 expected, called somewhere',
+        );
+
+        self::assertTrue(new ArgumentCountHint()->appliesTo($e));
+    }
+
+    public function test_extracts_arity_when_message_matches(): void
+    {
+        $e = new ArgumentCountError('Too few arguments to function user\\bar(), 1 passed and exactly 2 expected');
+
+        self::assertSame('wrong arity: expected 2 arguments, got 1.', new ArgumentCountHint()->hint($e));
+    }
+
+    public function test_singular_argument_label(): void
+    {
+        $e = new ArgumentCountError('Too few arguments to function user\\bar(), 0 passed and exactly 1 expected');
+
+        self::assertSame('wrong arity: expected 1 argument, got 0.', new ArgumentCountHint()->hint($e));
+    }
+
+    public function test_falls_back_when_message_unparseable(): void
+    {
+        $e = new ArgumentCountError('weird message');
+
+        self::assertSame('wrong number of arguments passed.', new ArgumentCountHint()->hint($e));
+    }
+}

--- a/tests/php/Unit/Run/Domain/Repl/Hint/NotCallableHintTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/Hint/NotCallableHintTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Repl\Hint;
+
+use Error;
+use Phel\Run\Domain\Repl\Hint\NotCallableHint;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class NotCallableHintTest extends TestCase
+{
+    public function test_does_not_apply_when_message_unrelated(): void
+    {
+        $hint = new NotCallableHint();
+
+        self::assertFalse($hint->appliesTo(new RuntimeException('something broke')));
+    }
+
+    public function test_applies_to_not_callable_message(): void
+    {
+        $hint = new NotCallableHint();
+        $e = new Error('Object of type Phel\\Lang\\Collections\\LazySeq\\ChunkedSeq is not callable');
+
+        self::assertTrue($hint->appliesTo($e));
+        self::assertStringContainsString("'sequence'", $hint->hint($e));
+        self::assertStringContainsString('first', $hint->hint($e));
+    }
+
+    public function test_maps_vector_type(): void
+    {
+        $hint = new NotCallableHint();
+        $e = new Error('Object of type Phel\\Lang\\Collections\\Vector\\PersistentVector is not callable');
+
+        self::assertStringContainsString("'vector'", $hint->hint($e));
+    }
+
+    public function test_falls_back_to_fqcn_for_unknown_phel_type(): void
+    {
+        $hint = new NotCallableHint();
+        $e = new Error('Object of type App\\Custom\\Thing is not callable');
+
+        self::assertStringContainsString("'App\\Custom\\Thing'", $hint->hint($e));
+    }
+}

--- a/tests/php/Unit/Run/Domain/Repl/Hint/UndefinedSymbolHintTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/Hint/UndefinedSymbolHintTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Repl\Hint;
+
+use Error;
+use Phel\Run\Domain\Repl\Hint\UndefinedSymbolHint;
+use PHPUnit\Framework\TestCase;
+
+final class UndefinedSymbolHintTest extends TestCase
+{
+    public function test_extracts_phel_resolve_symbol(): void
+    {
+        $hint = new UndefinedSymbolHint();
+        $e = new Error("Cannot resolve symbol 'frobnicate'");
+
+        self::assertTrue($hint->appliesTo($e));
+        self::assertStringContainsString("'frobnicate'", $hint->hint($e));
+        self::assertStringContainsString(':require', $hint->hint($e));
+    }
+
+    public function test_extracts_undefined_function(): void
+    {
+        $hint = new UndefinedSymbolHint();
+        $e = new Error('Call to undefined function App\\does_not_exist()');
+
+        self::assertTrue($hint->appliesTo($e));
+        self::assertStringContainsString('does_not_exist', $hint->hint($e));
+    }
+
+    public function test_does_not_apply_when_message_unrelated(): void
+    {
+        self::assertFalse(new UndefinedSymbolHint()->appliesTo(new Error('different problem')));
+    }
+}

--- a/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Domain\Repl;
+
+use Error;
+use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
+use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
+use Phel\Run\Domain\Repl\Hint\NotCallableHint;
+use Phel\Run\Domain\Repl\ReplErrorFormatter;
+use Phel\Shared\ColorStyle;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+final class ReplErrorFormatterTest extends TestCase
+{
+    public function test_filters_internal_compiler_frames(): void
+    {
+        $trace = implode(PHP_EOL, [
+            'Error: boom',
+            'in string:1 (gen: ...)',
+            '',
+            '#0 /repo/phel-lang/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26): eval()',
+            '#1 /repo/phel-lang/src/php/Run/Infrastructure/Command/ReplCommand.php(214): Foo->bar()',
+            '#2 /home/user/code/myproject.phel(3): user_call()',
+        ]);
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('boom'));
+
+        self::assertStringContainsString('myproject.phel', $result->trace);
+        self::assertStringNotContainsString('InMemoryEvaluator', $result->trace);
+        self::assertStringNotContainsString('ReplCommand.php', $result->trace);
+        self::assertStringContainsString('2 internal frames hidden', $result->trace);
+    }
+
+    public function test_renders_headline_with_short_class_name(): void
+    {
+        $formatter = $this->buildFormatter('');
+
+        $rendered = $formatter->render(new RuntimeException('something broke'));
+
+        self::assertStringContainsString('RuntimeException: something broke', $rendered);
+    }
+
+    public function test_includes_hint_when_match(): void
+    {
+        $formatter = new ReplErrorFormatter(
+            [new NotCallableHint()],
+            $this->stubPrinter(''),
+            ColorStyle::noStyles(),
+        );
+
+        $rendered = $formatter->render(
+            new Error('Object of type Phel\\Lang\\Collections\\LazySeq\\ChunkedSeq is not callable'),
+        );
+
+        self::assertStringContainsString('hint:', $rendered);
+        self::assertStringContainsString("'sequence'", $rendered);
+    }
+
+    public function test_no_hint_section_when_no_match(): void
+    {
+        $formatter = new ReplErrorFormatter(
+            [new NotCallableHint()],
+            $this->stubPrinter(''),
+            ColorStyle::noStyles(),
+        );
+
+        $rendered = $formatter->render(new RuntimeException('unrelated'));
+
+        self::assertStringNotContainsString('hint:', $rendered);
+    }
+
+    public function test_empty_message_falls_back_to_no_message_marker(): void
+    {
+        $formatter = $this->buildFormatter('');
+
+        $rendered = $formatter->render(new RuntimeException(''));
+
+        self::assertStringContainsString('*no message*', $rendered);
+    }
+
+    private function buildFormatter(string $trace): ReplErrorFormatter
+    {
+        return new ReplErrorFormatter(
+            [],
+            $this->stubPrinter($trace),
+            ColorStyle::noStyles(),
+        );
+    }
+
+    private function stubPrinter(string $trace): ExceptionPrinterInterface
+    {
+        return new readonly class($trace) implements ExceptionPrinterInterface {
+            public function __construct(private string $trace) {}
+
+            public function getStackTraceString(Throwable $e): string
+            {
+                return $this->trace;
+            }
+
+            public function printStackTrace(Throwable $e): void {}
+
+            public function printException(AbstractLocatedException $e, CodeSnippet $codeSnippet): void {}
+
+            public function getExceptionString(AbstractLocatedException $e, CodeSnippet $codeSnippet): string
+            {
+                return '';
+            }
+
+            public function printError(string $error): void {}
+        };
+    }
+}


### PR DESCRIPTION
Closes #1910

## 🤔 Background

REPL eval errors currently dump raw PHP stack traces with internal compiler/run/build/command frames, surface PHP class names like `Phel\Lang\Collections\LazySeq\ChunkedSeq` directly to the user, and offer no nudge toward a fix. For Phel devs working in the REPL the noise drowns the signal:

```
user:10> (active-names)
Error: Object of type Phel\Lang\Collections\LazySeq\ChunkedSeq is not callable
in string:10 (gen: /Users/.../InMemoryEvaluator.php(26) : eval()'d code:3)
#0 /Users/.../InMemoryEvaluator.php(26): eval()
#1 /Users/.../EvalCompiler.php(114): InMemoryEvaluator->eval(...)
#2 /Users/.../EvalCompiler.php(69): EvalCompiler->evalNode(...)
#3 /Users/.../CompilerFacade.php(57): EvalCompiler->evalString(...)
#4 /Users/.../RunFacade.php(67): CompilerFacade->eval(...)
#5 /Users/.../ReplCommand.php(214): RunFacade->eval(...)
#6 /Users/.../ReplCommand.php(142): ReplCommand->analyzeInputBuffer()
```

## 💡 Goal

Render eval-time errors as: short headline, optional Phel-flavored hint, and a trace with internal phel-lang frames hidden. Keep the door open for adding more hints over time.

## 🔖 Changes

- New `ReplErrorFormatter` (`src/php/Run/Domain/Repl/`) wraps any `Throwable` into headline + hint + filtered trace + full trace
- New `ReplHintInterface` registry under `Domain/Repl/Hint/` with three concrete hints:
  - `NotCallableHint`: maps `Object of type X is not callable` to a Phel type label (sequence, vector, map, keyword, ...) and suggests `first`, `nth`, or `get`
  - `ArgumentCountHint`: extracts arity from `ArgumentCountError` messages
  - `UndefinedSymbolHint`: matches `Cannot resolve symbol '...'` and `Call to undefined function ...`, suggests `(:require ...)` or spell-check
- New `writeReplError(Throwable)` method on `ReplCommandIoInterface`; `ReplCommand`'s eval-time catches use it instead of `writeStackTrace`. Startup-time catch keeps the raw trace
- `RunFactory::createReplErrorFormatter` and `createReplHints` make hints registerable from one place
- `CommandFacadeInterface` exposes `getExceptionPrinter()` so callers outside the Command module can build their own renderers
- Unit tests cover the formatter (frame filter, headline, hint wiring, empty-message fallback) and each hint
- CHANGELOG note under Unreleased / REPL
- `src/php/Run/CLAUDE.md` updated to mention the new `Hint/` subdirectory and how to register hints