### PR TITLE
Polish REPL error rendering: unwrap, drop prefix, hide more frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
 
 #### REPL
-- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command frames
+- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command/console, symfony console, and `bin/phel` frames; `EvaluatedCodeException` wrappers are unwrapped to the inner exception class for the headline
 
 ### Fixed
 

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Run\Domain\Repl;
 
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Run\Domain\Repl\Hint\ReplHintInterface;
 use Phel\Shared\ColorStyleInterface;
 use Throwable;
@@ -19,6 +20,16 @@ use const PHP_EOL;
 
 final readonly class ReplErrorFormatter
 {
+    private const array INTERNAL_FRAME_PATHS = [
+        '/phel-lang/src/php/Compiler/',
+        '/phel-lang/src/php/Run/',
+        '/phel-lang/src/php/Build/',
+        '/phel-lang/src/php/Command/',
+        '/phel-lang/src/php/Console/',
+        '/vendor/symfony/console/',
+        '/phel-lang/bin/phel',
+    ];
+
     /**
      * @param list<ReplHintInterface> $hints
      */
@@ -30,11 +41,12 @@ final readonly class ReplErrorFormatter
 
     public function format(Throwable $e): ReplFormattedError
     {
+        $cause = $this->unwrap($e);
         $fullTrace = $this->exceptionPrinter->getStackTraceString($e);
 
         return new ReplFormattedError(
-            $this->buildHeadline($e),
-            $this->lookupHint($e),
+            $this->buildHeadline($cause),
+            $this->lookupHint($cause),
             $this->filterTrace($fullTrace),
             $fullTrace,
         );
@@ -55,6 +67,15 @@ final readonly class ReplErrorFormatter
         }
 
         return implode(PHP_EOL, $parts);
+    }
+
+    private function unwrap(Throwable $e): Throwable
+    {
+        if ($e instanceof EvaluatedCodeException) {
+            return $e->getOriginalException();
+        }
+
+        return $e;
     }
 
     private function buildHeadline(Throwable $e): string
@@ -81,14 +102,33 @@ final readonly class ReplErrorFormatter
         $lines = explode(PHP_EOL, $trace);
         $kept = [];
         $dropped = 0;
+        $sawFrame = false;
+        $keepingCurrentFrame = false;
 
         foreach ($lines as $line) {
-            if ($this->isInternalFrame($line)) {
-                ++$dropped;
+            $isFrame = preg_match('/^#\d+\s/', $line) === 1;
+
+            if (!$sawFrame && !$isFrame) {
                 continue;
             }
 
-            $kept[] = $line;
+            if ($isFrame) {
+                $sawFrame = true;
+
+                if ($this->isInternalFrame($line)) {
+                    ++$dropped;
+                    $keepingCurrentFrame = false;
+                    continue;
+                }
+
+                $keepingCurrentFrame = true;
+                $kept[] = $line;
+                continue;
+            }
+
+            if ($keepingCurrentFrame) {
+                $kept[] = $line;
+            }
         }
 
         if ($dropped > 0) {
@@ -100,14 +140,7 @@ final readonly class ReplErrorFormatter
 
     private function isInternalFrame(string $line): bool
     {
-        if (preg_match('/^#\d+\s/', $line) !== 1) {
-            return false;
-        }
-
-        return str_contains($line, '/phel-lang/src/php/Compiler/')
-            || str_contains($line, '/phel-lang/src/php/Run/')
-            || str_contains($line, '/phel-lang/src/php/Build/')
-            || str_contains($line, '/phel-lang/src/php/Command/');
+        return array_any(self::INTERNAL_FRAME_PATHS, static fn(string $needle): bool => str_contains($line, $needle));
     }
 
     private function shortClassName(string $fqcn): string

--- a/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Run\Domain\Repl;
 
 use Error;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Compiler\Domain\Evaluator\Exceptions\EvaluatedCodeException;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Phel\Run\Domain\Repl\Hint\NotCallableHint;
@@ -35,6 +36,58 @@ final class ReplErrorFormatterTest extends TestCase
         self::assertStringNotContainsString('InMemoryEvaluator', $result->trace);
         self::assertStringNotContainsString('ReplCommand.php', $result->trace);
         self::assertStringContainsString('2 internal frames hidden', $result->trace);
+    }
+
+    public function test_drops_prefix_lines_before_first_frame(): void
+    {
+        $trace = implode(PHP_EOL, [
+            'Error: original message',
+            'in string:5 (gen: /tmp/eval.php:3)',
+            '',
+            '#0 /home/user/code/myproject.phel(3): user_call()',
+        ]);
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('original message'));
+
+        self::assertStringNotContainsString('Error: original message', $result->trace);
+        self::assertStringNotContainsString('in string:5', $result->trace);
+        self::assertStringContainsString('#0 /home/user/code/myproject.phel', $result->trace);
+    }
+
+    public function test_filters_symfony_console_and_bin_phel_frames(): void
+    {
+        $trace = implode(PHP_EOL, [
+            '#0 /home/runner/work/phel-lang/phel-lang/vendor/symfony/console/Application.php(195): Foo->run()',
+            '#1 /home/runner/work/phel-lang/phel-lang/bin/phel(97): Bar->call()',
+            '#2 /home/user/code/myproject.phel(3): user_call()',
+        ]);
+
+        $formatter = $this->buildFormatter($trace);
+        $result = $formatter->format(new RuntimeException('boom'));
+
+        self::assertStringNotContainsString('symfony/console', $result->trace);
+        self::assertStringNotContainsString('bin/phel', $result->trace);
+        self::assertStringContainsString('myproject.phel', $result->trace);
+        self::assertStringContainsString('2 internal frames hidden', $result->trace);
+    }
+
+    public function test_unwraps_evaluated_code_exception_for_headline_and_hint(): void
+    {
+        $original = new Error('Object of type Phel\\Lang\\Collections\\LazySeq\\ChunkedSeq is not callable');
+        $wrapped = EvaluatedCodeException::fromThrowableAndCompiledCode($original, "// some.phel\n", 0);
+
+        $formatter = new ReplErrorFormatter(
+            [new NotCallableHint()],
+            $this->stubPrinter(''),
+            ColorStyle::noStyles(),
+        );
+
+        $rendered = $formatter->render($wrapped);
+
+        self::assertStringContainsString('Error: Object of type', $rendered);
+        self::assertStringNotContainsString('EvaluatedCodeException', $rendered);
+        self::assertStringContainsString("'sequence'", $rendered);
     }
 
     public function test_renders_headline_with_short_class_name(): void


### PR DESCRIPTION
Follow-up to #1911.

## 🤔 Background

Live-testing #1911 in the REPL surfaced three rough edges in the new error output:

```
EvaluatedCodeException: Object of type Phel\Lang\Collections\LazySeq\ChunkedSeq is not callable
hint: value of type 'sequence' is not a function...

Error: Object of type Phel\Lang\Collections\LazySeq\ChunkedSeq is not callable
in string:3 (gen: ...)

// ;;...')
#8 .../symfony/console/Application.php(195): ...
#9 .../symfony/console/Application.php(356): ...
#10 .../bin/phel(97): ...
... internal frames hidden
```

1. Headline shows the wrapper class `EvaluatedCodeException` instead of the real underlying error type.
2. The stack-trace printer's prefix (`Error: ...` + `in string:3 (gen: ...)`) gets re-printed below the new headline.
3. Frames from `vendor/symfony/console/`, `bin/phel`, and the Console module stay in the trace even though they always sit above the user's own code.
4. Multi-line `eval()` args (the compiled PHP source map comments) leak through as orphan lines like `// ;;...')`.

## 💡 Goal

Make the rendered output match the headline+hint+filtered-trace contract one more step further so REPL errors read cleanly:

```
Error: Object of type Phel\Lang\Collections\LazySeq\ChunkedSeq is not callable
hint: value of type 'sequence' is not a function. Drop the parens, or use an accessor like (first), (nth), or (get).

  ... 16 internal frames hidden
```

## 🔖 Changes

- `ReplErrorFormatter::unwrap` returns the inner `Throwable` for `EvaluatedCodeException`, used for headline + hint lookup
- `filterTrace` skips everything before the first `#N` frame, removing the printer's `Type: msg` + `in file:line` prefix
- Continuation lines that follow an internal frame (from multi-line `eval()` args) are dropped with their owning frame; continuation lines after a kept frame are still printed
- Internal-frame path list extended with `/phel-lang/src/php/Console/`, `/vendor/symfony/console/`, and `/phel-lang/bin/phel`
- Tests cover the prefix drop, the symfony/bin filter, and the `EvaluatedCodeException` unwrap path
- CHANGELOG entry updated under Unreleased / REPL