### PR TITLE
Strip PHP eval() path suffix from REPL error headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
 
 #### REPL
-- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command/console, symfony console, and `bin/phel` frames; `EvaluatedCodeException` wrappers are unwrapped to the inner exception class for the headline
+- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command/console, symfony console, and `bin/phel` frames; `EvaluatedCodeException` wrappers are unwrapped to the inner exception class for the headline; PHP's ` in <path>(<line>) : eval()'d code on line <N>` location suffix is stripped from the headline message
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 #### Test
-- `(is (= a b))` failures on collections render a `+`/`-`/`~` diff block under the existing summary
-- `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags for flake hunting and reproducible test order
+- `(is (= a b))` failures on collections render a unified diff block
+- `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags
 
 #### REPL
-- Eval errors render with a Phel-flavored headline, an optional hint (e.g. calling a sequence as a function, wrong arity, undefined symbol), and a trace that hides internal compiler/run/build/command/console, symfony console, and `bin/phel` frames; `EvaluatedCodeException` wrappers are unwrapped to the inner exception class for the headline; PHP's ` in <path>(<line>) : eval()'d code on line <N>` location suffix is stripped from the headline message
+- Eval errors show a short headline, optional hint, and a trace with internal frames hidden
 
 ### Fixed
 
 #### Test
-- Default reporter dot output wraps uniformly at 80 columns when tests use `with-output-buffer`
+- Default reporter wraps dot output at 80 columns under `with-output-buffer`
 
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 

--- a/src/php/Run/Domain/Repl/ReplErrorFormatter.php
+++ b/src/php/Run/Domain/Repl/ReplErrorFormatter.php
@@ -13,8 +13,10 @@ use Throwable;
 use function explode;
 use function implode;
 use function preg_match;
+use function preg_replace;
 use function sprintf;
 use function str_contains;
+use function trim;
 
 use const PHP_EOL;
 
@@ -81,9 +83,24 @@ final readonly class ReplErrorFormatter
     private function buildHeadline(Throwable $e): string
     {
         $type = $this->shortClassName($e::class);
-        $message = $e->getMessage() !== '' ? $e->getMessage() : '*no message*';
+        $message = $this->cleanMessage($e->getMessage());
 
         return $this->style->red(sprintf('%s: %s', $type, $message));
+    }
+
+    private function cleanMessage(string $message): string
+    {
+        if ($message === '') {
+            return '*no message*';
+        }
+
+        $cleaned = preg_replace(
+            '/ in [^\s]+\(\d+\)\s*:\s*eval\(\)\'d code on line \d+/',
+            '',
+            $message,
+        );
+
+        return trim($cleaned ?? $message);
     }
 
     private function lookupHint(Throwable $e): ?string

--- a/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplErrorFormatterTest.php
@@ -137,6 +137,27 @@ final class ReplErrorFormatterTest extends TestCase
         self::assertStringContainsString('*no message*', $rendered);
     }
 
+    public function test_strips_eval_path_from_php_injected_message(): void
+    {
+        $formatter = $this->buildFormatter('');
+        $message = "Too few arguments to function Foo::bar(), 0 passed in /Users/dev/repo/src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code on line 3 and exactly 1 expected";
+
+        $rendered = $formatter->render(new RuntimeException($message));
+
+        self::assertStringContainsString('0 passed and exactly 1 expected', $rendered);
+        self::assertStringNotContainsString('InMemoryEvaluator.php', $rendered);
+        self::assertStringNotContainsString("eval()'d code", $rendered);
+    }
+
+    public function test_leaves_message_untouched_when_no_eval_path_present(): void
+    {
+        $formatter = $this->buildFormatter('');
+
+        $rendered = $formatter->render(new RuntimeException('plain user-provided message'));
+
+        self::assertStringContainsString('plain user-provided message', $rendered);
+    }
+
     private function buildFormatter(string $trace): ReplErrorFormatter
     {
         return new ReplErrorFormatter(


### PR DESCRIPTION
Follow-up to #1911 / #1912.

## 🤔 Background

When user code throws inside the REPL, PHP automatically appends a source-location suffix to the error message:

```
Too few arguments to function ...AbstractPersistentVector::__invoke(), 0 passed in /Users/.../src/php/Compiler/Domain/Evaluator/InMemoryEvaluator.php(26) : eval()'d code on line 3 and exactly 1 expected
```

The path points into `InMemoryEvaluator.php`, which is the same internal we already hide from traces. It still leaks into the headline because the headline reads `$throwable->getMessage()` directly.

## 💡 Goal

Headline shows only the user-relevant message:

```
ArgumentCountError: Too few arguments to function ...AbstractPersistentVector::__invoke(), 0 passed and exactly 1 expected
hint: wrong arity: expected 1 argument, got 0.
```

## 🔖 Changes

- `ReplErrorFormatter::cleanMessage` strips matches of `' in <path>(<line>) : eval()'d code on line <N>'` from the message before the headline is rendered. Empty messages still fall back to `*no message*`.
- Two new unit tests cover the strip behaviour and the no-op path for plain messages.
- CHANGELOG entry under Unreleased / REPL extended with the suffix-stripping note.