### PR TITLE
perf(compiler): emit $this for self-recursive global-fn calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 #### REPL
 - Eval errors show a short headline, optional hint, and a trace with internal frames hidden
 
+### Changed
+
+#### Compiler
+- Recursive global-fn calls inside their own body emit `$this(...)` instead of a registry lookup (#1914)
+
 ### Fixed
 
 #### Test

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
@@ -169,9 +170,39 @@ final class CallEmitter implements NodeEmitterInterface
 
     private function emitDynamicFunctionName(CallNode $node): void
     {
+        if ($this->isSelfCall($node)) {
+            $this->outputEmitter->emitStr('$this', $node->getStartSourceLocation());
+            return;
+        }
+
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getFn());
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+    }
+
+    /**
+     * A call is a self-call when the callee resolves to the same global fn
+     * whose body we are currently emitting. In that case `$this` already
+     * references the AbstractFn instance, so we skip the registry lookup.
+     *
+     * `let` and `loop` extend boundTo with a `.<sym>` suffix while analysing
+     * their inits, so an exact match is not enough.
+     */
+    private function isSelfCall(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        $boundTo = $node->getEnv()->getBoundTo();
+        if ($boundTo === '') {
+            return false;
+        }
+
+        $expected = $fn->getNamespace() . '\\' . $fn->getName()->getName();
+        return $boundTo === $expected
+            || str_starts_with($boundTo, $expected . '.');
     }
 
     private function emitFunctionArguments(CallNode $node): void

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -1,0 +1,30 @@
+--PHEL--
+(defn rec [n] (rec n))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rec",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rec";
+
+    public function __invoke($n) {
+      return $this($n);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Call/self-call-direct.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Call/self-call-direct.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 22
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -1,0 +1,35 @@
+--PHEL--
+(defn rec [n] (if (php/== n 0) n (rec (php/- n 1))))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rec",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rec";
+
+    public function __invoke($n) {
+      if (($__truthy = ($n == 0)) !== null && $__truthy !== false) {
+        return $n;
+      } else {
+        return $this(($n - 1));
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Call/self-call-with-if.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Call/self-call-with-if.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 52
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
+);


### PR DESCRIPTION
## 🤔 Background

Closes #1914 (§1; §2 deferred to #1917).

Every Phel global-fn call compiles to a registry lookup wrapped in invocation:

```php
(\Phel::getDefinition("user", "fib"))($n - 1);
```

For tight recursion (naive `fib`, mutual recursion, traversal kernels), the per-call overhead, static method call + hashmap lookup + `AbstractFn::__invoke` dispatch, dominates runtime.

## 💡 Goal

Inside an emitted `defn` body, `$this` already references the `AbstractFn` instance, so a self-call can skip the registry lookup entirely. After this change:

```php
public function __invoke($n) {
  if (...) {
    return $n;
  } else {
    return $this(($n - 1));
  }
}
```

## 🔖 Changes

- `CallEmitter::emitDynamicFunctionName` checks for self-calls and emits `$this` instead of `(\Phel::getDefinition("ns", "name"))`.
- `CallEmitter::isSelfCall` matches the call's `GlobalVarNode` against `env->getBoundTo()`. Handles the `let` and `loop` boundTo suffix extension via `str_starts_with($boundTo, $expected . '.')`.
- Two new integration fixtures under `tests/php/Integration/Fixtures/Call/`:
  - `self-call-direct.test`: `(defn rec [n] (rec n))` -> `$this($n)`
  - `self-call-with-if.test`: `(defn rec [n] (if (php/== n 0) n (rec (php/- n 1))))` -> `$this(($n - 1))` in else branch
- CHANGELOG `Unreleased > Changed > Compiler` entry.

## 📊 Benchmark

PHPBench, fib(22), 10 iterations, 2 warmups, PHP 8.4 + opcache, eval-mode (compile + run per rev):

| Build | Mode | rstdev |
|-------|------|--------|
| Baseline (`413d67da`, no optimization) | 55.31 ms | ±1.94% |
| Optimized (`bee68ffe`, this PR) | 15.12 ms | ±1.89% |

**Speedup: 3.66x** on the recursive hot loop. Within the 2-5x estimate from #1914.

## Scope notes

- The cached global-fn lookup proposed in #1914 §2 is deferred to #1917 (open design questions: REPL redefinition strategy, statement-level placement of `static` decls).
- Refactor pass folded into the implementation commit (no separate `ref(...)` commit). Touched files reviewed: `CallEmitter.php` is tight, two fixtures are minimal and cover return-tail and if-else positions; no further changes surfaced.

## Verification

- `composer test-compiler` (3187 tests, 8671 assertions, 3 skipped) green.
- `composer test-core` (5402 tests) green.
- `composer csrun`, `composer phpstan`, `composer rector` clean.
- `composer psalm` crashed with a vendor-side `Amp\Cache\LocalCache not found` (pre-existing env issue, unrelated).