### PR TITLE
fix(api): preload required namespaces when analyzing source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 #### Test
 - Default reporter wraps dot output at 80 columns under `with-output-buffer`
 
+#### Api
+- `phel analyze` preloads namespaces required by the file under analysis, eliminating false `PHEL001 Cannot resolve symbol` diagnostics for aliased project symbols (#1919)
+
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 
 ### Added

--- a/src/php/Api/ApiFactory.php
+++ b/src/php/Api/ApiFactory.php
@@ -6,6 +6,7 @@ namespace Phel\Api;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Api\Application\Analysis\LexAndParseStage;
+use Phel\Api\Application\Analysis\PreloadDependenciesStage;
 use Phel\Api\Application\Analysis\ReadAndAnalyzeStage;
 use Phel\Api\Application\PhelFnGroupKeyGenerator;
 use Phel\Api\Application\PhelFnNormalizer;
@@ -61,6 +62,7 @@ final class ApiFactory extends AbstractFactory
         $compilerFacade = $this->getCompilerFacade();
 
         return new SourceAnalyzer([
+            new PreloadDependenciesStage($this->getRunFacade()),
             new LexAndParseStage($compilerFacade),
             new ReadAndAnalyzeStage($compilerFacade),
         ]);

--- a/src/php/Api/Application/Analysis/PreloadDependenciesStage.php
+++ b/src/php/Api/Application/Analysis/PreloadDependenciesStage.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Api\Application\Analysis;
+
+use Phel\Api\Domain\AnalysisStageInterface;
+use Phel\Shared\Facade\RunFacadeInterface;
+use Throwable;
+
+use function dirname;
+use function is_file;
+
+/**
+ * Pre-load phel core and the project namespaces required (transitively) by
+ * the file under analysis. Without this the analyzer reports false positives
+ * (`PHEL001 Cannot resolve symbol`) for any aliased reference into a project
+ * namespace, e.g. `c/step` where `(:require phelgeon\core :as c)`.
+ *
+ * Best-effort: any failure leaves the global env partially populated and
+ * lets the following stages run, so legitimate diagnostics still surface.
+ */
+final readonly class PreloadDependenciesStage implements AnalysisStageInterface
+{
+    public function __construct(
+        private RunFacadeInterface $runFacade,
+    ) {}
+
+    public function run(string $source, string $uri, array &$context): array
+    {
+        try {
+            $this->runFacade->loadPhelNamespaces();
+        } catch (Throwable) {
+            return [];
+        }
+
+        if ($uri === '' || !is_file($uri)) {
+            return [];
+        }
+
+        try {
+            $namespace = $this->runFacade->getNamespaceFromFile($uri)->getNamespace();
+        } catch (Throwable) {
+            return [];
+        }
+
+        $directories = [
+            dirname($uri),
+            ...$this->runFacade->getAllPhelDirectories(),
+        ];
+
+        try {
+            $deps = $this->runFacade->getDependenciesForNamespace($directories, [$namespace]);
+        } catch (Throwable) {
+            return [];
+        }
+
+        foreach ($deps as $dep) {
+            if ($dep->getNamespace() === $namespace) {
+                continue;
+            }
+
+            try {
+                $this->runFacade->evalFile($dep);
+            } catch (Throwable) {
+                // Skip a single bad dep so the rest can still load.
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/php/Api/CLAUDE.md
+++ b/src/php/Api/CLAUDE.md
@@ -42,7 +42,7 @@ Tooling support layer: REPL autocompletion, function introspection, documentatio
 ```
 Api/
 ├── Application/
-│   ├── Analysis/              LexAndParseStage, ReadAndAnalyzeStage
+│   ├── Analysis/              PreloadDependenciesStage, LexAndParseStage, ReadAndAnalyzeStage
 │   ├── PhelFnGroupKeyGenerator, PhelFnNormalizer, ReplCompleter
 │   ├── SourceAnalyzer         pipeline runner over AnalysisStageInterface
 │   ├── SymbolExtractor        per-file def/ref extractor (read + traverse forms)

--- a/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
+++ b/src/php/Api/Infrastructure/Command/AnalyzeCommand.php
@@ -7,7 +7,6 @@ namespace Phel\Api\Infrastructure\Command;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Api\ApiFacade;
-use Phel\Api\ApiFactory;
 use Phel\Api\Transfer\Diagnostic;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -23,7 +22,6 @@ use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 
 #[ServiceMap(method: 'getFacade', className: ApiFacade::class)]
-#[ServiceMap(method: 'getFactory', className: ApiFactory::class)]
 final class AnalyzeCommand extends Command
 {
     use ServiceResolverAwareTrait;
@@ -49,10 +47,6 @@ final class AnalyzeCommand extends Command
             $output->writeln(sprintf('<error>Unable to read file: %s</error>', $file));
             return self::FAILURE;
         }
-
-        // Load phel core so analyzeSource() resolves core symbols like `when-not`, `defn`, `let`, etc.
-        // Without this the analyzer flags every core macro as "Cannot resolve symbol ...".
-        $this->getFactory()->getRunFacade()->loadPhelNamespaces();
 
         $diagnostics = $this->getFacade()->analyzeSource($source, $file);
         $payload = array_map(static fn(Diagnostic $d): array => $d->toArray(), $diagnostics);

--- a/tests/php/Integration/Api/AnalyzeCommandTest.php
+++ b/tests/php/Integration/Api/AnalyzeCommandTest.php
@@ -55,6 +55,24 @@ final class AnalyzeCommandTest extends TestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function test_analyze_command_resolves_aliased_symbols_from_project_namespace(): void
+    {
+        $this->bootstrap();
+
+        $tester = new CommandTester(new AnalyzeCommand());
+        $exit = $tester->execute(['file' => __DIR__ . '/Fixtures/bar.phel']);
+        self::assertSame(0, $exit);
+
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        self::assertSame(
+            [],
+            $decoded,
+            'Expected no diagnostics for aliased symbols pointing to a required project namespace',
+        );
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function test_analyze_command_fails_when_file_missing(): void
     {
         $this->bootstrap();

--- a/tests/php/Integration/Api/phel-config.php
+++ b/tests/php/Integration/Api/phel-config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'src-dirs' => [
         '../../../../src/phel/',
+        'Fixtures/',
     ],
     'test-dirs' => [],
     'vendor' => '../../../../../vendor/',


### PR DESCRIPTION
## 🤔 Background

`phel analyze <file>` reports false-positive `PHEL001 Cannot resolve symbol` errors for any symbol referenced via an alias from a project namespace (e.g. `c/step` where `(:require phelgeon\core :as c)`). The same code compiles cleanly with `phel build`. The root cause is that `AnalyzeCommand` only preloaded `phel\core`; the file's required project namespaces were never loaded into the analyzer's global env, so every aliased reference into one was rejected.

This makes editor integrations (e.g. the VS Code extension) flood users with false errors on any multi-file project, rendering analyze diagnostics unusable in real codebases.

Closes #1919.

## 💡 Goal

`phel analyze <file>` should pre-load the namespaces required by the file under analysis (transitively) so `PHEL001` only fires on truly undefined symbols.

## 🔖 Changes

- Add `PreloadDependenciesStage` as the first stage of the `analyzeSource` pipeline. It loads `phel\core` and walks the file's `(:require ...)` graph, mirroring `FileRunner` by including the file's own directory in the search path. Failures are swallowed so legitimate diagnostics still surface.
- Wire the stage into `ApiFactory::createSourceAnalyzer`.
- Drop the now-redundant `loadPhelNamespaces()` call from `AnalyzeCommand`.
- Regression test in `AnalyzeCommandTest`: analyzing a file that references an aliased project namespace produces no diagnostics.
