### PR TITLE
feat(compiler): opt-in `^:memoize` / `^:memoize-lru` metadata on defn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+#### Core
+- `^:memoize` and `^{:memoize-lru N}` metadata on `defn` wrap the fn with `memoize` / `memoize-lru` (#1915)
+
 #### Test
 - `(is (= a b))` failures on collections render a unified diff block
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags
@@ -19,6 +22,9 @@ All notable changes to this project will be documented in this file.
 - Recursive global-fn calls inside their own body emit `$this(...)` instead of a registry lookup; ~3.66x faster on `fib(22)` (#1914)
 
 ### Fixed
+
+#### Core
+- `memoize` / `memoize-lru` no longer drop entries that recursive calls add to the cache during a single invocation (#1915)
 
 #### Test
 - Default reporter wraps dot output at 80 columns under `with-output-buffer`

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -68,8 +68,16 @@
                                   nil))
                               (php/implode "\n" sigs)))
           docstring       (php/. "```phel\n" signatures "\n```\n" docstring)
-          meta            (php/-> meta (put :doc docstring))]
-      `(def ~name ~meta (fn ~@fdecl)))))
+          meta            (php/-> meta (put :doc docstring))
+          memoize-flag    (php/aget meta :memoize)
+          memoize-lru     (php/aget meta :memoize-lru)]
+      (if memoize-lru
+        (if (php/=== memoize-lru true)
+          `(def ~name ~meta (memoize-lru (fn ~@fdecl)))
+          `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru)))
+        (if memoize-flag
+          `(def ~name ~meta (memoize (fn ~@fdecl)))
+          `(def ~name ~meta (fn ~@fdecl)))))))
 
 (def defn
   {:macro true

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -70,11 +70,11 @@
           docstring       (php/. "```phel\n" signatures "\n```\n" docstring)
           meta            (php/-> meta (put :doc docstring))
           memoize-flag    (php/aget meta :memoize)
-          memoize-lru     (php/aget meta :memoize-lru)]
-      (if memoize-lru
-        (if (php/=== memoize-lru true)
+          memoize-lru-arg (php/aget meta :memoize-lru)]
+      (if memoize-lru-arg
+        (if (php/=== memoize-lru-arg true)
           `(def ~name ~meta (memoize-lru (fn ~@fdecl)))
-          `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru)))
+          `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg)))
         (if memoize-flag
           `(def ~name ~meta (memoize (fn ~@fdecl)))
           `(def ~name ~meta (fn ~@fdecl)))))))

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -30,7 +30,9 @@
 (def defn-builder
   {:macro true :private true}
   (fn [name meta & fdecl]
-    (let [meta            (if (php/is_string (first fdecl))
+    (let [sym-meta        (php/-> name (getMeta))
+          meta            (if sym-meta (php/-> sym-meta (merge meta)) meta)
+          meta            (if (php/is_string (first fdecl))
                             (php/-> meta (put :doc (first fdecl)))
                             meta)
           fdecl           (if (php/is_string (first fdecl))

--- a/src/phel/core/fns-sets.phel
+++ b/src/phel/core/fns-sets.phel
@@ -173,7 +173,10 @@
         (if (contains? c args)
           (get c args)
           (let [res (apply f args)]
-            (reset! memoize-cache (assoc c args res))
+            ;; Merge into the *current* cache so recursive calls that
+            ;; populated it inside `(apply f args)` are not overwritten by
+            ;; this stale `c` snapshot.
+            (swap! memoize-cache assoc args res)
             res))))))
 
 (defn memoize-lru
@@ -199,23 +202,26 @@
              t (swap! tick #(php/+ 1 %))]
          (if (contains? c args)
            (let [entry (get c args)]
-             (reset! cache (assoc c args {:value (get entry :value) :accessed t}))
+             (swap! cache assoc args {:value (get entry :value) :accessed t})
              (get entry :value))
-           (let [res       (apply f args)
-                 new-entry {:value res :accessed t}
-                 new-cache (assoc c args new-entry)]
-             (if (php/> (count new-cache) max-size)
-               (let [ks      (keys new-cache)
-                     lru-key (reduce
-                              (fn [oldest-key current-key]
-                                (if (php/< (get (get new-cache current-key) :accessed)
-                                           (get (get new-cache oldest-key) :accessed))
-                                  current-key
-                                  oldest-key))
-                              (first ks)
-                              ks)]
-                 (reset! cache (dissoc new-cache lru-key)))
-               (reset! cache new-cache))
+           ;; Compute first so any recursive populates land in the atom; then
+           ;; merge against the *current* cache and apply the LRU eviction.
+           (let [res (apply f args)]
+             (swap! cache
+                    (fn [latest]
+                      (let [merged    (assoc latest args {:value res :accessed t})]
+                        (if (php/> (count merged) max-size)
+                          (let [ks      (keys merged)
+                                lru-key (reduce
+                                         (fn [oldest-key current-key]
+                                           (if (php/< (get (get merged current-key) :accessed)
+                                                      (get (get merged oldest-key) :accessed))
+                                             current-key
+                                             oldest-key))
+                                         (first ks)
+                                         ks)]
+                            (dissoc merged lru-key))
+                          merged))))
              res)))))))
 
 ;; -----------------------

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -233,8 +233,14 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
     private function isMemoised(PersistentMapInterface $meta): bool
     {
-        return $meta[Keyword::create('memoize')] === true
-            || $meta[Keyword::create('memoize-lru')] !== null;
+        return $this->metaTruthy($meta, 'memoize')
+            || $this->metaTruthy($meta, 'memoize-lru');
+    }
+
+    private function metaTruthy(PersistentMapInterface $meta, string $key): bool
+    {
+        $value = $meta[Keyword::create($key)];
+        return $value !== null && $value !== false;
     }
 
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -69,7 +69,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $init = $this->injectMacroImplicitParams($init);
         }
 
-        $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol);
+        $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol, $metaMap);
         if ($initNode instanceof FnNode) {
             $initNode->markAsDefinition();
         }
@@ -215,13 +215,26 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $nameSymbol,
+        PersistentMapInterface $meta,
     ): AbstractNode {
         $initEnv = $env
-            ->withBoundTo($namespace . '\\' . $nameSymbol->__toString())
             ->withExpressionContext()
             ->withDisallowRecurFrame();
 
+        // The self-call shortcut keys off boundTo. For memoised defs the
+        // wrapper, not the inner fn, must receive recursive calls, so leave
+        // boundTo unset to keep recursion routed through the registry.
+        if (!$this->isMemoised($meta)) {
+            $initEnv = $initEnv->withBoundTo($namespace . '\\' . $nameSymbol->__toString());
+        }
+
         return $this->analyzer->analyze($init, $initEnv);
+    }
+
+    private function isMemoised(PersistentMapInterface $meta): bool
+    {
+        return $meta[Keyword::create('memoize')] === true
+            || $meta[Keyword::create('memoize-lru')] !== null;
     }
 
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -213,11 +213,7 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         $meta = $fn->getMeta();
-        if ($meta[Keyword::create('memoize')] || $meta[Keyword::create('memoize-lru')]) {
-            return false;
-        }
-
-        return true;
+        return !$meta[Keyword::create('memoize')] && !$meta[Keyword::create('memoize-lru')];
     }
 
     private function emitFunctionArguments(CallNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function assert;
@@ -187,6 +188,9 @@ final class CallEmitter implements NodeEmitterInterface
      *
      * `let` and `loop` extend boundTo with a `.<sym>` suffix while analysing
      * their inits, so an exact match is not enough.
+     *
+     * Memoized fns must keep the registry-lookup path so self-recursion goes
+     * through the wrapper instead of the inner `$this`.
      */
     private function isSelfCall(CallNode $node): bool
     {
@@ -201,8 +205,19 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         $expected = $fn->getNamespace() . '\\' . $fn->getName()->getName();
-        return $boundTo === $expected
+        $matchesEnclosing = $boundTo === $expected
             || str_starts_with($boundTo, $expected . '.');
+
+        if (!$matchesEnclosing) {
+            return false;
+        }
+
+        $meta = $fn->getMeta();
+        if ($meta[Keyword::create('memoize')] || $meta[Keyword::create('memoize-lru')]) {
+            return false;
+        }
+
+        return true;
     }
 
     private function emitFunctionArguments(CallNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -10,7 +10,6 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
-use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function assert;
@@ -189,8 +188,9 @@ final class CallEmitter implements NodeEmitterInterface
      * `let` and `loop` extend boundTo with a `.<sym>` suffix while analysing
      * their inits, so an exact match is not enough.
      *
-     * Memoized fns must keep the registry-lookup path so self-recursion goes
-     * through the wrapper instead of the inner `$this`.
+     * Memoised defs deliberately leave boundTo unset in `DefSymbol`, so self
+     * recursion routes through the registry (and therefore the memo wrapper)
+     * rather than `$this`.
      */
     private function isSelfCall(CallNode $node): bool
     {
@@ -205,15 +205,8 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         $expected = $fn->getNamespace() . '\\' . $fn->getName()->getName();
-        $matchesEnclosing = $boundTo === $expected
+        return $boundTo === $expected
             || str_starts_with($boundTo, $expected . '.');
-
-        if (!$matchesEnclosing) {
-            return false;
-        }
-
-        $meta = $fn->getMeta();
-        return !$meta[Keyword::create('memoize')] && !$meta[Keyword::create('memoize-lru')];
     }
 
     private function emitFunctionArguments(CallNode $node): void

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -162,10 +162,10 @@
 
 (deftest test-defn-memoize-skips-self-call
   (reset! memoize-fib-counter 0)
-  (is (= 832040 (memoize-fib 30)) "fib 30")
-  ;; Without ^:memoize, naive recursion runs the body ~2.7M times for fib(30).
+  (is (= 6765 (memoize-fib 20)) "fib 20")
+  ;; Without ^:memoize, naive recursion runs the body ~21k times for fib(20).
   ;; Memoized self-recursion runs the body exactly n+1 times.
-  (is (= 31 (deref memoize-fib-counter)) "memo cache hit during recursion"))
+  (is (= 21 (deref memoize-fib-counter)) "memo cache hit during recursion"))
 
 (def memoize-lru-meta-counter (atom 0))
 

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -137,3 +137,61 @@
     (is (= 3 (f 1 2)) "cached multi-arg call")
     (is (= 7 (f 3 4)) "different multi-arg call")
     (is (= 2 (deref counter)) "two executions")))
+
+(def memoize-meta-counter (atom 0))
+
+(defn ^:memoize memoize-meta-add [a b]
+  (swap! memoize-meta-counter inc)
+  (+ a b))
+
+(deftest test-defn-memoize-basic
+  (reset! memoize-meta-counter 0)
+  (is (= 3 (memoize-meta-add 1 2)) "first call computes")
+  (is (= 3 (memoize-meta-add 1 2)) "second call cached")
+  (is (= 1 (deref memoize-meta-counter)) "fn body ran exactly once")
+  (is (= 7 (memoize-meta-add 3 4)) "different args compute")
+  (is (= 2 (deref memoize-meta-counter)) "second compute for new args"))
+
+(def memoize-fib-counter (atom 0))
+
+(defn ^:memoize memoize-fib [n]
+  (swap! memoize-fib-counter inc)
+  (if (< n 2)
+    n
+    (+ (memoize-fib (- n 1)) (memoize-fib (- n 2)))))
+
+(deftest test-defn-memoize-skips-self-call
+  (reset! memoize-fib-counter 0)
+  (is (= 832040 (memoize-fib 30)) "fib 30")
+  ;; Without ^:memoize, naive recursion runs the body ~2.7M times for fib(30).
+  ;; Memoized self-recursion runs the body exactly n+1 times.
+  (is (= 31 (deref memoize-fib-counter)) "memo cache hit during recursion"))
+
+(def memoize-lru-meta-counter (atom 0))
+
+(defn ^:memoize-lru memoize-lru-meta-default [x]
+  (swap! memoize-lru-meta-counter inc)
+  (* x 10))
+
+(deftest test-defn-memoize-lru-default
+  (reset! memoize-lru-meta-counter 0)
+  (is (= 10 (memoize-lru-meta-default 1)) "first call")
+  (is (= 10 (memoize-lru-meta-default 1)) "cached call")
+  (is (= 20 (memoize-lru-meta-default 2)) "different arg")
+  (is (= 2 (deref memoize-lru-meta-counter)) "two executions"))
+
+(def memoize-lru-sized-counter (atom 0))
+
+(defn ^{:memoize-lru 2} memoize-lru-sized [x]
+  (swap! memoize-lru-sized-counter inc)
+  x)
+
+(deftest test-defn-memoize-lru-with-size
+  (reset! memoize-lru-sized-counter 0)
+  (memoize-lru-sized 1)
+  (memoize-lru-sized 2)
+  (memoize-lru-sized 1)
+  (is (= 2 (deref memoize-lru-sized-counter)) "two distinct args within cap")
+  (memoize-lru-sized 3) ; evicts 2 (least recently used)
+  (memoize-lru-sized 2) ; recompute since evicted
+  (is (= 4 (deref memoize-lru-sized-counter)) "eviction triggers recompute"))


### PR DESCRIPTION
## 🤔 Background

Closes #1915.

Phel ships `memoize` and `memoize-lru` (`src/phel/core/fns-sets.phel:159` and `:179`) but using them requires manual rebinding:

```phel
(def fib (memoize (fn [n] ...)))
```

This PR adds `^:memoize` / `^:memoize-lru` metadata on `defn` so a tree-recursive pure fn becomes O(n) without the boilerplate.

## 💡 Goal

```phel
(defn ^:memoize fib [n]
  (if (< n 2) n
    (+ (fib (- n 1)) (fib (- n 2)))))

(defn ^:memoize-lru cached-lookup [k] ...)         ; default 128-entry cache
(defn ^{:memoize-lru 1000} bigger-cache [k] ...)   ; explicit size
```

## 🔖 Changes

- `src/phel/core/defs.phel` — `defn-builder` extracts symbol meta (e.g. `^:memoize fib`) into the meta map and wraps the inner fn with `memoize` / `memoize-lru` when the meta opts in. Mirrors how `^:dynamic` already flows through on raw `def`.
- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php` — leaves `boundTo` unset when the def carries `:memoize` / `:memoize-lru`, so self-recursive calls route through the registry (and the memo wrapper) instead of the `$this(...)` shortcut from #1914.
- `src/phel/core/fns-sets.phel` — `memoize` and `memoize-lru` switched to `swap! cache assoc args res`. The previous `(reset! cache (assoc c args res))` lost cache entries that recursive calls populated inside `(apply f args)`, so self-recursive fib never benefited from memoization (full naive call count). Now it does.
- `tests/phel/core/function-operation.phel` — Phel `deftest` blocks: basic memoize, recursive fib counter, lru default size, lru explicit size.
- `CHANGELOG.md` — `Added > Core` and `Fixed > Core` entries.

## Verification

- `composer test-compiler` (PHPUnit unit + integration): 3188 tests, 8673 assertions, 3 skipped, green.
- `composer test-core` (Phel core): 5415 tests, all green.
- `composer csrun`, `composer phpstan`, `composer rector`: clean on touched files.
- Manual: `(defn ^:memoize fib [n] ...) (fib 30)` runs O(n), counter exactly `n+1` rather than `2*F(n+1)-1`.

## Notes

- The recursive memoize fix (`reset!` to `swap!`) is a real bug — without it, `^:memoize` on a self-recursive fib would have produced no speedup. Caught by the integration deftest in this PR.
- Compatible with the self-call shortcut from #1914: only memoised defs leave `boundTo` unset.
- No new runtime; pure macro sugar over existing `memoize` / `memoize-lru` plus the recursion-cache fix.