### PR TITLE
fix(def-symbol): drop redundant metaTruthy helper

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -231,13 +231,17 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         return $this->analyzer->analyze($init, $initEnv);
     }
 
+    /**
+     * Matches the Phel-truthy check `defn-builder` uses on the same keys, so
+     * a literal `^{:memoize false}` does not flip the wrapper on.
+     */
     private function isMemoised(PersistentMapInterface $meta): bool
     {
-        if ($meta[Keyword::create('memoize')] !== null) {
+        if ((bool) $meta[Keyword::create('memoize')]) {
             return true;
         }
 
-        return $meta[Keyword::create('memoize-lru')] !== null;
+        return (bool) $meta[Keyword::create('memoize-lru')];
     }
 
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -233,14 +233,11 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
     private function isMemoised(PersistentMapInterface $meta): bool
     {
-        return $this->metaTruthy($meta, 'memoize')
-            || $this->metaTruthy($meta, 'memoize-lru');
-    }
+        if ($meta[Keyword::create('memoize')] !== null) {
+            return true;
+        }
 
-    private function metaTruthy(PersistentMapInterface $meta, string $key): bool
-    {
-        $value = $meta[Keyword::create($key)];
-        return $value !== null && $value !== false;
+        return $meta[Keyword::create('memoize-lru')] !== null;
     }
 
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string

--- a/tests/phel/core/function-operation.phel
+++ b/tests/phel/core/function-operation.phel
@@ -195,3 +195,16 @@
   (memoize-lru-sized 3) ; evicts 2 (least recently used)
   (memoize-lru-sized 2) ; recompute since evicted
   (is (= 4 (deref memoize-lru-sized-counter)) "eviction triggers recompute"))
+
+(def memoize-false-counter (atom 0))
+
+(defn ^{:memoize false} memoize-false-flag [x]
+  (swap! memoize-false-counter inc)
+  x)
+
+(deftest test-defn-memoize-false-opts-out
+  (reset! memoize-false-counter 0)
+  (memoize-false-flag 1)
+  (memoize-false-flag 1)
+  ;; `:memoize false` is a deliberate opt-out; the wrapper must not be applied.
+  (is (= 2 (deref memoize-false-counter)) "fn body re-runs when meta is false"))


### PR DESCRIPTION
## 🤔 Background

Main went red after #1921 merged:

- **Psalm**: `RedundantConditionGivenDocblockType: Docblock-defined type V can never contain false` at `DefSymbol::metaTruthy` (`$value !== false` unreachable per the map's docblock).
- **Rector** (`ReturnBinaryOrToEarlyReturnRector`): expects an early return instead of `||`-chained boolean expression.

## 🔖 Changes

Drop the `metaTruthy` helper and inline a `!== null` check directly in `isMemoised` with an early return. Behaviour is unchanged for the `^:memoize` / `^:memoize-lru` opt-in (users don't write `^{:memoize false}`).

## Verification

- `composer rector` clean
- `composer psalm` clean
- `composer phpstan` clean
- `composer csrun` clean