### PR TITLE
docs(rules): add macro-hygiene rule for quasiquote name-shadowing

### DIFF
--- a/.claude/rules/macro-hygiene.md
+++ b/.claude/rules/macro-hygiene.md
@@ -1,0 +1,65 @@
+---
+description: Macro-hygiene pitfalls for quasiquote, gensym, and expand-time evaluation
+globs: src/phel/**,tests/phel/**
+---
+
+# Macro Hygiene
+
+Phel macros are non-hygienic: symbols inside `` ` `` quasiquote resolve in the **caller's** namespace, but `let`/`binding` names introduced in the **macro body** can shadow homonymous globals when unquoted. Failures are silent — wrong expansion, no error.
+
+## Rule 1: Local bindings must not share names with referenced globals
+
+Inside a macro body, every `let`-binding name is a candidate shadow. If the same name appears as a function call inside an unquoted template form, the local value wins.
+
+### Before/after — `defn-builder` shadow (commit `85be1479`)
+
+Buggy: local `memoize-lru` shadows global `memoize-lru` fn:
+
+```phel
+(let [memoize-flag (php/aget meta :memoize)
+      memoize-lru  (php/aget meta :memoize-lru)]   ; <-- local binds same name as global fn
+  (if memoize-lru
+    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru))))
+                       ;^^^^^^^^^^^                ^^^^^^^^^^^
+                       ; reads local value, not global function
+```
+
+Fix: rename local with a role suffix:
+
+```phel
+(let [memoize-flag    (php/aget meta :memoize)
+      memoize-lru-arg (php/aget meta :memoize-lru)]
+  (if memoize-lru-arg
+    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg))))
+```
+
+### Naming conventions for macro-local bindings
+
+- Suffix by role: `-arg`, `-flag`, `-val`, `-sym`, `-form`
+- Or use auto-gensym `name#` for symbols that must be fresh in the expansion
+
+## Rule 2: Use auto-gensym for new symbols introduced into the expansion
+
+Any symbol the macro **invents** for the user's runtime scope (loop vars, accumulators, temp bindings) must be gensym'd, otherwise it can capture or be captured by user code.
+
+```phel
+;; bad — `acc` collides with user's `acc`
+`(let [acc 0] ~@body)
+
+;; good
+`(let [acc# 0] ~@body)
+```
+
+## Rule 3: Expand-time vs runtime
+
+- Macro body runs at **expand-time**; only forms inside `` ` `` reach runtime.
+- Don't rely on runtime values inside the body — they don't exist yet.
+- Computed values from the body can be spliced via `~`, but the **identifier** they evaluate to (a symbol/keyword) must still resolve correctly in the caller.
+
+## Pre-commit checklist for `defmacro` / `defn-builder`-style expanders
+
+- [ ] List every `let`-binding name in the macro body
+- [ ] Grep each name against in-scope globals (own ns, `phel\core`, `use`d modules)
+- [ ] Any collision: rename local with role suffix or `#` auto-gensym
+- [ ] Any new symbol introduced into the expansion's scope: `name#`
+- [ ] Add a Phel test that **calls** the macro recursively or in a context where shadowing would diverge from the global behavior (recursion, self-reference, mutual call)

--- a/.claude/rules/macro-hygiene.md
+++ b/.claude/rules/macro-hygiene.md
@@ -5,61 +5,39 @@ globs: src/phel/**,tests/phel/**
 
 # Macro Hygiene
 
-Phel macros are non-hygienic: symbols inside `` ` `` quasiquote resolve in the **caller's** namespace, but `let`/`binding` names introduced in the **macro body** can shadow homonymous globals when unquoted. Failures are silent — wrong expansion, no error.
+Phel macros non-hygienic. `let`/`binding` names in macro body silently shadow homonymous globals when unquoted in `` ` ``. No error — wrong expansion.
 
-## Rule 1: Local bindings must not share names with referenced globals
+## 1. Local names must not collide with referenced globals
 
-Inside a macro body, every `let`-binding name is a candidate shadow. If the same name appears as a function call inside an unquoted template form, the local value wins.
-
-### Before/after — `defn-builder` shadow (commit `85be1479`)
-
-Buggy: local `memoize-lru` shadows global `memoize-lru` fn:
+Canonical bug (`defn-builder`, fixed in `85be1479`):
 
 ```phel
-(let [memoize-flag (php/aget meta :memoize)
-      memoize-lru  (php/aget meta :memoize-lru)]   ; <-- local binds same name as global fn
-  (if memoize-lru
-    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru))))
-                       ;^^^^^^^^^^^                ^^^^^^^^^^^
-                       ; reads local value, not global function
+;; bad — local `memoize-lru` shadows global `memoize-lru` fn
+(let [memoize-lru (php/aget meta :memoize-lru)]
+  `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru)))
+
+;; good — role suffix avoids shadow
+(let [memoize-lru-arg (php/aget meta :memoize-lru)]
+  `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg)))
 ```
 
-Fix: rename local with a role suffix:
+Convention: suffix macro-local bindings with role (`-arg`, `-flag`, `-val`, `-sym`, `-form`).
+
+## 2. New symbols introduced into expansion need auto-gensym
 
 ```phel
-(let [memoize-flag    (php/aget meta :memoize)
-      memoize-lru-arg (php/aget meta :memoize-lru)]
-  (if memoize-lru-arg
-    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg))))
+`(let [acc 0] ~@body)    ; bad — captures user's `acc`
+`(let [acc# 0] ~@body)   ; good
 ```
 
-### Naming conventions for macro-local bindings
+## 3. Expand-time vs runtime
 
-- Suffix by role: `-arg`, `-flag`, `-val`, `-sym`, `-form`
-- Or use auto-gensym `name#` for symbols that must be fresh in the expansion
+Macro body runs expand-time. Only forms inside `` ` `` reach runtime. Splice computed values via `~`; identifiers must still resolve in caller's ns.
 
-## Rule 2: Use auto-gensym for new symbols introduced into the expansion
+## Checklist
 
-Any symbol the macro **invents** for the user's runtime scope (loop vars, accumulators, temp bindings) must be gensym'd, otherwise it can capture or be captured by user code.
-
-```phel
-;; bad — `acc` collides with user's `acc`
-`(let [acc 0] ~@body)
-
-;; good
-`(let [acc# 0] ~@body)
-```
-
-## Rule 3: Expand-time vs runtime
-
-- Macro body runs at **expand-time**; only forms inside `` ` `` reach runtime.
-- Don't rely on runtime values inside the body — they don't exist yet.
-- Computed values from the body can be spliced via `~`, but the **identifier** they evaluate to (a symbol/keyword) must still resolve correctly in the caller.
-
-## Pre-commit checklist for `defmacro` / `defn-builder`-style expanders
-
-- [ ] List every `let`-binding name in the macro body
-- [ ] Grep each name against in-scope globals (own ns, `phel\core`, `use`d modules)
-- [ ] Any collision: rename local with role suffix or `#` auto-gensym
-- [ ] Any new symbol introduced into the expansion's scope: `name#`
-- [ ] Add a Phel test that **calls** the macro recursively or in a context where shadowing would diverge from the global behavior (recursion, self-reference, mutual call)
+- List every `let`-binding name in body
+- Grep each against in-scope globals (own ns, `phel\core`, `use`d modules)
+- Collision → suffix or `name#`
+- New scope-introduced symbol → `name#`
+- Add test exercising recursion / self-reference (where shadow diverges from global)

--- a/.claude/rules/phel.md
+++ b/.claude/rules/phel.md
@@ -29,3 +29,8 @@ Every public function should have metadata:
 - Follow Clojure-aligned semantics where possible
 - Prefer `conj` over `put` for collection operations
 - Use `defstruct` for data types, not PHP classes
+
+## Macros
+
+- Read [macro-hygiene.md](macro-hygiene.md) before editing any `defmacro` body or quasiquote expansion
+- Local `let` names inside `` ` `` can silently shadow globals; suffix with `-arg`/`-flag` or use `name#` auto-gensym

--- a/.claude/rules/phel.md
+++ b/.claude/rules/phel.md
@@ -32,5 +32,4 @@ Every public function should have metadata:
 
 ## Macros
 
-- Read [macro-hygiene.md](macro-hygiene.md) before editing any `defmacro` body or quasiquote expansion
-- Local `let` names inside `` ` `` can silently shadow globals; suffix with `-arg`/`-flag` or use `name#` auto-gensym
+Editing a `defmacro` body or `` ` `` quasiquote? Load [macro-hygiene.md](macro-hygiene.md) first — local `let` names can silently shadow globals.


### PR DESCRIPTION
## 🤔 Background

Closes #1922.

A subtle bug surfaced in #1921 (memoize metadata work): a local `let`-bound `memoize-lru` inside a quasiquote silently shadowed the global `memoize-lru` function. The macro expansion swapped the global fn reference with the local value, producing wrong code that still type-checked and passed nearby tests until a recursion-counting test exposed it (commit `85be1479`).

The pitfall generalises: any `let`/`binding` name inside a `` ` `` quasiquote can shadow a homonymous global, with no error, just a wrong expansion.

## 💡 Goal

Auto-loaded agent rule that catches this class of bug at write-time, before commit.

## 🔖 Changes

- `.claude/rules/macro-hygiene.md` (new) — auto-loaded via `globs: src/phel/**,tests/phel/**`, three rules with the canonical `memoize-lru` before/after, plus gensym hygiene, expand-time vs runtime, and a pre-commit checklist for `defmacro` / `defn-builder`-style expanders.
- `.claude/rules/phel.md` — new `## Macros` section linking to `macro-hygiene.md`.

## Notes

- Agent-only docs; no user-facing change, so CHANGELOG untouched.
- Final refactor pass: zero changes (rule file already scoped, concrete, linked).