### PR TITLE
feat(profile): add `phel profile` command for fn and compile-phase timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `^:memoize` and `^{:memoize-lru N}` metadata on `defn` wrap the fn with `memoize` / `memoize-lru` (#1915)
 
+#### Profile
+- `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling
+
 #### Test
 - `(is (= a b))` failures on collections render a unified diff block
 - `phel test --repeat=N`, `--seed=<int>`, and `--random-order` flags

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -26,7 +26,11 @@ use Phel\Compiler\Domain\Parser\ReadModel\ReaderResult;
 use Phel\Compiler\Domain\Reader\Exceptions\ReaderException;
 use Phel\Compiler\Domain\Reader\ReaderInterface;
 use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Lang\ProfilerHookInterface;
+use Phel\Lang\Registry;
 use Phel\Lang\TypeInterface;
+
+use function hrtime;
 
 final readonly class CodeCompiler implements CodeCompilerInterface
 {
@@ -48,26 +52,52 @@ final readonly class CodeCompiler implements CodeCompilerInterface
      */
     public function compileString(string $phelCode, CompileOptions $compileOptions): EmitterResult
     {
-        $tokenStream = $this->lexer->lexString(
-            $phelCode,
-            $compileOptions->getSource(),
-            $compileOptions->getStartingLine(),
-        );
+        $hook = Registry::$profilerHook;
+        $source = $compileOptions->getSource();
 
-        $this->fileEmitter->startFile($compileOptions->getSource());
+        if ($hook instanceof ProfilerHookInterface) {
+            $tStart = hrtime(true);
+            $tokenStream = $this->lexer->lexString($phelCode, $source, $compileOptions->getStartingLine());
+            $hook->recordPhase('lex', $source, (hrtime(true) - $tStart) / 1_000_000);
+        } else {
+            $tokenStream = $this->lexer->lexString($phelCode, $source, $compileOptions->getStartingLine());
+        }
+
+        $this->fileEmitter->startFile($source);
         while (true) {
             try {
-                $parseTree = $this->parser->parseNext($tokenStream);
+                if ($hook instanceof ProfilerHookInterface) {
+                    $tStart = hrtime(true);
+                    $parseTree = $this->parser->parseNext($tokenStream);
+                    $hook->recordPhase('parse', $source, (hrtime(true) - $tStart) / 1_000_000);
+                } else {
+                    $parseTree = $this->parser->parseNext($tokenStream);
+                }
+
                 // If we reached the end exit this loop
                 if (!$parseTree instanceof NodeInterface) {
                     break;
                 }
 
                 if (!$parseTree instanceof TriviaNodeInterface) {
-                    $readerResult = $this->reader->read($parseTree);
-                    $node = $this->analyze($readerResult);
-                    // We need to evaluate every statement because we may need it for macros.
-                    $this->emitNode($node, $compileOptions);
+                    if ($hook instanceof ProfilerHookInterface) {
+                        $tStart = hrtime(true);
+                        $readerResult = $this->reader->read($parseTree);
+                        $hook->recordPhase('read', $source, (hrtime(true) - $tStart) / 1_000_000);
+
+                        $tStart = hrtime(true);
+                        $node = $this->analyze($readerResult);
+                        $hook->recordPhase('analyze', $source, (hrtime(true) - $tStart) / 1_000_000);
+
+                        $tStart = hrtime(true);
+                        $this->emitNode($node, $compileOptions);
+                        $hook->recordPhase('emit', $source, (hrtime(true) - $tStart) / 1_000_000);
+                    } else {
+                        $readerResult = $this->reader->read($parseTree);
+                        $node = $this->analyze($readerResult);
+                        // We need to evaluate every statement because we may need it for macros.
+                        $this->emitNode($node, $compileOptions);
+                    }
                 }
             } catch (AbstractParserException|ReaderException $e) {
                 throw new CompilerException($e, $e->getCodeSnippet());

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -18,6 +18,7 @@ use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Domain\Lexer\Exceptions\LexerValueException;
 use Phel\Compiler\Domain\Lexer\LexerInterface;
+use Phel\Compiler\Domain\Lexer\TokenStream;
 use Phel\Compiler\Domain\Parser\Exceptions\AbstractParserException;
 use Phel\Compiler\Domain\Parser\ParserInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
@@ -55,50 +56,29 @@ final readonly class CodeCompiler implements CodeCompilerInterface
         $hook = Registry::$profilerHook;
         $source = $compileOptions->getSource();
 
-        if ($hook instanceof ProfilerHookInterface) {
-            $tStart = hrtime(true);
-            $tokenStream = $this->lexer->lexString($phelCode, $source, $compileOptions->getStartingLine());
-            $hook->recordPhase('lex', $source, (hrtime(true) - $tStart) / 1_000_000);
-        } else {
-            $tokenStream = $this->lexer->lexString($phelCode, $source, $compileOptions->getStartingLine());
-        }
+        $tokenStream = $this->timed($hook, 'lex', $source, fn(): TokenStream => $this->lexer->lexString(
+            $phelCode,
+            $source,
+            $compileOptions->getStartingLine(),
+        ));
 
         $this->fileEmitter->startFile($source);
         while (true) {
             try {
-                if ($hook instanceof ProfilerHookInterface) {
-                    $tStart = hrtime(true);
-                    $parseTree = $this->parser->parseNext($tokenStream);
-                    $hook->recordPhase('parse', $source, (hrtime(true) - $tStart) / 1_000_000);
-                } else {
-                    $parseTree = $this->parser->parseNext($tokenStream);
-                }
+                $parseTree = $this->timed($hook, 'parse', $source, fn(): ?NodeInterface => $this->parser->parseNext($tokenStream));
 
-                // If we reached the end exit this loop
                 if (!$parseTree instanceof NodeInterface) {
                     break;
                 }
 
-                if (!$parseTree instanceof TriviaNodeInterface) {
-                    if ($hook instanceof ProfilerHookInterface) {
-                        $tStart = hrtime(true);
-                        $readerResult = $this->reader->read($parseTree);
-                        $hook->recordPhase('read', $source, (hrtime(true) - $tStart) / 1_000_000);
-
-                        $tStart = hrtime(true);
-                        $node = $this->analyze($readerResult);
-                        $hook->recordPhase('analyze', $source, (hrtime(true) - $tStart) / 1_000_000);
-
-                        $tStart = hrtime(true);
-                        $this->emitNode($node, $compileOptions);
-                        $hook->recordPhase('emit', $source, (hrtime(true) - $tStart) / 1_000_000);
-                    } else {
-                        $readerResult = $this->reader->read($parseTree);
-                        $node = $this->analyze($readerResult);
-                        // We need to evaluate every statement because we may need it for macros.
-                        $this->emitNode($node, $compileOptions);
-                    }
+                if ($parseTree instanceof TriviaNodeInterface) {
+                    continue;
                 }
+
+                $readerResult = $this->timed($hook, 'read', $source, fn(): ReaderResult => $this->reader->read($parseTree));
+                $node = $this->timed($hook, 'analyze', $source, fn(): AbstractNode => $this->analyze($readerResult));
+                // We need to evaluate every statement because we may need it for macros.
+                $this->timed($hook, 'emit', $source, fn() => $this->emitNode($node, $compileOptions));
             } catch (AbstractParserException|ReaderException $e) {
                 throw new CompilerException($e, $e->getCodeSnippet());
             }
@@ -115,6 +95,26 @@ final readonly class CodeCompiler implements CodeCompilerInterface
         $node = $this->analyzer->analyze($form, NodeEnvironment::empty());
         $this->emitNode($node, $compileOptions);
         return $this->fileEmitter->endFile($compileOptions->isSourceMapsEnabled());
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $fn
+     *
+     * @return T
+     */
+    private function timed(?ProfilerHookInterface $hook, string $phase, string $source, callable $fn): mixed
+    {
+        if (!$hook instanceof ProfilerHookInterface) {
+            return $fn();
+        }
+
+        $start = hrtime(true);
+        $result = $fn();
+        $hook->recordPhase($phase, $source, (hrtime(true) - $start) / 1_000_000);
+
+        return $result;
     }
 
     /**

--- a/src/php/Console/ConsoleProvider.php
+++ b/src/php/Console/ConsoleProvider.php
@@ -18,6 +18,7 @@ use Phel\Console\Infrastructure\Command\InteropCommands;
 use Phel\Console\Infrastructure\Command\LintCommands;
 use Phel\Console\Infrastructure\Command\LspCommands;
 use Phel\Console\Infrastructure\Command\NreplCommands;
+use Phel\Console\Infrastructure\Command\ProfileCommands;
 use Phel\Console\Infrastructure\Command\RunCommands;
 use Phel\Console\Infrastructure\Command\WatchCommands;
 use Phel\Filesystem\FilesystemFacade;
@@ -107,6 +108,7 @@ final class ConsoleProvider extends AbstractProvider
             new FrameworkCommands(),
             new NreplCommands(),
             new LintCommands(),
+            new ProfileCommands(),
             new LspCommands(),
             new WatchCommands(),
         ];

--- a/src/php/Console/Infrastructure/Command/ProfileCommands.php
+++ b/src/php/Console/Infrastructure/Command/ProfileCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Console\Infrastructure\Command;
+
+use Phel\Console\Domain\ConsoleCommandProviderInterface;
+use Phel\Profile\Infrastructure\Command\ProfileCommand;
+
+final class ProfileCommands implements ConsoleCommandProviderInterface
+{
+    public function commands(): array
+    {
+        return [
+            new ProfileCommand(),
+        ];
+    }
+}

--- a/src/php/Lang/ProfilerHookInterface.php
+++ b/src/php/Lang/ProfilerHookInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+interface ProfilerHookInterface
+{
+    /**
+     * Wrap a freshly defined `AbstractFn` so future calls go through the
+     * profiler. Returning `$fn` unwrapped is acceptable when this fn
+     * should not be profiled (e.g. anonymous/inline closures).
+     */
+    public function wrapFn(AbstractFn $fn): AbstractFn;
+
+    public function recordPhase(string $phase, string $source, float $elapsedMs): void;
+}

--- a/src/php/Lang/Registry.php
+++ b/src/php/Lang/Registry.php
@@ -13,6 +13,13 @@ use function sprintf;
 
 final class Registry
 {
+    /**
+     * Set by `phel profile` to install a profiler hook. When non-null,
+     * `addDefinition` wraps every `AbstractFn` value with a profiling proxy
+     * before storing it. Off-state cost: one null-check per definition.
+     */
+    public static ?ProfilerHookInterface $profilerHook = null;
+
     /** @var array<string, array<string, mixed>> */
     private array $definitions = [];
 
@@ -64,6 +71,10 @@ final class Registry
 
     public function addDefinition(string $ns, string $name, mixed $value, ?PersistentMapInterface $metaData = null): PhelVar
     {
+        if (self::$profilerHook instanceof ProfilerHookInterface && $value instanceof AbstractFn) {
+            $value = self::$profilerHook->wrapFn($value);
+        }
+
         $this->definitions[$ns][$name] = $value;
         $this->definitionsMetaData[$ns][$name] = $metaData;
         PhelVarStateRegistry::getInstance()->invalidateDynamicCache($ns, $name);

--- a/src/php/Profile/CLAUDE.md
+++ b/src/php/Profile/CLAUDE.md
@@ -1,0 +1,54 @@
+# Profile Module
+
+`phel profile` command: instrumentation profiler for Phel scripts. Reports per-fn call counts, self/total/avg/max timings, and compile-time phase costs.
+
+## Gacela Pattern
+
+- **Facade**: `ProfileFacade` — `startSession()`, `renderTable()`, `renderJson()`
+- **Factory**: `ProfileFactory` — creates `ProfilerSession`, formatters; exposes `RunFacade`
+- **Config**: `ProfileConfig` — format/sort constants and defaults
+- **Provider**: `ProfileProvider` — injects `RunFacade` (`FACADE_RUN`)
+
+## Public API (Facade)
+
+- `startSession(): ProfilerSession`
+- `renderTable(ProfileReport, int $top, string $sort, bool $includeCompilePhases): string`
+- `renderJson(ProfileReport): string`
+
+## Hook Strategy
+
+`Phel\Lang\Registry` carries an optional `static ?ProfilerHookInterface $profilerHook`. When set, `Registry::addDefinition` wraps every `AbstractFn` value in a `ProfilingFn` proxy before storing. `GlobalVarEmitter` already routes every global-fn call through `\Phel::getDefinition(...)`, so no emitter or fixture changes are needed.
+
+Off-state cost: one null-check per `addDefinition` call. Zero call-site overhead when the profiler is off.
+
+## Structure
+
+```
+Profile/
+├── Domain/
+│   ├── Formatter/
+│   │   ├── JsonFormatter.php
+│   │   └── TableFormatter.php
+│   ├── ProfileReport.php       Immutable result: per-fn stats + per-source phase ms + wall-clock ms
+│   ├── ProfilerSession.php     Implements ProfilerHookInterface; stack-based self/total accounting
+│   └── ProfilingFn.php         AbstractFn proxy; times each __invoke via session
+├── Infrastructure/
+│   └── Command/
+│       └── ProfileCommand.php  Symfony Command; reuses RunFacade::runFile / runNamespace
+└── Gacela files                ProfileFacade, ProfileFactory, ProfileConfig, ProfileProvider
+```
+
+## Dependencies
+
+- **Run** (`RunFacade`) — `runFile`, `runNamespace`, `autoDetectEntryPoint`, `writeLocatedException`, `writeStackTrace`
+- **Compiler** (`Munge`) — namespace canonicalisation
+- **Lang** (`AbstractFn`, `ProfilerHookInterface`, `Registry`) — fn proxy and hook installation
+
+## Key Constraints
+
+- The hook only wraps fns at definition time; values that aren't `AbstractFn` pass through unchanged
+- `ProfilingFn` extends `AbstractFn` so any `instanceof AbstractFn` check downstream still succeeds
+- `ProfilingFn::__construct` copies inner meta to the proxy so `getMeta` / `withMeta` still work via `MetaTrait`
+- Self time is computed by maintaining a per-call stack and subtracting child inclusive time from parent
+- Self-recursive calls bypass the proxy (commit `bee78ffe` emits `$this(...)` instead of a registry lookup); the entry from outside is counted but recursive depth isn't. Cross-fn recursion is fully profiled
+- The hook is installed by `ProfileCommand` before invoking the run, and cleared in a `finally` block; do not leave it set across commands

--- a/src/php/Profile/CLAUDE.md
+++ b/src/php/Profile/CLAUDE.md
@@ -31,7 +31,9 @@ Profile/
 │   │   └── TableFormatter.php
 │   ├── ProfileReport.php       Immutable result: per-fn stats + per-source phase ms + wall-clock ms
 │   ├── ProfilerSession.php     Implements ProfilerHookInterface; stack-based self/total accounting
-│   └── ProfilingFn.php         AbstractFn proxy; times each __invoke via session
+│   ├── ProfilingFn.php         AbstractFn proxy; times each __invoke via session
+│   ├── ReportFormat.php        Enum: Table, Json, Both (with emitsTable/emitsJson predicates)
+│   └── SortOrder.php           Enum: SelfTime, TotalTime, Calls, Avg
 ├── Infrastructure/
 │   └── Command/
 │       └── ProfileCommand.php  Symfony Command; reuses RunFacade::runFile / runNamespace

--- a/src/php/Profile/Domain/Formatter/JsonFormatter.php
+++ b/src/php/Profile/Domain/Formatter/JsonFormatter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain\Formatter;
+
+use Phel\Profile\Domain\ProfileReport;
+
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+
+final class JsonFormatter
+{
+    public function render(ProfileReport $report): string
+    {
+        $fns = [];
+        foreach ($report->fnStats() as $boundTo => $r) {
+            $fns[] = [
+                'bound_to' => $boundTo,
+                'calls' => $r['calls'],
+                'self_ns' => $r['selfNs'],
+                'total_ns' => $r['totalNs'],
+                'max_ns' => $r['maxNs'],
+                'self_ms' => $r['selfNs'] / 1_000_000,
+                'total_ms' => $r['totalNs'] / 1_000_000,
+            ];
+        }
+
+        $phases = [];
+        foreach ($report->phaseMs() as $source => $byPhase) {
+            $phases[] = ['source' => $source] + $byPhase;
+        }
+
+        return (string) json_encode([
+            'wall_clock_ms' => $report->wallClockMs(),
+            'compile_phases' => $phases,
+            'fns' => $fns,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Profile\Domain\Formatter;
 
 use Phel\Profile\Domain\ProfileReport;
-use Phel\Profile\ProfileConfig;
+use Phel\Profile\Domain\SortOrder;
 
 use function array_keys;
 use function array_map;
@@ -25,7 +25,7 @@ use function uasort;
 
 final class TableFormatter
 {
-    public function render(ProfileReport $report, int $top, string $sort, bool $includeCompilePhases): string
+    public function render(ProfileReport $report, int $top, SortOrder $sort, bool $includeCompilePhases): string
     {
         $out = '';
 
@@ -85,7 +85,7 @@ final class TableFormatter
         return $line . '  ' . str_pad('total', 8, ' ', STR_PAD_LEFT) . "\n";
     }
 
-    private function renderFnStats(ProfileReport $report, int $top, string $sort): string
+    private function renderFnStats(ProfileReport $report, int $top, SortOrder $sort): string
     {
         $stats = $report->fnStats();
         if ($stats === []) {
@@ -98,7 +98,7 @@ final class TableFormatter
         $names = array_map($this->displayName(...), array_keys($rows));
         $nameWidth = max(20, ...array_map(strlen(...), $names));
 
-        $out = sprintf("Runtime fn profile (top %d, sort by %s)\n", count($rows), $sort);
+        $out = sprintf("Runtime fn profile (top %d, sort by %s)\n", count($rows), $sort->value);
         $out .= '  ' . str_pad('fn', $nameWidth) . '  '
             . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
             . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
@@ -130,13 +130,13 @@ final class TableFormatter
     /**
      * @return callable(array{calls:int, totalNs:int, selfNs:int, maxNs:int}, array{calls:int, totalNs:int, selfNs:int, maxNs:int}): int
      */
-    private function sortComparator(string $sort): callable
+    private function sortComparator(SortOrder $sort): callable
     {
         return match ($sort) {
-            ProfileConfig::SORT_TOTAL => static fn(array $a, array $b): int => $b['totalNs'] <=> $a['totalNs'],
-            ProfileConfig::SORT_CALLS => static fn(array $a, array $b): int => $b['calls'] <=> $a['calls'],
-            ProfileConfig::SORT_AVG => static fn(array $a, array $b): int => ((float) $b['totalNs'] / (float) max($b['calls'], 1)) <=> ((float) $a['totalNs'] / (float) max($a['calls'], 1)),
-            default => static fn(array $a, array $b): int => $b['selfNs'] <=> $a['selfNs'],
+            SortOrder::TotalTime => static fn(array $a, array $b): int => $b['totalNs'] <=> $a['totalNs'],
+            SortOrder::Calls => static fn(array $a, array $b): int => $b['calls'] <=> $a['calls'],
+            SortOrder::Avg => static fn(array $a, array $b): int => ((float) $b['totalNs'] / (float) max($b['calls'], 1)) <=> ((float) $a['totalNs'] / (float) max($a['calls'], 1)),
+            SortOrder::SelfTime => static fn(array $a, array $b): int => $b['selfNs'] <=> $a['selfNs'],
         };
     }
 

--- a/src/php/Profile/Domain/Formatter/TableFormatter.php
+++ b/src/php/Profile/Domain/Formatter/TableFormatter.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain\Formatter;
+
+use Phel\Profile\Domain\ProfileReport;
+use Phel\Profile\ProfileConfig;
+
+use function array_keys;
+use function array_map;
+use function array_slice;
+use function array_sum;
+use function count;
+use function max;
+use function number_format;
+use function rtrim;
+use function sprintf;
+use function str_pad;
+use function str_replace;
+use function strlen;
+use function strrpos;
+use function substr;
+use function uasort;
+
+final class TableFormatter
+{
+    public function render(ProfileReport $report, int $top, string $sort, bool $includeCompilePhases): string
+    {
+        $out = '';
+
+        if ($includeCompilePhases && $report->phaseMs() !== []) {
+            $out .= $this->renderCompilePhases($report) . "\n";
+        }
+
+        $out .= $this->renderFnStats($report, $top, $sort);
+
+        return $out . sprintf("\nWall-clock total: %s ms\n", $this->fmt($report->wallClockMs()));
+    }
+
+    private function renderCompilePhases(ProfileReport $report): string
+    {
+        $phases = ['lex', 'parse', 'read', 'analyze', 'emit'];
+        $rows = [];
+        foreach ($report->phaseMs() as $source => $byPhase) {
+            $row = ['source' => $this->shortenSource($source)];
+            $total = 0.0;
+            foreach ($phases as $p) {
+                $val = $byPhase[$p] ?? 0.0;
+                $row[$p] = $val;
+                $total += $val;
+            }
+
+            $row['total'] = $total;
+            $rows[] = $row;
+        }
+
+        uasort($rows, static fn(array $a, array $b): int => $b['total'] <=> $a['total']);
+
+        $sourceWidth = max(20, ...array_map(static fn(array $r): int => strlen($r['source']), $rows));
+        $header = $this->phaseHeader($sourceWidth, $phases);
+        $body = '';
+        foreach ($rows as $row) {
+            $body .= '  ' . str_pad($row['source'], $sourceWidth);
+            foreach ($phases as $p) {
+                $body .= '  ' . str_pad($this->fmt($row[$p]), 8, ' ', STR_PAD_LEFT);
+            }
+
+            $body .= '  ' . str_pad($this->fmt($row['total']), 8, ' ', STR_PAD_LEFT) . "\n";
+        }
+
+        return "Compile-time phases (ms)\n" . $header . $body;
+    }
+
+    /**
+     * @param list<string> $phases
+     */
+    private function phaseHeader(int $sourceWidth, array $phases): string
+    {
+        $line = '  ' . str_pad('source', $sourceWidth);
+        foreach ($phases as $p) {
+            $line .= '  ' . str_pad($p, 8, ' ', STR_PAD_LEFT);
+        }
+
+        return $line . '  ' . str_pad('total', 8, ' ', STR_PAD_LEFT) . "\n";
+    }
+
+    private function renderFnStats(ProfileReport $report, int $top, string $sort): string
+    {
+        $stats = $report->fnStats();
+        if ($stats === []) {
+            return "Runtime fn profile: no profiled calls recorded.\n";
+        }
+
+        uasort($stats, $this->sortComparator($sort));
+        $rows = array_slice($stats, 0, $top, true);
+
+        $names = array_map($this->displayName(...), array_keys($rows));
+        $nameWidth = max(20, ...array_map(strlen(...), $names));
+
+        $out = sprintf("Runtime fn profile (top %d, sort by %s)\n", count($rows), $sort);
+        $out .= '  ' . str_pad('fn', $nameWidth) . '  '
+            . str_pad('calls', 9, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('self ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('total ms', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('avg us', 10, ' ', STR_PAD_LEFT) . '  '
+            . str_pad('max us', 10, ' ', STR_PAD_LEFT) . "\n";
+
+        foreach ($rows as $boundTo => $r) {
+            $name = $this->displayName($boundTo);
+            $avgUs = $r['calls'] > 0 ? ((float) $r['totalNs'] / (float) $r['calls']) / 1_000.0 : 0.0;
+            $maxUs = (float) $r['maxNs'] / 1_000.0;
+            $selfMs = (float) $r['selfNs'] / 1_000_000.0;
+            $totalMs = (float) $r['totalNs'] / 1_000_000.0;
+
+            $out .= '  ' . str_pad($name, $nameWidth) . '  '
+                . str_pad((string) $r['calls'], 9, ' ', STR_PAD_LEFT) . '  '
+                . str_pad($this->fmt($selfMs), 10, ' ', STR_PAD_LEFT) . '  '
+                . str_pad($this->fmt($totalMs), 10, ' ', STR_PAD_LEFT) . '  '
+                . str_pad($this->fmt($avgUs), 10, ' ', STR_PAD_LEFT) . '  '
+                . str_pad($this->fmt($maxUs), 10, ' ', STR_PAD_LEFT) . "\n";
+        }
+
+        $totalSelfMs = array_sum(array_map(static fn(array $r): float => (float) $r['selfNs'] / 1_000_000.0, $stats));
+        $totalCalls = array_sum(array_map(static fn(array $r): int => $r['calls'], $stats));
+
+        return $out . sprintf("\nTotals: %d fns, %d calls, %s ms self.\n", count($stats), $totalCalls, $this->fmt($totalSelfMs));
+    }
+
+    /**
+     * @return callable(array{calls:int, totalNs:int, selfNs:int, maxNs:int}, array{calls:int, totalNs:int, selfNs:int, maxNs:int}): int
+     */
+    private function sortComparator(string $sort): callable
+    {
+        return match ($sort) {
+            ProfileConfig::SORT_TOTAL => static fn(array $a, array $b): int => $b['totalNs'] <=> $a['totalNs'],
+            ProfileConfig::SORT_CALLS => static fn(array $a, array $b): int => $b['calls'] <=> $a['calls'],
+            ProfileConfig::SORT_AVG => static fn(array $a, array $b): int => ((float) $b['totalNs'] / (float) max($b['calls'], 1)) <=> ((float) $a['totalNs'] / (float) max($a['calls'], 1)),
+            default => static fn(array $a, array $b): int => $b['selfNs'] <=> $a['selfNs'],
+        };
+    }
+
+    private function displayName(string $boundTo): string
+    {
+        $lastSep = strrpos($boundTo, '\\');
+        if ($lastSep === false) {
+            return str_replace('_', '-', $boundTo);
+        }
+
+        $ns = substr($boundTo, 0, $lastSep);
+        $name = substr($boundTo, $lastSep + 1);
+
+        return rtrim(str_replace('\\', '.', $ns), '.') . '/' . str_replace('_', '-', $name);
+    }
+
+    private function shortenSource(string $source): string
+    {
+        if (strlen($source) <= 40) {
+            return $source;
+        }
+
+        return '…' . substr($source, -39);
+    }
+
+    private function fmt(float $val): string
+    {
+        return number_format($val, 2, '.', '');
+    }
+}

--- a/src/php/Profile/Domain/ProfileReport.php
+++ b/src/php/Profile/Domain/ProfileReport.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain;
+
+final readonly class ProfileReport
+{
+    /**
+     * @param array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}> $fnStats
+     * @param array<string, array<string, float>>                                 $phaseMs
+     */
+    public function __construct(
+        private array $fnStats,
+        private array $phaseMs,
+        private float $wallClockMs,
+    ) {}
+
+    /**
+     * @return array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}>
+     */
+    public function fnStats(): array
+    {
+        return $this->fnStats;
+    }
+
+    /**
+     * @return array<string, array<string, float>>
+     */
+    public function phaseMs(): array
+    {
+        return $this->phaseMs;
+    }
+
+    public function wallClockMs(): float
+    {
+        return $this->wallClockMs;
+    }
+}

--- a/src/php/Profile/Domain/ProfilerSession.php
+++ b/src/php/Profile/Domain/ProfilerSession.php
@@ -24,8 +24,6 @@ final class ProfilerSession implements ProfilerHookInterface
 
     private readonly int $startedAtNs;
 
-    private int $stoppedAtNs = 0;
-
     public function __construct()
     {
         $this->startedAtNs = hrtime(true);
@@ -40,35 +38,20 @@ final class ProfilerSession implements ProfilerHookInterface
         return new ProfilingFn($fn, $this);
     }
 
-    public function enter(string $name): int
+    public function enter(string $name): void
     {
-        $now = hrtime(true);
-        $this->stack[] = ['name' => $name, 'enter' => $now, 'sub' => 0];
-
-        return $now;
+        $this->stack[] = ['name' => $name, 'enter' => hrtime(true), 'sub' => 0];
     }
 
-    public function exit(string $name, int $startNs): void
+    public function exit(): void
     {
-        $now = hrtime(true);
         $frame = array_pop($this->stack);
         if ($frame === null) {
             return;
         }
 
-        $inclusive = $now - $frame['enter'];
-        $self = $inclusive - $frame['sub'];
-
-        if (!isset($this->fnStats[$name])) {
-            $this->fnStats[$name] = ['calls' => 0, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0];
-        }
-
-        ++$this->fnStats[$name]['calls'];
-        $this->fnStats[$name]['totalNs'] += $inclusive;
-        $this->fnStats[$name]['selfNs'] += $self;
-        if ($inclusive > $this->fnStats[$name]['maxNs']) {
-            $this->fnStats[$name]['maxNs'] = $inclusive;
-        }
+        $inclusive = hrtime(true) - $frame['enter'];
+        $this->recordCall($frame['name'], $inclusive, $inclusive - $frame['sub']);
 
         $depth = count($this->stack);
         if ($depth > 0) {
@@ -79,22 +62,29 @@ final class ProfilerSession implements ProfilerHookInterface
 
     public function recordPhase(string $phase, string $source, float $elapsedMs): void
     {
-        if (!isset($this->phaseMs[$source])) {
-            $this->phaseMs[$source] = [];
-        }
-
-        $current = $this->phaseMs[$source][$phase] ?? 0.0;
-        $this->phaseMs[$source][$phase] = $current + $elapsedMs;
+        $this->phaseMs[$source][$phase] = ($this->phaseMs[$source][$phase] ?? 0.0) + $elapsedMs;
     }
 
     public function stop(): ProfileReport
     {
-        $this->stoppedAtNs = hrtime(true);
-
         return new ProfileReport(
             $this->fnStats,
             $this->phaseMs,
-            ($this->stoppedAtNs - $this->startedAtNs) / 1_000_000,
+            (hrtime(true) - $this->startedAtNs) / 1_000_000,
         );
+    }
+
+    private function recordCall(string $name, int $inclusive, int $self): void
+    {
+        if (!isset($this->fnStats[$name])) {
+            $this->fnStats[$name] = ['calls' => 0, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0];
+        }
+
+        ++$this->fnStats[$name]['calls'];
+        $this->fnStats[$name]['totalNs'] += $inclusive;
+        $this->fnStats[$name]['selfNs'] += $self;
+        if ($inclusive > $this->fnStats[$name]['maxNs']) {
+            $this->fnStats[$name]['maxNs'] = $inclusive;
+        }
     }
 }

--- a/src/php/Profile/Domain/ProfilerSession.php
+++ b/src/php/Profile/Domain/ProfilerSession.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain;
+
+use Phel\Lang\AbstractFn;
+use Phel\Lang\ProfilerHookInterface;
+
+use function array_pop;
+use function count;
+use function hrtime;
+
+final class ProfilerSession implements ProfilerHookInterface
+{
+    /** @var list<array{name:string, enter:int, sub:int}> */
+    private array $stack = [];
+
+    /** @var array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}> */
+    private array $fnStats = [];
+
+    /** @var array<string, array<string, float>> */
+    private array $phaseMs = [];
+
+    private readonly int $startedAtNs;
+
+    private int $stoppedAtNs = 0;
+
+    public function __construct()
+    {
+        $this->startedAtNs = hrtime(true);
+    }
+
+    public function wrapFn(AbstractFn $fn): ProfilingFn
+    {
+        if ($fn instanceof ProfilingFn) {
+            return $fn;
+        }
+
+        return new ProfilingFn($fn, $this);
+    }
+
+    public function enter(string $name): int
+    {
+        $now = hrtime(true);
+        $this->stack[] = ['name' => $name, 'enter' => $now, 'sub' => 0];
+
+        return $now;
+    }
+
+    public function exit(string $name, int $startNs): void
+    {
+        $now = hrtime(true);
+        $frame = array_pop($this->stack);
+        if ($frame === null) {
+            return;
+        }
+
+        $inclusive = $now - $frame['enter'];
+        $self = $inclusive - $frame['sub'];
+
+        if (!isset($this->fnStats[$name])) {
+            $this->fnStats[$name] = ['calls' => 0, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0];
+        }
+
+        ++$this->fnStats[$name]['calls'];
+        $this->fnStats[$name]['totalNs'] += $inclusive;
+        $this->fnStats[$name]['selfNs'] += $self;
+        if ($inclusive > $this->fnStats[$name]['maxNs']) {
+            $this->fnStats[$name]['maxNs'] = $inclusive;
+        }
+
+        $depth = count($this->stack);
+        if ($depth > 0) {
+            /** @psalm-suppress PropertyTypeCoercion */
+            $this->stack[$depth - 1]['sub'] += $inclusive;
+        }
+    }
+
+    public function recordPhase(string $phase, string $source, float $elapsedMs): void
+    {
+        if (!isset($this->phaseMs[$source])) {
+            $this->phaseMs[$source] = [];
+        }
+
+        $current = $this->phaseMs[$source][$phase] ?? 0.0;
+        $this->phaseMs[$source][$phase] = $current + $elapsedMs;
+    }
+
+    public function stop(): ProfileReport
+    {
+        $this->stoppedAtNs = hrtime(true);
+
+        return new ProfileReport(
+            $this->fnStats,
+            $this->phaseMs,
+            ($this->stoppedAtNs - $this->startedAtNs) / 1_000_000,
+        );
+    }
+}

--- a/src/php/Profile/Domain/ProfilingFn.php
+++ b/src/php/Profile/Domain/ProfilingFn.php
@@ -30,12 +30,12 @@ final class ProfilingFn extends AbstractFn
 
     public function __invoke(mixed ...$args): mixed
     {
-        $start = $this->session->enter($this->boundTo);
+        $this->session->enter($this->boundTo);
         try {
             /** @psalm-suppress InvalidFunctionCall */
             return ($this->inner)(...$args);
         } finally {
-            $this->session->exit($this->boundTo, $start);
+            $this->session->exit();
         }
     }
 
@@ -43,15 +43,5 @@ final class ProfilingFn extends AbstractFn
     public function __toString(): string
     {
         return (string) $this->inner;
-    }
-
-    public function unwrap(): AbstractFn
-    {
-        return $this->inner;
-    }
-
-    public function boundTo(): string
-    {
-        return $this->boundTo;
     }
 }

--- a/src/php/Profile/Domain/ProfilingFn.php
+++ b/src/php/Profile/Domain/ProfilingFn.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain;
+
+use Override;
+use Phel\Lang\AbstractFn;
+use ReflectionClass;
+
+use function is_string;
+
+/**
+ * Proxy that wraps a user `defn` so every call routed via `Registry`
+ * is timed. Self-recursive calls that the compiler emits as `$this(...)`
+ * bypass this proxy by design (see commit bee78ffe).
+ */
+final class ProfilingFn extends AbstractFn
+{
+    private readonly string $boundTo;
+
+    public function __construct(
+        private readonly AbstractFn $inner,
+        private readonly ProfilerSession $session,
+    ) {
+        $constant = new ReflectionClass($inner)->getConstant('BOUND_TO');
+        $this->boundTo = is_string($constant) && $constant !== '' ? $constant : '<anonymous>';
+        $this->withMeta($inner->getMeta());
+    }
+
+    public function __invoke(mixed ...$args): mixed
+    {
+        $start = $this->session->enter($this->boundTo);
+        try {
+            /** @psalm-suppress InvalidFunctionCall */
+            return ($this->inner)(...$args);
+        } finally {
+            $this->session->exit($this->boundTo, $start);
+        }
+    }
+
+    #[Override]
+    public function __toString(): string
+    {
+        return (string) $this->inner;
+    }
+
+    public function unwrap(): AbstractFn
+    {
+        return $this->inner;
+    }
+
+    public function boundTo(): string
+    {
+        return $this->boundTo;
+    }
+}

--- a/src/php/Profile/Domain/ReportFormat.php
+++ b/src/php/Profile/Domain/ReportFormat.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain;
+
+enum ReportFormat: string
+{
+    case Table = 'table';
+    case Json = 'json';
+    case Both = 'both';
+
+    public function emitsTable(): bool
+    {
+        return $this === self::Table || $this === self::Both;
+    }
+
+    public function emitsJson(): bool
+    {
+        return $this === self::Json || $this === self::Both;
+    }
+}

--- a/src/php/Profile/Domain/SortOrder.php
+++ b/src/php/Profile/Domain/SortOrder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Domain;
+
+enum SortOrder: string
+{
+    case SelfTime = 'self';
+    case TotalTime = 'total';
+    case Calls = 'calls';
+    case Avg = 'avg';
+}

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Application\Munge;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Lang\Registry;
 use Phel\Phel;
+use Phel\Profile\Domain\ProfileReport;
 use Phel\Profile\ProfileConfig;
 use Phel\Profile\ProfileFacade;
 use Phel\Profile\ProfileFactory;
@@ -74,52 +75,75 @@ final class ProfileCommand extends Command
             return self::FAILURE;
         }
 
-        $sort = $this->resolveSort($input, $output);
+        $sort = $this->validateChoice(
+            $input,
+            $output,
+            self::OPT_SORT,
+            [ProfileConfig::SORT_SELF, ProfileConfig::SORT_TOTAL, ProfileConfig::SORT_CALLS, ProfileConfig::SORT_AVG],
+        );
         if ($sort === null) {
             return self::FAILURE;
         }
 
-        $format = $this->resolveFormat($input, $output);
+        $format = $this->validateChoice(
+            $input,
+            $output,
+            self::OPT_FORMAT,
+            [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH],
+        );
         if ($format === null) {
             return self::FAILURE;
         }
 
         /** @var list<string>|string|null $rawArgv */
         $rawArgv = $input->getArgument(self::ARG_ARGV);
-        $userArgv = is_array($rawArgv) ? $rawArgv : [];
-        Phel::setupRuntimeArgs($path, $userArgv);
+        Phel::setupRuntimeArgs($path, is_array($rawArgv) ? $rawArgv : []);
 
+        $report = $this->runWithProfiler($path, $output);
+        if (!$report instanceof ProfileReport) {
+            return self::FAILURE;
+        }
+
+        $this->renderReport($report, $input, $output, $sort, $format);
+
+        return self::SUCCESS;
+    }
+
+    private function runWithProfiler(string $path, OutputInterface $output): ?ProfileReport
+    {
+        $runFacade = $this->getFactory()->getRunFacade();
         $session = $this->getFacade()->startSession();
         Registry::$profilerHook = $session;
 
         try {
-            $runFacade = $this->getFactory()->getRunFacade();
             if (file_exists($path)) {
                 $runFacade->runFile($path);
             } else {
                 $runFacade->runNamespace(Munge::canonicalNs($path));
             }
         } catch (CompilerException $e) {
-            Registry::$profilerHook = null;
-            $this->getFactory()->getRunFacade()->writeLocatedException($output, $e);
+            $runFacade->writeLocatedException($output, $e);
 
-            return self::FAILURE;
+            return null;
         } catch (Throwable $e) {
-            Registry::$profilerHook = null;
-            $this->getFactory()->getRunFacade()->writeStackTrace($output, $e);
+            $runFacade->writeStackTrace($output, $e);
 
-            return self::FAILURE;
+            return null;
         } finally {
             Registry::$profilerHook = null;
         }
 
-        $report = $session->stop();
+        return $session->stop();
+    }
 
-        $top = (int) $input->getOption(self::OPT_TOP);
-        if ($top <= 0) {
-            $top = ProfileConfig::DEFAULT_TOP;
-        }
-
+    private function renderReport(
+        ProfileReport $report,
+        InputInterface $input,
+        OutputInterface $output,
+        string $sort,
+        string $format,
+    ): void {
+        $top = $this->resolveTop($input);
         $includeCompilePhases = !$input->getOption(self::OPT_NO_COMPILE_PHASES);
 
         if (in_array($format, [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_BOTH], true)) {
@@ -127,22 +151,25 @@ final class ProfileCommand extends Command
         }
 
         $outputFile = $input->getOption(self::OPT_OUTPUT);
-        $writeJsonToFile = is_string($outputFile) && $outputFile !== '';
-
-        if ($writeJsonToFile || in_array($format, [ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH], true)) {
-            $json = $this->getFacade()->renderJson($report);
-            if ($writeJsonToFile) {
-                file_put_contents($outputFile, $json);
-                $output->writeln(sprintf('<info>JSON report written to %s</info>', $outputFile));
-            } elseif ($format === ProfileConfig::FORMAT_JSON) {
-                $output->writeln($json);
-            } else {
-                $output->writeln('');
-                $output->writeln($json);
-            }
+        $writeToFile = is_string($outputFile) && $outputFile !== '';
+        $emitJson = $writeToFile || in_array($format, [ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH], true);
+        if (!$emitJson) {
+            return;
         }
 
-        return self::SUCCESS;
+        $json = $this->getFacade()->renderJson($report);
+        if ($writeToFile) {
+            file_put_contents($outputFile, $json);
+            $output->writeln(sprintf('<info>JSON report written to %s</info>', $outputFile));
+
+            return;
+        }
+
+        if ($format === ProfileConfig::FORMAT_BOTH) {
+            $output->writeln('');
+        }
+
+        $output->writeln($json);
     }
 
     private function resolvePath(InputInterface $input, OutputInterface $output): ?string
@@ -163,29 +190,30 @@ final class ProfileCommand extends Command
         return $detected;
     }
 
-    private function resolveSort(InputInterface $input, OutputInterface $output): ?string
+    private function resolveTop(InputInterface $input): int
     {
-        $sort = (string) $input->getOption(self::OPT_SORT);
-        $valid = [ProfileConfig::SORT_SELF, ProfileConfig::SORT_TOTAL, ProfileConfig::SORT_CALLS, ProfileConfig::SORT_AVG];
-        if (!in_array($sort, $valid, true)) {
-            $output->writeln(sprintf('<error>Unknown sort: %s. Allowed: %s.</error>', $sort, implode(', ', $valid)));
+        $top = (int) $input->getOption(self::OPT_TOP);
 
-            return null;
-        }
-
-        return $sort;
+        return $top > 0 ? $top : ProfileConfig::DEFAULT_TOP;
     }
 
-    private function resolveFormat(InputInterface $input, OutputInterface $output): ?string
+    /**
+     * @param list<string> $allowed
+     */
+    private function validateChoice(InputInterface $input, OutputInterface $output, string $option, array $allowed): ?string
     {
-        $format = (string) $input->getOption(self::OPT_FORMAT);
-        $valid = [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH];
-        if (!in_array($format, $valid, true)) {
-            $output->writeln(sprintf('<error>Unknown format: %s. Allowed: %s.</error>', $format, implode(', ', $valid)));
-
-            return null;
+        $value = (string) $input->getOption($option);
+        if (in_array($value, $allowed, true)) {
+            return $value;
         }
 
-        return $format;
+        $output->writeln(sprintf(
+            '<error>Unknown %s: %s. Allowed: %s.</error>',
+            $option,
+            $value,
+            implode(', ', $allowed),
+        ));
+
+        return null;
     }
 }

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Profile\Infrastructure\Command;
 
+use BackedEnum;
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
 use Phel\Compiler\Application\Munge;
@@ -11,6 +12,8 @@ use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Lang\Registry;
 use Phel\Phel;
 use Phel\Profile\Domain\ProfileReport;
+use Phel\Profile\Domain\ReportFormat;
+use Phel\Profile\Domain\SortOrder;
 use Phel\Profile\ProfileConfig;
 use Phel\Profile\ProfileFacade;
 use Phel\Profile\ProfileFactory;
@@ -19,12 +22,13 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use Throwable;
 
+use function array_map;
 use function file_exists;
 use function file_put_contents;
 use function implode;
-use function in_array;
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -62,9 +66,9 @@ final class ProfileCommand extends Command
             ->addArgument(self::ARG_PATH, InputArgument::OPTIONAL, 'File path or namespace to profile.')
             ->addArgument(self::ARG_ARGV, InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional script arguments.', [])
             ->addOption(self::OPT_TOP, null, InputOption::VALUE_REQUIRED, 'Show top N fns in the table.', (string) ProfileConfig::DEFAULT_TOP)
-            ->addOption(self::OPT_FORMAT, null, InputOption::VALUE_REQUIRED, 'Output format: table, json, both.', ProfileConfig::FORMAT_TABLE)
+            ->addOption(self::OPT_FORMAT, null, InputOption::VALUE_REQUIRED, 'Output format: table, json, both.', ReportFormat::Table->value)
             ->addOption(self::OPT_OUTPUT, null, InputOption::VALUE_REQUIRED, 'Write JSON report to this file.')
-            ->addOption(self::OPT_SORT, null, InputOption::VALUE_REQUIRED, 'Sort fns by: self, total, calls, avg.', ProfileConfig::SORT_SELF)
+            ->addOption(self::OPT_SORT, null, InputOption::VALUE_REQUIRED, 'Sort fns by: self, total, calls, avg.', SortOrder::SelfTime->value)
             ->addOption(self::OPT_NO_COMPILE_PHASES, null, InputOption::VALUE_NONE, 'Skip the compile-time phase report.');
     }
 
@@ -75,23 +79,17 @@ final class ProfileCommand extends Command
             return self::FAILURE;
         }
 
-        $sort = $this->validateChoice(
-            $input,
-            $output,
-            self::OPT_SORT,
-            [ProfileConfig::SORT_SELF, ProfileConfig::SORT_TOTAL, ProfileConfig::SORT_CALLS, ProfileConfig::SORT_AVG],
-        );
+        $sort = SortOrder::tryFrom((string) $input->getOption(self::OPT_SORT));
         if ($sort === null) {
+            $this->writeUnknownOption($output, self::OPT_SORT, (string) $input->getOption(self::OPT_SORT), SortOrder::cases());
+
             return self::FAILURE;
         }
 
-        $format = $this->validateChoice(
-            $input,
-            $output,
-            self::OPT_FORMAT,
-            [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH],
-        );
+        $format = ReportFormat::tryFrom((string) $input->getOption(self::OPT_FORMAT));
         if ($format === null) {
+            $this->writeUnknownOption($output, self::OPT_FORMAT, (string) $input->getOption(self::OPT_FORMAT), ReportFormat::cases());
+
             return self::FAILURE;
         }
 
@@ -140,20 +138,19 @@ final class ProfileCommand extends Command
         ProfileReport $report,
         InputInterface $input,
         OutputInterface $output,
-        string $sort,
-        string $format,
+        SortOrder $sort,
+        ReportFormat $format,
     ): void {
         $top = $this->resolveTop($input);
         $includeCompilePhases = !$input->getOption(self::OPT_NO_COMPILE_PHASES);
 
-        if (in_array($format, [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_BOTH], true)) {
+        if ($format->emitsTable()) {
             $output->write($this->getFacade()->renderTable($report, $top, $sort, $includeCompilePhases));
         }
 
         $outputFile = $input->getOption(self::OPT_OUTPUT);
         $writeToFile = is_string($outputFile) && $outputFile !== '';
-        $emitJson = $writeToFile || in_array($format, [ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH], true);
-        if (!$emitJson) {
+        if (!$writeToFile && !$format->emitsJson()) {
             return;
         }
 
@@ -165,7 +162,7 @@ final class ProfileCommand extends Command
             return;
         }
 
-        if ($format === ProfileConfig::FORMAT_BOTH) {
+        if ($format === ReportFormat::Both) {
             $output->writeln('');
         }
 
@@ -198,14 +195,11 @@ final class ProfileCommand extends Command
     }
 
     /**
-     * @param list<string> $allowed
+     * @param list<BackedEnum> $cases
      */
-    private function validateChoice(InputInterface $input, OutputInterface $output, string $option, array $allowed): ?string
+    private function writeUnknownOption(OutputInterface $output, string $option, string $value, array $cases): void
     {
-        $value = (string) $input->getOption($option);
-        if (in_array($value, $allowed, true)) {
-            return $value;
-        }
+        $allowed = array_map(static fn(BackedEnum $c): string => (string) $c->value, $cases);
 
         $output->writeln(sprintf(
             '<error>Unknown %s: %s. Allowed: %s.</error>',
@@ -213,7 +207,5 @@ final class ProfileCommand extends Command
             $value,
             implode(', ', $allowed),
         ));
-
-        return null;
     }
 }

--- a/src/php/Profile/Infrastructure/Command/ProfileCommand.php
+++ b/src/php/Profile/Infrastructure/Command/ProfileCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Compiler\Application\Munge;
+use Phel\Compiler\Domain\Exceptions\CompilerException;
+use Phel\Lang\Registry;
+use Phel\Phel;
+use Phel\Profile\ProfileConfig;
+use Phel\Profile\ProfileFacade;
+use Phel\Profile\ProfileFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function file_exists;
+use function file_put_contents;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function sprintf;
+
+#[ServiceMap(method: 'getFacade', className: ProfileFacade::class)]
+#[ServiceMap(method: 'getFactory', className: ProfileFactory::class)]
+final class ProfileCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const string COMMAND_NAME = 'profile';
+
+    private const string ARG_PATH = 'path';
+
+    private const string ARG_ARGV = 'argv';
+
+    private const string OPT_TOP = 'top';
+
+    private const string OPT_FORMAT = 'format';
+
+    private const string OPT_OUTPUT = 'output';
+
+    private const string OPT_SORT = 'sort';
+
+    private const string OPT_NO_COMPILE_PHASES = 'no-compile-phases';
+
+    public function __construct()
+    {
+        parent::__construct(self::COMMAND_NAME);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Profile a Phel script: per-fn call counts and timings, plus compile-time phase costs.')
+            ->addArgument(self::ARG_PATH, InputArgument::OPTIONAL, 'File path or namespace to profile.')
+            ->addArgument(self::ARG_ARGV, InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Optional script arguments.', [])
+            ->addOption(self::OPT_TOP, null, InputOption::VALUE_REQUIRED, 'Show top N fns in the table.', (string) ProfileConfig::DEFAULT_TOP)
+            ->addOption(self::OPT_FORMAT, null, InputOption::VALUE_REQUIRED, 'Output format: table, json, both.', ProfileConfig::FORMAT_TABLE)
+            ->addOption(self::OPT_OUTPUT, null, InputOption::VALUE_REQUIRED, 'Write JSON report to this file.')
+            ->addOption(self::OPT_SORT, null, InputOption::VALUE_REQUIRED, 'Sort fns by: self, total, calls, avg.', ProfileConfig::SORT_SELF)
+            ->addOption(self::OPT_NO_COMPILE_PHASES, null, InputOption::VALUE_NONE, 'Skip the compile-time phase report.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $this->resolvePath($input, $output);
+        if ($path === null) {
+            return self::FAILURE;
+        }
+
+        $sort = $this->resolveSort($input, $output);
+        if ($sort === null) {
+            return self::FAILURE;
+        }
+
+        $format = $this->resolveFormat($input, $output);
+        if ($format === null) {
+            return self::FAILURE;
+        }
+
+        /** @var list<string>|string|null $rawArgv */
+        $rawArgv = $input->getArgument(self::ARG_ARGV);
+        $userArgv = is_array($rawArgv) ? $rawArgv : [];
+        Phel::setupRuntimeArgs($path, $userArgv);
+
+        $session = $this->getFacade()->startSession();
+        Registry::$profilerHook = $session;
+
+        try {
+            $runFacade = $this->getFactory()->getRunFacade();
+            if (file_exists($path)) {
+                $runFacade->runFile($path);
+            } else {
+                $runFacade->runNamespace(Munge::canonicalNs($path));
+            }
+        } catch (CompilerException $e) {
+            Registry::$profilerHook = null;
+            $this->getFactory()->getRunFacade()->writeLocatedException($output, $e);
+
+            return self::FAILURE;
+        } catch (Throwable $e) {
+            Registry::$profilerHook = null;
+            $this->getFactory()->getRunFacade()->writeStackTrace($output, $e);
+
+            return self::FAILURE;
+        } finally {
+            Registry::$profilerHook = null;
+        }
+
+        $report = $session->stop();
+
+        $top = (int) $input->getOption(self::OPT_TOP);
+        if ($top <= 0) {
+            $top = ProfileConfig::DEFAULT_TOP;
+        }
+
+        $includeCompilePhases = !$input->getOption(self::OPT_NO_COMPILE_PHASES);
+
+        if (in_array($format, [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_BOTH], true)) {
+            $output->write($this->getFacade()->renderTable($report, $top, $sort, $includeCompilePhases));
+        }
+
+        $outputFile = $input->getOption(self::OPT_OUTPUT);
+        $writeJsonToFile = is_string($outputFile) && $outputFile !== '';
+
+        if ($writeJsonToFile || in_array($format, [ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH], true)) {
+            $json = $this->getFacade()->renderJson($report);
+            if ($writeJsonToFile) {
+                file_put_contents($outputFile, $json);
+                $output->writeln(sprintf('<info>JSON report written to %s</info>', $outputFile));
+            } elseif ($format === ProfileConfig::FORMAT_JSON) {
+                $output->writeln($json);
+            } else {
+                $output->writeln('');
+                $output->writeln($json);
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function resolvePath(InputInterface $input, OutputInterface $output): ?string
+    {
+        /** @var string|null $path */
+        $path = $input->getArgument(self::ARG_PATH);
+        if ($path !== null && $path !== '') {
+            return $path;
+        }
+
+        $detected = $this->getFactory()->getRunFacade()->autoDetectEntryPoint();
+        if ($detected === null) {
+            $output->writeln('<error>No entry point found. Pass a file path or namespace.</error>');
+
+            return null;
+        }
+
+        return $detected;
+    }
+
+    private function resolveSort(InputInterface $input, OutputInterface $output): ?string
+    {
+        $sort = (string) $input->getOption(self::OPT_SORT);
+        $valid = [ProfileConfig::SORT_SELF, ProfileConfig::SORT_TOTAL, ProfileConfig::SORT_CALLS, ProfileConfig::SORT_AVG];
+        if (!in_array($sort, $valid, true)) {
+            $output->writeln(sprintf('<error>Unknown sort: %s. Allowed: %s.</error>', $sort, implode(', ', $valid)));
+
+            return null;
+        }
+
+        return $sort;
+    }
+
+    private function resolveFormat(InputInterface $input, OutputInterface $output): ?string
+    {
+        $format = (string) $input->getOption(self::OPT_FORMAT);
+        $valid = [ProfileConfig::FORMAT_TABLE, ProfileConfig::FORMAT_JSON, ProfileConfig::FORMAT_BOTH];
+        if (!in_array($format, $valid, true)) {
+            $output->writeln(sprintf('<error>Unknown format: %s. Allowed: %s.</error>', $format, implode(', ', $valid)));
+
+            return null;
+        }
+
+        return $format;
+    }
+}

--- a/src/php/Profile/ProfileConfig.php
+++ b/src/php/Profile/ProfileConfig.php
@@ -8,19 +8,5 @@ use Gacela\Framework\AbstractConfig;
 
 final class ProfileConfig extends AbstractConfig
 {
-    public const string FORMAT_TABLE = 'table';
-
-    public const string FORMAT_JSON = 'json';
-
-    public const string FORMAT_BOTH = 'both';
-
-    public const string SORT_SELF = 'self';
-
-    public const string SORT_TOTAL = 'total';
-
-    public const string SORT_CALLS = 'calls';
-
-    public const string SORT_AVG = 'avg';
-
     public const int DEFAULT_TOP = 20;
 }

--- a/src/php/Profile/ProfileConfig.php
+++ b/src/php/Profile/ProfileConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile;
+
+use Gacela\Framework\AbstractConfig;
+
+final class ProfileConfig extends AbstractConfig
+{
+    public const string FORMAT_TABLE = 'table';
+
+    public const string FORMAT_JSON = 'json';
+
+    public const string FORMAT_BOTH = 'both';
+
+    public const string SORT_SELF = 'self';
+
+    public const string SORT_TOTAL = 'total';
+
+    public const string SORT_CALLS = 'calls';
+
+    public const string SORT_AVG = 'avg';
+
+    public const int DEFAULT_TOP = 20;
+}

--- a/src/php/Profile/ProfileFacade.php
+++ b/src/php/Profile/ProfileFacade.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile;
+
+use Gacela\Framework\AbstractFacade;
+use Phel\Profile\Domain\ProfileReport;
+use Phel\Profile\Domain\ProfilerSession;
+
+/**
+ * @extends AbstractFacade<ProfileFactory>
+ */
+final class ProfileFacade extends AbstractFacade
+{
+    public function startSession(): ProfilerSession
+    {
+        return $this->getFactory()->createSession();
+    }
+
+    public function renderTable(ProfileReport $report, int $top, string $sort, bool $includeCompilePhases): string
+    {
+        return $this->getFactory()->createTableFormatter()->render($report, $top, $sort, $includeCompilePhases);
+    }
+
+    public function renderJson(ProfileReport $report): string
+    {
+        return $this->getFactory()->createJsonFormatter()->render($report);
+    }
+}

--- a/src/php/Profile/ProfileFacade.php
+++ b/src/php/Profile/ProfileFacade.php
@@ -7,6 +7,7 @@ namespace Phel\Profile;
 use Gacela\Framework\AbstractFacade;
 use Phel\Profile\Domain\ProfileReport;
 use Phel\Profile\Domain\ProfilerSession;
+use Phel\Profile\Domain\SortOrder;
 
 /**
  * @extends AbstractFacade<ProfileFactory>
@@ -18,7 +19,7 @@ final class ProfileFacade extends AbstractFacade
         return $this->getFactory()->createSession();
     }
 
-    public function renderTable(ProfileReport $report, int $top, string $sort, bool $includeCompilePhases): string
+    public function renderTable(ProfileReport $report, int $top, SortOrder $sort, bool $includeCompilePhases): string
     {
         return $this->getFactory()->createTableFormatter()->render($report, $top, $sort, $includeCompilePhases);
     }

--- a/src/php/Profile/ProfileFactory.php
+++ b/src/php/Profile/ProfileFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile;
+
+use Gacela\Framework\AbstractFactory;
+use Phel\Profile\Domain\Formatter\JsonFormatter;
+use Phel\Profile\Domain\Formatter\TableFormatter;
+use Phel\Profile\Domain\ProfilerSession;
+use Phel\Run\RunFacade;
+
+/**
+ * @extends AbstractFactory<ProfileConfig>
+ */
+final class ProfileFactory extends AbstractFactory
+{
+    public function createSession(): ProfilerSession
+    {
+        return new ProfilerSession();
+    }
+
+    public function createTableFormatter(): TableFormatter
+    {
+        return new TableFormatter();
+    }
+
+    public function createJsonFormatter(): JsonFormatter
+    {
+        return new JsonFormatter();
+    }
+
+    public function getRunFacade(): RunFacade
+    {
+        return $this->getProvidedDependency(ProfileProvider::FACADE_RUN);
+    }
+}

--- a/src/php/Profile/ProfileProvider.php
+++ b/src/php/Profile/ProfileProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Profile;
+
+use Gacela\Framework\AbstractProvider;
+use Gacela\Framework\Attribute\Provides;
+use Gacela\Framework\Container\Container;
+use Phel\Run\RunFacade;
+
+final class ProfileProvider extends AbstractProvider
+{
+    public const string FACADE_RUN = 'FACADE_RUN';
+
+    #[Provides(self::FACADE_RUN)]
+    public function runFacade(Container $container): RunFacade
+    {
+        return $container->getLocator()->getRequired(RunFacade::class);
+    }
+}

--- a/tests/php/Unit/Profile/ProfilerSessionTest.php
+++ b/tests/php/Unit/Profile/ProfilerSessionTest.php
@@ -14,12 +14,11 @@ final class ProfilerSessionTest extends TestCase
     {
         $session = new ProfilerSession();
 
-        $start = $session->enter('user/foo');
+        $session->enter('user/foo');
         usleep(1_000);
-        $session->exit('user/foo', $start);
+        $session->exit();
 
-        $report = $session->stop();
-        $stats = $report->fnStats();
+        $stats = $session->stop()->fnStats();
 
         self::assertArrayHasKey('user/foo', $stats);
         self::assertSame(1, $stats['user/foo']['calls']);
@@ -31,13 +30,13 @@ final class ProfilerSessionTest extends TestCase
     {
         $session = new ProfilerSession();
 
-        $outer = $session->enter('parent');
+        $session->enter('parent');
         usleep(500);
-        $inner = $session->enter('child');
+        $session->enter('child');
         usleep(2_000);
-        $session->exit('child', $inner);
+        $session->exit();
         usleep(500);
-        $session->exit('parent', $outer);
+        $session->exit();
 
         $stats = $session->stop()->fnStats();
 
@@ -50,8 +49,8 @@ final class ProfilerSessionTest extends TestCase
         $session = new ProfilerSession();
 
         for ($i = 0; $i < 5; ++$i) {
-            $token = $session->enter('user/loop');
-            $session->exit('user/loop', $token);
+            $session->enter('user/loop');
+            $session->exit();
         }
 
         $stats = $session->stop()->fnStats();

--- a/tests/php/Unit/Profile/ProfilerSessionTest.php
+++ b/tests/php/Unit/Profile/ProfilerSessionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Profile;
+
+use Phel\Lang\AbstractFn;
+use Phel\Profile\Domain\ProfilerSession;
+use PHPUnit\Framework\TestCase;
+
+final class ProfilerSessionTest extends TestCase
+{
+    public function test_records_per_fn_call_count_and_inclusive_time(): void
+    {
+        $session = new ProfilerSession();
+
+        $start = $session->enter('user/foo');
+        usleep(1_000);
+        $session->exit('user/foo', $start);
+
+        $report = $session->stop();
+        $stats = $report->fnStats();
+
+        self::assertArrayHasKey('user/foo', $stats);
+        self::assertSame(1, $stats['user/foo']['calls']);
+        self::assertGreaterThan(0, $stats['user/foo']['totalNs']);
+        self::assertSame($stats['user/foo']['selfNs'], $stats['user/foo']['totalNs']);
+    }
+
+    public function test_self_time_subtracts_nested_child_time(): void
+    {
+        $session = new ProfilerSession();
+
+        $outer = $session->enter('parent');
+        usleep(500);
+        $inner = $session->enter('child');
+        usleep(2_000);
+        $session->exit('child', $inner);
+        usleep(500);
+        $session->exit('parent', $outer);
+
+        $stats = $session->stop()->fnStats();
+
+        self::assertLessThan($stats['parent']['totalNs'], $stats['parent']['selfNs']);
+        self::assertSame($stats['child']['totalNs'], $stats['child']['selfNs']);
+    }
+
+    public function test_aggregates_repeated_calls(): void
+    {
+        $session = new ProfilerSession();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $token = $session->enter('user/loop');
+            $session->exit('user/loop', $token);
+        }
+
+        $stats = $session->stop()->fnStats();
+
+        self::assertSame(5, $stats['user/loop']['calls']);
+        self::assertGreaterThan(0, $stats['user/loop']['maxNs']);
+    }
+
+    public function test_records_compile_phase_durations(): void
+    {
+        $session = new ProfilerSession();
+        $session->recordPhase('lex', 'a.phel', 1.5);
+        $session->recordPhase('lex', 'a.phel', 0.5);
+        $session->recordPhase('parse', 'a.phel', 2.0);
+
+        $phases = $session->stop()->phaseMs();
+
+        self::assertSame(2.0, $phases['a.phel']['lex']);
+        self::assertSame(2.0, $phases['a.phel']['parse']);
+    }
+
+    public function test_wrap_fn_is_idempotent(): void
+    {
+        $session = new ProfilerSession();
+        $fn = new class() extends AbstractFn {
+            public const string BOUND_TO = 'user\\f';
+
+            public function __invoke(mixed ...$args): mixed
+            {
+                return null;
+            }
+        };
+
+        $wrapped = $session->wrapFn($fn);
+        $rewrapped = $session->wrapFn($wrapped);
+
+        self::assertSame($wrapped, $rewrapped);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel users today have no way to find perf bottlenecks in their code. `--with-time` reports only a coarse total; `(time expr)` measures one expression. PHPBench targets compiler authors, not user code.

## 💡 Goal

Ship a built-in profiler answering "which fns are hot?" and "where is compile time going?", in pure PHP (no Xdebug/SPX), with text and JSON output.

## 🔖 Changes

- New `phel profile <path>` command with `--top`, `--format=table|json|both`, `--output=<file>`, `--sort=self|total|calls|avg`, `--no-compile-phases`
- New `Phel\Profile` Gacela module: `ProfilerSession`, `ProfilingFn` proxy, `ProfileReport`, `Table`/`JsonFormatter`
- `Phel\Lang\Registry::$profilerHook` wraps every `AbstractFn` at `addDefinition` time. Since `GlobalVarEmitter` already routes calls through `\Phel::getDefinition(...)`, no emitter or fixture changes needed
- `CodeCompiler::compileString` records per-source `lex|parse|read|analyze|emit` ms when the hook is set; cold path unchanged when off
- Self-recursive calls bypass the proxy (`bee68ffe` `$this(...)` shortcut); cross-fn recursion fully profiled. Documented in `src/php/Profile/CLAUDE.md`