### PR TITLE
feat(compiler): emit PHP type declaration from `:tag` param meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 #### Core
 - `^:memoize` and `^{:memoize-lru N}` metadata on `defn` wrap the fn with `memoize` / `memoize-lru` (#1915)
 
+#### Compiler
+- `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature (#1916)
+
 #### Profile
 - `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -11,6 +11,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function count;
+use function is_string;
 
 final readonly class MethodEmitter
 {
@@ -41,10 +42,16 @@ final readonly class MethodEmitter
         $paramsCount = count($node->getParams());
 
         foreach ($node->getParams() as $i => $symbol) {
-            if ($i === $paramsCount - 1 && $node->isVariadic()) {
+            $isVariadicTail = $i === $paramsCount - 1 && $node->isVariadic();
+            $meta = $symbol->getMeta();
+            $tag = $this->extractTypeTag($meta);
+            if ($tag !== null) {
+                $this->outputEmitter->emitStr($tag . ' ', $node->getStartSourceLocation());
+            }
+
+            if ($isVariadicTail) {
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $asReference = false, $isVariadic = true);
             } else {
-                $meta = $symbol->getMeta();
                 $isReference = $meta instanceof PersistentMapInterface && $meta->find(Keyword::create('reference')) === true;
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $isReference);
             }
@@ -67,6 +74,16 @@ final readonly class MethodEmitter
 
         $this->emitMethodVariadicParameters($node);
         $this->emitMethodBody($node);
+    }
+
+    private function extractTypeTag(mixed $meta): ?string
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -1,0 +1,30 @@
+--PHEL--
+(defn add [^{:tag "int"} x ^{:tag "int"} y] (php/+ x y))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add";
+
+    public function __invoke(int $x, int $y) {
+      return ($x + $y);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-typed-params.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-typed-params.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 56
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-params.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^{:tag "int"} x ^{:tag "string"} y] x)
+--PHP--
+(function(int $x, string $y) {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-variadic.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-variadic.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [& ^{:tag "int"} xs] xs)
+--PHP--
+(function(int ...$xs) {
+  $xs = \Phel::vector($xs);
+  return $xs;
+});


### PR DESCRIPTION
## 🤔 Background

Phel `defn`/`fn` always emit untyped PHP signatures (`function __invoke($x)`). Closes one item from #1916: a manual opt-in path for users who want PHP-level type declarations on hot fns (visibility for static tools, OPcache JIT specialization).

## 💡 Goal

Allow users to attach a PHP type to any fn/defn parameter via existing Clojure-style metadata `^{:tag "<php-type>"}`, with no behavior change for unannotated code.

## 🔖 Changes

- `MethodEmitter::emitParameters` reads `:tag` keyword on each param symbol and emits the raw string before `$var`. Variadic and `:reference` paths preserved.
- Tag string is passed through verbatim, so `int`, `string`, `?float`, `\Foo\Bar`, `int|string` all work; PHP parser surfaces malformed types at compile-of-PHP time.
- Three integration fixtures covering closure form, variadic tail, and `defn` `__invoke` emit.
- CHANGELOG entry under `## Unreleased > Compiler`.

## Out of scope

- Return-type emission (`^{:return "int"}` on defn meta) — follow-up.
- Type inference. Manual annotation only.
- Bench harness for JIT speedup measurement — current `phpbench` setup measures cold compile/boot, wrong shape; tracked separately on #1916.

Related to #1916