### PR TITLE
feat(compiler): Clojure-style `^Type` shorthand for param :tag meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - `^:memoize` and `^{:memoize-lru N}` metadata on `defn` wrap the fn with `memoize` / `memoize-lru` (#1915)
 
 #### Compiler
-- `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature (#1916)
+- `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature; reader shorthands `^int x`, `^"?int" x`, `^"\\Foo\\Bar" x` all reduce to the same `:tag` form (#1916)
 
 #### Profile
 - `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -83,6 +83,10 @@ final readonly class MethodEmitter
         }
 
         $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
         return is_string($tag) && $tag !== '' ? $tag : null;
     }
 

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-fqn.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\\Phel\\Lang\\Symbol" s] s)
+--PHP--
+(function(\Phel\Lang\Symbol $s) {
+  return $s;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-nullable-symbol.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-nullable-symbol.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^?int x] x)
+--PHP--
+(function(?int $x) {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-string-shorthand.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-string-shorthand.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"?int" x ^"string|null" y] x)
+--PHP--
+(function(?int $x, string|null $y) {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-symbol.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-symbol.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int x ^string y] x)
+--PHP--
+(function(int $x, string $y) {
+  return $x;
+});


### PR DESCRIPTION
## 🤔 Background

#1927 landed `^{:tag "<php-type>"}` metadata on fn/defn params, but only the long map form was wired into the emitter. Phel's `MetaReader` already lifts `^X y` -> `{:tag X}` for Symbol/String values (`src/php/Compiler/Domain/Reader/ExpressionReader/MetaReader.php:33`), so the reader was already doing 90% of the work — the emitter just needed to accept Symbol as a tag value.

## 💡 Goal

Match Clojure's reader ergonomics. All four forms produce the same PHP signature:

```phel
(defn add [^int x ^int y] (php/+ x y))                  ; Symbol shorthand
(defn opt [^?int n] (or n 0))                           ; Symbol with ? (Phel symbol grammar allows it)
(defn cat [^"int|null" n] n)                            ; String form for non-symbol types
(defn fq  [^"\\Phel\\Lang\\Symbol" s] s)                ; String form for FQN with backslash
(defn map [^{:tag "callable"} f ^{:tag "array"} xs] f)  ; Long form (already supported)
```

Each compiles to the corresponding `int $x`, `?int $n`, `int|null $n`, `\Phel\Lang\Symbol $s`, `callable $f, array $xs` PHP signature.

## 🔖 Changes

- `MethodEmitter::extractTypeTag` unwraps `Symbol` via `getName()` before the string check; existing String/long-form paths unchanged.
- Four integration fixtures: Symbol shorthand, Symbol with `?` prefix, String form with `|`, String form with FQN backslashes.
- CHANGELOG entry under `## Unreleased > Compiler` extended with shorthand examples.

## DX notes

- Symbol shorthand only works for type strings that are valid Phel symbols (alphanumerics, `?`, `_`, etc.). Use the string form for anything containing `|`, `&`, `\`, or whitespace.
- `^:dynamic x` continues to read as `{:dynamic true}` — never collides with the type-hint path. Keyword shortcuts and tag shortcuts coexist.
- Long form `^{:tag "..."}` remains the canonical, tooling-friendly way to express the metadata; shorthands reduce to it at read time.

Related to #1916