### PR TITLE
feat(core): opt-in `^:async` metadata on defn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - `^:memoize` and `^{:memoize-lru N}` metadata on `defn` wrap the fn with `memoize` / `memoize-lru` (#1915)
+- `^:async` metadata on `defn` wraps the body in `async`, returning an `Amp\Future` that callers `await` (#1924)
 
 #### Compiler
 - `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature; reader shorthands `^int x`, `^"?int" x`, `^"\\Foo\\Bar" x` all reduce to the same `:tag` form (#1916)

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -42,6 +42,20 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Futur
 
 Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `PhelFuture` wrapper. Gotcha: must be called from inside a fiber.
 
+### `^:async` on `defn`
+
+Marking a `defn` with `^:async` wraps its body in `(async ...)`, so the function returns an `Amp\Future` that callers `await`. Saves the boilerplate of writing `(async ...)` at the top of every concurrent function body.
+
+```phel
+(defn ^:async fetch-pair [a b]
+  [(await (async a))
+   (await (async b))])
+
+(await (fetch-pair 1 2)) ;; => [1 2]
+```
+
+Multi-arity bodies are wrapped per arity. `^{:async false}` opts out without removing the metadata key.
+
 ### `delay` (in `phel.async`)
 
 ```phel

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -44,14 +44,13 @@ Blocks the current fiber until the Future resolves, then returns its value. Acce
 
 ### `^:async` on `defn`
 
-Marking a `defn` with `^:async` wraps its body in `(async ...)`, so the function returns an `Amp\Future` that callers `await`. Saves the boilerplate of writing `(async ...)` at the top of every concurrent function body.
+`^:async` on `defn` wraps the body in `(async ...)`, so the function returns an `Amp\Future` that callers `await`.
 
 ```phel
-(defn ^:async fetch-pair [a b]
-  [(await (async a))
-   (await (async b))])
+(defn ^:async fetch [url]
+  (await (http-get url)))
 
-(await (fetch-pair 1 2)) ;; => [1 2]
+(await (fetch "https://example.com"))
 ```
 
 Multi-arity bodies are wrapped per arity. `^{:async false}` opts out without removing the metadata key.

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -188,6 +188,7 @@
 ;; so they can still pass compile-time symbol resolution.
 (declare nil?)
 (declare seq)
+(declare map)
 
 (def *program*
   "The script path or namespace being executed."

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -72,14 +72,22 @@
           docstring       (php/. "```phel\n" signatures "\n```\n" docstring)
           meta            (php/-> meta (put :doc docstring))
           memoize-flag    (php/aget meta :memoize)
-          memoize-lru-arg (php/aget meta :memoize-lru)]
+          memoize-lru-arg (php/aget meta :memoize-lru)
+          async-flag      (php/aget meta :async)
+          fn-form         (if async-flag
+                            (if (php/instanceof (first fdecl) PersistentVectorInterface)
+                              `(fn ~(first fdecl) (async ~@(next fdecl)))
+                              `(fn ~@(map (fn [arity]
+                                            `(~(first arity) (async ~@(next arity))))
+                                          fdecl)))
+                            `(fn ~@fdecl))]
       (if memoize-lru-arg
         (if (php/=== memoize-lru-arg true)
-          `(def ~name ~meta (memoize-lru (fn ~@fdecl)))
-          `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg)))
+          `(def ~name ~meta (memoize-lru ~fn-form))
+          `(def ~name ~meta (memoize-lru ~fn-form ~memoize-lru-arg)))
         (if memoize-flag
-          `(def ~name ~meta (memoize (fn ~@fdecl)))
-          `(def ~name ~meta (fn ~@fdecl)))))))
+          `(def ~name ~meta (memoize ~fn-form))
+          `(def ~name ~meta ~fn-form))))))
 
 (def defn
   {:macro true

--- a/src/phel/core/defs.phel
+++ b/src/phel/core/defs.phel
@@ -75,7 +75,7 @@
           memoize-lru-arg (php/aget meta :memoize-lru)
           async-flag      (php/aget meta :async)
           fn-form         (if async-flag
-                            (if (php/instanceof (first fdecl) PersistentVectorInterface)
+                            (if is-single-arity
                               `(fn ~(first fdecl) (async ~@(next fdecl)))
                               `(fn ~@(map (fn [arity]
                                             `(~(first arity) (async ~@(next arity))))

--- a/tests/phel/core/async-in-core.phel
+++ b/tests/phel/core/async-in-core.phel
@@ -50,3 +50,42 @@
                            :done      (future-done? f)})))]
     (is (= true (get result :cancelled)) "future-cancelled? in core")
     (is (= true (get result :done)) "future-done? in core")))
+
+(defn ^:async async-meta-add [a b]
+  (+ a b))
+
+(deftest test-defn-async-basic
+  (is (= 5 (await (async-meta-add 2 3))) "^:async defn returns awaitable")
+  (is (= true (php/instanceof (async-meta-add 1 1) \Amp\Future))
+      "^:async defn returns Amp\\Future"))
+
+(defn ^:async async-meta-doc
+  "Adds two numbers asynchronously."
+  [a b]
+  (+ a b))
+
+(deftest test-defn-async-with-docstring
+  (is (= 7 (await (async-meta-doc 3 4)))
+      "^:async coexists with docstring"))
+
+(defn ^:async async-meta-await-inside [n]
+  (+ n (await (async 10))))
+
+(deftest test-defn-async-can-use-await-inside
+  (is (= 11 (await (async-meta-await-inside 1)))
+      "body can use await; outer caller awaits the future"))
+
+(defn ^:async async-meta-await-all [xs]
+  (await-all (for [x :in xs] (async (* x 2)))))
+
+(deftest test-defn-async-composes-with-await-all
+  (is (= [2 4 6] (await (async-meta-await-all [1 2 3])))
+      "^:async body can drive await-all"))
+
+(defn ^{:async false} async-meta-false [x]
+  x)
+
+(deftest test-defn-async-false-opts-out
+  (is (= 7 (async-meta-false 7)) "^{:async false} returns the value, not a future")
+  (is (= false (php/instanceof (async-meta-false 7) \Amp\Future))
+      "^{:async false} bypasses async wrapper"))


### PR DESCRIPTION
## 🤔 Background

#1924 asked whether Phel could grow a `^:async` hint on `defn` / `fn` to mirror ClojureScript's recent CLJS-3470 release. Phel already ships an AMPHP-backed async surface (`async`, `await`, `await-all`, `future`, `pmap`) plus a fiber scheduler, so the hint is a small piece of sugar over what is already there. This PR delivers the `defn` half, matching the pattern set by `^:memoize` (#1921) so the same call sites that reach for opt-in metadata stay consistent.

## 💡 Goal

Let users mark a `defn` as `^:async` and have the compiler wrap its body in `(async ...)` automatically, so the function returns an `Amp\Future` that callers `await`. Saves the boilerplate of writing `(async ...)` at the top of every concurrent function body.

## 🔖 Changes

- `defn-builder` (`src/phel/core/defs.phel`): when `:async` meta is present, wrap the body in `(async ...)`. Single-arity bodies wrap the whole tail; multi-arity bodies wrap each arity. Combinable with `^:memoize`/`^:memoize-lru` since the wrap happens before the memoize wrap.
- Forward-declare `map` in `src/phel/core.phel` so the multi-arity branch passes compile-time symbol resolution while `defs.phel` loads ahead of `core/seq-fns`.
- Phel tests covering single-arity, docstring + meta interaction, `await` inside the body, fan-out via `await-all`, and the `^{:async false}` opt-out.
- `docs/async-guide.md`: short reference section under the AMPHP layer.
- CHANGELOG entry under `## Unreleased`.

`fn` literal support is intentionally out of scope for this PR (would require touching `FnSymbol` in the analyzer); can land as a follow-up if there is appetite. The refactor pass surfaced no extra polish beyond the in-place edits already included in the feature commit.

Closes #1924