### PR TITLE
feat(compiler): Clojure-style `^Type` return-type declarations on fn/defn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 #### Compiler
 - `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature; reader shorthands `^int x`, `^"?int" x`, `^"\\Foo\\Bar" x` all reduce to the same `:tag` form (#1916)
+- Return-type declarations: `(fn ^int [x] x)`, `(defn ^int add [x y] ...)`, and per-arity `(fn (^int [x] x) (^int [x y] y))` emit `): <type>` on the compiled signature. `:tag` on the defn name propagates to every arity's param vector unless the vector already declares its own `:tag` (#1916)
 
 #### Profile
 - `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling

--- a/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/FnNode.php
@@ -29,8 +29,14 @@ final class FnNode extends AbstractNode
         private readonly bool $recurs,
         ?SourceLocation $sourceLocation = null,
         private readonly ?Symbol $name = null,
+        private readonly ?string $returnType = null,
     ) {
         parent::__construct($env, $sourceLocation);
+    }
+
+    public function getReturnType(): ?string
+    {
+        return $this->returnType;
     }
 
     public function getName(): ?Symbol

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -69,6 +69,8 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $init = $this->injectMacroImplicitParams($init);
         }
 
+        $init = $this->injectReturnTypeFromMeta($init, $metaMap);
+
         $initNode = $this->analyzeInit($init, $env, $namespace, $nameSymbol, $metaMap);
         if ($initNode instanceof FnNode) {
             $initNode->markAsDefinition();
@@ -135,7 +137,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         if ($nameMeta instanceof PersistentMapInterface) {
             foreach ($nameMeta->getIterator() as $key => $value) {
                 if ($key !== null) {
-                    $meta = $meta->put($key, $value);
+                    $meta = $meta->put($key, $this->normalizeMetaValue($key, $value));
                 }
             }
         }
@@ -174,6 +176,22 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         }
 
         return [$meta, $init];
+    }
+
+    /**
+     * `:tag` carries a PHP type expression used by the emitter for return-type
+     * declarations. The reader hands it in as a `Symbol` (`^int x`) or `String`
+     * (`^"?int" x`); store it as a string in the runtime meta map so the
+     * compiled `\Phel::map(:tag, ...)` literal does not resolve `int` against
+     * the global environment as a var reference.
+     */
+    private function normalizeMetaValue(mixed $key, mixed $value): mixed
+    {
+        if ($key instanceof Keyword && $key->getName() === 'tag' && $value instanceof Symbol) {
+            return $value->getName();
+        }
+
+        return $value;
     }
 
     private function normalizeMeta(mixed $meta, PersistentListInterface $list): PersistentMapInterface
@@ -344,6 +362,86 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         }
 
         return Phel::list($items)->copyLocationFrom($fnList);
+    }
+
+    /**
+     * When the def's metadata carries `:tag` (typically from the name symbol,
+     * e.g. `(defn ^int add [x y] ...)`), splice that tag onto each fn arity's
+     * param vector so `FnSymbol` can pick it up as the compiled signature's
+     * return type. Skips arities that already declare their own vector `:tag`
+     * (more local declaration wins).
+     */
+    private function injectReturnTypeFromMeta(mixed $init, PersistentMapInterface $meta): mixed
+    {
+        $tag = $meta->find(Keyword::create('tag'));
+        if (!($tag instanceof Symbol) && !is_string($tag)) {
+            return $init;
+        }
+
+        if (!$init instanceof PersistentListInterface) {
+            return $init;
+        }
+
+        $head = $init->first();
+        if (!$head instanceof Symbol || $head->getName() !== Symbol::NAME_FN) {
+            return $init;
+        }
+
+        $second = $init->get(1);
+        if ($second instanceof PersistentVectorInterface) {
+            return $this->rewriteSingleArityWithTag($init, $tag);
+        }
+
+        if ($second instanceof PersistentListInterface) {
+            return $this->rewriteMultiArityWithTag($init, $tag);
+        }
+
+        return $init;
+    }
+
+    private function rewriteSingleArityWithTag(PersistentListInterface $fnList, mixed $tag): PersistentListInterface
+    {
+        $items = $fnList->toArray();
+        /** @var PersistentVectorInterface $params */
+        $params = $items[1];
+        $items[1] = $this->withReturnTypeTag($params, $tag);
+
+        return Phel::list($items)->copyLocationFrom($fnList);
+    }
+
+    private function rewriteMultiArityWithTag(PersistentListInterface $fnList, mixed $tag): PersistentListInterface
+    {
+        $items = $fnList->toArray();
+        for ($i = 1, $n = count($items); $i < $n; ++$i) {
+            $arity = $items[$i];
+            if (!$arity instanceof PersistentListInterface) {
+                continue;
+            }
+
+            $arityItems = $arity->toArray();
+            if ($arityItems === [] || !$arityItems[0] instanceof PersistentVectorInterface) {
+                continue;
+            }
+
+            $arityItems[0] = $this->withReturnTypeTag($arityItems[0], $tag);
+            $items[$i] = Phel::list($arityItems)->copyLocationFrom($arity);
+        }
+
+        return Phel::list($items)->copyLocationFrom($fnList);
+    }
+
+    private function withReturnTypeTag(PersistentVectorInterface $params, mixed $tag): PersistentVectorInterface
+    {
+        $existing = $params->getMeta();
+        if ($existing instanceof PersistentMapInterface
+            && $existing->find(Keyword::create('tag')) !== null
+        ) {
+            return $params;
+        }
+
+        $merged = ($existing ?? Phel::map())->put(Keyword::create('tag'), $tag);
+
+        return $params->withMeta($merged);
     }
 
     private function prependImplicitParams(PersistentVectorInterface $params): PersistentVectorInterface

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -16,11 +16,13 @@ use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReadModel\FnSymbolTup
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use RuntimeException;
 
 use function array_slice;
 use function count;
+use function is_string;
 
 /**
  * (fn name? [params] body) or (fn name? ([params] body)+).
@@ -150,7 +152,27 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
             $recurFrame->isActive(),
             $list->getStartLocation(),
             $effectiveName,
+            $this->extractReturnType($list->get(1)),
         );
+    }
+
+    private function extractReturnType(mixed $paramVector): ?string
+    {
+        if (!$paramVector instanceof PersistentVectorInterface) {
+            return null;
+        }
+
+        $meta = $paramVector->getMeta();
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/FnAsClassEmitter.php
@@ -50,7 +50,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
         $this->methodEmitter->emitParameters($node);
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->emitUseClause($node);
-        $this->outputEmitter->emitLine(' {', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine($this->methodEmitter->returnTypeSuffix($node) . ' {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
 
         $this->methodEmitter->emitBody($node);
@@ -90,7 +90,7 @@ final readonly class FnAsClassEmitter implements NodeEmitterInterface
         $this->methodEmitter->emitParameters($node);
         $this->outputEmitter->emitStr(')', $loc);
         $this->emitUseClauseWithSelfReference($node, $nameVar);
-        $this->outputEmitter->emitLine(' {', $loc);
+        $this->outputEmitter->emitLine($this->methodEmitter->returnTypeSuffix($node) . ' {', $loc);
         $this->outputEmitter->increaseIndentLevel();
 
         $this->methodEmitter->emitBody($node);

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -24,13 +24,24 @@ final readonly class MethodEmitter
     {
         $this->emitMethodBegin($methodName, $node);
         $this->emitMethodParameterList($node);
-        $this->outputEmitter->emitLine(') {', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine(')' . $this->returnTypeSuffix($node) . ' {', $node->getStartSourceLocation());
         $this->outputEmitter->increaseIndentLevel();
         $this->emitMethodParametersExtraction($node);
         $this->emitSelfNameBinding($node);
         $this->emitMethodVariadicParameters($node);
         $this->emitMethodBody($node);
         $this->emitMethodEnd($node);
+    }
+
+    /**
+     * Returns `: <type>` when the fn carries an explicit return type tag,
+     * otherwise an empty string. Used to splice the return-type declaration
+     * into a PHP signature between the closing paren and the opening brace.
+     */
+    public function returnTypeSuffix(FnNode $node): string
+    {
+        $type = $node->getReturnType();
+        return $type === null ? '' : ': ' . $type;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn ^int add [^int x ^int y] (php/+ x y))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add";
+
+    public function __invoke(int $x, int $y): int {
+      return ($x + $y);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("tag"), "int",
+    \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-return-type-name.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-return-type-name.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 43
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
@@ -1,0 +1,30 @@
+--PHEL--
+(fn foo (^int [x] x) (^int [x y] y))
+--PHP--
+new class() extends \Phel\Lang\AbstractFn {
+  public const BOUND_TO = "";
+  private $fn0;
+  private $fn1;
+
+  public function __construct() {
+    $this->fn0 = (function($x): int {
+      $foo = $this;
+      return $x;
+    });;
+    $this->fn1 = (function($x, $y): int {
+      $foo = $this;
+      return $y;
+    });;
+  }
+
+  public function __invoke(...$args) {
+    $argc = \count($args);
+    switch ($argc) {
+      case 1:
+        return ($this->fn0)($args[0]);
+      case 2:
+        return ($this->fn1)($args[0], $args[1]);
+      }
+      throw new \InvalidArgumentException("No matching function arity");
+    }
+  };

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-string.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn ^"?int" [x] x)
+--PHP--
+(function($x): ?int {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-symbol.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-symbol.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn ^int [x] x)
+--PHP--
+(function($x): int {
+  return $x;
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-typed-params-and-return.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-typed-params-and-return.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn ^int [^int x ^int y] (php/+ x y))
+--PHP--
+(function(int $x, int $y): int {
+  return ($x + $y);
+});


### PR DESCRIPTION
## 🤔 Background

#1927 + #1928 added per-parameter `:tag` metadata for emitting PHP type declarations. This PR closes the symmetric gap from #1916: **return-type** declarations.

Clojure attaches the return-type via `:tag` on either the fn name or the param vector. Phel's `MetaReader` already produces `:tag` from all three reader shorthands (`^Symbol`, `^"string"`, `^{:tag ...}`), so the work was wiring the analyzer + emitter. Both single-arity and multi-arity supported; `:tag` on the defn name propagates onto every arity's param vector.

## 💡 Goal

All five Clojure-style return-type surfaces produce the same `: <type>` PHP signature, with no existing-code regressions:

```phel
(fn ^int [x] x)                            ; Symbol shorthand on vector
(fn ^"?int" [x] x)                         ; String shorthand for non-symbol types
(fn ^{:tag "int|null"} [x] x)              ; Long form on vector
(defn ^int add [x y] (php/+ x y))          ; Meta on defn name -> propagated to vector
(fn foo (^int [x] x) (^int [x y] y))       ; Per-arity return type in multi-arity fn
```

```php
(function($x): int { return $x; });
(function($x): ?int { return $x; });
(function($x): int|null { return $x; });
public function __invoke(int $x, int $y): int { return ($x + $y); }
// + multi-arity, each closure typed independently
```

Composes cleanly with the existing param `:tag`: `(defn ^int add [^int x ^int y] (php/+ x y))` gives `__invoke(int $x, int $y): int`.

## 🔖 Changes

### Analyzer

- `FnNode::__construct` gains `?string $returnType` + `getReturnType()`. (`src/php/Compiler/Domain/Analyzer/Ast/FnNode.php`)
- `FnSymbol::extractReturnType` reads `:tag` (Symbol or String) from the param-vector meta and threads it into the new `FnNode` field. (`src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php`)
- `DefSymbol::injectReturnTypeFromMeta` walks the `(fn ...)` init when the def's meta carries `:tag` and splices the tag onto each arity's param vector — unless that vector already declares its own `:tag`, in which case the more local declaration wins. (`src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php`)
- `DefSymbol::normalizeMetaValue` converts `:tag` Symbol values to strings before storing in the runtime meta map, so the compiled `\Phel::map(:tag, ...)` literal does not resolve `int` against the global env as a var reference.

### Emitter

- `MethodEmitter::returnTypeSuffix` builds `: <type>` (or empty). Spliced into all three signature paths between `)` and ` {`:
  - `MethodEmitter::emit` — defn `__invoke`
  - `FnAsClassEmitter::emitAsClosure` — anonymous closures
  - `FnAsClassEmitter::emitAsNamedClosure` — named closure IIFE

### Fixtures

- `Fn/fn-return-type-symbol.test`, `Fn/fn-return-type-string.test`, `Fn/fn-typed-params-and-return.test`, `Fn/fn-return-type-multi-arity.test`, `Def/defn-return-type-name.test`.

### CHANGELOG

`## Unreleased > Compiler` extended.

## DX notes

- Tag string is passed through verbatim; PHP type system is not modeled here. `int`, `?int`, `int|null`, `iterable`, `\Foo\Bar` all survive untouched. Errors surface at first parse of the emitted PHP, same trade-off as the param-tag PR.
- `:tag` on a name vs. a param vector vs. a param symbol disambiguates by location, mirroring Clojure: name tag -> return type (propagated), vector tag -> return type, symbol tag -> param type.
- Vector-local `:tag` overrides defn-name `:tag` — useful for multi-arity where each overload needs its own return type and you do not want the defn-name annotation to clobber it.

## Follow-ups (filed separately)

- **Type inference.** The compiler does not synthesize tags from body shape. Tracked separately so this PR stays scoped to the metadata channel.
- **Static type checker.** Beyond emitting type decls; needs an analysis pass plus diagnostics. Tracked separately.
- **JIT bench harness.** `phpbench` currently measures cold compile/boot; need a hot-loop fixture under `opcache.jit=tracing` to quantify the perf payoff. Tracked separately.

Closes the typed-signatures item from #1916. Three follow-up issues opened for the items the original investigation flagged as out of scope.

Related to #1916