### PR TITLE
feat(compiler): infer fn return type from primitive ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `^{:tag "<php-type>"}` metadata on a fn or defn parameter emits a PHP type declaration on the compiled signature; reader shorthands `^int x`, `^"?int" x`, `^"\\Foo\\Bar" x` all reduce to the same `:tag` form (#1916)
 - Return-type declarations: `(fn ^int [x] x)`, `(defn ^int add [x y] ...)`, and per-arity `(fn (^int [x] x) (^int [x y] y))` emit `): <type>` on the compiled signature. `:tag` on the defn name propagates to every arity's param vector unless the vector already declares its own `:tag` (#1916)
 - `composer bench-jit-baseline` and `composer bench-jit-tracing` run typed-vs-untyped `fib`, `sum-squares`, and `mandel-point` kernels under OPcache JIT (#1931)
+- Fn return type is inferred from a tail-position primitive op on tagged params (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`, with `if` / `let` / `loop` propagation), unless the user supplied an explicit `:tag` (#1932)
 
 #### Profile
 - `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -37,6 +37,7 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
     public function __construct(
         private AnalyzerInterface $analyzer,
         private bool $assertsEnabled = true,
+        private ReturnTypeInferrer $returnTypeInferrer = new ReturnTypeInferrer(),
     ) {}
 
     public function analyze(PersistentListInterface $list, NodeEnvironmentInterface $env): AbstractNode
@@ -143,16 +144,25 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         // don't emit a colliding `use (&$name)` / `$name = $this;`.
         $effectiveName = $this->resolveEffectiveName($name, $fnSymbolTuple->params());
 
+        $body = $this->analyzeBody($fnSymbolTuple, $recurFrame, $env, $effectiveName);
+        $declaredReturnType = $this->extractReturnType($list->get(1));
+        $returnType = $declaredReturnType
+            ?? $this->returnTypeInferrer->infer(
+                $body,
+                $fnSymbolTuple->params(),
+                $fnSymbolTuple->isVariadic(),
+            );
+
         return new FnNode(
             $env,
             $fnSymbolTuple->params(),
-            $this->analyzeBody($fnSymbolTuple, $recurFrame, $env, $effectiveName),
+            $body,
             $this->buildUsesFromEnv($env, $fnSymbolTuple, $effectiveName),
             $fnSymbolTuple->isVariadic(),
             $recurFrame->isActive(),
             $list->getStartLocation(),
             $effectiveName,
-            $this->extractReturnType($list->get(1)),
+            $returnType,
         );
     }
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+
+use function count;
+use function in_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+
+/**
+ * Conservative tail-position type inference for `fn` bodies. Walks the
+ * body's tail expression looking for a primitive PHP operator on
+ * already-typed locals or scalar literals, and surfaces the implied
+ * PHP type so the emitter can stamp it on the compiled signature.
+ *
+ * Inference is intentionally narrow: any non-recognized node, an
+ * untyped local, or a branch disagreement returns `null`, leaving the
+ * fn's return type unset. Explicit `:tag` declarations on the param
+ * vector or the def name take precedence — this class only fills the
+ * gap when the user has not annotated.
+ */
+final class ReturnTypeInferrer
+{
+    /**
+     * Sentinel for nodes that do not produce a runtime value (`recur`,
+     * `throw`). Used to merge `if` branches where one side is bottom
+     * and the other yields a concrete type.
+     */
+    private const string BOTTOM = '@bottom';
+
+    /** @var array<string, string> */
+    private const array COMPARISON_OPS = [
+        '<' => 'bool', '>' => 'bool', '<=' => 'bool', '>=' => 'bool',
+        '==' => 'bool', '===' => 'bool', '!=' => 'bool', '!==' => 'bool',
+        '<=>' => 'int', 'instanceof' => 'bool',
+    ];
+
+    /** @var list<string> */
+    private const array NUMERIC_OPS = [
+        '+', '-', '*', '/', '%', '**', '<<', '>>', '|', '&', '^',
+    ];
+
+    /**
+     * Set during a walk when a primitive PHP operator is encountered.
+     * Only then does the function publish an inferred return type;
+     * pure literal / pass-through bodies stay untyped so the emitter
+     * does not synthesize an annotation the user never asked for.
+     */
+    private bool $sawOperator = false;
+
+    /**
+     * @param list<Symbol> $params
+     *
+     * @psalm-suppress RedundantCondition `inferNode` mutates `sawOperator`
+     */
+    public function infer(AbstractNode $body, array $params, bool $isVariadic = false): ?string
+    {
+        $paramTypes = $this->collectParamTypes($params, $isVariadic);
+        $this->sawOperator = false;
+        $type = $this->inferNode($body, $paramTypes);
+
+        if (!$this->sawOperator) {
+            return null;
+        }
+
+        return $type === self::BOTTOM ? null : $type;
+    }
+
+    /**
+     * The variadic tail's `:tag` describes the element type, not the
+     * value bound in the body (which is a Phel `Vector`). Skip it so
+     * the inferrer does not see a fake int/string local where the
+     * runtime actually carries a collection.
+     *
+     * @param list<Symbol> $params
+     *
+     * @return array<string, string>
+     */
+    private function collectParamTypes(array $params, bool $isVariadic): array
+    {
+        $types = [];
+        $lastIndex = $isVariadic ? count($params) - 1 : count($params);
+        for ($i = 0; $i < $lastIndex; ++$i) {
+            $param = $params[$i];
+            $tag = $this->extractTag($param);
+            if ($tag !== null) {
+                $types[$param->getName()] = $tag;
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param array<string, string> $locals
+     *
+     * @phpstan-impure mutates `sawOperator` when a primitive op fires
+     */
+    private function inferNode(AbstractNode $node, array $locals): ?string
+    {
+        return match (true) {
+            $node instanceof DoNode => $this->inferDo($node, $locals),
+            $node instanceof IfNode => $this->inferIf($node, $locals),
+            $node instanceof LetNode => $this->inferLet($node, $locals),
+            $node instanceof CallNode => $this->inferCall($node, $locals),
+            $node instanceof LiteralNode => $this->inferLiteral($node),
+            $node instanceof LocalVarNode => $locals[$node->getName()->getName()] ?? null,
+            $node instanceof RecurNode => $this->inferRecur($node, $locals),
+            $node instanceof ThrowNode => self::BOTTOM,
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferDo(DoNode $node, array $locals): ?string
+    {
+        return $this->inferNode($node->getRet(), $locals);
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferIf(IfNode $node, array $locals): ?string
+    {
+        // Walk the test for its operator side-effect: `(if (php/< x 0) ...)`
+        // should mark the inference triggered even though the test's type
+        // never reaches the return slot.
+        $this->inferNode($node->getTestExpr(), $locals);
+        $then = $this->inferNode($node->getThenExpr(), $locals);
+        $else = $this->inferNode($node->getElseExpr(), $locals);
+        if ($then === null || $else === null) {
+            return null;
+        }
+
+        if ($then === self::BOTTOM) {
+            return $else;
+        }
+
+        if ($else === self::BOTTOM) {
+            return $then;
+        }
+
+        return $then === $else ? $then : null;
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferRecur(RecurNode $node, array $locals): string
+    {
+        // Recur jumps; it never produces a value. Walk the rebinding
+        // expressions so any operator hidden in them still trips the
+        // `sawOperator` gate.
+        foreach ($node->getExpressions() as $expr) {
+            $this->inferNode($expr, $locals);
+        }
+
+        return self::BOTTOM;
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferLet(LetNode $node, array $locals): ?string
+    {
+        foreach ($node->getBindings() as $binding) {
+            $type = $this->inferNode($binding->getInitExpr(), $locals);
+            if ($type !== null && $type !== self::BOTTOM) {
+                $locals[$this->bindingName($binding)] = $type;
+            }
+        }
+
+        return $this->inferNode($node->getBodyExpr(), $locals);
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferCall(CallNode $node, array $locals): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof PhpVarNode) {
+            return null;
+        }
+
+        $op = $fn->getName();
+
+        if (isset(self::COMPARISON_OPS[$op])) {
+            $this->sawOperator = true;
+            return self::COMPARISON_OPS[$op];
+        }
+
+        if ($op === '.') {
+            $this->sawOperator = true;
+            return 'string';
+        }
+
+        if (in_array($op, self::NUMERIC_OPS, true)) {
+            $this->sawOperator = true;
+            return $this->inferNumeric($node, $locals);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferNumeric(CallNode $node, array $locals): ?string
+    {
+        $hasFloat = false;
+        foreach ($node->getArguments() as $arg) {
+            $type = $this->inferNode($arg, $locals);
+            if ($type === null || $type === self::BOTTOM) {
+                return null;
+            }
+
+            if ($type === 'float') {
+                $hasFloat = true;
+                continue;
+            }
+
+            if ($type !== 'int') {
+                return null;
+            }
+        }
+
+        return $hasFloat ? 'float' : 'int';
+    }
+
+    private function inferLiteral(LiteralNode $node): ?string
+    {
+        $value = $node->getValue();
+        return match (true) {
+            is_int($value) => 'int',
+            is_float($value) => 'float',
+            is_bool($value) => 'bool',
+            is_string($value) => 'string',
+            default => null,
+        };
+    }
+
+    private function extractTag(Symbol $param): ?string
+    {
+        $meta = $param->getMeta();
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            return $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
+    }
+
+    private function bindingName(BindingNode $binding): string
+    {
+        return $binding->getShadow()->getName();
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -35,8 +35,8 @@ use function is_string;
  * Inference is intentionally narrow: any non-recognized node, an
  * untyped local, or a branch disagreement returns `null`, leaving the
  * fn's return type unset. Explicit `:tag` declarations on the param
- * vector or the def name take precedence — this class only fills the
- * gap when the user has not annotated.
+ * vector or the def name take precedence; this class only fills the
+ * gap when no `:tag` is present.
  */
 final class ReturnTypeInferrer
 {

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -7,7 +7,7 @@
   new class() extends \Phel\Lang\AbstractFn {
     public const BOUND_TO = "user\\add";
 
-    public function __invoke(int $x, int $y) {
+    public function __invoke(int $x, int $y): int {
       return ($x + $y);
     }
   },

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
@@ -1,0 +1,11 @@
+--PHEL--
+(fn [^int x] (if (php/< x 0) nil (php/+ x 1)))
+--PHP--
+(function(int $x) {
+  if (($__truthy = ($x < 0)) !== null && $__truthy !== false) {
+    return null;
+  } else {
+    return ($x + 1);
+  }
+
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -1,0 +1,35 @@
+--PHEL--
+(defn fib [^int n] (if (php/< n 2) n (php/+ (fib (php/- n 1)) (fib (php/- n 2)))))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "fib",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\fib";
+
+    public function __invoke(int $n) {
+      if (($__truthy = ($n < 2)) !== null && $__truthy !== false) {
+        return $n;
+      } else {
+        return ($this(($n - 1)) + $this(($n - 2)));
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(fib n)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-bail-on-self-recursion.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-bail-on-self-recursion.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 82
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-untyped-param.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-untyped-param.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x y] (php/+ x y))
+--PHP--
+(function($x, $y) {
+  return ($x + $y);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-explicit-tag-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-explicit-tag-wins.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn ^bool [^int x ^int y] (php/+ x y))
+--PHP--
+(function(int $x, int $y): bool {
+  return ($x + $y);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-bool.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-bool.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int x ^int y] (php/< x y))
+--PHP--
+(function(int $x, int $y): bool {
+  return ($x < $y);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-float.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-float.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^float x ^int n] (php/+ x n))
+--PHP--
+(function(float $x, int $n): float {
+  return ($x + $n);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
@@ -1,0 +1,11 @@
+--PHEL--
+(fn [^int x] (if (php/< x 0) 0 (php/+ x 1)))
+--PHP--
+(function(int $x): int {
+  if (($__truthy = ($x < 0)) !== null && $__truthy !== false) {
+    return 0;
+  } else {
+    return ($x + 1);
+  }
+
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-int.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-int.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int x ^int y] (php/+ x y))
+--PHP--
+(function(int $x, int $y): int {
+  return ($x + $y);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-loop-factorial.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-loop-factorial.test
@@ -1,0 +1,24 @@
+--PHEL--
+(fn [^int n]
+  (loop [i n acc 1]
+    (if (php/<= i 1)
+      acc
+      (recur (php/- i 1) (php/* acc i)))))
+--PHP--
+(function(int $n): int {
+  $i_1 = $n;
+  $acc_2 = 1;
+  while (true) {
+    if (($__truthy = ($i_1 <= 1)) !== null && $__truthy !== false) {
+      return $acc_2;
+    } else {
+      $__phel_3 = ($i_1 - 1);
+      $__phel_4 = ($acc_2 * $i_1);
+      $i_1 = $__phel_3;
+      $acc_2 = $__phel_4;
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-string.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^string a ^string b] (php/. a b))
+--PHP--
+(function(string $a, string $b): string {
+  return ($a . $b);
+});

--- a/tests/php/Integration/Fixtures/Fn/hash-fn-zero-args.test
+++ b/tests/php/Integration/Fixtures/Fn/hash-fn-zero-args.test
@@ -1,6 +1,6 @@
 --PHEL--
 #(php/+ 1 2)
 --PHP--
-(function() {
+(function(): int {
   return (1 + 2);
 });

--- a/tests/php/Integration/Fixtures/Reify/reify-with-args.test
+++ b/tests/php/Integration/Fixtures/Reify/reify-with-args.test
@@ -2,7 +2,7 @@
 (reify* (greet [this name] (php/. "Hello, " name)))
 --PHP--
 new class() {
-  public function greet($name) {
+  public function greet($name): string {
     $this_1 = $this;
     return ("Hello, " . $name);
   }


### PR DESCRIPTION
## 🤔 Background

`:tag` metadata now drives PHP signature emission for params and explicit return types (#1927 / #1928 / #1930). For numeric kernels the return tag is mechanically derivable from the fn's body shape — adding inference avoids forcing every author to annotate.

## 💡 Goal

Synthesize a return-type tag for fns whose tail expression is a PHP primitive operator on already-typed locals or scalar literals. Conservative: fail silently the moment a branch is non-primitive. Explicit `:tag` (vector, then def name, then inferred) still wins.

## 🔖 Changes

- New `ReturnTypeInferrer` walks tail-position nodes (`do` / `if` / `let` / `loop` / `recur` / scalar literals / `php/`-rooted call) and resolves:
  - arithmetic / bitwise ops on `int`-tagged params or int literals -> `int`; `float` taints to `float`.
  - comparison ops -> `bool`; `<=>` -> `int`.
  - `php/.` -> `string`.
- `if` propagates only when both branches infer the same primitive; `recur` and `throw` are bottom and merge into the surviving branch.
- A "saw operator" gate prevents pure literal-return / pass-through bodies (`(fn [^int x] x)`, reify methods returning a string literal) from gaining a synthesized type they never had.
- Variadic tail param's `:tag` is excluded from the local-type table (it describes element type, not the bound `Vector`).
- Wired into `FnSymbol::analyzeSingle` as the fallback when `extractReturnType($paramVector)` is `null`.
- Integration fixtures cover: int / bool / float / string concat, `if` merge, loop+recur factorial, explicit-wins, untyped-param bail, mixed-branch bail, self-recursion bail (fixpoint inference is out of scope for this PR).
- Three pre-existing fixtures updated to reflect the synthesized return types they now produce: `defn-typed-params`, `hash-fn-zero-args`, `reify-with-args`.
- CHANGELOG entry under `## Unreleased`.

## Out of scope

- Self-recursive fixpoint inference (fib / factorial-via-recursion). Tracked separately; the present PR demonstrates loop-based factorial which does infer.
- Param-type inference. Manual `:tag` only.

Related to #1932