### PR TITLE
feat(compiler): static type checker for :tag annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Return-type declarations: `(fn ^int [x] x)`, `(defn ^int add [x y] ...)`, and per-arity `(fn (^int [x] x) (^int [x y] y))` emit `): <type>` on the compiled signature. `:tag` on the defn name propagates to every arity's param vector unless the vector already declares its own `:tag` (#1916)
 - `composer bench-jit-baseline` and `composer bench-jit-tracing` run typed-vs-untyped `fib`, `sum-squares`, and `mandel-point` kernels under OPcache JIT (#1931)
 - Fn return type is inferred from a tail-position primitive op on tagged params (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`, with `if` / `let` / `loop` propagation), unless the user supplied an explicit `:tag` (#1932)
+- Static type checker flags `:tag` mismatches at compile time with a Phel diagnostic instead of a deeper PHP `TypeError`: literal call args vs. param tags, `recur` args vs. binding tags, and tail literal vs. declared return tag (#1933)
 
 #### Profile
 - `phel profile <path>` command: per-fn call counts and self/total/avg/max timings, plus compile-time phase costs (lex, parse, read, analyze, emit). Text table by default; `--format=json|both` and `--output=<file>` for tooling

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -91,6 +91,11 @@ final class Analyzer implements AnalyzerInterface
         $this->globalEnvironment->addDefinition($ns, $symbol);
     }
 
+    public function setCompileTimeMeta(string $ns, Symbol $symbol, PersistentMapInterface $meta): void
+    {
+        $this->globalEnvironment->setCompileTimeMeta($ns, $symbol, $meta);
+    }
+
     public function addInterface(string $ns, Symbol $name): void
     {
         $this->globalEnvironment->addInterface($ns, $name);

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Analyzer;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
 
 interface AnalyzerInterface
@@ -34,6 +35,8 @@ interface AnalyzerInterface
     public function addRefers(string $ns, array $referSymbols, Symbol $nsSymbol): void;
 
     public function addDefinition(string $ns, Symbol $symbol): void;
+
+    public function setCompileTimeMeta(string $ns, Symbol $symbol, PersistentMapInterface $meta): void;
 
     public function addInterface(string $ns, Symbol $name): void;
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -24,6 +24,17 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     /** @var array<string, array<string, bool>> */
     private array $definitions = [];
 
+    /**
+     * Compile-time metadata stash for definitions analyzed in the
+     * current session. Lets `getDefinition` return a richer map than
+     * the runtime registry can offer for forms that have not yet been
+     * evaluated (e.g. a `defn` followed by a call to it in the same
+     * file under compile-only flows).
+     *
+     * @var array<string, array<string, PersistentMapInterface>>
+     */
+    private array $compileTimeMeta = [];
+
     /** @var array<string, array<string, Symbol>> */
     private array $refers = [];
 
@@ -71,6 +82,11 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->definitions[$namespace][$name->getName()] = true;
     }
 
+    public function setCompileTimeMeta(string $namespace, Symbol $name, PersistentMapInterface $meta): void
+    {
+        $this->compileTimeMeta[$namespace][$name->getName()] = $meta;
+    }
+
     public function hasDefinition(string $namespace, Symbol $name): bool
     {
         return (
@@ -84,14 +100,36 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
 
     public function getDefinition(string $namespace, Symbol $name): ?PersistentMapInterface
     {
-        if ($this->hasDefinition($namespace, $name)) {
-            return Phel::getDefinitionMetaData(
-                $this->mungeEncodeNs($namespace),
-                $name->getName(),
-            ) ?? Phel::map();
+        if (!$this->hasDefinition($namespace, $name)) {
+            return null;
         }
 
-        return null;
+        $key = $name->getName();
+        $registryMeta = Phel::getDefinitionMetaData($this->mungeEncodeNs($namespace), $key);
+        $compileMeta = $this->compileTimeMeta[$namespace][$key] ?? null;
+
+        if ($registryMeta instanceof PersistentMapInterface) {
+            // Runtime meta wins because forms like `:inline` carry an
+            // evaluated callable that the analyzer-time map only has
+            // as a source-form `(fn ...)` list. The compile-time-only
+            // `:param-tags` channel is folded back in so the static
+            // type checker has its inputs even after the def has been
+            // evaluated into the registry.
+            if ($compileMeta instanceof PersistentMapInterface) {
+                $paramTags = $compileMeta->find(Keyword::create('param-tags'));
+                if ($paramTags !== null) {
+                    return $registryMeta->put(Keyword::create('param-tags'), $paramTags);
+                }
+            }
+
+            return $registryMeta;
+        }
+
+        if ($compileMeta instanceof PersistentMapInterface) {
+            return $compileMeta;
+        }
+
+        return Phel::map();
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -16,6 +16,8 @@ interface GlobalEnvironmentInterface
 
     public function addDefinition(string $namespace, Symbol $name): void;
 
+    public function setCompileTimeMeta(string $namespace, Symbol $name, PersistentMapInterface $meta): void;
+
     public function hasDefinition(string $namespace, Symbol $name): bool;
 
     public function getDefinition(string $namespace, Symbol $name): ?PersistentMapInterface;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -89,6 +89,23 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $metaMap = $metaMap->put('arglists', $this->buildMultiFnNodeArglists($initNode, $skip));
         }
 
+        // Stash a compile-time-only superset of the meta with `:param-tags`
+        // attached so subsequent calls in the same compilation unit can
+        // run static type checks against the def's declared param tags
+        // without round-tripping through the runtime registry (which
+        // `compile`-only flows never populate). The runtime `$meta`
+        // built below intentionally omits `:param-tags` so the emitted
+        // PHP keeps its existing shape.
+        if ($initNode instanceof FnNode) {
+            $this->analyzer->setCompileTimeMeta(
+                $namespace,
+                $nameSymbol,
+                $metaMap->put(Keyword::create('param-tags'), $this->buildParamTags($initNode, $skip)),
+            );
+        } else {
+            $this->analyzer->setCompileTimeMeta($namespace, $nameSymbol, $metaMap);
+        }
+
         $meta = $this->analyzer->analyze($metaMap, $env->withExpressionContext());
         assert($meta instanceof MapNode);
 
@@ -265,6 +282,32 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string
     {
         return $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
+    }
+
+    /**
+     * Static-checker view of the params: a Phel vector with the same
+     * arity, where each slot is the param's `:tag` (string) or `null`
+     * if untagged. The variadic tail is excluded — its `:tag` describes
+     * element type, not the bound `Vector`.
+     */
+    private function buildParamTags(FnNode $fnNode, int $skipFirst = 0): PersistentVectorInterface
+    {
+        $params = $fnNode->getParams();
+        if ($skipFirst > 0) {
+            $params = array_slice($params, $skipFirst);
+        }
+
+        $count = count($params);
+        if ($fnNode->isVariadic() && $count > 0) {
+            --$count;
+        }
+
+        $tags = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $tags[] = TagCompatibility::extractParamTag($params[$i]);
+        }
+
+        return Phel::vector($tags);
     }
 
     private function buildMultiFnNodeArglists(MultiFnNode $multiFnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -23,6 +23,7 @@ use RuntimeException;
 use function array_slice;
 use function count;
 use function is_string;
+use function sprintf;
 
 /**
  * (fn name? [params] body) or (fn name? ([params] body)+).
@@ -146,6 +147,16 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
 
         $body = $this->analyzeBody($fnSymbolTuple, $recurFrame, $env, $effectiveName);
         $declaredReturnType = $this->extractReturnType($list->get(1));
+        if ($declaredReturnType !== null) {
+            $tailType = TagCompatibility::tailLiteralType($body);
+            if ($tailType !== null && !TagCompatibility::accepts($declaredReturnType, $tailType)) {
+                throw AnalyzerException::withLocation(
+                    sprintf("Fn return type '%s' is incompatible with tail expression of type '%s'", $declaredReturnType, $tailType),
+                    $list,
+                );
+            }
+        }
+
         $returnType = $declaredReturnType
             ?? $this->returnTypeInferrer->infer(
                 $body,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -16,6 +16,7 @@ use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\TypeInterface;
@@ -63,12 +64,61 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
 
         $this->rejectNonCallableLiteral($f, $list);
 
+        $args = $this->arguments($list->rest(), $env);
+
+        if ($f instanceof GlobalVarNode) {
+            $this->verifyArgsAgainstParamTags($f, $args, $list);
+        }
+
         return new CallNode(
             $env,
             $f,
-            $this->arguments($list->rest(), $env),
+            $args,
             $list->getStartLocation(),
         );
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function verifyArgsAgainstParamTags(
+        GlobalVarNode $f,
+        array $args,
+        PersistentListInterface $list,
+    ): void {
+        $paramTags = $f->getMeta()->find(Keyword::create('param-tags'));
+        if (!$paramTags instanceof PersistentVectorInterface) {
+            return;
+        }
+
+        $tagsCount = count($paramTags);
+        foreach ($args as $i => $arg) {
+            if ($i >= $tagsCount) {
+                return;
+            }
+
+            $tag = $paramTags->get($i);
+            if (!is_string($tag)) {
+                continue;
+            }
+
+            if ($tag === '') {
+                continue;
+            }
+
+            $literalType = TagCompatibility::literalTypeOf($arg);
+            if ($literalType === null) {
+                continue;
+            }
+
+            if (!TagCompatibility::accepts($tag, $literalType)) {
+                throw AnalyzerException::withLocation(
+                    'Arg #' . ($i + 1) . " to '" . $f->getName()->getName()
+                    . sprintf("' has type '%s' but param is tagged '%s'", $literalType, $tag),
+                    $list,
+                );
+            }
+        }
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/RecurSymbol.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
@@ -13,6 +14,7 @@ use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
 
 use function count;
+use function sprintf;
 
 /**
  * (recur args...).
@@ -47,10 +49,13 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
 
         $currentFrame->setIsActive(true);
 
+        $expressions = $this->expressions($list, $env);
+        $this->verifyParamTagsAgainstExpressions($currentFrame, $expressions, $list);
+
         return new RecurNode(
             $env,
             $currentFrame,
-            $this->expressions($list, $env),
+            $expressions,
             $list->getStartLocation(),
         );
     }
@@ -66,6 +71,40 @@ final class RecurSymbol implements SpecialFormAnalyzerInterface
         }
 
         return $expressions;
+    }
+
+    /**
+     * @param list<AbstractNode> $expressions
+     */
+    private function verifyParamTagsAgainstExpressions(
+        RecurFrame $frame,
+        array $expressions,
+        PersistentListInterface $list,
+    ): void {
+        foreach ($frame->getParams() as $i => $param) {
+            $tag = TagCompatibility::extractParamTag($param);
+            if ($tag === null) {
+                continue;
+            }
+
+            $arg = $expressions[$i] ?? null;
+            if ($arg === null) {
+                continue;
+            }
+
+            $literalType = TagCompatibility::literalTypeOf($arg);
+            if ($literalType === null) {
+                continue;
+            }
+
+            if (!TagCompatibility::accepts($tag, $literalType)) {
+                throw AnalyzerException::withLocation(
+                    "'recur arg #" . ($i + 1) . sprintf(" has type '%s' but param '", $literalType)
+                    . $param->getName() . sprintf("' is tagged '%s'", $tag),
+                    $list,
+                );
+            }
+        }
     }
 
     private function isValidRecurTuple(PersistentListInterface $list): bool

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TagCompatibility.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/TagCompatibility.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+
+use function array_map;
+use function explode;
+use function in_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function str_contains;
+use function str_starts_with;
+use function substr;
+
+/**
+ * Lightweight literal-type probe + tag compatibility check used by the
+ * static type checker. Recognizes only the cases the analyzer already
+ * has direct AST evidence for (`LiteralNode`, `VectorNode`, `MapNode`,
+ * `SetNode`); anything else returns `null`, which the caller treats
+ * as "skip — no false positive".
+ */
+final class TagCompatibility
+{
+    /**
+     * Reads the `:tag` keyword from a Symbol's metadata. Symbol values
+     * (`^int x`) and string values (`^"int|null" x`) resolve to the
+     * raw type string; anything else is `null`.
+     */
+    public static function extractParamTag(Symbol $param): ?string
+    {
+        $meta = $param->getMeta();
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            return $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
+    }
+
+    public static function literalTypeOf(AbstractNode $node): ?string
+    {
+        return match (true) {
+            $node instanceof LiteralNode => self::scalarType($node->getValue()),
+            $node instanceof VectorNode => 'vector',
+            $node instanceof MapNode => 'map',
+            $node instanceof SetNode => 'set',
+            default => null,
+        };
+    }
+
+    /**
+     * Tail-position literal type. Walks `do` / `let` / `if` down to a
+     * leaf; for `if`, only resolves when both branches agree on a
+     * concrete type. Anything else returns `null` so the caller can
+     * skip without false-positives.
+     */
+    public static function tailLiteralType(AbstractNode $node): ?string
+    {
+        if ($node instanceof DoNode) {
+            return self::tailLiteralType($node->getRet());
+        }
+
+        if ($node instanceof LetNode) {
+            return self::tailLiteralType($node->getBodyExpr());
+        }
+
+        if ($node instanceof IfNode) {
+            $then = self::tailLiteralType($node->getThenExpr());
+            $else = self::tailLiteralType($node->getElseExpr());
+            if ($then === null || $else === null) {
+                return null;
+            }
+
+            return $then === $else ? $then : null;
+        }
+
+        return self::literalTypeOf($node);
+    }
+
+    /**
+     * `tag` is a raw PHP type expression as written by the user
+     * (`int`, `?int`, `int|null`, `\Foo\Bar`). `literalType` is one of
+     * the strings produced by `literalTypeOf`. Returns `false` only
+     * when the literal definitively cannot satisfy the tag.
+     */
+    public static function accepts(string $tag, string $literalType): bool
+    {
+        $tag = trim($tag);
+        if ($tag === '' || $tag === 'mixed') {
+            return true;
+        }
+
+        if (str_starts_with($tag, '?')) {
+            return $literalType === 'nil'
+                || self::accepts(substr($tag, 1), $literalType);
+        }
+
+        if (str_contains($tag, '|')) {
+            $parts = array_map(trim(...), explode('|', $tag));
+            return array_any($parts, static fn(string $part): bool => self::accepts($part, $literalType));
+        }
+
+        if ($literalType === 'nil') {
+            return $tag === 'null';
+        }
+
+        return self::scalarTagMatches($tag, $literalType);
+    }
+
+    private static function scalarType(mixed $value): ?string
+    {
+        return match (true) {
+            $value === null => 'nil',
+            is_bool($value) => 'bool',
+            is_int($value) => 'int',
+            is_float($value) => 'float',
+            is_string($value) => 'string',
+            $value instanceof Keyword => 'keyword',
+            default => null,
+        };
+    }
+
+    private static function scalarTagMatches(string $tag, string $literalType): bool
+    {
+        return match ($tag) {
+            'int' => $literalType === 'int',
+            'float' => $literalType === 'float' || $literalType === 'int',
+            'string' => $literalType === 'string',
+            'bool' => $literalType === 'bool',
+            'array' => $literalType === 'vector' || $literalType === 'map',
+            'iterable' => in_array($literalType, ['vector', 'map', 'set'], true),
+            default => true,
+        };
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/StaticTypeCheckerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/StaticTypeCheckerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class StaticTypeCheckerTest extends TestCase
+{
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+    }
+
+    protected function setUp(): void
+    {
+        GlobalEnvironmentSingleton::getInstance()->setNs('user');
+        Symbol::resetGen();
+        $this->compilerFacade = new CompilerFacade();
+    }
+
+    public function test_call_site_arg_type_mismatch_raises_diagnostic(): void
+    {
+        $this->expectExceptionMessageMatches(
+            "/Arg #1 to 'add' has type 'string' but param is tagged 'int'/",
+        );
+        $this->compile('(defn ^int add [^int x ^int y] (php/+ x y))(add "x" 1)');
+    }
+
+    public function test_call_site_arg_type_match_compiles_without_error(): void
+    {
+        $php = $this->compile('(defn ^int add [^int x ^int y] (php/+ x y))(add 1 2)');
+        self::assertStringContainsString('add', $php);
+    }
+
+    public function test_untagged_param_is_unchecked(): void
+    {
+        // Body returns its first arg verbatim — no `+`-on-string runtime
+        // surprise; the assertion is that the analyzer accepts the call
+        // without throwing despite the type-shape mismatch a tagged
+        // version would have caught.
+        $php = $this->compile('(defn pick-first [x y] x)(pick-first "x" 1)');
+        self::assertStringContainsString('pick-first', $php);
+    }
+
+    public function test_recur_arg_type_mismatch_raises_diagnostic(): void
+    {
+        $this->expectExceptionMessageMatches(
+            "/'recur arg #1 has type 'string' but param '\w+' is tagged 'int'/",
+        );
+        $this->compile('(loop [^int i 0] (recur "x"))');
+    }
+
+    public function test_return_type_literal_mismatch_raises_diagnostic(): void
+    {
+        $this->expectExceptionMessageMatches(
+            "/Fn return type 'int' is incompatible with tail expression of type 'string'/",
+        );
+        $this->compile('(fn ^int [] "wrong")');
+    }
+
+    public function test_return_type_compatible_literal_compiles(): void
+    {
+        $php = $this->compile('(fn ^int [] 42)');
+        self::assertStringContainsString('return 42', $php);
+    }
+
+    public function test_nullable_return_accepts_nil_branch(): void
+    {
+        $php = $this->compile('(fn ^"?int" [^int x] (if (php/< x 0) nil x))');
+        self::assertStringContainsString('?int', $php);
+    }
+
+    private function compile(string $source): string
+    {
+        BuildFacade::enableBuildMode();
+        try {
+            return $this->compilerFacade
+                ->compile($source, new CompileOptions())
+                ->getPhpCode();
+        } finally {
+            BuildFacade::disableBuildMode();
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`:tag` metadata feeds emitted PHP type declarations (#1927 / #1928 / #1930) but the only diagnostic on a violation today is a deeper PHP `TypeError` from inside the runtime — poor DX, especially when the call site is the obvious culprit.

## 💡 Goal

Surface tag mismatches at compile time as Phel-located errors, before the offending call ever runs.

## 🔖 Changes

- New `TagCompatibility` utility: literal-type probe (`LiteralNode` / `VectorNode` / `MapNode` / `SetNode`) plus a tag matcher that handles `?T`, `T|U`, plus the scalar primitives. Anything outside that set is treated as compatible to keep the check false-positive-free.
- `FnSymbol::analyzeSingle` now diffs the declared return tag against the body's tail literal; `(fn ^int [] "wrong")` raises an `AnalyzerException` instead of compiling and dying at runtime.
- `RecurSymbol::analyze` checks each `recur` expression's literal type against the recur frame param's `:tag`; `(loop [^int i 0] (recur "x"))` errors at compile time.
- `InvokeSymbol::analyze` checks each call-site literal arg against the callee's compile-time `:param-tags`; `(add "x" 1)` on `(defn ^int add [^int x ^int y] (php/+ x y))` errors before emission.
- `GlobalEnvironment` gains a compile-time meta side-table so the analyzer can read a def's `:param-tags` even before its `\Phel::addDefinition` call has run (compile-only flows). Runtime registry meta still wins for the keys it has (e.g. `:inline`); `:param-tags` is the compile-time-only channel.
- `DefSymbol` builds `:param-tags` (one nullable string per param, variadic tail excluded) and stashes it via `setCompileTimeMeta`. The runtime metaMap stays unchanged - emitted PHP shape is unaffected.
- `StaticTypeCheckerTest` covers seven scenarios: arg mismatch, arg match, untagged-callee bypass, recur mismatch, return-flow mismatch, return-flow match, nullable-return accepts `nil` branch.
- CHANGELOG entry under `## Unreleased`.

## Out of scope

- Multi-arity `defn` arg-type check (only single-arity FnNodes carry `:param-tags` for now).
- Cross-file / whole-program inference.
- Replacing PHP type decls with Phel-level guards. The PHP signature stays; this pass only adds earlier diagnostics.

Refactor pass surfaced no further substantive cleanup beyond the autofixes already folded into the feat commit.

Related to #1933