### PR TITLE
docs: simplify guides, modernize phel snippets, drop em dashes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,41 +2,41 @@
 
 ## Start here
 
-1. [Quick Start](quickstart.md) — install, REPL, first script
-2. [Common Patterns](patterns.md) — idioms used every day
-3. [PHP/Phel Interop](php-interop.md) — call PHP from Phel and back
+1. [Quick Start](quickstart.md): install, REPL, first script
+2. [Common Patterns](patterns.md): everyday idioms
+3. [PHP/Phel Interop](php-interop.md): call PHP from Phel and back
 
 Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 
 ## Language
 
-- [Reader Shortcuts](reader-shortcuts.md) — `#inst`, `#regex`, `#php`, anonymous fn `#(...)`
-- [Reader Conditionals](reader-conditionals.md) — `.cljc` portability
-- [Data Structures](data-structures-guide.md) — vectors, maps, sets, transients
-- [Lazy Sequences](lazy-sequences.md) — `lazy-seq`, infinite seqs, realization
-- [Transducers](transducers.md) — composable transformations
-- [Pattern Matching](match-guide.md) — `match` with guards and destructuring
+- [Reader Shortcuts](reader-shortcuts.md): `#inst`, `#regex`, `#php`, anonymous fn `#(...)`
+- [Reader Conditionals](reader-conditionals.md): `.cljc` portability
+- [Data Structures](data-structures-guide.md): vectors, maps, sets, transients
+- [Lazy Sequences](lazy-sequences.md): `lazy-seq`, infinite seqs, realization
+- [Transducers](transducers.md): composable transformations
+- [Pattern Matching](match-guide.md): `match` with guards and destructuring
 
 ## Tooling
 
-- [REPL & nREPL](nrepl-guide.md) — editor integration over bencode/TCP
-- [Language Server](lsp-guide.md) — hover, definition, references, completion
-- [Linter](lint-guide.md) — `phel lint` rules and config
-- [Watch](watch-guide.md) — hot-reload changed namespaces
-- [CLI Builder](cli-guide.md) — build CLIs with `phel\cli`
-- [Performance](performance.md) — opcache setup, cache reset
-- [Mocking](mocking-guide.md) — test seams for PHP calls
+- [REPL & nREPL](nrepl-guide.md): editor integration over bencode/TCP
+- [Language Server](lsp-guide.md): hover, definition, references, completion
+- [Linter](lint-guide.md): `phel lint` rules and config
+- [Watch](watch-guide.md): hot-reload changed namespaces
+- [CLI Builder](cli-guide.md): build CLIs with `phel\cli`
+- [Performance](performance.md): opcache setup, cache reset
+- [Mocking](mocking-guide.md): test seams for PHP calls
 
 ## Modules
 
-- [Async](async-guide.md) — fibers, promises, futures, AMPHP
-- [Schema](schema-guide.md) — validate, coerce, generate
-- [AI](ai-guide.md) — `chat-with-tools`, OpenAI tool use
+- [Async](async-guide.md): fibers, promises, futures, AMPHP
+- [Schema](schema-guide.md): validate, coerce, generate
+- [AI](ai-guide.md): `chat-with-tools`, OpenAI tool use
 
 ## Apps
 
-- [Framework Integration](framework-integration.md) — Laravel, Symfony, framework-less
-- [Examples](examples/README.md) — runnable single-file samples
+- [Framework Integration](framework-integration.md): Laravel, Symfony, framework-less
+- [Examples](examples/README.md): runnable single-file samples
 
 ## Internals
 
@@ -53,5 +53,5 @@ Overview: [internals/](internals/README.md).
 
 ## AI agents
 
-- [resources/agents/](../resources/agents/README.md) — Claude Code, Cursor, Codex, Gemini, Copilot, Aider
+- [resources/agents/](../resources/agents/README.md): Claude Code, Cursor, Codex, Gemini, Copilot, Aider
 - [agent-docs](agent-docs.md) · [agent-metrics](agent-metrics.md)

--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -1,6 +1,6 @@
 # AI coding agents
 
-`resources/agents/` ships docs, task recipes, and skill files so AI coding tools (Claude Code, Cursor, Codex, Gemini, Copilot, Aider) can build Phel apps without scraping the website on cold start.
+`resources/agents/` ships docs, task recipes, and skill files so AI coding tools (Claude Code, Cursor, Codex, Gemini, Copilot, Aider) build Phel apps without scraping the website on cold start.
 
 ## Install
 
@@ -42,7 +42,7 @@ Each installed file routes the agent to `.agents/index.md` for task recipes: sca
 
 ## Repository maintenance adapters
 
-The repository also contains AI tool config for maintaining phel-lang itself. Keep these separate from the downstream `resources/agents/` package:
+The repo also contains AI tool config for maintaining phel-lang itself. Keep these separate from the downstream `resources/agents/` package:
 
 | Path | Audience |
 |------|----------|

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -9,7 +9,7 @@ Fresh project, fresh chat session. Prompt: **"Build a todo HTTP API in Phel with
 Target:
 - HTTP endpoint for create/list/show/delete
 - Tests pass via `./vendor/bin/phel test`
-- Total wall time from first prompt to green tests
+- Wall time: first prompt to green tests
 
 ## Table
 
@@ -30,12 +30,12 @@ Target:
 
 ## How to contribute a run
 
-1. Pick an agent and start a fresh session in an empty directory.
+1. Pick an agent. Start a fresh session in an empty directory.
 2. Run `composer require phel-lang/phel-lang`.
 3. For "yes" rows only: `./vendor/bin/phel agent-install <platform>`.
 4. Feed the prompt above. Time from send to green `phel test`.
-5. Open a PR updating this table with your result and attach the transcript as a gist or comment link.
+5. Open a PR updating this table with your result. Attach the transcript as a gist or comment link.
 
 ## Why this matters
 
-Before bundled agent assets, a cold run took around 23 minutes for Claude Code to build a todo app, most of it scraping phel-lang.org. The goal of `resources/agents/` is to drive that well under 5 minutes for any supported agent.
+Before bundled agent assets, a cold run took ~23 minutes for Claude Code to build a todo app, most of it scraping phel-lang.org. `resources/agents/` aims to drive that well under 5 minutes for any supported agent.

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -44,7 +44,7 @@ Every per-call `opts` map on `chat`, `complete`, `chat-with-tools`, `extract`, a
 (ai/complete "Summarize the news" {:provider :openai :model "gpt-4o-mini"})
 ```
 
-For scoped configuration that auto-restores (including on exceptions), use `with-config`:
+For scoped config that auto-restores (even on exceptions), use `with-config`:
 
 ```phel
 (ai/with-config {:provider :openai :model "gpt-4o"}
@@ -71,7 +71,7 @@ Multi-turn via `chat-with-history`:
 
 ## Structured extraction
 
-Ask the model to populate a schema:
+Populate a schema:
 
 ```phel
 (ai/extract
@@ -84,7 +84,7 @@ Ask the model to populate a schema:
 
 ## Tool use
 
-Define tools with provider-agnostic `tool`, then either drive the loop manually with `chat-with-tools` + `tool-result`, or hand it off to `run-tools`.
+Define tools with provider-agnostic `tool`, then drive the loop manually with `chat-with-tools` + `tool-result`, or hand off to `run-tools`.
 
 ```phel
 (def tools
@@ -102,7 +102,7 @@ Define tools with provider-agnostic `tool`, then either drive the loop manually 
 ;; => "It's 72F and sunny in Paris."
 ```
 
-`run-tools` repeatedly sends the conversation, resolves any tool calls via `handlers` (a map of tool name to fn), feeds the results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
+`run-tools` sends the conversation, resolves tool calls via `handlers` (map of tool name to fn), feeds results back, and stops when the model returns plain text or `:max-turns` is reached. Anthropic-only.
 
 For finer control, use `chat-with-tools` directly:
 
@@ -131,7 +131,7 @@ For finer control, use `chat-with-tools` directly:
 ; => [{:text "cats purr" :embedding [...] :similarity 0.87}]
 ```
 
-Vector math primitives are exported for custom pipelines: `dot-product`, `magnitude`, `cosine-similarity`, `nearest`.
+Vector math primitives for custom pipelines: `dot-product`, `magnitude`, `cosine-similarity`, `nearest`.
 
 ## Retry & timeouts
 
@@ -143,11 +143,11 @@ Vector math primitives are exported for custom pipelines: `dot-product`, `magnit
 
 ## Errors
 
-All failures throw `\RuntimeException`. The message includes the HTTP status and provider error body when available.
+All failures throw `\RuntimeException`. Messages include HTTP status and provider error body when available.
 
 ## Testing without a live API
 
-`phel\ai` exposes an internal HTTP seam `*http-post*` that tests can rebind to return canned responses. With `phel\mock`, this removes the dependency on a real provider.
+`phel\ai` exposes an HTTP seam `*http-post*` that tests rebind to return canned responses. Combined with `phel\mock`, this removes the dependency on a real provider.
 
 ```phel
 (ns my-app\test\ai-test
@@ -163,7 +163,7 @@ All failures throw `\RuntimeException`. The message includes the HTTP status and
       (is (= 1 (call-count fake))))))
 ```
 
-`phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string rather than going through `json/encode`.
+`phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string instead of using `json/encode`.
 
 ## See also
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -1,12 +1,12 @@
 # Async Module Guide
 
-Two cooperating concurrency layers over PHP fibers. Most primitives live in `phel.core` and need no require; `delay` lives in `phel.async` because Phel's `delay` sleeps while `clojure.core/delay` is a lazy-thunk wrapper.
+Two concurrency layers over PHP fibers. Most primitives live in `phel.core` (no require). `delay` lives in `phel.async` because Phel's `delay` sleeps, unlike `clojure.core/delay` (a lazy-thunk wrapper).
 
 ## Overview
 
-**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, and `future-cancelled?` are in `phel.core`; `delay` is in `phel.async`. Use this layer inside an event loop, or when you need timers, IO multiplexing, or fan-out across many Futures.
+**AMPHP-backed layer.** Built on `amphp/amp`. An event loop drives fiber-based IO, timers, and combinators. `async`, `await`, `await-all`, `await-any`, `pmap`, `future`, `future-cancel`, `future-cancelled?` in `phel.core`; `delay` in `phel.async`. Use inside an event loop, or for timers, IO multiplexing, or fan-out across many Futures.
 
-**Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, and `future?` are in `phel.core`. Safe at the top level of a script or REPL; convenient for CPU coordination, producer/consumer handoffs, and lightweight deref-with-timeout.
+**Fiber-backed layer.** Cooperative single-threaded scheduler in `\Phel\Fiber\FiberFacade`, no event loop. `promise`, `deliver`, `future-call`, `future-fiber`, `future?` in `phel.core`. Safe at the top level of a script or REPL. Good for CPU coordination, producer/consumer handoffs, lightweight deref-with-timeout.
 
 ## When to use which
 
@@ -16,9 +16,9 @@ Two cooperating concurrency layers over PHP fibers. Most primitives live in `phe
 | CPU coordination, producer/consumer handoff | fiber layer |
 | IO parallelism, timers, fan-out | AMPHP layer (`async`, `delay`, `await-all`, `await-any`) |
 | Mixing AMPHP-based libs (HTTP clients, servers) | AMPHP layer |
-| Clojure-style `future` with `deref` timeout inside a loop | AMPHP `future` inside `async`, or fiber `future-call` at top level |
+| `future` with `deref` timeout inside a loop | AMPHP `future` inside `async`, or fiber `future-call` at top level |
 
-Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or existing AMPHP code are involved.
+Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or AMPHP code are involved.
 
 ## AMPHP layer reference
 
@@ -28,7 +28,7 @@ Rule of thumb: fiber layer for plain scripts; AMPHP layer when IO, timers, or ex
 (async body...)
 ```
 
-Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Future`. Gotcha: needs an active event loop; call inside `Amp\Loop::run` or a command that opens one. Exceptions raised in the body surface when the Future is awaited.
+Schedules `body` on the AMPHP event loop in a fresh fiber. Returns `Amp\Future`. Needs an active event loop (call inside `Amp\Loop::run` or a command that opens one). Exceptions in the body surface when awaited.
 
 ```phel
 (await (async (+ 1 2))) ;; => 3
@@ -40,11 +40,11 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns an `Amp\Futur
 (await future)
 ```
 
-Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `PhelFuture` wrapper. Gotcha: must be called from inside a fiber.
+Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `PhelFuture` wrapper. Must be called from inside a fiber.
 
 ### `^:async` on `defn`
 
-`^:async` on `defn` wraps the body in `(async ...)`, so the function returns an `Amp\Future` that callers `await`.
+`^:async` wraps the body in `(async ...)`. The function returns `Amp\Future` for callers to `await`.
 
 ```phel
 (defn ^:async fetch [url]
@@ -61,9 +61,9 @@ Multi-arity bodies are wrapped per arity. `^{:async false}` opts out without rem
 (delay seconds)
 ```
 
-Suspends execution for `seconds` (float). At the top level behaves like `php/sleep`; inside an `async`/`future` body it suspends the *fiber* (not the process) and the delay becomes cancellable via `future-cancel`. Uses `Amp\delay`.
+Suspends for `seconds` (float). At top level behaves like `php/sleep`. Inside `async`/`future` body suspends the *fiber* only and becomes cancellable via `future-cancel`. Uses `Amp\delay`.
 
-> **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) so the difference stays visible to `.cljc` portable code.
+> **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) to keep the difference visible to `.cljc` portable code.
 
 ```phel
 (:require phel\async :refer [delay])
@@ -77,7 +77,7 @@ Suspends execution for `seconds` (float). At the top level behaves like `php/sle
 (await-all futures)
 ```
 
-Awaits every Future in the collection and returns a vector of resolved values in order. Gotcha: if any Future fails, the exception propagates and the others keep running until their next checkpoint.
+Awaits every Future and returns resolved values in order. If any Future fails, the exception propagates; others keep running to their next checkpoint.
 
 ```phel
 (await-all [(async (fetch :a)) (async (fetch :b))])
@@ -89,7 +89,7 @@ Awaits every Future in the collection and returns a vector of resolved values in
 (await-any futures)
 ```
 
-Returns the value of the first Future to resolve. Gotcha: losing Futures are not cancelled for you; pair with `future-cancel` when that matters.
+Returns the value of the first Future to resolve. Losing Futures are not auto-cancelled; pair with `future-cancel` when needed.
 
 ### `pmap`
 
@@ -97,7 +97,7 @@ Returns the value of the first Future to resolve. Gotcha: losing Futures are not
 (pmap f coll) (pmap f coll1 coll2 ...)
 ```
 
-Concurrent `map` via fibers; results returned in input order. PHP fibers are cooperative on a single thread, so `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU-bound work across cores. Unlike `clojure.core/pmap`, which uses a thread pool; ClojureScript and Basilisp follow the same single-threaded model.
+Concurrent `map` via fibers; results in input order. PHP fibers are cooperative on a single thread: `pmap` overlaps IO-bound work (HTTP, DB, file IO) but does **not** parallelize CPU work across cores. ClojureScript and Basilisp follow the same single-threaded model; `clojure.core/pmap` uses a thread pool.
 
 ### `future`
 
@@ -105,7 +105,7 @@ Concurrent `map` via fibers; results returned in input order. PHP fibers are coo
 (future body...)
 ```
 
-Wraps `body` in an `Amp\Future` and returns a `PhelFuture` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, and `future-done?`. Gotcha: requires a fiber context; call inside `async` or an AMPHP loop.
+Wraps `body` in `Amp\Future`, returns a `PhelFuture` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, `future-done?`. Requires a fiber context (call inside `async` or an AMPHP loop).
 
 ```phel
 (async
@@ -119,7 +119,7 @@ Wraps `body` in an `Amp\Future` and returns a `PhelFuture` supporting `deref`, `
 (future-cancel f)
 ```
 
-Signals the Future's internal `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Cancellation is cooperative; the body keeps running until it hits a cancellation-aware checkpoint.
+Signals the Future's `DeferredCancellation` token. Pending and subsequent `deref` calls throw `Amp\CancelledException` (or return the fallback for the 3-arg form). Cooperative: the body runs until it hits a cancellation-aware checkpoint.
 
 ### `future-cancelled?`
 
@@ -127,7 +127,7 @@ Signals the Future's internal `DeferredCancellation` token. Pending and subseque
 (future-cancelled? f)
 ```
 
-Returns `true` once `future-cancel` was called. Does not imply the body has stopped; use `future-done?` for terminal state.
+Returns `true` once `future-cancel` was called. Does not imply the body stopped; use `future-done?` for terminal state.
 
 ## Fiber layer reference
 
@@ -137,7 +137,7 @@ Returns `true` once `future-cancel` was called. Does not imply the body has stop
 (promise)
 ```
 
-Returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from the top level. Not thread-safe across processes; lives in a single PHP process.
+Returns a new unrealized promise. Single delivery: once set, the value is frozen. `deref` suspends cooperatively from inside a fiber, or drains the scheduler from top level. Single-process; not cross-process safe.
 
 ### `deliver`
 
@@ -145,7 +145,7 @@ Returns a new unrealized promise. Single delivery: once set, the value is frozen
 (deliver p value)
 ```
 
-Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Idempotent: the second call is a no-op and the stored value never changes.
+Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already realized. Idempotent: subsequent calls are no-ops; stored value never changes.
 
 ```phel
 (let [p (promise)]
@@ -160,7 +160,7 @@ Delivers `value` to promise `p`. Returns `p` on first delivery, `nil` if already
 (future-call f)
 ```
 
-Runs the zero-arg function `f` in a new fiber via the cooperative scheduler. Returns a `PhelFiberFuture` supporting `deref`, `realized?`, `future-done?`, and `future-cancel`. `f` must be zero-arg; use a closure to capture state.
+Runs zero-arg `f` in a new fiber via the cooperative scheduler. Returns `PhelFiberFuture` supporting `deref`, `realized?`, `future-done?`, `future-cancel`. `f` must be zero-arg; use a closure to capture state.
 
 ### `future-fiber`
 
@@ -168,7 +168,7 @@ Runs the zero-arg function `f` in a new fiber via the cooperative scheduler. Ret
 (future-fiber body...)
 ```
 
-Macro over `future-call`. Lets you write `@(future-fiber (expensive))` without an outer `async` block. Unlike AMPHP `future`, this cannot use the event loop, so blocking PHP calls freeze the scheduler until they return.
+Macro over `future-call`. Write `@(future-fiber (expensive))` without an outer `async` block. No event loop, so blocking PHP calls freeze the scheduler until they return.
 
 ### `future?`
 
@@ -176,37 +176,37 @@ Macro over `future-call`. Lets you write `@(future-fiber (expensive))` without a
 (future? x)
 ```
 
-Returns `true` if `x` is a fiber-future or a `PhelFuture`. Useful when receiving Futures from code that may use either layer.
+Returns `true` if `x` is a fiber-future or `PhelFuture`. Useful when receiving Futures from code that may use either layer.
 
 ## Shared primitives
 
-`deref` is overloaded and dispatches to the right layer at runtime.
+`deref` dispatches to the right layer at runtime.
 
 | Form | Behavior |
 |------|----------|
 | `(deref x)` / `@x` | Block until realized. Fiber path suspends cooperatively; AMPHP path awaits via the event loop |
-| `(deref x timeout-ms timeout-val)` | Return `timeout-val` if not realized within `timeout-ms`. Fiber path uses a deadline poll; AMPHP path uses `Future::await` with a `TimeoutCancellation` |
-| `(realized? x)` | `true` once a value is available. Works for promises, fiber futures, and `PhelFuture` |
-| `(future-done? x)` | For fiber futures, checks `isDone`; for anything else, falls back to `realized?`. Use this when you need "terminal state including cancellation", not just "value present" |
+| `(deref x timeout-ms timeout-val)` | Return `timeout-val` if not realized within `timeout-ms`. Fiber path uses a deadline poll; AMPHP path uses `Future::await` with `TimeoutCancellation` |
+| `(realized? x)` | `true` once a value is available. Works for promises, fiber futures, `PhelFuture` |
+| `(future-done? x)` | For fiber futures, checks `isDone`; otherwise falls back to `realized?`. Use for "terminal state including cancellation", not just "value present" |
 
 ## Error and cancellation model
 
-- **AMPHP path**: exceptions thrown inside a `future` or `async` body surface out of `await` / `deref`. Cancellation uses `Amp\DeferredCancellation`; after `future-cancel`, any `deref` raises `Amp\CancelledException`, and the 3-arg form returns its fallback.
-- **Fiber path**: exceptions thrown in a `future-call` body are re-raised on `deref`. `future-cancel` flips a flag checked at cooperative checkpoints; the 3-arg `deref` returns its fallback without waiting.
-- **`deliver` is idempotent**: the first call wins; the return value tells you whether you set it. Use for "first writer wins" handoffs without locks.
+- **AMPHP path**: exceptions in a `future`/`async` body surface from `await`/`deref`. Cancellation via `Amp\DeferredCancellation`; after `future-cancel`, `deref` raises `Amp\CancelledException`, and the 3-arg form returns its fallback.
+- **Fiber path**: exceptions in `future-call` bodies re-raise on `deref`. `future-cancel` flips a flag checked at cooperative checkpoints; the 3-arg `deref` returns its fallback without waiting.
+- **`deliver` is idempotent**: first call wins; the return value tells you whether you set it. Use for "first writer wins" handoffs without locks.
 
 ## Interop
 
-- `->closure` converts a Phel function into a PHP `\Closure`. Many PHP libraries (AMPHP, ReactPHP) type-hint `\Closure` and reject Phel's `AbstractFn` even though it is callable. Wrap before handing a Phel fn to such a library.
-- Bare `Amp\Future` values from AMPHP libs pass to `await`, `await-all`, and `await-any` directly; no wrapping required.
+- `->closure` converts a Phel function to a PHP `\Closure`. Many PHP libraries (AMPHP, ReactPHP) type-hint `\Closure` and reject Phel's `AbstractFn`. Wrap before passing a Phel fn.
+- Bare `Amp\Future` values from AMPHP libs pass to `await`, `await-all`, `await-any` directly; no wrapping needed.
 - To feed a fiber-layer result to AMPHP code, deref it inside an `async` block: `(async (use-value @(future-fiber ...)))`.
 
 ## Pitfalls
 
-- **Calling `future` outside an event loop**. The AMPHP `future` macro needs a fiber context; use `future-fiber` for top-level scripts.
-- **Mixing future types**. `future?` is the safe predicate when either may arrive; type-specific dispatch is baked into `deref`, `realized?`, and `future-done?`.
-- **CPU-bound `pmap`**. PHP fibers share one thread. If `f` is CPU-heavy, `pmap` will not speed it up and may add overhead. Shell out to workers for parallelism.
-- **Blocking PHP calls inside fiber futures**. `sleep`, `usleep`, synchronous `curl`, and blocking socket reads freeze the cooperative scheduler. Use `delay` (AMPHP) or non-blocking IO.
+- **`future` outside an event loop**. AMPHP `future` needs a fiber context; use `future-fiber` for top-level scripts.
+- **Mixing future types**. `future?` is the safe predicate; `deref`, `realized?`, `future-done?` dispatch by type.
+- **CPU-bound `pmap`**. PHP fibers share one thread. CPU-heavy `f` won't speed up and may add overhead. Shell out to workers for parallelism.
+- **Blocking PHP calls inside fiber futures**. `sleep`, `usleep`, synchronous `curl`, blocking socket reads freeze the scheduler. Use `delay` (AMPHP) or non-blocking IO.
 
 ## Recipes
 
@@ -273,9 +273,9 @@ Wall time tracks the slowest branch, not the sum.
 (println (await (launch)))
 ```
 
-`future-cancel` is cooperative, so `slow` finishes its current step before observing cancellation, but any `deref` on it now throws `Amp\CancelledException`.
+`future-cancel` is cooperative: `slow` finishes its current step before observing cancellation. Any `deref` on it now throws `Amp\CancelledException`.
 
 ## See also
 
 - [Example: `docs/examples/11_async-concurrency.phel`](examples/11_async-concurrency.phel)
-- [`phel\http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls that slot into this model
+- [`phel\http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,6 +1,6 @@
 # Building CLIs with `phel\cli`
 
-`phel\cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html): subcommands, arguments, options, prompts, tables, progress bars, shell completion, signal handling, all as plain Phel maps. No extra dependency; `symfony/console` already ships with phel-lang.
+`phel\cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling all defined as plain Phel maps. No extra dependency; `symfony/console` ships with phel-lang.
 
 ## Quickstart
 
@@ -97,10 +97,7 @@ Your `:run` handler receives a **context map**:
  :style     <SymfonyStyle>}
 ```
 
-Return:
-
-- `nil` or `0` -> success
-- any other `int` -> exit code
+Return `nil` or `0` for success, any other `int` for an exit code.
 
 Uncaught `Throwable` becomes a red `<error>` line plus exit code `1`. With `-v`, the stack trace is written.
 
@@ -204,7 +201,7 @@ my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
 
 ## Testing your CLI
 
-`phel\cli` ships test helpers so handlers run without spawning a process:
+Test helpers run handlers without spawning a process:
 
 ```phel
 (ns my-tool-test\test\main
@@ -234,7 +231,7 @@ For prompt testing, pipe canned STDIN:
 
 ## Running under `phel run`
 
-When running a CLI script via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. User-facing arguments come through the Phel core var `argv`. Pass them to `cli/run` explicitly:
+When invoked via `./bin/phel run path/to/script.phel arg1 arg2`, Phel's own Symfony console occupies `$_SERVER['argv']`. User-facing arguments come through the Phel core var `argv`. Pass them to `cli/run` explicitly:
 
 ```phel
 ;; Bad: reads the wrapper's argv, so "run" looks like your first command.
@@ -244,18 +241,18 @@ When running a CLI script via `./bin/phel run path/to/script.phel arg1 arg2`, Ph
 (cli/run app (cli/argv argv))
 ```
 
-This is only needed when the script is invoked via `phel run`. A compiled standalone binary built with `phel build` uses `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
+Only needed under `phel run`. A standalone binary built with `phel build` uses `$_SERVER['argv']` directly, so `(cli/run app)` is fine there.
 
 ## Best practices
 
-- **Spec validation is eager.** Malformed maps throw `InvalidArgumentException` at build time with a Phel-friendly message: catch bugs before ship.
-- **Return exit codes.** Never call `php/exit` from a handler (except in signal handlers). Return an `int`, and `phel\cli` handles it.
-- **Use `:coerce`.** Don't `(php/intval (arg ctx "port"))` in every handler; specify `:coerce :int` once.
+- **Spec validation is eager.** Malformed maps throw `InvalidArgumentException` at build time with a Phel-friendly message.
+- **Return exit codes.** Never call `php/exit` from a handler (except in signal handlers). Return an `int`.
+- **Use `:coerce`.** Avoid `(php/intval (arg ctx "port"))` in every handler; specify `:coerce :int` once.
 - **Lift handlers to top-level fns.** Keeps `:run` small and testable.
-- **Keep `:default`** set to a safe command. With no args and no default, Symfony shows help, usually fine but explicit is nicer.
+- **Keep `:default`** set to a safe command. With no args and no default, Symfony shows help.
 
 ## See also
 
 - [`phel\router`](../src/phel/router.phel): companion for HTTP apps
 - [`phel\http-client`](../src/phel/http-client.phel): outbound HTTP
-- [symfony/console docs](https://symfony.com/doc/current/components/console.html): full underlying API
+- [symfony/console docs](https://symfony.com/doc/current/components/console.html): underlying API

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -1,6 +1,6 @@
 # Clojure to Phel Migration Guide
 
-Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know Clojure, you already know most of Phel. This guide covers the differences. Jump to [Quick reference](#quick-reference) for the at-a-glance view.
+Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. This guide covers the differences. Jump to [Quick reference](#quick-reference) for the at-a-glance view.
 
 ## Quick reference
 
@@ -19,7 +19,7 @@ Phel is a functional Lisp inspired by Clojure that compiles to PHP. If you know 
 
 ## What's the same
 
-Most of Clojure's core library works identically in Phel:
+Most of Clojure's core library works identically:
 
 - **Data structures**: persistent vectors `[]`, maps `{}`, sets, lists `'()`, lazy-seqs, sorted collections (`sorted-map`, `sorted-map-by`, `sorted-set`, `sorted-set-by`)
 - **Collection API**: `conj`, `conj!`, `disj`, `into`, `assoc`, `dissoc`, `get`, `get-in`, `update`, `update-in`, `merge`, `select-keys`, `keys`, `vals`, `update-keys`, `update-vals`, `rename-keys`, `zipmap`, `frequencies`, `group-by`
@@ -43,7 +43,7 @@ Most of Clojure's core library works identically in Phel:
 
 ## Reader syntax
 
-Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still work but are deprecated:
+Clojure reader syntax is accepted wholesale. Older Phel-specific forms still work but are deprecated:
 
 | Syntax | Meaning | Old Phel form (deprecated) |
 |--------|---------|----------------------------|
@@ -54,8 +54,8 @@ Clojure's reader syntax is accepted wholesale. Older Phel-specific forms still w
 | `\a`, `\space`, `\uNNNN`, `\oNNN` | Character literal (compiles to single-char PHP string) | |
 | `##Inf`, `##-Inf`, `##NaN` | Symbolic numeric literal | |
 | `2r1111`, `16rFF` | Radix literal (bases 2 to 36) | |
-| `1N`, `1.5M` | BigInt / BigDecimal suffix (accepted, truncated to PHP int/float) | |
-| `1/2`, `-3/4` | Ratio literal (accepted, evaluated as float division; `1/0` → `INF`, `0/0` → `NaN`) | |
+| `1N`, `1.5M` | BigInteger / BigDecimal suffix (read as `Phel\Lang\BigInteger` / `Phel\Lang\BigDecimal`) | |
+| `1/2`, `-3/4` | Ratio literal (read as `Phel\Lang\Rational`; integer-valued ratios collapse to `int`/`BigInteger`) | |
 | `#"regex"` | Regex literal | |
 | `#?(...)`, `#?@(...)` | Reader conditionals (for `.cljc`) | |
 | `#<tag> form` | Tagged literal dispatch | |
@@ -64,12 +64,12 @@ Notes:
 
 - Named `fn` for self-recursion: `(fn fact [n] (if (zero? n) 1 (* n (fact (dec n)))))`. Multi-arity named fns resolve the name across arities.
 - `defmacro` bodies have `&form` (original macro call) and `&env` (locals at the call site), enabling dialect detection via `(:ns &env)` in `.cljc` sources.
-- No first-class `Var` or `Char` type. `#'foo` compiles to a bare symbol reference; `\A` compiles to the single-character string `"A"`.
+- `#'foo` reads as a first-class `Phel\Lang\Var` (see `var?`, `var-get`, `find-var`, `bound?`, `with-redefs`). No `Char` type: `\A` compiles to the single-character string `"A"`.
 - Unknown `#<tag>` literals inside unselected `#?` branches parse without error, so `.cljc` files with foreign tags like `#cpp` in non-`:phel` branches work.
 
 ## Namespace syntax
 
-Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` for Clojure compatibility:
+Phel uses `\` as the native namespace separator (matching PHP). It also accepts `.`:
 
 ```phel
 ;; Both work:
@@ -80,9 +80,9 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 (ns my.app (:require [phel\string :as str :refer [upper-case]]))
 ```
 
-**Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists, so `.cljc` files that `(:require [clojure.string :as str])` work without changes.
+**Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists. `.cljc` files using `(:require [clojure.string :as str])` work unchanged.
 
-**Importing PHP classes**: use `(:use ...)` in the `ns` form to import a PHP class by short name, like PHP's `use` statement. This is Phel's equivalent of Clojure's `(:import ...)`:
+**Importing PHP classes**: use `(:use ...)` in the `ns` form (Phel's equivalent of `(:import ...)`):
 
 ```phel
 (ns my\app
@@ -94,7 +94,7 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 (php/:: Symbol (create "foo"))  ; FQN Phel\Lang\Symbol is aliased
 ```
 
-`:use` is optional. Classes can always be referenced by fully-qualified name at the call site: `(php/new \DateTime)`.
+`:use` is optional. Classes can always be referenced by FQN: `(php/new \DateTime)`.
 
 ## PHP interop (vs Java interop)
 
@@ -111,7 +111,7 @@ Phel uses `\` as the native namespace separator (matching PHP), but accepts `.` 
 | PHP function | N/A | `(php/strlen "hello")` |
 | String concat | `(str a b)` | `(str a b)` or `(php/. a b)` |
 
-Any PHP function can be called with the `php/` prefix:
+Any PHP function works with the `php/` prefix:
 
 ```phel
 (php/array_map f arr)
@@ -122,7 +122,7 @@ Any PHP function can be called with the `php/` prefix:
 
 ## .cljc cross-compilation
 
-Phel supports `.cljc` files with reader conditionals for sharing code between Clojure and Phel:
+`.cljc` files with reader conditionals share code between Clojure and Phel:
 
 ```clojure
 (ns shared.utils
@@ -145,11 +145,11 @@ Splice variant for embedding multiple forms:
 
 ## Clojure-compatible renames
 
-These Clojure names were added; the old Phel-specific names still work but are deprecated:
+Old Phel-specific names still work but are deprecated:
 
 | Clojure name | Old Phel name |
 |--------------|---------------|
-| `atom`, `atom?` | `var`, `var?` |
+| `atom`, `atom?` | `var`, `var?` (legacy alias; `var` / `var?` now refer to first-class Vars) |
 | `reset!` | `set!` |
 | `identical?` | `id` |
 | `fn?` | `function?` |
@@ -159,30 +159,29 @@ These Clojure names were added; the old Phel-specific names still work but are d
 | `NaN?` | `nan?` |
 | `integer?` | `int?` (alias, not deprecated) |
 
-The deprecated names will be removed in a future major version.
+Deprecated names are removed in a future major version.
 
 ## What's not available (and why)
 
-Phel runs on PHP. Some Clojure features don't translate directly:
+Some Clojure features don't translate to PHP:
 
 | Clojure feature | Why it's absent | Alternative |
 |-----------------|----------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
 | **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel\core`, no require needed | See [docs/async-guide.md](async-guide.md) |
-| **BigInt / BigDecimal / Ratio** | PHP number model | Suffix literals (`1N`, `1.5M`) and ratio literals (`1/2`) are accepted; ratios evaluate to `num / den` as a float. Use `bcmath` / `gmp` via `php/` interop for real arbitrary precision |
+| **BigInt / BigDecimal / Ratio** | First-class `Phel\Lang\BigInteger`, `Phel\Lang\BigDecimal`, `Phel\Lang\Rational` ship in core | Use literals `1N`, `1.5M`, `1/2` or constructors `bigint`, `bigdec`, `rationalize`. See [numeric-tower.md](numeric-tower.md) |
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
-| **Vars (Clojure sense)** | PHP has no thread-local bindings | `def` creates namespace-level bindings directly |
-| **`alter-var-root`** | No first-class vars to re-root | Use an `atom` with `swap!` for mutable state, or redefine the top-level binding with `def`. Calling `alter-var-root` at runtime throws `BadMethodCallException` with this hint |
+| **`alter-var-root`** | Available: `(alter-var-root #'sym f)` re-roots the global binding | Use `with-redefs` for scoped overrides; `add-watch`/`remove-watch` on vars for change tracking |
 
-The Clojure-parity async surface lives in `phel\core`, reachable without any require: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus the Phel fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. The implementation uses AMPHP fibers. Semantics match Clojure's `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative rather than thread-interrupt, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). The one async symbol that still needs `(:require phel\async)` is `delay`, kept out of core because Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md) for the decision guide.
+The async surface lives in `phel\core`, no require needed: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel\async)`, since Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md).
 
 ## Structural differences
 
 ### defstruct, defrecord, and deftype
 
-Phel's native type form is `defstruct`. `defrecord` and `deftype` are thin macros over `defstruct` and produce the `->Name` / `map->Name` factory functions Clojure programmers expect:
+Phel's native type form is `defstruct`. `defrecord` and `deftype` are thin macros over `defstruct` and produce the `->Name` / `map->Name` factories:
 
 ```phel
 ;; defstruct (native)
@@ -200,7 +199,7 @@ Phel's native type form is `defstruct`. `defrecord` and `deftype` are thin macro
 (->PointT 1 2)           ;; positional factory (no map-> counterpart)
 ```
 
-Inline protocol methods work in both macro bodies; they are spliced into an `extend-type` call:
+Inline protocol methods work in both macro bodies (spliced into `extend-type`):
 
 ```phel
 (defprotocol Drawable
@@ -211,18 +210,18 @@ Inline protocol methods work in both macro bodies; they are spliced into an `ext
   (draw [this canvas] (str canvas ":" (get this :label))))
 ```
 
-`reify` is also supported for anonymous protocol implementation:
+`reify` supports anonymous protocol implementation:
 
 ```phel
 (reify Drawable
   (draw [this canvas] (str canvas ":anon")))
 ```
 
-Phel's `deftype` shares the map-backed `defstruct` infrastructure, so instances remain map-like (keys accessible via `get`). Clojure's `deftype` creates a non-map type; if you need that, fall back to native PHP interop.
+Phel's `deftype` shares the map-backed `defstruct` infrastructure: instances stay map-like (keys accessible via `get`). For Clojure's non-map `deftype`, fall back to native PHP interop.
 
 ### No lazy-seq by default
 
-Phel sequences are eager by default. Use `lazy-seq` explicitly when needed:
+Phel sequences are eager. Use `lazy-seq` when needed:
 
 ```phel
 (defn lazy-fib
@@ -230,11 +229,11 @@ Phel sequences are eager by default. Use `lazy-seq` explicitly when needed:
   ([a b] (lazy-seq (cons a (lazy-fib b (+ a b))))))
 ```
 
-`(range)` with 0 arguments returns an infinite lazy sequence (matching Clojure).
+`(range)` with 0 arguments returns an infinite lazy sequence.
 
 ### Test framework
 
-Phel's test framework lives in `phel\test` and mirrors `clojure.test`:
+`phel\test` mirrors `clojure.test`:
 
 ```phel
 (ns my-app\test
@@ -249,7 +248,7 @@ Phel's test framework lives in `phel\test` and mirrors `clojure.test`:
       3 3 6)))
 ```
 
-Extend `is` with custom assertion forms by adding a `phel\test/assert-expr` method:
+Extend `is` with custom assertions via `phel\test/assert-expr`:
 
 ```phel
 (defmethod phel\test/assert-expr 'my-form [msg form] ...)

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -19,15 +19,15 @@ Functions for manipulating Phel's immutable data structures: vectors, maps, sets
 
 ## Introduction
 
-Phel's data structures are **immutable** and **persistent**. Operations return new versions while sharing structure with the original: reads stay O(1) amortized, updates cost log32(n).
+Phel's data structures are **immutable** and **persistent**. Operations return new versions while sharing structure with the original. Reads stay O(1) amortized; updates cost log32(n).
 
-Function names follow common Lisp conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). See the [quick reference](#quick-reference) at the end.
+Function names follow common Lisp conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). See the [quick reference](#quick-reference).
 
 ---
 
 ## String Iteration
 
-Strings work directly with all sequence functions:
+Strings work with all sequence functions:
 
 ```phel
 ;; Iterate with for
@@ -56,8 +56,6 @@ Strings work directly with all sequence functions:
 
 ### Sequence Operations on Strings
 
-All core sequence functions work directly with strings:
-
 ```phel
 ;; first, next, rest
 (first "hello")   ; => "h"
@@ -80,13 +78,13 @@ All core sequence functions work directly with strings:
 
 ### String Conversion Functions
 
-**`seq`** - Convert string to vector of characters (optional, for backward compatibility):
+**`seq`** - Convert string to vector of characters:
 ```phel
 (seq "hello")
 ;; => ["h" "e" "l" "l" "o"]
 ```
 
-**`phel\string/chars`** - Convenience function for string → character vector:
+**`phel\string/chars`** - String to character vector:
 ```phel
 (use phel\string)
 (chars "hello")
@@ -95,7 +93,7 @@ All core sequence functions work directly with strings:
 
 ### Unicode Support
 
-All string operations properly handle multibyte UTF-8 characters:
+String operations handle multibyte UTF-8:
 
 ```phel
 (count "café")      ; => 4
@@ -104,15 +102,13 @@ All string operations properly handle multibyte UTF-8 characters:
 (map identity "🎉🎊🎈")  ; => ["🎉" "🎊" "🎈"]
 ```
 
-**Note:** Phel strings are fully seqable. `seq` remains available for backward compatibility and explicit conversion.
-
 ---
 
 ## Adding & Building Collections
 
 ### `conj` - Conjoin (Universal Add)
 
-Adds elements to any collection type. Behavior varies by collection:
+Adds elements to any collection. Behavior varies by type:
 
 ```phel
 ;; Vectors - appends to end
@@ -150,7 +146,7 @@ Adds elements to any collection type. Behavior varies by collection:
 
 ### `assoc` - Associate Key-Value Pairs
 
-Associates a value with a key. For maps, adds or updates key-value pairs. For vectors, updates by index.
+Associates a value with a key. Maps: add or update entries. Vectors: update by index.
 
 ```phel
 ;; Maps - add or update key
@@ -173,7 +169,7 @@ Associates a value with a key. For maps, adds or updates key-value pairs. For ve
 
 ### `into` - Bulk Addition
 
-Returns a collection with all elements from one or more source collections added.
+Returns a collection with all elements from the source(s) added.
 
 ```phel
 (into [1 2] [3 4 5])
@@ -305,7 +301,7 @@ Returns the first item where the predicate returns true.
 
 **Signature:** `[pred coll]`
 
-**Clojure note:** Differs from Clojure: Clojure's `find` returns a map entry `[key value]` for associative structures. Phel's `find` is a general search function.
+**Clojure note:** Clojure's `find` returns a `[key value]` entry on associative structures. Phel's `find` is a general search function.
 
 ---
 
@@ -492,8 +488,6 @@ Returns a map with keys and values swapped.
 
 **Signature:** `[map]`
 
-**Clojure note:** Equivalent to `clojure.set/map-invert`. Phel includes it in core.
-
 ---
 
 ## Analysis Functions
@@ -512,7 +506,7 @@ Returns a map of items to occurrence counts.
 
 **Signature:** `[coll]`
 
-**Clojure note:** Identical to Clojure's `frequencies`. Phel also supports strings as iterable sequences.
+Phel additionally accepts strings as iterable sequences.
 
 ---
 
@@ -534,7 +528,7 @@ Groups elements by the result of applying a function.
 
 ## Working with Nested Structures
 
-All `*-in` functions accept a path (sequence of keys) to navigate the structure.
+`*-in` functions take a path (sequence of keys) to navigate the structure.
 
 ### Common Patterns
 
@@ -573,7 +567,7 @@ Paths work with any combination of map keys and vector indices:
 
 ## Transient Collections
 
-For performance-critical code with many sequential updates, use **transient collections**. They allow efficient mutable operations, then convert back to persistent.
+For hot paths with many sequential updates, use **transient collections**. They allow efficient mutable operations, then convert back to persistent.
 
 ### Workflow
 
@@ -581,37 +575,35 @@ For performance-critical code with many sequential updates, use **transient coll
 ;; 1. Create transient version
 (def t (transient []))
 
-;; 2. Perform mutations (use same functions: conj, assoc, dissoc)
-(conj t 1)
-(conj t 2)
-(conj t 3)
+;; 2. Perform mutations (use bang variants: conj!, assoc!, dissoc!)
+(conj! t 1)
+(conj! t 2)
+(conj! t 3)
 
 ;; 3. Convert back to persistent
-(def result (persistent t))
+(def result (persistent! t))
 ;; => [1 2 3]
 ```
 
 ### Example: Building a large map
 
 ```phel
-(defn build-map [n]
+(defn build-map [^int n]
   (let [t (transient {})]
     (loop [i 0]
       (when (< i n)
-        (assoc t i (* i i))
+        (assoc! t i (* i i))
         (recur (inc i))))
-    (persistent t)))
+    (persistent! t)))
 ```
 
-**Clojure note:** Phel uses `persistent`; Clojure uses `persistent!`.
-
-**Important:** Don't use the transient version after calling `persistent`.
+Phel ships both `persistent` and `persistent!` (alias). Don't use the transient after calling either.
 
 ---
 
 ## Phel-Specific Extensions ⭐
 
-Functions not found in Clojure core.
+Functions not in Clojure core.
 
 ### `dissoc-in` - Nested Dissociation
 
@@ -725,17 +717,15 @@ The predicate receives `%1` (index) and `%2` (item).
 
 ## Deprecated Functions
 
-These functions have been deprecated in favor of Clojure-compatible alternatives:
+| Deprecated (v0.25.0) | Use Instead |
+|---------------------|-------------|
+| `push` | `conj` |
+| `put` | `assoc` |
+| `unset` | `dissoc` |
+| `put-in` | `assoc-in` |
+| `unset-in` | `dissoc-in` |
 
-| Deprecated (v0.25.0) | Use Instead | Reason |
-|---------------------|-------------|---------|
-| `push` | `conj` | Align with Clojure naming |
-| `put` | `assoc` | Align with Clojure naming |
-| `unset` | `dissoc` | Align with Clojure naming |
-| `put-in` | `assoc-in` | Align with Clojure naming |
-| `unset-in` | `dissoc-in` | Align with Clojure naming |
-
-**Migration:** Replace the old name with the new one. Signatures and behavior are identical.
+Signatures and behavior are identical; replace the name.
 
 ```phel
 ;; Old (deprecated)
@@ -751,13 +741,11 @@ These functions have been deprecated in favor of Clojure-compatible alternatives
 
 ## Summary
 
-Key takeaways:
-
-- **`conj`** is the universal "add" function
-- **`assoc`** sets explicit key-value pairs
-- **`*-in` functions** handle nested operations
-- **Phel extensions** like `deep-merge` and `dissoc-in` simplify nested work
-- **Transient collections** speed up performance-critical batch updates
-- Migrate from **deprecated functions** to Clojure-compatible names
+- `conj`: universal add
+- `assoc`: set key-value
+- `*-in`: nested operations
+- `deep-merge`, `dissoc-in`: Phel extensions for nested work
+- Transients: batch update performance
+- Migrate deprecated names to Clojure-compatible ones
 
 See `docs/examples/05_data-structures.phel`.

--- a/docs/examples/01_basic-types.phel
+++ b/docs/examples/01_basic-types.phel
@@ -1,12 +1,17 @@
 (ns examples\basic-types)
 
 ;; Demonstrates literals for strings, integers, floats, keywords, booleans, lists, tuples, and maps.
+;; Also: BigInteger (1N), BigDecimal (1.5M), Rational (1/2), and #uuid tagged literal.
 (def data
   {:string "Phel"
    :int 42
+   :bigint 9999999999999999999N        ; arbitrary-precision integer
    :float 3.14
+   :bigdec 0.1M                        ; exact decimal (no float drift)
+   :ratio 1/3                          ; exact rational
    :keyword :learning
    :boolean true
+   :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
    :list '(1 2 3)
    :tuple ["x" "y" "z"]
    :map {:language "Phel" :type "Functional"}})

--- a/docs/examples/02_arithmetic.phel
+++ b/docs/examples/02_arithmetic.phel
@@ -1,12 +1,24 @@
 (ns examples\arithmetic)
 
 ;; Play with numeric operations and helper functions.
-(defn summarize [a b]
+;; ^int :tag emits a PHP int parameter type and unlocks a JIT-friendly call shape.
+(defn summarize [^int a ^int b]
   {:add (+ a b)
    :subtract (- a b)
    :multiply (* a b)
-   :divide (/ a b)
-   :average (/ (+ a b) 2)})
+   :divide (/ a b)             ; integer division returns a Rational when not even
+   :quotient (quot a b)        ; integer truncation toward zero
+   :remainder (rem a b)
+   :average (/ (+ a b) 2)
+   :sqrt (sqrt a)
+   :rounded (round (/ a b))})
+
+;; Auto-promoting ops avoid silent overflow on PHP int (64-bit). Use them
+;; when an intermediate product can exceed PHP_INT_MAX.
+(defn product [& xs] (apply *' xs))
+
+;; Exact decimal via the `1.5M` BigDecimal literal: no float drift.
+(def tax-rate 0.0825M)
 
 (defn main []
   (let [x 9
@@ -14,6 +26,8 @@
         results (summarize x y)]
     (println "Working with numbers:")
     (for [[op value] :pairs results]
-      (println (str (name op) ": " value)))))
+      (println (str (name op) ": " value)))
+    (println "product 10^20 (BigInteger):" (product 100000 100000 100000 100000))
+    (println "tax-rate (BigDecimal):" tax-rate)))
 
 (main)

--- a/docs/examples/03_control-flow.phel
+++ b/docs/examples/03_control-flow.phel
@@ -1,7 +1,7 @@
 (ns examples\control-flow)
 
 ;; Showcase conditionals and pattern matching via cond and case.
-(defn classify-temperature [celsius]
+(defn classify-temperature [^int celsius]
   (cond
     (< celsius 0) :freezing
     (< celsius 10) :cold

--- a/docs/examples/04_functions-recursion.phel
+++ b/docs/examples/04_functions-recursion.phel
@@ -1,19 +1,20 @@
 (ns examples\functions-recursion)
 
 ;; Define reusable functions and a classic recursive implementation.
-(defn shout [message]
+(defn ^string shout [^string message]
   (str message "!!!"))
 
-(defn factorial [n]
+;; `*'` auto-promotes to BigInteger if PHP int overflows: factorial(21) needs it.
+(defn factorial [^int n]
   (if (<= n 1)
     1
-    (* n (factorial (- n 1)))))
+    (*' n (factorial (dec n)))))
 
-(defn fib [n]
-  (loop [a 0 b 1 count n]
-    (if (zero? count)
+(defn fib [^int n]
+  (loop [a 0 b 1 c n]
+    (if (zero? c)
       a
-      (recur b (+ a b) (- count 1)))))
+      (recur b (+' a b) (dec c)))))
 
 (defn main []
   (println (shout "Functions compose wonderfully"))

--- a/docs/examples/05_data-structures.phel
+++ b/docs/examples/05_data-structures.phel
@@ -206,13 +206,13 @@
 
 (println "\n=== Transient Collections ===")
 
-(defn build-large-map [n]
+(defn build-large-map [^int n]
   (let [t (transient {})]
     (loop [i 0]
       (when (< i n)
-        (assoc t i (* i i))
+        (assoc! t i (* i i))
         (recur (inc i))))
-    (persistent t)))
+    (persistent! t)))
 
 (def large-map (build-large-map 100))
 (println "Built large map with" (count large-map) "entries")

--- a/docs/examples/10_html-rendering.phel
+++ b/docs/examples/10_html-rendering.phel
@@ -26,7 +26,7 @@
        (for [session :in sessions]
          [:li
           [:time {:datetime (get session :time)} (get session :time)]
-          " — "
+          " - "
           [:strong (get session :title)]])]]
      [:section
       [:h2 "Attendees"]

--- a/docs/examples/11_async-concurrency.phel
+++ b/docs/examples/11_async-concurrency.phel
@@ -13,12 +13,13 @@
 
 ;; --- 2. Concurrent work ---
 
-(defn fetch-data
+;; `^:async` metadata wraps the body in `async` automatically: every call
+;; returns a future. Equivalent to wrapping the body manually with `(async ...)`.
+(defn ^:async fetch-data
   "Simulates an async I/O operation with a delay."
   [label ms]
-  (async
-    (delay (php/fdiv ms 1000))
-    (str label " (took " ms "ms)")))
+  (delay (php/fdiv ms 1000))
+  (str label " (took " ms "ms)"))
 
 (println)
 (println "--- Concurrent fetches ---")

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -22,7 +22,7 @@ Standalone scripts from primitive literals through concurrency to a full CLI. Ru
 | 10 | `10_html-rendering.phel` | HTML templating with `phel\html` |
 | 11 | `11_async-concurrency.phel` | AMPHP + fiber concurrency (`async`, `await`, `promise`) |
 | 12 | `12_cli.phel` | A todo-list CLI on `phel\cli` with subcommands and tables |
-| — | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
+| extra | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
 
 Copy any file into your project and tweak it.
 
@@ -51,7 +51,7 @@ Copy any file into your project and tweak it.
 | `atom`, `swap!`, `reset!` | `snippets/atom.phel` |
 | `phel\string` ops | `snippets/string.phel` |
 
-Each snippet is runnable: `./bin/phel run docs/examples/snippets/<name>.phel`. Use as REPL warm-ups or copy/paste recipes.
+Each snippet is runnable: `./bin/phel run docs/examples/snippets/<name>.phel`. Use as REPL warm-ups or copy-paste recipes.
 
 ## Run all
 

--- a/docs/examples/snippets/defn.phel
+++ b/docs/examples/snippets/defn.phel
@@ -1,6 +1,7 @@
 (ns examples\snippets\defn)
 
-(defn square [x] (* x x))
+;; ^int :tag emits a PHP int parameter type and unlocks JIT-friendly call shape.
+(defn ^int square [^int x] (* x x))
 (println (square 5))                       ; 25
 
 ;; Multi-arity
@@ -18,5 +19,14 @@
 ;; Docstring + private (defn-)
 (defn- helper
   "Multiply by ten."
-  [x] (* x 10))
+  [^int x] (* x 10))
 (println (helper 7))                       ; 70
+
+;; Memoization metadata (^:memoize) caches by argument vector.
+;; Use ^{:memoize-lru N} to bound the cache size.
+(defn ^{:memoize-lru 32} fib
+  "Memoized Fibonacci."
+  [^int n]
+  (if (< n 2) n
+      (+ (fib (- n 1)) (fib (- n 2)))))
+(println (fib 30))                         ; 832040

--- a/docs/examples/snippets/lazy.phel
+++ b/docs/examples/snippets/lazy.phel
@@ -1,7 +1,7 @@
 (ns examples\snippets\lazy)
 
 ;; lazy-seq defers computation until elements are realized
-(defn ints-from [n] (lazy-seq (cons n (ints-from (inc n)))))
+(defn ints-from [^int n] (lazy-seq (cons n (ints-from (inc n)))))
 
 (println (take 5 (ints-from 10)))          ; (10 11 12 13 14)
 

--- a/docs/examples/snippets/loop-recur.phel
+++ b/docs/examples/snippets/loop-recur.phel
@@ -1,9 +1,10 @@
 (ns examples\snippets\loop-recur)
 
-;; Factorial with loop/recur (constant stack)
-(defn fact [n]
+;; Factorial with loop/recur (constant stack).
+;; `*'` auto-promotes to BigInteger if PHP int overflows, e.g. (fact 21).
+(defn fact [^int n]
   (loop [i n acc 1]
-    (if (<= i 1) acc (recur (dec i) (* acc i)))))
+    (if (<= i 1) acc (recur (dec i) (*' acc i)))))
 
 (println (fact 5))                         ; 120
 (println (fact 10))                        ; 3628800

--- a/docs/examples/transducers.phel
+++ b/docs/examples/transducers.phel
@@ -342,12 +342,14 @@
 
 (def raw-scores [nil 85 "invalid" 92 nil 78 101 65 -5 88])
 
-;; Pipeline: remove nils -> keep numbers in 0..100 -> normalize to 0.0..1.0
+;; Pipeline: remove nils -> keep numbers in 0..100 -> normalize to 0.0..1.0.
+;; Use `(/ % 100.0)` (float divisor) to get floats; `(/ 85 100)` returns the
+;; rational 17/20 under the numeric tower.
 (def normalized-scores
   (let [xf (comp (filter #(not (nil? %)))
                  (filter number?)
                  (filter #(and (>= % 0) (<= % 100)))
-                 (map #(/ % 100)))]
+                 (map #(/ % 100.0)))]
     (into [] xf raw-scores)))
 ;; => [0.85 0.92 0.78 0.65 0.88]
 
@@ -362,7 +364,7 @@
                    (case (count args)
                      0 {:sum 0 :count 0}
                      1 (let [r (first args)]
-                         (/ (get r :sum) (get r :count)))
+                         (/ (get r :sum) (double (get r :count))))
                      2 (let [acc (first args)
                              x (second args)]
                          {:sum (+ (get acc :sum) x)

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -1,14 +1,14 @@
 # Framework Integration Recipes
 
-Add Phel to an existing PHP project without touching `app/` or `src/`.
+Add Phel to a PHP project without touching `app/` or `src/`.
 
 ## Core idea
 
 1. Keep Phel sources under `phel/`.
 2. Mark public functions with `{:export true}`.
-3. Create **one boot namespace** (`app\boot`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
+3. Create one boot namespace (`app\boot`) that `:require`s every feature namespace. Loading it registers all exported functions at once.
 4. Export PHP wrappers under your framework's `App\` PSR-4 root via `phel export`.
-5. Prod: build at deploy (`phel build`), `require 'build/app/boot.php'` at boot. Dev: `\Phel::run($root, 'app\\boot')` compiles on first call.
+5. Prod: `phel build` at deploy, `require 'build/app/boot.php'` at boot. Dev: `\Phel::run($root, 'app\\boot')` compiles on first call.
 
 Two ways to call Phel from PHP:
 
@@ -58,7 +58,7 @@ phel/
   (:require auth\tokens))
 ```
 
-Loading `app\boot` (via `require` or `\Phel::run()`) registers **every** exported function across all three namespaces. Any controller can then call any wrapper:
+Loading `app\boot` (via `require` or `\Phel::run()`) registers every exported function across all three namespaces. Any controller can call any wrapper:
 
 ```php
 App\PhelGenerated\Shop\Pricing::applyDiscount(...)
@@ -66,7 +66,7 @@ App\PhelGenerated\Reports\Daily::summary(...)
 App\PhelGenerated\Auth\Tokens::makeToken(...)
 ```
 
-New Phel feature: add the file, add one `:require` in `app/boot.phel`, run `phel export` + `phel build`.
+New feature: add the file, add one `:require` in `app/boot.phel`, run `phel export` + `phel build`.
 
 ---
 
@@ -121,7 +121,7 @@ final class PhelServiceProvider extends ServiceProvider
 }
 ```
 
-Controller (any wrapper works without further setup):
+Controller:
 
 ```php
 use App\PhelGenerated\Shop\Pricing;
@@ -194,7 +194,7 @@ public function boot(): void
 }
 ```
 
-Controllers use any wrapper: `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the single boot load.
+Controllers use any wrapper: `App\PhelGenerated\Reports\Daily`, `App\PhelGenerated\Shop\Pricing`, etc. All registered by the boot load.
 
 ---
 
@@ -238,13 +238,13 @@ echo $greet('World') . "\n";
 
 ## Notes
 
-- **Boot namespace**: `phel/app/boot.phel` lists one `(:require other\ns)` per feature namespace. The build step walks those requires transitively, so `build/app/boot.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function in one shot. Controllers then call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` in `app/boot.phel`, rerun `phel export` + `phel build`.
+- **Boot namespace**: `phel/app/boot.phel` lists one `(:require other\ns)` per feature namespace. The build walks requires transitively, so `build/app/boot.php` `require_once`s every dependency. Loading it from the provider/kernel registers every `{:export true}` function. Controllers call any wrapper without knowing which Phel files exist. New feature: create the `.phel` file, add one `:require` in `app/boot.phel`, rerun `phel export` + `phel build`.
 - Namespace path matches directory: `phel/shop/pricing.phel` to `(ns shop\pricing)`. Single-segment ns exports invalid PHP; use at least two segments.
 - Hyphens become camelCase: `(ns my-lib\core)` to `App\PhelGenerated\MyLib\Core`; `apply-discount` to `applyDiscount`.
-- Prod path (`require build/app/boot.php`): self-contained, no Gacela bootstrap, no compiler, just `\Phel::addDefinition()` calls.
+- Prod path (`require build/app/boot.php`): self-contained, no Gacela bootstrap, no compiler. Just `\Phel::addDefinition()` calls.
 - Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag; never call from Laravel `register()` or per-request hot paths.
 - `setBuildConfig()` dest dir is relative to the project root.
-- Commit `build/` in the deploy artifact or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
+- Commit `build/` in the deploy artifact, or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 
 ## See also

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -8,17 +8,17 @@
 4. [Macros](macros.md): `macroexpand`, quasiquote, auto-gensym.
 5. [Runtime](runtime.md): `Lang/`, persistent collections, `Registry`, `\Phel` facade.
 6. [Benchmarks](benchmarks.md): PHPBench setup.
-7. [FAQ](faq.md): grouped by reader (PHP dev, Clojure dev, compiler hacker, tool builder, bug hunter).
+7. [FAQ](faq.md): grouped by reader.
 
 ## What to read for what
 
 | Goal | Path |
 |------|------|
-| Whole system | architecture → compiler → runtime |
-| Add a special form / fix analyzer | compiler → special-forms |
+| Whole system | architecture, compiler, runtime |
+| Add a special form / fix analyzer | compiler, special-forms |
 | Write or debug a macro | macros + `(macroexpand-1 ...)` |
-| Build an editor / linter / tool | architecture → faq (tool builder) |
-| Compilation bug | compiler → faq (bug hunting) |
+| Build an editor / linter / tool | architecture, faq (tool builder) |
+| Compilation bug | compiler, faq (bug hunting) |
 | Profile | benchmarks |
 
 ## Adjacent

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -14,7 +14,7 @@ Compiler is PHP. Stdlib is Phel: bulk in `src/phel/core.phel`.
 
 ## Modules
 
-Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) module: `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring.
+Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) module. `Facade` for public API, `Provider` for cross-module deps, `Factory` for internal wiring.
 
 | Module | Purpose |
 |--------|---------|
@@ -52,7 +52,7 @@ Rules:
 
 - Never instantiate another module's class directly. Go via Facade.
 - Never reach into another module's `Domain/`.
-- Add a method to *your* facade before consuming someone else's internals.
+- Add a method to your facade before consuming someone else's internals.
 
 Provider declares deps as facade constants:
 
@@ -82,13 +82,11 @@ Each module ships `CLAUDE.md` with API + constraints. Read it before editing.
           Lang  ◄── Printer
 ```
 
-- Everything → `Compiler/`, `Lang/`.
+- Everything depends on `Compiler/` and `Lang/`.
 - `Lang/` is a leaf (one outbound `__toString()` to `Printer`).
 - `Lsp/`, `Nrepl/`, `Watch/` reuse the compiler facade; not on the compile path.
 
 ## Compile-time vs runtime
-
-Two conceptual processes:
 
 - **Compile**: `CompilerFacade::compile()`. Holds `GlobalEnvironment`, macros, `TypeFactory`/`Registry`.
 - **Runtime**: executes emitted PHP. Sees only `\Phel::*`, `\phel\core\*`, `Lang/` types.

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -1,16 +1,14 @@
 # Benchmarking Phel
 
-[PHPBench](https://phpbench.readthedocs.io/) is in `require-dev` to measure runtime cost of developer workflows and core data structures. Run the suite regularly to spot regressions before release.
+[PHPBench](https://phpbench.readthedocs.io/) is in `require-dev` to measure runtime cost of developer workflows and core data structures. Run the suite to spot regressions before release.
 
-The suite covers three areas:
+Three areas:
 
-- **CLI commands**: `phel run` and `phel test` exercised end-to-end.
-- **Persistent collections**: vectors and hash maps checked for hot operations like `append`, `update`, and `put`.
-- **Core bootstrap**: loading and executing the bundled `phel\core` namespace keeps compiler startup time predictable.
+- **CLI commands**: `phel run` and `phel test` end-to-end.
+- **Persistent collections**: vectors and hash maps for hot ops like `append`, `update`, `put`.
+- **Core bootstrap**: loading and executing the bundled `phel\core` namespace, to track compiler startup time.
 
 ## Running the suite
-
-Execute the full suite with:
 
 ```bash
 composer phpbench
@@ -19,19 +17,28 @@ composer phpbench
 Record a baseline and compare the current branch against it:
 
 ```bash
-# Create or update the baseline numbers (stored under the `baseline` tag)
+# Create or update baseline (stored under the `baseline` tag)
 composer phpbench-base
 
-# Compare the current state with the recorded baseline
+# Compare current state with baseline
 composer phpbench-ref
 ```
 
 The assertion in [`phpbench.json`](../../phpbench.json) fails the comparison when the measured mode deviates beyond the configured threshold.
 
-For quick local checks, override iterations and revolutions:
+Override iterations and revolutions for quick local checks:
 
 ```bash
 composer phpbench -- --iterations=2 --revs=10
 ```
 
-See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting and configuration.
+JIT specialization wins on `:tag`-annotated fns can be measured by `TypedSignatureBench`:
+
+```bash
+composer bench-jit-baseline   # opcache off, no JIT
+composer bench-jit-tracing    # opcache on, tracing JIT
+```
+
+Compare the two runs to see what typed signatures unlock at runtime.
+
+See the [PHPBench docs](https://phpbench.readthedocs.io/) for advanced reporting.

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -15,7 +15,7 @@ Paths are relative to `src/php/Compiler/`.
 
 ## Public entry points (`CompilerFacade`)
 
-- `compile()` / `compileForCache()`: full pipeline → `EmitterResult`
+- `compile()` / `compileForCache()`: full pipeline to `EmitterResult`
 - `compileForm()`: start from already-read Phel data
 - `eval()` / `evalForm()`: compile + execute
 - `lexString()` / `parseAll()` / `read()` / `analyze()`: single-stage hooks for LSP, nREPL, linter
@@ -32,18 +32,18 @@ T_STRING            "\"hi\""
 T_CLOSE_PARENTHESIS ")"
 ```
 
-**Parser**: sub-parsers under `Domain/Parser/ExpressionParser/` (`ListParser`, `VectorParser`, `MapParser`, …) wired by `ExpressionParserFactory`. Tree retains trivia.
+**Parser**: sub-parsers under `Domain/Parser/ExpressionParser/` (`ListParser`, `VectorParser`, `MapParser`, ...) wired by `ExpressionParserFactory`. Tree retains trivia.
 
 ```text
 ListNode → SymbolNode("print"), WhitespaceNode, StringNode("\"hi\"")
 ```
 
-**Reader**: parse tree → Phel data backed by `Lang/Collections/`. Drops trivia. Expands reader macros: `'x`, `` `x ``, `~x`, `~@x`, `#(...)`, `#inst`, `#regex`, `#php`, custom `#tag` (`Lang/TagHandlers/`). Quasiquote rewrite + auto-gensym in `Domain/Reader/QuasiquoteTransformer.php`.
+**Reader**: parse tree to Phel data backed by `Lang/Collections/`. Drops trivia. Expands reader macros: `'x`, `` `x ``, `~x`, `~@x`, `#(...)`, `#inst`, `#regex`, `#php`, custom `#tag` (`Lang/TagHandlers/`). Quasiquote rewrite + auto-gensym in `Domain/Reader/QuasiquoteTransformer.php`.
 
-**Analyzer**: Phel data → AST in `Domain/Analyzer/Ast/`. Dispatch by value type in `Domain/Analyzer/TypeAnalyzer/`:
+**Analyzer**: Phel data to AST in `Domain/Analyzer/Ast/`. Dispatch by value type in `Domain/Analyzer/TypeAnalyzer/`:
 
 - `AnalyzeLiteral`: scalars, keywords
-- `AnalyzeSymbol`: locals → globals → suggestion error
+- `AnalyzeSymbol`: locals, then globals, then suggestion error
 - `AnalyzePersistentList`: special form (see [special-forms.md](special-forms.md)) or `InvokeSymbol`
 - `AnalyzePersistentVector` / `Map` / `Set`: collection literals
 
@@ -55,12 +55,12 @@ Every node carries `NodeEnvironment` with:
 - **locals** + **shadowed**: `withMergedLocals`, `withShadowedLocal`
 - **recur frame**: innermost `loop`/`fn`
 
-Wrong context → wrong PHP. Emitter trusts what analyzer wrote.
+Wrong context yields wrong PHP. Emitter trusts what analyzer wrote.
 
-**Emitter**: one `*Emitter.php` per AST node under `Domain/Emitter/OutputEmitter/NodeEmitter/`. Unknown node = throw.
+**Emitter**: one `*Emitter.php` per AST node under `Domain/Emitter/OutputEmitter/NodeEmitter/`. Unknown node throws.
 
-- **Munge** (`Application/Munge.php`): `my-fn?` → `my_fn_QMARK_`, `+` → `_PLUS_`. Same algorithm in `Lang/Collections/Struct/StructKeyEncoder`.
-- **Source maps** (`Domain/Emitter/OutputEmitter/SourceMap/`): emitted line → Phel `SourceLocation`.
+- **Munge** (`Application/Munge.php`): `my-fn?` becomes `my_fn_QMARK_`, `+` becomes `_PLUS_`. Same algorithm in `Lang/Collections/Struct/StructKeyEncoder`.
+- **Source maps** (`Domain/Emitter/OutputEmitter/SourceMap/`): emitted line back to Phel `SourceLocation`.
 - **Modes** (`EmitMode`): `STATEMENT` (REPL, `eval`), `FILE` (cached compilation). `StatementEmitter` vs `FileEmitter`.
 
 ```php
@@ -69,10 +69,10 @@ Wrong context → wrong PHP. Emitter trusts what analyzer wrote.
 
 **Evaluator**
 
-- `RequireEvaluator`: temp file + `require`. Production path; opcache-friendly.
+- `RequireEvaluator`: temp file + `require`. Production path, opcache-friendly.
 - `InMemoryEvaluator`: `eval()` for tests.
 
-Each top-level form runs lex→…→eval before the next is analysed, so `defmacro` is available to following forms. See `Application/CodeCompiler.php`.
+Each top-level form runs lex through eval before the next is analysed, so `defmacro` is available to following forms. See `Application/CodeCompiler.php`.
 
 ## See also
 

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -14,7 +14,7 @@ Grouped by reader.
 
 **Xdebug, Psalm, PHPStan?** Yes, on the generated PHP. Source maps point traces back to `.phel`. `composer test-quality` runs Psalm + PHPStan on `src/php/`.
 
-**Call cost?** Function: one `__invoke` plus arg unpacking. Negligible. Collections: trie-backed, O(log32 n) with small constants. See [benchmarks.md](benchmarks.md).
+**Call cost?** Function: one `__invoke` plus arg unpacking, negligible. Collections: trie-backed, O(log32 n) with small constants. See [benchmarks.md](benchmarks.md).
 
 ## Coming from Clojure
 
@@ -24,7 +24,7 @@ Grouped by reader.
 
 **Hygienic macros?** Quasiquote namespace-qualifies symbols at read time. `x#` inside a quasiquote expands to a fresh gensym consistent within that quasiquote. See [macros.md](macros.md).
 
-**REPL? nREPL?** Both. `phel repl` interactive; `phel nrepl` over bencode/TCP. See [nrepl-guide.md](../nrepl-guide.md).
+**REPL? nREPL?** Both. `phel repl` is interactive. `phel nrepl` runs over bencode/TCP. See [nrepl-guide.md](../nrepl-guide.md).
 
 **`recur` and tail calls.** Loop body becomes `while (true) { ... }` rebinding parameters. No stack growth. PHP has no TCO; `recur` does not need it.
 
@@ -51,7 +51,7 @@ $emit   = $facade->compile('(print "hi")', new CompileOptions());
 
 **Add a core function.** Pure Phel: `src/phel/core/...` with `:doc`, `:see-also`, `:example`. Run `composer test-core`. Needs PHP: thin wrapper under `src/phel/...` calling a PHP helper, run `composer test-compiler` + `composer test-core`.
 
-**`NodeEnvironment` context.** `Expression`, `Statement`, `Return`. Analyzer picks based on position (function body last form: `Return`; `if` branch in expression position: `Expression`). Wrong PHP output? 90% of the time wrong context, not the emitter. Helpers: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
+**`NodeEnvironment` context.** `Expression`, `Statement`, `Return`. Analyzer picks based on position (function body last form: `Return`; `if` branch in expression position: `Expression`). Wrong PHP output is usually a wrong context, not an emitter bug. Helpers: `withReturnContext()`, `withStatementContext()`, `withExpressionContext()`.
 
 **Broken integration fixture.** Update only if new PHP is intentional. Verify by hand first. The `fixture-reviewer` agent (`.claude/agents/`) audits drift.
 
@@ -79,11 +79,11 @@ $emit   = $facade->compile('(print "hi")', new CompileOptions());
 
 ## Bug hunting
 
-**"Cannot resolve symbol X".** `AnalyzeSymbol` checks locals → current ns globals → `use` aliases → `phel\core`. Miss: `SymbolSuggestionProvider` builds a suggestion + throws with `SourceLocation`. Common cause: missing `(require ...)`.
+**"Cannot resolve symbol X".** `AnalyzeSymbol` checks locals, then current-ns globals, then `use` aliases, then `phel\core`. Miss: `SymbolSuggestionProvider` builds a suggestion and throws with `SourceLocation`. Common cause: missing `(require ...)`.
 
 **"Type X cannot be coerced" or unexpected `nil`.** Run `(macroexpand-1 'form)`. Often a macro expansion surprise.
 
-**Compiles fine, runtime is weird.** Read the cached `.php`. Surprising emit = analyzer bug (wrong context, wrong recur frame, wrong locals). Emitter just transcribes.
+**Compiles fine, runtime is weird.** Read the cached `.php`. Surprising emit usually means an analyzer bug (wrong context, wrong recur frame, wrong locals). The emitter only transcribes.
 
 **`Lang/` change breaks ten modules.** Working as designed. `composer test` before push. Faster signal: `composer test-compiler`.
 

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -1,10 +1,10 @@
 # Macros
 
-Compile-time function. Takes Phel forms, returns Phel forms. Analyzer replaces the call with the result. Emitter never sees the macro.
+Compile-time function. Takes Phel forms, returns Phel forms. Analyzer replaces the call with the result. The emitter never sees the macro.
 
 ## Mechanism
 
-`(defmacro when [test & body] ...)` is a `def` whose `Variable` carries `:macro true`. At runtime: a function. At compile time, the analyzer:
+`(defmacro when [test & body] ...)` is a `def` whose `Variable` carries `:macro true`. At runtime it is a function. At compile time, the analyzer:
 
 1. Sees `(when x y)`.
 2. Resolves head to `GlobalVarNode`.
@@ -73,10 +73,10 @@ Explicit form: `(gensym)` or `(gensym "prefix")`.
 
 ## Common bites
 
-- **Order matters.** `defmacro` only affects later forms. `(defmacro foo ...)` and `(foo ...)` in the same compilation unit will not see each other; split.
+- **Order matters.** `defmacro` only affects later forms. `(defmacro foo ...)` and `(foo ...)` in the same compilation unit will not see each other. Split them.
 - **Return Phel data, not PHP values.** `(rand)` in a macro body bakes one number into source.
 - **Compile-time side effects fire during compile.** `println` in a macro runs at build, not runtime.
-- **`macroexpand` ends on `equals()`.** A macro that produces a structurally identical form terminates fine; non-converging chain is a bug.
+- **`macroexpand` ends on `equals()`.** A macro that produces a structurally identical form terminates fine. A non-converging chain is a bug.
 
 ## Debugging
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -20,8 +20,8 @@ Three concerns: types, per-namespace `Registry`, value equality + hashing.
 | Type | Notes |
 |------|-------|
 | `Symbol` | Identifier with optional ns. `NAME_*` constants name special forms. |
-| `Keyword` | Interned `:foo`. Implements `FnInterface` → `(:foo m)` is a map lookup. |
-| `Variable` | Mutable cell with watches/validators; `def` wraps values in one. |
+| `Keyword` | Interned `:foo`. Implements `FnInterface`, so `(:foo m)` is a map lookup. |
+| `Variable` | Mutable cell with watches/validators. `def` wraps values in one. |
 | `Delay` | One-shot lazy value (not a sequence). |
 | `Volatile` | Mutable box for transducer state. |
 | `Reduced` | Early-termination sentinel for `reduce`/`transduce`. |
@@ -32,27 +32,27 @@ All types implement `TypeInterface` (composes `MetaInterface`, `SourceLocationIn
 
 ## Persistent collections (`Lang/Collections/`)
 
-Immutable; "modify" returns a new value with structural sharing.
+Immutable. "Modify" returns a new value with structural sharing.
 
 | Type | Impl |
 |------|------|
 | Vector | `PersistentVector`: 32-way trie |
-| Map | `PersistentArrayMap` (small) → `PersistentHashMap` (HAMT) |
+| Map | `PersistentArrayMap` (small) promoted to `PersistentHashMap` (HAMT) |
 | List | `PersistentList` (singly linked) |
 | Set | `PersistentHashSet` (over hash map) |
 | Lazy seq | `LazySeq`: realise + cache per element |
 | Struct | `AbstractPersistentStruct`: fixed-key map, subclassed by `defstruct` |
 
-Transients for bulk building: `as-transient` → mutate → `persistent!`. Never let a transient escape its scope.
+Transients for bulk building: `as-transient`, mutate, `persistent!`. Never let a transient escape its scope.
 
 `TypeFactory` (singleton): `emptyVector()`, `emptyMap()`, `vectorFromArray()`. Compiler emits via `\Phel::vector(...)`, `\Phel::map(...)`, `\Phel::set(...)`.
 
 ## Equality + hashing
 
-Value equality: `(= [1 2] [1 2])` true regardless of object identity.
+Value equality: `(= [1 2] [1 2])` is true regardless of object identity.
 
 - `Equalizer`: `===` for scalars, structural for collections.
-- `Hasher`: `int` hashes that agree with `Equalizer`. Mismatch = lost map entries.
+- `Hasher`: `int` hashes that agree with `Equalizer`. A mismatch loses map entries.
 
 Built-in types participate. PHP objects fall back to `spl_object_hash` (identity).
 
@@ -63,18 +63,18 @@ Built-in types participate. PHP objects fall back to `spl_object_hash` (identity
 | `Lang\Registry` (singleton) | runtime | `ns → name → value` + metadata |
 | `GlobalEnvironment` (`Compiler/Domain/Analyzer/Environment/`) | compile time | what analyzer knows about declared names |
 
-Each top-level form compiles + evaluates before the next is analysed → both stay in sync. `defmacro` becomes available immediately to following forms. Reset both: `CompilerFacade::resetGlobalEnvironment()`.
+Each top-level form compiles + evaluates before the next is analysed, so both stay in sync. `defmacro` becomes available immediately to following forms. Reset both with `CompilerFacade::resetGlobalEnvironment()`.
 
 ## `\Phel` static facade
 
-`src/php/Phel.php` is the runtime ABI. Cached `.php` files in the wild call into it. Signature changes = breaking.
+`src/php/Phel.php` is the runtime ABI. Cached `.php` files in the wild call into it. Signature changes are breaking.
 
 - `addDefinition($ns, $name, $value, $meta = null)`
 - `keyword($name)` / `namespacedKeyword($ns, $name)` / `symbol($name)`
 - `vector(...$items)` / `map(...$kvs)` / `set(...$items)`
 - `ns($name)`: switch current namespace
 
-Change a signature → audit `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/*Emitter.php`.
+Changing a signature requires auditing `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/*Emitter.php`.
 
 ## Reader tags (`#tag`)
 
@@ -82,7 +82,7 @@ Change a signature → audit `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/
 
 ## Source locations
 
-Carried lexer → AST → emitted source map. Don't drop. When constructing a form inside a special-form handler, `Symbol::copyLocationFrom($nearby)` (examples throughout `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`).
+Carried lexer to AST to emitted source map. Don't drop. When constructing a form inside a special-form handler, use `Symbol::copyLocationFrom($nearby)`. Examples throughout `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`.
 
 ## See also
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -1,10 +1,10 @@
 # Special Forms
 
-List with a recognised head symbol routed to a dedicated analyzer. Anything else (not a special form, not a macro, not a literal collection) is a function call. Macros expand into special forms: special forms are the bottom.
+A list with a recognised head symbol routes to a dedicated analyzer. Anything else (not a special form, not a macro, not a literal collection) is a function call. Macros expand into special forms; special forms are the bottom.
 
 ## Dispatch
 
-`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. Match → `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. Miss → `InvokeSymbol`.
+`Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php` matches the head against `Symbol::NAME_*` constants in `src/php/Lang/Symbol.php`. On match, dispatches to a `SpecialFormAnalyzerInterface` impl in `Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/`. On miss, falls through to `InvokeSymbol`.
 
 ```php
 match ($symbolName) {
@@ -49,7 +49,7 @@ Each handler returns one `AbstractNode`. Emitter has 1:1 mapping to `*Emitter.ph
 
 ## Type definitions (low-level)
 
-Trailing `*` = not user-facing. Macros `defstruct`, `definterface`, `defexception`, `reify` expand into these.
+Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexception`, `reify` expand into these.
 
 | Form | Const | Handler | Node |
 |------|-------|---------|------|
@@ -74,15 +74,15 @@ Trailing `*` = not user-facing. Macros `defstruct`, `definterface`, `defexceptio
 
 ## Not special forms
 
-- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>` → macros in `phel\core`
-- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify` → macros over `*` forms
-- `+`, `-`, `=`, `map`, `filter`, … → functions in `phel\core`
+- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`: macros in `phel\core`
+- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify`: macros over `*` forms
+- `+`, `-`, `=`, `map`, `filter`, ...: functions in `phel\core`
 
-`(macroexpand-1 'form)` to see the truth.
+Run `(macroexpand-1 'form)` to see the truth.
 
 ## Adding one
 
-5 touches. Skip → throws at compile time.
+5 touches. Skipping any throws at compile time.
 
 1. `public const string NAME_FOO = 'foo';` in `src/php/Lang/Symbol.php`
 2. `FooNode extends AbstractNode` in `Compiler/Domain/Analyzer/Ast/`

--- a/docs/lazy-sequences.md
+++ b/docs/lazy-sequences.md
@@ -1,16 +1,10 @@
 # Lazy Sequences in Phel
 
-Work with potentially infinite collections by deferring computation until values are needed.
-
-## Overview
-
-Two constructs:
-- **`lazy-seq`**: creates a lazy sequence from an expression
-- **`lazy-cat`**: lazily concatenates multiple collections
+Defer computation until values are needed. Two constructs: `lazy-seq` wraps an expression; `lazy-cat` concatenates collections.
 
 ## The `lazy-seq` Macro
 
-`lazy-seq` takes a body returning a sequence or nil and yields a LazySeq that invokes the body on first access, caching the result.
+`lazy-seq` takes a body returning a sequence or nil. It yields a LazySeq that runs the body on first access and caches the result.
 
 ### Basic Usage
 
@@ -32,7 +26,7 @@ Combine `lazy-seq` with recursion to build infinite sequences:
 
 ```phel
 ;; Generate infinite sequence of integers starting from n
-(defn ints-from [n]
+(defn ints-from [^int n]
   (lazy-seq
     (cons n (ints-from (inc n)))))
 
@@ -50,11 +44,7 @@ Combine `lazy-seq` with recursion to build infinite sequences:
 
 ## The `lazy-cat` Macro
 
-Convenient syntax for concatenating collections.
-
-**Important:** `lazy-cat` expands to `concat` and evaluates all arguments eagerly.
-Fine for combining finite or already-realized lazy sequences, but
-**NOT suitable for recursive infinite sequences**.
+Concatenates collections. Expands to `concat` and evaluates arguments eagerly. Fine for finite or already-realized sequences, **not** for recursive infinite ones.
 
 ### Basic Concatenation
 
@@ -91,9 +81,7 @@ When building recursive infinite sequences, use `cons` instead:
   (lazy-seq (lazy-cat [n] (ints (inc n)))))  ; Don't do this!
 ```
 
-**Why?** `lazy-cat` evaluates all arguments before concatenating, so the
-recursive call `(ints (inc n))` runs immediately and recurses forever.
-Use `cons` to defer evaluation.
+`lazy-cat` evaluates all arguments before concatenating, so the recursive call runs immediately and never returns. `cons` defers evaluation.
 
 ## Common Patterns
 
@@ -116,7 +104,7 @@ Use `cons` to defer evaluation.
   (let [sieve (fn sieve [s]
                 (lazy-seq
                   (cons (first s)
-                        (sieve (filter (fn [x] (not= 0 (php/% x (first s))))
+                        (sieve (filter (fn [x] (not= 0 (mod x (first s))))
                                        (rest s))))))]
     (sieve (ints-from 2))))
 
@@ -164,7 +152,7 @@ Many core functions return lazy sequences:
 
 ;; Lazy composition
 (->> (range 100)
-     (filter (fn [x] (= 0 (php/% x 2))))
+     (filter even?)
      (map (fn [x] (* x x)))
      (take 5))
 ;; => [0 4 16 36 64]
@@ -178,20 +166,20 @@ Many core functions return lazy sequences:
 
 ### When to Use Lazy Sequences
 
-**Use lazy sequences when:**
-- Working with large or infinite collections
+**Use:**
+- Large or infinite collections
 - Not all elements will be consumed
-- Composition of transformations is important
+- Composing transformations
 - Memory efficiency matters
 
-**Avoid lazy sequences when:**
-- All elements will be accessed immediately
+**Avoid:**
+- All elements accessed immediately
 - Multiple iterations over the same sequence
-- Holding onto the head causes memory leaks
+- Holding the head causes memory leaks
 
 ### Chunking
 
-Phel's lazy sequences realize elements in chunks rather than one at a time. This reduces overhead but means:
+Lazy sequences realize elements in chunks. Lower overhead, but:
 
 ```phel
 ;; Side effects may happen in chunks
@@ -275,20 +263,6 @@ Side effects run on realization, not creation:
 
 ## Further Reading
 
-- Lazy sequence examples: `docs/examples/`
-- Core function reference: docstrings in `src/phel/core.phel`
+- Examples: `docs/examples/`
+- Core function reference: docstrings in `src/phel/core/`
 - Clojure lazy sequences: https://clojure.org/reference/sequences
-
-## Summary
-
-Lazy sequences provide:
-- **Memory efficiency**: process large datasets without loading everything
-- **Composability**: chain transformations
-- **Infinite sequences**: work with conceptually infinite collections
-- **Performance**: compute only what's needed
-
-Key takeaways:
-- Use `lazy-seq` for custom lazy sequences
-- Use `cons` (not `lazy-cat`) for recursive infinite sequences
-- Watch for chunking and head retention
-- Force realization with `doall`/`dorun` when needed

--- a/docs/lint-guide.md
+++ b/docs/lint-guide.md
@@ -1,6 +1,6 @@
 # Linter Guide
 
-`phel lint` catches common mistakes without running code. Source files or directories; outputs human, JSON, or GitHub Actions format.
+`phel lint` catches common mistakes without running code. Accepts files or directories; outputs human, JSON, or GitHub Actions format.
 
 ## Quickstart
 
@@ -48,11 +48,11 @@ Pass a custom path with `--config=path/to/lint.phel`.
 
 ## Cache
 
-Results are cached per file by content hash; subsequent runs only reanalyze changed files. Disable with `--no-cache`.
+Results are cached per file by content hash. Subsequent runs only reanalyze changed files. Disable with `--no-cache`.
 
 ## Editor integration
 
-Use `--format=json` from an editor plugin, or run `phel lsp` for real-time diagnostics as you type.
+Use `--format=json` from an editor plugin, or run `phel lsp` for live diagnostics.
 
 ## See also
 

--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -1,6 +1,6 @@
 # Language Server Guide
 
-`phel lsp` speaks LSP v3.17 over stdio (JSON-RPC 2.0). Provides hover, goto-definition, completion, references, rename, formatting, document/workspace symbols, and live diagnostics.
+`phel lsp` speaks LSP v3.17 over stdio (JSON-RPC 2.0). Hover, goto-definition, completion, references, rename, formatting, document/workspace symbols, live diagnostics.
 
 ## Starting the server
 
@@ -8,7 +8,7 @@
 ./vendor/bin/phel lsp
 ```
 
-Reads LSP messages on stdin, writes responses on stdout, logs to stderr.
+Reads on stdin, writes on stdout, logs to stderr.
 
 ## Capabilities
 
@@ -28,7 +28,7 @@ Reads LSP messages on stdin, writes responses on stdout, logs to stderr.
 
 ### VS Code
 
-Install a generic LSP client extension and point it at `./vendor/bin/phel lsp` with `phel` as the language id and `.phel` as the file extension.
+Install a generic LSP client extension. Point it at `./vendor/bin/phel lsp` with `phel` as the language id and `.phel` as the file extension.
 
 ### Neovim (built-in LSP)
 
@@ -50,13 +50,13 @@ vim.lsp.start({
 
 ## Diagnostics
 
-Diagnostics include compiler errors, unresolved symbols, arity mismatches, and lint violations. Publication is debounced so typing does not thrash.
+Compiler errors, unresolved symbols, arity mismatches, and lint violations. Publication is debounced so typing does not thrash.
 
 ## Pitfalls
 
-- The server scans files under the project root; keep `phel-config.php` current for require resolution
-- Large projects benefit from running `phel index` ahead of time to warm the symbol cache
-- LSP runs in its own PHP process; REPL state is not shared with a running `phel nrepl`
+- The server scans files under the project root. Keep `phel-config.php` current for require resolution.
+- Large projects benefit from running `phel index` to warm the symbol cache.
+- LSP runs in its own PHP process. REPL state is not shared with a running `phel nrepl`.
 
 ## See also
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -1,18 +1,12 @@
-# Migration: backslash namespace separator → dot
+# Migration: backslash namespace separator to dot
 
-Phel historically uses the PHP-style backslash (`\`) as the namespace
-separator in every position: `ns` forms, `:require`/`:use` clauses,
-fully-qualified call sites, and class FQNs. The dot (`.`) is the
-target form going forward. The backslash form is **deprecated** and
-will be removed in a future release.
+Phel historically used the PHP-style backslash (`\`) as the namespace separator in every position: `ns` forms, `:require`/`:use` clauses, fully-qualified call sites, and class FQNs. The dot (`.`) is the target form going forward. The backslash form is **deprecated** and will be removed in a future release.
 
-See tracking issue:
-[phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
+Tracking issue: [phel-lang/phel-lang#1567](https://github.com/phel-lang/phel-lang/issues/1567).
 
 ## Opt-in to deprecation warnings
 
-Three equivalent ways to enable warnings; pick whichever fits
-your pipeline:
+Three equivalent ways. Pick whichever fits your pipeline.
 
 **CLI flag** (recommended for one-off runs and CI configs):
 
@@ -34,30 +28,17 @@ return PhelConfig::forProject()
     ->setWarnDeprecations(true);
 ```
 
-When enabled, the compiler emits one `E_USER_DEPRECATED` per unique
-`(file, symbol)` pair so large projects do not drown in duplicates.
-`--warn-deprecations` is consumed by the `phel` bootstrap before
-Symfony's per-command parsers run, so it works with every subcommand.
-
+When enabled, the compiler emits one `E_USER_DEPRECATED` per unique `(file, symbol)` pair so large projects do not drown in duplicates. `--warn-deprecations` is consumed by the `phel` bootstrap before Symfony's per-command parsers run, so it works with every subcommand.
 
 ## What is detected today
 
-Symbols flowing through the analyzer's `SymbolResolver` or the
-`ns`-form analyzer emit warnings:
+Symbols flowing through the analyzer's `SymbolResolver` or the `ns`-form analyzer emit warnings:
 
-- **Namespace declarations** (Phase 1b): `(ns phel\foo)` → use
-  `(ns phel.foo)`
-- **`:require` targets** (Phase 1b, flat and `[ns :as alias]` vector
-  forms): `(:require phel\walk)` → `(:require phel.walk)`
-- **Fully-qualified call sites** (Phase 1a): `(phel\core/map inc xs)`
-  → `(phel.core/map inc xs)`
-- **Leading-backslash class FQNs** (Phase 1a):
-  `\Phel\Lang\ExInfoException` → `Phel.Lang.ExInfoException` (the dot
-  alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553))
-
-- **`:use` targets**: `(:use Phel\Lang\Foo)` → `(:use Phel.Lang.Foo)`.
-  The analyzer already accepted the dot form; the warning just makes
-  the migration target explicit.
+- **Namespace declarations** (Phase 1b): `(ns phel\foo)` becomes `(ns phel.foo)`
+- **`:require` targets** (Phase 1b, flat and `[ns :as alias]` vector forms): `(:require phel\walk)` becomes `(:require phel.walk)`
+- **Fully-qualified call sites** (Phase 1a): `(phel\core/map inc xs)` becomes `(phel.core/map inc xs)`
+- **Leading-backslash class FQNs** (Phase 1a): `\Phel\Lang\ExInfoException` becomes `Phel.Lang.ExInfoException`. Dot alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553).
+- **`:use` targets**: `(:use Phel\Lang\Foo)` becomes `(:use Phel.Lang.Foo)`. The analyzer already accepted the dot form; the warning makes the migration target explicit.
 
 ## What is NOT yet detected
 
@@ -67,16 +48,12 @@ Tracked as follow-up sub-tasks in #1567:
 - `load` forms (take strings, not symbols)
 - Reader-macro / quoting forms that carry namespace strings as data
 
-It is safe to migrate the non-detected positions by hand now — the
-new dot forms already work at the language level.
+Migrate the non-detected positions by hand now. The new dot forms already work at the language level.
 
 ## Suppression
 
-Warnings are suppressed automatically for files under phel's bundled
-stdlib. User projects that use the nested `src/phel` layout still emit
-warnings normally.
+Warnings are suppressed automatically for files under phel's bundled stdlib. User projects that use the nested `src/phel` layout still emit warnings normally.
 
 ## Removal target
 
-TBD — tracked in #1567. At minimum one full minor-release cycle after
-the warning flag flips on by default.
+TBD, tracked in #1567. At minimum one full minor-release cycle after the warning flag flips on by default.

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -9,7 +9,7 @@ Replace dependencies with controlled stand-ins for testing.
 
 (deftest test-fetch-user
   (let [mock-http (mock {:id 1 :name "Alice"})]
-    (binding [http-get mock-http]
+    (with-redefs [http-get mock-http]
       (fetch-user 123)
       (is (called-with? mock-http "/users/123")))))
 ```
@@ -77,7 +77,5 @@ For long-running processes:
 ```phel
 (clear-all-mocks!)
 ```
-
----
 
 See `tests/phel/mock.phel` for more examples.

--- a/docs/nrepl-guide.md
+++ b/docs/nrepl-guide.md
@@ -1,6 +1,6 @@
 # nREPL Guide
 
-`phel nrepl` starts a bencode-over-TCP nREPL server. Any nREPL client (CIDER, Calva, vim-iced, neovim-nrepl) connects.
+`phel nrepl` starts a bencode-over-TCP nREPL server. Compatible with CIDER, Calva, vim-iced, and neovim-nrepl.
 
 ## Starting the server
 
@@ -42,13 +42,13 @@ Run `Calva: Connect to a running REPL`, choose `Generic nREPL`, and point at `12
 
 ### Neovim (vim-iced or Conjure)
 
-Both detect `.nrepl-port` in the repo root; set it after launching the server.
+Both detect `.nrepl-port` in the repo root. Set it after launching the server.
 
 ## Pitfalls
 
-- Single-user by default; multiple clients sharing a session see interleaved output
-- Bind to `127.0.0.1` unless on a trusted network; there is no auth
-- `interrupt` stops the eval in that session only, not other sessions or fibers
+- Single-user by default. Multiple clients sharing a session see interleaved output.
+- Bind to `127.0.0.1` unless on a trusted network. No auth.
+- `interrupt` stops the eval in that session only, not other sessions or fibers.
 
 ## See also
 

--- a/docs/numeric-tower.md
+++ b/docs/numeric-tower.md
@@ -1,27 +1,33 @@
 # Numeric tower
 
-Phel has a numeric tower built around four scalar shapes:
+Phel has a numeric tower built around five scalar shapes:
 
 | Type | Where it comes from | Notes |
 |------|---------------------|-------|
 | `int` | Native PHP `int` | 64-bit signed on common platforms |
 | `Phel\Lang\BigInteger` | `bigint`, `+'`, `*'`, etc. | Arbitrary-precision signed integer |
 | `Phel\Lang\Rational` | `1/2` literals, `/`, `rationalize` | Always normalised; collapses to `int`/`BigInteger` when integral |
+| `Phel\Lang\BigDecimal` | `1.5M` literal, `bigdec` | Arbitrary-precision exact decimal |
 | `float` | Native PHP `float` (IEEE-754 double) | Inexact |
 
 `+`, `-`, `*`, `/`, comparisons, and the predicates dispatch on these types via `Phel\Lang\NumericOperations`. PHP's native operators do not dispatch on objects, so the runtime helper does.
 
-## Differences from Clojure
+## Notes
 
-Phel diverges from Clojure's numeric tower in deliberate ways. Map your mental model:
+### Exact decimal literals: `1.5M`
 
-### No `BigDecimal`
+`M`-suffixed numerals read as `BigDecimal`. Use for monetary values and any computation where binary float drift is unacceptable.
 
-Phel does not have a base-10 floating-point type. For exact non-integer values use `Rational` (`1/3`, `(/ 1 3)`, `(rationalize 0.1)`). For inexact use `float`.
+```phel
+1.5M                ; => 1.5M (a BigDecimal)
+(+ 0.1M 0.2M)       ; => 0.3M (no float drift)
+(bigdec "3.14159")  ; => 3.14159M
+(bigdec? 1.5M)      ; => true
+```
 
-### No `1N` / `1M` literal suffixes
+### Promoting integers: `bigint` and `+'`
 
-Clojure writes `1N` for `BigInt` and `1M` for `BigDecimal`. Phel has neither suffix. Promote with the explicit constructors:
+Promote with the explicit constructors:
 
 ```phel
 (bigint 42)         ; => 42N (a BigInteger)
@@ -29,7 +35,12 @@ Clojure writes `1N` for `BigInt` and `1M` for `BigDecimal`. Phel has neither suf
 (rationalize 0.1)   ; => 1/10
 ```
 
-The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) return `BigInteger`.
+The promoting arithmetic ops (`+'`, `-'`, `*'`, `inc'`, `dec'`) auto-promote to `BigInteger` on overflow, so use them whenever overflow is possible:
+
+```phel
+(*' 1000000000 1000000000 1000000000)  ; => big enough to overflow PHP int
+(inc' 9223372036854775807)             ; => 9223372036854775808N
+```
 
 ### Large integer literals lex as `float`
 
@@ -49,7 +60,7 @@ PHP's lexer parses oversize integer literals as `float`, so the same happens in 
 
 ### `==` arity-1 asserts numeric
 
-Clojure's `(==)` and `(== x)` return `true` for any single argument. Phel's `==` requires its argument to be numeric and otherwise throws — single-argument `==` is treated as a numeric assertion, not an identity.
+Clojure's `(==)` and `(== x)` return `true` for any single argument. Phel's `==` requires its argument to be numeric and otherwise throws. Single-argument `==` is a numeric assertion, not an identity.
 
 ### `rationalize` uses shortest round-trip decimal
 
@@ -62,8 +73,9 @@ Clojure's `(==)` and `(== x)` return `true` for any single argument. Phel's `==`
 | Need | Use |
 |------|-----|
 | Exact integer beyond PHP `int` | `(bigint "...")` or promoting ops `+'`, `*'` |
-| Exact non-integer | `Rational` literal `1/2`, `(/ a b)`, `(rationalize x)` |
+| Exact non-integer ratio | `Rational` literal `1/2`, `(/ a b)`, `(rationalize x)` |
+| Exact decimal (money, etc.) | `BigDecimal` literal `1.5M`, `(bigdec "...")` |
 | Inexact decimal | native `float` |
-| Predicate | `int?`, `bigint?`, `ratio?`, `float?`, `number?` |
+| Predicate | `int?`, `bigint?`, `ratio?`, `bigdec?`, `decimal?`, `float?`, `number?` |
 | Numerator / denominator | `numerator`, `denominator` |
 | Float to exact | `rationalize` |

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -19,7 +19,7 @@
 ### Safe Navigation
 
 ```phel
-;; Instead of nested ifs
+;; Nested ifs
 (if user
   (if (get user :profile)
     (if (get (get user :profile) :address)
@@ -28,22 +28,21 @@
     nil)
   nil)
 
-;; Use threading with get
+;; Threading with get
 (-> user
     (get :profile)
     (get :address)
     (get :city))
 
-;; Or use get-in
+;; Or get-in
 (get-in user [:profile :address :city])
 ```
 
 ### Default Values
 
 ```phel
-;; Provide defaults
-(get config :port 8080)                    ; Default to 8080
-(or (get config :host) "localhost")        ; Fallback to localhost
+(get config :port 8080)                    ; Default 8080
+(or (get config :host) "localhost")        ; Fallback
 
 ;; Multiple fallbacks
 (or (get-in user [:settings :theme])
@@ -54,27 +53,27 @@
 ### Nil-Safe Operations
 
 ```phel
-;; when - executes body only if condition is truthy
+;; when: body runs only on truthy
 (when user
   (println "User:" (get user :name))
   (send-email user))
 
-;; when-let - bind and check in one
+;; when-let: bind + check
 (when-let [email (get user :email)]
   (send-notification email))
 
-;; if-let - with else clause
+;; if-let: with else
 (if-let [role (get user :role)]
   (str "User is a " role)
   "User has no role")
 
-;; some? - true when value is not nil (1-arg form)
-(some? user)                              ; => true if user is not nil
+;; some?: not nil
+(some? user)                              ; => true if not nil
 (filter some? [1 nil 2 nil 3])            ; => [1 2 3]
 
-;; boolean - coerce any value to true/false
+;; boolean: coerce
 (boolean nil)                             ; => false
-(boolean 0)                               ; => true   ; only nil/false are falsy
+(boolean 0)                               ; => true   (only nil/false falsy)
 (boolean "")                              ; => true
 ```
 
@@ -83,16 +82,15 @@
 ### Map Operations
 
 ```phel
-;; Transform all elements
 (map inc [1 2 3])                          ; => [2 3 4]
 (map str/upper-case ["hello" "world"])     ; => ["HELLO" "WORLD"]
 (map #(* % 2) [1 2 3 4])                   ; => [2 4 6 8]
 
-;; Map with index
+;; With index
 (map-indexed (fn [i x] [i x]) ["a" "b" "c"])
 ;; => [[0 "a"] [1 "b"] [2 "c"]]
 
-;; Map over multiple collections
+;; Multiple collections
 (map + [1 2 3] [10 20 30])                 ; => [11 22 33]
 (map str ["a" "b"] [1 2])                  ; => ["a1" "b2"]
 ```
@@ -100,11 +98,11 @@
 ### Filter Operations
 
 ```phel
-;; Keep matching elements
+;; Keep matching
 (filter even? [1 2 3 4 5 6])               ; => [2 4 6]
 (filter #(> % 10) [5 15 8 20 3])           ; => [15 20]
 
-;; Remove matching elements
+;; Remove matching
 (remove nil? [1 nil 2 nil 3])              ; => [1 2 3]
 (remove empty? ["a" "" "b" "" "c"])        ; => ["a" "b" "c"]
 
@@ -132,7 +130,7 @@
         [1 2 3 4 5 6])
 ;; => {:even [2 4 6] :odd [1 3 5]}
 
-;; Find maximum
+;; Maximum
 (let [coll [3 1 4 1 5 9 2 6]]
   (reduce (fn [max x] (if (> x max) x max))
           (first coll)
@@ -143,7 +141,7 @@
 ### Partition and Group
 
 ```phel
-;; Split into chunks
+;; Chunks
 (partition 2 [1 2 3 4 5 6])                ; => [[1 2] [3 4] [5 6]]
 (partition-all 3 [1 2 3 4 5])              ; => [[1 2 3] [4 5]]
 
@@ -166,16 +164,15 @@
 Threads value as **first** argument:
 
 ```phel
-;; Without threading
+;; Without
 (get (assoc (dissoc user :password) :active true) :name)
 
-;; With threading
+;; With
 (-> user
     (dissoc :password)
     (assoc :active true)
     (get :name))
 
-;; Practical example
 (-> "  Hello World  "
     (str/trim)
     (str/lower-case)
@@ -188,14 +185,12 @@ Threads value as **first** argument:
 Threads value as **last** argument:
 
 ```phel
-;; Process a collection
 (->> [1 2 3 4 5 6 7 8 9 10]
      (filter even?)
      (map #(* % 2))
      (reduce +))
 ;; => 60
 
-;; Data pipeline
 (->> users
      (filter #(get % :active))
      (map #(get % :email))
@@ -206,12 +201,12 @@ Threads value as **last** argument:
 ### When to Use Which
 
 ```phel
-;; -> for object/map operations (first arg)
+;; -> for object/map ops (first arg)
 (-> user
     (get :profile)
     (assoc :verified true))
 
-;; ->> for collection operations (last arg)
+;; ->> for collection ops (last arg)
 (->> numbers
      (filter pos?)
      (map square)
@@ -220,7 +215,7 @@ Threads value as **last** argument:
 
 ## Pattern Matching
 
-`phel\match` destructures by shape and binds symbols in one step. Use it when `cond`/`case` would force you to re-query the same value from multiple angles.
+`phel\match` destructures by shape and binds symbols in one step. Use when `cond`/`case` would re-query the same value from multiple angles.
 ```phel
 (ns app\commands
   (:require phel\match :refer [match]))
@@ -248,7 +243,7 @@ Pattern elements:
 | `(pat :as x)` | Match `pat` and also bind whole value to `x` |
 | `(:or a b c)` | Any of the alternatives |
 
-The outer `[event]` vector lets you match several values at once:
+The outer `[event]` vector matches several values at once:
 
 ```phel
 (match [http-status role]
@@ -259,7 +254,7 @@ The outer `[event]` vector lets you match several values at once:
   :else              :unknown)
 ```
 
-Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. Add `:else` when "none of these" is a valid outcome.
+Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else` when "none of these" is valid.
 
 ## Error Handling
 
@@ -283,7 +278,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Result Types (Either Pattern)
 
 ```phel
-;; Return maps with :ok or :error
+;; Maps with :ok or :error
 (defn validate-email [email]
   (if (str/contains? email "@")
     {:ok email}
@@ -295,7 +290,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
       (create-user data)
       result)))
 
-;; Alternative: use nil for errors
+;; Or nil for errors
 (defn safe-parse-int [s]
   (when (php/is_numeric s)
     (php/intval s)))
@@ -324,19 +319,18 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Atoms (Mutable References)
 
 ```phel
-;; Create atom
 (def counter (atom 0))
 
-;; Read value
+;; Read
 (deref counter)                            ; => 0
-@counter                                   ; Same (@ is shorthand)
+@counter                                   ; shorthand
 
-;; Update value
+;; Update
 (swap! counter inc)                        ; => 1
 (swap! counter #(+ % 10))                  ; => 11
 (swap! counter + 5)                        ; => 16
 
-;; Set value directly
+;; Set
 (reset! counter 0)                         ; => 0
 ```
 
@@ -372,7 +366,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
   (when *debug*
     (println "[DEBUG]" msg)))
 
-;; Temporarily override
+;; Override temporarily
 (binding [*debug* true]
   (log "This will print")
   (do-something))
@@ -385,10 +379,11 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Simple Recursion
 
 ```phel
-(defn factorial [n]
+;; Note: `*'` auto-promotes to BigInteger if PHP int overflows.
+(defn factorial [^int n]
   (if (<= n 1)
     1
-    (* n (factorial (dec n)))))
+    (*' n (factorial (dec n)))))
 
 (defn sum-list [coll]
   (if (empty? coll)
@@ -399,14 +394,12 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Tail Recursion with `recur`
 
 ```phel
-;; Tail-recursive factorial
-(defn factorial [n]
+(defn factorial [^int n]
   (loop [n n acc 1]
     (if (<= n 1)
       acc
-      (recur (dec n) (* acc n)))))
+      (recur (dec n) (*' acc n)))))
 
-;; Tail-recursive sum
 (defn sum-list [coll]
   (loop [items coll total 0]
     (if (empty? items)
@@ -417,7 +410,6 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Iterating with `loop`
 
 ```phel
-;; Process items with accumulator
 (loop [items [1 2 3 4 5]
        evens []
        odds []]
@@ -448,11 +440,10 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Vector Destructuring
 
 ```phel
-;; Basic
 (let [[a b c] [1 2 3]]
   (+ a b c))                               ; => 6
 
-;; With rest
+;; Rest
 (let [[first & rest] [1 2 3 4 5]]
   [first rest])                            ; => [1 [2 3 4 5]]
 
@@ -460,7 +451,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 (let [[a [b c]] [1 [2 3]]]
   (+ a b c))                               ; => 6
 
-;; In function parameters
+;; Function params
 (defn process-coords [[x y]]
   (+ x y))
 
@@ -470,20 +461,19 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 ### Map Destructuring
 
 ```phel
-;; Basic keys
 (let [{:name name :age age} {:name "Alice" :age 30}]
   (str name " is " age))
 ;; => "Alice is 30"
 
-;; Shorthand (keys same as binding names)
+;; :keys shorthand
 (let [{:keys [name age]} {:name "Alice" :age 30}]
   (str name " is " age))
 
-;; With defaults
+;; :or defaults
 (let [{:keys [name age] :or {age 18}} {:name "Bob"}]
   age)                                     ; => 18
 
-;; In function parameters
+;; Function params
 (defn greet-user [{:keys [name title] :or {title "User"}}]
   (str "Hello, " title " " name))
 
@@ -518,12 +508,12 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 (defn validate-user [user]
   (let [errors (transient [])]
     (when-not (valid-email? (get user :email))
-      (conj errors "Invalid email"))
+      (conj! errors "Invalid email"))
     (when-not (valid-age? (get user :age))
-      (conj errors "Invalid age"))
+      (conj! errors "Invalid age"))
     (when-not (php/is_string (get user :name))
-      (conj errors "Name must be a string"))
-    (let [err-list (persistent errors)]
+      (conj! errors "Name must be a string"))
+    (let [err-list (persistent! errors)]
       (if (empty? err-list)
         {:ok user}
         {:errors err-list}))))
@@ -562,7 +552,7 @@ Without an `:else` clause, `match` throws `RuntimeException` when nothing fits. 
 
 ### Auto-gensym for Hygienic Bindings
 
-Inside a syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique symbol. Reuse the same `name#` to refer to the same generated binding:
+Inside syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh unique symbol. Reuse `name#` to refer to the same generated binding:
 
 ```phel
 (defmacro unless
@@ -579,14 +569,14 @@ Inside a syntax-quote (`` ` ``), a symbol ending in `#` expands to a fresh uniqu
      ret#))
 ```
 
-`start#` and `ret#` won't collide with caller bindings, even if `start` or `ret` are already in scope.
+`start#` and `ret#` won't collide with caller bindings.
 
 ### Implicit `&form` and `&env`
 
 Every `defmacro` body has two implicit symbols:
 
-- `&form`: the original macro call as written by the user (useful for source-aware error messages)
-- `&env`: a map of locals in scope at the call site, keyed by symbol
+- `&form`: the original macro call (for source-aware error messages)
+- `&env`: a map of in-scope locals, keyed by symbol
 
 ```phel
 ;; Inspect lexical scope at the call site
@@ -603,7 +593,7 @@ Every `defmacro` body has two implicit symbols:
                    " in " (quote ~&form))))))
 ```
 
-`(:ns &env)` is always `nil` under Phel, so portability macros land on the right branch:
+`(:ns &env)` is always `nil` in Phel, so portability macros land on the right branch:
 
 ```phel
 (defmacro dialect [] (if (:ns &env) "cljs" "phel"))
@@ -612,13 +602,13 @@ Every `defmacro` body has two implicit symbols:
 
 ### Extending `is` with Custom Assertions
 
-`phel\test/assert-expr` is an open multimethod, so you can teach the `is` macro to expand new assertion forms. A `defmethod` takes the original `form` and the user-supplied `message`, and returns the code that the outer `is` should run:
+`phel\test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the original `form` and user-supplied `message`, and returns the code `is` should run:
 
 ```phel
 (ns my-app\test\helpers
   (:require phel\test :refer [deftest is]))
 
-;; Approximate equality for floats — expand to a plain `is` over a tolerance check.
+;; Approximate equality for floats: expand to `is` over a tolerance check.
 (defmethod phel\test/assert-expr 'approx= [form message]
   (let [a (second form)
         b (second (next form))
@@ -629,22 +619,22 @@ Every `defmacro` body has two implicit symbols:
   (is (approx= 3.14159 (calc-pi)) "calc-pi should land near pi"))
 ```
 
-When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:default` arm handles binary equality and predicate forms, so existing tests are unaffected.
+When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:default` arm handles binary equality and predicate forms.
 
-> Cross-namespace registration must use the fully-qualified `phel\test/assert-expr` so the methods table resolves in `phel\test` rather than the local namespace.
+> Cross-namespace registration must use fully-qualified `phel\test/assert-expr` so the methods table resolves in `phel\test`, not the local namespace.
 
 ## Tips for Writing Idiomatic Phel
 
 ### Prefer Higher-Order Functions
 
 ```phel
-;; Instead of loop
+;; Loop
 (loop [coll [1 2 3 4] result []]
   (if (empty? coll)
     result
     (recur (rest coll) (conj result (* 2 (first coll))))))
 
-;; Use map
+;; map
 (map #(* % 2) [1 2 3 4])
 ```
 
@@ -654,7 +644,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 ;; Hard to read
 (reduce + (map #(* % 2) (filter even? numbers)))
 
-;; Clear pipeline
+;; Pipeline
 (->> numbers
      (filter even?)
      (map #(* % 2))
@@ -664,7 +654,6 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 ### Keep Functions Small
 
 ```phel
-;; Instead of one big function
 (defn process-order [order]
   (-> order
       validate-order
@@ -685,7 +674,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 (defn active-users [users]
   (filter :active users))
 
-;; Best - with docstring
+;; Best (with docstring)
 (defn active-users
   "Returns only active users from the collection."
   [users]
@@ -694,7 +683,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 
 ## Build-safe Entry Points
 
-`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register correctly. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run, which can block the build indefinitely.
+`phel build` evaluates every top-level form at compile time so macros, `def`, `defn`, and `ns` register. Top-level **side effects** (game loops, `stdin` reads, sockets, sleeps) also run and can block the build indefinitely.
 
 Guard imperative entry calls with `*build-mode*`:
 
@@ -711,7 +700,7 @@ Guard imperative entry calls with `*build-mode*`:
   (play))
 ```
 
-`*build-mode*` is `true` while the compiler evaluates your file during `phel build`, and `false` during `phel run` or when the compiled artifact loads at runtime. The same applies to any stdin/network/sleep call at top level:
+`*build-mode*` is `true` while the compiler evaluates your file during `phel build`, `false` during `phel run` or runtime artifact loading. Same applies to any top-level stdin/network/sleep call:
 
 ```phel
 ;; Bad: blocks `phel build` forever on fgets.
@@ -729,11 +718,11 @@ Guard imperative entry calls with `*build-mode*`:
 
 `defn`, `def` of pure values, `ns`, and `(:require ...)` are always safe at top level. Only imperative work needs the guard.
 
-> `phel build` suppresses stdout from compiled code during compilation, so stray `println` calls no longer leak to the terminal. Execution still happens, so anything that **blocks** (stdin reads, `sleep`, sockets, infinite loops) still needs `(when-not *build-mode* ...)`.
+> `phel build` suppresses stdout from compiled code during compilation, so stray `println` calls don't leak. Execution still happens, so anything that **blocks** (stdin reads, `sleep`, sockets, infinite loops) needs `(when-not *build-mode* ...)`.
 
 ## See Also
 
-- [PHP Interop](php-interop.md): Working with PHP code
-- [Quick Start](quickstart.md): Get started
-- [Reader Shortcuts](reader-shortcuts.md): Syntax reference
-- [Lazy Sequences](lazy-sequences.md): Performance patterns
+- [PHP Interop](php-interop.md)
+- [Quick Start](quickstart.md)
+- [Reader Shortcuts](reader-shortcuts.md)
+- [Lazy Sequences](lazy-sequences.md)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,6 +1,6 @@
 # Performance Tips
 
-How to make `phel test`, `phel run`, and other CLI commands fast. Applies to source-checkout use; PHAR users get the same benefits.
+Make `phel test`, `phel run`, and other CLI commands fast. Applies to source-checkout use; PHAR users get the same benefits.
 
 ## TL;DR
 
@@ -17,15 +17,17 @@ Create the directory once: `mkdir -p /tmp/php-opcache`. Restart your shell. Repe
 
 ## Why it is slow without opcache
 
-Every `bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file on every run: `vendor/`, Phel compiler, Symfony console, project classes. With `opcache.file_cache` enabled, compiled bytecode persists across processes.
+Every `bin/phel` invocation is a fresh PHP process. Without CLI opcache, PHP re-parses every `.php` file every run: `vendor/`, Phel compiler, Symfony console, project classes. With `opcache.file_cache`, compiled bytecode persists across processes.
 
-Phel also maintains its own compiled-code cache (under `sys_get_temp_dir() . '/phel'` by default) that memoizes Phel-to-PHP compilation per source hash. The two caches are complementary: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
+Phel also maintains a compiled-code cache (under `sys_get_temp_dir() . '/phel'` by default) memoizing Phel-to-PHP compilation per source hash. The two caches complement each other: Phel's cache skips recompilation; opcache skips re-parsing the resulting PHP.
 
-Cache invalidation is automatic. Each run hashes the `.phel` source (`md5`) and compares against the stored entry; on mismatch, the file is recompiled and transitive dependents are invalidated. No manual clear is needed after editing a `.phel` file. Fresh compiles also call `opcache_compile_file()` on the generated PHP. Use the reset steps below only if something gets wedged.
+Cache invalidation is automatic. Each run hashes the `.phel` source (`md5`) against the stored entry. On mismatch, the file is recompiled and transitive dependents are invalidated. No manual clear is needed after editing a `.phel` file. Fresh compiles also call `opcache_compile_file()` on the generated PHP. Use the reset steps below only if something gets wedged.
+
+For hot numeric / string fns, add `:tag` annotations on params and return slot (`^int`, `^float`, `^string`, `^bool`). The compiler emits the matching PHP type declarations and infers the return type from primitive ops in tail position, which lets the tracing JIT specialize the call. Tag mismatches surface as Phel diagnostics at compile time. Measure the win locally with `composer bench-jit-baseline` and `composer bench-jit-tracing` (see [`internals/benchmarks.md`](internals/benchmarks.md)).
 
 ## Memory limit
 
-`bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php bin/phel ...`) or embed Phel in another tool, bump the limit yourself; the compiler's `token_get_all` validation can exceed 128M on large projects.
+`bin/phel` raises `memory_limit` to `-1` automatically. If you invoke PHP directly (`php bin/phel ...`) or embed Phel, bump the limit yourself. The compiler's `token_get_all` validation can exceed 128M on large projects.
 
 ```bash
 php -d memory_limit=-1 bin/phel test

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -40,9 +40,9 @@ Prefix PHP functions with `php/`:
 (php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
 ```
 
-The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path (use `\\` to disambiguate from the root namespace). Case is preserved, so `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
+The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path (use `\\` to disambiguate from the root namespace). Case is preserved: `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
 
-Capture the function reference with `def` to shorten calls:
+Capture references with `def` to shorten calls:
 
 ```phel
 (def trap-signal php/\Amp\trapSignal)
@@ -129,7 +129,7 @@ Use `:use` for PHP classes:
 
 ### Requiring Phel Namespaces
 
-`:require` accepts both list-style and vector entries, so the same form works in `.phel` and shared `.cljc` files:
+`:require` accepts list-style and vector entries (works in both `.phel` and `.cljc`):
 
 ```phel
 ;; List entry
@@ -143,7 +143,7 @@ Use `:use` for PHP classes:
             [phel\json :as json :refer [encode decode]]))
 ```
 
-`.` works as an alternate namespace separator (alongside `\`):
+`.` is an alternate separator (alongside `\`):
 
 ```phel
 (ns my.cljc.file
@@ -198,16 +198,15 @@ Both `phel\string` and `phel.string` resolve to the same namespace.
 <?php
 require 'vendor/autoload.php';
 
-use Phel\Run\RunFacade;
+// Bootstrap Phel and load the namespace (compiles on first call).
+\Phel::run(__DIR__, 'app\\hello');
 
-$phel = RunFacade::initialize();
+// Call Phel functions by name; getDefinition returns the registered fn.
+$greet = \Phel::getDefinition('app\\hello', 'greet');
+echo $greet('World'); // => "Hello, World!"
 
-// Call Phel function
-$result = \Phel::callPhel('app\hello', 'greet', 'World');
-echo $result; // => "Hello, World!"
-
-$sum = \Phel::callPhel('app\hello', 'add', 5, 10);
-echo $sum; // => 15
+$add = \Phel::getDefinition('app\\hello', 'add');
+echo $add(5, 10); // => 15
 ```
 
 ### Web Application Example
@@ -232,17 +231,20 @@ echo $sum; // => 15
 <?php
 require 'vendor/autoload.php';
 
-use Phel\Run\RunFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-RunFacade::initialize();
+\Phel::run(__DIR__, 'app\\routes');
 
 $request = Request::createFromGlobals();
 $path = $request->getPathInfo();
 
+$home = \Phel::getDefinition('app\\routes', 'handle-home');
+$api  = \Phel::getDefinition('app\\routes', 'handle-api');
+
 $response = match ($path) {
-    '/' => \Phel::callPhel('app\routes', 'handle-home', $request),
-    '/api' => \Phel::callPhel('app\routes', 'handle-api', $request),
+    '/'    => $home($request),
+    '/api' => $api($request),
     default => new Response('Not Found', 404),
 };
 
@@ -374,29 +376,29 @@ $response->send();
 
 ## Tips for PHP Developers
 
-- **Immutability**: collections don't mutate. `(conj vec item)` returns a *new* vector
-- **No `$` sigil**: variables don't need `$`
-- **Keywords**: use `:keyword` for map keys
-- **Truthiness**: only `false` and `nil` are falsy (not `0` or `""`)
-- **Parens matter**: `(func arg)` calls the function, `func` is the value
+- **Immutability**: collections don't mutate. `(conj vec item)` returns a *new* vector.
+- **No `$` sigil**: variables don't need `$`.
+- **Keywords**: use `:keyword` for map keys.
+- **Truthiness**: only `false` and `nil` are falsy (not `0` or `""`).
+- **Parens**: `(func arg)` calls; `func` is the value.
 
 ## Tips for Clojure Developers
 
-- **PHP interop**: use `php/` prefix (not `.` or `..`)
-- **Method calls**: `(php/-> obj (method))` not `(.method obj)`
-- **Deref**: `@my-atom` is shorthand for `(deref my-atom)`
-- **Import classes**: use `:use` in `ns`, not `:import`
-- **Require vectors**: `(:require [phel\string :as str :refer [upper-case]])` works alongside the list form
-- **Namespace separators**: both `\` and `.` work; `phel\string` and `phel.string` resolve to the same namespace
-- **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files
-- **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` are deprecated)
-- **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated)
-- **Macro env**: `&form` and `&env` are implicitly bound inside every `defmacro`. `&env` is a map of in-scope locals keyed by symbol; `(:ns &env)` is always `nil`, so the `.cljc` `(if (:ns &env) "cljs" ...)` dialect-detection trick lands on the non-cljs branch
-- **Lambda syntax**: `#(+ %1 %2)` recommended; `|(+ $1 $2)` deprecated
-- **PHP arrays**: work with them directly or convert to Phel collections
+- **PHP interop**: use `php/` prefix (not `.` or `..`).
+- **Method calls**: `(php/-> obj (method))` (also `(.method obj)`).
+- **Deref**: `@my-atom` shortcuts `(deref my-atom)`.
+- **Import classes**: `:use` in `ns`, not `:import`.
+- **Require vectors**: `(:require [phel\string :as str :refer [upper-case]])` works alongside the list form.
+- **Namespace separators**: `\` and `.` both work; `phel\string` and `phel.string` resolve to the same namespace.
+- **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files.
+- **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` deprecated).
+- **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated).
+- **Macro env**: `&form` and `&env` are implicit in every `defmacro`. `&env` is a map of in-scope locals keyed by symbol. `(:ns &env)` is always `nil`, so the `.cljc` `(if (:ns &env) "cljs" ...)` trick lands on the non-cljs branch.
+- **Lambda syntax**: `#(+ %1 %2)` recommended; `|(+ $1 $2)` deprecated.
+- **PHP arrays**: use directly or convert to Phel collections.
 
 ## See Also
 
-- [Examples](examples/README.md): practical code samples
-- [Reader Shortcuts](reader-shortcuts.md): syntax reference
-- [Common Patterns](patterns.md): idiomatic Phel code
+- [Examples](examples/README.md)
+- [Reader Shortcuts](reader-shortcuts.md)
+- [Common Patterns](patterns.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Up and running with Phel in five minutes.
+Phel running in five minutes.
 
 ## Install
 
@@ -9,7 +9,7 @@ composer require phel-lang/phel-lang
 ./vendor/bin/phel init
 ```
 
-`phel init` writes `phel-config.php`, `src/phel/main.phel`, and `tests/phel/main_test.phel`. Add `--minimal` for a single-file root layout, `--flat` to drop the `phel/` subdirectory, `--dry-run` to preview.
+`phel init` writes `phel-config.php`, `src/phel/main.phel`, and `tests/phel/main_test.phel`. Flags: `--minimal` (single-file root layout), `--flat` (drop the `phel/` subdirectory), `--dry-run` (preview).
 
 Already have a PHP project? Write `phel-config.php` by hand:
 
@@ -72,7 +72,7 @@ user:5> (/ 1 0)
 user:6> *e                        ; last exception
 ```
 
-The prompt shows the current namespace (it switches on `(ns ...)` / `(in-ns ...)`). `*1`, `*2`, `*3` hold the last three REPL results; `*e` the last exception. Type `(exit)` or press Ctrl-D to quit.
+The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)`. `*1`, `*2`, `*3` hold the last three REPL results; `*e` holds the last exception. Type `(exit)` or press Ctrl-D to quit.
 
 ## Collections
 
@@ -109,8 +109,8 @@ The prompt shows the current namespace (it switches on `(ns ...)` / `(in-ns ...)
 ## Functions
 
 ```phel
-;; Define a function
-(defn square [x]
+;; Define a function (^int :tag emits a PHP int return-type)
+(defn ^int square [^int x]
   (* x x))
 
 (square 5)                        ; => 25
@@ -181,7 +181,7 @@ echo \Phel::getDefinition('app_greet', 'hello')('World');
 
 `getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores.
 
-For a full HTTP example see [Framework Integration](framework-integration.md).
+Full HTTP example: [Framework Integration](framework-integration.md).
 
 ## Tests
 
@@ -234,4 +234,4 @@ Clojure devs: PHP interop uses `php/` prefix or shortcuts (`.method`, `.-field`,
 
 ## Next Steps
 
-Full guide index: [docs/README.md](README.md).
+Guide index: [docs/README.md](README.md).

--- a/docs/reader-conditionals.md
+++ b/docs/reader-conditionals.md
@@ -1,14 +1,12 @@
 # Reader Conditionals in Phel
 
-## What are reader conditionals?
+Reader conditionals enable platform-specific code in shared source files. They resolve at parse time, before compilation. Phel selects the `:phel` branch, ignores other platforms (`:clj`, `:cljs`, ...), and falls back to `:default` when present.
 
-Reader conditionals allow platform-specific code in shared source files. They are evaluated at read time (during parsing), before compilation. The Phel compiler selects the `:phel` branch, ignores branches for other platforms (`:clj`, `:cljs`, etc.), and optionally falls back to `:default`.
-
-This enables `.cljc` files: source files shared between Phel, Clojure, and other Lisp dialects that support reader conditionals.
+This enables `.cljc` files shared between Phel, Clojure, and other Lisp dialects.
 
 ## Basic usage: `#?()`
 
-A reader conditional selects one form based on the platform:
+Selects one form based on platform:
 
 ```phel
 #?(:phel  (php/time)
@@ -51,7 +49,7 @@ A reader conditional selects one form based on the platform:
 
 ## Splicing: `#?@()`
 
-Reader conditional splicing inserts multiple elements from a collection into the surrounding form:
+Splices multiple elements from a collection into the surrounding form:
 
 ```phel
 [1 #?@(:phel [2 3]) 4]
@@ -79,7 +77,7 @@ The matched branch **must be a sequential collection** (vector or list). Its ele
 
 ### Top-level restriction
 
-`#?@()` is only valid inside a collection (list, vector, map, set). Using it at the top level is an error:
+`#?@()` is only valid inside a collection (list, vector, map, set). Top-level use is an error:
 
 ```phel
 ;; ERROR: Reader conditional splicing #?@() is not allowed at the top level
@@ -90,7 +88,7 @@ The matched branch **must be a sequential collection** (vector or list). Its ele
 
 ### Cross-platform source files (`.cljc`)
 
-Phel discovers and compiles `.cljc` files alongside `.phel` files, letting you share code between Phel and Clojure:
+Phel discovers and compiles `.cljc` files alongside `.phel` files:
 
 ```phel
 ;; src/shared/utils.cljc
@@ -137,7 +135,7 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files, letting you s
 
 ### Inside control flow
 
-Reader conditionals resolve at parse time, so they work naturally inside any form:
+Reader conditionals resolve at parse time, so they work inside any form:
 
 ```phel
 (if #?(:phel true :clj false)
@@ -151,12 +149,12 @@ Reader conditionals resolve at parse time, so they work naturally inside any for
 Reader conditionals resolve during the **parsing phase** (Lexer -> **Parser** -> Analyzer -> Emitter). The parser:
 
 1. Reads keyword-form pairs inside `#?()` or `#?@()`
-2. Selects the `:phel` branch if present, otherwise `:default`
-3. For `#?()`: replaces the entire conditional with the selected form
-4. For `#?@()`: splices the selected collection's elements into the parent
-5. If no branch matches: the conditional is dropped as trivia (like a comment)
+2. Selects `:phel` if present, else `:default`
+3. `#?()`: replaces the conditional with the selected form
+4. `#?@()`: splices the selected collection into the parent
+5. No match: drops the conditional as trivia
 
-Since this happens at parse time, the analyzer and emitter never see the reader conditional; they only see the selected form.
+The analyzer and emitter only see the selected form.
 
 ## Summary
 

--- a/docs/reader-shortcuts.md
+++ b/docs/reader-shortcuts.md
@@ -1,6 +1,6 @@
 # Reader Shortcuts and Special Syntax
 
-Reader shortcuts are processed by the reader during compilation.
+Reader shortcuts are resolved by the reader during compilation.
 
 ## Collection Literals
 
@@ -68,7 +68,7 @@ Evaluates and splices a sequence into the containing form:
 > **Deprecated:** `,@` as an unquote-splicing reader macro. Use `~@` instead.
 
 ### Auto-gensym `name#`
-Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique symbol. All occurrences of the same `name#` within one syntax-quote resolve to the same generated name, enabling hygienic macros without calling `gensym`:
+Inside a syntax-quote, a symbol ending in `#` expands to a fresh unique name. All occurrences of the same `name#` in one syntax-quote share that name, giving hygienic macros without calling `gensym`:
 
 ```phel
 (defmacro time
@@ -113,11 +113,12 @@ Shorthand for `(deref ...)`:
 
 ## Tagged Literals `#<tag> form`
 
-Tagged literals convert a form into a different value at read time. Two built-ins ship with Phel:
+Tagged literals convert a form to a value at read time. Three ship built-in:
 
 ```phel
 #inst "2026-01-01T00:00:00Z"     ; reads as \DateTimeImmutable
 #regex "\\d+"                     ; reads as a PCRE pattern string
+#uuid "550e8400-e29b-41d4-a716-446655440000"  ; reads as Phel\Lang\Uuid
 ```
 
 Register your own with `phel\reader/register-tag`:

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -1,6 +1,6 @@
 # Schema Guide
 
-`phel\schema` validates, coerces, and generates values. Schemas are plain Phel data (keywords or vectors); no DSL.
+`phel\schema` validates, coerces, and generates values. Schemas are plain Phel data (keywords or vectors), no DSL.
 
 ## Quickstart
 
@@ -53,7 +53,7 @@
 ## Function instrumentation
 
 ```phel
-(defn add [a b] (+ a b))
+(defn ^int add [^int a ^int b] (+ a b))
 (s/instrument! 'add add [:=> [:int :int] :int])
 ;; (add "x" 2)  ; throws with schema failure
 ```
@@ -62,7 +62,7 @@
 
 - `:map` is open by default; add `{:closed? true}` to reject extra keys
 - `[:re ...]` expects a `#"regex"` literal, not a string
-- `generate` may fail for over-constrained `[:and ...]` or `[:re ...]` schemas; add a `[:gen ...]` hint if needed
+- `generate` may fail on over-constrained `[:and ...]` or `[:re ...]` schemas; pass `{:gen <gen-fn>}` in schema options to override
 
 ## See also
 

--- a/docs/transducers.md
+++ b/docs/transducers.md
@@ -2,16 +2,16 @@
 
 ## What are transducers?
 
-Transducers are composable transformation pipelines that decouple the "what" (map, filter, take) from the "how" (building a vector, summing, writing to a file). They transform one reducing function into another without creating intermediate collections at each step.
+Transducers are composable pipelines that decouple the transformation (map, filter, take) from the consumer (build a vector, sum, write to a file). They turn one reducing function into another without intermediate collections.
 
-A regular pipeline creates a temporary sequence at every step:
+A normal pipeline allocates at every step:
 
 ```phel
 ;; Two intermediate lazy sequences created
 (filter even? (map inc [1 2 3 4 5]))
 ```
 
-With transducers, the transformations fuse into a single pass:
+Transducers fuse the steps into a single pass:
 
 ```phel
 ;; No intermediate collections
@@ -25,7 +25,7 @@ Three ways to consume a transducer:
 
 ### `transduce` -- reduce with a transformation
 
-Apply a transducer, then reduce with a combining function:
+Apply a transducer, then reduce:
 
 ```phel
 ;; Sum all values after incrementing
@@ -40,7 +40,6 @@ Apply a transducer, then reduce with a combining function:
 ### `into` -- pour transformed elements into a collection
 
 ```phel
-;; Apply a transducer and collect into a target collection
 (into [] (map inc) [1 2 3])
 ; => [2 3 4]
 
@@ -48,9 +47,9 @@ Apply a transducer, then reduce with a combining function:
 ; => [{:name "a" :active true} {:name "b" :active true}]
 ```
 
-### `sequence` -- get a vector of transformed results
+### `sequence` -- vector of transformed results
 
-A shorthand for `(into [] xf coll)`:
+Shorthand for `(into [] xf coll)`:
 
 ```phel
 (sequence (filter even?) [1 2 3 4 5 6])
@@ -59,7 +58,7 @@ A shorthand for `(into [] xf coll)`:
 
 ## Transducer-producing functions
 
-Most sequence functions are dual-purpose: call them **with** a collection and they return a lazy sequence; call them **without** and they return a transducer.
+Most sequence functions are dual-purpose. Called **with** a collection they return a lazy sequence; called **without** they return a transducer.
 
 | Function | Transducer form | Description |
 |---|---|---|
@@ -81,7 +80,7 @@ Most sequence functions are dual-purpose: call them **with** a collection and th
 
 ## Composing transducers
 
-Use `comp` to build a pipeline. Transducers compose left-to-right (the leftmost runs first):
+`comp` builds a pipeline. Transducers compose left-to-right; the leftmost runs first:
 
 ```phel
 (def xf (comp
@@ -93,7 +92,7 @@ Use `comp` to build a pipeline. Transducers compose left-to-right (the leftmost 
 ; => [4 16 36]
 ```
 
-This is the opposite of normal function composition, but matches the order written with threading:
+Opposite of normal function composition, matching the order of `->>`:
 
 ```phel
 ;; Equivalent lazy-sequence version (creates intermediates):
@@ -107,7 +106,7 @@ This is the opposite of normal function composition, but matches the order writt
 
 ### `reduced`, `reduced?`, `unreduced`
 
-A reducing function signals "stop iterating" by wrapping its return value in `reduced`:
+A reducing function signals "stop" by wrapping its return value in `reduced`:
 
 ```phel
 ;; Sum until the accumulator exceeds 10
@@ -124,7 +123,7 @@ A reducing function signals "stop iterating" by wrapping its return value in `re
 
 ### How built-in transducers use early termination
 
-`take` and `take-while` use `reduced` internally. When `take` has collected enough elements, it wraps the result in `reduced` so the outer `reduce`/`transduce` stops immediately rather than walking the rest of the collection.
+`take` and `take-while` use `reduced` internally. Once `take` has enough elements, it wraps the result so the outer `reduce`/`transduce` stops rather than walking the rest:
 
 ```phel
 ;; Stops processing after 2 elements, does not touch the rest
@@ -134,14 +133,14 @@ A reducing function signals "stop iterating" by wrapping its return value in `re
 
 ## Stateful transducers
 
-Some transducers need mutable state across steps (counters, sets of seen values). Phel provides volatile references:
+Some transducers need mutable state across steps (counters, seen-sets). Phel provides volatile references:
 
 - `(volatile! val)` -- create a mutable reference initialized to `val`
 - `@vol` (deref) -- read the current value
 - `(vreset! vol new-val)` -- set a new value, returns `new-val`
 - `(vswap! vol f & args)` -- apply `f` to current value + args, set and return result
 
-For example, `distinct` internally uses a volatile hash-set to track seen elements:
+`distinct` uses a volatile hash-set to track seen elements:
 
 ```phel
 ;; Simplified view of how distinct works internally:
@@ -153,17 +152,17 @@ For example, `distinct` internally uses a volatile hash-set to track seen elemen
 
 ## Custom transducers
 
-A transducer takes a reducing function `rf` and returns a new reducing function. The returned function handles three arities:
+A transducer takes a reducing function `rf` and returns a new one. The returned function handles three arities:
 
-- **0-arity** (init): return `(rf)` -- delegate to the downstream init
-- **1-arity** (completion): return `(rf result)` -- delegate completion, optionally flush state
-- **2-arity** (step): the actual transformation logic
+- **0** (init): return `(rf)`, delegate downstream init
+- **1** (completion): return `(rf result)`, optionally flush state
+- **2** (step): the transformation logic
 
-Due to a compiler limitation with nested multi-arity `fn`, use variadic `[& args]` with `case (count args)` dispatch instead.
+Nested multi-arity `fn` is not supported, so use variadic `[& args]` with `case (count args)` dispatch.
 
 ### Using `xf-step` (recommended)
 
-The private helper `xf-step` handles the 0/1 arity boilerplate. Write only the 2-arity step:
+`xf-step` handles 0/1 arity boilerplate. Write only the 2-arity step:
 
 ```phel
 ;; A transducer that doubles every element
@@ -208,7 +207,7 @@ For custom completion logic (e.g. flushing buffered state), write all three arit
 
 ### With early termination
 
-To stop processing, wrap the result in `reduced`:
+Wrap the result in `reduced` to stop:
 
 ```phel
 ;; Take until predicate returns true (inclusive)
@@ -225,7 +224,7 @@ To stop processing, wrap the result in `reduced`:
 
 ## Relationship to lazy sequences
 
-Every dual-purpose function works in two modes:
+Every dual-purpose function has two modes:
 
 ```phel
 ;; With collection: returns a lazy sequence
@@ -239,11 +238,8 @@ Every dual-purpose function works in two modes:
 
 **When to use which:**
 
-- **Lazy sequences** for simple, linear pipelines. Compose naturally with `->>`.
-- **Transducers** when you need to:
-  - Avoid intermediate collections in a multi-step pipeline
-  - Reuse one transformation with different sources or destinations
-  - Reduce into something other than a sequence (sums, maps, side effects)
+- **Lazy sequences**: simple linear pipelines. Compose with `->>`.
+- **Transducers**: avoid intermediates in multi-step pipelines, reuse one transformation across sources/destinations, or reduce into something that isn't a sequence (sums, maps, side effects).
 
 ```phel
 ;; Define once, reuse everywhere

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -29,7 +29,7 @@ On each change, `phel watch` reloads the changed namespace and its dependents in
 (watch! ["src/" "tests/"])
 ```
 
-Returns a handle. Stop with `(stop-watch! h)`.
+Blocks until interrupted (Ctrl+C). Reloads changed namespaces in dependency order. Register per-namespace hooks with `register-on-reload`.
 
 ## Pitfalls
 


### PR DESCRIPTION
## 🤔 Background

The `docs/` tree had drifted: stale APIs in `php-interop.md`, transient examples that silently no-op'd, post-`v0.36` features (`BigDecimal`, `BigInteger`, `Rational`, `Uuid`, first-class `Var`, auto-promoting math) absent from the reference guides, and prose loaded with em dashes / filler.

## 💡 Goal

Bring every file under `docs/` to current best practice for DX and perf, in small reviewable commits.

## 🔖 Changes (per commit)

1. `docs(examples)`: modernize `docs/examples/**/*.phel` with `:tag` annotations on hot numeric/string fns, BigDecimal `M` literals, ratio `1/2`, `#uuid`, BigInteger `N`, queue / map-entry, and overflow-aware `+'` / `*'` / `inc'`.
2. `docs(php-interop)`: replace bootstrap snippets that called the non-existent `RunFacade::initialize()` and `\Phel::callPhel(...)` with `\Phel::run` + `\Phel::getDefinition` (matches `framework-integration.md`).
3. `docs(mocking)`: switch a `binding` block to `with-redefs` (the rebound fn is not `^:dynamic`).
4. `docs`: surface recently-shipped features in `performance.md`, `internals/benchmarks.md`, `numeric-tower.md`, `reader-shortcuts.md`, `clojure-migration.md`, `schema-guide.md` (`:tag` JIT note, `bench-jit-*` scripts, BigDecimal coverage, `#uuid`, Var/BigInt rows corrected).
5. `docs(transients)`: data-structures and patterns examples now use `conj!` / `assoc!` / `persistent!` instead of the persistent variants on transient values, plus tighter prose and `:tag` / `*'` on factorial demos.
6. `docs`: single-pass tighten across every remaining guide and `internals/`: shorter sentences, drop filler ("simply", "just", "in order to"), remove em dashes (every `—` replaced with colon / comma / period / parens).

Also folded into `## Unreleased` already on `main`: typed-signature changelog notes (`#1916/#1931/#1932/#1933`) collapsed into a single coherent block.

## Test plan
- [ ] `composer test-quality` (no code changes, but verify nothing broke)
- [ ] `grep -r "—" docs/` returns no hits
- [ ] Spot-check `docs/php-interop.md` bootstrap snippet matches actual `\Phel` API
- [ ] Spot-check `docs/examples/05_data-structures.phel` transient block compiles