### PR TITLE
fix(api): seed namespace loader with every requested namespace

### DIFF
--- a/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
+++ b/src/php/Api/Infrastructure/PhelFunctionRuntimeLoader.php
@@ -52,12 +52,17 @@ final readonly class PhelFunctionRuntimeLoader
                 ->getNamespaceFromFile($phelFile)
                 ->getNamespace();
 
+            // Seed the topological sort with every requested namespace
+            // (in addition to the temp doc namespace and core) so a stray
+            // parse / require failure on the generated doc.phel cannot
+            // silently drop one of them. CI saw `phel.async` go missing
+            // intermittently otherwise.
             $namespaceInformation = $this->runFacade->getDependenciesForNamespace(
                 [
                     dirname($phelFile),
                     ...$this->runFacade->getAllPhelDirectories(),
                 ],
-                [$namespace, 'phel.core'],
+                [$namespace, 'phel.core', ...$namespaces],
             );
 
             foreach ($namespaceInformation as $info) {


### PR DESCRIPTION
## 🤔 Background

`ApiFacadeTest::test_can_load_phel_functions_from_all_namespaces` flaked on PHP 8.5 in CI with:

\`\`\`
Expected namespace 'async' to be loaded. Loaded namespaces: core, php
Failed asserting that an array contains 'async'.
\`\`\`

## 💡 Goal

Stop relying on the generated doc.phel \`(:require ...)\` clauses to bootstrap the dependency walk; pass every requested namespace as an explicit seed instead.

## 🔖 Changes

- `PhelFunctionRuntimeLoader::load`: seed `getDependenciesForNamespace` with `[$docNs, 'phel.core', ...$namespaces]` rather than `[$docNs, 'phel.core']`. Documented why with a 4-line comment.

## Test plan
- [ ] `composer test-compiler` (full suite green locally)
- [ ] CI green on both PHP 8.4 and 8.5 across two runs