### PR TITLE
docs: prefer dot namespace separator across guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 - [Language Server](lsp-guide.md): hover, definition, references, completion
 - [Linter](lint-guide.md): `phel lint` rules and config
 - [Watch](watch-guide.md): hot-reload changed namespaces
-- [CLI Builder](cli-guide.md): build CLIs with `phel\cli`
+- [CLI Builder](cli-guide.md): build CLIs with `phel.cli`
 - [Performance](performance.md): opcache setup, cache reset
 - [Mocking](mocking-guide.md): test seams for PHP calls
 

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -1,6 +1,6 @@
 # AI Module Guide
 
-`phel\ai` is a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
+`phel.ai` is a small, provider-agnostic client for LLM chat, structured extraction, tool use, embeddings, and semantic search.
 
 Supported providers:
 
@@ -13,8 +13,8 @@ Supported providers:
 ## Quickstart
 
 ```phel
-(ns my-app\main
-  (:require phel\ai :as ai))
+(ns my-app.main
+  (:require phel.ai :as ai))
 
 ;; Either set env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, VOYAGE_API_KEY)
 ;; or configure explicitly:
@@ -147,13 +147,13 @@ All failures throw `\RuntimeException`. Messages include HTTP status and provide
 
 ## Testing without a live API
 
-`phel\ai` exposes an HTTP seam `*http-post*` that tests rebind to return canned responses. Combined with `phel\mock`, this removes the dependency on a real provider.
+`phel.ai` exposes an HTTP seam `*http-post*` that tests rebind to return canned responses. Combined with `phel.mock`, this removes the dependency on a real provider.
 
 ```phel
-(ns my-app\test\ai-test
-  (:require phel\test :refer [deftest is])
-  (:require phel\ai :as ai)
-  (:require phel\mock :refer [mock-fn call-count first-call]))
+(ns my-app.test.ai-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.ai :as ai)
+  (:require phel.mock :refer [mock-fn call-count first-call]))
 
 (deftest test-my-ai-logic
   (let [fake (mock-fn (fn [_ _] {:status 200
@@ -163,7 +163,7 @@ All failures throw `\RuntimeException`. Messages include HTTP status and provide
       (is (= 1 (call-count fake))))))
 ```
 
-`phel\json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string instead of using `json/encode`.
+`phel.json` stringifies floats during `json/encode`. When a mock must return embedding arrays, build the response body as a raw JSON string instead of using `json/encode`.
 
 ## See also
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -66,7 +66,7 @@ Suspends for `seconds` (float). At top level behaves like `php/sleep`. Inside `a
 > **Not Clojure's `delay`.** `clojure.core/delay` is a lazy-thunk wrapper, not a sleep. Phel's `delay` lives in `phel.async` (not `phel.core`) to keep the difference visible to `.cljc` portable code.
 
 ```phel
-(:require phel\async :refer [delay])
+(:require phel.async :refer [delay])
 
 (async (delay 0.1) :done)
 ```
@@ -213,7 +213,7 @@ Returns `true` if `x` is a fiber-future or `PhelFuture`. Useful when receiving F
 ### Producer/consumer via `promise`
 
 ```phel
-(ns demo\producer)
+(ns demo.producer)
 
 (let [inbox (promise)]
   (future-call (fn []
@@ -226,8 +226,8 @@ Run with `./bin/phel run demo/producer.phel`.
 ### Fan-out, fan-in with `await-all`
 
 ```phel
-(ns demo\fanout
-  (:require phel\async :refer [delay]))
+(ns demo.fanout
+  (:require phel.async :refer [delay]))
 
 (defn fetch [label ms]
   (async
@@ -245,7 +245,7 @@ Wall time tracks the slowest branch, not the sum.
 ### Timeout race with 3-arg `deref`
 
 ```phel
-(ns demo\timeout)
+(ns demo.timeout)
 
 (let [p (promise)]
   ;; No producer wired up: the deref expires and returns the fallback.
@@ -256,8 +256,8 @@ Wall time tracks the slowest branch, not the sum.
 ### Cancel on first error
 
 ```phel
-(ns demo\cancel-on-error
-  (:require phel\async :refer [delay]))
+(ns demo.cancel-on-error
+  (:require phel.async :refer [delay]))
 
 (defn launch []
   (async
@@ -278,4 +278,4 @@ Wall time tracks the slowest branch, not the sum.
 ## See also
 
 - [Example: `docs/examples/11_async-concurrency.phel`](examples/11_async-concurrency.phel)
-- [`phel\http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls
+- [`phel.http-client`](../src/phel/http-client.phel) for AMPHP-based HTTP calls

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,12 +1,12 @@
-# Building CLIs with `phel\cli`
+# Building CLIs with `phel.cli`
 
-`phel\cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling all defined as plain Phel maps. No extra dependency; `symfony/console` ships with phel-lang.
+`phel.cli` is a data-driven wrapper over [`symfony/console`](https://symfony.com/doc/current/components/console.html). Subcommands, arguments, options, prompts, tables, progress bars, shell completion, and signal handling all defined as plain Phel maps. No extra dependency; `symfony/console` ships with phel-lang.
 
 ## Quickstart
 
 ```phel
-(ns my-tool\main
-  (:require phel\cli :as cli))
+(ns my-tool.main
+  (:require phel.cli :as cli))
 
 (defn- greet [ctx]
   (let [name (or (cli/arg ctx "name")
@@ -204,9 +204,9 @@ my-tool _complete --generate-hook=bash > ~/.bash_completion.d/my-tool
 Test helpers run handlers without spawning a process:
 
 ```phel
-(ns my-tool-test\test\main
-  (:require phel\cli :as cli)
-  (:require phel\test :refer [deftest is]))
+(ns my-tool-test.test.main
+  (:require phel.cli :as cli)
+  (:require phel.test :refer [deftest is]))
 
 (deftest test-greet
   (let [spec   {:name "greet"
@@ -253,6 +253,6 @@ Only needed under `phel run`. A standalone binary built with `phel build` uses `
 
 ## See also
 
-- [`phel\router`](../src/phel/router.phel): companion for HTTP apps
-- [`phel\http-client`](../src/phel/http-client.phel): outbound HTTP
+- [`phel.router`](../src/phel/router.phel): companion for HTTP apps
+- [`phel.http-client`](../src/phel/http-client.phel): outbound HTTP
 - [symfony/console docs](https://symfony.com/doc/current/components/console.html): underlying API

--- a/docs/clojure-migration.md
+++ b/docs/clojure-migration.md
@@ -6,7 +6,7 @@ Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. Thi
 
 | Clojure | Phel | Notes |
 |---------|------|-------|
-| `(ns my.app (:require [clojure.string :as str]))` | `(ns my\app (:require phel\string :as str))` | `\` separator; `.` also works |
+| `(ns my.app (:require [clojure.string :as str]))` | `(ns my.app (:require phel.string :as str))` | `.` separator (matches Clojure); `\` accepted for back-compat but deprecated |
 | `(.method obj arg)` | `(php/-> obj (method arg))` | Instance method |
 | `(Class/staticMethod arg)` | `(php/:: Class (method arg))` | Static method |
 | `(ClassName. arg)` | `(ClassName. arg)`, `(new ClassName arg)`, or `(php/new ClassName arg)` | `ClassName.` and `new` both read as `(php/new ClassName ...)` |
@@ -14,8 +14,8 @@ Phel is a Lisp compiling to PHP. If you know Clojure, you know most of Phel. Thi
 | `(:import [java.util Date])` | `(:use DateTime)` in the `ns` form | Imports a PHP class by short name; also works with FQNs: `(:use Phel\Lang\Symbol)` |
 | `(instance? Type x)` | `(instance? Type x)` or `(php/instanceof x Type)` | Phel ships an `instance?` macro that wraps `php/instanceof` with Clojure's argument order |
 | `(class x)` | `(type x)` | Returns a keyword like `:string`, `:int`, `:hash-map` |
-| `(subs s start end)` | `(phel\string\slice s start end)` | Substring |
-| `(clojure.string/upper-case s)` | `(phel\string\upper-case s)` | String utils in `phel\string` |
+| `(subs s start end)` | `(phel.string/slice s start end)` | Substring |
+| `(clojure.string/upper-case s)` | `(phel.string/upper-case s)` | String utils in `phel.string` |
 
 ## What's the same
 
@@ -37,8 +37,8 @@ Most of Clojure's core library works identically:
 - **Delays and futures**: `delay`, `force`, `delay?`, `realized?`, `future`, `future-cancel`, `future-cancelled?`, `future-done?` (fiber-based via AMPHP)
 - **Exceptions**: `ex-info`, `ex-data`, `ex-message`, `ex-cause`, `throw`, `try` / `catch` / `finally`
 - **Transducers**: `transduce`, `into` (3-arg), `sequence`, `completing`, `cat`, plus transducer arities for `map`, `filter`, `take`, `drop`, `keep`, `distinct`, `dedupe`, `mapcat`, `interpose`, and more
-- **Testing**: `deftest`, `is`, `testing`, `are`, `do-report`, extensible `assert-expr` (in `phel\test`)
-- **String utils**: `phel\string` with `upper-case`, `lower-case`, `split`, `join`, `trim`, `replace`, `starts-with?`, `ends-with?`, and more
+- **Testing**: `deftest`, `is`, `testing`, `are`, `do-report`, extensible `assert-expr` (in `phel.test`)
+- **String utils**: `phel.string` with `upper-case`, `lower-case`, `split`, `join`, `trim`, `replace`, `starts-with?`, `ends-with?`, and more
 - **Regex**: `re-find`, `re-matches`, `re-pattern`, `#"..."` literals
 
 ## Reader syntax
@@ -69,23 +69,25 @@ Notes:
 
 ## Namespace syntax
 
-Phel uses `\` as the native namespace separator (matching PHP). It also accepts `.`:
+Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated; new code should use `.`.
 
 ```phel
-;; Both work:
-(ns my\app (:require phel\string :as str))
+;; Preferred (Clojure-style):
 (ns my.app (:require phel.string :as str))
 
-;; Vector-style :require also works:
-(ns my.app (:require [phel\string :as str :refer [upper-case]]))
+;; Vector-style :require:
+(ns my.app (:require [phel.string :as str :refer [upper-case]]))
+
+;; Legacy (deprecated, still parses):
+(ns my\app (:require phel\string :as str))
 ```
 
 **Automatic aliasing**: `clojure.*` namespaces in `:require` resolve to `phel.*` when the target exists. `.cljc` files using `(:require [clojure.string :as str])` work unchanged.
 
-**Importing PHP classes**: use `(:use ...)` in the `ns` form (Phel's equivalent of `(:import ...)`):
+**Importing PHP classes**: use `(:use ...)` in the `ns` form (Phel's equivalent of `(:import ...)`). PHP class names keep `\` as their native separator:
 
 ```phel
-(ns my\app
+(ns my.app
   (:use DateTime)
   (:use \JsonException)
   (:use Phel\Lang\Symbol))
@@ -126,7 +128,7 @@ Any PHP function works with the `php/` prefix:
 
 ```clojure
 (ns shared.utils
-  (:require #?(:phel phel\string
+  (:require #?(:phel phel.string
                :clj  [clojure.string :as str])))
 
 (defn greet [name]
@@ -169,13 +171,13 @@ Some Clojure features don't translate to PHP:
 |-----------------|----------------|-------------|
 | **Refs / STM** | No concurrent transactions in PHP | Use `atom` for mutable state |
 | **Agents** | No background threads | PHP job queues via interop |
-| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel\core`, no require needed | See [docs/async-guide.md](async-guide.md) |
+| **core.async** | No goroutines/CSP, but fiber primitives (`promise`, `deliver`, `future-fiber`) cover CSP-lite handoffs, all in `phel.core`, no require needed | See [docs/async-guide.md](async-guide.md) |
 | **BigInt / BigDecimal / Ratio** | First-class `Phel\Lang\BigInteger`, `Phel\Lang\BigDecimal`, `Phel\Lang\Rational` ship in core | Use literals `1N`, `1.5M`, `1/2` or constructors `bigint`, `bigdec`, `rationalize`. See [numeric-tower.md](numeric-tower.md) |
 | **Character type** | PHP has no char type | Character literals (`\a`) and `char` / `char?` are supported but compile to single-character strings |
 | **Spec** | Not ported | Use runtime assertions or PHP validation |
 | **`alter-var-root`** | Available: `(alter-var-root #'sym f)` re-roots the global binding | Use `with-redefs` for scoped overrides; `add-watch`/`remove-watch` on vars for change tracking |
 
-The async surface lives in `phel\core`, no require needed: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel\async)`, since Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md).
+The async surface lives in `phel.core`, no require needed: `future`, `future-cancel`, `future-cancelled?`, `future-done?`, `future?`, `pmap`, `promise`, `deliver`, plus fiber combinators `async`, `await`, `await-all`, `await-any`, `future-call`, `future-fiber`, and `->closure`. Built on AMPHP fibers. Semantics match `future` where possible (including timeout-bounded `deref`), but cancellation is cooperative, and `pmap` is single-threaded (overlaps IO, does not parallelize CPU). Only `delay` needs `(:require phel.async)`, since Phel's `delay` is a sleep primitive while `clojure.core/delay` is a lazy thunk. See [docs/async-guide.md](async-guide.md).
 
 ## Structural differences
 
@@ -233,11 +235,11 @@ Phel sequences are eager. Use `lazy-seq` when needed:
 
 ### Test framework
 
-`phel\test` mirrors `clojure.test`:
+`phel.test` mirrors `clojure.test`:
 
 ```phel
-(ns my-app\test
-  (:require phel\test :refer [deftest is testing are]))
+(ns my-app.test
+  (:require phel.test :refer [deftest is testing are]))
 
 (deftest test-addition
   (testing "basic math"
@@ -248,10 +250,10 @@ Phel sequences are eager. Use `lazy-seq` when needed:
       3 3 6)))
 ```
 
-Extend `is` with custom assertions via `phel\test/assert-expr`:
+Extend `is` with custom assertions via `phel.test/assert-expr`:
 
 ```phel
-(defmethod phel\test/assert-expr 'my-form [msg form] ...)
+(defmethod phel.test/assert-expr 'my-form [msg form] ...)
 ```
 
 Run tests with `./bin/phel test`.
@@ -259,8 +261,8 @@ Run tests with `./bin/phel test`.
 ## Migration checklist
 
 1. Rename `.clj` files to `.phel` (or `.cljc` for shared code)
-2. Update namespace separators: `my.app.core` → `my\app\core` (or keep `.`, both work)
+2. Keep namespace separators as `.` (e.g. `my.app.core`); the legacy `\` form still parses but is deprecated
 3. Replace Java interop with PHP interop (`(.method obj)` → `(php/-> obj (method))`)
 4. Rewrite `(:import [java.util Date])` clauses as `(:use DateTime)` in the `ns` form
-5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed primitives in `phel\core` (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel\async :refer [delay])` only for the sleep primitive
+5. Replace concurrency primitives (refs, agents, core.async) with `atom` or the AMPHP-backed primitives in `phel.core` (`future`, `pmap`, `promise`, `deliver`, ...); add `(:require phel.async :refer [delay])` only for the sleep primitive
 6. Run `./bin/phel test` to verify

--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -84,9 +84,9 @@ Strings work with all sequence functions:
 ;; => ["h" "e" "l" "l" "o"]
 ```
 
-**`phel\string/chars`** - String to character vector:
+**`phel.string/chars`** - String to character vector:
 ```phel
-(use phel\string)
+(use phel.string)
 (chars "hello")
 ;; => ["h" "e" "l" "l" "o"]
 ```

--- a/docs/examples/01_basic-types.phel
+++ b/docs/examples/01_basic-types.phel
@@ -1,4 +1,4 @@
-(ns examples\basic-types)
+(ns examples.basic-types)
 
 ;; Demonstrates literals for strings, integers, floats, keywords, booleans, lists, tuples, and maps.
 ;; Also: BigInteger (1N), BigDecimal (1.5M), Rational (1/2), and #uuid tagged literal.

--- a/docs/examples/02_arithmetic.phel
+++ b/docs/examples/02_arithmetic.phel
@@ -1,4 +1,4 @@
-(ns examples\arithmetic)
+(ns examples.arithmetic)
 
 ;; Play with numeric operations and helper functions.
 ;; ^int :tag emits a PHP int parameter type and unlocks a JIT-friendly call shape.

--- a/docs/examples/03_control-flow.phel
+++ b/docs/examples/03_control-flow.phel
@@ -1,4 +1,4 @@
-(ns examples\control-flow)
+(ns examples.control-flow)
 
 ;; Showcase conditionals and pattern matching via cond and case.
 (defn classify-temperature [^int celsius]

--- a/docs/examples/04_functions-recursion.phel
+++ b/docs/examples/04_functions-recursion.phel
@@ -1,4 +1,4 @@
-(ns examples\functions-recursion)
+(ns examples.functions-recursion)
 
 ;; Define reusable functions and a classic recursive implementation.
 (defn ^string shout [^string message]

--- a/docs/examples/05_data-structures.phel
+++ b/docs/examples/05_data-structures.phel
@@ -1,4 +1,4 @@
-(ns examples\data-structures)
+(ns examples.data-structures)
 
 ;; Explore vectors, maps, destructuring, and data manipulation.
 

--- a/docs/examples/06_data-pipeline.phel
+++ b/docs/examples/06_data-pipeline.phel
@@ -1,4 +1,4 @@
-(ns examples\data-pipeline)
+(ns examples.data-pipeline)
 
 ;; Compose transformations over a collection with threading and higher-order helpers.
 

--- a/docs/examples/07_macro-playground.phel
+++ b/docs/examples/07_macro-playground.phel
@@ -1,4 +1,4 @@
-(ns examples\macro-playground)
+(ns examples.macro-playground)
 
 ;; Use a macro to build a declarative DSL for milestone planning.
 

--- a/docs/examples/08_interfaces.phel
+++ b/docs/examples/08_interfaces.phel
@@ -1,4 +1,4 @@
-(ns examples\interfaces)
+(ns examples.interfaces)
 
 ;; Define an interface and implement it with a struct.
 (definterface Greeter

--- a/docs/examples/09_php-integration.phel
+++ b/docs/examples/09_php-integration.phel
@@ -1,6 +1,6 @@
-(ns examples\php-integration
+(ns examples.php-integration
   (:use DateInterval DateTimeImmutable DateTimeZone)
-  (:require phel\json :as json))
+  (:require phel.json :as json))
 
 (def workshop-blocks
   [{:title "Welcome coffee" :length "PT30M"}

--- a/docs/examples/10_html-rendering.phel
+++ b/docs/examples/10_html-rendering.phel
@@ -1,5 +1,5 @@
-(ns examples\html-rendering
-  (:require phel\html :as html))
+(ns examples.html-rendering
+  (:require phel.html :as html))
 
 ;; Generate HTML strings with the built-in templating helpers.
 (def sessions

--- a/docs/examples/11_async-concurrency.phel
+++ b/docs/examples/11_async-concurrency.phel
@@ -1,5 +1,5 @@
-(ns examples\async-concurrency
-  (:require phel\async :refer [delay]))
+(ns examples.async-concurrency
+  (:require phel.async :refer [delay]))
 
 ;; Async concurrency with Phel and AMPHP (amphp/amp).
 ;; Run: ./bin/phel run docs/examples/11_async-concurrency.phel

--- a/docs/examples/12_cli.phel
+++ b/docs/examples/12_cli.phel
@@ -1,4 +1,4 @@
-;; Runnable phel\cli demo: a tiny todo-list CLI.
+;; Runnable phel.cli demo: a tiny todo-list CLI.
 ;;
 ;;   ./bin/phel run docs/examples/12_cli.phel add "buy milk"
 ;;   ./bin/phel run docs/examples/12_cli.phel list
@@ -8,9 +8,9 @@
 ;;
 ;; Persists to /tmp/phel-todo.json, not production-grade, just a demo.
 
-(ns examples\cli
-  (:require phel\cli :as cli)
-  (:require phel\json :as json))
+(ns examples.cli
+  (:require phel.cli :as cli)
+  (:require phel.json :as json))
 
 (def store-file "/tmp/phel-todo.json")
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -19,9 +19,9 @@ Standalone scripts from primitive literals through concurrency to a full CLI. Ru
 | 07 | `07_macro-playground.phel` | A small DSL built with `defmacro` |
 | 08 | `08_interfaces.phel` | `definterface` + `defstruct` polymorphism |
 | 09 | `09_php-integration.phel` | PHP interop: `DateTimeImmutable`, `DateInterval`, JSON |
-| 10 | `10_html-rendering.phel` | HTML templating with `phel\html` |
+| 10 | `10_html-rendering.phel` | HTML templating with `phel.html` |
 | 11 | `11_async-concurrency.phel` | AMPHP + fiber concurrency (`async`, `await`, `promise`) |
-| 12 | `12_cli.phel` | A todo-list CLI on `phel\cli` with subcommands and tables |
+| 12 | `12_cli.phel` | A todo-list CLI on `phel.cli` with subcommands and tables |
 | extra | `transducers.phel` | Composable transformations: `into`, `transduce`, `sequence` |
 
 Copy any file into your project and tweak it.
@@ -49,7 +49,7 @@ Copy any file into your project and tweak it.
 | `defn`, multi-arity | `snippets/defn.phel` |
 | `lazy-seq`, infinite seqs | `snippets/lazy.phel` |
 | `atom`, `swap!`, `reset!` | `snippets/atom.phel` |
-| `phel\string` ops | `snippets/string.phel` |
+| `phel.string` ops | `snippets/string.phel` |
 
 Each snippet is runnable: `./bin/phel run docs/examples/snippets/<name>.phel`. Use as REPL warm-ups or copy-paste recipes.
 

--- a/docs/examples/snippets/apply.phel
+++ b/docs/examples/snippets/apply.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\apply)
+(ns examples.snippets.apply)
 
 (println (apply + [1 2 3 4 5]))            ; 15
 (println (apply max [3 1 4 1 5 9 2 6]))    ; 9

--- a/docs/examples/snippets/assoc.phel
+++ b/docs/examples/snippets/assoc.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\assoc)
+(ns examples.snippets.assoc)
 
 (println (assoc {:a 1} :b 2))              ; {:a 1 :b 2}
 (println (assoc {:a 1 :b 2} :a 99))        ; {:a 99 :b 2}

--- a/docs/examples/snippets/atom.phel
+++ b/docs/examples/snippets/atom.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\atom)
+(ns examples.snippets.atom)
 
 (defn main []
   (let [counter (atom 0)]

--- a/docs/examples/snippets/conj.phel
+++ b/docs/examples/snippets/conj.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\conj)
+(ns examples.snippets.conj)
 
 ;; Vectors: append
 (println (conj [1 2 3] 4))                 ; @[1 2 3 4]

--- a/docs/examples/snippets/defn.phel
+++ b/docs/examples/snippets/defn.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\defn)
+(ns examples.snippets.defn)
 
 ;; ^int :tag emits a PHP int parameter type and unlocks JIT-friendly call shape.
 (defn ^int square [^int x] (* x x))

--- a/docs/examples/snippets/destructure.phel
+++ b/docs/examples/snippets/destructure.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\destructure)
+(ns examples.snippets.destructure)
 
 ;; Vector destructuring
 (let [[a b c] [10 20 30]]

--- a/docs/examples/snippets/filter.phel
+++ b/docs/examples/snippets/filter.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\filter)
+(ns examples.snippets.filter)
 
 (println (filter pos? [1 -2 3 0 -4 5]))   ; @[1 3 5]
 (println (filter even? (range 10)))       ; @[0 2 4 6 8]

--- a/docs/examples/snippets/get.phel
+++ b/docs/examples/snippets/get.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\get)
+(ns examples.snippets.get)
 
 (println (get {:a 1 :b 2} :a))             ; 1
 (println (get {:a 1} :missing))            ; nil

--- a/docs/examples/snippets/if-cond.phel
+++ b/docs/examples/snippets/if-cond.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\if-cond)
+(ns examples.snippets.if-cond)
 
 (println (if (> 5 3) :yes :no))            ; :yes
 (println (if nil :yes :no))                ; :no

--- a/docs/examples/snippets/into.phel
+++ b/docs/examples/snippets/into.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\into)
+(ns examples.snippets.into)
 
 ;; into adds all elements of src into dest, keeping dest's type
 (println (into [] (range 5)))              ; @[0 1 2 3 4]

--- a/docs/examples/snippets/lazy.phel
+++ b/docs/examples/snippets/lazy.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\lazy)
+(ns examples.snippets.lazy)
 
 ;; lazy-seq defers computation until elements are realized
 (defn ints-from [^int n] (lazy-seq (cons n (ints-from (inc n)))))

--- a/docs/examples/snippets/let.phel
+++ b/docs/examples/snippets/let.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\let)
+(ns examples.snippets.let)
 
 (println (let [x 10 y 20] (+ x y)))        ; 30
 

--- a/docs/examples/snippets/loop-recur.phel
+++ b/docs/examples/snippets/loop-recur.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\loop-recur)
+(ns examples.snippets.loop-recur)
 
 ;; Factorial with loop/recur (constant stack).
 ;; `*'` auto-promotes to BigInteger if PHP int overflows, e.g. (fact 21).

--- a/docs/examples/snippets/map.phel
+++ b/docs/examples/snippets/map.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\map)
+(ns examples.snippets.map)
 
 (println (map inc [1 2 3]))                ; @[2 3 4]
 (println (map + [1 2 3] [10 20 30]))       ; @[11 22 33]

--- a/docs/examples/snippets/merge.phel
+++ b/docs/examples/snippets/merge.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\merge)
+(ns examples.snippets.merge)
 
 (println (merge {:a 1} {:b 2}))            ; {:a 1 :b 2}
 

--- a/docs/examples/snippets/range.phel
+++ b/docs/examples/snippets/range.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\range)
+(ns examples.snippets.range)
 
 (println (range 5))                        ; (0 1 2 3 4)
 (println (range 2 8))                      ; (2 3 4 5 6 7)

--- a/docs/examples/snippets/reduce.phel
+++ b/docs/examples/snippets/reduce.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\reduce)
+(ns examples.snippets.reduce)
 
 (println (reduce + [1 2 3 4 5]))           ; 15
 (println (reduce + 100 [1 2 3]))           ; 106

--- a/docs/examples/snippets/string.phel
+++ b/docs/examples/snippets/string.phel
@@ -1,5 +1,5 @@
-(ns examples\snippets\string
-  (:require phel\string :as str))
+(ns examples.snippets.string
+  (:require phel.string :as str))
 
 (println (str "Hello, " "World" "!"))      ; "Hello, World!"
 (println (str/upper-case "phel"))          ; "PHEL"

--- a/docs/examples/snippets/threading.phel
+++ b/docs/examples/snippets/threading.phel
@@ -1,4 +1,4 @@
-(ns examples\snippets\threading)
+(ns examples.snippets.threading)
 
 ;; -> threads as the second argument
 (println (-> 5 (+ 3) (* 2)))               ; 16   ; (* (+ 5 3) 2)

--- a/docs/examples/transducers.phel
+++ b/docs/examples/transducers.phel
@@ -1,4 +1,4 @@
-(ns examples\transducers)
+(ns examples.transducers)
 
 ;; -------------------------------------------------------
 ;; Phel Transducers -- A Practical Guide

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -89,7 +89,7 @@ Each module ships `CLAUDE.md` with API + constraints. Read it before editing.
 ## Compile-time vs runtime
 
 - **Compile**: `CompilerFacade::compile()`. Holds `GlobalEnvironment`, macros, `TypeFactory`/`Registry`.
-- **Runtime**: executes emitted PHP. Sees only `\Phel::*`, `\phel\core\*`, `Lang/` types.
+- **Runtime**: executes emitted PHP. Sees only `\Phel::*` (with dot-form registry keys like `"phel.core"`) and `Lang/` types.
 
 Same physical PHP process (REPL, `phel run`) or different (cached files in a framework). Boundary is "being analysed" vs "being executed".
 

--- a/docs/internals/benchmarks.md
+++ b/docs/internals/benchmarks.md
@@ -6,7 +6,7 @@ Three areas:
 
 - **CLI commands**: `phel run` and `phel test` end-to-end.
 - **Persistent collections**: vectors and hash maps for hot ops like `append`, `update`, `put`.
-- **Core bootstrap**: loading and executing the bundled `phel\core` namespace, to track compiler startup time.
+- **Core bootstrap**: loading and executing the bundled `phel.core` namespace, to track compiler startup time.
 
 ## Running the suite
 

--- a/docs/internals/compiler.md
+++ b/docs/internals/compiler.md
@@ -64,7 +64,7 @@ Wrong context yields wrong PHP. Emitter trusts what analyzer wrote.
 - **Modes** (`EmitMode`): `STATEMENT` (REPL, `eval`), `FILE` (cached compilation). `StatementEmitter` vs `FileEmitter`.
 
 ```php
-\phel\core\print_("hi");
+(\Phel::getDefinition("phel.core", "print"))("hi");
 ```
 
 **Evaluator**

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -6,7 +6,7 @@ Grouped by reader.
 
 **Interpreter or compiler?** Compiler. Each top-level form lowers to PHP source, written to a file, then `require`d. No runtime AST walker.
 
-**What does emitted PHP look like?** Cached files under `var/cache/` after one `phel run`, or the `--PHP--` section of any fixture in `tests/php/Integration/Fixtures/`. Regular PHP calling `\Phel::*` and `\phel\core\*`.
+**What does emitted PHP look like?** Cached files under `var/cache/` after one `phel run`, or the `--PHP--` section of any fixture in `tests/php/Integration/Fixtures/`. Regular PHP calling `\Phel::*` with dot-form registry keys like `"phel.core"`.
 
 **Why `\Phel::addDefinition()` instead of plain functions?** Phel namespaces are runtime values (see [runtime.md](runtime.md)). Single static surface tracks definitions, metadata, reloads. One `require` registers a whole namespace, no per-definition class-loading.
 
@@ -79,7 +79,7 @@ $emit   = $facade->compile('(print "hi")', new CompileOptions());
 
 ## Bug hunting
 
-**"Cannot resolve symbol X".** `AnalyzeSymbol` checks locals, then current-ns globals, then `use` aliases, then `phel\core`. Miss: `SymbolSuggestionProvider` builds a suggestion and throws with `SourceLocation`. Common cause: missing `(require ...)`.
+**"Cannot resolve symbol X".** `AnalyzeSymbol` checks locals, then current-ns globals, then `use` aliases, then `phel.core`. Miss: `SymbolSuggestionProvider` builds a suggestion and throws with `SourceLocation`. Common cause: missing `(require ...)`.
 
 **"Type X cannot be coerced" or unexpected `nil`.** Run `(macroexpand-1 'form)`. Often a macro expansion surprise.
 

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -56,7 +56,7 @@ Matches user-facing `&form` / `&env`.
 | `` `(a ~@xs b) `` | `(concat (list (quote a)) xs (list (quote b)))` |
 | `` `[a ~x] `` | `(vec (concat (list (quote a)) (list x)))` |
 
-Symbols inside quasiquote get namespace-qualified to the *defining* namespace. Easy half of hygiene: `` `(map f xs) `` resolves to `phel\core/map` regardless of caller shadowing.
+Symbols inside quasiquote get namespace-qualified to the *defining* namespace. Easy half of hygiene: `` `(map f xs) `` resolves to `phel.core/map` regardless of caller shadowing.
 
 ## Auto-gensym (`x#`)
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -8,7 +8,7 @@ What emitted PHP runs against. `src/php/Lang/` plus `src/php/Phel.php`. Independ
 \Phel::addDefinition(
     "user",
     "greet",
-    function ($name) { return \phel\core\str("hello, ", $name); },
+    function ($name) { return (\Phel::getDefinition("phel.core", "str"))("hello, ", $name); },
     \Phel::map(\Phel::keyword("doc"), "Greet someone."),
 );
 ```

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -74,9 +74,9 @@ Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexce
 
 ## Not special forms
 
-- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`: macros in `phel\core`
+- `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`: macros in `phel.core`
 - `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify`: macros over `*` forms
-- `+`, `-`, `=`, `map`, `filter`, ...: functions in `phel\core`
+- `+`, `-`, `=`, `map`, `filter`, ...: functions in `phel.core`
 
 Run `(macroexpand-1 'form)` to see the truth.
 

--- a/docs/lazy-sequences.md
+++ b/docs/lazy-sequences.md
@@ -119,7 +119,7 @@ When building recursive infinite sequences, use `cons` instead:
 (defn process-records [records]
   (->> records
        (filter (fn [x] (not (empty? x))))
-       (map (fn [x] (phel\string/trim x)))
+       (map (fn [x] (phel.string/trim x)))
        (map parse-record)))
 
 ;; Only processes records as needed

--- a/docs/match-guide.md
+++ b/docs/match-guide.md
@@ -1,12 +1,12 @@
 # Pattern Matching Guide
 
-`phel\match` provides a `match` macro that destructures by shape. Expands to nested `cond` + `let` at compile time.
+`phel.match` provides a `match` macro that destructures by shape. Expands to nested `cond` + `let` at compile time.
 
 ## Quickstart
 
 ```phel
-(ns my-app\main
-  (:require phel\match :refer [match]))
+(ns my-app.main
+  (:require phel.match :refer [match]))
 
 (defn describe [x]
   (match [x]
@@ -54,5 +54,5 @@
 
 ## See also
 
-- `phel\schema`: shapes reusable across validation and matching
+- `phel.schema`: shapes reusable across validation and matching
 - `cond`, `case`, `condp`: simpler dispatch without destructuring

--- a/docs/mocking-guide.md
+++ b/docs/mocking-guide.md
@@ -3,9 +3,9 @@
 Replace dependencies with controlled stand-ins for testing.
 
 ```phel
-(ns my-app\test\user-test
-  (:require phel\test :refer [deftest is])
-  (:require phel\mock :refer [mock called-with?]))
+(ns my-app.test.user-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.mock :refer [mock called-with?]))
 
 (deftest test-fetch-user
   (let [mock-http (mock {:id 1 :name "Alice"})]

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -215,10 +215,10 @@ Threads value as **last** argument:
 
 ## Pattern Matching
 
-`phel\match` destructures by shape and binds symbols in one step. Use when `cond`/`case` would re-query the same value from multiple angles.
+`phel.match` destructures by shape and binds symbols in one step. Use when `cond`/`case` would re-query the same value from multiple angles.
 ```phel
-(ns app\commands
-  (:require phel\match :refer [match]))
+(ns app.commands
+  (:require phel.match :refer [match]))
 
 (defn handle [event]
   (match [event]
@@ -264,14 +264,14 @@ Without `:else`, `match` throws `RuntimeException` when nothing fits. Add `:else
 (defn safe-divide [a b]
   (try
     (/ a b)
-    (catch php\DivisionByZeroError e
+    (catch \DivisionByZeroError e
       (println "Cannot divide by zero")
       nil)))
 
 (defn parse-json [str]
   (try
     (php/json_decode str true)
-    (catch php\JsonException e
+    (catch \JsonException e
       {:error (php/-> e (getMessage))})))
 ```
 
@@ -602,14 +602,14 @@ Every `defmacro` body has two implicit symbols:
 
 ### Extending `is` with Custom Assertions
 
-`phel\test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the original `form` and user-supplied `message`, and returns the code `is` should run:
+`phel.test/assert-expr` is an open multimethod. Teach `is` to expand new assertion forms via `defmethod`. The method takes the original `form` and user-supplied `message`, and returns the code `is` should run:
 
 ```phel
-(ns my-app\test\helpers
-  (:require phel\test :refer [deftest is]))
+(ns my-app.test.helpers
+  (:require phel.test :refer [deftest is]))
 
 ;; Approximate equality for floats: expand to `is` over a tolerance check.
-(defmethod phel\test/assert-expr 'approx= [form message]
+(defmethod phel.test/assert-expr 'approx= [form message]
   (let [a (second form)
         b (second (next form))
         epsilon 0.001]
@@ -621,7 +621,7 @@ Every `defmacro` body has two implicit symbols:
 
 When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:default` arm handles binary equality and predicate forms.
 
-> Cross-namespace registration must use fully-qualified `phel\test/assert-expr` so the methods table resolves in `phel\test`, not the local namespace.
+> Cross-namespace registration must use fully-qualified `phel.test/assert-expr` so the methods table resolves in `phel.test`, not the local namespace.
 
 ## Tips for Writing Idiomatic Phel
 
@@ -688,7 +688,7 @@ When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:d
 Guard imperative entry calls with `*build-mode*`:
 
 ```phel
-(ns app\main)
+(ns app.main)
 
 (defn play []
   (loop [state (initial-state)]

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -20,7 +20,7 @@ Call PHP from Phel and Phel from PHP.
 Prefix PHP functions with `php/`:
 
 ```phel
-(ns app\example)
+(ns app.example)
 
 ;; String functions
 (php/strlen "hello")              ; => 5
@@ -55,7 +55,7 @@ Capture references with `def` to shorten calls:
 ### Classes and Objects
 
 ```phel
-(ns app\example
+(ns app.example
   (:use DateTime DateInterval))
 
 ;; Create instance (all forms are equivalent)
@@ -117,7 +117,7 @@ Capture references with `def` to shorten calls:
 Use `:use` for PHP classes:
 
 ```phel
-(ns app\services
+(ns app.services
   (:use PDO)                      ; Single class
   (:use DateTime DateInterval)   ; Multiple classes
   (:use Symfony\Component\HttpFoundation\Request))
@@ -133,24 +133,22 @@ Use `:use` for PHP classes:
 
 ```phel
 ;; List entry
-(ns app\services
-  (:require phel\string :as str)
-  (:require phel\json :as json :refer [encode decode]))
+(ns app.services
+  (:require phel.string :as str)
+  (:require phel.json :as json :refer [encode decode]))
 
 ;; Vector entry, same meaning
-(ns app\services
-  (:require [phel\string :as str]
-            [phel\json :as json :refer [encode decode]]))
+(ns app.services
+  (:require [phel.string :as str]
+            [phel.json :as json :refer [encode decode]]))
 ```
 
-`.` is an alternate separator (alongside `\`):
+Phel uses `.` as the namespace separator, matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated; new code should use `.`.
 
 ```phel
 (ns my.cljc.file
   (:require [phel.string :as str]))
 ```
-
-Both `phel\string` and `phel.string` resolve to the same namespace.
 
 ## Type Conversions
 
@@ -184,7 +182,7 @@ Both `phel\string` and `phel.string` resolve to the same namespace.
 
 **hello.phel:**
 ```phel
-(ns app\hello)
+(ns app.hello)
 
 (defn greet [name]
   (str "Hello, " name "!"))
@@ -199,13 +197,13 @@ Both `phel\string` and `phel.string` resolve to the same namespace.
 require 'vendor/autoload.php';
 
 // Bootstrap Phel and load the namespace (compiles on first call).
-\Phel::run(__DIR__, 'app\\hello');
+\Phel::run(__DIR__, 'app.hello');
 
 // Call Phel functions by name; getDefinition returns the registered fn.
-$greet = \Phel::getDefinition('app\\hello', 'greet');
+$greet = \Phel::getDefinition('app.hello', 'greet');
 echo $greet('World'); // => "Hello, World!"
 
-$add = \Phel::getDefinition('app\\hello', 'add');
+$add = \Phel::getDefinition('app.hello', 'add');
 echo $add(5, 10); // => 15
 ```
 
@@ -213,7 +211,7 @@ echo $add(5, 10); // => 15
 
 **routes.phel:**
 ```phel
-(ns app\routes
+(ns app.routes
   (:use Symfony\Component\HttpFoundation\Response))
 
 (defn handle-home [request]
@@ -234,13 +232,13 @@ require 'vendor/autoload.php';
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-\Phel::run(__DIR__, 'app\\routes');
+\Phel::run(__DIR__, 'app.routes');
 
 $request = Request::createFromGlobals();
 $path = $request->getPathInfo();
 
-$home = \Phel::getDefinition('app\\routes', 'handle-home');
-$api  = \Phel::getDefinition('app\\routes', 'handle-api');
+$home = \Phel::getDefinition('app.routes', 'handle-home');
+$api  = \Phel::getDefinition('app.routes', 'handle-api');
 
 $response = match ($path) {
     '/'    => $home($request),
@@ -256,7 +254,7 @@ $response->send();
 ### Catching PHP Exceptions
 
 ```phel
-(ns app\db
+(ns app.db
   (:use PDO PDOException))
 
 (defn connect [dsn user pass]
@@ -277,7 +275,7 @@ $response->send();
 ### Throwing Exceptions
 
 ```phel
-(ns app\validator
+(ns app.validator
   (:use InvalidArgumentException))
 
 (defn validate-age [age]
@@ -324,7 +322,7 @@ $response->send();
 ### Database Access
 
 ```phel
-(ns app\db
+(ns app.db
   (:use PDO))
 
 (defn query-all [pdo sql params]
@@ -341,8 +339,8 @@ $response->send();
 ### HTTP Requests
 
 ```phel
-(ns app\http
-  (:require phel\json :as json))
+(ns app.http
+  (:require phel.json :as json))
 
 (defn fetch-json [url]
   (let [response (php/file_get_contents url)
@@ -363,7 +361,7 @@ $response->send();
 ### File Operations
 
 ```phel
-(ns app\files)
+(ns app.files)
 
 (defn read-lines [filename]
   (let [content (php/file_get_contents filename)]
@@ -388,8 +386,8 @@ $response->send();
 - **Method calls**: `(php/-> obj (method))` (also `(.method obj)`).
 - **Deref**: `@my-atom` shortcuts `(deref my-atom)`.
 - **Import classes**: `:use` in `ns`, not `:import`.
-- **Require vectors**: `(:require [phel\string :as str :refer [upper-case]])` works alongside the list form.
-- **Namespace separators**: `\` and `.` both work; `phel\string` and `phel.string` resolve to the same namespace.
+- **Require vectors**: `(:require [phel.string :as str :refer [upper-case]])` works alongside the list form.
+- **Namespace separators**: Phel uses `.` matching Clojure. The legacy `\` separator is still accepted for back-compat but deprecated.
 - **Reader conditionals**: `#?(:phel ...)` and `#?@(:phel ...)` for `.cljc` files.
 - **Unquote**: `~` and `~@` inside syntax-quote (`,` / `,@` deprecated).
 - **Auto-gensym**: `name#` inside syntax-quote produces a unique symbol (`name$` deprecated).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ return PhelConfig::forProject();          // auto-detects layout and namespace
 Create `src/hello.phel`:
 
 ```phel
-(ns app\hello)
+(ns app.hello)
 
 (defn greet [name]
   (str "Hello, " name "!"))
@@ -141,8 +141,8 @@ The prompt shows the current namespace; it switches on `(ns ...)` / `(in-ns ...)
 ## Pattern Matching
 
 ```phel
-(ns app\routing
-  (:require phel\match :refer [match]))
+(ns app.routing
+  (:require phel.match :refer [match]))
 
 (defn route [req]
   (match [req]
@@ -162,7 +162,7 @@ See [Pattern Matching Guide](match-guide.md) for guards, destructuring, and more
 `src/greet.phel`:
 
 ```phel
-(ns app\greet)
+(ns app.greet)
 
 (defn hello [name] (str "Hello, " name "!"))
 ```
@@ -174,12 +174,12 @@ See [Pattern Matching Guide](match-guide.md) for guards, destructuring, and more
 require __DIR__ . '/../vendor/autoload.php';
 
 \Phel::bootstrap(__DIR__ . '/..');
-\Phel::run(__DIR__ . '/..', 'app\\greet');
+\Phel::run(__DIR__ . '/..', 'app.greet');
 
-echo \Phel::getDefinition('app_greet', 'hello')('World');
+echo \Phel::getDefinition('app.greet', 'hello')('World');
 ```
 
-`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores.
+`getDefinition` resolves any Phel function as a PHP callable. Namespace hyphens become underscores in registry keys (`my-app.lib` becomes `my_app.lib`).
 
 Full HTTP example: [Framework Integration](framework-integration.md).
 
@@ -188,9 +188,9 @@ Full HTTP example: [Framework Integration](framework-integration.md).
 `tests/hello_test.phel`:
 
 ```phel
-(ns tests\hello-test
-  (:require phel\test :refer [deftest is])
-  (:require app\hello :refer [greet]))
+(ns tests.hello-test
+  (:require phel.test :refer [deftest is])
+  (:require app.hello :refer [greet]))
 
 (deftest test-greet
   (is (= "Hello, World!" (greet "World"))))
@@ -207,11 +207,11 @@ Tag tests with `^{:tags [:integration]}` and select via `--include`/`--exclude`.
 ## REPL Workflow
 
 ```phel
-user:1> (require 'app\hello)
-user:2> (in-ns 'app\hello)
-app\hello:3> (greet "REPL")        ; => "Hello, REPL!"
-app\hello:4> (doc map)             ; show docs
-app\hello:5> (resolve 'map)        ; => #'phel\core/map
+user:1> (require 'app.hello)
+user:2> (in-ns 'app.hello)
+app.hello:3> (greet "REPL")        ; => "Hello, REPL!"
+app.hello:4> (doc map)             ; show docs
+app.hello:5> (resolve 'map)        ; => #'phel.core/map
 ```
 
 ## Common Gotchas

--- a/docs/reader-conditionals.md
+++ b/docs/reader-conditionals.md
@@ -105,7 +105,7 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files:
      :default "unknown"))
 ```
 
-> **Tip:** `.cljc` files can use either `\` or `.` as the namespace separator (`shared\utils` or `shared.utils`). Both forms resolve to the same namespace, so the dot form parses cleanly under Clojure too.
+> **Tip:** `.cljc` files should use `.` as the namespace separator (`shared.utils`) so the file parses cleanly under Clojure too. The legacy `\` separator (`shared\utils`) still resolves but is deprecated.
 
 ### Platform-specific dependencies
 
@@ -119,7 +119,7 @@ Phel discovers and compiles `.cljc` files alongside `.phel` files:
      :clj  (json/read-str s)))
 ```
 
-> Phel accepts both vector entries (`[phel.json :as json :refer [encode]]`) and the older list form (`phel\json :as json`) inside `:require`, so the same `(ns ...)` form parses on both sides.
+> Phel accepts both vector entries (`[phel.json :as json :refer [encode]]`) and the list form (`phel.json :as json`) inside `:require`, so the same `(ns ...)` form parses on both sides.
 
 ### Conditional data structures
 

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -1,12 +1,12 @@
 # Schema Guide
 
-`phel\schema` validates, coerces, and generates values. Schemas are plain Phel data (keywords or vectors), no DSL.
+`phel.schema` validates, coerces, and generates values. Schemas are plain Phel data (keywords or vectors), no DSL.
 
 ## Quickstart
 
 ```phel
-(ns my-app\main
-  (:require phel\schema :as s))
+(ns my-app.main
+  (:require phel.schema :as s))
 
 (def User
   [:map {:closed? true}
@@ -66,5 +66,5 @@
 
 ## See also
 
-- `phel\match` for destructuring matched shapes
-- `phel\test\gen` for property-based testing driven by schemas
+- `phel.match` for destructuring matched shapes
+- `phel.test.gen` for property-based testing driven by schemas

--- a/docs/watch-guide.md
+++ b/docs/watch-guide.md
@@ -23,8 +23,8 @@ On each change, `phel watch` reloads the changed namespace and its dependents in
 ## Programmatic API
 
 ```phel
-(ns dev\watcher
-  (:require phel\watch :refer [watch!]))
+(ns dev.watcher
+  (:require phel.watch :refer [watch!]))
 
 (watch! ["src/" "tests/"])
 ```


### PR DESCRIPTION
## 🤔 Background

`docs/clojure-migration.md` (and most other docs and example snippets) still teach the legacy `\` namespace separator as the canonical form, even though Phel now encourages Clojure-style `.` separators. The `\` form parses for back-compat but is deprecated (see `docs/migration/backslash-to-dot.md`).

## 💡 Goal

Make the docs reflect the current convention: `.` is the preferred separator, `\` is legacy and deprecated.

## 🔖 Changes

- `docs/clojure-migration.md`: flip narrative; quick-reference and namespace-syntax sections lead with `.`, the legacy `\` block is labelled deprecated.
- Convert ns declarations, `:require`/`:use` targets, and fn refs across:
  - top-level guides (`php-interop`, `quickstart`, `patterns`, `match-guide`, `schema-guide`, `mocking-guide`, `async-guide`, `watch-guide`, `cli-guide`, `ai-guide`, `lazy-sequences`, `data-structures-guide`, `reader-conditionals`, `README`)
  - `docs/internals/*.md`
  - all `docs/examples/*.phel` and `docs/examples/snippets/*.phel`
- Fn refs use Clojure-style slash: `phel\string\upper-case` becomes `phel.string/upper-case`.
- PHP class FQNs (`\DateTime`, `Phel\Lang\Symbol`, `Symfony\Component\...`, etc.) and char literals (`\a`, `\space`) preserved.
- `docs/migration/backslash-to-dot.md` left untouched: its side-by-side examples are the migration target itself.
- Bootstrap PHP examples in `quickstart.md` / `php-interop.md` updated to `Phel::getDefinition('app.hello', ...)` to match the dot-form registry keys actually emitted (verified against `tests/php/Integration/Fixtures/**`).

No code or compiler behavior changes.