### PR TITLE
docs(agents): surface typed defn, ^:async, ^:memoize in resources/agents

### DIFF
--- a/resources/agents/README.md
+++ b/resources/agents/README.md
@@ -22,9 +22,9 @@ Targets: [`skills/INSTALL.md`](skills/INSTALL.md).
 
 | Path | Purpose |
 |------|---------|
-| [`RULES.md`](RULES.md) | Rules + CLI cheatsheet. Every installed adapter loads this from `.agents/RULES.md`. |
+| [`RULES.md`](RULES.md) | Rules, modern-feature reference (typed `defn`, `^:async`, `^:memoize`), CLI cheatsheet. Every installed adapter loads this from `.agents/RULES.md`. |
 | [`index.md`](index.md) | Intent → task recipe. |
-| [`tasks/`](tasks/) | One recipe per workflow. |
+| [`tasks/`](tasks/) | One recipe per workflow (`typed-defn`, `http-app`, `cli-tool`, ...). |
 | [`skills/`](skills/) | Per-platform adapters. |
 | [`examples/`](examples/) | Runnable projects (`todo-app`, `http-json-api`, `cli-wordcount`). |
 | [`VERSION`](VERSION) | phel-lang release this doc targets. |

--- a/resources/agents/RULES.md
+++ b/resources/agents/RULES.md
@@ -10,14 +10,15 @@ Single source for every skill adapter.
 4. PHP interop: `(php/fn args)`, `(php/-> obj (method args))`, `(php/:: Class (static args))`, `(php/new Class args)`. Shorthands: `(.method obj args)`, `(.-prop obj)`, `(Class/method args)`, `Class/CONST`.
 5. Threading: `->` first-arg, `->>` last-arg, `some->` / `some->>` nil-safe, `cond->` conditional.
 6. Only `false` and `nil` are falsy. `0`, `""`, `[]` truthy.
-7. Namespaces need ≥ 2 segments (`app\main`). File path matches ns under src dir.
+7. Namespaces need ≥ 2 segments. Prefer `.` separator (`app.main`); `\` still parses but is deprecated. File path matches ns under src dir.
 8. Comments: `;` inline, `;;` standalone, `#_` form, `#| |#` block.
 9. PHP assoc array: `#php {"k" "v"}` or `(to-php-array m)`. Not `{:k "v"}`.
 10. Catch PHP: `(catch php\SomeException e ...)`.
+11. Annotate hot-path `defn` with `:tag` on params + return for PHP type emission, JIT-friendly call shape, and compile-time mismatch diagnostics. See `tasks/typed-defn.md`.
 
 ## New features (v0.30 – main)
 
-Use these when appropriate — they are stable and tested.
+Use these when appropriate; stable and tested.
 
 | Feature | Syntax | Since |
 |---------|--------|-------|
@@ -26,12 +27,27 @@ Use these when appropriate — they are stable and tested.
 | Multimethods | `(defmulti area :shape)` + `(defmethod area :circle [{:radius r}] ...)` | v0.30 |
 | Transducers | `(into [] (filter odd?) [1 2 3])`, `(transduce (map inc) + 0 coll)` | v0.31 |
 | Regex literals | `#"^\d+$"`, `(re-find #"\d+" "abc123")` → `"123"` | v0.31 |
-| Pretty-print | `(require phel\pprint)` → `(pprint data)` | v0.30 |
+| Pretty-print | `(require phel.pprint)` → `(pprint data)` | v0.30 |
 | Sorted colls | `(sorted-map :a 1 :b 2)`, `(sorted-set 3 1 2)` | v0.32 |
 | `condp` | `(condp = x 1 "one" 2 "two" "other")` | v0.32 |
 | `defrecord` w/ protocols | `(defrecord Foo [x] MyProto (my-fn [this] ...))` | v0.32 |
-| `doseq` | `(doseq [x :in coll] (println x))` — side-effecting iteration | v0.31 |
-| `for` comprehension | `(for [x :in xs :when (odd? x)] (* x x))` — builds sequence | v0.31 |
+| `doseq` | `(doseq [x :in coll] (println x))`; side-effecting iteration | v0.31 |
+| `for` comprehension | `(for [x :in xs :when (odd? x)] (* x x))`; builds sequence | v0.31 |
+| `:tag` types | `(defn ^int square [^int x] (* x x))`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`. Emits PHP type decls; static checker rejects literal mismatches | main |
+| Return inference | Tagged params + tail primitive op (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`) infers return; `if` / `let` / `loop` propagate. Explicit `:tag` always wins | main |
+| `^:async` defn | `(defn ^:async fetch [url] (await (http-get url)))`; body wrapped in `async`, returns `Amp\Future` | main |
+| `^:memoize` / `^{:memoize-lru N}` | `(defn ^{:memoize-lru 32} fib [^int n] ...)`; opt-in caching by arg vector, LRU bound optional | main |
+
+`:tag` reader shorthands:
+
+```phel
+(defn ^int  add  [^int a ^int b] (+ a b))               ; param + return
+(defn ^"?int" maybe-id [^string s] ...)                 ; nullable
+(defn ^"\\DateTimeImmutable" now [] (php/new \DateTimeImmutable))
+(defn ^{:tag "array"} pairs [m] ...)                    ; map form
+```
+
+Defn-name tag propagates to every arity unless an arity vector overrides it. See `tasks/typed-defn.md`.
 
 ## Gotchas
 
@@ -54,6 +70,7 @@ See [`tasks/common-gotchas.md`](tasks/common-gotchas.md) for details. Quick summ
 | Build | `./vendor/bin/phel build` |
 | Doc | `./vendor/bin/phel doc <fn>` |
 | Format | `./vendor/bin/phel format <file>` |
+| Profile | `./vendor/bin/phel profile <path> [--format=text\|json\|both] [--output=<file>]` |
 | Install skill | `./vendor/bin/phel agent-install <platform>\|--all` |
 
 ## Workflow
@@ -61,8 +78,9 @@ See [`tasks/common-gotchas.md`](tasks/common-gotchas.md) for details. Quick summ
 1. `phel init` if empty.
 2. Unknowns → REPL `(doc <fn>)` before guessing.
 3. Code `src/<ns>.phel` (flat) or `src/phel/<ns>.phel` (`--nested`).
-4. `phel\test`: `deftest`, `is`. Run `phel test`.
+4. `phel.test`: `deftest`, `is`. Run `phel test`.
 5. `phel run` or web entry.
+6. Hot loops: add `:tag` to params + return; `phel profile` to find them.
 
 ## Commits
 

--- a/resources/agents/index.md
+++ b/resources/agents/index.md
@@ -12,7 +12,11 @@ Rules + CLI: [`RULES.md`](RULES.md).
 | Add tests | [`tasks/add-tests.md`](tasks/add-tests.md) | `src/phel/test.phel`, `docs/mocking-guide.md` |
 | REPL | [`tasks/repl-workflow.md`](tasks/repl-workflow.md) | `src/phel/repl.phel` |
 | Find core fn | [`tasks/use-core-lib.md`](tasks/use-core-lib.md) | `(phel doc <fn>)`, `docs/patterns.md` |
+| Type a fn (params + return) | [`tasks/typed-defn.md`](tasks/typed-defn.md) | `docs/quickstart.md`, `docs/schema-guide.md` |
 | Debug errors | [`tasks/debug-errors.md`](tasks/debug-errors.md) | `docs/patterns.md` § Error Handling |
+| Profile hot paths | [`tasks/typed-defn.md`](tasks/typed-defn.md) § Find hot paths | `phel profile <path>` |
+| Async / fibers | — | `docs/async-guide.md`, `src/phel/async.phel` |
+| Memoize | — | `(doc memoize)`, `(doc memoize-lru)` |
 | Common pitfalls | [`tasks/common-gotchas.md`](tasks/common-gotchas.md) | `RULES.md` § Gotchas |
 | Use a PHP library | [`tasks/use-php-libs.md`](tasks/use-php-libs.md) | `docs/php-interop.md` |
 | Validate data | [`tasks/validate-with-schema.md`](tasks/validate-with-schema.md) | `src/phel/schema.phel`, `docs/schema-guide.md` |

--- a/resources/agents/skills/aider/CONVENTIONS.md
+++ b/resources/agents/skills/aider/CONVENTIONS.md
@@ -4,6 +4,7 @@ Phel is a Lisp that compiles to PHP. Pass this to Aider via `--read CONVENTIONS.
 
 - Hard rules, CLI, workflow: `.agents/RULES.md`
 - Task recipes: `.agents/tasks/`
+- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`
 - Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`
 - Deep reference: `docs/`, `src/phel/`
 

--- a/resources/agents/skills/claude/phel-lang/SKILL.md
+++ b/resources/agents/skills/claude/phel-lang/SKILL.md
@@ -17,22 +17,40 @@ Lisp dialect that compiles to PHP. PHP interop via `php/` prefix.
 
 ## Before you start coding
 
-- Read `.agents/RULES.md` § Gotchas — saves 5-10 min of debugging
+- Read `.agents/RULES.md` § Gotchas; saves 5-10 min of debugging
 - Use `*argv*` for CLI args, NOT `php/$argv`
 - Use `doseq` for side effects, `for` for building sequences
-- String module is `phel\string` (not `phel\str`)
-- Use `defrecord`, `defprotocol`, `defmulti` for structured code — they are stable since v0.30-0.32
+- String module is `phel.string` (not `phel.str`); prefer `.` ns separator (`\` deprecated)
+- Use `defrecord`, `defprotocol`, `defmulti` for structured code; stable since v0.30-0.32
+- Add `:tag` to params + return on hot or public fns; PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`
+- Opt-in `defn` metadata: `^:async` (wraps body in `async`, returns `Amp\Future`), `^:memoize` / `^{:memoize-lru N}` (cache by arg vector)
+- `phel profile <path>` finds the fns to type first
 
 ## Working examples
 
-`.agents/examples/{todo-app, http-json-api, cli-wordcount}/` — copy, adapt, run.
+`.agents/examples/{todo-app, http-json-api, cli-wordcount}/`; copy, adapt, run.
 
 ## Quick syntax reference
 
 ```phel
-;; Define + call
-(defn greet [name] (str "Hello, " name "!"))
+;; Define + call (^int :tag emits PHP int return-type and unlocks JIT-friendly call shape)
+(defn ^string greet [^string name] (str "Hello, " name "!"))
 (greet "World")
+
+;; Multi-arity, name-tag propagates to every arity unless overridden
+(defn ^int fib
+  ([^int n] (fib n 0 1))
+  ([^int n ^int a ^int b]
+   (if (zero? n) a (recur (dec n) b (+ a b)))))
+
+;; Memoize + type tag together
+(defn ^{:memoize-lru 256 :tag "int"} slow-fib
+  [^int n]
+  (if (< n 2) n (+ (slow-fib (- n 1)) (slow-fib (- n 2)))))
+
+;; Async defn -> Amp\Future
+(defn ^:async fetch [^string url]
+  (await (http-get url)))
 
 ;; Records
 (defrecord Todo [id text done])
@@ -56,7 +74,7 @@ Lisp dialect that compiles to PHP. PHP interop via `php/` prefix.
 (re-find #"\d+" "abc123")  ; => "123"
 
 ;; JSON
-(:require phel\json :as json)
+(:require phel.json :as json)
 (json/encode {:a 1})  ; => "{\"a\":1}"
 (json/decode "{\"a\":1}")  ; => {:a 1}
 

--- a/resources/agents/skills/codex/AGENTS.md
+++ b/resources/agents/skills/codex/AGENTS.md
@@ -9,9 +9,15 @@ Phel is a Lisp dialect that compiles to PHP. This file follows the AGENTS.md con
 3. `.agents/tasks/<intent>.md` — recipe for the current task
 4. `src/phel/` and `docs/` only when a recipe points there
 
+## Modern features to prefer
+
+- `:tag` types on `defn` params + return for PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`.
+- Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
+- `phel profile <path>` to locate hot fns before tagging.
+
 ## Working examples
 
-`.agents/examples/{todo-app, http-json-api, cli-wordcount}/` — copy, adapt, run.
+`.agents/examples/{todo-app, http-json-api, cli-wordcount}/`; copy, adapt, run.
 
 ## Commit conventions
 

--- a/resources/agents/skills/copilot/copilot-instructions.md
+++ b/resources/agents/skills/copilot/copilot-instructions.md
@@ -4,7 +4,10 @@ Phel is a Lisp that compiles to PHP. For `.phel` files and `phel-config.php`:
 
 - Hard rules, syntax, CLI: `.agents/RULES.md`
 - Task recipes: `.agents/tasks/`
+- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`
 - Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`
 - Deep reference: `docs/`, `src/phel/`
 
 Never invent fn names. Confirm against `src/phel/core/` or `./vendor/bin/phel doc <fn>`.
+
+Prefer `.` ns separator (`app.main`); `\` still parses but is deprecated.

--- a/resources/agents/skills/cursor/phel.mdc
+++ b/resources/agents/skills/cursor/phel.mdc
@@ -11,5 +11,8 @@ Before suggesting code:
 - Collections are immutable. Rebind with `def`/`let`.
 - PHP interop prefix `php/`. See `.agents/RULES.md` for full syntax.
 - Guard top-level side effects with `(when-not *build-mode* ...)`.
+- Hot or public `defn`: add `:tag` to params + return (`^int`, `^string`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`). See `.agents/tasks/typed-defn.md`.
+- Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
+- Prefer `.` ns separator (`app.main`); `\` still parses but is deprecated.
 
 Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`.

--- a/resources/agents/skills/gemini/GEMINI.md
+++ b/resources/agents/skills/gemini/GEMINI.md
@@ -2,4 +2,10 @@
 
 Phel is a Lisp that compiles to PHP. Load `.agents/RULES.md` for hard rules and CLI; `.agents/index.md` for the task map; `.agents/tasks/<intent>.md` for the matching recipe.
 
+Modern features to prefer when relevant:
+
+- `:tag` types on `defn` (`^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`) for PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`.
+- Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
+- `phel profile <path>` to find hot fns before tagging.
+
 Working examples under `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`. Deep reference in `docs/` and `src/phel/`.

--- a/resources/agents/tasks/add-tests.md
+++ b/resources/agents/tasks/add-tests.md
@@ -19,9 +19,9 @@ Namespace: `tests\<name>-test`.
 ```phel
 (ns my-app\math)
 
-(defn add [a b] (+ a b))
+(defn ^int add [^int a ^int b] (+ a b))
 
-(defn divide [a b]
+(defn divide [^"int|float" a ^"int|float" b]
   (when (zero? b)
     (throw (php/new \InvalidArgumentException "division by zero")))
   (/ a b))
@@ -106,7 +106,8 @@ Full: `docs/mocking-guide.md`.
 - `:refer [deftest is]` required.
 - `(thrown? body)` catches any `\Throwable`; specify class to target.
 - No `:reload`. Restart REPL or run `phel test`.
+- Typed fn under test: literal arg mismatch is now a compile error in the test file too. Cast or use a non-literal binding to test runtime paths.
 
 ## Next
 
-`src/phel/test.phel`, `docs/mocking-guide.md`, `tests/phel/*.phel`
+`src/phel/test.phel`, `docs/mocking-guide.md`, `tests/phel/*.phel`, `tasks/typed-defn.md`

--- a/resources/agents/tasks/common-gotchas.md
+++ b/resources/agents/tasks/common-gotchas.md
@@ -47,17 +47,19 @@ For the full `phel\cli` module (subcommands, options, prompts), see `tasks/cli-t
 (for [x :in xs :when (odd? x)] (* x x))
 ```
 
-## 4. `phel\string` (not `phel\str`)
+## 4. `phel.string` (not `phel.str`)
 
-Since v0.33, the string module is `phel\string`:
+Since v0.33, the string module is `phel.string`:
 
 ```phel
 ;; DON'T
-(:require phel\str :as str)
+(:require phel.str :as str)
 
 ;; DO
-(:require phel\string :as string)
+(:require phel.string :as string)
 ```
+
+(`\` separator still parses but is deprecated.)
 
 ## 5. Namespace segment count
 
@@ -107,7 +109,35 @@ Don't try `to-list` (doesn't exist) or `to-vec` (doesn't exist). Use `vec`.
 ```phel
 (defrecord Point [x y])
 (let [p (->Point 1 2)]
-  ;; DON'T: (.-x p) — this is PHP property access
+  ;; DON'T: (.-x p); this is PHP property access
   ;; DO:
   (get p :x))
 ```
+
+## 9. `:tag` literal-arg mismatch is a compile error
+
+```phel
+(defn ^int square [^int x] (* x x))
+
+;; DON'T: literal mismatch fails at compile time, not runtime
+(square "abc")
+
+;; DO: pass an int, or widen the tag
+(square 7)
+(defn ^int square [^"int|string" x] ...)   ; if you really want both
+```
+
+Same for `recur` args vs. binding tags and tail literal vs. declared return tag. See `tasks/typed-defn.md`.
+
+## 10. `^` tags one symbol; map form for unusual types
+
+```phel
+;; DON'T: ^?int parses as a symbol named "?int"
+(defn parse [^?int s] ...)
+
+;; DO: quote the type string
+(defn parse [^"?int" s] ...)
+(defn parse [^{:tag "?int"} s] ...)
+```
+
+Class FQNs need leading `\\`: `^"\\App\\User"`.

--- a/resources/agents/tasks/debug-errors.md
+++ b/resources/agents/tasks/debug-errors.md
@@ -8,9 +8,9 @@ Errors print `file:line:col` when available. Re-read the snippet there.
 |-------|---------------|
 | Lexer | Unbalanced paren, unterminated string |
 | Reader | Invalid literal, bad `#reader` form |
-| Analyzer | "Can not resolve symbol", arity mismatch, bad special form |
+| Analyzer | "Can not resolve symbol", arity mismatch, bad special form, `:tag` mismatch |
 | Emitter | Rare; compiler bug, report upstream |
-| Runtime | PHP exception, nil method call |
+| Runtime | PHP exception, nil method call, untyped `recur` arity mismatch |
 
 ## Common fixes
 
@@ -64,6 +64,18 @@ Use `some->`:
 (php-array-to-map arr)                         ; reverse
 ```
 
+### `:phel/static-type` mismatch
+
+Compile-time arg vs. param tag, `recur` vs. binding tag, or tail vs. declared return tag. Either fix the call site, widen the tag (`^"?int"`, `^"int|string"`), or drop the tag if the caller really is dynamic.
+
+### Profiling a slow path
+
+```bash
+./vendor/bin/phel profile src/main.phel --format=both --output=profile.json
+```
+
+Per-fn self/total/avg/max + compile-phase costs. Tag the top-N self-time fns; see `tasks/typed-defn.md`.
+
 ### Macro surprises
 
 ```phel
@@ -96,4 +108,4 @@ Check `~`, `` ` ``, auto-gensym `name#`.
 
 ## Next
 
-`docs/patterns.md` § Error Handling, `docs/php-interop.md` § Error Handling, `tasks/repl-workflow.md`
+`docs/patterns.md` § Error Handling, `docs/php-interop.md` § Error Handling, `tasks/repl-workflow.md`, `tasks/typed-defn.md`

--- a/resources/agents/tasks/repl-workflow.md
+++ b/resources/agents/tasks/repl-workflow.md
@@ -61,6 +61,15 @@ Errors print trace and keep REPL alive. `(try expr (catch php\Foo e (.getMessage
 - `in-ns` on missing ns creates empty one. `require` first.
 - `(def map ...)` shadows core until restart.
 
+## Profile from CLI
+
+```bash
+./vendor/bin/phel profile src/main.phel             # text table
+./vendor/bin/phel profile src/main.phel --format=json --output=profile.json
+```
+
+Per-fn call counts and self/total/avg/max plus compile-phase costs. Use to pick fns worth tagging (`tasks/typed-defn.md`).
+
 ## Next
 
-`tasks/use-core-lib.md`, `tasks/debug-errors.md`, `src/phel/repl.phel`
+`tasks/use-core-lib.md`, `tasks/debug-errors.md`, `tasks/typed-defn.md`, `src/phel/repl.phel`

--- a/resources/agents/tasks/typed-defn.md
+++ b/resources/agents/tasks/typed-defn.md
@@ -1,0 +1,119 @@
+# Typed `defn` (`:tag` metadata)
+
+`:tag` on a `defn` (or `fn`) emits a PHP type declaration on the compiled signature: per-param, per-arity, plus the return slot. Three wins:
+
+- **DX**: literal call-site mismatches and `recur` / tail-position mismatches surface as Phel diagnostics at compile time, not runtime PHP `TypeError`.
+- **Perf**: typed signatures unlock OPcache JIT tracing on the generated PHP. Hot kernels (`fib`, `sum-squares`, `mandel-point`) bench faster typed than untyped.
+- **Interop**: PHP callers see real type declarations.
+
+## Reader shorthands
+
+```phel
+(defn ^int      square  [^int x]            (* x x))
+(defn ^float    avg     [^"int|float" a ^"int|float" b] (/ (+ a b) 2))
+(defn ^"?int"   parse   [^string s]          (try (php/intval s) (catch \Throwable _ nil)))
+(defn ^string   greet   [^string name]       (str "Hello, " name "!"))
+(defn ^bool     valid?  [^string s]          (php/!== "" s))
+(defn ^"\\DateTimeImmutable" now [] (php/new \DateTimeImmutable))
+(defn ^{:tag "array"} pairs [m] (to-php-array m))
+```
+
+| Shorthand | Compiles to |
+|-----------|-------------|
+| `^int`, `^string`, `^bool`, `^float`, `^array`, `^void`, `^mixed` | builtin scalars |
+| `^"?int"` | `?int` (nullable) |
+| `^"int\|string"` | union |
+| `^"\\Foo\\Bar"` | leading `\\` for FQ class name |
+| `^{:tag "..."}` | map form (any string accepted by PHP) |
+
+## Defn-name tag propagation
+
+A tag on the defn name applies to every arity's return slot unless the arity vector overrides it:
+
+```phel
+(defn ^int fib                  ; default return :int for both arities
+  ([^int n] (fib n 0 1))
+  ([^int n ^int a ^int b]
+   (if (zero? n) a (recur (dec n) b (+ a b)))))
+
+(defn ^int parse-or-default     ; default return :int...
+  ([^string s] (parse-or-default s 0))
+  ([^string s ^"?int" fallback]
+   ^"?int"                      ; ...overridden to ?int for this arity
+   (or (parse s) fallback)))
+```
+
+## Return inference
+
+If you tag the params and the tail expression is a primitive op, the compiler infers the return type. Explicit `^tag` on the name still wins.
+
+| Tail form | Inferred |
+|-----------|----------|
+| `(php/+ ...)`, `(php/* ...)`, `(php/- ...)` | `int` if all int args, else `float` |
+| `(php/. ...)` (PHP concat) | `string` |
+| `(php/=== ...)`, `(php/< ...)`, `(php/> ...)` | `bool` |
+| `if`, `let`, `loop` | propagate from each branch |
+
+```phel
+(defn add [^int a ^int b]      ; no return tag; inferred as `int`
+  (+ a b))
+
+(defn label [^string s]         ; inferred `string`
+  (php/. "row:" s))
+```
+
+## Static checker
+
+Compile time: literal call args, `recur` args against the surrounding binding tags, and the tail literal against the declared return are all checked. Mismatch is a `:phel/static-type` diagnostic with `file:line:col`, no PHP `TypeError`.
+
+```phel
+(defn ^int square [^int x] (* x x))
+
+(square "abc")                  ; compile error: arg 1 expects int, got string
+```
+
+## Combine with metadata flags
+
+Type tags compose with `^:async`, `^:memoize`, `^{:memoize-lru N}`:
+
+```phel
+(defn ^{:memoize-lru 256 :tag "int"} fib
+  [^int n]
+  (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+
+(defn ^:async ^"\\Amp\\Future" fetch [^string url]
+  (await (http-get url)))
+```
+
+`^{:async false}` opts out without removing the metadata key; same for `:memoize false`.
+
+## When to add tags
+
+| Scenario | Tag? |
+|----------|------|
+| Hot inner loop, primitive args | yes; inference fills the return |
+| Public API on a record / handler | yes; doubles as documentation + interop |
+| Glue code with mixed shapes | usually no; tag adds noise |
+| `defn-` private wrapper | only if the body benefits |
+
+## Find hot paths
+
+```bash
+./vendor/bin/phel profile src/main.phel --format=both --output=profile.json
+```
+
+Per-fn call counts and self/total/avg/max timings, plus compile-phase cost (lex, parse, read, analyze, emit). Tag the top-N self-time fns first.
+
+## Gotchas
+
+- `^int` tags a single symbol; `^{:tag "..."}` is the only form for arbitrary type strings.
+- `:tag` on `def` of a non-fn is ignored (no PHP slot to type).
+- A bound symbol passed to a typed param is checked at runtime (PHP-level), not compile time; only literal mismatches are static.
+- `(php/+ 1 1.0)` infers `float`, not `int`. Promotion follows PHP rules.
+- Class FQNs need leading `\\`: `^"\\App\\User"`, otherwise the reader treats it as a relative ns symbol.
+
+## See also
+
+- `RULES.md` § New features
+- `tasks/use-core-lib.md` for non-typed core ops
+- `docs/schema-guide.md` § Function instrumentation for runtime contracts on top of `:tag`

--- a/resources/agents/tasks/use-core-lib.md
+++ b/resources/agents/tasks/use-core-lib.md
@@ -140,6 +140,19 @@ Core: `(str a b c)`, `(name :k)`, `(keyword "x")`, `(symbol "x")`.
 git grep 'defn <fn>' src/phel/core
 ```
 
+## Modern fn shape
+
+Hot or public `defn`: tag params + return. PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics.
+
+```phel
+(defn ^int sum-squares [^int n]
+  (loop [i 0 acc 0]
+    (if (php/=== i n) acc
+        (recur (php/+ i 1) (php/+ acc (php/* i i))))))
+```
+
+Detail: [`tasks/typed-defn.md`](typed-defn.md). Find candidates: `phel profile <path>`.
+
 ## Next
 
-`docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`, `docs/cli-guide.md`, `tasks/http-app.md`, `tasks/cli-tool.md`
+`docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`, `docs/cli-guide.md`, `tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/typed-defn.md`


### PR DESCRIPTION
## 🤔 Background

`resources/agents/` ships the agent-agnostic docs that `phel agent-install` mirrors into user projects as `.agents/`. The tree predates the recent metadata-driven `defn` features (`:tag`, `^:async`, `^:memoize`, `^{:memoize-lru N}`) and the `phel profile` command, so installed adapters never mentioned them. Agents kept emitting untyped `defn` and missed compile-time checks plus JIT-friendly call shapes.

## 💡 Goal

Modernize the downstream agent docs so every assistant (Claude, Codex, Cursor, Copilot, Gemini, Aider) suggests typed signatures and the new metadata flags by default, and knows where to find the corresponding recipe.

## 🔖 Changes

- New `tasks/typed-defn.md` recipe: reader shorthands (`^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`), defn-name tag propagation, return inference table, static checker behavior, combination with `^:async` / `^:memoize` / `^{:memoize-lru N}`, and a `phel profile` workflow for picking which fns to tag.
- `RULES.md`: new "rule 11" calling out `:tag` for hot paths; "New features" table extended with type tags, return inference, `^:async`, `^:memoize`; reader-shorthand snippet; `phel profile` row in the CLI table; workflow step on hot loops; ns separator now prefers `.` (per `b666923b`).
- `index.md`: intent rows for "Type a fn", "Profile hot paths", "Async / fibers", "Memoize".
- Skill adapters (Claude `SKILL.md`, Codex `AGENTS.md`, Cursor `phel.mdc`, Copilot, Gemini, Aider): point at `tasks/typed-defn.md`, mention `^:async` / `^:memoize`, surface dot ns separator. Claude `SKILL.md` quick-reference now opens with a typed example, multi-arity `fib`, memoized `slow-fib`, and `^:async fetch`.
- Recipe refresh: `add-tests.md` typed sample fns + new gotcha; `debug-errors.md` adds `:phel/static-type` mismatch and a profiling section; `use-core-lib.md` gets a "Modern fn shape" snippet; `repl-workflow.md` adds the profile CLI; `common-gotchas.md` gains entries for typed-arg compile errors and the `^"..."` quoted-string requirement.

`composer test-agents` runs all three example projects (cli-wordcount, http-json-api, todo-app) green; example sources are unchanged.