### PR TITLE
feat(compiler): broaden return-type inference (closes #1941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 #### Compiler
 - `:tag` metadata emits PHP type declarations on the compiled fn / defn signature: params, return slot, and per-arity. Reader shorthands `^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`. `:tag` on a defn name propagates to every arity unless the vector overrides it (#1916)
 - Return type inferred from a tail-position primitive op on tagged params (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`; `if` / `let` / `loop` propagate). Explicit `:tag` always wins (#1932)
+- Return type inference also covers tail calls to globals with a `:tag` (cross-fn propagation) and a curated set of pure PHP built-ins (`strlen`, `intval`, `is_*`, `floatval`, `floor`, `ceil`, `round`, `boolval`, `strtolower`, `strtoupper`, `trim`, `sprintf`, …) (#1941)
 - Static checker turns `:tag` mismatches into a Phel diagnostic at compile time instead of a runtime PHP `TypeError`: literal call args vs. param tags, `recur` args vs. binding tags, tail literal vs. declared return tag (#1933)
 - `composer bench-jit-baseline` / `bench-jit-tracing` measure typed-vs-untyped `fib`, `sum-squares`, `mandel-point` kernels under OPcache JIT (#1931)
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
@@ -57,6 +58,50 @@ final class ReturnTypeInferrer
     /** @var list<string> */
     private const array NUMERIC_OPS = [
         '+', '-', '*', '/', '%', '**', '<<', '>>', '|', '&', '^',
+    ];
+
+    /**
+     * Pure PHP built-ins whose return type is fixed regardless of argument
+     * type. Limited to side-effect-free functions with a stable signature
+     * across supported PHP versions; anything whose return type depends on
+     * argument types or runtime mode stays out so the inferrer never
+     * stamps the wrong tag.
+     *
+     * @var array<string, string>
+     */
+    private const array PURE_PHP_FN_RETURN = [
+        'strlen' => 'int',
+        'intval' => 'int',
+        'mb_strlen' => 'int',
+        'count' => 'int',
+        'floatval' => 'float',
+        'doubleval' => 'float',
+        'floor' => 'float',
+        'ceil' => 'float',
+        'round' => 'float',
+        'boolval' => 'bool',
+        'is_int' => 'bool',
+        'is_integer' => 'bool',
+        'is_long' => 'bool',
+        'is_float' => 'bool',
+        'is_double' => 'bool',
+        'is_string' => 'bool',
+        'is_bool' => 'bool',
+        'is_null' => 'bool',
+        'is_array' => 'bool',
+        'is_object' => 'bool',
+        'is_callable' => 'bool',
+        'is_numeric' => 'bool',
+        'strval' => 'string',
+        'strtolower' => 'string',
+        'strtoupper' => 'string',
+        'mb_strtolower' => 'string',
+        'mb_strtoupper' => 'string',
+        'trim' => 'string',
+        'ltrim' => 'string',
+        'rtrim' => 'string',
+        'sprintf' => 'string',
+        'gettype' => 'string',
     ];
 
     /**
@@ -200,6 +245,11 @@ final class ReturnTypeInferrer
     private function inferCall(CallNode $node, array $locals): ?string
     {
         $fn = $node->getFn();
+
+        if ($fn instanceof GlobalVarNode) {
+            return $this->inferGlobalCall($fn);
+        }
+
         if (!$fn instanceof PhpVarNode) {
             return null;
         }
@@ -221,7 +271,36 @@ final class ReturnTypeInferrer
             return $this->inferNumeric($node, $locals);
         }
 
+        if (isset(self::PURE_PHP_FN_RETURN[$op])) {
+            $this->sawOperator = true;
+            return self::PURE_PHP_FN_RETURN[$op];
+        }
+
         return null;
+    }
+
+    /**
+     * Cross-fn propagation: when the tail call resolves to another
+     * global definition, trust its `:tag` meta as the inferred return
+     * type. The callee's tag is either user-declared or already filled
+     * by this inferrer on a previous pass; either way it represents the
+     * same contract the call site is bound to honour, so propagating it
+     * cannot disagree with what the callee actually returns.
+     */
+    private function inferGlobalCall(GlobalVarNode $fn): ?string
+    {
+        $meta = $fn->getMeta();
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        if (!is_string($tag) || $tag === '') {
+            return null;
+        }
+
+        $this->sawOperator = true;
+        return $tag;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -245,25 +245,26 @@ final class ReturnTypeInferrer
     private function inferCall(CallNode $node, array $locals): ?string
     {
         $fn = $node->getFn();
+        return match (true) {
+            $fn instanceof GlobalVarNode => $this->inferGlobalCall($fn),
+            $fn instanceof PhpVarNode => $this->inferPhpCall($fn, $node, $locals),
+            default => null,
+        };
+    }
 
-        if ($fn instanceof GlobalVarNode) {
-            return $this->inferGlobalCall($fn);
-        }
-
-        if (!$fn instanceof PhpVarNode) {
-            return null;
-        }
-
+    /**
+     * @param array<string, string> $locals
+     */
+    private function inferPhpCall(PhpVarNode $fn, CallNode $node, array $locals): ?string
+    {
         $op = $fn->getName();
 
         if (isset(self::COMPARISON_OPS[$op])) {
-            $this->sawOperator = true;
-            return self::COMPARISON_OPS[$op];
+            return $this->publish(self::COMPARISON_OPS[$op]);
         }
 
         if ($op === '.') {
-            $this->sawOperator = true;
-            return 'string';
+            return $this->publish('string');
         }
 
         if (in_array($op, self::NUMERIC_OPS, true)) {
@@ -272,8 +273,7 @@ final class ReturnTypeInferrer
         }
 
         if (isset(self::PURE_PHP_FN_RETURN[$op])) {
-            $this->sawOperator = true;
-            return self::PURE_PHP_FN_RETURN[$op];
+            return $this->publish(self::PURE_PHP_FN_RETURN[$op]);
         }
 
         return null;
@@ -289,18 +289,14 @@ final class ReturnTypeInferrer
      */
     private function inferGlobalCall(GlobalVarNode $fn): ?string
     {
-        $meta = $fn->getMeta();
-        $tag = $meta->find(Keyword::create('tag'));
-        if ($tag instanceof Symbol) {
-            $tag = $tag->getName();
-        }
+        $tag = $this->tagFromMeta($fn->getMeta());
+        return $tag === null ? null : $this->publish($tag);
+    }
 
-        if (!is_string($tag) || $tag === '') {
-            return null;
-        }
-
+    private function publish(string $type): string
+    {
         $this->sawOperator = true;
-        return $tag;
+        return $type;
     }
 
     /**
@@ -343,10 +339,14 @@ final class ReturnTypeInferrer
     private function extractTag(Symbol $param): ?string
     {
         $meta = $param->getMeta();
-        if (!$meta instanceof PersistentMapInterface) {
-            return null;
-        }
+        return $meta instanceof PersistentMapInterface ? $this->tagFromMeta($meta) : null;
+    }
 
+    /**
+     * @param PersistentMapInterface<mixed, mixed> $meta
+     */
+    private function tagFromMeta(PersistentMapInterface $meta): ?string
+    {
         $tag = $meta->find(Keyword::create('tag'));
         if ($tag instanceof Symbol) {
             return $tag->getName();

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -1,0 +1,35 @@
+--PHEL--
+(defn ^int produce [^int a] (php/* a 2))
+(fn ^bool [^int x] (produce x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "produce",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\produce";
+
+    public function __invoke(int $a): int {
+      return ($a * 2);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("tag"), "int",
+    \Phel::keyword("doc"), "```phel\n(produce a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-explicit-wins.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-explicit-wins.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 40
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);
+(function(int $x): bool {
+  return (\Phel::getDefinition("user", "produce"))($x);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -1,0 +1,35 @@
+--PHEL--
+(defn ^int sum [^int a ^int b] (php/+ a b))
+(fn [^int x] (sum x 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "sum",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\sum";
+
+    public function __invoke(int $a, int $b): int {
+      return ($a + $b);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("tag"), "int",
+    \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-tagged.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-tagged.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 43
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
+);
+(function(int $x): int {
+  return (\Phel::getDefinition("user", "sum"))($x, 1);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -1,0 +1,34 @@
+--PHEL--
+(defn add [^int a ^int b] (php/+ a b))
+(fn [^int x] (add x 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add";
+
+    public function __invoke(int $a, int $b): int {
+      return ($a + $b);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add a b)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-untagged.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-untagged.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 38
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
+);
+(function(int $x) {
+  return (\Phel::getDefinition("user", "add"))($x, 1);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-floatval-float.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-floatval-float.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x] (php/floatval x))
+--PHP--
+(function($x): float {
+  return floatval($x);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-is-int-bool.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-is-int-bool.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x] (php/is_int x))
+--PHP--
+(function($x): bool {
+  return is_int($x);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-strlen-int.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-strlen-int.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^string s] (php/strlen s))
+--PHP--
+(function(string $s): int {
+  return strlen($s);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-strtolower-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-strtolower-string.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^string s] (php/strtolower s))
+--PHP--
+(function(string $s): string {
+  return strtolower($s);
+});


### PR DESCRIPTION
## 🤔 Background

PR #1936 introduced `ReturnTypeInferrer`: literals, `php/` comparison & numeric ops, `if`/`do`/`let` tail merging, recur/throw bottom, untyped-param bail, explicit-tag wins. Issue #1941 asks the compiler to keep going: when the user omits `:tag`, infer more cases so the emitter can stamp a PHP type and OPcache/JIT can specialise.

## 💡 Goal

Two new sources of inferred return types, both conservative and BC:

1. **Cross-fn propagation.** A tail call to a global var with `:tag` in its meta surfaces that tag as the caller's inferred return type. Trust here is the same trust the static checker already applies on the call site.
2. **Pure PHP builtin registry.** A curated set of side-effect-free PHP functions emit fixed return types: `strlen`, `intval`, `count`, `mb_strlen`, `floatval`, `floor`, `ceil`, `round`, `boolval`, `is_*`, `strval`, `strtolower`, `strtoupper`, `mb_strto*`, `trim`, `ltrim`, `rtrim`, `sprintf`, `gettype`.

User `:tag` always wins; no annotation is invented when the callee's contract is unknown. Existing fixtures untouched.

## 🔖 Changes

- `ReturnTypeInferrer::inferCall` dispatches on the call's fn node:
  - `GlobalVarNode` ➜ read `:tag` from the global's meta.
  - `PhpVarNode` ➜ existing op tables plus the new `PURE_PHP_FN_RETURN` registry.
- `inferGlobalCall`, `inferPhpCall`, `publish`, and `tagFromMeta` extracted (second commit) so the dispatcher reads as a one-liner per branch.
- 7 new fixtures under `tests/php/Integration/Fixtures/Fn/`:
  - `fn-infer-call-global-tagged`, `-untagged`, `-explicit-wins`
  - `fn-infer-php-strlen-int`, `-strtolower-string`, `-is-int-bool`, `-floatval-float`
- CHANGELOG entry under `## Unreleased / Compiler`.

### Deferred (follow-up PRs after this one merges)

- Param-type inference from body usage. Unsound under current Phel call semantics: PHP's coercion currently lets mixed-type calls succeed, so stamping a PHP type on a param would change runtime behaviour. Wants its own design pass (advisory mode? opt-in flag?).
- Phel core fns (`count`, `str`, `vector`, `keyword`, predicates) gaining `:tag` annotations. Once tagged, cross-fn propagation picks them up automatically without further compiler work.