### PR TITLE
feat(compiler): persist inferred return type into def meta (follow-up to #1941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `:tag` metadata emits PHP type declarations on the compiled fn / defn signature: params, return slot, and per-arity. Reader shorthands `^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`. `:tag` on a defn name propagates to every arity unless the vector overrides it (#1916)
 - Return type inferred from a tail-position primitive op on tagged params (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`; `if` / `let` / `loop` propagate). Explicit `:tag` always wins (#1932)
 - Return type inference also covers tail calls to globals with a `:tag` (cross-fn propagation) and a curated set of pure PHP built-ins (`strlen`, `intval`, `is_*`, `floatval`, `floor`, `ceil`, `round`, `boolval`, `strtolower`, `strtoupper`, `trim`, `sprintf`, …) (#1941)
+- Inferred return types now persist into the def's runtime meta as `:tag`, so cross-fn propagation cascades through callees that the user never tagged explicitly (#1941)
 - Static checker turns `:tag` mismatches into a Phel diagnostic at compile time instead of a runtime PHP `TypeError`: literal call args vs. param tags, `recur` args vs. binding tags, tail literal vs. declared return tag (#1933)
 - `composer bench-jit-baseline` / `bench-jit-tracing` measure typed-vs-untyped `fib`, `sum-squares`, `mandel-point` kernels under OPcache JIT (#1931)
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -83,15 +83,15 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
             $metaMap = $metaMap->put('arglists', $this->buildFnNodeArglist($initNode, $skip));
-            $metaMap = $this->persistInferredReturnTag($metaMap, $initNode->getReturnType());
         } elseif ($initNode instanceof MultiFnNode) {
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
             $maxArity = $initNode->getMaxArity();
             $metaMap = $metaMap->put('max-arity', $maxArity === null ? null : max(0, $maxArity - $skip));
             $metaMap = $metaMap->put('arglists', $this->buildMultiFnNodeArglists($initNode, $skip));
-            $metaMap = $this->persistInferredReturnTag($metaMap, $this->commonMultiFnReturnType($initNode));
         }
+
+        $metaMap = $this->persistInferredReturnTag($metaMap, $this->inferredReturnTypeOf($initNode));
 
         // Stash a compile-time-only superset of the meta with `:param-tags`
         // attached so subsequent calls in the same compilation unit can
@@ -332,14 +332,24 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     }
 
     /**
-     * Multi-arity defns expose a single declared return type only when
-     * every arity agrees. Disagreement leaves the def untyped, mirroring
-     * how the inferrer bails on branches that disagree.
+     * Single source of truth for the inferred return type used to
+     * stamp `:tag` on the def's runtime meta. Single-arity surfaces
+     * its FnNode return type directly; multi-arity surfaces a return
+     * type only when every arity agrees, mirroring how the inferrer
+     * bails on `if` branches that disagree.
      */
-    private function commonMultiFnReturnType(MultiFnNode $multiFnNode): ?string
+    private function inferredReturnTypeOf(?AbstractNode $initNode): ?string
     {
+        if ($initNode instanceof FnNode) {
+            return $initNode->getReturnType();
+        }
+
+        if (!$initNode instanceof MultiFnNode) {
+            return null;
+        }
+
         $shared = null;
-        foreach ($multiFnNode->getFnNodes() as $fnNode) {
+        foreach ($initNode->getFnNodes() as $fnNode) {
             $type = $fnNode->getReturnType();
             if ($type === null) {
                 return null;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -83,12 +83,14 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
             $metaMap = $metaMap->put('arglists', $this->buildFnNodeArglist($initNode, $skip));
+            $metaMap = $this->persistInferredReturnTag($metaMap, $initNode->getReturnType());
         } elseif ($initNode instanceof MultiFnNode) {
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
             $metaMap = $metaMap->put('is-variadic', $initNode->isVariadic());
             $maxArity = $initNode->getMaxArity();
             $metaMap = $metaMap->put('max-arity', $maxArity === null ? null : max(0, $maxArity - $skip));
             $metaMap = $metaMap->put('arglists', $this->buildMultiFnNodeArglists($initNode, $skip));
+            $metaMap = $this->persistInferredReturnTag($metaMap, $this->commonMultiFnReturnType($initNode));
         }
 
         // Stash a compile-time-only superset of the meta with `:param-tags`
@@ -304,6 +306,56 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     private function buildFnNodeArglist(FnNode $fnNode, int $skipFirst = 0): string
     {
         return $this->formatParamsVector($fnNode->getParams(), $fnNode->isVariadic(), $skipFirst);
+    }
+
+    /**
+     * Inferred return type writes back to the def's runtime meta as `:tag`
+     * so cross-fn inference can see it on the next call site without
+     * having to re-walk the callee's body. User `:tag` already in meta
+     * stays untouched.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $metaMap
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    private function persistInferredReturnTag(PersistentMapInterface $metaMap, ?string $returnType): PersistentMapInterface
+    {
+        if ($returnType === null || $returnType === '') {
+            return $metaMap;
+        }
+
+        if ($metaMap->find(Keyword::create('tag')) !== null) {
+            return $metaMap;
+        }
+
+        return $metaMap->put(Keyword::create('tag'), $returnType);
+    }
+
+    /**
+     * Multi-arity defns expose a single declared return type only when
+     * every arity agrees. Disagreement leaves the def untyped, mirroring
+     * how the inferrer bails on branches that disagree.
+     */
+    private function commonMultiFnReturnType(MultiFnNode $multiFnNode): ?string
+    {
+        $shared = null;
+        foreach ($multiFnNode->getFnNodes() as $fnNode) {
+            $type = $fnNode->getReturnType();
+            if ($type === null) {
+                return null;
+            }
+
+            if ($shared === null) {
+                $shared = $type;
+                continue;
+            }
+
+            if ($shared !== $type) {
+                return null;
+            }
+        }
+
+        return $shared;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -25,6 +25,7 @@
     ),
     "min-arity", 2,
     "is-variadic", false,
-    "arglists", "[x y]"
+    "arglists", "[x y]",
+    \Phel::keyword("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -1,0 +1,35 @@
+--PHEL--
+(defn check [x] (php/is_int x))
+(fn [x] (check x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "check",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\check";
+
+    public function __invoke($x): bool {
+      return is_int($x);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(check x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-inferred-callee.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-call-global-inferred-callee.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 31
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel::keyword("tag"), "bool"
+  )
+);
+(function($x): bool {
+  return (\Phel::getDefinition("user", "check"))($x);
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -26,9 +26,10 @@
     ),
     "min-arity", 2,
     "is-variadic", false,
-    "arglists", "[a b]"
+    "arglists", "[a b]",
+    \Phel::keyword("tag"), "int"
   )
 );
-(function(int $x) {
+(function(int $x): int {
   return (\Phel::getDefinition("user", "add"))($x, 1);
 });


### PR DESCRIPTION
## 🤔 Background

PR #1943 broadened the return-type inferrer with cross-fn propagation and a pure PHP builtin registry, but the inferred type only lived on the `FnNode` and never reached the def's runtime meta. So a callee whose body the inferrer could analyse — e.g. `(defn check [x] (php/is_int x))` — emitted `: bool` on its own signature but did not surface a `:tag` for downstream callers, leaving cross-fn propagation blind to it.

## 💡 Goal

Make compile-time inference cascade through the call graph. When DefSymbol finishes analysing a def's init expression, write the inferred return type back to the def's runtime meta as `:tag`, so subsequent callers' inference picks it up automatically.

## 🔖 Changes

- `DefSymbol::analyze` now calls `persistInferredReturnTag` for both single-arity and multi-arity defs.
- `inferredReturnTypeOf` (factored out in the second commit) returns the FnNode's inferred type, or for multi-arity surfaces a shared type only when every arity agrees — mirroring the inferrer's branch-merge bail.
- User-supplied `:tag` always wins; the helper short-circuits when the meta already carries one.
- Existing fixtures `Def/defn-typed-params.test` and `Fn/fn-infer-call-global-untagged.test` updated to reflect the now-stamped `:tag` (no PHP behaviour change beyond the meta payload).
- New fixture `Fn/fn-infer-call-global-inferred-callee.test` exercises a callee whose tag is inferred (not user-declared) and shows the caller picking it up.

### Deferred

Param-type inference is tracked separately in #1944 — it is unsound to emit naively under current Phel call semantics and needs its own design.