### PR TITLE
fix(compiler): drop loop binding tag on recur type drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+#### Compiler
+- Return-type inference no longer stamps a tag on a `loop` whose `recur` rebinds a binding to a different (or unknown) type, preventing runtime `TypeError`s when a loop accumulator widens (e.g. `*'` promoting to `BigInteger`)
+
 #### Core
 - `memoize` / `memoize-lru` no longer drop entries that recursive calls add to the cache during a single invocation (#1915)
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -229,14 +229,71 @@ final class ReturnTypeInferrer
      */
     private function inferLet(LetNode $node, array $locals): ?string
     {
-        foreach ($node->getBindings() as $binding) {
+        $bindings = $node->getBindings();
+        $names = [];
+        foreach ($bindings as $i => $binding) {
+            $name = $this->bindingName($binding);
+            $names[$i] = $name;
             $type = $this->inferNode($binding->getInitExpr(), $locals);
             if ($type !== null && $type !== self::BOTTOM) {
-                $locals[$this->bindingName($binding)] = $type;
+                $locals[$name] = $type;
+            }
+        }
+
+        if ($node->isLoop()) {
+            // Loop bindings are rebindable via recur; drop any whose recur
+            // argument types disagree with (or are unknown relative to) the
+            // initial type, so the body never sees an over-narrow tag.
+            $recurTypes = [];
+            $this->collectRecurArgTypes($node->getBodyExpr(), $locals, $recurTypes);
+            foreach ($names as $i => $name) {
+                if (!isset($locals[$name])) {
+                    continue;
+                }
+
+                $alts = $recurTypes[$i] ?? null;
+                if ($alts === null || !in_array($locals[$name], $alts, true) || count($alts) > 1) {
+                    unset($locals[$name]);
+                }
             }
         }
 
         return $this->inferNode($node->getBodyExpr(), $locals);
+    }
+
+    /**
+     * Walks tail-position descendants for `recur` invocations targeting the
+     * enclosing loop and records each argument's inferred type per binding
+     * index. Nested loops own their own recurs and are skipped.
+     *
+     * @param array<string, string>     $locals
+     * @param array<int, list<?string>> $types
+     */
+    private function collectRecurArgTypes(AbstractNode $node, array $locals, array &$types): void
+    {
+        if ($node instanceof RecurNode) {
+            foreach ($node->getExpressions() as $i => $expr) {
+                $type = $this->inferNode($expr, $locals);
+                $types[$i][] = ($type === null || $type === self::BOTTOM) ? null : $type;
+            }
+
+            return;
+        }
+
+        if ($node instanceof IfNode) {
+            $this->collectRecurArgTypes($node->getThenExpr(), $locals, $types);
+            $this->collectRecurArgTypes($node->getElseExpr(), $locals, $types);
+            return;
+        }
+
+        if ($node instanceof DoNode) {
+            $this->collectRecurArgTypes($node->getRet(), $locals, $types);
+            return;
+        }
+
+        if ($node instanceof LetNode && !$node->isLoop()) {
+            $this->collectRecurArgTypes($node->getBodyExpr(), $locals, $types);
+        }
     }
 
     /**


### PR DESCRIPTION
## 🤔 Background

CI's "Run examples" job started failing on `main` after the inferred-tag persistence change (#1945). `docs/examples/snippets/loop-recur.phel` calls `(*' acc i)` inside a `loop`/`recur`; `*'` auto-promotes ints to `BigInteger` on overflow but the inferrer stamped `:int` on the fn's return slot, so PHP raised `Return value must be of type int, BigInteger returned`.

## 💡 Goal

Make return-type inference safe for loops by accounting for the fact that `recur` can rebind a loop binding to a different (or unknown) type at runtime.

## 🔖 Changes

- `ReturnTypeInferrer::inferLet` now walks the body for `recur` calls targeting the enclosing loop and drops any binding whose recur argument types are unknown or disagree with the initial type — so the body never sees an over-narrow tag. Nested loops own their own `recur`s and are skipped during the walk.
- Existing `php/*` factorial fixture still infers `: int` (typed args, typed recur). Mixed/unknown recur args bail.