### PR TITLE
test(compiler): cover loop/recur return-type inference branches

### DIFF
--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
@@ -1,0 +1,19 @@
+--PHEL--
+(fn [^int n]
+  (loop [acc n]
+    (if (php/<= acc 1) acc (recur (php/. "x" acc)))))
+--PHP--
+(function(int $n) {
+  $acc_1 = $n;
+  while (true) {
+    if (($__truthy = ($acc_1 <= 1)) !== null && $__truthy !== false) {
+      return $acc_1;
+    } else {
+      $__phel_2 = ("x" . $acc_1);
+      $acc_1 = $__phel_2;
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
@@ -1,0 +1,19 @@
+--PHEL--
+(fn [^int n stop]
+  (loop [acc n]
+    (if (php/<= acc 1) acc (recur stop))))
+--PHP--
+(function(int $n, $stop) {
+  $acc_1 = $n;
+  while (true) {
+    if (($__truthy = ($acc_1 <= 1)) !== null && $__truthy !== false) {
+      return $acc_1;
+    } else {
+      $__phel_2 = $stop;
+      $acc_1 = $__phel_2;
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
@@ -1,0 +1,34 @@
+--PHEL--
+(fn [^int n]
+  (loop [outer n]
+    (if (php/<= outer 0)
+      outer
+      (recur (loop [inner outer] (if (php/<= inner 1) inner (recur (php/- inner 1))))))))
+--PHP--
+(function(int $n): int {
+  $outer_1 = $n;
+  while (true) {
+    if (($__truthy = ($outer_1 <= 0)) !== null && $__truthy !== false) {
+      return $outer_1;
+    } else {
+      $__phel_3 = (function() use($n,$outer_1) {
+        $inner_2 = $outer_1;
+        while (true) {
+          if (($__truthy = ($inner_2 <= 1)) !== null && $__truthy !== false) {
+            return $inner_2;
+          } else {
+            $__phel_4 = ($inner_2 - 1);
+            $inner_2 = $__phel_4;
+            continue;
+
+          }
+          break;
+        }
+      })();
+      $outer_1 = $__phel_3;
+      continue;
+
+    }
+    break;
+  }
+});


### PR DESCRIPTION
## 🤔 Background

PR #1946 added loop/recur awareness to `ReturnTypeInferrer::inferLet`, but only the regressing example script (`docs/examples/snippets/loop-recur.phel`) exercised the new code path. No unit/integration test locked the branches in.

## 💡 Goal

Add integration fixtures so the loop branches of return-type inference stay covered going forward.

## 🔖 Changes

- `fn-infer-bail-on-loop-recur-drift`: recur arg type (string via `php/.`) disagrees with initial (int); inferrer drops the tag.
- `fn-infer-bail-on-loop-recur-unknown`: recur arg is an untyped local; inferrer drops the tag.
- `fn-infer-return-nested-loops`: nested loop owns its own `recur`; outer loop keeps its inferred `: int` return tag.

Follow-up to #1946.