### PR TITLE
feat(compiler): infer param tags as advisory diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Return type inferred from a tail-position primitive op on tagged params (`(php/+ ...)` -> `int`, `(php/. ...)` -> `string`, comparisons -> `bool`; `if` / `let` / `loop` propagate). Explicit `:tag` always wins (#1932)
 - Return type inference also covers tail calls to globals with a `:tag` (cross-fn propagation) and a curated set of pure PHP built-ins (`strlen`, `intval`, `is_*`, `floatval`, `floor`, `ceil`, `round`, `boolval`, `strtolower`, `strtoupper`, `trim`, `sprintf`, …) (#1941)
 - Inferred return types now persist into the def's runtime meta as `:tag`, so cross-fn propagation cascades through callees that the user never tagged explicitly (#1941)
+- Param types inferred from primitive body uses (`(php/+ x ...)` implies `int`, `(php/. x ...)` implies `string`) feed the static checker as advisory contracts; emitted PHP signatures stay untyped so runtime coercion is preserved. Branch disagreement, comparisons, and explicit `:tag` declarations all skip inference (#1944)
 - Static checker turns `:tag` mismatches into a Phel diagnostic at compile time instead of a runtime PHP `TypeError`: literal call args vs. param tags, `recur` args vs. binding tags, tail literal vs. declared return tag (#1933)
 - `composer bench-jit-baseline` / `bench-jit-tracing` measure typed-vs-untyped `fib`, `sum-squares`, `mandel-point` kernels under OPcache JIT (#1931)
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -118,14 +118,11 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
             // Runtime meta wins because forms like `:inline` carry an
             // evaluated callable that the analyzer-time map only has
             // as a source-form `(fn ...)` list. The compile-time-only
-            // `:param-tags` channel is folded back in so the static
-            // type checker has its inputs even after the def has been
-            // evaluated into the registry.
+            // `:param-tags` and `:inferred-param-tags` channels are
+            // folded back in so the static type checker has its inputs
+            // even after the def has been evaluated into the registry.
             if ($compileMeta instanceof PersistentMapInterface) {
-                $paramTags = $compileMeta->find(Keyword::create('param-tags'));
-                if ($paramTags !== null) {
-                    return $registryMeta->put(Keyword::create('param-tags'), $paramTags);
-                }
+                return $this->mergeCompileTimeChannels($registryMeta, $compileMeta);
             }
 
             return $registryMeta;
@@ -297,6 +294,31 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         }
 
         return array_keys($symbols);
+    }
+
+    /**
+     * Folds the compile-time-only static-checker channels (`:param-tags`,
+     * `:inferred-param-tags`) into the registry meta read at call sites,
+     * leaving every other key on the registry side untouched.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $registryMeta
+     * @param PersistentMapInterface<mixed, mixed> $compileMeta
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    private function mergeCompileTimeChannels(
+        PersistentMapInterface $registryMeta,
+        PersistentMapInterface $compileMeta,
+    ): PersistentMapInterface {
+        foreach (['param-tags', 'inferred-param-tags'] as $channel) {
+            $key = Keyword::create($channel);
+            $value = $compileMeta->find($key);
+            if ($value !== null) {
+                $registryMeta = $registryMeta->put($key, $value);
+            }
+        }
+
+        return $registryMeta;
     }
 
     private function initializeNamespace(string $namespace): void

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -100,12 +100,25 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         // `compile`-only flows never populate). The runtime `$meta`
         // built below intentionally omits `:param-tags` so the emitted
         // PHP keeps its existing shape.
+        //
+        // `:inferred-param-tags` is the advisory companion: a same-shape
+        // vector filled in for params that have no user `:tag` but show
+        // an unambiguous primitive use in the body. It rides the same
+        // compile-time channel and is folded back into the meta read by
+        // `InvokeSymbol`, but the emitter never sees it so PHP signatures
+        // stay coercion-friendly.
         if ($initNode instanceof FnNode) {
-            $this->analyzer->setCompileTimeMeta(
-                $namespace,
-                $nameSymbol,
-                $metaMap->put(Keyword::create('param-tags'), $this->buildParamTags($initNode, $skip)),
-            );
+            $paramTags = $this->buildParamTags($initNode, $skip);
+            $compileTimeMeta = $metaMap->put(Keyword::create('param-tags'), $paramTags);
+            $inferredTags = $this->buildInferredParamTags($initNode, $paramTags, $skip);
+            if ($inferredTags instanceof PersistentVectorInterface) {
+                $compileTimeMeta = $compileTimeMeta->put(
+                    Keyword::create('inferred-param-tags'),
+                    $inferredTags,
+                );
+            }
+
+            $this->analyzer->setCompileTimeMeta($namespace, $nameSymbol, $compileTimeMeta);
         } else {
             $this->analyzer->setCompileTimeMeta($namespace, $nameSymbol, $metaMap);
         }
@@ -394,6 +407,72 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         }
 
         return Phel::vector($tags);
+    }
+
+    /**
+     * Companion vector to `:param-tags` filled by walking the fn body
+     * with `ParamTypeInferrer`. Slots stay `null` for params the user
+     * already tagged or that the inferrer could not resolve, so the
+     * call-site checker can use `:inferred-param-tags` only as a
+     * fallback when no explicit tag is present.
+     *
+     * Returns `null` when the inferrer found nothing — keeps the
+     * compile-time meta map free of empty advisory data.
+     *
+     * @param PersistentVectorInterface<mixed> $explicitTags
+     *
+     * @return PersistentVectorInterface<mixed>|null
+     */
+    private function buildInferredParamTags(
+        FnNode $fnNode,
+        PersistentVectorInterface $explicitTags,
+        int $skipFirst = 0,
+    ): ?PersistentVectorInterface {
+        $params = $fnNode->getParams();
+        if ($skipFirst > 0) {
+            $params = array_slice($params, $skipFirst);
+        }
+
+        $count = count($params);
+        if ($fnNode->isVariadic() && $count > 0) {
+            --$count;
+        }
+
+        if ($count === 0) {
+            return null;
+        }
+
+        $paramSlice = array_slice($params, 0, $count);
+        $inferred = new ParamTypeInferrer()->infer(
+            $fnNode->getBody(),
+            $paramSlice,
+            $fnNode->isVariadic(),
+        );
+
+        if ($inferred === []) {
+            return null;
+        }
+
+        $tags = [];
+        $any = false;
+        for ($i = 0; $i < $count; ++$i) {
+            $explicit = $explicitTags->get($i);
+            if (is_string($explicit) && $explicit !== '') {
+                // User tag wins; never overwrite an explicit declaration.
+                $tags[] = null;
+                continue;
+            }
+
+            $name = $params[$i]->getName();
+            $tag = $inferred[$name] ?? null;
+            if ($tag !== null) {
+                $any = true;
+            }
+
+            $tags[] = $tag;
+        }
+
+        return $any ? Phel::vector($tags) : null;
     }
 
     private function buildMultiFnNodeArglists(MultiFnNode $multiFnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -23,7 +23,9 @@ use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 
 use function array_map;
+use function array_pop;
 use function array_slice;
+use function array_values;
 use function assert;
 use function count;
 use function implode;
@@ -391,20 +393,11 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
      */
     private function buildParamTags(FnNode $fnNode, int $skipFirst = 0): PersistentVectorInterface
     {
-        $params = $fnNode->getParams();
-        if ($skipFirst > 0) {
-            $params = array_slice($params, $skipFirst);
-        }
-
-        $count = count($params);
-        if ($fnNode->isVariadic() && $count > 0) {
-            --$count;
-        }
-
-        $tags = [];
-        for ($i = 0; $i < $count; ++$i) {
-            $tags[] = TagCompatibility::extractParamTag($params[$i]);
-        }
+        $params = $this->scalarParamSlice($fnNode, $skipFirst);
+        $tags = array_map(
+            static fn(Symbol $p): ?string => TagCompatibility::extractParamTag($p),
+            $params,
+        );
 
         return Phel::vector($tags);
     }
@@ -428,24 +421,14 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
         PersistentVectorInterface $explicitTags,
         int $skipFirst = 0,
     ): ?PersistentVectorInterface {
-        $params = $fnNode->getParams();
-        if ($skipFirst > 0) {
-            $params = array_slice($params, $skipFirst);
-        }
-
-        $count = count($params);
-        if ($fnNode->isVariadic() && $count > 0) {
-            --$count;
-        }
-
-        if ($count === 0) {
+        $params = $this->scalarParamSlice($fnNode, $skipFirst);
+        if ($params === []) {
             return null;
         }
 
-        $paramSlice = array_slice($params, 0, $count);
         $inferred = new ParamTypeInferrer()->infer(
             $fnNode->getBody(),
-            $paramSlice,
+            $params,
             $fnNode->isVariadic(),
         );
 
@@ -455,24 +438,50 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
 
         $tags = [];
         $any = false;
-        for ($i = 0; $i < $count; ++$i) {
-            $explicit = $explicitTags->get($i);
-            if (is_string($explicit) && $explicit !== '') {
-                // User tag wins; never overwrite an explicit declaration.
+        foreach ($params as $i => $param) {
+            // User tag wins; never overwrite an explicit declaration.
+            if ($this->hasExplicitTag($explicitTags, $i)) {
                 $tags[] = null;
                 continue;
             }
 
-            $name = $params[$i]->getName();
-            $tag = $inferred[$name] ?? null;
-            if ($tag !== null) {
-                $any = true;
-            }
-
+            $tag = $inferred[$param->getName()] ?? null;
+            $any = $any || $tag !== null;
             $tags[] = $tag;
         }
 
         return $any ? Phel::vector($tags) : null;
+    }
+
+    /**
+     * Skips the leading macro implicit params (`&form`, `&env`) and the
+     * variadic tail. Both `:param-tags` consumers operate on this slice
+     * because the variadic tail's `:tag` describes the element type, not
+     * the bound `Vector`.
+     *
+     * @return list<Symbol>
+     */
+    private function scalarParamSlice(FnNode $fnNode, int $skipFirst): array
+    {
+        $params = $fnNode->getParams();
+        if ($skipFirst > 0) {
+            $params = array_slice($params, $skipFirst);
+        }
+
+        if ($fnNode->isVariadic() && $params !== []) {
+            array_pop($params);
+        }
+
+        return array_values($params);
+    }
+
+    /**
+     * @param PersistentVectorInterface<mixed> $explicitTags
+     */
+    private function hasExplicitTag(PersistentVectorInterface $explicitTags, int $i): bool
+    {
+        $tag = $explicitTags->get($i);
+        return is_string($tag) && $tag !== '';
     }
 
     private function buildMultiFnNodeArglists(MultiFnNode $multiFnNode, int $skipFirst = 0): string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -25,7 +25,6 @@ use Phel\Lang\TypeInterface;
 use function array_map;
 use function array_pop;
 use function array_slice;
-use function array_values;
 use function assert;
 use function count;
 use function implode;
@@ -395,7 +394,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
     {
         $params = $this->scalarParamSlice($fnNode, $skipFirst);
         $tags = array_map(
-            static fn(Symbol $p): ?string => TagCompatibility::extractParamTag($p),
+            TagCompatibility::extractParamTag(...),
             $params,
         );
 
@@ -472,7 +471,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             array_pop($params);
         }
 
-        return array_values($params);
+        return $params;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -92,10 +92,14 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         array $args,
         PersistentListInterface $list,
     ): void {
-        $paramTags = $f->getMeta()->find(Keyword::create('param-tags'));
+        $meta = $f->getMeta();
+        $paramTags = $meta->find(Keyword::create('param-tags'));
         if (!$paramTags instanceof PersistentVectorInterface) {
             return;
         }
+
+        $rawInferred = $meta->find(Keyword::create('inferred-param-tags'));
+        $inferredTags = $rawInferred instanceof PersistentVectorInterface ? $rawInferred : null;
 
         $tagsCount = count($paramTags);
         foreach ($args as $i => $arg) {
@@ -103,12 +107,8 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
                 return;
             }
 
-            $tag = $paramTags->get($i);
-            if (!is_string($tag)) {
-                continue;
-            }
-
-            if ($tag === '') {
+            $tag = $this->resolveParamTag($paramTags, $inferredTags, $i);
+            if ($tag === null) {
                 continue;
             }
 
@@ -125,6 +125,36 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
                 );
             }
         }
+    }
+
+    /**
+     * Resolves the contract for a single param slot. Explicit `:param-tags`
+     * wins; the inferred companion is consulted only when the explicit slot
+     * is empty (`null` or `''`). Returns `null` when no contract applies.
+     *
+     * @param PersistentVectorInterface<mixed>      $explicitTags
+     * @param PersistentVectorInterface<mixed>|null $inferredTags
+     */
+    private function resolveParamTag(
+        PersistentVectorInterface $explicitTags,
+        ?PersistentVectorInterface $inferredTags,
+        int $i,
+    ): ?string {
+        $explicit = $explicitTags->get($i);
+        if (is_string($explicit) && $explicit !== '') {
+            return $explicit;
+        }
+
+        if (!$inferredTags instanceof PersistentVectorInterface) {
+            return null;
+        }
+
+        if ($i >= count($inferredTags)) {
+            return null;
+        }
+
+        $inferred = $inferredTags->get($i);
+        return is_string($inferred) && $inferred !== '' ? $inferred : null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -140,21 +140,21 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
         ?PersistentVectorInterface $inferredTags,
         int $i,
     ): ?string {
-        $explicit = $explicitTags->get($i);
-        if (is_string($explicit) && $explicit !== '') {
-            return $explicit;
-        }
+        return $this->tagAt($explicitTags, $i)
+            ?? $this->tagAt($inferredTags, $i);
+    }
 
-        if (!$inferredTags instanceof PersistentVectorInterface) {
+    /**
+     * @param PersistentVectorInterface<mixed>|null $vec
+     */
+    private function tagAt(?PersistentVectorInterface $vec, int $i): ?string
+    {
+        if (!$vec instanceof PersistentVectorInterface || $i >= count($vec)) {
             return null;
         }
 
-        if ($i >= count($inferredTags)) {
-            return null;
-        }
-
-        $inferred = $inferredTags->get($i);
-        return is_string($inferred) && $inferred !== '' ? $inferred : null;
+        $tag = $vec->get($i);
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InvokeSymbol.php
@@ -98,56 +98,45 @@ final class InvokeSymbol implements SpecialFormAnalyzerInterface
             return;
         }
 
-        $rawInferred = $meta->find(Keyword::create('inferred-param-tags'));
-        $inferredTags = $rawInferred instanceof PersistentVectorInterface ? $rawInferred : null;
-
+        $inferredTags = $meta->find(Keyword::create('inferred-param-tags'));
         $tagsCount = count($paramTags);
         foreach ($args as $i => $arg) {
             if ($i >= $tagsCount) {
                 return;
             }
 
-            $tag = $this->resolveParamTag($paramTags, $inferredTags, $i);
-            if ($tag === null) {
-                continue;
-            }
-
-            $literalType = TagCompatibility::literalTypeOf($arg);
-            if ($literalType === null) {
-                continue;
-            }
-
-            if (!TagCompatibility::accepts($tag, $literalType)) {
-                throw AnalyzerException::withLocation(
-                    'Arg #' . ($i + 1) . " to '" . $f->getName()->getName()
-                    . sprintf("' has type '%s' but param is tagged '%s'", $literalType, $tag),
-                    $list,
-                );
+            // Explicit `:param-tags` wins; the inferred companion is
+            // consulted only when the explicit slot is empty.
+            $tag = $this->tagAt($paramTags, $i) ?? $this->tagAt($inferredTags, $i);
+            if ($tag !== null) {
+                $this->ensureLiteralMatchesTag($f, $list, $i, $arg, $tag);
             }
         }
     }
 
     /**
-     * Resolves the contract for a single param slot. Explicit `:param-tags`
-     * wins; the inferred companion is consulted only when the explicit slot
-     * is empty (`null` or `''`). Returns `null` when no contract applies.
-     *
-     * @param PersistentVectorInterface<mixed>      $explicitTags
-     * @param PersistentVectorInterface<mixed>|null $inferredTags
+     * @param PersistentListInterface<mixed> $list
      */
-    private function resolveParamTag(
-        PersistentVectorInterface $explicitTags,
-        ?PersistentVectorInterface $inferredTags,
+    private function ensureLiteralMatchesTag(
+        GlobalVarNode $f,
+        PersistentListInterface $list,
         int $i,
-    ): ?string {
-        return $this->tagAt($explicitTags, $i)
-            ?? $this->tagAt($inferredTags, $i);
+        AbstractNode $arg,
+        string $tag,
+    ): void {
+        $literalType = TagCompatibility::literalTypeOf($arg);
+        if ($literalType === null || TagCompatibility::accepts($tag, $literalType)) {
+            return;
+        }
+
+        throw AnalyzerException::withLocation(
+            'Arg #' . ($i + 1) . " to '" . $f->getName()->getName()
+            . sprintf("' has type '%s' but param is tagged '%s'", $literalType, $tag),
+            $list,
+        );
     }
 
-    /**
-     * @param PersistentVectorInterface<mixed>|null $vec
-     */
-    private function tagAt(?PersistentVectorInterface $vec, int $i): ?string
+    private function tagAt(mixed $vec, int $i): ?string
     {
         if (!$vec instanceof PersistentVectorInterface || $i >= count($vec)) {
             return null;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -172,30 +172,19 @@ final class ParamTypeInferrer
         $this->walk($fn);
 
         if ($fn instanceof GlobalVarNode && $this->isGuardGlobal($fn)) {
-            foreach ($node->getArguments() as $arg) {
-                $this->markGuarded($arg);
-                $this->walk($arg);
-            }
-
+            $this->walkArgs($node, fn(AbstractNode $a) => $this->markGuarded($a));
             return;
         }
 
         if (!$fn instanceof PhpVarNode) {
-            foreach ($node->getArguments() as $arg) {
-                $this->walk($arg);
-            }
-
+            $this->walkArgs($node);
             return;
         }
 
         $op = $fn->getName();
 
         if ($op === self::STRING_CONCAT_OP) {
-            foreach ($node->getArguments() as $arg) {
-                $this->constrainArgAsScalar($arg, 'string');
-                $this->walk($arg);
-            }
-
+            $this->walkArgs($node, fn(AbstractNode $a) => $this->constrainArgAsScalar($a, 'string'));
             return;
         }
 
@@ -208,56 +197,60 @@ final class ParamTypeInferrer
         // arg expressions for nested operators without constraining the
         // local: PHP comparisons coerce both sides at runtime, and
         // unknown functions could accept anything.
-        foreach ($node->getArguments() as $arg) {
-            $this->walk($arg);
-        }
+        $this->walkArgs($node);
     }
 
     private function walkNumericCall(CallNode $node): void
     {
         $args = $node->getArguments();
-        $hasFloat = false;
-        foreach ($args as $arg) {
-            if ($arg instanceof LiteralNode && is_float($arg->getValue())) {
-                $hasFloat = true;
-            }
-        }
+        $hasFloat = array_any($args, static fn($arg): bool => $arg instanceof LiteralNode && is_float($arg->getValue()));
 
         $type = $hasFloat ? 'float' : 'int';
-        foreach ($args as $arg) {
-            $this->constrainArgAsScalar($arg, $type);
+        $this->walkArgs($node, fn(AbstractNode $a) => $this->constrainArgAsScalar($a, $type));
+    }
+
+    /**
+     * @param (callable(AbstractNode): void)|null $observe
+     */
+    private function walkArgs(CallNode $node, ?callable $observe = null): void
+    {
+        foreach ($node->getArguments() as $arg) {
+            if ($observe !== null) {
+                $observe($arg);
+            }
+
             $this->walk($arg);
         }
     }
 
     private function constrainArgAsScalar(AbstractNode $arg, string $type): void
     {
+        $name = $this->paramNameOf($arg);
+        if ($name !== null) {
+            $this->observations[$name][] = $type;
+        }
+    }
+
+    private function markGuarded(AbstractNode $arg): void
+    {
+        $name = $this->paramNameOf($arg);
+        if ($name !== null) {
+            $this->guarded[$name] = true;
+        }
+    }
+
+    private function paramNameOf(AbstractNode $arg): ?string
+    {
         if (!$arg instanceof LocalVarNode) {
-            return;
+            return null;
         }
 
         $name = $arg->getName()->getName();
-        if (!isset($this->params[$name])) {
-            return;
-        }
-
-        $this->observations[$name][] = $type;
+        return isset($this->params[$name]) ? $name : null;
     }
 
     private function isGuardGlobal(GlobalVarNode $fn): bool
     {
         return in_array($fn->getName()->getName(), self::GUARD_GLOBALS, true);
-    }
-
-    private function markGuarded(AbstractNode $arg): void
-    {
-        if (!$arg instanceof LocalVarNode) {
-            return;
-        }
-
-        $name = $arg->getName()->getName();
-        if (isset($this->params[$name])) {
-            $this->guarded[$name] = true;
-        }
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Lang\Symbol;
+
+use function array_unique;
+use function count;
+use function in_array;
+use function is_float;
+
+/**
+ * Walks a fn body to surface conservative param-type contracts that the
+ * static type checker can use to flag obvious call-site mismatches. The
+ * inferred map is advisory only: it never reaches the emitter, so the
+ * compiled PHP signature stays untyped and runtime coercion behaviour is
+ * preserved.
+ *
+ * Inference is deliberately narrow. A param earns a tag only when every
+ * use across every reached branch agrees on the same primitive. Any
+ * operator that coerces (comparisons), any nested fn body (closures own
+ * their own params), or any disagreement drops the param so the checker
+ * never raises a spurious diagnostic.
+ */
+final class ParamTypeInferrer
+{
+    /** @var list<string> */
+    private const array NUMERIC_OPS = [
+        '+', '-', '*', '/', '%', '**', '<<', '>>', '|', '&', '^',
+    ];
+
+    private const string STRING_CONCAT_OP = '.';
+
+    /** @var array<string, list<string>> */
+    private array $observations = [];
+
+    /** @var array<string, true> */
+    private array $params = [];
+
+    /**
+     * @param list<Symbol> $params
+     *
+     * @return array<string, string>
+     */
+    public function infer(AbstractNode $body, array $params, bool $isVariadic = false): array
+    {
+        $this->observations = [];
+        $this->params = [];
+
+        $lastIndex = $isVariadic ? count($params) - 1 : count($params);
+        for ($i = 0; $i < $lastIndex; ++$i) {
+            // The variadic tail binds a `Vector`, not a scalar; excluding
+            // it keeps numeric/string observations from constraining the
+            // wrong runtime shape.
+            $this->params[$params[$i]->getName()] = true;
+        }
+
+        if ($this->params === []) {
+            return [];
+        }
+
+        $this->walk($body);
+
+        $result = [];
+        foreach ($this->observations as $name => $types) {
+            $unique = array_unique($types);
+            if (count($unique) === 1) {
+                $result[$name] = $unique[0];
+            }
+        }
+
+        return $result;
+    }
+
+    private function walk(AbstractNode $node): void
+    {
+        if ($node instanceof FnNode) {
+            // Closures own their own params; a `$x` inside is unrelated
+            // to the outer fn's `$x`.
+            return;
+        }
+
+        if ($node instanceof DoNode) {
+            foreach ($node->getStmts() as $stmt) {
+                $this->walk($stmt);
+            }
+
+            $this->walk($node->getRet());
+            return;
+        }
+
+        if ($node instanceof IfNode) {
+            $this->walk($node->getTestExpr());
+            $this->walk($node->getThenExpr());
+            $this->walk($node->getElseExpr());
+            return;
+        }
+
+        if ($node instanceof LetNode) {
+            foreach ($node->getBindings() as $binding) {
+                $this->walk($binding->getInitExpr());
+            }
+
+            $this->walk($node->getBodyExpr());
+            return;
+        }
+
+        if ($node instanceof RecurNode) {
+            // recur rebinds loop locals positionally; we can't constrain
+            // the bound names from the call site without tracking the
+            // matching loop frame, so just walk arg expressions for any
+            // operator usage they contain.
+            foreach ($node->getExpressions() as $expr) {
+                $this->walk($expr);
+            }
+
+            return;
+        }
+
+        if ($node instanceof ThrowNode) {
+            return;
+        }
+
+        if ($node instanceof CallNode) {
+            $this->walkCall($node);
+            return;
+        }
+    }
+
+    private function walkCall(CallNode $node): void
+    {
+        $fn = $node->getFn();
+        // Recurse into the callee position first: descending captures any
+        // operator hidden in a higher-order arg without blocking the
+        // fn-position itself from acting as a constraint source.
+        $this->walk($fn);
+
+        if (!$fn instanceof PhpVarNode) {
+            foreach ($node->getArguments() as $arg) {
+                $this->walk($arg);
+            }
+
+            return;
+        }
+
+        $op = $fn->getName();
+
+        if ($op === self::STRING_CONCAT_OP) {
+            foreach ($node->getArguments() as $arg) {
+                $this->constrainArgAsScalar($arg, 'string');
+                $this->walk($arg);
+            }
+
+            return;
+        }
+
+        if (in_array($op, self::NUMERIC_OPS, true)) {
+            $this->walkNumericCall($node);
+            return;
+        }
+
+        // Everything else (comparisons, `aget`, unknown PHP fns) walks
+        // arg expressions for nested operators without constraining the
+        // local: PHP comparisons coerce both sides at runtime, and
+        // unknown functions could accept anything.
+        foreach ($node->getArguments() as $arg) {
+            $this->walk($arg);
+        }
+    }
+
+    private function walkNumericCall(CallNode $node): void
+    {
+        $args = $node->getArguments();
+        $hasFloat = false;
+        foreach ($args as $arg) {
+            if ($arg instanceof LiteralNode && is_float($arg->getValue())) {
+                $hasFloat = true;
+            }
+        }
+
+        $type = $hasFloat ? 'float' : 'int';
+        foreach ($args as $arg) {
+            $this->constrainArgAsScalar($arg, $type);
+            $this->walk($arg);
+        }
+    }
+
+    private function constrainArgAsScalar(AbstractNode $arg, string $type): void
+    {
+        if (!$arg instanceof LocalVarNode) {
+            return;
+        }
+
+        $name = $arg->getName()->getName();
+        if (!isset($this->params[$name])) {
+            return;
+        }
+
+        $this->observations[$name][] = $type;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -44,11 +44,28 @@ final class ParamTypeInferrer
 
     private const string STRING_CONCAT_OP = '.';
 
+    /**
+     * Globals that signal "the function defensively rejects bad inputs at
+     * runtime". A param threaded through any of these escapes inference
+     * even when later used by a primitive op, so deliberate negative tests
+     * (e.g. `(bit-and nil 1)` against an `assert-non-nil` guard) keep
+     * compiling and reach the runtime guard.
+     *
+     * @var list<string>
+     */
+    private const array GUARD_GLOBALS = [
+        'assert-non-nil',
+        'assert',
+    ];
+
     /** @var array<string, list<string>> */
     private array $observations = [];
 
     /** @var array<string, true> */
     private array $params = [];
+
+    /** @var array<string, true> */
+    private array $guarded = [];
 
     /**
      * @param list<Symbol> $params
@@ -59,6 +76,7 @@ final class ParamTypeInferrer
     {
         $this->observations = [];
         $this->params = [];
+        $this->guarded = [];
 
         $lastIndex = $isVariadic ? count($params) - 1 : count($params);
         for ($i = 0; $i < $lastIndex; ++$i) {
@@ -76,6 +94,10 @@ final class ParamTypeInferrer
 
         $result = [];
         foreach ($this->observations as $name => $types) {
+            if (isset($this->guarded[$name])) {
+                continue;
+            }
+
             $unique = array_unique($types);
             if (count($unique) === 1) {
                 $result[$name] = $unique[0];
@@ -148,6 +170,15 @@ final class ParamTypeInferrer
         // fn-position itself from acting as a constraint source.
         $this->walk($fn);
 
+        if ($fn instanceof GlobalVarNode && $this->isGuardGlobal($fn)) {
+            foreach ($node->getArguments() as $arg) {
+                $this->markGuarded($arg);
+                $this->walk($arg);
+            }
+
+            return;
+        }
+
         if (!$fn instanceof PhpVarNode) {
             foreach ($node->getArguments() as $arg) {
                 $this->walk($arg);
@@ -210,5 +241,22 @@ final class ParamTypeInferrer
         }
 
         $this->observations[$name][] = $type;
+    }
+
+    private function isGuardGlobal(GlobalVarNode $fn): bool
+    {
+        return in_array($fn->getName()->getName(), self::GUARD_GLOBALS, true);
+    }
+
+    private function markGuarded(AbstractNode $arg): void
+    {
+        if (!$arg instanceof LocalVarNode) {
+            return;
+        }
+
+        $name = $arg->getName()->getName();
+        if (isset($this->params[$name])) {
+            $this->guarded[$name] = true;
+        }
     }
 }

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -1,0 +1,37 @@
+--PHEL--
+(defn mixed [x flag] (if flag (php/+ x 1) (php/. x "!")))
+(mixed "x" false)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "mixed",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\mixed";
+
+    public function __invoke($x, $flag) {
+      if (($__truthy = $flag) !== null && $__truthy !== false) {
+        return ($x + 1);
+      } else {
+        return ($x . "!");
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(mixed x flag)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-mixed-branches-bails.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-mixed-branches-bails.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 57
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x flag]"
+  )
+);
+(\Phel::getDefinition("user", "mixed"))("x", false);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric-no-signature-change.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric-no-signature-change.test
@@ -1,0 +1,32 @@
+--PHEL--
+(defn add1 [x] (php/+ x 1))
+(add1 42)
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add1",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add1";
+
+    public function __invoke($x) {
+      return ($x + 1);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add1 x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-numeric-no-signature-change.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-numeric-no-signature-change.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 27
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);
+(\Phel::getDefinition("user", "add1"))(42);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string-no-signature-change.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string-no-signature-change.test
@@ -1,0 +1,33 @@
+--PHEL--
+(defn greet [x] (php/. "hi " x))
+(greet "world")
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "greet",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\greet";
+
+    public function __invoke($x): string {
+      return ("hi " . $x);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(greet x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-string-no-signature-change.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-param-infer-string-no-signature-change.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 32
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel::keyword("tag"), "string"
+  )
+);
+(\Phel::getDefinition("user", "greet"))("world");

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/StaticTypeCheckerTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/StaticTypeCheckerTest.php
@@ -86,6 +86,56 @@ final class StaticTypeCheckerTest extends TestCase
         self::assertStringContainsString('?int', $php);
     }
 
+    public function test_inferred_int_param_flags_string_literal_at_call_site(): void
+    {
+        $this->expectExceptionMessageMatches(
+            "/Arg #1 to 'add1' has type 'string' but param is tagged 'int'/",
+        );
+        $this->compile('(defn add1 [x] (php/+ x 1))(add1 "x")');
+    }
+
+    public function test_inferred_string_param_flags_int_literal_at_call_site(): void
+    {
+        $this->expectExceptionMessageMatches(
+            "/Arg #1 to 'shout' has type 'int' but param is tagged 'string'/",
+        );
+        $this->compile('(defn shout [x] (php/. x "!"))(shout 1)');
+    }
+
+    public function test_inferred_param_does_not_emit_php_signature_hint(): void
+    {
+        // Advisory inference must not change the runtime contract: the
+        // emitted PHP keeps the param untyped so callers that rely on
+        // PHP's int/float/string coercion still work.
+        $php = $this->compile('(defn add1 [x] (php/+ x 1))');
+        self::assertStringNotContainsString('int $x', $php);
+        self::assertStringContainsString('__invoke($x)', $php);
+    }
+
+    public function test_branch_disagreement_drops_inferred_param(): void
+    {
+        // `x` is used as both int and string across branches, so the
+        // inferrer must not commit to either; both call shapes compile
+        // without a diagnostic.
+        $php = $this->compile(
+            '(defn mixed [x flag] (if flag (php/+ x 1) (php/. x "!")))'
+            . '(mixed 1 true)'
+            . '(mixed "x" false)',
+        );
+        self::assertStringContainsString('mixed', $php);
+    }
+
+    public function test_explicit_param_tag_wins_over_inferred(): void
+    {
+        // The body suggests `string` for `x` via `php/.`, but the
+        // explicit `^int` declaration is the authoritative contract;
+        // the diagnostic must use the explicit tag.
+        $this->expectExceptionMessageMatches(
+            "/Arg #1 to 'tag-wins' has type 'string' but param is tagged 'int'/",
+        );
+        $this->compile('(defn tag-wins [^int x] (php/. x "!"))(tag-wins "x")');
+    }
+
     private function compile(string $source): string
     {
         BuildFacade::enableBuildMode();


### PR DESCRIPTION
## 🤔 Background

PR #1943 covered return-type inference. Param-type inference was deferred: stamping a PHP type on a fn parameter would silently break callers that rely on `("5" + 3)`-style coercion.

## 💡 Goal

Closes #1944. Surface obvious call-site mismatches at compile time without changing the emitted PHP signature.

## 🔖 Changes

- New `ParamTypeInferrer` walks fn bodies for primitive PHP ops on local params: `(php/+ x ...)` -> `int`, `(php/. x ...)` -> `string`, comparisons stay coercion-friendly. Branch disagreement, nested fn bodies, and params threaded through guard globals (`assert-non-nil`, `assert`) all skip inference.
- `DefSymbol` persists the result on the compile-time meta as `:inferred-param-tags`. The runtime metaMap stays untouched, so emitted PHP keeps no `int $x` hints.
- `InvokeSymbol` falls back to `:inferred-param-tags` only when the explicit slot is empty; explicit `:param-tags` always win.
- `GlobalEnvironment` folds both compile-time channels back into the registry meta read at call sites.
- Tests: 5 new `StaticTypeCheckerTest` cases and 3 fixtures confirming emitted PHP stays untyped.
- CHANGELOG entry under `## Unreleased`.

Out of scope: opt-in `^{:strict-params true}` for emitted hints, and whole-program analysis. Multi-arity defns are not inferred.