### PR TITLE
ref(profile): trim hot-path allocations and add user guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 - [Watch](watch-guide.md): hot-reload changed namespaces
 - [CLI Builder](cli-guide.md): build CLIs with `phel.cli`
 - [Performance](performance.md): opcache setup, cache reset
+- [Profile](profile-guide.md): `phel profile` per-fn timings and compile-phase costs
 - [Mocking](mocking-guide.md): test seams for PHP calls
 
 ## Modules

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -75,4 +75,5 @@ Full suite (4 440 tests) dropped from ~76 s to ~61 s after enabling opcache CLI.
 ## Related
 
 - [`docs/internals/benchmarks.md`](internals/benchmarks.md): PHPBench suite for tracking regressions in the Phel compiler itself
+- [Profile Guide](profile-guide.md): instrument a script to find hot fns
 - PHP manual: [opcache configuration](https://www.php.net/manual/en/opcache.configuration.php)

--- a/docs/profile-guide.md
+++ b/docs/profile-guide.md
@@ -1,0 +1,79 @@
+# Profile Guide
+
+`phel profile` instruments a script and reports per-fn call counts, self / total / avg / max timings, and compile-time phase costs. Use it to find hot fns and where compilation time goes.
+
+## Quickstart
+
+```sh
+./vendor/bin/phel profile src/phel/main.phel
+./vendor/bin/phel profile my.namespace
+./vendor/bin/phel profile               # auto-detects entry point
+```
+
+Without an argument the command runs `core.phel` / `main.phel` if `phel-config.php` declares one.
+
+## Sample output
+
+```
+Wall clock: 142.31 ms
+
+Top 20 functions by self time:
+  fn                          calls    self ms    total ms     avg ms     max ms
+  user/parse-line             10000     38.420      52.110      0.005      0.114
+  user/normalise-token        10000     11.604      11.604      0.001      0.043
+  user/load-fixture               1     30.281     142.014    142.014    142.014
+  ...
+
+Compile phases (ms):
+  src/phel/main.phel              lex 4.12   parse 1.88   read 1.02   analyze 8.41   emit 2.77
+```
+
+JSON form:
+
+```sh
+./vendor/bin/phel profile main.phel --format=json
+./vendor/bin/phel profile main.phel --format=both --output=profile.json
+```
+
+`--output=<file>` always writes the JSON report. `--format` controls stdout (table / json / both).
+
+## Options
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--top=<N>` | `20` | Rows in the table; non-positive falls back to default |
+| `--format=table|json|both` | `table` | Stdout shape |
+| `--output=<file>` | — | Write JSON to a file (independent of `--format`) |
+| `--sort=self|total|calls|avg` | `self` | Table row ordering |
+| `--no-compile-phases` | off | Drop the per-source phase block |
+
+Argv after the path is forwarded to the script:
+
+```sh
+./vendor/bin/phel profile bench.phel -- --iters=1000
+```
+
+## How it works
+
+The profiler is an **instrumentation** profiler, not a sampler.
+
+1. `Registry::$profilerHook` is set before the run starts. While set, `Registry::addDefinition` wraps every `AbstractFn` in a `ProfilingFn` proxy.
+2. `GlobalVarEmitter` already routes every global-fn call through `\Phel::getDefinition(...)`, so each call hits the proxy's `__invoke` without any emitter or fixture changes.
+3. Each `__invoke` notifies the session on entry / exit. The session keeps a per-call stack tracking `[name, enterNs, childInclusiveNs]`.
+4. On exit, total = `now - enterNs` and self = `total - childInclusiveNs`. The parent frame's `childInclusiveNs` is bumped so its self time stays accurate when it returns.
+5. Compile-phase timings come from the existing compiler hook (`recordPhase`), keyed by source file.
+6. The hook is cleared in a `finally` block so it never leaks across commands.
+
+The off-state cost is one null-check per `Registry::addDefinition`. Zero overhead at call sites when the profiler is not running.
+
+## Caveats
+
+- **Self-recursive calls** emit `$this(...)` instead of a registry lookup ([commit `bee78ffe`](https://github.com/phel-lang/phel-lang/commit/bee78ffe)). The outer entry is timed; recursive depth inside that call is not. Cross-fn recursion is fully profiled.
+- **Macros** run at compile time. Their cost shows up under the `analyze` phase, not as fn rows.
+- **Anonymous fns** (`fn`, `#(...)`) are not registered globally, so they do not appear in the per-fn table. Wrap them in a `defn` if you need to profile them.
+- **Variadic spread** in `__invoke` adds a small per-call overhead. For micro-benchmarks below a microsecond, prefer `composer bench-jit-baseline` / `bench-jit-tracing`.
+
+## See also
+
+- [Performance Tips](performance.md): opcache, JIT, compiled-code cache
+- [Internals: Benchmarks](internals/benchmarks.md): typed-vs-untyped JIT kernels

--- a/src/php/Profile/Domain/ProfilerSession.php
+++ b/src/php/Profile/Domain/ProfilerSession.php
@@ -8,12 +8,17 @@ use Phel\Lang\AbstractFn;
 use Phel\Lang\ProfilerHookInterface;
 
 use function array_pop;
-use function count;
 use function hrtime;
 
 final class ProfilerSession implements ProfilerHookInterface
 {
-    /** @var list<array{name:string, enter:int, sub:int}> */
+    /**
+     * Positional tuple per frame: [name, enterNs, childInclusiveNs]. Keyed
+     * arrays would allocate a hash slot per call; the positional layout
+     * keeps `enter` to a single push on every fn invocation.
+     *
+     * @var list<array{0:string, 1:int, 2:int}>
+     */
     private array $stack = [];
 
     /** @var array<string, array{calls:int, totalNs:int, selfNs:int, maxNs:int}> */
@@ -21,6 +26,8 @@ final class ProfilerSession implements ProfilerHookInterface
 
     /** @var array<string, array<string, float>> */
     private array $phaseMs = [];
+
+    private int $depth = 0;
 
     private readonly int $startedAtNs;
 
@@ -40,7 +47,8 @@ final class ProfilerSession implements ProfilerHookInterface
 
     public function enter(string $name): void
     {
-        $this->stack[] = ['name' => $name, 'enter' => hrtime(true), 'sub' => 0];
+        $this->stack[] = [$name, hrtime(true), 0];
+        ++$this->depth;
     }
 
     public function exit(): void
@@ -50,13 +58,13 @@ final class ProfilerSession implements ProfilerHookInterface
             return;
         }
 
-        $inclusive = hrtime(true) - $frame['enter'];
-        $this->recordCall($frame['name'], $inclusive, $inclusive - $frame['sub']);
+        --$this->depth;
+        $inclusive = hrtime(true) - $frame[1];
+        $this->recordCall($frame[0], $inclusive, $inclusive - $frame[2]);
 
-        $depth = count($this->stack);
-        if ($depth > 0) {
+        if ($this->depth > 0) {
             /** @psalm-suppress PropertyTypeCoercion */
-            $this->stack[$depth - 1]['sub'] += $inclusive;
+            $this->stack[$this->depth - 1][2] += $inclusive;
         }
     }
 
@@ -76,15 +84,20 @@ final class ProfilerSession implements ProfilerHookInterface
 
     private function recordCall(string $name, int $inclusive, int $self): void
     {
+        // Bind a reference to the bucket so the four hot-path mutations
+        // touch a single hash slot instead of re-resolving `$name` each
+        // time. Tight inner loops compound these lookups quickly.
         if (!isset($this->fnStats[$name])) {
             $this->fnStats[$name] = ['calls' => 0, 'totalNs' => 0, 'selfNs' => 0, 'maxNs' => 0];
         }
 
-        ++$this->fnStats[$name]['calls'];
-        $this->fnStats[$name]['totalNs'] += $inclusive;
-        $this->fnStats[$name]['selfNs'] += $self;
-        if ($inclusive > $this->fnStats[$name]['maxNs']) {
-            $this->fnStats[$name]['maxNs'] = $inclusive;
+        /** @psalm-suppress UnsupportedPropertyReferenceUsage */
+        $stat = &$this->fnStats[$name];
+        ++$stat['calls'];
+        $stat['totalNs'] += $inclusive;
+        $stat['selfNs'] += $self;
+        if ($inclusive > $stat['maxNs']) {
+            $stat['maxNs'] = $inclusive;
         }
     }
 }


### PR DESCRIPTION
## 🤔 Background

`phel profile` shipped without user-facing docs (CHANGELOG one-liner only) and the hot path in `ProfilerSession` carried a few avoidable allocations / lookups.

## 💡 Goal

- Make the command discoverable from `docs/`.
- Trim per-call overhead in the profiler stack and per-fn bookkeeping.

## 🔖 Changes

- `ProfilerSession` frames are now positional tuples (`[name, enterNs, childInclusiveNs]`) rather than keyed arrays, removing the per-call hash slot.
- Stack depth is cached as an `int` counter; `exit` no longer calls `count()` on every pop.
- `recordCall` binds a reference to the per-fn bucket so the four mutations on the hot path resolve the hash slot once.
- `docs/profile-guide.md` documents usage, sample output, options, the hook mechanism, and caveats (self-recursive bypass, anonymous fns, macros).
- `docs/README.md` lists the new guide under Tooling. `docs/performance.md` cross-links from "Related".

No behavior change. Profile suite green; full quality (`composer test-quality`) green.