### PR TITLE
feat(compiler): backslash-free php/ namespace function syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - `^:async` metadata on `defn` wraps the body in `async`, returning an `Amp\Future` that callers `await` (#1924)
 
 #### Compiler
+- `php/Foo.Bar/baz` and `php/Foo.Bar.baz` accepted as backslash-free aliases for `php/Foo\Bar\baz` (#1952)
 - `:tag` metadata emits PHP type declarations; reader shorthands `^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}` (#1916)
 - Return-type inference from tail primitive ops on tagged params (#1932)
 - Return-type inference covers tail calls to tagged globals and pure PHP built-ins (#1941)

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -39,7 +39,7 @@ Prefix PHP functions with `php/`:
 (php/Amp\trapSignal [php/SIGINT php/SIGTERM])
 (php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
 
-;; Backslash-free alternatives — `.` and `/` are also accepted as namespace
+;; Backslash-free alternatives: `.` and `/` are also accepted as namespace
 ;; separators, so the same call can be written without escaping in `.cljc`
 ;; files or shared snippets:
 (php/Amp.ByteStream/getStdout)

--- a/docs/php-interop.md
+++ b/docs/php-interop.md
@@ -38,9 +38,16 @@ Prefix PHP functions with `php/`:
 ;; Namespaced functions: keep the original casing
 (php/Amp\trapSignal [php/SIGINT php/SIGTERM])
 (php/\Monolog\Logger\Utils\detectAndCleanUtf8 "input")
+
+;; Backslash-free alternatives — `.` and `/` are also accepted as namespace
+;; separators, so the same call can be written without escaping in `.cljc`
+;; files or shared snippets:
+(php/Amp.ByteStream/getStdout)
+(php/Amp.ByteStream.getStdout)
+(php/Monolog.Logger.Utils.detectAndCleanUtf8 "input")
 ```
 
-The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path (use `\\` to disambiguate from the root namespace). Case is preserved: `php/Amp\trapSignal` compiles to `\Amp\trapSignal(...)`.
+The `php/` prefix resolves any global or namespaced PHP function. The name after `php/` is the full PHP path; `\`, `.`, and `/` are interchangeable as namespace separators, so `php/Amp\trapSignal`, `php/Amp.trapSignal`, and `php/Amp/trapSignal` all compile to `\Amp\trapSignal(...)`. Case is preserved.
 
 Capture references with `def` to shorten calls:
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
@@ -108,8 +108,8 @@ final class PhpVarNode extends AbstractNode
         }
 
         // `.` and `/` are also infix PHP operators (string concat / division);
-        // only treat them as namespace separators on multi-segment names.
-        if (in_array($this->name, self::INFIX_OPERATORS, true)) {
+        // a single-token infix is never a namespaced reference.
+        if ($this->isInfix()) {
             return false;
         }
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
@@ -74,15 +74,10 @@ final class PhpVarNode extends AbstractNode
     }
 
     /**
-     * Returns the name suitable for emitting as a PHP function reference.
-     *
-     * Namespaced PHP functions are returned as fully qualified names with a
-     * single leading backslash so they resolve against the global namespace,
-     * regardless of any active `namespace ...;` declaration in the emitted
-     * PHP file. Dot (`.`) and forward-slash (`/`) inside the name are treated
-     * as namespace separators and rewritten to backslashes, so that the same
-     * function can be referenced as `php/Amp\ByteStream\getStdout`,
-     * `php/Amp.ByteStream/getStdout`, or `php/Amp.ByteStream.getStdout`.
+     * Fully qualified PHP name for emission. Backslash, dot, and forward
+     * slash are interchangeable namespace separators in the source name; a
+     * leading `\` ensures resolution against the root namespace regardless
+     * of the surrounding `namespace ...;` declaration in emitted PHP.
      */
     public function getAbsoluteName(): string
     {

--- a/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/PhpVarNode.php
@@ -12,6 +12,7 @@ use function in_array;
 use function is_callable;
 use function ltrim;
 use function str_contains;
+use function str_replace;
 
 final class PhpVarNode extends AbstractNode
 {
@@ -75,18 +76,23 @@ final class PhpVarNode extends AbstractNode
     /**
      * Returns the name suitable for emitting as a PHP function reference.
      *
-     * Namespaced PHP functions (containing a backslash) are returned as
-     * fully qualified names with a single leading backslash so they resolve
-     * against the global namespace, regardless of any active `namespace ...;`
-     * declaration in the emitted PHP file.
+     * Namespaced PHP functions are returned as fully qualified names with a
+     * single leading backslash so they resolve against the global namespace,
+     * regardless of any active `namespace ...;` declaration in the emitted
+     * PHP file. Dot (`.`) and forward-slash (`/`) inside the name are treated
+     * as namespace separators and rewritten to backslashes, so that the same
+     * function can be referenced as `php/Amp\ByteStream\getStdout`,
+     * `php/Amp.ByteStream/getStdout`, or `php/Amp.ByteStream.getStdout`.
      */
     public function getAbsoluteName(): string
     {
-        if (!str_contains($this->name, '\\')) {
+        if (!$this->isNamespaced()) {
             return $this->name;
         }
 
-        return '\\' . ltrim($this->name, '\\');
+        $normalized = str_replace(['/', '.'], '\\', $this->name);
+
+        return '\\' . ltrim($normalized, '\\');
     }
 
     public function isInfix(): bool
@@ -96,6 +102,22 @@ final class PhpVarNode extends AbstractNode
 
     public function isCallable(): bool
     {
-        return is_callable($this->name) || in_array($this->name, self::CALLABLE_KEYWORDS, true);
+        return is_callable($this->getAbsoluteName())
+            || in_array($this->name, self::CALLABLE_KEYWORDS, true);
+    }
+
+    private function isNamespaced(): bool
+    {
+        if (str_contains($this->name, '\\')) {
+            return true;
+        }
+
+        // `.` and `/` are also infix PHP operators (string concat / division);
+        // only treat them as namespace separators on multi-segment names.
+        if (in_array($this->name, self::INFIX_OPERATORS, true)) {
+            return false;
+        }
+
+        return str_contains($this->name, '.') || str_contains($this->name, '/');
     }
 }

--- a/tests/php/Integration/Fixtures/Call/php-namespaced-function-call-dot-syntax.test
+++ b/tests/php/Integration/Fixtures/Call/php-namespaced-function-call-dot-syntax.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/Amp.ByteStream/getStdout)
+--PHP--
+\Amp\ByteStream\getStdout();

--- a/tests/php/Integration/Fixtures/Call/php-namespaced-function-call-fully-dotted.test
+++ b/tests/php/Integration/Fixtures/Call/php-namespaced-function-call-fully-dotted.test
@@ -1,0 +1,4 @@
+--PHEL--
+(php/Amp.ByteStream.getStdout)
+--PHP--
+\Amp\ByteStream\getStdout();

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -145,4 +145,32 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
     }
 
+    public function test_dotted_namespaced_php_function_is_emitted_as_fully_qualified(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp.File/write');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
+    }
+
+    public function test_fully_dotted_php_function_is_emitted_as_fully_qualified(): void
+    {
+        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp.File.write');
+        $args = [
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
+            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
+        ];
+
+        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
+        $this->callEmitter->emit($applyNode);
+
+        $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
+    }
+
 }

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/CallEmitterTest.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\CallEmitter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CallEmitterTest extends TestCase
@@ -131,9 +132,10 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('return print("abc");');
     }
 
-    public function test_namespaced_php_function_is_emitted_as_fully_qualified(): void
+    #[DataProvider('providerNamespacedPhpFunctionForms')]
+    public function test_namespaced_php_function_is_emitted_as_fully_qualified(string $name): void
     {
-        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp\\File\\write');
+        $node = new PhpVarNode(NodeEnvironment::empty(), $name);
         $args = [
             new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
             new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
@@ -145,32 +147,10 @@ final class CallEmitterTest extends TestCase
         $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
     }
 
-    public function test_dotted_namespaced_php_function_is_emitted_as_fully_qualified(): void
+    public static function providerNamespacedPhpFunctionForms(): iterable
     {
-        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp.File/write');
-        $args = [
-            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
-            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
-        ];
-
-        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
-        $this->callEmitter->emit($applyNode);
-
-        $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
+        yield 'backslash separators' => ['Amp\\File\\write'];
+        yield 'dotted namespace, slash before fn' => ['Amp.File/write'];
+        yield 'fully dotted' => ['Amp.File.write'];
     }
-
-    public function test_fully_dotted_php_function_is_emitted_as_fully_qualified(): void
-    {
-        $node = new PhpVarNode(NodeEnvironment::empty(), 'Amp.File.write');
-        $args = [
-            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'foo.txt'),
-            new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'data'),
-        ];
-
-        $applyNode = new CallNode(NodeEnvironment::empty(), $node, $args);
-        $this->callEmitter->emit($applyNode);
-
-        $this->expectOutputString('\Amp\File\write("foo.txt", "data");');
-    }
-
 }


### PR DESCRIPTION
## 🤔 Background

PHP namespace-level functions currently require an awkward backslash-laden form like `php/\Amp\ByteStream\getStdout`. The backslashes also break round-tripping in `.cljc` files shared with Clojure dialects, where `\` inside symbol names is a parse error. Issue #1952 (continuation of #1460) asks for a backslash-free spelling.

## 💡 Goal

Accept `.` and `/` as namespace separators inside any `php/...` symbol so the same call can be written in three equivalent ways.

## 🔖 Changes

- `PhpVarNode::getAbsoluteName()` rewrites `.` and `/` to `\` and prepends a leading `\`, treating bare infix operators (`.`, `/`) as a special case so `php/.` and `php//` still emit unchanged.
- `PhpVarNode::isCallable()` resolves on the absolute name so first-class refs (`(def f php/Amp.File/write)`) wrap in a closure when the function is loaded.
- Unit coverage in `CallEmitterTest` plus integration fixtures `php-namespaced-function-call-dot-syntax.test` and `php-namespaced-function-call-fully-dotted.test`.
- `docs/php-interop.md` documents the three equivalent forms.

```phel
(php/Amp\ByteStream\getStdout)        ; existing
(php/Amp.ByteStream/getStdout)        ; new, mirrors the issue suggestion
(php/Amp.ByteStream.getStdout)        ; new, fully dotted
;; all compile to: \Amp\ByteStream\getStdout()
```

Closes #1952.