### PR TITLE
feat(filesystem): consolidate runtime artifacts under .phel/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ All notable changes to this project will be documented in this file.
 #### Compiler
 - Recursive self-calls emit `$this(...)`; ~3.66x faster on `fib(22)` (#1914)
 
+#### DX
+- Auto-write `.phel/.gitignore` (`*`) on first directory creation; user edits preserved (#1954)
+
 ### Fixed
 
 #### Compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 - Recursive self-calls emit `$this(...)`; ~3.66x faster on `fib(22)` (#1914)
 
 #### DX
-- Auto-write `.phel/.gitignore` (`*`) on first directory creation; user edits preserved (#1954)
+- Runtime state consolidated under `.phel/` (cache, REPL history, last-failed, error log) with self-seeded `.gitignore`; legacy `.phel-repl-history` auto-migrated; relocate the whole directory via `setPhelDir()` or `PHEL_DIR` env, narrow cache override via `PHEL_CACHE_DIR` (#1954)
 
 ### Fixed
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -1,0 +1,42 @@
+# Project Layout
+
+Phel writes per-project runtime state under a single `.phel/` directory at the
+project root. The directory is created lazily on first use and is auto-ignored
+by Git via a self-seeded `.phel/.gitignore` (`*`).
+
+| Path                            | Owner            | Purpose                              |
+| ------------------------------- | ---------------- | ------------------------------------ |
+| `.phel/cache/`                  | Build / compiler | Namespace + compiled-code cache      |
+| `.phel/lint-cache/index.json`   | Lint             | Per-file diagnostic cache            |
+| `.phel/last-failed.txt`         | Test runner      | Backing file for `phel test --last-failed` |
+| `.phel/repl-history`            | REPL             | Readline history (was `.phel-repl-history`) |
+| `.phel/error.log`               | Runtime          | Error log (was `/tmp/phel-error.log`) |
+| `out/`                          | Build            | Compiled PHP entry points (build artifacts; lifecycle differs) |
+
+## Overrides
+
+- **Relocate everything**: `$config->setPhelDir('/var/cache/phel')` in
+  `phel-config.php` moves cache, REPL history, last-failed file and error log
+  out of the project root. Useful for WordPress plugins, shared hosting, or
+  any setup where `.phel/` would otherwise sit under a web-accessible path.
+- **`PHEL_DIR` env var** — same effect at runtime; wins over `setPhelDir()`.
+- **`PhelConfig::setCacheDir($path)`** — narrower override for just the build
+  cache.
+- **`PHEL_CACHE_DIR` env var** — final cache override; wins over `PHEL_DIR`
+  and explicit `setCacheDir()`. Useful for CI / Nix builds.
+- **`PHEL_QUIET_MIGRATION=1`** — silences the one-line stderr notice emitted
+  when the legacy `.phel-repl-history` is migrated into `.phel/repl-history`.
+
+## Migration
+
+Existing projects with a top-level `.phel-repl-history` get the file renamed
+into `.phel/repl-history` automatically the next time the REPL boots. No
+action required; the legacy filename will be removed in a future release.
+
+## Read-only filesystems
+
+Directory creation is best-effort. On a read-only filesystem (Lambda, Docker
+`:ro` mounts, sandbox runners), Phel skips `.phel/` creation silently and
+runs without cache, last-failed tracking, or REPL history persistence. Set
+`PHEL_CACHE_DIR=/some/writable/path` (e.g. `/tmp/phel-cache`) to relocate the
+build cache when you still want caching.

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -7,6 +7,9 @@ namespace Phel\Build;
 use Gacela\Framework\AbstractConfig;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
+use Phel\Filesystem\Application\PhelProjectDirectory;
+
+use function is_string;
 
 final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 {
@@ -63,41 +66,20 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
 
     public function getCacheDir(): string
     {
-        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, 'cache');
-
-        // If absolute path, use as-is; otherwise relative to app root
-        if ($this->isAbsolutePath($cacheDir)) {
-            return $cacheDir;
+        $envOverride = getenv('PHEL_CACHE_DIR');
+        if (is_string($envOverride) && $envOverride !== '') {
+            return $envOverride;
         }
 
-        return $this->getAppRootDir() . '/' . $cacheDir;
+        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, '.phel/cache');
+        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+
+        return PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
     }
 
     public function getNamespaceCacheFile(): string
     {
         return $this->getCacheDir() . '/namespace-cache.php';
-    }
-
-    /**
-     * Cross-platform absolute-path detection so Windows cache dirs
-     * (drive letters, UNC shares) aren't mistaken for relative paths
-     * and prefixed with the app root.
-     */
-    private function isAbsolutePath(string $path): bool
-    {
-        if ($path === '') {
-            return false;
-        }
-
-        if ($path[0] === '/' || $path[0] === '\\') {
-            return true;
-        }
-
-        if (str_starts_with($path, 'phar://')) {
-            return true;
-        }
-
-        return (bool) preg_match('~^[A-Za-z]:[\\\\/]~', $path);
     }
 
     /**

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -8,6 +8,7 @@ use Gacela\Framework\AbstractConfig;
 use Phel\Command\Domain\CodeDirectories;
 use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
+use Phel\Filesystem\Application\PhelProjectDirectory;
 
 use function dirname;
 
@@ -57,6 +58,9 @@ final class CommandConfig extends AbstractConfig
 
     public function getErrorLogFile(): string
     {
-        return (string) $this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE);
+        $path = (string) $this->get(PhelConfig::ERROR_LOG_FILE, self::DEFAULT_ERROR_LOG_FILE);
+        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+
+        return PhelProjectDirectory::resolve($this->getAppRootDir(), $path, $phelDir);
     }
 }

--- a/src/php/Command/Infrastructure/ErrorLog.php
+++ b/src/php/Command/Infrastructure/ErrorLog.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Phel\Command\Infrastructure;
 
 use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Filesystem\Application\PhelProjectDirectory;
+
+use function dirname;
 
 final readonly class ErrorLog implements ErrorLogInterface
 {
@@ -14,10 +17,27 @@ final readonly class ErrorLog implements ErrorLogInterface
 
     public function writeln(string $text): void
     {
+        $this->ensureParentDirectory();
+
         file_put_contents(
             $this->filepath,
             $text . PHP_EOL,
             FILE_APPEND | LOCK_EX,
         );
+    }
+
+    private function ensureParentDirectory(): void
+    {
+        $dir = dirname($this->filepath);
+        // Route logs landing inside `<projectRoot>/.phel/` through the
+        // shared helper so the auto `.gitignore` is seeded too.
+        if (basename($dir) === PhelProjectDirectory::DIRECTORY_NAME) {
+            PhelProjectDirectory::ensure(dirname($dir));
+            return;
+        }
+
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0o755, true);
+        }
     }
 }

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -40,10 +40,14 @@ final class PhelConfig implements JsonSerializable
 
     public const string CACHE_DIR = 'cache-dir';
 
+    public const string PHEL_DIR = 'phel-dir';
+
     /** @var list<string> */
     public const array DEFAULT_SRC_DIRS = ['src'];
 
     private const string PHEL_TEMP_SUBDIR = '/phel';
+
+    private const string DEFAULT_CACHE_DIR = '.phel/cache';
 
     /** @var list<string> */
     private array $srcDirs = self::DEFAULT_SRC_DIRS;
@@ -53,7 +57,7 @@ final class PhelConfig implements JsonSerializable
 
     private string $vendorDir = 'vendor';
 
-    private string $errorLogFile = '/tmp/phel-error.log';
+    private string $errorLogFile = '.phel/error.log';
 
     private PhelExportConfig $exportConfig;
 
@@ -69,7 +73,9 @@ final class PhelConfig implements JsonSerializable
 
     private string $tempDir;
 
-    private string $cacheDir;
+    // Cache lives under <projectRoot>/.phel/cache by default — BuildConfig
+    // resolves relative paths against the app root.
+    private string $cacheDir = self::DEFAULT_CACHE_DIR;
 
     /** @var list<string> */
     private array $formatDirs = ['src', 'tests'];
@@ -82,15 +88,20 @@ final class PhelConfig implements JsonSerializable
 
     private bool $enableCompiledCodeCache = true;
 
+    /**
+     * Custom location for the per-project `.phel/` state directory.
+     * Empty string keeps the default (`.phel/` next to the project root).
+     * Absolute paths are honored verbatim. Overridden at runtime by the
+     * `PHEL_DIR` environment variable.
+     */
+    private string $phelDir = '';
+
     public function __construct()
     {
         $this->exportConfig = new PhelExportConfig();
         $this->buildConfig = new PhelBuildConfig();
 
-        // Single syscall for temp directory
-        $baseTemp = sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR;
-        $this->tempDir = $baseTemp . '/tmp';
-        $this->cacheDir = $baseTemp . '/cache';
+        $this->tempDir = sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR . '/tmp';
     }
 
     /**
@@ -402,6 +413,25 @@ final class PhelConfig implements JsonSerializable
     }
 
     /**
+     * Redirect the entire per-project state directory (`.phel/` by default)
+     * to a different location. Useful when the project lives behind a web
+     * server: e.g. a WordPress plugin can move state out of the document
+     * root via `$config->setPhelDir('/var/cache/phel')`. Honors `PHEL_DIR`
+     * env var as a higher-priority override.
+     */
+    public function setPhelDir(string $dir): self
+    {
+        $this->phelDir = $dir;
+
+        return $this;
+    }
+
+    public function getPhelDir(): string
+    {
+        return $this->phelDir;
+    }
+
+    /**
      * @param list<string> $list
      */
     public function setFormatDirs(array $list): self
@@ -496,6 +526,7 @@ final class PhelConfig implements JsonSerializable
             self::ENABLE_NAMESPACE_CACHE => $this->enableNamespaceCache,
             self::ENABLE_COMPILED_CODE_CACHE => $this->enableCompiledCodeCache,
             self::CACHE_DIR => $this->cacheDir,
+            self::PHEL_DIR => $this->phelDir,
         ];
     }
 

--- a/src/php/Filesystem/Application/PhelProjectDirectory.php
+++ b/src/php/Filesystem/Application/PhelProjectDirectory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Filesystem\Application;
+
+use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
+
+use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
+
+/**
+ * Owns the per-project `.phel/` directory: creates it on demand and
+ * seeds a `.gitignore` so consumers never see the directory in
+ * `git status`. Pattern borrowed from pytest / mypy / ruff.
+ */
+final class PhelProjectDirectory
+{
+    public const string DIRECTORY_NAME = '.phel';
+
+    private const string GITIGNORE_FILENAME = '.gitignore';
+
+    private const string GITIGNORE_CONTENT = "# Created automatically by Phel.\n*\n";
+
+    /**
+     * Creates `<projectRoot>/.phel/` if missing and seeds `.gitignore` once.
+     * Existing `.gitignore` content is preserved.
+     *
+     * @throws FileException when the directory cannot be created
+     *
+     * @return string Absolute path to the `.phel/` directory.
+     */
+    public static function ensure(string $projectRoot): string
+    {
+        $dir = rtrim($projectRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::DIRECTORY_NAME;
+
+        if (!is_dir($dir) && !@mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw FileException::canNotCreateDirectory($dir);
+        }
+
+        $gitignore = $dir . DIRECTORY_SEPARATOR . self::GITIGNORE_FILENAME;
+        if (!file_exists($gitignore)) {
+            @file_put_contents($gitignore, self::GITIGNORE_CONTENT, LOCK_EX);
+        }
+
+        return $dir;
+    }
+}

--- a/src/php/Filesystem/Application/PhelProjectDirectory.php
+++ b/src/php/Filesystem/Application/PhelProjectDirectory.php
@@ -4,45 +4,124 @@ declare(strict_types=1);
 
 namespace Phel\Filesystem\Application;
 
-use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
+use function is_string;
+use function strlen;
 
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 
 /**
- * Owns the per-project `.phel/` directory: creates it on demand and
- * seeds a `.gitignore` so consumers never see the directory in
- * `git status`. Pattern borrowed from pytest / mypy / ruff.
+ * Owns the per-project `.phel/` directory: creates it on demand, seeds a
+ * `.gitignore` so consumers never see the directory in `git status`, and
+ * resolves the effective location (overridable via `PHEL_DIR` env var or
+ * `PhelConfig::setPhelDir()`). Pattern borrowed from pytest / mypy / ruff.
+ *
+ * Best-effort: never throws. On read-only filesystems or sandboxed runners
+ * the helper silently no-ops and returns the path it would have created;
+ * downstream writes surface the real OS error at their actual call site.
  */
 final class PhelProjectDirectory
 {
     public const string DIRECTORY_NAME = '.phel';
+
+    public const string DIR_ENV = 'PHEL_DIR';
 
     private const string GITIGNORE_FILENAME = '.gitignore';
 
     private const string GITIGNORE_CONTENT = "# Created automatically by Phel.\n*\n";
 
     /**
-     * Creates `<projectRoot>/.phel/` if missing and seeds `.gitignore` once.
-     * Existing `.gitignore` content is preserved.
-     *
-     * @throws FileException when the directory cannot be created
-     *
-     * @return string Absolute path to the `.phel/` directory.
+     * Best-effort: creates the resolved state directory if missing and seeds
+     * `.gitignore` once. Returns the path even when creation failed.
      */
     public static function ensure(string $projectRoot): string
     {
-        $dir = rtrim($projectRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::DIRECTORY_NAME;
+        $dir = self::path($projectRoot);
 
-        if (!is_dir($dir) && !@mkdir($dir, 0o755, true) && !is_dir($dir)) {
-            throw FileException::canNotCreateDirectory($dir);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0o755, true);
         }
 
         $gitignore = $dir . DIRECTORY_SEPARATOR . self::GITIGNORE_FILENAME;
-        if (!file_exists($gitignore)) {
+        if (is_dir($dir) && !file_exists($gitignore)) {
             @file_put_contents($gitignore, self::GITIGNORE_CONTENT, LOCK_EX);
         }
 
         return $dir;
+    }
+
+    /**
+     * Absolute path to `<resolvedDir>/<subpath>`. Resolution order:
+     * `PHEL_DIR` env var → caller-provided override → `<projectRoot>/.phel`.
+     * Subpath segments are joined with `/`; an empty subpath returns the
+     * directory itself.
+     */
+    public static function path(string $projectRoot, string $subpath = '', string $configuredDir = ''): string
+    {
+        $base = self::resolveBase($projectRoot, $configuredDir);
+
+        return $subpath === ''
+            ? $base
+            : $base . DIRECTORY_SEPARATOR . ltrim($subpath, '/\\');
+    }
+
+    /**
+     * Resolve a config-supplied path string against the project root,
+     * rewriting `.phel/...` prefixes through the active state directory.
+     * Used by `BuildConfig::getCacheDir` and `CommandConfig::getErrorLogFile`
+     * so `PHEL_DIR` / `setPhelDir()` relocates derived paths automatically.
+     */
+    public static function resolve(string $projectRoot, string $configPath, string $configuredDir = ''): string
+    {
+        if ($configPath === '') {
+            return '';
+        }
+
+        if (self::isAbsolutePath($configPath)) {
+            return $configPath;
+        }
+
+        $prefix = self::DIRECTORY_NAME . DIRECTORY_SEPARATOR;
+        if (str_starts_with($configPath, $prefix) || str_starts_with($configPath, self::DIRECTORY_NAME . '/')) {
+            $sub = substr($configPath, strlen(self::DIRECTORY_NAME) + 1);
+            return self::path($projectRoot, $sub, $configuredDir);
+        }
+
+        if ($configPath === self::DIRECTORY_NAME) {
+            return self::path($projectRoot, '', $configuredDir);
+        }
+
+        return rtrim($projectRoot, '/\\') . DIRECTORY_SEPARATOR . $configPath;
+    }
+
+    private static function resolveBase(string $projectRoot, string $configuredDir): string
+    {
+        $env = getenv(self::DIR_ENV);
+        $candidate = is_string($env) && $env !== ''
+            ? $env
+            : ($configuredDir !== '' ? $configuredDir : self::DIRECTORY_NAME);
+
+        if (self::isAbsolutePath($candidate)) {
+            return rtrim($candidate, '/\\');
+        }
+
+        return rtrim($projectRoot, '/\\') . DIRECTORY_SEPARATOR . $candidate;
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if ($path[0] === '/' || $path[0] === '\\') {
+            return true;
+        }
+
+        if (str_starts_with($path, 'phar://')) {
+            return true;
+        }
+
+        return (bool) preg_match('~^[A-Za-z]:[\\\\/]~', $path);
     }
 }

--- a/src/php/Filesystem/CLAUDE.md
+++ b/src/php/Filesystem/CLAUDE.md
@@ -25,7 +25,7 @@ File system abstraction for compilation: temp directory management and compiled 
 
 ```
 Filesystem/
-├── Application/        FileIo (wraps is_writable), TempDirFinder
+├── Application/        FileIo (wraps is_writable), TempDirFinder, PhelProjectDirectory
 ├── Domain/             FilesystemInterface, FileIoInterface, NullFilesystem
 ├── Infrastructure/     RealFilesystem (tracks files in static array)
 └── Gacela files        FilesystemFacade, FilesystemFactory, FilesystemConfig
@@ -36,4 +36,5 @@ Filesystem/
 - **Strategy pattern**: `RealFilesystem` (normal) vs `NullFilesystem` (when `KEEP_GENERATED_TEMP_FILES` is true)
 - `RealFilesystem` uses a static array to track files — `clearAll()` deletes them all
 - `TempDirFinder` creates/validates temp directory and throws `FileException` on permission failures
+- `PhelProjectDirectory::ensure(string $projectRoot)` is the single entry point for creating `<projectRoot>/.phel/`. Best-effort: never throws. Seeds `.phel/.gitignore` (`*`) on first create; preserves user edits. On read-only filesystems (Lambda, PHAR running over a `:ro` mount, sandbox runners) it silently no-ops and returns the intended path — callers attempt the actual write and surface OS-level errors there.
 - This is a small, focused module — keep it minimal

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -196,7 +196,7 @@ final class LintCommand extends Command
         }
 
         PhelProjectDirectory::ensure($cwd);
-        $cacheDir = rtrim($cwd, '/') . '/' . LintConfig::defaultCacheDir();
+        $cacheDir = PhelProjectDirectory::path($cwd, LintConfig::CACHE_SUBPATH);
 
         return $this->getFacade()->createCache($cacheDir);
     }

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Lint\Infrastructure\Command;
 
 use Gacela\Framework\ServiceResolver\ServiceMap;
 use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Filesystem\Application\PhelProjectDirectory;
 use Phel\Lint\Application\Cache\LintCache;
 use Phel\Lint\Application\Config\RuleSettings;
 use Phel\Lint\Application\Formatter\HumanFormatter;
@@ -194,6 +195,7 @@ final class LintCommand extends Command
             return null;
         }
 
+        PhelProjectDirectory::ensure($cwd);
         $cacheDir = rtrim($cwd, '/') . '/' . LintConfig::defaultCacheDir();
 
         return $this->getFacade()->createCache($cacheDir);

--- a/src/php/Lint/LintConfig.php
+++ b/src/php/Lint/LintConfig.php
@@ -15,6 +15,8 @@ final class LintConfig extends AbstractConfig
 
     public const string CACHE_DIR = '.phel/lint-cache';
 
+    public const string CACHE_SUBPATH = 'lint-cache';
+
     /**
      * Default severities for every rule shipped in v1. Rules not listed
      * here are disabled by default and must be opted into via config.

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -6,10 +6,12 @@ namespace Phel;
 
 use Closure;
 use Gacela\Framework\Bootstrap\GacelaConfig;
+use Gacela\Framework\Config\Config;
 use Gacela\Framework\Gacela;
 use Phar;
 use Phel\Config\PhelConfig;
 use Phel\Config\ProjectLayout;
+use Phel\Filesystem\Application\PhelProjectDirectory;
 use Phel\Filesystem\FilesystemFacade;
 use Phel\Run\RunFacade;
 use RuntimeException;
@@ -88,6 +90,8 @@ class Phel
         }
 
         Gacela::bootstrap($projectRootDir, self::configFn());
+
+        self::mirrorPhelDirToEnv();
     }
 
     /**
@@ -173,6 +177,27 @@ class Phel
     public static function resetAutoDetectedConfig(): void
     {
         self::$autoDetectedConfig = null;
+    }
+
+    /**
+     * Mirror `PhelConfig::PHEL_DIR` (configured via `setPhelDir()` in
+     * `phel-config.php`) into the `PHEL_DIR` env var so every consumer
+     * — including CLI commands that don't read Gacela config directly —
+     * sees one source of truth. Any pre-existing env value wins.
+     */
+    private static function mirrorPhelDirToEnv(): void
+    {
+        if (getenv(PhelProjectDirectory::DIR_ENV) !== false) {
+            return;
+        }
+
+        $configured = (string) Config::getInstance()
+            ->get(PhelConfig::PHEL_DIR, '');
+        if ($configured === '') {
+            return;
+        }
+
+        putenv(PhelProjectDirectory::DIR_ENV . '=' . $configured);
     }
 
     /**

--- a/src/php/Run/Application/ReplHistoryPathResolver.php
+++ b/src/php/Run/Application/ReplHistoryPathResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Filesystem\Application\PhelProjectDirectory;
+
+use function defined;
+use function sprintf;
+
+use const DIRECTORY_SEPARATOR;
+use const STDERR;
+
+/**
+ * Resolves the REPL history path under `<projectRoot>/.phel/repl-history`,
+ * migrating from the legacy `<projectRoot>/.phel-repl-history` location on
+ * first call. Set `PHEL_QUIET_MIGRATION=1` to silence the deprecation notice.
+ */
+final class ReplHistoryPathResolver
+{
+    public const string FILENAME = 'repl-history';
+
+    public const string LEGACY_FILENAME = '.phel-repl-history';
+
+    public const string QUIET_ENV = 'PHEL_QUIET_MIGRATION';
+
+    /** @var resource|null */
+    private $stderr;
+
+    /**
+     * @param resource|null $stderr Stream the deprecation notice is written
+     *                              to. Defaults to PHP `STDERR` at runtime.
+     */
+    public function __construct(
+        private readonly string $projectRoot,
+        $stderr = null,
+    ) {
+        $this->stderr = $stderr ?? (defined('STDERR') ? STDERR : null);
+    }
+
+    public function resolve(): string
+    {
+        $phelDir = PhelProjectDirectory::ensure($this->projectRoot);
+        $newPath = $phelDir . DIRECTORY_SEPARATOR . self::FILENAME;
+        $legacyPath = rtrim($this->projectRoot, DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . self::LEGACY_FILENAME;
+
+        if (!file_exists($newPath) && is_file($legacyPath) && @rename($legacyPath, $newPath)) {
+            $this->emitDeprecation($legacyPath, $newPath);
+        }
+
+        return $newPath;
+    }
+
+    private function emitDeprecation(string $oldPath, string $newPath): void
+    {
+        if (getenv(self::QUIET_ENV) === '1' || $this->stderr === null) {
+            return;
+        }
+
+        @fwrite($this->stderr, sprintf(
+            "phel: migrated REPL history %s -> %s (set %s=1 to silence)\n",
+            $oldPath,
+            $newPath,
+            self::QUIET_ENV,
+        ));
+    }
+}

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -48,7 +48,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and al
 
 ```
 Run/
-├── Application/        BundledNamespaces, EntryPointDetector, EvalExecutor, FileRunner, NamespaceLoader, NamespaceRunner, NamespacesLoader, StructuredEvaluator
+├── Application/        BundledNamespaces, EntryPointDetector, EvalExecutor, FileRunner, NamespaceLoader, NamespaceRunner, NamespacesLoader, ReplHistoryPathResolver, StructuredEvaluator
 ├── Domain/
 │   ├── Init/           NamespaceNormalizer, ProjectTemplateGenerator
 │   ├── Repl/           EvalResult, EvalError, ReplCommandIoInterface, ReplErrorFormatter, ReplFormattedError, ReplHistory, ReplPrompt, startup.phel, Hint/
@@ -67,6 +67,7 @@ Run/
 - `EvalResult` uses static constructors: `success()`, `incomplete()`, `failure()` — never throws
 - REPL supports environment snapshot/restore on eval failure
 - `ReplCommandSystemIo` requires PHP `readline` extension; falls back to `ReplCommandFallbackIo`
+- `ReplHistoryPathResolver` returns `<projectRoot>/.phel/repl-history`; transparently migrates a legacy `<projectRoot>/.phel-repl-history` (rename + one-line stderr notice unless `PHEL_QUIET_MIGRATION=1`)
 - `ReplHistory` registers `*1`/`*2`/`*3`/`*e` in `phel\core` after REPL boot; updates on every eval/exception
 - `ReplPrompt` reads `GlobalEnvironmentSingleton::getNs()` to render the current namespace in the prompt
 - `ReplErrorFormatter` renders eval-time `Throwable`s for REPL output: short headline, optional hint, trace with internal compiler/run/build/command frames hidden. `Hint/` holds `ReplHintInterface` implementations (`NotCallableHint`, `ArgumentCountHint`, `UndefinedSymbolHint`); register new hints via `RunFactory::createReplHints`

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Exceptions\CompilerException;
 use Phel\Compiler\Infrastructure\CompileOptions;
+use Phel\Filesystem\Application\PhelProjectDirectory;
 use Phel\Run\Domain\Test\TestCommandOptions;
 use Phel\Run\Domain\Test\TestNamespacePruner;
 use Phel\Run\RunFacade;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function count;
+use function getcwd;
 use function is_numeric;
 use function is_string;
 use function sprintf;
@@ -277,6 +279,13 @@ final class TestCommand extends Command
         $output = $input->getOption(self::OPT_OUTPUT);
         $listOnly = (bool) $input->getOption(self::OPT_LIST);
         $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
+
+        if (!$listOnly) {
+            $cwd = getcwd();
+            if (is_string($cwd)) {
+                PhelProjectDirectory::ensure($cwd);
+            }
+        }
 
         return [
             TestCommandOptions::FILTER => null,

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -70,7 +70,7 @@ final class TestCommand extends Command
 
     private const string OPT_RANDOM_ORDER = 'random-order';
 
-    private const string LAST_FAILED_FILE = '.phel/last-failed.txt';
+    private const string LAST_FAILED_FILENAME = 'last-failed.txt';
 
     protected function configure(): void
     {
@@ -142,7 +142,7 @@ final class TestCommand extends Command
                 self::OPT_LAST_FAILED,
                 null,
                 InputOption::VALUE_NONE,
-                'Re-run only tests that failed on the previous run. Reads ' . self::LAST_FAILED_FILE . ' from the current directory. Combine with --repeat to hammer flaky tests.',
+                'Re-run only tests that failed on the previous run. Reads `<phel-dir>/last-failed.txt` from the current project. Combine with --repeat to hammer flaky tests.',
             )->addOption(
                 self::OPT_SLOWEST,
                 null,
@@ -280,11 +280,10 @@ final class TestCommand extends Command
         $listOnly = (bool) $input->getOption(self::OPT_LIST);
         $lastFailed = (bool) $input->getOption(self::OPT_LAST_FAILED);
 
-        if (!$listOnly) {
-            $cwd = getcwd();
-            if (is_string($cwd)) {
-                PhelProjectDirectory::ensure($cwd);
-            }
+        $lastFailedFile = $this->lastFailedFilePath();
+
+        if (!$listOnly && $lastFailedFile !== null) {
+            PhelProjectDirectory::ensure((string) getcwd());
         }
 
         return [
@@ -300,12 +299,22 @@ final class TestCommand extends Command
             TestCommandOptions::FILTERS => (array) $input->getOption(self::OPT_FILTER),
             TestCommandOptions::LIST_ONLY => $listOnly,
             TestCommandOptions::ONLY_TESTS => $lastFailed ? $this->readLastFailed() : [],
-            TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : self::LAST_FAILED_FILE,
+            TestCommandOptions::LAST_FAILED_FILE => $listOnly ? null : $lastFailedFile,
             TestCommandOptions::SLOWEST => (int) $input->getOption(self::OPT_SLOWEST),
             TestCommandOptions::REPEAT => $this->parseRepeat($input),
             TestCommandOptions::SEED => $this->parseSeed($input),
             TestCommandOptions::RANDOM_ORDER => (bool) $input->getOption(self::OPT_RANDOM_ORDER),
         ];
+    }
+
+    private function lastFailedFilePath(): ?string
+    {
+        $cwd = getcwd();
+        if (!is_string($cwd)) {
+            return null;
+        }
+
+        return PhelProjectDirectory::path($cwd, self::LAST_FAILED_FILENAME);
     }
 
     private function parseRepeat(InputInterface $input): int
@@ -341,11 +350,12 @@ final class TestCommand extends Command
      */
     private function readLastFailed(): array
     {
-        if (!is_file(self::LAST_FAILED_FILE)) {
+        $path = $this->lastFailedFilePath();
+        if ($path === null || !is_file($path)) {
             return [];
         }
 
-        $contents = @file_get_contents(self::LAST_FAILED_FILE);
+        $contents = @file_get_contents($path);
         if (!is_string($contents) || $contents === '') {
             return [];
         }

--- a/src/php/Run/RunConfig.php
+++ b/src/php/Run/RunConfig.php
@@ -8,11 +8,6 @@ use Gacela\Framework\AbstractConfig;
 
 final class RunConfig extends AbstractConfig
 {
-    public function getPhelReplHistory(): string
-    {
-        return $this->getAppRootDir() . '.phel-repl-history';
-    }
-
     public function getReplStartupFile(): string
     {
         return __DIR__ . '/Domain/Repl/startup.phel';

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -15,6 +15,7 @@ use Phel\Run\Application\FileRunner;
 use Phel\Run\Application\NamespaceLoader;
 use Phel\Run\Application\NamespaceRunner;
 use Phel\Run\Application\NamespacesLoader;
+use Phel\Run\Application\ReplHistoryPathResolver;
 use Phel\Run\Application\StructuredEvaluator;
 use Phel\Run\Domain\Repl\Hint\ArgumentCountHint;
 use Phel\Run\Domain\Repl\Hint\NotCallableHint;
@@ -98,7 +99,7 @@ class RunFactory extends AbstractFactory
     {
         if (extension_loaded('readline')) {
             return new ReplCommandSystemIo(
-                $this->getConfig()->getPhelReplHistory(),
+                $this->createReplHistoryPathResolver()->resolve(),
                 $this->getCommandFacade(),
                 $this->getApiFacade(),
                 $this->createReplErrorFormatter(),
@@ -109,6 +110,11 @@ class RunFactory extends AbstractFactory
             $this->getCommandFacade(),
             $this->createReplErrorFormatter(),
         );
+    }
+
+    public function createReplHistoryPathResolver(): ReplHistoryPathResolver
+    {
+        return new ReplHistoryPathResolver($this->getConfig()->getAppRootDir());
     }
 
     public function createReplErrorFormatter(): ReplErrorFormatter

--- a/tests/php/Unit/Build/BuildConfigTest.php
+++ b/tests/php/Unit/Build/BuildConfigTest.php
@@ -73,6 +73,34 @@ final class BuildConfigTest extends TestCase
         self::assertNotSame('cache', $config->getCacheDir());
     }
 
+    public function test_phel_cache_dir_env_overrides_configured_value(): void
+    {
+        $this->bootstrapWithCacheDir('/configured/cache');
+        putenv('PHEL_CACHE_DIR=/env/override/cache');
+
+        try {
+            $config = new BuildConfig();
+
+            self::assertSame('/env/override/cache', $config->getCacheDir());
+        } finally {
+            putenv('PHEL_CACHE_DIR');
+        }
+    }
+
+    public function test_phel_cache_dir_env_ignored_when_empty(): void
+    {
+        $this->bootstrapWithCacheDir('/configured/cache');
+        putenv('PHEL_CACHE_DIR=');
+
+        try {
+            $config = new BuildConfig();
+
+            self::assertSame('/configured/cache', $config->getCacheDir());
+        } finally {
+            putenv('PHEL_CACHE_DIR');
+        }
+    }
+
     private function bootstrapWithCacheDir(string $cacheDir): void
     {
         Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($cacheDir): void {

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -20,7 +20,7 @@ final class PhelConfigTest extends TestCase
             PhelConfig::SRC_DIRS => ['src'],
             PhelConfig::TEST_DIRS => ['tests'],
             PhelConfig::VENDOR_DIR => 'vendor',
-            PhelConfig::ERROR_LOG_FILE => '/tmp/phel-error.log',
+            PhelConfig::ERROR_LOG_FILE => '.phel/error.log',
             PhelConfig::BUILD_CONFIG => [
                 PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
                 PhelBuildConfig::DEST_DIR => 'out',
@@ -41,7 +41,8 @@ final class PhelConfigTest extends TestCase
             PhelConfig::WARN_DEPRECATIONS => false,
             PhelConfig::ENABLE_NAMESPACE_CACHE => true,
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
-            PhelConfig::CACHE_DIR => sys_get_temp_dir() . '/phel/cache',
+            PhelConfig::CACHE_DIR => '.phel/cache',
+            PhelConfig::PHEL_DIR => '',
         ];
 
         self::assertSame($expected, $config->jsonSerialize());
@@ -247,9 +248,19 @@ final class PhelConfigTest extends TestCase
             PhelConfig::ENABLE_NAMESPACE_CACHE => true,
             PhelConfig::ENABLE_COMPILED_CODE_CACHE => true,
             PhelConfig::CACHE_DIR => '.cache',
+            PhelConfig::PHEL_DIR => '',
         ];
 
         self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_set_phel_dir_persists_in_json(): void
+    {
+        $config = new PhelConfig();
+        $config->setPhelDir('/var/cache/phel');
+
+        self::assertSame('/var/cache/phel', $config->getPhelDir());
+        self::assertSame('/var/cache/phel', $config->jsonSerialize()[PhelConfig::PHEL_DIR]);
     }
 
     public function test_getters(): void
@@ -259,7 +270,7 @@ final class PhelConfigTest extends TestCase
         self::assertSame(['src'], $config->getSrcDirs());
         self::assertSame(['tests'], $config->getTestDirs());
         self::assertSame('vendor', $config->getVendorDir());
-        self::assertSame('/tmp/phel-error.log', $config->getErrorLogFile());
+        self::assertSame('.phel/error.log', $config->getErrorLogFile());
         self::assertInstanceOf(PhelBuildConfig::class, $config->getBuildConfig());
         self::assertInstanceOf(PhelExportConfig::class, $config->getExportConfig());
         self::assertSame([], $config->getIgnoreWhenBuilding());
@@ -313,16 +324,20 @@ final class PhelConfigTest extends TestCase
         self::assertStringContainsString('Vendor directory', $errors[0]);
     }
 
-    public function test_temp_dir_uses_single_base_path(): void
+    public function test_temp_dir_default_lives_under_system_temp(): void
     {
         $config = new PhelConfig();
 
         $tempDir = $config->getTempDir();
-        $cacheDir = $config->getCacheDir();
 
         self::assertStringContainsString('/phel/', $tempDir);
-        self::assertStringContainsString('/phel/', $cacheDir);
         self::assertStringEndsWith('/tmp', $tempDir);
-        self::assertStringEndsWith('/cache', $cacheDir);
+    }
+
+    public function test_cache_dir_default_is_relative_to_project_root(): void
+    {
+        $config = new PhelConfig();
+
+        self::assertSame('.phel/cache', $config->getCacheDir());
     }
 }

--- a/tests/php/Unit/Filesystem/Application/PhelProjectDirectoryTest.php
+++ b/tests/php/Unit/Filesystem/Application/PhelProjectDirectoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Filesystem\Application;
 
-use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
 use Phel\Filesystem\Application\PhelProjectDirectory;
 use PHPUnit\Framework\TestCase;
 
@@ -16,23 +15,13 @@ final class PhelProjectDirectoryTest extends TestCase
     {
         $this->projectRoot = sys_get_temp_dir() . '/phel-proj-' . uniqid('', true);
         mkdir($this->projectRoot);
+        putenv(PhelProjectDirectory::DIR_ENV);
     }
 
     protected function tearDown(): void
     {
-        $phelDir = $this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME;
-        $gitignore = $phelDir . '/.gitignore';
-        if (is_file($gitignore)) {
-            unlink($gitignore);
-        }
-
-        if (is_dir($phelDir)) {
-            rmdir($phelDir);
-        }
-
-        if (is_dir($this->projectRoot)) {
-            rmdir($this->projectRoot);
-        }
+        putenv(PhelProjectDirectory::DIR_ENV);
+        $this->removeTree($this->projectRoot);
     }
 
     public function test_creates_directory_and_seeds_gitignore_on_first_call(): void
@@ -78,17 +67,104 @@ final class PhelProjectDirectoryTest extends TestCase
         self::assertSame($this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME, $dir);
     }
 
-    public function test_throws_when_directory_cannot_be_created(): void
+    public function test_best_effort_returns_path_when_directory_cannot_be_created(): void
     {
         $unwritable = sys_get_temp_dir() . '/phel-unwritable-' . uniqid('', true);
         mkdir($unwritable, 0o555);
 
         try {
-            $this->expectException(FileException::class);
-            PhelProjectDirectory::ensure($unwritable);
+            $dir = @PhelProjectDirectory::ensure($unwritable);
+
+            self::assertSame(
+                $unwritable . '/' . PhelProjectDirectory::DIRECTORY_NAME,
+                $dir,
+            );
+            self::assertDirectoryDoesNotExist($dir);
         } finally {
             chmod($unwritable, 0o755);
             rmdir($unwritable);
         }
+    }
+
+    public function test_env_var_relocates_directory_to_absolute_path(): void
+    {
+        $relocated = sys_get_temp_dir() . '/phel-elsewhere-' . uniqid('', true);
+        putenv(PhelProjectDirectory::DIR_ENV . '=' . $relocated);
+
+        try {
+            $dir = PhelProjectDirectory::ensure($this->projectRoot);
+
+            self::assertSame($relocated, $dir);
+            self::assertDirectoryExists($relocated);
+            self::assertDirectoryDoesNotExist($this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME);
+        } finally {
+            $this->removeTree($relocated);
+        }
+    }
+
+    public function test_path_with_configured_dir_resolves_against_project_root(): void
+    {
+        $dir = PhelProjectDirectory::path($this->projectRoot, 'cache', 'state');
+
+        self::assertSame($this->projectRoot . '/state/cache', $dir);
+    }
+
+    public function test_env_wins_over_configured_dir(): void
+    {
+        $relocated = sys_get_temp_dir() . '/phel-env-wins-' . uniqid('', true);
+        putenv(PhelProjectDirectory::DIR_ENV . '=' . $relocated);
+
+        try {
+            $dir = PhelProjectDirectory::path($this->projectRoot, '', '/ignored/configured');
+
+            self::assertSame($relocated, $dir);
+        } finally {
+            if (is_dir($relocated)) {
+                rmdir($relocated);
+            }
+        }
+    }
+
+    public function test_resolve_rewrites_phel_prefixed_config_paths(): void
+    {
+        putenv(PhelProjectDirectory::DIR_ENV . '=/foo');
+
+        try {
+            self::assertSame('/foo/cache', PhelProjectDirectory::resolve($this->projectRoot, '.phel/cache'));
+            self::assertSame('/foo', PhelProjectDirectory::resolve($this->projectRoot, '.phel'));
+            self::assertSame('/etc/phel-cache', PhelProjectDirectory::resolve($this->projectRoot, '/etc/phel-cache'));
+            self::assertSame(
+                $this->projectRoot . '/custom-cache',
+                PhelProjectDirectory::resolve($this->projectRoot, 'custom-cache'),
+            );
+        } finally {
+            putenv(PhelProjectDirectory::DIR_ENV);
+        }
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $this->removeTree($path . '/' . $entry);
+        }
+
+        rmdir($path);
     }
 }

--- a/tests/php/Unit/Filesystem/Application/PhelProjectDirectoryTest.php
+++ b/tests/php/Unit/Filesystem/Application/PhelProjectDirectoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Filesystem\Application;
+
+use Phel\Compiler\Domain\Evaluator\Exceptions\FileException;
+use Phel\Filesystem\Application\PhelProjectDirectory;
+use PHPUnit\Framework\TestCase;
+
+final class PhelProjectDirectoryTest extends TestCase
+{
+    private string $projectRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/phel-proj-' . uniqid('', true);
+        mkdir($this->projectRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $phelDir = $this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME;
+        $gitignore = $phelDir . '/.gitignore';
+        if (is_file($gitignore)) {
+            unlink($gitignore);
+        }
+
+        if (is_dir($phelDir)) {
+            rmdir($phelDir);
+        }
+
+        if (is_dir($this->projectRoot)) {
+            rmdir($this->projectRoot);
+        }
+    }
+
+    public function test_creates_directory_and_seeds_gitignore_on_first_call(): void
+    {
+        $dir = PhelProjectDirectory::ensure($this->projectRoot);
+
+        self::assertSame($this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME, $dir);
+        self::assertDirectoryExists($dir);
+
+        self::assertSame(
+            "# Created automatically by Phel.\n*\n",
+            file_get_contents($dir . '/.gitignore'),
+        );
+    }
+
+    public function test_preserves_existing_gitignore_content(): void
+    {
+        $dir = $this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME;
+        mkdir($dir);
+        file_put_contents($dir . '/.gitignore', "# user edit\nfoo\n");
+
+        PhelProjectDirectory::ensure($this->projectRoot);
+
+        self::assertSame("# user edit\nfoo\n", file_get_contents($dir . '/.gitignore'));
+    }
+
+    public function test_idempotent_when_directory_already_exists(): void
+    {
+        PhelProjectDirectory::ensure($this->projectRoot);
+        $dir = PhelProjectDirectory::ensure($this->projectRoot);
+
+        self::assertDirectoryExists($dir);
+        self::assertSame(
+            "# Created automatically by Phel.\n*\n",
+            file_get_contents($dir . '/.gitignore'),
+        );
+    }
+
+    public function test_strips_trailing_separator_from_project_root(): void
+    {
+        $dir = PhelProjectDirectory::ensure($this->projectRoot . '/');
+
+        self::assertSame($this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME, $dir);
+    }
+
+    public function test_throws_when_directory_cannot_be_created(): void
+    {
+        $unwritable = sys_get_temp_dir() . '/phel-unwritable-' . uniqid('', true);
+        mkdir($unwritable, 0o555);
+
+        try {
+            $this->expectException(FileException::class);
+            PhelProjectDirectory::ensure($unwritable);
+        } finally {
+            chmod($unwritable, 0o755);
+            rmdir($unwritable);
+        }
+    }
+}

--- a/tests/php/Unit/Run/Application/ReplHistoryPathResolverTest.php
+++ b/tests/php/Unit/Run/Application/ReplHistoryPathResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Filesystem\Application\PhelProjectDirectory;
+use Phel\Run\Application\ReplHistoryPathResolver;
+use PHPUnit\Framework\TestCase;
+
+use function is_resource;
+
+final class ReplHistoryPathResolverTest extends TestCase
+{
+    private string $projectRoot = '';
+
+    /** @var resource */
+    private $stderr;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/phel-repl-' . uniqid('', true);
+        mkdir($this->projectRoot);
+        $this->stderr = fopen('php://memory', 'w+b');
+        putenv(ReplHistoryPathResolver::QUIET_ENV);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(ReplHistoryPathResolver::QUIET_ENV);
+        if (is_resource($this->stderr)) {
+            fclose($this->stderr);
+        }
+
+        $this->removeTree($this->projectRoot);
+    }
+
+    public function test_returns_new_path_and_creates_phel_directory(): void
+    {
+        $resolver = new ReplHistoryPathResolver($this->projectRoot, $this->stderr);
+
+        $path = $resolver->resolve();
+
+        self::assertSame(
+            $this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME . '/' . ReplHistoryPathResolver::FILENAME,
+            $path,
+        );
+        self::assertDirectoryExists($this->projectRoot . '/' . PhelProjectDirectory::DIRECTORY_NAME);
+        self::assertSame('', $this->capturedStderr());
+    }
+
+    public function test_migrates_legacy_history_and_emits_deprecation(): void
+    {
+        $legacy = $this->projectRoot . '/' . ReplHistoryPathResolver::LEGACY_FILENAME;
+        file_put_contents($legacy, "(println :foo)\n");
+
+        $path = new ReplHistoryPathResolver($this->projectRoot, $this->stderr)->resolve();
+
+        self::assertFileDoesNotExist($legacy);
+        self::assertFileExists($path);
+        self::assertSame("(println :foo)\n", file_get_contents($path));
+        self::assertStringContainsString('migrated REPL history', $this->capturedStderr());
+        self::assertStringContainsString(ReplHistoryPathResolver::QUIET_ENV, $this->capturedStderr());
+    }
+
+    public function test_quiet_env_silences_deprecation_notice(): void
+    {
+        putenv(ReplHistoryPathResolver::QUIET_ENV . '=1');
+        file_put_contents($this->projectRoot . '/' . ReplHistoryPathResolver::LEGACY_FILENAME, "x\n");
+
+        new ReplHistoryPathResolver($this->projectRoot, $this->stderr)->resolve();
+
+        self::assertSame('', $this->capturedStderr());
+    }
+
+    public function test_does_not_migrate_when_new_path_already_exists(): void
+    {
+        $phelDir = PhelProjectDirectory::ensure($this->projectRoot);
+        $newPath = $phelDir . '/' . ReplHistoryPathResolver::FILENAME;
+        file_put_contents($newPath, "kept\n");
+        $legacy = $this->projectRoot . '/' . ReplHistoryPathResolver::LEGACY_FILENAME;
+        file_put_contents($legacy, "stale\n");
+
+        new ReplHistoryPathResolver($this->projectRoot, $this->stderr)->resolve();
+
+        self::assertSame("kept\n", file_get_contents($newPath));
+        self::assertSame("stale\n", file_get_contents($legacy));
+        self::assertSame('', $this->capturedStderr());
+    }
+
+    private function capturedStderr(): string
+    {
+        rewind($this->stderr);
+        return (string) stream_get_contents($this->stderr);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $this->removeTree($path . '/' . $entry);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Phel writes per-project runtime state in scattered locations: `.phel/last-failed.txt`, `.phel/lint-cache/`, `<systemTemp>/phel/cache/`, `<projectRoot>/.phel-repl-history`. Every downstream project has to remember matching `.gitignore` entries, and the cache living in system temp is wiped on reboot.

Closes #1954.

## 💡 Goal

Single project-local directory `.phel/` for everything Phel writes inside a user's repo. Self-seeded `.gitignore` (`*`) makes it invisible to Git, so brand-new projects need zero config.

## 🔖 Changes

### Auto-`.gitignore`

- New `Phel\Filesystem\Application\PhelProjectDirectory::ensure(string $projectRoot)` static helper. Creates `.phel/` if missing; atomically writes `.phel/.gitignore` with `*` only if missing (`LOCK_EX`). Throws `FileException` on mkdir failure.
- `TestCommand` calls the helper before forwarding to the runner; gated on `!--list-only`.
- `LintCommand::maybeCache` calls the helper before instantiating `LintCache`.

### Cache consolidation

- `PhelConfig::cacheDir` default changes from `sys_get_temp_dir() . '/phel/cache'` (absolute) to `.phel/cache` (relative). `BuildConfig` resolves it against the app root, so the effective default is `<projectRoot>/.phel/cache`.
- `BuildConfig::getCacheDir()` honors `PHEL_CACHE_DIR` env var as the final override (wins over both default and explicit `setCacheDir()`).
- `PhelConfig::setCacheDir()` continues to override the default when no env var is set.

### REPL history migration

- `Phel\Run\Application\ReplHistoryPathResolver` resolves history at `<projectRoot>/.phel/repl-history`. If the legacy `<projectRoot>/.phel-repl-history` exists and the new path doesn't, it renames the file and emits a one-line stderr notice. Set `PHEL_QUIET_MIGRATION=1` to silence.
- `RunConfig::getPhelReplHistory()` removed; `RunFactory` builds the resolver from `getAppRootDir()`.

### Tests

- `PhelProjectDirectoryTest` (5 cases): create, preserve existing content, idempotent, trailing-separator, mkdir failure.
- `ReplHistoryPathResolverTest` (4 cases): fresh project, legacy migration emits notice, `PHEL_QUIET_MIGRATION=1` silences, both-present is no-op.
- `BuildConfigTest` (2 new cases): env override wins; empty env ignored.
- `PhelConfigTest` adjusted: split former `single_base_path` test to reflect new defaults.

### Docs

- New `docs/project-layout.md` documents the `.phel/` directory contract, override env vars, migration.
- `src/php/Filesystem/CLAUDE.md` lists `PhelProjectDirectory` in the structure tree + key constraints.
- `src/php/Run/CLAUDE.md` lists `ReplHistoryPathResolver` + migration constraint.

## Out of scope

- `out/` build directory unchanged (different lifecycle: deliverable artifact, sometimes committed/Docker-shipped).
- `phel init` `.gitignore` template untouched (it never listed `data/` or `.phel-repl-history`).
- cli-skeleton update is a follow-up PR.

## Manual verification

```
$ phel test
$ ls .phel/
.gitignore  cache/  last-failed.txt
$ cat .phel/.gitignore
# Created automatically by Phel.
*
$ git status            # clean

$ phel repl             # legacy .phel-repl-history -> .phel/repl-history
phel: migrated REPL history /path/.phel-repl-history -> /path/.phel/repl-history (set PHEL_QUIET_MIGRATION=1 to silence)

$ PHEL_CACHE_DIR=/tmp/ci-cache phel build   # cache lands at /tmp/ci-cache
```