### PR TITLE
fix(build): map `.` to directory separator in NamespacePathTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this project will be documented in this file.
 #### Api
 - `phel analyze` preloads namespaces required by the file under analysis (#1919)
 
+#### Build
+- Entry-point `main.php` `require_once` resolves dotted main namespaces to nested paths (#1956)
+
 ## [0.36.0](https://github.com/phel-lang/phel-lang/compare/v0.35.0...v0.36.0) - 2026-05-08
 
 ### Added

--- a/src/php/Build/Domain/Compile/Output/NamespacePathTransformer.php
+++ b/src/php/Build/Domain/Compile/Output/NamespacePathTransformer.php
@@ -10,7 +10,7 @@ final class NamespacePathTransformer
     {
         return strtr(
             $namespace,
-            ['\\' => '/', '-' => '_'],
+            ['\\' => '/', '.' => '/', '-' => '_'],
         );
     }
 }

--- a/tests/php/Unit/Build/Domain/Compile/Output/EntryPointPhpFileTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/Output/EntryPointPhpFileTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Build\Domain\Compile\Output;
+
+use Phel\Build\Domain\Compile\Output\EntryPointPhpFile;
+use Phel\Build\Domain\Compile\Output\NamespacePathTransformer;
+use Phel\Config\PhelBuildConfig;
+use PHPUnit\Framework\TestCase;
+
+final class EntryPointPhpFileTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/phel-entrypoint-' . uniqid();
+        mkdir($this->tempDir . '/out', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tempDir . '/out/main.php');
+        @rmdir($this->tempDir . '/out');
+        @rmdir($this->tempDir);
+    }
+
+    public function test_multi_segment_namespace_points_at_nested_path(): void
+    {
+        $buildConfig = new PhelBuildConfig()
+            ->setMainPhelNamespace('cli-skeleton.main')
+            ->setMainPhpPath('out/main.php');
+
+        $entry = new EntryPointPhpFile(
+            $buildConfig,
+            new NamespacePathTransformer(),
+            $this->tempDir,
+        );
+
+        $entry->createFile();
+
+        $contents = (string) file_get_contents($this->tempDir . '/out/main.php');
+
+        self::assertStringContainsString(
+            '$compiledFile = __DIR__ . "/cli_skeleton/main.php";',
+            $contents,
+        );
+    }
+}

--- a/tests/php/Unit/Build/Domain/Compile/Output/NamespacePathTransformerTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/Output/NamespacePathTransformerTest.php
@@ -55,4 +55,12 @@ final class NamespacePathTransformerTest extends TestCase
             $this->transformer->transform('test-ns\hello'),
         );
     }
+
+    public function test_dot_to_forward_slash(): void
+    {
+        self::assertSame(
+            'cli_skeleton/main',
+            $this->transformer->transform('cli-skeleton.main'),
+        );
+    }
 }


### PR DESCRIPTION
## 🤔 Background

Closes #1956.

`NamespacePathTransformer::transform()` maps `\` → `/` and `-` → `_` but not `.` → `/`. Output diverges from `CompiledTargetPathResolver::fromNamespace` (which splits on `\` after `encodeNs`, so dots become directory separators).

`EntryPointPhpFile::outputMainPhelPath()` consumes the transformer to splice the `require_once` path into `out/main.php`. For main namespace `cli-skeleton.main`:
- Bootstrap `require_once`s `out/cli_skeleton.main.php`
- Compiler writes `out/cli_skeleton/main.php`
- `php out/main.php …` fatals with `Failed opening required …`

## 💡 Goal

Align `NamespacePathTransformer` output with `CompiledTargetPathResolver::fromNamespace` for dotted namespaces.

## 🔖 Changes

- `src/php/Build/Domain/Compile/Output/NamespacePathTransformer.php`: add `'.' => '/'` to the `strtr` map.
- `tests/php/Unit/Build/Domain/Compile/Output/NamespacePathTransformerTest.php`: cover `cli-skeleton.main` → `cli_skeleton/main`.
- `tests/php/Unit/Build/Domain/Compile/Output/EntryPointPhpFileTest.php`: regression test driving `EntryPointPhpFile` for a multi-segment namespace, asserting the generated `$compiledFile` line points at the nested path.
- `CHANGELOG.md`: unreleased entry under Fixed › Build.

`Munge::encodePhpNs` for `cli-skeleton.main` returns `cli_skeleton\main` (its `nsMapping` only maps `-` → `_`, no reserved-word collision handling). The simple `strtr` matches that exactly; no other callers of the transformer require richer encoding.