### PR TITLE
ref(config): immutable with*() API for PhelConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ All notable changes to this project will be documented in this file.
 - Recursive self-calls emit `$this(...)`; ~3.66x faster on `fib(22)` (#1914)
 
 #### DX
-- Runtime state consolidated under `.phel/` (cache, REPL history, last-failed, error log) with self-seeded `.gitignore`; legacy `.phel-repl-history` auto-migrated; relocate the whole directory via `setPhelDir()` or `PHEL_DIR` env, narrow cache override via `PHEL_CACHE_DIR` (#1954)
+- Runtime state consolidated under `.phel/` (cache, REPL history, last-failed, error log) with self-seeded `.gitignore`; legacy `.phel-repl-history` auto-migrated; relocate the whole directory via `withPhelDir()` or `PHEL_DIR` env, narrow cache override via `PHEL_CACHE_DIR` (#1954)
+- `PhelConfig`, `PhelBuildConfig`, `PhelExportConfig` are now immutable. Use `withX()` chain on `PhelConfig`; build/export fields flat on the root config (no nested `new PhelBuildConfig()->set...()`). Legacy `setX()` and `useLayout`/`useNestedLayout`/`useFlatLayout` retained as `#[Deprecated]` shims, removed in a future major.
 
 ### Fixed
 

--- a/docs/framework-integration.md
+++ b/docs/framework-integration.md
@@ -77,18 +77,15 @@ New feature: add the file, add one `:require` in `app/boot.phel`, run `phel expo
 ```php
 <?php
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
-use Phel\Config\PhelExportConfig;
 
 return PhelConfig::forProject()
-    ->setSrcDirs(['phel'])
-    ->setTestDirs(['tests-phel'])
-    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
-    ->setExportConfig((new PhelExportConfig())
-        ->setFromDirectories(['phel'])
-        ->setNamespacePrefix('App\\PhelGenerated')
-        ->setTargetDirectory(__DIR__ . '/app/PhelGenerated'));
+    ->withSrcDirs(['phel'])
+    ->withTestDirs(['tests-phel'])
+    ->withBuildDestDir('build')
+    ->withExportFromDirectories(['phel'])
+    ->withExportNamespacePrefix('App\\PhelGenerated')
+    ->withExportTargetDirectory(__DIR__ . '/app/PhelGenerated');
 ```
 
 `app/Providers/PhelServiceProvider.php` (loads the boot ns once, all wrappers ready):
@@ -153,18 +150,15 @@ final class CheckoutController
 ```php
 <?php
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
-use Phel\Config\PhelExportConfig;
 
 return PhelConfig::forProject()
-    ->setSrcDirs(['phel'])
-    ->setTestDirs(['tests/phel'])
-    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'))
-    ->setExportConfig((new PhelExportConfig())
-        ->setFromDirectories(['phel'])
-        ->setNamespacePrefix('App\\PhelGenerated')
-        ->setTargetDirectory(__DIR__ . '/src/PhelGenerated'));
+    ->withSrcDirs(['phel'])
+    ->withTestDirs(['tests/phel'])
+    ->withBuildDestDir('build')
+    ->withExportFromDirectories(['phel'])
+    ->withExportNamespacePrefix('App\\PhelGenerated')
+    ->withExportTargetDirectory(__DIR__ . '/src/PhelGenerated');
 ```
 
 Default `App\ → src/` PSR-4 covers `App\PhelGenerated\`.
@@ -205,13 +199,12 @@ Controllers use any wrapper: `App\PhelGenerated\Reports\Daily`, `App\PhelGenerat
 ```php
 <?php
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
 return PhelConfig::forProject(mainNamespace: 'app\\boot')
-    ->setSrcDirs(['phel'])
-    ->setTestDirs(['tests/phel'])
-    ->setBuildConfig((new PhelBuildConfig())->setDestDir('build'));
+    ->withSrcDirs(['phel'])
+    ->withTestDirs(['tests/phel'])
+    ->withBuildDestDir('build');
 ```
 
 Entry script:
@@ -243,7 +236,7 @@ echo $greet('World') . "\n";
 - Hyphens become camelCase: `(ns my-lib\core)` to `App\PhelGenerated\MyLib\Core`; `apply-discount` to `applyDiscount`.
 - Prod path (`require build/app/boot.php`): self-contained, no Gacela bootstrap, no compiler. Just `\Phel::addDefinition()` calls.
 - Dev path (`\Phel::run()`) boots Gacela and compiles to temp files on first call. Guard with a static flag; never call from Laravel `register()` or per-request hot paths.
-- `setBuildConfig()` dest dir is relative to the project root.
+- `withBuildDestDir()` is relative to the project root.
 - Commit `build/` in the deploy artifact, or run `phel build` in CI. Skip committing in dev so `is_file()` is false and `\Phel::run()` kicks in.
 - Add `vendor/bin/phel test` to CI alongside `phpunit`.
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -25,7 +25,7 @@ PHEL_WARN_DEPRECATIONS=1 vendor/bin/phel run src/app.phel
 
 ```php
 return PhelConfig::forProject()
-    ->setWarnDeprecations(true);
+    ->withWarnDeprecations(true);
 ```
 
 When enabled, the compiler emits one `E_USER_DEPRECATED` per unique `(file, symbol)` pair so large projects do not drown in duplicates. `--warn-deprecations` is consumed by the `phel` bootstrap before Symfony's per-command parsers run, so it works with every subcommand.

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -15,15 +15,15 @@ by Git via a self-seeded `.phel/.gitignore` (`*`).
 
 ## Overrides
 
-- **Relocate everything**: `$config->setPhelDir('/var/cache/phel')` in
+- **Relocate everything**: `$config->withPhelDir('/var/cache/phel')` in
   `phel-config.php` moves cache, REPL history, last-failed file and error log
   out of the project root. Useful for WordPress plugins, shared hosting, or
   any setup where `.phel/` would otherwise sit under a web-accessible path.
-- **`PHEL_DIR` env var** — same effect at runtime; wins over `setPhelDir()`.
-- **`PhelConfig::setCacheDir($path)`** — narrower override for just the build
+- **`PHEL_DIR` env var** — same effect at runtime; wins over `withPhelDir()`.
+- **`PhelConfig::withCacheDir($path)`** — narrower override for just the build
   cache.
 - **`PHEL_CACHE_DIR` env var** — final cache override; wins over `PHEL_DIR`
-  and explicit `setCacheDir()`. Useful for CI / Nix builds.
+  and explicit `withCacheDir()`. Useful for CI / Nix builds.
 - **`PHEL_QUIET_MIGRATION=1`** — silences the one-line stderr notice emitted
   when the legacy `.phel-repl-history` is migrated into `.phel/repl-history`.
 

--- a/phel-config.php
+++ b/phel-config.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Phel\Config\PhelConfig;
+use Phel\Config\ProjectLayout;
 
-return PhelConfig::forProject('phel\core')
-    ->useNestedLayout()
-    ->setIgnoreWhenBuilding(['src/phel/local.phel']);
+return PhelConfig::forProject('phel\core', ProjectLayout::Nested)
+    ->withIgnoreWhenBuilding(['src/phel/local.phel']);

--- a/src/php/Build/BuildConfig.php
+++ b/src/php/Build/BuildConfig.php
@@ -42,7 +42,7 @@ final class BuildConfig extends AbstractConfig implements BuildConfigInterface
         if ($config->getMainPhelNamespace() === '') {
             $detected = $this->autoDetectMainNamespace();
             if ($detected !== '') {
-                $config->setMainPhelNamespace($detected);
+                $config = $config->withMainPhelNamespace($detected);
             }
         }
 

--- a/src/php/Config/CLAUDE.md
+++ b/src/php/Config/CLAUDE.md
@@ -9,21 +9,29 @@ This module does **not** follow Gacela internally — no Facade, Factory, or Dep
 ## Key Classes
 
 ### `PhelConfig` (main)
-Factory: `PhelConfig::forProject(?string $mainNamespace)` — creates config with optional namespace.
 
-**Directory config**: `setSrcDirs()`, `setTestDirs()`, `setVendorDir()`, `setFormatDirs()`
-**Build config**: `setBuildConfig(PhelBuildConfig)`, `setMainPhelNamespace()`, `setBuildDestDir()`
-**Export config**: `setExportConfig(PhelExportConfig)`, `setExportNamespacePrefix()`, `setExportTargetDirectory()`
-**Cache**: `setCacheDir()`, `setTempDir()`, `setEnableNamespaceCache()`, `setEnableCompiledCodeCache()`
-**Other**: `setIgnoreWhenBuilding()`, `setNoCacheWhenBuilding()`, `setKeepGeneratedTempFiles()`, `setEnableAsserts()`, `setWarnDeprecations()`
+Immutable `final readonly class`. Every mutation returns a new instance.
+
+Factory: `PhelConfig::forProject(string $mainNamespace = '', ?ProjectLayout $layout = null)` — creates config with optional namespace; auto-detects layout from cwd when omitted.
+
+**Directory**: `withSrcDirs()`, `withTestDirs()`, `withVendorDir()`, `withFormatDirs()`
+**Layout**: `withLayout(ProjectLayout)`
+**Build (flat on root)**: `withMainPhelNamespace()`, `withMainPhpPath()`, `withBuildDestDir()`, `withBuildConfig(PhelBuildConfig)` (escape hatch)
+**Export (flat on root)**: `withExportNamespacePrefix()`, `withExportTargetDirectory()`, `withExportFromDirectories()`, `withExportConfig(PhelExportConfig)` (escape hatch)
+**Cache**: `withCacheDir()`, `withTempDir()`, `withEnableNamespaceCache()`, `withEnableCompiledCodeCache()`, `withPhelDir()`
+**Other**: `withIgnoreWhenBuilding()`, `withNoCacheWhenBuilding()`, `withKeepGeneratedTempFiles()`, `withEnableAsserts()`, `withWarnDeprecations()`, `withErrorLogFile()`
 **Validation**: `validate(): array` — returns list of errors
 **Serialization**: `jsonSerialize(): array` — implements `JsonSerializable`
 
+**Deprecated (since 0.37, removed in future major)**: every `setX()` and `useLayout()`/`useNestedLayout()`/`useFlatLayout()` shim to its `withX()` / `withLayout()` counterpart. Annotated with `#[Deprecated]`.
+
 ### `PhelBuildConfig`
-Build-specific: `setMainPhelNamespace()`, `setMainPhpPath()`, `setDestDir()`, `shouldCreateEntryPointPhpFile()`
+
+Immutable value object. Constructor accepts named args: `mainPhelNamespace`, `mainPhpPath`, `destDir`. Use `withMainPhelNamespace()`, `withMainPhpPath()`, `withDestDir()` for chained updates. Setters retained as `#[Deprecated]` shims.
 
 ### `PhelExportConfig`
-Export/interop: `setFromDirectories()`, `setNamespacePrefix()`, `setTargetDirectory()`
+
+Immutable value object. Constructor accepts named args: `fromDirectories`, `namespacePrefix`, `targetDirectory`. `withFromDirectories()`, `withNamespacePrefix()`, `withTargetDirectory()` for updates. Setters retained as `#[Deprecated]` shims.
 
 ### `ProjectLayout` (enum)
 - `Flat` — `src`, `tests` (default)
@@ -41,5 +49,6 @@ None. This is a leaf module with zero internal dependencies.
 ## Key Constraints
 
 - Config constants (e.g. `PhelConfig::SRC_DIRS`) are used as keys throughout Gacela's config system
-- Default source dirs: `['src/phel']`, test dirs: `['tests/phel']` (changed by `useLayout`)
+- `jsonSerialize()` wire shape on all three classes is the contract with Gacela's `AbstractConfig::get()` — never change keys/casing
 - Auto-detection in `Phel.php` checks for nested (`src/phel`) vs flat (`src`) layout when no `phel-config.php` exists
+- Every `with*()` returns a new instance; callers must capture the return value (`$config = $config->withX(...)`), never call for side effect

--- a/src/php/Config/PhelBuildConfig.php
+++ b/src/php/Config/PhelBuildConfig.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Phel\Config;
 
+use Deprecated;
 use JsonSerializable;
 
 use function count;
 use function sprintf;
 
-final class PhelBuildConfig implements JsonSerializable
+final readonly class PhelBuildConfig implements JsonSerializable
 {
     public const string DEST_DIR = 'dir';
 
@@ -23,31 +24,28 @@ final class PhelBuildConfig implements JsonSerializable
 
     private const string DEFAULT_PHP_FILENAME = 'index.php';
 
-    private string $mainPhelNamespace = '';
+    public string $mainPhpPath;
 
-    private string $destDir = '';
-
-    private string $mainPhpPath = '';
+    public function __construct(
+        public string $mainPhelNamespace = '',
+        string $mainPhpPath = '',
+        public string $destDir = '',
+    ) {
+        $this->mainPhpPath = $mainPhpPath === ''
+            ? ''
+            : $this->normalizePhpExtension($mainPhpPath);
+    }
 
     /**
      * @param array<string, mixed> $array
      */
     public static function fromArray(array $array): self
     {
-        $self = new self();
-        if (isset($array[self::MAIN_PHEL_NAMESPACE])) {
-            $self->mainPhelNamespace = $array[self::MAIN_PHEL_NAMESPACE];
-        }
-
-        if (isset($array[self::DEST_DIR])) {
-            $self->destDir = $array[self::DEST_DIR];
-        }
-
-        if (isset($array[self::MAIN_PHP_PATH])) {
-            $self->mainPhpPath = $array[self::MAIN_PHP_PATH];
-        }
-
-        return $self;
+        return new self(
+            mainPhelNamespace: (string) ($array[self::MAIN_PHEL_NAMESPACE] ?? ''),
+            mainPhpPath: (string) ($array[self::MAIN_PHP_PATH] ?? ''),
+            destDir: (string) ($array[self::DEST_DIR] ?? ''),
+        );
     }
 
     /**
@@ -63,10 +61,15 @@ final class PhelBuildConfig implements JsonSerializable
         ];
     }
 
+    public function withMainPhelNamespace(string $namespace): self
+    {
+        return new self($namespace, $this->mainPhpPath, $this->destDir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhelNamespace()')]
     public function setMainPhelNamespace(string $namespace): self
     {
-        $this->mainPhelNamespace = $namespace;
-        return $this;
+        return $this->withMainPhelNamespace($namespace);
     }
 
     public function getMainPhelNamespace(): string
@@ -74,10 +77,15 @@ final class PhelBuildConfig implements JsonSerializable
         return $this->mainPhelNamespace;
     }
 
+    public function withMainPhpPath(string $path): self
+    {
+        return new self($this->mainPhelNamespace, $path, $this->destDir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhpPath()')]
     public function setMainPhpPath(string $path): self
     {
-        $this->mainPhpPath = $this->normalizePhpExtension($path);
-        return $this;
+        return $this->withMainPhpPath($path);
     }
 
     public function getMainPhpPath(): string
@@ -93,10 +101,15 @@ final class PhelBuildConfig implements JsonSerializable
         );
     }
 
+    public function withDestDir(string $dir): self
+    {
+        return new self($this->mainPhelNamespace, $this->mainPhpPath, $dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withDestDir()')]
     public function setDestDir(string $dir): self
     {
-        $this->destDir = $dir;
-        return $this;
+        return $this->withDestDir($dir);
     }
 
     public function shouldCreateEntryPointPhpFile(): bool

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -609,34 +609,13 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Returns a new instance with the supplied fields overridden. Internal
-     * plumbing for every `with*()` method — keeps each wither one line.
+     * Returns a new instance with the supplied fields overridden.
      *
      * @param array<string, mixed> $overrides
      */
     private function with(array $overrides): self
     {
-        $base = [
-            'srcDirs' => $this->srcDirs,
-            'testDirs' => $this->testDirs,
-            'vendorDir' => $this->vendorDir,
-            'errorLogFile' => $this->errorLogFile,
-            'exportConfig' => $this->exportConfig,
-            'buildConfig' => $this->buildConfig,
-            'ignoreWhenBuilding' => $this->ignoreWhenBuilding,
-            'noCacheWhenBuilding' => $this->noCacheWhenBuilding,
-            'keepGeneratedTempFiles' => $this->keepGeneratedTempFiles,
-            'tempDir' => $this->tempDir,
-            'cacheDir' => $this->cacheDir,
-            'formatDirs' => $this->formatDirs,
-            'enableAsserts' => $this->enableAsserts,
-            'warnDeprecations' => $this->warnDeprecations,
-            'enableNamespaceCache' => $this->enableNamespaceCache,
-            'enableCompiledCodeCache' => $this->enableCompiledCodeCache,
-            'phelDir' => $this->phelDir,
-        ];
-
-        return new self(...[...$base, ...$overrides]);
+        return new self(...[...get_object_vars($this), ...$overrides]);
     }
 
     /**

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Config;
 
+use Deprecated;
 use JsonSerializable;
 
-final class PhelConfig implements JsonSerializable
+final readonly class PhelConfig implements JsonSerializable
 {
     public const string SRC_DIRS = 'src-dirs';
 
@@ -49,59 +50,37 @@ final class PhelConfig implements JsonSerializable
 
     private const string DEFAULT_CACHE_DIR = '.phel/cache';
 
-    /** @var list<string> */
-    private array $srcDirs = self::DEFAULT_SRC_DIRS;
-
-    /** @var list<string> */
-    private array $testDirs = ['tests'];
-
-    private string $vendorDir = 'vendor';
-
-    private string $errorLogFile = '.phel/error.log';
-
-    private PhelExportConfig $exportConfig;
-
-    private PhelBuildConfig $buildConfig;
-
-    /** @var list<string> */
-    private array $ignoreWhenBuilding = [];
-
-    /** @var list<string> */
-    private array $noCacheWhenBuilding = [];
-
-    private bool $keepGeneratedTempFiles = false;
-
-    private string $tempDir;
-
-    // Cache lives under <projectRoot>/.phel/cache by default — BuildConfig
-    // resolves relative paths against the app root.
-    private string $cacheDir = self::DEFAULT_CACHE_DIR;
-
-    /** @var list<string> */
-    private array $formatDirs = ['src', 'tests'];
-
-    private bool $enableAsserts = true;
-
-    private bool $warnDeprecations = false;
-
-    private bool $enableNamespaceCache = true;
-
-    private bool $enableCompiledCodeCache = true;
+    public string $tempDir;
 
     /**
-     * Custom location for the per-project `.phel/` state directory.
-     * Empty string keeps the default (`.phel/` next to the project root).
-     * Absolute paths are honored verbatim. Overridden at runtime by the
-     * `PHEL_DIR` environment variable.
+     * @param list<string> $srcDirs
+     * @param list<string> $testDirs
+     * @param list<string> $ignoreWhenBuilding
+     * @param list<string> $noCacheWhenBuilding
+     * @param list<string> $formatDirs
      */
-    private string $phelDir = '';
-
-    public function __construct()
-    {
-        $this->exportConfig = new PhelExportConfig();
-        $this->buildConfig = new PhelBuildConfig();
-
-        $this->tempDir = sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR . '/tmp';
+    public function __construct(
+        public array $srcDirs = self::DEFAULT_SRC_DIRS,
+        public array $testDirs = ['tests'],
+        public string $vendorDir = 'vendor',
+        public string $errorLogFile = '.phel/error.log',
+        public PhelExportConfig $exportConfig = new PhelExportConfig(),
+        public PhelBuildConfig $buildConfig = new PhelBuildConfig(),
+        public array $ignoreWhenBuilding = [],
+        public array $noCacheWhenBuilding = [],
+        public bool $keepGeneratedTempFiles = false,
+        ?string $tempDir = null,
+        public string $cacheDir = self::DEFAULT_CACHE_DIR,
+        public array $formatDirs = ['src', 'tests'],
+        public bool $enableAsserts = true,
+        public bool $warnDeprecations = false,
+        public bool $enableNamespaceCache = true,
+        public bool $enableCompiledCodeCache = true,
+        public string $phelDir = '',
+    ) {
+        $this->tempDir = $tempDir === null
+            ? sys_get_temp_dir() . self::PHEL_TEMP_SUBDIR . '/tmp'
+            : rtrim($tempDir, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -114,7 +93,7 @@ final class PhelConfig implements JsonSerializable
      *   from `core.phel` / `main.phel` at the configured source roots.
      *
      * Examples:
-     *   return PhelConfig::forProject();                                 // zero-config, auto-detects layout + namespace
+     *   return PhelConfig::forProject();                                 // zero-config
      *   return PhelConfig::forProject('my-app\core');                    // explicit namespace
      *   return PhelConfig::forProject(layout: ProjectLayout::Root);      // single-file / scratch project
      *   return PhelConfig::forProject('my-app\main', ProjectLayout::Nested);
@@ -123,11 +102,10 @@ final class PhelConfig implements JsonSerializable
         string $mainNamespace = '',
         ?ProjectLayout $layout = null,
     ): self {
-        $config = new self();
-        $config->useLayout($layout ?? self::detectLayout());
+        $config = new self()->withLayout($layout ?? self::detectLayout());
 
         if ($mainNamespace !== '') {
-            $config->setMainPhelNamespace($mainNamespace);
+            return $config->withMainPhelNamespace($mainNamespace);
         }
 
         return $config;
@@ -232,258 +210,358 @@ final class PhelConfig implements JsonSerializable
         return $this->enableCompiledCodeCache;
     }
 
+    public function getPhelDir(): string
+    {
+        return $this->phelDir;
+    }
+
     // ========================================
-    // Layout Configuration
+    // Layout
     // ========================================
 
     /**
-     * Apply a project layout (nested or flat).
+     * Apply a project layout (nested or flat). Returns a new instance with src,
+     * test, format, and export-from directories aligned with the layout.
      */
+    public function withLayout(ProjectLayout $layout): self
+    {
+        return $this->with([
+            'srcDirs' => [$layout->getSrcDir()],
+            'testDirs' => [$layout->getTestDir()],
+            'formatDirs' => $layout->getFormatDirs(),
+            'exportConfig' => $this->exportConfig->withFromDirectories($layout->getExportFromDirs()),
+        ]);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withLayout()')]
     public function useLayout(ProjectLayout $layout): self
     {
-        $this->srcDirs = [$layout->getSrcDir()];
-        $this->testDirs = [$layout->getTestDir()];
-        $this->formatDirs = $layout->getFormatDirs();
-        $this->exportConfig->setFromDirectories($layout->getExportFromDirs());
-
-        return $this;
+        return $this->withLayout($layout);
     }
 
-    /**
-     * Use nested directory layout: src/phel and tests/phel.
-     * Useful when the project also hosts PHP sources alongside Phel.
-     */
+    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Nested)')]
     public function useNestedLayout(): self
     {
-        return $this->useLayout(ProjectLayout::Nested);
+        return $this->withLayout(ProjectLayout::Nested);
     }
 
-    /**
-     * Use flat directory layout: src and tests (default, simpler projects).
-     */
+    #[Deprecated(message: 'since 0.37, use withLayout(ProjectLayout::Flat)')]
     public function useFlatLayout(): self
     {
-        return $this->useLayout(ProjectLayout::Flat);
+        return $this->withLayout(ProjectLayout::Flat);
     }
 
     // ========================================
-    // Convenience Setters
+    // Immutable with*() API
     // ========================================
 
     /**
-     * Direct setter for the main Phel namespace (convenience method).
-     * Automatically configures build output to out/index.php.
+     * @param list<string> $list
      */
-    public function setMainPhelNamespace(string $namespace): self
+    public function withSrcDirs(array $list): self
     {
-        $this->buildConfig->setMainPhelNamespace($namespace);
-        if ($this->buildConfig->getMainPhpPath() === 'out/index.php' || $this->buildConfig->getMainPhpPath() === '') {
-            $this->buildConfig->setMainPhpPath('out/index.php');
+        return $this->with(['srcDirs' => $list]);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    public function withTestDirs(array $list): self
+    {
+        return $this->with(['testDirs' => $list]);
+    }
+
+    public function withVendorDir(string $dir): self
+    {
+        return $this->with(['vendorDir' => $dir]);
+    }
+
+    public function withErrorLogFile(string $filepath): self
+    {
+        return $this->with(['errorLogFile' => $filepath]);
+    }
+
+    public function withBuildConfig(PhelBuildConfig $buildConfig): self
+    {
+        return $this->with(['buildConfig' => $buildConfig]);
+    }
+
+    public function withExportConfig(PhelExportConfig $exportConfig): self
+    {
+        return $this->with(['exportConfig' => $exportConfig]);
+    }
+
+    /**
+     * Flattens the build namespace onto PhelConfig. Sets the entry-point PHP
+     * path to `out/index.php` when none has been configured yet.
+     */
+    public function withMainPhelNamespace(string $namespace): self
+    {
+        $build = $this->buildConfig->withMainPhelNamespace($namespace);
+        $currentPath = $this->buildConfig->getMainPhpPath();
+        if ($currentPath === 'out/index.php' || $currentPath === '') {
+            $build = $build->withMainPhpPath('out/index.php');
         }
 
-        return $this;
+        return $this->with(['buildConfig' => $build]);
     }
 
-    /**
-     * Direct setter for the main PHP output path (convenience method).
-     */
-    public function setMainPhpPath(string $path): self
+    public function withMainPhpPath(string $path): self
     {
-        $this->buildConfig->setMainPhpPath($path);
-
-        return $this;
+        return $this->with(['buildConfig' => $this->buildConfig->withMainPhpPath($path)]);
     }
 
-    /**
-     * Direct setter for the build destination directory (convenience method).
-     */
-    public function setBuildDestDir(string $dir): self
+    public function withBuildDestDir(string $dir): self
     {
-        $this->buildConfig->setDestDir($dir);
-
-        return $this;
+        return $this->with(['buildConfig' => $this->buildConfig->withDestDir($dir)]);
     }
 
-    /**
-     * Direct setter for export namespace prefix (convenience method).
-     */
-    public function setExportNamespacePrefix(string $prefix): self
+    public function withExportNamespacePrefix(string $prefix): self
     {
-        $this->exportConfig->setNamespacePrefix($prefix);
-
-        return $this;
+        return $this->with(['exportConfig' => $this->exportConfig->withNamespacePrefix($prefix)]);
     }
 
-    /**
-     * Direct setter for export target directory (convenience method).
-     */
-    public function setExportTargetDirectory(string $dir): self
+    public function withExportTargetDirectory(string $dir): self
     {
-        $this->exportConfig->setTargetDirectory($dir);
-
-        return $this;
+        return $this->with(['exportConfig' => $this->exportConfig->withTargetDirectory($dir)]);
     }
 
     /**
-     * Direct setter for export from directories (convenience method).
-     *
      * @param list<string> $dirs
      */
-    public function setExportFromDirectories(array $dirs): self
+    public function withExportFromDirectories(array $dirs): self
     {
-        $this->exportConfig->setFromDirectories($dirs);
-
-        return $this;
-    }
-
-    // ========================================
-    // Standard Setters
-    // ========================================
-
-    /**
-     * @param list<string> $list
-     */
-    public function setSrcDirs(array $list): self
-    {
-        $this->srcDirs = $list;
-
-        return $this;
+        return $this->with(['exportConfig' => $this->exportConfig->withFromDirectories($dirs)]);
     }
 
     /**
      * @param list<string> $list
      */
-    public function setTestDirs(array $list): self
+    public function withIgnoreWhenBuilding(array $list): self
     {
-        $this->testDirs = $list;
-
-        return $this;
-    }
-
-    public function setVendorDir(string $dir): self
-    {
-        $this->vendorDir = $dir;
-
-        return $this;
-    }
-
-    public function setExportConfig(PhelExportConfig $exportConfig): self
-    {
-        $this->exportConfig = $exportConfig;
-
-        return $this;
-    }
-
-    public function setErrorLogFile(string $filepath): self
-    {
-        $this->errorLogFile = $filepath;
-
-        return $this;
-    }
-
-    public function setBuildConfig(PhelBuildConfig $buildConfig): self
-    {
-        $this->buildConfig = $buildConfig;
-
-        return $this;
+        return $this->with(['ignoreWhenBuilding' => $list]);
     }
 
     /**
      * @param list<string> $list
      */
-    public function setIgnoreWhenBuilding(array $list): self
+    public function withNoCacheWhenBuilding(array $list): self
     {
-        $this->ignoreWhenBuilding = $list;
-
-        return $this;
+        return $this->with(['noCacheWhenBuilding' => $list]);
     }
 
-    public function setKeepGeneratedTempFiles(bool $flag): self
+    public function withKeepGeneratedTempFiles(bool $flag): self
     {
-        $this->keepGeneratedTempFiles = $flag;
-
-        return $this;
+        return $this->with(['keepGeneratedTempFiles' => $flag]);
     }
 
-    public function setTempDir(string $dir): self
+    public function withTempDir(string $dir): self
     {
-        $this->tempDir = rtrim($dir, DIRECTORY_SEPARATOR);
+        return $this->with(['tempDir' => rtrim($dir, DIRECTORY_SEPARATOR)]);
+    }
 
-        return $this;
+    public function withCacheDir(string $dir): self
+    {
+        return $this->with(['cacheDir' => rtrim($dir, DIRECTORY_SEPARATOR)]);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    public function withFormatDirs(array $list): self
+    {
+        return $this->with(['formatDirs' => $list]);
+    }
+
+    public function withEnableAsserts(bool $flag): self
+    {
+        return $this->with(['enableAsserts' => $flag]);
+    }
+
+    public function withWarnDeprecations(bool $flag): self
+    {
+        return $this->with(['warnDeprecations' => $flag]);
+    }
+
+    public function withEnableNamespaceCache(bool $flag): self
+    {
+        return $this->with(['enableNamespaceCache' => $flag]);
+    }
+
+    public function withEnableCompiledCodeCache(bool $flag): self
+    {
+        return $this->with(['enableCompiledCodeCache' => $flag]);
     }
 
     /**
      * Redirect the entire per-project state directory (`.phel/` by default)
      * to a different location. Useful when the project lives behind a web
      * server: e.g. a WordPress plugin can move state out of the document
-     * root via `$config->setPhelDir('/var/cache/phel')`. Honors `PHEL_DIR`
-     * env var as a higher-priority override.
+     * root via `withPhelDir('/var/cache/phel')`. Honors `PHEL_DIR` env var
+     * as a higher-priority override.
      */
-    public function setPhelDir(string $dir): self
+    public function withPhelDir(string $dir): self
     {
-        $this->phelDir = $dir;
-
-        return $this;
+        return $this->with(['phelDir' => $dir]);
     }
 
-    public function getPhelDir(): string
+    // ========================================
+    // Deprecated mutating setters (shim → with*())
+    // ========================================
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withSrcDirs()')]
+    public function setSrcDirs(array $list): self
     {
-        return $this->phelDir;
+        return $this->withSrcDirs($list);
     }
 
     /**
      * @param list<string> $list
      */
-    public function setFormatDirs(array $list): self
+    #[Deprecated(message: 'since 0.37, use withTestDirs()')]
+    public function setTestDirs(array $list): self
     {
-        $this->formatDirs = $list;
+        return $this->withTestDirs($list);
+    }
 
-        return $this;
+    #[Deprecated(message: 'since 0.37, use withVendorDir()')]
+    public function setVendorDir(string $dir): self
+    {
+        return $this->withVendorDir($dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withErrorLogFile()')]
+    public function setErrorLogFile(string $filepath): self
+    {
+        return $this->withErrorLogFile($filepath);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withBuildConfig()')]
+    public function setBuildConfig(PhelBuildConfig $buildConfig): self
+    {
+        return $this->withBuildConfig($buildConfig);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportConfig()')]
+    public function setExportConfig(PhelExportConfig $exportConfig): self
+    {
+        return $this->withExportConfig($exportConfig);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhelNamespace()')]
+    public function setMainPhelNamespace(string $namespace): self
+    {
+        return $this->withMainPhelNamespace($namespace);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withMainPhpPath()')]
+    public function setMainPhpPath(string $path): self
+    {
+        return $this->withMainPhpPath($path);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withBuildDestDir()')]
+    public function setBuildDestDir(string $dir): self
+    {
+        return $this->withBuildDestDir($dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportNamespacePrefix()')]
+    public function setExportNamespacePrefix(string $prefix): self
+    {
+        return $this->withExportNamespacePrefix($prefix);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withExportTargetDirectory()')]
+    public function setExportTargetDirectory(string $dir): self
+    {
+        return $this->withExportTargetDirectory($dir);
+    }
+
+    /**
+     * @param list<string> $dirs
+     */
+    #[Deprecated(message: 'since 0.37, use withExportFromDirectories()')]
+    public function setExportFromDirectories(array $dirs): self
+    {
+        return $this->withExportFromDirectories($dirs);
     }
 
     /**
      * @param list<string> $list
      */
+    #[Deprecated(message: 'since 0.37, use withIgnoreWhenBuilding()')]
+    public function setIgnoreWhenBuilding(array $list): self
+    {
+        return $this->withIgnoreWhenBuilding($list);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withNoCacheWhenBuilding()')]
     public function setNoCacheWhenBuilding(array $list): self
     {
-        $this->noCacheWhenBuilding = $list;
-
-        return $this;
+        return $this->withNoCacheWhenBuilding($list);
     }
 
-    public function setEnableAsserts(bool $flag): self
+    #[Deprecated(message: 'since 0.37, use withKeepGeneratedTempFiles()')]
+    public function setKeepGeneratedTempFiles(bool $flag): self
     {
-        $this->enableAsserts = $flag;
-
-        return $this;
+        return $this->withKeepGeneratedTempFiles($flag);
     }
 
-    public function setWarnDeprecations(bool $flag): self
+    #[Deprecated(message: 'since 0.37, use withTempDir()')]
+    public function setTempDir(string $dir): self
     {
-        $this->warnDeprecations = $flag;
-
-        return $this;
+        return $this->withTempDir($dir);
     }
 
-    public function setEnableNamespaceCache(bool $flag): self
-    {
-        $this->enableNamespaceCache = $flag;
-
-        return $this;
-    }
-
-    public function setEnableCompiledCodeCache(bool $flag): self
-    {
-        $this->enableCompiledCodeCache = $flag;
-
-        return $this;
-    }
-
+    #[Deprecated(message: 'since 0.37, use withCacheDir()')]
     public function setCacheDir(string $dir): self
     {
-        $this->cacheDir = rtrim($dir, DIRECTORY_SEPARATOR);
+        return $this->withCacheDir($dir);
+    }
 
-        return $this;
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withFormatDirs()')]
+    public function setFormatDirs(array $list): self
+    {
+        return $this->withFormatDirs($list);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableAsserts()')]
+    public function setEnableAsserts(bool $flag): self
+    {
+        return $this->withEnableAsserts($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withWarnDeprecations()')]
+    public function setWarnDeprecations(bool $flag): self
+    {
+        return $this->withWarnDeprecations($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableNamespaceCache()')]
+    public function setEnableNamespaceCache(bool $flag): self
+    {
+        return $this->withEnableNamespaceCache($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withEnableCompiledCodeCache()')]
+    public function setEnableCompiledCodeCache(bool $flag): self
+    {
+        return $this->withEnableCompiledCodeCache($flag);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withPhelDir()')]
+    public function setPhelDir(string $dir): self
+    {
+        return $this->withPhelDir($dir);
     }
 
     // ========================================
@@ -528,6 +606,37 @@ final class PhelConfig implements JsonSerializable
             self::CACHE_DIR => $this->cacheDir,
             self::PHEL_DIR => $this->phelDir,
         ];
+    }
+
+    /**
+     * Returns a new instance with the supplied fields overridden. Internal
+     * plumbing for every `with*()` method — keeps each wither one line.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function with(array $overrides): self
+    {
+        $base = [
+            'srcDirs' => $this->srcDirs,
+            'testDirs' => $this->testDirs,
+            'vendorDir' => $this->vendorDir,
+            'errorLogFile' => $this->errorLogFile,
+            'exportConfig' => $this->exportConfig,
+            'buildConfig' => $this->buildConfig,
+            'ignoreWhenBuilding' => $this->ignoreWhenBuilding,
+            'noCacheWhenBuilding' => $this->noCacheWhenBuilding,
+            'keepGeneratedTempFiles' => $this->keepGeneratedTempFiles,
+            'tempDir' => $this->tempDir,
+            'cacheDir' => $this->cacheDir,
+            'formatDirs' => $this->formatDirs,
+            'enableAsserts' => $this->enableAsserts,
+            'warnDeprecations' => $this->warnDeprecations,
+            'enableNamespaceCache' => $this->enableNamespaceCache,
+            'enableCompiledCodeCache' => $this->enableCompiledCodeCache,
+            'phelDir' => $this->phelDir,
+        ];
+
+        return new self(...[...$base, ...$overrides]);
     }
 
     /**

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -350,7 +350,7 @@ final readonly class PhelConfig implements JsonSerializable
         return $this->with(['noCacheWhenBuilding' => $list]);
     }
 
-    public function withKeepGeneratedTempFiles(bool $flag): self
+    public function withKeepGeneratedTempFiles(bool $flag = true): self
     {
         return $this->with(['keepGeneratedTempFiles' => $flag]);
     }
@@ -373,22 +373,22 @@ final readonly class PhelConfig implements JsonSerializable
         return $this->with(['formatDirs' => $list]);
     }
 
-    public function withEnableAsserts(bool $flag): self
+    public function withEnableAsserts(bool $flag = true): self
     {
         return $this->with(['enableAsserts' => $flag]);
     }
 
-    public function withWarnDeprecations(bool $flag): self
+    public function withWarnDeprecations(bool $flag = true): self
     {
         return $this->with(['warnDeprecations' => $flag]);
     }
 
-    public function withEnableNamespaceCache(bool $flag): self
+    public function withEnableNamespaceCache(bool $flag = true): self
     {
         return $this->with(['enableNamespaceCache' => $flag]);
     }
 
-    public function withEnableCompiledCodeCache(bool $flag): self
+    public function withEnableCompiledCodeCache(bool $flag = true): self
     {
         return $this->with(['enableCompiledCodeCache' => $flag]);
     }

--- a/src/php/Config/PhelConfig.php
+++ b/src/php/Config/PhelConfig.php
@@ -609,13 +609,34 @@ final readonly class PhelConfig implements JsonSerializable
     }
 
     /**
-     * Returns a new instance with the supplied fields overridden.
+     * Returns a new instance with the supplied fields overridden. Internal
+     * plumbing for every `with*()` method — keeps each wither one line.
      *
      * @param array<string, mixed> $overrides
      */
     private function with(array $overrides): self
     {
-        return new self(...[...get_object_vars($this), ...$overrides]);
+        $base = [
+            'srcDirs' => $this->srcDirs,
+            'testDirs' => $this->testDirs,
+            'vendorDir' => $this->vendorDir,
+            'errorLogFile' => $this->errorLogFile,
+            'exportConfig' => $this->exportConfig,
+            'buildConfig' => $this->buildConfig,
+            'ignoreWhenBuilding' => $this->ignoreWhenBuilding,
+            'noCacheWhenBuilding' => $this->noCacheWhenBuilding,
+            'keepGeneratedTempFiles' => $this->keepGeneratedTempFiles,
+            'tempDir' => $this->tempDir,
+            'cacheDir' => $this->cacheDir,
+            'formatDirs' => $this->formatDirs,
+            'enableAsserts' => $this->enableAsserts,
+            'warnDeprecations' => $this->warnDeprecations,
+            'enableNamespaceCache' => $this->enableNamespaceCache,
+            'enableCompiledCodeCache' => $this->enableCompiledCodeCache,
+            'phelDir' => $this->phelDir,
+        ];
+
+        return new self(...[...$base, ...$overrides]);
     }
 
     /**

--- a/src/php/Config/PhelExportConfig.php
+++ b/src/php/Config/PhelExportConfig.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Config;
 
+use Deprecated;
 use JsonSerializable;
 
-final class PhelExportConfig implements JsonSerializable
+final readonly class PhelExportConfig implements JsonSerializable
 {
     public const string FROM_DIRECTORIES = 'from-directories';
 
@@ -14,35 +15,52 @@ final class PhelExportConfig implements JsonSerializable
 
     public const string TARGET_DIRECTORY = 'target-directory';
 
-    /** @var list<string> */
-    private array $fromDirectories = ['src'];
-
-    private string $namespacePrefix = 'PhelGenerated';
-
-    private string $targetDirectory = 'src/PhelGenerated';
+    /**
+     * @param list<string> $fromDirectories
+     */
+    public function __construct(
+        public array $fromDirectories = ['src'],
+        public string $namespacePrefix = 'PhelGenerated',
+        public string $targetDirectory = 'src/PhelGenerated',
+    ) {}
 
     /**
      * @param list<string> $list
      */
+    public function withFromDirectories(array $list): self
+    {
+        return new self($list, $this->namespacePrefix, $this->targetDirectory);
+    }
+
+    /**
+     * @param list<string> $list
+     */
+    #[Deprecated(message: 'since 0.37, use withFromDirectories()')]
     public function setFromDirectories(array $list): self
     {
-        $this->fromDirectories = $list;
-
-        return $this;
+        return $this->withFromDirectories($list);
     }
 
+    public function withNamespacePrefix(string $prefix): self
+    {
+        return new self($this->fromDirectories, $prefix, $this->targetDirectory);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withNamespacePrefix()')]
     public function setNamespacePrefix(string $prefix): self
     {
-        $this->namespacePrefix = $prefix;
-
-        return $this;
+        return $this->withNamespacePrefix($prefix);
     }
 
+    public function withTargetDirectory(string $dir): self
+    {
+        return new self($this->fromDirectories, $this->namespacePrefix, $dir);
+    }
+
+    #[Deprecated(message: 'since 0.37, use withTargetDirectory()')]
     public function setTargetDirectory(string $dir): self
     {
-        $this->targetDirectory = $dir;
-
-        return $this;
+        return $this->withTargetDirectory($dir);
     }
 
     /**

--- a/src/php/Phel.php
+++ b/src/php/Phel.php
@@ -114,13 +114,13 @@ class Phel
 
         // Determine layout based on detected structure
         if ($hasSrcPhel || $hasTestsPhel) {
-            $config->useLayout(ProjectLayout::Nested);
+            $config = $config->withLayout(ProjectLayout::Nested);
         } elseif ($hasSrc || $hasTests) {
-            $config->useLayout(ProjectLayout::Flat);
+            $config = $config->withLayout(ProjectLayout::Flat);
         }
 
         if ($hasVendor) {
-            $config->setVendorDir('vendor');
+            return $config->withVendorDir('vendor');
         }
 
         return $config;

--- a/tests/php/Integration/Build/Command/phel-config-load-e2e.php
+++ b/tests/php/Integration/Build/Command/phel-config-load-e2e.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs([__DIR__ . '/src-load-e2e'])
-    ->setVendorDir('')
-    ->setBuildConfig(new PhelBuildConfig()
-        ->setMainPhelNamespace('loade2e\core')
-        ->setMainPhpPath('out-load-e2e/main.php')
-        ->setDestDir('out-load-e2e'))
-    ->setIgnoreWhenBuilding([])
-;
+    ->withSrcDirs([__DIR__ . '/src-load-e2e'])
+    ->withVendorDir('')
+    ->withMainPhelNamespace('loade2e\core')
+    ->withMainPhpPath('out-load-e2e/main.php')
+    ->withBuildDestDir('out-load-e2e')
+    ->withIgnoreWhenBuilding([]);

--- a/tests/php/Integration/Build/Command/phel-config-no-namespace.php
+++ b/tests/php/Integration/Build/Command/phel-config-no-namespace.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs([__DIR__ . '/../'])
-    ->setVendorDir('')
-    ->setBuildConfig(new PhelBuildConfig()
-        ->setDestDir('out'))
-    ->setIgnoreWhenBuilding(['local.phel', 'failing.phel'])
-;
+    ->withSrcDirs([__DIR__ . '/../'])
+    ->withVendorDir('')
+    ->withBuildDestDir('out')
+    ->withIgnoreWhenBuilding(['local.phel', 'failing.phel']);

--- a/tests/php/Integration/Build/Command/phel-config.php
+++ b/tests/php/Integration/Build/Command/phel-config.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs([__DIR__ . '/src'])
-    ->setVendorDir('')
-    ->setBuildConfig(new PhelBuildConfig()
-        ->setMainPhelNamespace('test-ns\hello')
-        ->setMainPhpPath('out/main.php'))
-    ->setIgnoreWhenBuilding(['local.phel', 'failing.phel'])
-    ->setNoCacheWhenBuilding(['no-cache.phel'])
-;
+    ->withSrcDirs([__DIR__ . '/src'])
+    ->withVendorDir('')
+    ->withMainPhelNamespace('test-ns\hello')
+    ->withMainPhpPath('out/main.php')
+    ->withIgnoreWhenBuilding(['local.phel', 'failing.phel'])
+    ->withNoCacheWhenBuilding(['no-cache.phel']);

--- a/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/phel-config.php
+++ b/tests/php/Integration/Command/Domain/DirectoryFinder/testing-vendor/root-1/root-3/phel-config.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs(['custom-src-3']);
+    ->withSrcDirs(['custom-src-3']);

--- a/tests/php/Integration/Interop/Command/Export/phel-config.php
+++ b/tests/php/Integration/Interop/Command/Export/phel-config.php
@@ -3,11 +3,9 @@
 declare(strict_types=1);
 
 use Phel\Config\PhelConfig;
-use Phel\Config\PhelExportConfig;
 
 return new PhelConfig()
-    ->setSrcDirs([__DIR__ . '/src'])
-    ->setExportConfig(new PhelExportConfig()
-        ->setFromDirectories(['src'])
-        ->setNamespacePrefix('PhelTest\Integration\Interop\Command\Export\PhelGenerated')
-        ->setTargetDirectory(__DIR__ . '/PhelGenerated'));
+    ->withSrcDirs([__DIR__ . '/src'])
+    ->withExportFromDirectories(['src'])
+    ->withExportNamespacePrefix('PhelTest\Integration\Interop\Command\Export\PhelGenerated')
+    ->withExportTargetDirectory(__DIR__ . '/PhelGenerated');

--- a/tests/php/Integration/Run/Command/Repl/config/phel-config.php
+++ b/tests/php/Integration/Run/Command/Repl/config/phel-config.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-return [
-    'src-dirs' => [
-        '../../../../../../src/phel/',
-    ],
-    'test-dirs' => [],
-    'vendor-dir' => 'vendor',
-];
+use Phel\Config\PhelConfig;
+
+return new PhelConfig()
+    ->withSrcDirs(['../../../../../../../src/phel/'])
+    ->withTestDirs(['Fixtures'])
+    ->withVendorDir('')
+    ->withErrorLogFile('data/error.log');

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/config/phel-config.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectFailure/config/phel-config.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs(['../../../../../../../src/phel/'])
-    ->setTestDirs(['Fixtures'])
-    ->setVendorDir('')
-    ->setErrorLogFile('data/error.log')
-;
+    ->withSrcDirs(['../../../../../../../src/phel/'])
+    ->withTestDirs(['Fixtures'])
+    ->withVendorDir('')
+    ->withErrorLogFile('data/error.log');

--- a/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/config/phel-config.php
+++ b/tests/php/Integration/Run/Command/Test/TestCommandProjectSuccess/config/phel-config.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 use Phel\Config\PhelConfig;
 
 return new PhelConfig()
-    ->setSrcDirs(['../../../../../../../src/phel/'])
-    ->setTestDirs(['Fixtures'])
-    ->setVendorDir('')
-    ->setErrorLogFile('data/error.log')
-;
+    ->withSrcDirs(['../../../../../../../src/phel/'])
+    ->withTestDirs(['Fixtures'])
+    ->withVendorDir('')
+    ->withErrorLogFile('data/error.log');

--- a/tests/php/Unit/Build/Domain/Compile/Output/EntryPointPhpFileTest.php
+++ b/tests/php/Unit/Build/Domain/Compile/Output/EntryPointPhpFileTest.php
@@ -28,9 +28,10 @@ final class EntryPointPhpFileTest extends TestCase
 
     public function test_multi_segment_namespace_points_at_nested_path(): void
     {
-        $buildConfig = new PhelBuildConfig()
-            ->setMainPhelNamespace('cli-skeleton.main')
-            ->setMainPhpPath('out/main.php');
+        $buildConfig = new PhelBuildConfig(
+            mainPhelNamespace: 'cli-skeleton.main',
+            mainPhpPath: 'out/main.php',
+        );
 
         $entry = new EntryPointPhpFile(
             $buildConfig,

--- a/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelBuildConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Config;
 
 use Phel\Config\PhelBuildConfig;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 final class PhelBuildConfigTest extends TestCase
@@ -23,10 +24,28 @@ final class PhelBuildConfigTest extends TestCase
         self::assertSame($expected, $config->jsonSerialize());
     }
 
+    public function test_named_arg_constructor(): void
+    {
+        $config = new PhelBuildConfig(
+            mainPhelNamespace: 'test-ns/boot',
+            mainPhpPath: 'custom/index.php',
+            destDir: 'custom',
+        );
+
+        $expected = [
+            PhelBuildConfig::MAIN_PHEL_NAMESPACE => 'test-ns/boot',
+            PhelBuildConfig::DEST_DIR => 'custom',
+            PhelBuildConfig::MAIN_PHP_FILENAME => 'index.php',
+            PhelBuildConfig::MAIN_PHP_PATH => 'custom/index.php',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
     public function test_defined_phel_ns(): void
     {
         $config = new PhelBuildConfig()
-            ->setMainPhelNamespace('test-ns/boot');
+            ->withMainPhelNamespace('test-ns/boot');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => 'test-ns/boot',
@@ -41,7 +60,7 @@ final class PhelBuildConfigTest extends TestCase
     public function test_dest_dir(): void
     {
         $config = new PhelBuildConfig()
-            ->setDestDir('custom-out');
+            ->withDestDir('custom-out');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -56,8 +75,8 @@ final class PhelBuildConfigTest extends TestCase
     public function test_dest_dir_and_main_php_path(): void
     {
         $config = new PhelBuildConfig()
-            ->setDestDir('custom-out')
-            ->setMainPhpPath('custom-out/custom-index.php');
+            ->withDestDir('custom-out')
+            ->withMainPhpPath('custom-out/custom-index.php');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -72,22 +91,7 @@ final class PhelBuildConfigTest extends TestCase
     public function test_main_php_path_takes_precedence(): void
     {
         $config = new PhelBuildConfig()
-            ->setMainPhpPath('custom-out/custom-index.php');
-
-        $expected = [
-            PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
-            PhelBuildConfig::DEST_DIR => 'custom-out',
-            PhelBuildConfig::MAIN_PHP_FILENAME => 'custom-index.php',
-            PhelBuildConfig::MAIN_PHP_PATH => 'custom-out/custom-index.php',
-        ];
-
-        self::assertSame($expected, $config->jsonSerialize());
-    }
-
-    public function test_main_php_path(): void
-    {
-        $config = new PhelBuildConfig()
-            ->setMainPhpPath('custom-out/custom-index.php');
+            ->withMainPhpPath('custom-out/custom-index.php');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -102,7 +106,7 @@ final class PhelBuildConfigTest extends TestCase
     public function test_main_php_path_without_ext(): void
     {
         $config = new PhelBuildConfig()
-            ->setMainPhpPath('custom-flip');
+            ->withMainPhpPath('custom-flip');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -117,7 +121,7 @@ final class PhelBuildConfigTest extends TestCase
     public function test_main_php_path_bug_when_not_dir_defined(): void
     {
         $config = new PhelBuildConfig()
-            ->setMainPhpPath('custom-index');
+            ->withMainPhpPath('custom-index');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -132,7 +136,7 @@ final class PhelBuildConfigTest extends TestCase
     public function test_main_php_path_bug_when_nested_dir_defined(): void
     {
         $config = new PhelBuildConfig()
-            ->setMainPhpPath('custom-dir1/dir2/custom-index');
+            ->withMainPhpPath('custom-dir1/dir2/custom-index');
 
         $expected = [
             PhelBuildConfig::MAIN_PHEL_NAMESPACE => '',
@@ -142,5 +146,32 @@ final class PhelBuildConfigTest extends TestCase
         ];
 
         self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_with_methods_are_immutable(): void
+    {
+        $original = new PhelBuildConfig();
+        $updated = $original->withMainPhelNamespace('app\\core');
+
+        self::assertNotSame($original, $updated);
+        self::assertSame('', $original->getMainPhelNamespace());
+        self::assertSame('app\\core', $updated->getMainPhelNamespace());
+    }
+
+    #[Group('deprecated')]
+    public function test_deprecated_setters_still_work(): void
+    {
+        /** @psalm-suppress DeprecatedMethod */
+        $legacy = new PhelBuildConfig()
+            ->setMainPhelNamespace('app\\boot')
+            ->setMainPhpPath('dist/main.php')
+            ->setDestDir('dist');
+
+        $modern = new PhelBuildConfig()
+            ->withMainPhelNamespace('app\\boot')
+            ->withMainPhpPath('dist/main.php')
+            ->withDestDir('dist');
+
+        self::assertSame($modern->jsonSerialize(), $legacy->jsonSerialize());
     }
 }

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -8,6 +8,7 @@ use Phel\Config\PhelBuildConfig;
 use Phel\Config\PhelConfig;
 use Phel\Config\PhelExportConfig;
 use Phel\Config\ProjectLayout;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 final class PhelConfigTest extends TestCase
@@ -147,9 +148,9 @@ final class PhelConfigTest extends TestCase
         }
     }
 
-    public function test_use_flat_layout(): void
+    public function test_with_layout_flat(): void
     {
-        $config = new PhelConfig()->useFlatLayout();
+        $config = new PhelConfig()->withLayout(ProjectLayout::Flat);
 
         $serialized = $config->jsonSerialize();
 
@@ -159,9 +160,9 @@ final class PhelConfigTest extends TestCase
         self::assertSame(['src'], $serialized[PhelConfig::EXPORT_CONFIG][PhelExportConfig::FROM_DIRECTORIES]);
     }
 
-    public function test_use_nested_layout(): void
+    public function test_with_layout_nested(): void
     {
-        $config = new PhelConfig()->useFlatLayout()->useNestedLayout();
+        $config = new PhelConfig()->withLayout(ProjectLayout::Nested);
 
         $serialized = $config->jsonSerialize();
 
@@ -171,12 +172,12 @@ final class PhelConfigTest extends TestCase
         self::assertSame(['src/phel'], $serialized[PhelConfig::EXPORT_CONFIG][PhelExportConfig::FROM_DIRECTORIES]);
     }
 
-    public function test_direct_setters_for_build_config(): void
+    public function test_with_main_phel_namespace_sets_default_php_path(): void
     {
         $config = new PhelConfig()
-            ->setMainPhelNamespace('my-app\\main')
-            ->setMainPhpPath('build/app.php')
-            ->setBuildDestDir('build');
+            ->withMainPhelNamespace('my-app\\main')
+            ->withMainPhpPath('build/app.php')
+            ->withBuildDestDir('build');
 
         $serialized = $config->jsonSerialize();
 
@@ -185,12 +186,12 @@ final class PhelConfigTest extends TestCase
         self::assertSame('build', $serialized[PhelConfig::BUILD_CONFIG][PhelBuildConfig::DEST_DIR]);
     }
 
-    public function test_direct_setters_for_export_config(): void
+    public function test_with_export_proxy_methods(): void
     {
         $config = new PhelConfig()
-            ->setExportNamespacePrefix('MyGenerated')
-            ->setExportTargetDirectory('generated')
-            ->setExportFromDirectories(['lib/phel']);
+            ->withExportNamespacePrefix('MyGenerated')
+            ->withExportTargetDirectory('generated')
+            ->withExportFromDirectories(['lib/phel']);
 
         $serialized = $config->jsonSerialize();
 
@@ -199,28 +200,26 @@ final class PhelConfigTest extends TestCase
         self::assertSame(['lib/phel'], $serialized[PhelConfig::EXPORT_CONFIG][PhelExportConfig::FROM_DIRECTORIES]);
     }
 
-    public function test_custom_json_serialize(): void
+    public function test_custom_json_serialize_with_immutable_api(): void
     {
         $config = new PhelConfig()
-            ->setSrcDirs(['some/directory'])
-            ->setTestDirs(['another/directory'])
-            ->setVendorDir('vendor')
-            ->setErrorLogFile('error-log.file')
-            ->setBuildConfig(new PhelBuildConfig()
-                ->setMainPhpPath('out/custom-index.php')
-                ->setMainPhelNamespace('test-ns/boot'))
-            ->setExportConfig(new PhelExportConfig()
-                ->setFromDirectories(['some/other/dir'])
-                ->setNamespacePrefix('Generated')
-                ->setTargetDirectory('src/Generated'))
-            ->setIgnoreWhenBuilding(['src/ignore.me'])
-            ->setNoCacheWhenBuilding(['should-not-be-cached'])
-            ->setKeepGeneratedTempFiles(true)
-            ->setTempDir('/tmp/custom')
-            ->setFormatDirs(['src', 'tests', 'phel'])
-            ->setEnableAsserts(false)
-            ->setWarnDeprecations(true)
-            ->setCacheDir('.cache');
+            ->withSrcDirs(['some/directory'])
+            ->withTestDirs(['another/directory'])
+            ->withVendorDir('vendor')
+            ->withErrorLogFile('error-log.file')
+            ->withMainPhelNamespace('test-ns/boot')
+            ->withMainPhpPath('out/custom-index.php')
+            ->withExportFromDirectories(['some/other/dir'])
+            ->withExportNamespacePrefix('Generated')
+            ->withExportTargetDirectory('src/Generated')
+            ->withIgnoreWhenBuilding(['src/ignore.me'])
+            ->withNoCacheWhenBuilding(['should-not-be-cached'])
+            ->withKeepGeneratedTempFiles(true)
+            ->withTempDir('/tmp/custom')
+            ->withFormatDirs(['src', 'tests', 'phel'])
+            ->withEnableAsserts(false)
+            ->withWarnDeprecations(true)
+            ->withCacheDir('.cache');
 
         $expected = [
             PhelConfig::SRC_DIRS => ['some/directory'],
@@ -254,13 +253,58 @@ final class PhelConfigTest extends TestCase
         self::assertSame($expected, $config->jsonSerialize());
     }
 
-    public function test_set_phel_dir_persists_in_json(): void
+    public function test_with_phel_dir_persists_in_json(): void
     {
-        $config = new PhelConfig();
-        $config->setPhelDir('/var/cache/phel');
+        $config = new PhelConfig()->withPhelDir('/var/cache/phel');
 
         self::assertSame('/var/cache/phel', $config->getPhelDir());
         self::assertSame('/var/cache/phel', $config->jsonSerialize()[PhelConfig::PHEL_DIR]);
+    }
+
+    public function test_with_methods_return_new_instance(): void
+    {
+        $original = new PhelConfig();
+        $updated = $original->withVendorDir('custom-vendor');
+
+        self::assertNotSame($original, $updated);
+        self::assertSame('vendor', $original->getVendorDir());
+        self::assertSame('custom-vendor', $updated->getVendorDir());
+    }
+
+    public function test_immutability_of_build_config_via_proxy(): void
+    {
+        $original = new PhelConfig();
+        $updated = $original->withMainPhelNamespace('app\\boot');
+
+        self::assertNotSame($original, $updated);
+        self::assertNotSame($original->getBuildConfig(), $updated->getBuildConfig());
+        self::assertSame('', $original->getBuildConfig()->getMainPhelNamespace());
+        self::assertSame('app\\boot', $updated->getBuildConfig()->getMainPhelNamespace());
+    }
+
+    public function test_with_build_config_replaces_whole_value_object(): void
+    {
+        $build = new PhelBuildConfig(
+            mainPhelNamespace: 'lib\\entry',
+            mainPhpPath: 'dist/app.php',
+        );
+
+        $config = new PhelConfig()->withBuildConfig($build);
+
+        self::assertSame($build, $config->getBuildConfig());
+    }
+
+    public function test_with_export_config_replaces_whole_value_object(): void
+    {
+        $export = new PhelExportConfig(
+            fromDirectories: ['lib'],
+            namespacePrefix: 'Generated',
+            targetDirectory: 'gen',
+        );
+
+        $config = new PhelConfig()->withExportConfig($export);
+
+        self::assertSame($export, $config->getExportConfig());
     }
 
     public function test_getters(): void
@@ -285,18 +329,16 @@ final class PhelConfigTest extends TestCase
 
     public function test_validate_passes_for_relative_paths(): void
     {
-        $config = new PhelConfig();
-        $errors = $config->validate();
+        $errors = new PhelConfig()->validate();
 
         self::assertSame([], $errors);
     }
 
     public function test_validate_fails_for_absolute_src_dir(): void
     {
-        $config = new PhelConfig();
-        $config->setSrcDirs(['/absolute/path']);
-
-        $errors = $config->validate();
+        $errors = new PhelConfig()
+            ->withSrcDirs(['/absolute/path'])
+            ->validate();
 
         self::assertCount(1, $errors);
         self::assertStringContainsString('should be relative', $errors[0]);
@@ -304,10 +346,9 @@ final class PhelConfigTest extends TestCase
 
     public function test_validate_fails_for_absolute_test_dir(): void
     {
-        $config = new PhelConfig();
-        $config->setTestDirs(['/absolute/tests']);
-
-        $errors = $config->validate();
+        $errors = new PhelConfig()
+            ->withTestDirs(['/absolute/tests'])
+            ->validate();
 
         self::assertCount(1, $errors);
         self::assertStringContainsString('Test directory', $errors[0]);
@@ -315,10 +356,9 @@ final class PhelConfigTest extends TestCase
 
     public function test_validate_fails_for_absolute_vendor_dir(): void
     {
-        $config = new PhelConfig();
-        $config->setVendorDir('/absolute/vendor');
-
-        $errors = $config->validate();
+        $errors = new PhelConfig()
+            ->withVendorDir('/absolute/vendor')
+            ->validate();
 
         self::assertCount(1, $errors);
         self::assertStringContainsString('Vendor directory', $errors[0]);
@@ -326,9 +366,7 @@ final class PhelConfigTest extends TestCase
 
     public function test_temp_dir_default_lives_under_system_temp(): void
     {
-        $config = new PhelConfig();
-
-        $tempDir = $config->getTempDir();
+        $tempDir = new PhelConfig()->getTempDir();
 
         self::assertStringContainsString('/phel/', $tempDir);
         self::assertStringEndsWith('/tmp', $tempDir);
@@ -336,8 +374,55 @@ final class PhelConfigTest extends TestCase
 
     public function test_cache_dir_default_is_relative_to_project_root(): void
     {
-        $config = new PhelConfig();
+        self::assertSame('.phel/cache', new PhelConfig()->getCacheDir());
+    }
 
-        self::assertSame('.phel/cache', $config->getCacheDir());
+    #[Group('deprecated')]
+    public function test_deprecated_setters_still_produce_equivalent_output(): void
+    {
+        /** @psalm-suppress DeprecatedMethod */
+        $legacy = new PhelConfig()
+            ->setSrcDirs(['lib'])
+            ->setVendorDir('vendor-x')
+            ->setBuildConfig(new PhelBuildConfig()
+                ->setMainPhelNamespace('app\\boot')
+                ->setMainPhpPath('dist/app.php'))
+            ->setExportConfig(new PhelExportConfig()
+                ->setFromDirectories(['lib'])
+                ->setNamespacePrefix('Gen')
+                ->setTargetDirectory('gen'))
+            ->setIgnoreWhenBuilding(['skip.phel'])
+            ->setEnableAsserts(false);
+
+        $modern = new PhelConfig()
+            ->withSrcDirs(['lib'])
+            ->withVendorDir('vendor-x')
+            ->withMainPhelNamespace('app\\boot')
+            ->withMainPhpPath('dist/app.php')
+            ->withExportFromDirectories(['lib'])
+            ->withExportNamespacePrefix('Gen')
+            ->withExportTargetDirectory('gen')
+            ->withIgnoreWhenBuilding(['skip.phel'])
+            ->withEnableAsserts(false);
+
+        self::assertSame($modern->jsonSerialize(), $legacy->jsonSerialize());
+    }
+
+    #[Group('deprecated')]
+    public function test_deprecated_layout_shortcuts_match_with_layout(): void
+    {
+        /** @psalm-suppress DeprecatedMethod */
+        $legacyFlat = new PhelConfig()->useFlatLayout();
+        /** @psalm-suppress DeprecatedMethod */
+        $legacyNested = new PhelConfig()->useNestedLayout();
+
+        self::assertSame(
+            new PhelConfig()->withLayout(ProjectLayout::Flat)->jsonSerialize(),
+            $legacyFlat->jsonSerialize(),
+        );
+        self::assertSame(
+            new PhelConfig()->withLayout(ProjectLayout::Nested)->jsonSerialize(),
+            $legacyNested->jsonSerialize(),
+        );
     }
 }

--- a/tests/php/Unit/Compiler/Config/PhelConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelConfigTest.php
@@ -253,6 +253,22 @@ final class PhelConfigTest extends TestCase
         self::assertSame($expected, $config->jsonSerialize());
     }
 
+    public function test_boolean_withers_default_to_true(): void
+    {
+        $config = new PhelConfig()
+            ->withWarnDeprecations()
+            ->withKeepGeneratedTempFiles()
+            ->withEnableAsserts(false)
+            ->withEnableNamespaceCache(false)
+            ->withEnableCompiledCodeCache(false);
+
+        self::assertTrue($config->shouldWarnDeprecations());
+        self::assertTrue($config->getKeepGeneratedTempFiles());
+        self::assertFalse($config->isAssertsEnabled());
+        self::assertFalse($config->isNamespaceCacheEnabled());
+        self::assertFalse($config->isCompiledCodeCacheEnabled());
+    }
+
     public function test_with_phel_dir_persists_in_json(): void
     {
         $config = new PhelConfig()->withPhelDir('/var/cache/phel');

--- a/tests/php/Unit/Compiler/Config/PhelExportConfigTest.php
+++ b/tests/php/Unit/Compiler/Config/PhelExportConfigTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Config;
+
+use Phel\Config\PhelExportConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+final class PhelExportConfigTest extends TestCase
+{
+    public function test_default(): void
+    {
+        $config = new PhelExportConfig();
+
+        $expected = [
+            PhelExportConfig::TARGET_DIRECTORY => 'src/PhelGenerated',
+            PhelExportConfig::FROM_DIRECTORIES => ['src'],
+            PhelExportConfig::NAMESPACE_PREFIX => 'PhelGenerated',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    public function test_named_arg_constructor(): void
+    {
+        $config = new PhelExportConfig(
+            fromDirectories: ['lib'],
+            namespacePrefix: 'MyGen',
+            targetDirectory: 'gen',
+        );
+
+        self::assertSame(['lib'], $config->fromDirectories);
+        self::assertSame('MyGen', $config->namespacePrefix);
+        self::assertSame('gen', $config->targetDirectory);
+    }
+
+    public function test_with_methods_are_immutable(): void
+    {
+        $original = new PhelExportConfig();
+        $updated = $original->withNamespacePrefix('MyGen');
+
+        self::assertNotSame($original, $updated);
+        self::assertSame('PhelGenerated', $original->namespacePrefix);
+        self::assertSame('MyGen', $updated->namespacePrefix);
+    }
+
+    public function test_with_methods_chain(): void
+    {
+        $config = new PhelExportConfig()
+            ->withFromDirectories(['lib/phel'])
+            ->withNamespacePrefix('Generated')
+            ->withTargetDirectory('out');
+
+        $expected = [
+            PhelExportConfig::TARGET_DIRECTORY => 'out',
+            PhelExportConfig::FROM_DIRECTORIES => ['lib/phel'],
+            PhelExportConfig::NAMESPACE_PREFIX => 'Generated',
+        ];
+
+        self::assertSame($expected, $config->jsonSerialize());
+    }
+
+    #[Group('deprecated')]
+    public function test_deprecated_setters_still_work(): void
+    {
+        /** @psalm-suppress DeprecatedMethod */
+        $legacy = new PhelExportConfig()
+            ->setFromDirectories(['lib'])
+            ->setNamespacePrefix('Gen')
+            ->setTargetDirectory('out');
+
+        $modern = new PhelExportConfig()
+            ->withFromDirectories(['lib'])
+            ->withNamespacePrefix('Gen')
+            ->withTargetDirectory('out');
+
+        self::assertSame($modern->jsonSerialize(), $legacy->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel-config.php` had a clunky setter API. Highlights: ~30 mutating `setX()` methods, nested `->setBuildConfig(new PhelBuildConfig()->setMainPhelNamespace(...)->setMainPhpPath(...))` construction at the call site, and six partial "convenience setters" already trying to flatten the build/export surface.

## 💡 Goal

Single fluent `withX()` chain on `PhelConfig`, immutable internals, no nested `new` at the call site. Legacy `setX()` and layout shortcuts stay as `#[Deprecated]` shims so existing `phel-config.php` files keep working until removed in a future major.

```php
return PhelConfig::forProject('test-ns\hello')
    ->withSrcDirs([__DIR__ . '/src'])
    ->withVendorDir('')
    ->withMainPhpPath('out/main.php')
    ->withIgnoreWhenBuilding(['local.phel', 'failing.phel']);
```

## 🔖 Changes

- `PhelConfig`, `PhelBuildConfig`, `PhelExportConfig` are now `final readonly`. Every field has a sibling `withX()` returning a new instance.
- Build and export fields flat on `PhelConfig`: `withMainPhelNamespace()`, `withMainPhpPath()`, `withBuildDestDir()`, `withExportNamespacePrefix()`, `withExportTargetDirectory()`, `withExportFromDirectories()`. `withBuildConfig()` / `withExportConfig()` keep the "drop in a pre-built value object" escape hatch.
- `withLayout(ProjectLayout)` replaces `useLayout()`; `useNestedLayout()` / `useFlatLayout()` shortcuts kept as deprecated shims.
- All legacy `setX()` / `useX()` carry `#[Deprecated(message: 'since 0.37, use withX()')]` and delegate. Removal is a mechanical sweep.
- `PhelBuildConfig` / `PhelExportConfig` gain named-arg constructors.
- `jsonSerialize()` wire shape unchanged: Gacela's `AbstractConfig::get()` consumes the same kebab-case keys.
- Latent bugs fixed in `BuildConfig::getPhelBuildConfig()` and `Phel::detectProjectStructure()` (both were relying on mutating-by-reference setters).
- Root `phel-config.php` and 8 integration fixtures rewritten with `withX()` chains.
- Unit tests rewritten around `withX()` plus immutability and named-arg coverage; new `PhelExportConfigTest`. One deprecated-parity test per class confirms legacy `setX()` chains produce identical `jsonSerialize()` output.
- `CHANGELOG.md`, `src/php/Config/CLAUDE.md`, `docs/framework-integration.md`, `docs/project-layout.md`, `docs/migration/backslash-to-dot.md` updated to the new API.