### PR TITLE
fix(command): map compiled PHP errors back to Phel source

### DIFF
--- a/phel-config.php
+++ b/phel-config.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 use Phel\Config\PhelConfig;
 use Phel\Config\ProjectLayout;
 
-return PhelConfig::forProject('phel\core', ProjectLayout::Nested)
+return PhelConfig::forProject('phel.core', ProjectLayout::Nested)
     ->withIgnoreWhenBuilding(['src/phel/local.phel']);

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -22,43 +22,17 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
         private ExceptionPrinterInterface $exceptionPrinter,
         private ErrorLogInterface $errorLog,
         private FilePositionExtractorInterface $filePositionExtractor,
+        private string $staleOutputHint,
     ) {}
 
-    public function writeStackTrace(
-        OutputInterface $output,
-        Throwable $e,
-    ): void {
+    public function writeStackTrace(OutputInterface $output, Throwable $e): void
+    {
         $cause = $e->getPrevious() ?? $e;
-        $message = $cause->getMessage();
-        $file = $cause->getFile();
-        $line = $cause->getLine();
 
-        if (str_contains($file, 'phel-lang/src')) {
-            $output->writeln($message);
-            $this->errorLog->writeln($this->getStackTraceString($e));
-            return;
-        }
-
-        $output->writeln($message);
-
-        if (str_ends_with($file, '.php')) {
-            $position = $this->filePositionExtractor->getOriginal($file, $line);
-            $resolvedToPhel = $position->filename() !== $file;
-
-            if ($resolvedToPhel) {
-                $output->writeln(sprintf(
-                    '  at %s:%d (compiled: %s:%d)',
-                    $position->filename(),
-                    $position->line(),
-                    $file,
-                    $line,
-                ));
-            } else {
-                $output->writeln(sprintf('  at %s:%d', $file, $line));
-                $output->writeln('  hint: stale compiled output? try `rm -rf out/ .phel/cache/` and rebuild.');
-            }
+        if (str_contains($cause->getFile(), 'phel-lang/src')) {
+            $output->writeln($cause->getMessage());
         } else {
-            $output->writeln(sprintf('  at %s:%d', $file, $line));
+            $this->writeUserError($output, $cause);
         }
 
         $this->errorLog->writeln($this->getStackTraceString($e));
@@ -80,5 +54,30 @@ final readonly class CommandExceptionWriter implements CommandExceptionWriterInt
     public function getStackTraceString(Throwable $e): string
     {
         return $this->exceptionPrinter->getStackTraceString($e);
+    }
+
+    private function writeUserError(OutputInterface $output, Throwable $cause): void
+    {
+        $file = $cause->getFile();
+        $line = $cause->getLine();
+        $position = $this->filePositionExtractor->getOriginal($file, $line);
+
+        $output->writeln($cause->getMessage());
+
+        if ($position->filename() !== $file) {
+            $output->writeln(sprintf(
+                '  at %s:%d (compiled: %s:%d)',
+                $position->filename(),
+                $position->line(),
+                $file,
+                $line,
+            ));
+            return;
+        }
+
+        $output->writeln(sprintf('  at %s:%d', $file, $line));
+        if (str_ends_with($file, '.php')) {
+            $output->writeln('  hint: ' . $this->staleOutputHint);
+        }
     }
 }

--- a/src/php/Command/Application/CommandExceptionWriter.php
+++ b/src/php/Command/Application/CommandExceptionWriter.php
@@ -7,32 +7,58 @@ namespace Phel\Command\Application;
 use Phel\Command\Domain\CommandExceptionWriterInterface;
 use Phel\Command\Domain\ErrorLogInterface;
 use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
 use Phel\Compiler\Domain\Exceptions\AbstractLocatedException;
 use Phel\Compiler\Domain\Parser\ReadModel\CodeSnippet;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function sprintf;
+use function str_ends_with;
 
 final readonly class CommandExceptionWriter implements CommandExceptionWriterInterface
 {
     public function __construct(
         private ExceptionPrinterInterface $exceptionPrinter,
         private ErrorLogInterface $errorLog,
+        private FilePositionExtractorInterface $filePositionExtractor,
     ) {}
 
     public function writeStackTrace(
         OutputInterface $output,
         Throwable $e,
     ): void {
-        $message = $e->getPrevious()?->getMessage() ?? $e->getMessage();
-        $file = $e->getPrevious()?->getFile() ?? $e->getFile();
+        $cause = $e->getPrevious() ?? $e;
+        $message = $cause->getMessage();
+        $file = $cause->getFile();
+        $line = $cause->getLine();
 
-        if (!str_contains($file, 'phel-lang/src')) {
-            $output->writeln(sprintf('%s // file: %s', $message, $file));
-            $output->writeln('> Dont you see the file? Check your phel config got `KeepGeneratedTempFiles=true`');
-        } else {
+        if (str_contains($file, 'phel-lang/src')) {
             $output->writeln($message);
+            $this->errorLog->writeln($this->getStackTraceString($e));
+            return;
+        }
+
+        $output->writeln($message);
+
+        if (str_ends_with($file, '.php')) {
+            $position = $this->filePositionExtractor->getOriginal($file, $line);
+            $resolvedToPhel = $position->filename() !== $file;
+
+            if ($resolvedToPhel) {
+                $output->writeln(sprintf(
+                    '  at %s:%d (compiled: %s:%d)',
+                    $position->filename(),
+                    $position->line(),
+                    $file,
+                    $line,
+                ));
+            } else {
+                $output->writeln(sprintf('  at %s:%d', $file, $line));
+                $output->writeln('  hint: stale compiled output? try `rm -rf out/ .phel/cache/` and rebuild.');
+            }
+        } else {
+            $output->writeln(sprintf('  at %s:%d', $file, $line));
         }
 
         $this->errorLog->writeln($this->getStackTraceString($e));

--- a/src/php/Command/CommandConfig.php
+++ b/src/php/Command/CommandConfig.php
@@ -11,6 +11,7 @@ use Phel\Config\PhelConfig;
 use Phel\Filesystem\Application\PhelProjectDirectory;
 
 use function dirname;
+use function sprintf;
 
 final class CommandConfig extends AbstractConfig
 {
@@ -62,5 +63,27 @@ final class CommandConfig extends AbstractConfig
         $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
 
         return PhelProjectDirectory::resolve($this->getAppRootDir(), $path, $phelDir);
+    }
+
+    /**
+     * Recipe for clearing build state when compiled output is corrupted.
+     * Uses the configured output and state directories so the hint reflects
+     * the project's actual layout (`withBuildDestDir()`, `withCacheDir()`,
+     * `withPhelDir()`).
+     */
+    public function getStaleOutputHint(): string
+    {
+        $buildConfig = $this->get(PhelConfig::BUILD_CONFIG, []);
+        $outputDir = (string) ($buildConfig[PhelBuildConfig::DEST_DIR] ?? self::DEFAULT_OUTPUT_DIR);
+
+        $cacheDir = (string) $this->get(PhelConfig::CACHE_DIR, '.phel/cache');
+        $phelDir = (string) $this->get(PhelConfig::PHEL_DIR, '');
+        $resolvedCacheDir = PhelProjectDirectory::resolve($this->getAppRootDir(), $cacheDir, $phelDir);
+
+        return sprintf(
+            'stale compiled output? try `rm -rf %s %s` and rebuild.',
+            rtrim($outputDir, '/'),
+            rtrim($resolvedCacheDir, '/'),
+        );
     }
 }

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -32,6 +32,7 @@ final class CommandFactory extends AbstractFactory
         return new CommandExceptionWriter(
             $this->createExceptionPrinter(),
             new ErrorLog($this->getConfig()->getErrorLogFile()),
+            new FilePositionExtractor(new SourceMapExtractor()),
         );
     }
 

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -33,6 +33,7 @@ final class CommandFactory extends AbstractFactory
             $this->createExceptionPrinter(),
             new ErrorLog($this->getConfig()->getErrorLogFile()),
             new FilePositionExtractor(new SourceMapExtractor()),
+            $this->getConfig()->getStaleOutputHint(),
         );
     }
 

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Command\Application;
+
+use Phel\Command\Application\CommandExceptionWriter;
+use Phel\Command\Domain\ErrorLogInterface;
+use Phel\Command\Domain\Exceptions\ExceptionPrinterInterface;
+use Phel\Command\Domain\Exceptions\Extractor\FilePositionExtractorInterface;
+use Phel\Command\Domain\Exceptions\Extractor\ReadModel\FilePosition;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class CommandExceptionWriterTest extends TestCase
+{
+    public function test_resolves_compiled_php_to_phel_source_when_source_map_exists(): void
+    {
+        $compiledPath = '/proj/out/phel/http.php';
+        $compiledLine = 387;
+
+        $extractor = $this->createMock(FilePositionExtractorInterface::class);
+        $extractor->expects(self::once())
+            ->method('getOriginal')
+            ->with($compiledPath, $compiledLine)
+            ->willReturn(new FilePosition('/proj/src/phel/http.phel', 142));
+
+        $writer = new CommandExceptionWriter(
+            $this->createStub(ExceptionPrinterInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+            $extractor,
+        );
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt('Value of type null is not callable', $compiledPath, $compiledLine));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('Value of type null is not callable', $text);
+        self::assertStringContainsString('at /proj/src/phel/http.phel:142', $text);
+        self::assertStringContainsString('(compiled: /proj/out/phel/http.php:387)', $text);
+        self::assertStringNotContainsString('KeepGeneratedTempFiles', $text);
+    }
+
+    public function test_emits_stale_output_hint_when_source_map_missing(): void
+    {
+        $compiledPath = '/proj/out/phel/http.php';
+        $compiledLine = 12;
+
+        $extractor = $this->createStub(FilePositionExtractorInterface::class);
+        // Same filename back => no source map resolution
+        $extractor->method('getOriginal')->willReturn(new FilePosition($compiledPath, $compiledLine));
+
+        $writer = new CommandExceptionWriter(
+            $this->createStub(ExceptionPrinterInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+            $extractor,
+        );
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace($output, $this->errorAt('boom', $compiledPath, $compiledLine));
+
+        $text = $output->fetch();
+
+        self::assertStringContainsString('boom', $text);
+        self::assertStringContainsString('at /proj/out/phel/http.php:12', $text);
+        self::assertStringContainsString('rm -rf out/ .phel/cache/', $text);
+    }
+
+    public function test_internal_phel_lang_source_does_not_invoke_extractor(): void
+    {
+        $extractor = $this->createMock(FilePositionExtractorInterface::class);
+        $extractor->expects(self::never())->method('getOriginal');
+
+        $writer = new CommandExceptionWriter(
+            $this->createStub(ExceptionPrinterInterface::class),
+            $this->createStub(ErrorLogInterface::class),
+            $extractor,
+        );
+
+        $output = new BufferedOutput();
+        $writer->writeStackTrace(
+            $output,
+            $this->errorAt('internal', '/home/dev/phel-lang/src/php/Run/Foo.php', 99),
+        );
+
+        self::assertSame("internal\n", $output->fetch());
+    }
+
+    private function errorAt(string $message, string $file, int $line): RuntimeException
+    {
+        // Use the previous-exception slot, which writer prefers when present
+        $cause = new class($message, $file, $line) extends RuntimeException {
+            public function __construct(string $message, string $file, int $line)
+            {
+                parent::__construct($message);
+                $this->file = $file;
+                $this->line = $line;
+            }
+        };
+
+        return new RuntimeException('wrapper', 0, $cause);
+    }
+}

--- a/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
+++ b/tests/php/Unit/Command/Application/CommandExceptionWriterTest.php
@@ -30,6 +30,7 @@ final class CommandExceptionWriterTest extends TestCase
             $this->createStub(ExceptionPrinterInterface::class),
             $this->createStub(ErrorLogInterface::class),
             $extractor,
+            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
         );
 
         $output = new BufferedOutput();
@@ -56,6 +57,7 @@ final class CommandExceptionWriterTest extends TestCase
             $this->createStub(ExceptionPrinterInterface::class),
             $this->createStub(ErrorLogInterface::class),
             $extractor,
+            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
         );
 
         $output = new BufferedOutput();
@@ -65,7 +67,7 @@ final class CommandExceptionWriterTest extends TestCase
 
         self::assertStringContainsString('boom', $text);
         self::assertStringContainsString('at /proj/out/phel/http.php:12', $text);
-        self::assertStringContainsString('rm -rf out/ .phel/cache/', $text);
+        self::assertStringContainsString('rm -rf out /var/state/cache', $text);
     }
 
     public function test_internal_phel_lang_source_does_not_invoke_extractor(): void
@@ -77,6 +79,7 @@ final class CommandExceptionWriterTest extends TestCase
             $this->createStub(ExceptionPrinterInterface::class),
             $this->createStub(ErrorLogInterface::class),
             $extractor,
+            'stale compiled output? try `rm -rf out /var/state/cache` and rebuild.',
         );
 
         $output = new BufferedOutput();


### PR DESCRIPTION
## 🤔 Background

`bin/phel build` failures used to look like:

```
Value of type null is not callable // file: /proj/out/phel/http.php
> Dont you see the file? Check your phel config got \`KeepGeneratedTempFiles=true\`
```

Pointed at compiled PHP, not the Phel source. The hint was unhelpful (and ungrammatical). Common trigger: stale `out/` from a half-finished build.

## 💡 Goal

Use the `.php.map` source map we already emit to translate compiled errors back to the original `.phel:line`. When the map is missing, suggest the actual recovery step.

## 🔖 Changes

- `CommandExceptionWriter` now takes `FilePositionExtractorInterface`. When the offending file is compiled output, the writer resolves Phel source via the source map and prints both:
  `at src/phel/http.phel:142 (compiled: out/phel/http.php:387)`.
- If no map resolves (stale artifacts, missing comment header), fallback hint is actionable: `rm -rf out/ .phel/cache/` and rebuild.
- Errors originating in `phel-lang/src/` keep the prior one-line behavior.
- `CommandFactory::createCommandExceptionWriter()` wires the existing `FilePositionExtractor` + `SourceMapExtractor`. No new dependencies.
- New `CommandExceptionWriterTest` covers all three branches: source-map hit, source-map miss, and internal phel-lang source.