### PR TITLE
fix(tests): stabilize ReplPromptTest under random order

### DIFF
--- a/tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php
+++ b/tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhelTest\Unit\Run\Domain\Repl;
 
+use Gacela\Framework\Gacela;
 use Phel\Compiler\CompilerFacade;
 use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Run\Domain\Repl\ReplPrompt;
@@ -15,6 +16,7 @@ final class ReplPromptTest extends TestCase
 
     protected function setUp(): void
     {
+        Gacela::bootstrap(__DIR__);
         GlobalEnvironmentSingleton::reset();
         $this->compilerFacade = new CompilerFacade();
     }


### PR DESCRIPTION
## 🤔 Background

CI run [25702621353](https://github.com/phel-lang/phel-lang/actions/runs/25702621353) failed on PHP 8.5 with random seed `1778540838`:

```
1) PhelTest\Unit\Run\Domain\Repl\ReplPromptTest::test_initial_prompt_renders_namespace_in_display_form
RuntimeException: You have to call createWithSetup() first. Have you forgot to bootstrap Gacela?
2) PhelTest\Unit\Run\Domain\Repl\ReplPromptTest::test_initial_prompt_uses_default_namespace_when_env_uninitialized
RuntimeException: You have to call createWithSetup() first. ...
```

`ReplPrompt::currentNamespace()` calls `CompilerFacade::isGlobalEnvironmentInitialized()`, which routes through Gacela's `FactoryResolver`. When PHPUnit's random order placed `ReplPromptTest` before any test that bootstraps Gacela, the resolver had no config and threw.

Reproducible locally: `./vendor/bin/phpunit --testsuite unit --filter ReplPromptTest` fails the same way.

## 💡 Goal

Remove the hidden order dependency. Suite must pass under every random seed.

## 🔖 Changes

- `tests/php/Unit/Run/Domain/Repl/ReplPromptTest.php`: `Gacela::bootstrap(__DIR__)` in `setUp`, matching `CacheableCompilerFacadeTest` pattern.

Verified with previously failing seed `1778540838`: `OK, but there were issues! Tests: 2663, Assertions: 4806`.