### PR TITLE
ref(agents): optimize and unify AI agent skill files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file.
 - Recursive self-calls emit `$this(...)`: ~3.66x faster (#1914)
 
 #### DX
+- `phel agent-install` stamps installed skill files with `<!-- phel-agents vX.Y.Z -->` from `VERSION`; idempotent on re-install
+- Slimmer Claude skill (89 → 36 lines); shared syntax cheatsheet moved to `resources/agents/quick-syntax.md`; aider/codex/gemini/copilot/cursor pointers unified
 - Runtime state (cache, REPL history, error log) consolidated under `.phel/`; relocate via `withPhelDir()` or `PHEL_DIR` env (#1954)
 - Module boundary tightening: `Munge`, `CompileOptions`, `PhelProjectDirectory`, `VersionFinder` moved to `Phel\Shared`; `GlobalEnvironment`, `DebugLineTap` exposed via `CompilerFacade` (#1963, #1964)
 - `PhelConfig` immutable via `withX()` chain; build/export fields flat on root; old `setX()` shims deprecated

--- a/resources/agents/index.md
+++ b/resources/agents/index.md
@@ -24,7 +24,7 @@ Rules + CLI: [`RULES.md`](RULES.md).
 | Lint code | — | `docs/lint-guide.md` |
 | Editor integration | — | `docs/lsp-guide.md`, `docs/nrepl-guide.md` |
 | Hot-reload | — | `docs/watch-guide.md` |
-| Syntax reference | — | `docs/quickstart.md`, `docs/reader-shortcuts.md` |
+| Syntax reference | [`quick-syntax.md`](quick-syntax.md) | `docs/quickstart.md`, `docs/reader-shortcuts.md` |
 | Idioms | — | `docs/patterns.md`, `docs/examples/` |
 | Call Phel from PHP | — | `docs/framework-integration.md` |
 | Data structures | — | `docs/data-structures-guide.md`, `docs/lazy-sequences.md` |

--- a/resources/agents/quick-syntax.md
+++ b/resources/agents/quick-syntax.md
@@ -1,0 +1,59 @@
+# Quick syntax reference
+
+One-screen cheatsheet. For exhaustive rules see [`RULES.md`](RULES.md); for typing details see [`tasks/typed-defn.md`](tasks/typed-defn.md).
+
+```phel
+;; Define + call (^int :tag emits PHP int return-type and unlocks JIT-friendly call shape)
+(defn ^string greet [^string name] (str "Hello, " name "!"))
+(greet "World")
+
+;; Multi-arity, name-tag propagates to every arity unless overridden
+(defn ^int fib
+  ([^int n] (fib n 0 1))
+  ([^int n ^int a ^int b]
+   (if (zero? n) a (recur (dec n) b (+ a b)))))
+
+;; Memoize + type tag together
+(defn ^{:memoize-lru 256 :tag "int"} slow-fib
+  [^int n]
+  (if (< n 2) n (+ (slow-fib (- n 1)) (slow-fib (- n 2)))))
+
+;; Async defn -> Amp\Future
+(defn ^:async fetch [^string url]
+  (await (http-get url)))
+
+;; Records
+(defrecord Todo [id text done])
+(->Todo 1 "Buy milk" false)            ; positional constructor
+(map->Todo {:id 1 :text "X" :done false}) ; map constructor
+
+;; Protocols
+(defprotocol Showable (show [this]))
+(extend-type Todo Showable (show [t] (str "#" (get t :id) " " (get t :text))))
+
+;; Multimethods
+(defmulti handle-cmd (fn [cmd & _] cmd))
+(defmethod handle-cmd "add" [_ text] (add-item text))
+(defmethod handle-cmd :default [cmd & _] (println "Unknown:" cmd))
+
+;; Transducers
+(into [] (comp (filter odd?) (map inc)) [1 2 3 4 5])  ; => [2 4 6]
+(transduce (map :score) + 0 items)
+
+;; Regex
+(re-find #"\d+" "abc123")  ; => "123"
+
+;; JSON
+(:require phel.json :as json)
+(json/encode {:a 1})  ; => "{\"a\":1}"
+(json/decode "{\"a\":1}")  ; => {:a 1}
+
+;; File I/O
+(slurp "data.txt")
+(spit "out.txt" "content")
+
+;; PHP interop
+(php/new \DateTime "now")
+(php/-> obj (method args))
+(php/:: Class (staticMethod))
+```

--- a/resources/agents/skills/INSTALL.md
+++ b/resources/agents/skills/INSTALL.md
@@ -5,9 +5,12 @@
 ./vendor/bin/phel agent-install --all                # every platform
 ./vendor/bin/phel agent-install --all --with-docs    # also install docs into .agents/
 ./vendor/bin/phel agent-install --dry-run claude     # preview
+./vendor/bin/phel agent-install --force claude       # overwrite without backup
 ```
 
 Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup.
+
+Each installed file gets a footer `<!-- phel-agents vX.Y.Z -->` stamped from `resources/agents/VERSION`. Re-running `agent-install` after `composer update phel-lang/phel-lang` refreshes the stamp.
 
 ## Destinations
 
@@ -19,6 +22,12 @@ Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup.
 | Gemini CLI | `skills/gemini/GEMINI.md` | `GEMINI.md` |
 | GitHub Copilot | `skills/copilot/copilot-instructions.md` | `.github/copilot-instructions.md` |
 | Aider | `skills/aider/CONVENTIONS.md` | `CONVENTIONS.md` |
+
+## Recommended setup
+
+1. `./vendor/bin/phel agent-install --all --with-docs` — installs every skill plus the `.agents/` reference tree.
+2. Commit `.agents/` and the per-platform files so teammates' agents share the same context.
+3. After upgrading phel-lang, re-run `agent-install --all --force` to refresh content and version stamp.
 
 ## Manual fallback
 

--- a/resources/agents/skills/aider/CONVENTIONS.md
+++ b/resources/agents/skills/aider/CONVENTIONS.md
@@ -1,11 +1,23 @@
 # Aider conventions: Phel
 
-Phel is a Lisp that compiles to PHP. Pass this to Aider via `--read CONVENTIONS.md` or add to `.aider.conf.yml` under `read`.
+Phel is a Lisp that compiles to PHP. Pass to Aider via `--read CONVENTIONS.md` or add to `.aider.conf.yml` under `read`.
 
-- Hard rules, CLI, workflow: `.agents/RULES.md`
-- Task recipes: `.agents/tasks/`
-- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`
-- Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`
-- Deep reference: `docs/`, `src/phel/`
+## Load order
 
-Commits: conventional (`feat:`, `fix:`, `ref:`, `chore:`, `docs:`, `test:`). No AI or LLM references in messages.
+1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
+3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`
+4. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+5. `docs/`, `src/phel/` — deep reference
+
+## Before suggesting code
+
+- Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
+- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`.
+- Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.
+
+Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`.
+
+## Commits
+
+Conventional (`feat:`, `fix:`, `ref:`, `chore:`, `docs:`, `test:`). No AI or LLM references in messages.

--- a/resources/agents/skills/claude/phel-lang/SKILL.md
+++ b/resources/agents/skills/claude/phel-lang/SKILL.md
@@ -5,85 +5,29 @@ description: Building applications WITH Phel (Lisp that compiles to PHP). Trigge
 
 # Phel
 
-Lisp dialect that compiles to PHP. PHP interop via `php/` prefix.
+Lisp dialect compiling to PHP. PHP interop via `php/` prefix.
 
 ## Load order
 
-1. `.agents/RULES.md` — hard rules, new features reference, and CLI cheatsheet
-2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code to avoid common pitfalls
+1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
 3. `.agents/index.md` — task map
-4. `.agents/tasks/<intent>.md` — recipe for the current task
-5. `src/phel/` and `docs/` only when a recipe points there
+4. `.agents/tasks/<intent>.md` — recipe for current task
+5. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+6. `src/phel/` and `docs/` only when a recipe points there
 
-## Before you start coding
+## Hard rules (skim, then load RULES.md)
 
-- Read `.agents/RULES.md` § Gotchas; saves 5-10 min of debugging
-- Use `*argv*` for CLI args, NOT `php/$argv`
-- Use `doseq` for side effects, `for` for building sequences
-- String module is `phel.string` (not `phel.str`); prefer `.` ns separator (`\` deprecated)
-- Use `defrecord`, `defprotocol`, `defmulti` for structured code; stable since v0.30-0.32
-- Add `:tag` to params + return on hot or public fns; PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`
-- Opt-in `defn` metadata: `^:async` (wraps body in `async`, returns `Amp\Future`), `^:memoize` / `^{:memoize-lru N}` (cache by arg vector)
-- `phel profile <path>` finds the fns to type first
+- Verify fn names with `(doc <fn>)` or grep `src/phel/core/`. Never invent.
+- Collections immutable. `(conj v x)` returns new; rebind via `def`/`let`/`atom`.
+- CLI args: `*argv*`, not `php/$argv`.
+- Side effects: `doseq`; building sequences: `for`.
+- String module is `phel.string` (was `phel.str` pre-v0.33).
+- Namespace separator: prefer `.` (`app.main`); `\` deprecated.
+- Hot or public `defn`: add `:tag` to params + return. See `.agents/tasks/typed-defn.md`.
+- Opt-in `defn` metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
+- Top-level side effects break `phel build`; guard with `(when-not *build-mode* ...)`.
 
 ## Working examples
 
-`.agents/examples/{todo-app, http-json-api, cli-wordcount}/`; copy, adapt, run.
-
-## Quick syntax reference
-
-```phel
-;; Define + call (^int :tag emits PHP int return-type and unlocks JIT-friendly call shape)
-(defn ^string greet [^string name] (str "Hello, " name "!"))
-(greet "World")
-
-;; Multi-arity, name-tag propagates to every arity unless overridden
-(defn ^int fib
-  ([^int n] (fib n 0 1))
-  ([^int n ^int a ^int b]
-   (if (zero? n) a (recur (dec n) b (+ a b)))))
-
-;; Memoize + type tag together
-(defn ^{:memoize-lru 256 :tag "int"} slow-fib
-  [^int n]
-  (if (< n 2) n (+ (slow-fib (- n 1)) (slow-fib (- n 2)))))
-
-;; Async defn -> Amp\Future
-(defn ^:async fetch [^string url]
-  (await (http-get url)))
-
-;; Records
-(defrecord Todo [id text done])
-(->Todo 1 "Buy milk" false)            ; positional constructor
-(map->Todo {:id 1 :text "X" :done false}) ; map constructor
-
-;; Protocols
-(defprotocol Showable (show [this]))
-(extend-type Todo Showable (show [t] (str "#" (get t :id) " " (get t :text))))
-
-;; Multimethods
-(defmulti handle-cmd (fn [cmd & _] cmd))
-(defmethod handle-cmd "add" [_ text] (add-item text))
-(defmethod handle-cmd :default [cmd & _] (println "Unknown:" cmd))
-
-;; Transducers
-(into [] (comp (filter odd?) (map inc)) [1 2 3 4 5])  ; => [2 4 6]
-(transduce (map :score) + 0 items)
-
-;; Regex
-(re-find #"\d+" "abc123")  ; => "123"
-
-;; JSON
-(:require phel.json :as json)
-(json/encode {:a 1})  ; => "{\"a\":1}"
-(json/decode "{\"a\":1}")  ; => {:a 1}
-
-;; File I/O
-(slurp "data.txt")
-(spit "out.txt" "content")
-
-;; PHP interop
-(php/new \DateTime "now")
-(php/-> obj (method args))
-(php/:: Class (staticMethod))
-```
+`.agents/examples/{todo-app, http-json-api, cli-wordcount}/` — copy, adapt, run.

--- a/resources/agents/skills/codex/AGENTS.md
+++ b/resources/agents/skills/codex/AGENTS.md
@@ -1,24 +1,27 @@
 # AGENTS.md: Phel project
 
-Phel is a Lisp dialect that compiles to PHP. This file follows the AGENTS.md convention and covers tools that honor it (Codex, Aider, generic LLMs).
+Phel is a Lisp dialect that compiles to PHP. Follows the AGENTS.md convention; honored by Codex, Aider, and generic LLM tools.
 
 ## Load order
 
-1. `.agents/RULES.md` — hard rules, CLI cheatsheet, workflow
-2. `.agents/index.md` — task map
-3. `.agents/tasks/<intent>.md` — recipe for the current task
-4. `src/phel/` and `docs/` only when a recipe points there
+1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
+3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`
+4. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+5. `src/phel/` and `docs/` only when a recipe points there
 
-## Modern features to prefer
+## Before suggesting code
 
-- `:tag` types on `defn` params + return for PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`.
+- Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
+- Hot or public `defn`: add `:tag` to params + return. See `.agents/tasks/typed-defn.md`.
 - Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
-- `phel profile <path>` to locate hot fns before tagging.
+- `phel profile <path>` locates hot fns before tagging.
+- Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.
 
 ## Working examples
 
-`.agents/examples/{todo-app, http-json-api, cli-wordcount}/`; copy, adapt, run.
+`.agents/examples/{todo-app, http-json-api, cli-wordcount}/` — copy, adapt, run.
 
-## Commit conventions
+## Commits
 
-Conventional commits (`feat:`, `fix:`, `ref:`, `chore:`, `docs:`, `test:`). No AI or LLM references in messages.
+Conventional (`feat:`, `fix:`, `ref:`, `chore:`, `docs:`, `test:`). No AI or LLM references in messages.

--- a/resources/agents/skills/copilot/copilot-instructions.md
+++ b/resources/agents/skills/copilot/copilot-instructions.md
@@ -2,12 +2,18 @@
 
 Phel is a Lisp that compiles to PHP. For `.phel` files and `phel-config.php`:
 
-- Hard rules, syntax, CLI: `.agents/RULES.md`
-- Task recipes: `.agents/tasks/`
-- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`
-- Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`
-- Deep reference: `docs/`, `src/phel/`
+## Load order
 
-Never invent fn names. Confirm against `src/phel/core/` or `./vendor/bin/phel doc <fn>`.
+1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
+3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`
+4. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+5. `docs/`, `src/phel/` — deep reference
 
-Prefer `.` ns separator (`app.main`); `\` still parses but is deprecated.
+## Before suggesting code
+
+- Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
+- Typed `defn` (`:tag` on params + return, `^:async`, `^:memoize`, `^{:memoize-lru N}`): `.agents/tasks/typed-defn.md`.
+- Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.
+
+Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`.

--- a/resources/agents/skills/cursor/phel.mdc
+++ b/resources/agents/skills/cursor/phel.mdc
@@ -4,15 +4,23 @@ globs: ["**/*.phel", "**/phel-config.php"]
 alwaysApply: false
 ---
 
-Phel is a Lisp dialect that compiles to PHP. Hard rules, CLI cheatsheet, and workflow live in `.agents/RULES.md`. Task recipes in `.agents/tasks/`. Route by intent via `.agents/index.md`.
+Phel is a Lisp dialect that compiles to PHP.
 
-Before suggesting code:
-- Verify fn names in `src/phel/core/` or `(phel doc <fn>)`.
-- Collections are immutable. Rebind with `def`/`let`.
+## Load order
+
+1. `.agents/RULES.md` — hard rules, modern features (`:tag`, `^:async`, `^:memoize`), CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
+3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`
+4. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+
+## Before suggesting code
+
+- Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
+- Collections immutable. Rebind with `def`/`let` or use `atom`.
 - PHP interop prefix `php/`. See `.agents/RULES.md` for full syntax.
-- Guard top-level side effects with `(when-not *build-mode* ...)`.
-- Hot or public `defn`: add `:tag` to params + return (`^int`, `^string`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`). See `.agents/tasks/typed-defn.md`.
+- Top-level side effects: guard with `(when-not *build-mode* ...)`.
+- Hot or public `defn`: add `:tag` (`^int`, `^string`, `^"?int"`, `^"\\Foo\\Bar"`). See `.agents/tasks/typed-defn.md`.
 - Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
-- Prefer `.` ns separator (`app.main`); `\` still parses but is deprecated.
+- Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.
 
 Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`.

--- a/resources/agents/skills/gemini/GEMINI.md
+++ b/resources/agents/skills/gemini/GEMINI.md
@@ -1,11 +1,21 @@
 # GEMINI.md: Phel project
 
-Phel is a Lisp that compiles to PHP. Load `.agents/RULES.md` for hard rules and CLI; `.agents/index.md` for the task map; `.agents/tasks/<intent>.md` for the matching recipe.
+Phel is a Lisp dialect that compiles to PHP.
 
-Modern features to prefer when relevant:
+## Load order
 
-- `:tag` types on `defn` (`^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`) for PHP type emission, JIT-friendly call shape, compile-time mismatch diagnostics. See `.agents/tasks/typed-defn.md`.
+1. `.agents/RULES.md` — hard rules, modern features, CLI cheatsheet
+2. `.agents/tasks/common-gotchas.md` — read BEFORE writing code
+3. `.agents/index.md` — task map; pick `.agents/tasks/<intent>.md`
+4. `.agents/quick-syntax.md` — one-screen syntax cheatsheet
+5. `src/phel/` and `docs/` only when a recipe points there
+
+## Before suggesting code
+
+- Verify fn names in `src/phel/core/` or `./vendor/bin/phel doc <fn>`. Never invent.
+- Hot or public `defn`: add `:tag` (`^int`, `^"?int"`, `^"\\Foo\\Bar"`, `^{:tag "..."}`). See `.agents/tasks/typed-defn.md`.
 - Opt-in defn metadata: `^:async`, `^:memoize`, `^{:memoize-lru N}`.
-- `phel profile <path>` to find hot fns before tagging.
+- `phel profile <path>` locates hot fns before tagging.
+- Namespace separator: prefer `.` (`app.main`); `\` still parses but is deprecated.
 
-Working examples under `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`. Deep reference in `docs/` and `src/phel/`.
+Working examples: `.agents/examples/{todo-app, http-json-api, cli-wordcount}/`.

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -37,6 +37,12 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_DRY_RUN = 'dry-run';
 
+    private const string AGENTS_DIR = '.agents';
+
+    private const string VERSION_FILE = 'VERSION';
+
+    private const string BACKUP_SUFFIX = '.pre-phel.bak';
+
     private const string STAMP_PATTERN = '/\n?<!-- phel-agents v[^>]*-->\s*$/';
 
     /** @var array<string, array{source: string, target: string}> */
@@ -78,34 +84,24 @@ final class AgentInstallCommand extends Command
             )
             ->addOption(self::OPT_ALL, null, InputOption::VALUE_NONE, 'Install all supported platforms')
             ->addOption(self::OPT_WITH_DOCS, null, InputOption::VALUE_NONE, 'Also copy the bundled agent docs tree to .agents/')
-            ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to .pre-phel.bak)')
+            ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to ' . self::BACKUP_SUFFIX . ')')
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $platform = $input->getArgument(self::ARG_PLATFORM);
-        $installAll = (bool) $input->getOption(self::OPT_ALL);
-
-        if ($platform === null && !$installAll) {
-            $output->writeln('<error>Provide a platform or use --all</error>');
-            $output->writeln(sprintf('Platforms: %s', implode(', ', array_keys(self::PLATFORMS))));
+        $platforms = $this->selectPlatforms($input, $output);
+        if ($platforms === null) {
             return Command::INVALID;
         }
 
-        $platforms = $installAll ? array_keys(self::PLATFORMS) : [$platform];
         $sourceRoot = $this->agentsRoot();
         $projectRoot = (string) getcwd();
         $dryRun = (bool) $input->getOption(self::OPT_DRY_RUN);
         $force = (bool) $input->getOption(self::OPT_FORCE);
 
-        foreach ($platforms as $p) {
-            if (!isset(self::PLATFORMS[$p])) {
-                $output->writeln(sprintf('<error>Unknown platform: %s</error>', $p));
-                return Command::INVALID;
-            }
-
-            $this->installPlatform($output, $sourceRoot, $projectRoot, $p, $force, $dryRun);
+        foreach ($platforms as $platform) {
+            $this->installPlatform($output, $sourceRoot, $projectRoot, $platform, $force, $dryRun);
         }
 
         if ((bool) $input->getOption(self::OPT_WITH_DOCS)) {
@@ -113,6 +109,32 @@ final class AgentInstallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<string>|null list of platform keys, or null on invalid input
+     */
+    private function selectPlatforms(InputInterface $input, OutputInterface $output): ?array
+    {
+        $platform = $input->getArgument(self::ARG_PLATFORM);
+        $installAll = (bool) $input->getOption(self::OPT_ALL);
+
+        if ($installAll) {
+            return array_keys(self::PLATFORMS);
+        }
+
+        if ($platform === null) {
+            $output->writeln('<error>Provide a platform or use --all</error>');
+            $output->writeln(sprintf('Platforms: %s', implode(', ', array_keys(self::PLATFORMS))));
+            return null;
+        }
+
+        if (!isset(self::PLATFORMS[$platform])) {
+            $output->writeln(sprintf('<error>Unknown platform: %s</error>', $platform));
+            return null;
+        }
+
+        return [$platform];
     }
 
     private function installPlatform(
@@ -136,26 +158,28 @@ final class AgentInstallCommand extends Command
             return;
         }
 
-        $dstDir = dirname($dst);
-        if (!is_dir($dstDir) && !mkdir($dstDir, 0o755, true) && !is_dir($dstDir)) {
-            throw new RuntimeException(sprintf('Cannot create directory: %s', $dstDir));
-        }
-
-        if (is_file($dst) && !$force) {
-            $backup = $dst . '.pre-phel.bak';
-            copy($dst, $backup);
-            $output->writeln(sprintf('Backed up existing -> %s', $backup));
-        }
+        $this->ensureDir(dirname($dst));
+        $this->backupIfExists($output, $dst, $force);
 
         $contents = (string) file_get_contents($src);
-        $stamped = $this->stampVersion($contents, $sourceRoot);
-        file_put_contents($dst, $stamped);
+        file_put_contents($dst, $this->stampVersion($contents, $sourceRoot));
         $output->writeln(sprintf('<info>Installed</info> %s skill: %s', $platform, $dst));
+    }
+
+    private function backupIfExists(OutputInterface $output, string $dst, bool $force): void
+    {
+        if (!is_file($dst) || $force) {
+            return;
+        }
+
+        $backup = $dst . self::BACKUP_SUFFIX;
+        copy($dst, $backup);
+        $output->writeln(sprintf('Backed up existing -> %s', $backup));
     }
 
     private function stampVersion(string $contents, string $sourceRoot): string
     {
-        $versionFile = $sourceRoot . '/VERSION';
+        $versionFile = $sourceRoot . '/' . self::VERSION_FILE;
         if (!is_file($versionFile)) {
             return $contents;
         }
@@ -176,7 +200,7 @@ final class AgentInstallCommand extends Command
         bool $force,
         bool $dryRun,
     ): void {
-        $dst = $projectRoot . '/.agents';
+        $dst = $projectRoot . '/' . self::AGENTS_DIR;
         if ($dryRun) {
             $output->writeln(sprintf('[dry-run] copy %s -> %s', $agentsRoot, $dst));
             return;
@@ -193,9 +217,7 @@ final class AgentInstallCommand extends Command
 
     private function recursiveCopy(string $src, string $dst): void
     {
-        if (!is_dir($dst) && !mkdir($dst, 0o755, true) && !is_dir($dst)) {
-            throw new RuntimeException(sprintf('Cannot create directory: %s', $dst));
-        }
+        $this->ensureDir($dst);
 
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
@@ -205,12 +227,21 @@ final class AgentInstallCommand extends Command
         foreach ($iterator as $item) {
             $target = $dst . '/' . $iterator->getSubPathname();
             if ($item->isDir()) {
-                if (!is_dir($target) && !mkdir($target, 0o755, true) && !is_dir($target)) {
-                    throw new RuntimeException(sprintf('Cannot create directory: %s', $target));
-                }
+                $this->ensureDir($target);
             } else {
                 copy($item->getPathname(), $target);
             }
+        }
+    }
+
+    private function ensureDir(string $dir): void
+    {
+        if (is_dir($dir)) {
+            return;
+        }
+
+        if (!mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('Cannot create directory: %s', $dir));
         }
     }
 

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -16,9 +16,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function dirname;
+use function file_get_contents;
+use function file_put_contents;
 use function is_dir;
 use function is_file;
+use function preg_replace;
+use function rtrim;
 use function sprintf;
+use function trim;
 
 final class AgentInstallCommand extends Command
 {
@@ -31,6 +36,8 @@ final class AgentInstallCommand extends Command
     private const string OPT_FORCE = 'force';
 
     private const string OPT_DRY_RUN = 'dry-run';
+
+    private const string STAMP_PATTERN = '/\n?<!-- phel-agents v[^>]*-->\s*$/';
 
     /** @var array<string, array{source: string, target: string}> */
     private const array PLATFORMS = [
@@ -140,8 +147,26 @@ final class AgentInstallCommand extends Command
             $output->writeln(sprintf('Backed up existing -> %s', $backup));
         }
 
-        copy($src, $dst);
+        $contents = (string) file_get_contents($src);
+        $stamped = $this->stampVersion($contents, $sourceRoot);
+        file_put_contents($dst, $stamped);
         $output->writeln(sprintf('<info>Installed</info> %s skill: %s', $platform, $dst));
+    }
+
+    private function stampVersion(string $contents, string $sourceRoot): string
+    {
+        $versionFile = $sourceRoot . '/VERSION';
+        if (!is_file($versionFile)) {
+            return $contents;
+        }
+
+        $version = trim((string) file_get_contents($versionFile));
+        if ($version === '') {
+            return $contents;
+        }
+
+        $stripped = (string) preg_replace(self::STAMP_PATTERN, '', $contents);
+        return rtrim($stripped) . sprintf("\n\n<!-- phel-agents v%s -->\n", $version);
     }
 
     private function copyDocs(

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\AgentInstall;
+
+use Phel\Run\Infrastructure\Command\AgentInstallCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class AgentInstallCommandTest extends TestCase
+{
+    private string $testDir;
+
+    private string $originalCwd;
+
+    protected function setUp(): void
+    {
+        $this->originalCwd = (string) getcwd();
+        $this->testDir = sys_get_temp_dir() . '/phel-agent-install-test-' . uniqid();
+        mkdir($this->testDir, 0o755, true);
+        chdir($this->testDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+        $this->removeDirectory($this->testDir);
+    }
+
+    public function test_install_all_creates_every_skill_target(): void
+    {
+        $result = $this->install(['--all' => true]);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileExists($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
+        self::assertFileExists($this->testDir . '/.cursor/rules/phel.mdc');
+        self::assertFileExists($this->testDir . '/AGENTS.md');
+        self::assertFileExists($this->testDir . '/GEMINI.md');
+        self::assertFileExists($this->testDir . '/.github/copilot-instructions.md');
+        self::assertFileExists($this->testDir . '/CONVENTIONS.md');
+    }
+
+    public function test_install_single_platform_only_creates_that_target(): void
+    {
+        $this->install(['platform' => 'claude']);
+
+        self::assertFileExists($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
+        self::assertFileDoesNotExist($this->testDir . '/AGENTS.md');
+        self::assertFileDoesNotExist($this->testDir . '/GEMINI.md');
+        self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md');
+    }
+
+    public function test_missing_platform_and_no_all_returns_invalid(): void
+    {
+        $output = new BufferedOutput();
+        $command = new AgentInstallCommand();
+
+        $result = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(Command::INVALID, $result);
+        self::assertStringContainsString('Provide a platform or use --all', $output->fetch());
+    }
+
+    public function test_unknown_platform_returns_invalid(): void
+    {
+        $output = new BufferedOutput();
+        $command = new AgentInstallCommand();
+
+        $result = $command->run(new ArrayInput(['platform' => 'borg']), $output);
+
+        self::assertSame(Command::INVALID, $result);
+        self::assertStringContainsString('Unknown platform: borg', $output->fetch());
+    }
+
+    public function test_dry_run_does_not_create_files(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['--all' => true, '--dry-run' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileDoesNotExist($this->testDir . '/AGENTS.md');
+        self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md');
+        self::assertStringContainsString('[dry-run]', $output->fetch());
+    }
+
+    public function test_reinstall_backs_up_existing_file(): void
+    {
+        $this->install(['platform' => 'codex']);
+        file_put_contents($this->testDir . '/AGENTS.md', 'user-edited content');
+
+        $this->install(['platform' => 'codex']);
+
+        self::assertFileExists($this->testDir . '/AGENTS.md.pre-phel.bak');
+        self::assertSame('user-edited content', file_get_contents($this->testDir . '/AGENTS.md.pre-phel.bak'));
+    }
+
+    public function test_force_skips_backup(): void
+    {
+        $this->install(['platform' => 'codex']);
+
+        $this->install(['platform' => 'codex', '--force' => true]);
+
+        self::assertFileDoesNotExist($this->testDir . '/AGENTS.md.pre-phel.bak');
+    }
+
+    public function test_installed_file_carries_version_stamp(): void
+    {
+        $this->install(['platform' => 'aider']);
+
+        $content = (string) file_get_contents($this->testDir . '/CONVENTIONS.md');
+        self::assertMatchesRegularExpression('/<!-- phel-agents v\d+\.\d+\.\d+ -->/', $content);
+    }
+
+    public function test_reinstall_does_not_duplicate_version_stamp(): void
+    {
+        $this->install(['platform' => 'aider']);
+        $this->install(['platform' => 'aider', '--force' => true]);
+
+        $content = (string) file_get_contents($this->testDir . '/CONVENTIONS.md');
+        self::assertSame(
+            1,
+            preg_match_all('/<!-- phel-agents v/', $content),
+            'Version stamp must appear exactly once after reinstall',
+        );
+    }
+
+    public function test_with_docs_copies_agents_tree(): void
+    {
+        $this->install(['platform' => 'claude', '--with-docs' => true]);
+
+        self::assertDirectoryExists($this->testDir . '/.agents');
+        self::assertFileExists($this->testDir . '/.agents/RULES.md');
+        self::assertFileExists($this->testDir . '/.agents/index.md');
+        self::assertFileExists($this->testDir . '/.agents/quick-syntax.md');
+        self::assertDirectoryExists($this->testDir . '/.agents/tasks');
+        self::assertDirectoryExists($this->testDir . '/.agents/examples');
+    }
+
+    public function test_with_docs_skips_when_agents_dir_already_exists(): void
+    {
+        mkdir($this->testDir . '/.agents', 0o755, true);
+        file_put_contents($this->testDir . '/.agents/marker.txt', 'keep me');
+
+        $output = new BufferedOutput();
+        $this->install(['platform' => 'claude', '--with-docs' => true], $output);
+
+        self::assertFileExists($this->testDir . '/.agents/marker.txt');
+        self::assertStringContainsString('.agents/ already exists', $output->fetch());
+    }
+
+    public function test_claude_skill_references_quick_syntax(): void
+    {
+        $this->install(['platform' => 'claude']);
+
+        $content = (string) file_get_contents($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
+        self::assertStringContainsString('quick-syntax.md', $content);
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     */
+    private function install(array $args, ?BufferedOutput $output = null): int
+    {
+        $command = new AgentInstallCommand();
+        return $command->run(new ArrayInput($args), $output ?? new BufferedOutput());
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`./vendor/bin/phel agent-install` installs skill files for 6 AI coding agents (Claude Code, Cursor, Codex, Gemini, Copilot, Aider). The Claude skill was carrying 55 lines of inline syntax cheatsheet that duplicated `RULES.md` + `tasks/typed-defn.md`, loaded into every Claude session that triggered the skill. The 5 pointer skills had drifted: not all mentioned the `\` ns-separator deprecation, only Copilot warned against inventing fn names, and there was no way to tell which phel-lang version produced an installed file.

## 💡 Goal

Provide the best agentic dev experience for Phel across any agent: one source of truth, smaller per-session token cost, and a clear upgrade path after `composer update`.

## 🔖 Changes

- **Slim Claude SKILL.md** from 89 to 36 lines; inline cheatsheet moved to `resources/agents/quick-syntax.md` (lazy-loaded only when the agent needs it).
- **DRY pointer skills** (aider/codex/gemini/copilot/cursor): same load order, same fn-verification rule, same `.` ns-separator note, same examples list.
- **Version stamping**: `agent-install` appends `<!-- phel-agents vX.Y.Z -->` (read from `resources/agents/VERSION`) to every installed file. Re-running after `composer update phel-lang/phel-lang` refreshes the stamp; idempotent (no duplicate stamps).
- **`AgentInstallCommand` refactor**: extracted `ensureDir`, `backupIfExists`, `selectPlatforms`, `stampVersion`; magic strings (`.pre-phel.bak`, `.agents`, `VERSION`) hoisted to constants.
- **`AgentInstallCommandTest`** (12 tests): covers `--all`, single-platform, dry-run, backup/force, version-stamp idempotence, `--with-docs`, invalid input.
- **`INSTALL.md`**: documents version stamp + recommended re-install after upgrades.
- **`index.md`**: surfaces `quick-syntax.md` under "Syntax reference".
- **CHANGELOG.md**: noted under Unreleased › DX.

## Why

Smaller per-session footprint, single source of truth, easier upgrades, fewer drift bugs across the 6 agent integrations.