### PR TITLE
feat(agents): agent-install DX overhaul (--check, --list, --uninstall, --auto, doctor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project will be documented in this file.
 #### DX
 - `phel agent-install` stamps installed skill files with `<!-- phel-agents vX.Y.Z -->` from `VERSION`; idempotent on re-install
 - Slimmer Claude skill (89 → 36 lines); shared syntax cheatsheet moved to `resources/agents/quick-syntax.md`; aider/codex/gemini/copilot/cursor pointers unified
+- `phel agent-install --check` reports installed vs current skill version per platform; exits 1 on drift
+- `phel agent-install --list` enumerates platforms, source templates, install targets, and current state
+- `phel agent-install --uninstall` removes skill file(s) and restores `.pre-phel.bak` if present; `--with-docs` also drops `.agents/`
+- `phel agent-install --auto` installs skills only for agents already used in the project (detects `.claude/`, `.cursor/`, `AGENTS.md`, `GEMINI.md`, etc.)
+- `phel doctor` now reports installed agent skills and surfaces stale versions in one place
 - Runtime state (cache, REPL history, error log) consolidated under `.phel/`; relocate via `withPhelDir()` or `PHEL_DIR` env (#1954)
 - Module boundary tightening: `Munge`, `CompileOptions`, `PhelProjectDirectory`, `VersionFinder` moved to `Phel\Shared`; `GlobalEnvironment`, `DebugLineTap` exposed via `CompilerFacade` (#1963, #1964)
 - `PhelConfig` immutable via `withX()` chain; build/export fields flat on root; old `setX()` shims deprecated

--- a/resources/agents/skills/INSTALL.md
+++ b/resources/agents/skills/INSTALL.md
@@ -3,31 +3,40 @@
 ```bash
 ./vendor/bin/phel agent-install <platform>           # single platform
 ./vendor/bin/phel agent-install --all                # every platform
+./vendor/bin/phel agent-install --auto               # only platforms already used in the project
 ./vendor/bin/phel agent-install --all --with-docs    # also install docs into .agents/
 ./vendor/bin/phel agent-install --dry-run claude     # preview
 ./vendor/bin/phel agent-install --force claude       # overwrite without backup
+./vendor/bin/phel agent-install --check              # report install + version drift; exit 1 if stale
+./vendor/bin/phel agent-install --list               # list platforms with sources, targets, and state
+./vendor/bin/phel agent-install --uninstall claude   # remove (restores .pre-phel.bak if present)
+./vendor/bin/phel agent-install --uninstall --all --with-docs   # full removal
 ```
 
 Existing targets back up to `<path>.pre-phel.bak`. `--force` skips backup.
 
 Each installed file gets a footer `<!-- phel-agents vX.Y.Z -->` stamped from `resources/agents/VERSION`. Re-running `agent-install` after `composer update phel-lang/phel-lang` refreshes the stamp.
 
+`phel doctor` also reports installed agent skills and flags stale versions in one place — no need to remember `--check`.
+
 ## Destinations
 
-| Platform | Source template | Installed path |
-|----------|------------------|-----------------|
-| Claude Code | `skills/claude/phel-lang/SKILL.md` | `.claude/skills/phel-lang/SKILL.md` |
-| Cursor | `skills/cursor/phel.mdc` | `.cursor/rules/phel.mdc` |
-| Codex (or AGENTS.md) | `skills/codex/AGENTS.md` | `AGENTS.md` |
-| Gemini CLI | `skills/gemini/GEMINI.md` | `GEMINI.md` |
-| GitHub Copilot | `skills/copilot/copilot-instructions.md` | `.github/copilot-instructions.md` |
-| Aider | `skills/aider/CONVENTIONS.md` | `CONVENTIONS.md` |
+| Platform | Source template | Installed path | Detection signal |
+|----------|------------------|-----------------|------------------|
+| Claude Code | `skills/claude/phel-lang/SKILL.md` | `.claude/skills/phel-lang/SKILL.md` | `.claude/` |
+| Cursor | `skills/cursor/phel.mdc` | `.cursor/rules/phel.mdc` | `.cursor/` |
+| Codex (or AGENTS.md) | `skills/codex/AGENTS.md` | `AGENTS.md` | `AGENTS.md`, `.codex/` |
+| Gemini CLI | `skills/gemini/GEMINI.md` | `GEMINI.md` | `GEMINI.md`, `.gemini/` |
+| GitHub Copilot | `skills/copilot/copilot-instructions.md` | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
+| Aider | `skills/aider/CONVENTIONS.md` | `CONVENTIONS.md` | `CONVENTIONS.md`, `.aider.conf.yml` |
+
+`--auto` uses the detection signals to install only for the agents you already use.
 
 ## Recommended setup
 
-1. `./vendor/bin/phel agent-install --all --with-docs` — installs every skill plus the `.agents/` reference tree.
+1. `./vendor/bin/phel agent-install --auto --with-docs` — installs skills for agents the project already touches, plus `.agents/` reference tree.
 2. Commit `.agents/` and the per-platform files so teammates' agents share the same context.
-3. After upgrading phel-lang, re-run `agent-install --all --force` to refresh content and version stamp.
+3. After upgrading phel-lang, run `agent-install --check`; if it exits 1, re-run `agent-install --all --force` to refresh content and version stamp.
 
 ## Manual fallback
 

--- a/src/php/Run/Application/Agent/AgentInstallStatusInspector.php
+++ b/src/php/Run/Application/Agent/AgentInstallStatusInspector.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use Phel\Run\Domain\Agent\AgentPlatform;
+use Phel\Run\Domain\Agent\AgentPlatformRegistry;
+use Phel\Run\Domain\Agent\AgentPlatformStatus;
+
+use function is_file;
+
+final readonly class AgentInstallStatusInspector
+{
+    public function __construct(
+        private AgentPlatformRegistry $registry,
+        private AgentVersionStamper $stamper,
+    ) {}
+
+    /**
+     * @return list<AgentPlatformStatus>
+     */
+    public function inspect(string $projectRoot): array
+    {
+        $current = $this->stamper->currentVersion() ?? 'unknown';
+        $statuses = [];
+
+        foreach ($this->registry->all() as $platform) {
+            $statuses[] = $this->inspectPlatform($platform, $projectRoot, $current);
+        }
+
+        return $statuses;
+    }
+
+    private function inspectPlatform(AgentPlatform $platform, string $projectRoot, string $current): AgentPlatformStatus
+    {
+        $path = $projectRoot . '/' . $platform->target;
+
+        if (!is_file($path)) {
+            return new AgentPlatformStatus($platform, AgentPlatformStatus::NOT_INSTALLED, null, $current, $path);
+        }
+
+        $installed = $this->stamper->installedVersion($path);
+        if ($installed === null) {
+            return new AgentPlatformStatus($platform, AgentPlatformStatus::UNSTAMPED, null, $current, $path);
+        }
+
+        $state = $installed === $current
+            ? AgentPlatformStatus::CURRENT
+            : AgentPlatformStatus::STALE;
+
+        return new AgentPlatformStatus($platform, $state, $installed, $current, $path);
+    }
+}

--- a/src/php/Run/Application/Agent/AgentPlatformDetector.php
+++ b/src/php/Run/Application/Agent/AgentPlatformDetector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use Phel\Run\Domain\Agent\AgentPlatformRegistry;
+
+use function file_exists;
+
+final readonly class AgentPlatformDetector
+{
+    private const array SIGNALS = [
+        'claude' => ['.claude'],
+        'cursor' => ['.cursor'],
+        'codex' => ['AGENTS.md', '.codex'],
+        'gemini' => ['GEMINI.md', '.gemini'],
+        'copilot' => ['.github/copilot-instructions.md'],
+        'aider' => ['CONVENTIONS.md', '.aider.conf.yml'],
+    ];
+
+    public function __construct(private AgentPlatformRegistry $registry) {}
+
+    /**
+     * @return list<string> ordered platform keys whose signals are present in $projectRoot
+     */
+    public function detect(string $projectRoot): array
+    {
+        $detected = [];
+        foreach ($this->registry->keys() as $key) {
+            foreach (self::SIGNALS[$key] ?? [] as $signal) {
+                if (file_exists($projectRoot . '/' . $signal)) {
+                    $detected[] = $key;
+                    break;
+                }
+            }
+        }
+
+        return $detected;
+    }
+}

--- a/src/php/Run/Application/Agent/AgentVersionStamper.php
+++ b/src/php/Run/Application/Agent/AgentVersionStamper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application\Agent;
+
+use function file_get_contents;
+use function is_file;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function sprintf;
+use function trim;
+
+final readonly class AgentVersionStamper
+{
+    public const string STAMP_PATTERN = '/\n?<!-- phel-agents v[^>]*-->\s*$/';
+
+    public const string STAMP_EXTRACT_PATTERN = '/<!-- phel-agents v([^\s>]+) -->/';
+
+    public const string VERSION_FILE = 'VERSION';
+
+    public function __construct(private string $sourceRoot) {}
+
+    public function currentVersion(): ?string
+    {
+        $versionFile = $this->sourceRoot . '/' . self::VERSION_FILE;
+        if (!is_file($versionFile)) {
+            return null;
+        }
+
+        $version = trim((string) file_get_contents($versionFile));
+        return $version === '' ? null : $version;
+    }
+
+    public function installedVersion(string $path): ?string
+    {
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $contents = (string) file_get_contents($path);
+        if (preg_match(self::STAMP_EXTRACT_PATTERN, $contents, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    public function stamp(string $contents): string
+    {
+        $version = $this->currentVersion();
+        if ($version === null) {
+            return $contents;
+        }
+
+        $stripped = (string) preg_replace(self::STAMP_PATTERN, '', $contents);
+        return rtrim($stripped) . sprintf("\n\n<!-- phel-agents v%s -->\n", $version);
+    }
+}

--- a/src/php/Run/Domain/Agent/AgentPlatform.php
+++ b/src/php/Run/Domain/Agent/AgentPlatform.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Agent;
+
+final readonly class AgentPlatform
+{
+    public function __construct(
+        public string $key,
+        public string $source,
+        public string $target,
+    ) {}
+}

--- a/src/php/Run/Domain/Agent/AgentPlatformRegistry.php
+++ b/src/php/Run/Domain/Agent/AgentPlatformRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Agent;
+
+use function array_keys;
+
+final class AgentPlatformRegistry
+{
+    /** @var array<string, AgentPlatform> */
+    private array $platforms;
+
+    public function __construct()
+    {
+        $this->platforms = [
+            'claude' => new AgentPlatform('claude', 'skills/claude/phel-lang/SKILL.md', '.claude/skills/phel-lang/SKILL.md'),
+            'cursor' => new AgentPlatform('cursor', 'skills/cursor/phel.mdc', '.cursor/rules/phel.mdc'),
+            'codex' => new AgentPlatform('codex', 'skills/codex/AGENTS.md', 'AGENTS.md'),
+            'gemini' => new AgentPlatform('gemini', 'skills/gemini/GEMINI.md', 'GEMINI.md'),
+            'copilot' => new AgentPlatform('copilot', 'skills/copilot/copilot-instructions.md', '.github/copilot-instructions.md'),
+            'aider' => new AgentPlatform('aider', 'skills/aider/CONVENTIONS.md', 'CONVENTIONS.md'),
+        ];
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->platforms[$key]);
+    }
+
+    public function get(string $key): AgentPlatform
+    {
+        return $this->platforms[$key];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->platforms);
+    }
+
+    /**
+     * @return array<string, AgentPlatform>
+     */
+    public function all(): array
+    {
+        return $this->platforms;
+    }
+}

--- a/src/php/Run/Domain/Agent/AgentPlatformStatus.php
+++ b/src/php/Run/Domain/Agent/AgentPlatformStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Domain\Agent;
+
+final readonly class AgentPlatformStatus
+{
+    public const string NOT_INSTALLED = 'not_installed';
+
+    public const string CURRENT = 'current';
+
+    public const string STALE = 'stale';
+
+    public const string UNSTAMPED = 'unstamped';
+
+    public function __construct(
+        public AgentPlatform $platform,
+        public string $state,
+        public ?string $installedVersion,
+        public string $currentVersion,
+        public string $installedPath,
+    ) {}
+
+    public function isDrift(): bool
+    {
+        return $this->state === self::STALE
+            || $this->state === self::UNSTAMPED;
+    }
+}

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -41,6 +41,8 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_CHECK = 'check';
 
+    private const string OPT_LIST = 'list';
+
     private const string AGENTS_DIR = '.agents';
 
     private const string BACKUP_SUFFIX = '.pre-phel.bak';
@@ -68,7 +70,8 @@ final class AgentInstallCommand extends Command
             ->addOption(self::OPT_WITH_DOCS, null, InputOption::VALUE_NONE, 'Also copy the bundled agent docs tree to .agents/')
             ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to ' . self::BACKUP_SUFFIX . ')')
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
-            ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift');
+            ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift')
+            ->addOption(self::OPT_LIST, null, InputOption::VALUE_NONE, 'List supported platforms with source template, install target, and current state');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -79,6 +82,10 @@ final class AgentInstallCommand extends Command
 
         if ((bool) $input->getOption(self::OPT_CHECK)) {
             return $this->runCheck($output, $projectRoot, $stamper);
+        }
+
+        if ((bool) $input->getOption(self::OPT_LIST)) {
+            return $this->runList($output, $projectRoot, $stamper);
         }
 
         $platforms = $this->selectPlatforms($input, $output);
@@ -98,6 +105,36 @@ final class AgentInstallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function runList(OutputInterface $output, string $projectRoot, AgentVersionStamper $stamper): int
+    {
+        $inspector = new AgentInstallStatusInspector($this->registry, $stamper);
+        $statuses = $inspector->inspect($projectRoot);
+
+        $output->writeln(sprintf('<info>Platform</info>  <info>Source</info>%s  <info>Target</info>%s  <info>State</info>', str_repeat(' ', 36), str_repeat(' ', 30)));
+        foreach ($statuses as $status) {
+            $output->writeln(sprintf(
+                '  %-8s  %-40s  %-34s  %s',
+                $status->platform->key,
+                $status->platform->source,
+                $status->platform->target,
+                $this->stateLabel($status),
+            ));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function stateLabel(AgentPlatformStatus $status): string
+    {
+        return match ($status->state) {
+            AgentPlatformStatus::CURRENT => sprintf('current (v%s)', $status->installedVersion ?? '?'),
+            AgentPlatformStatus::STALE => sprintf('stale (v%s, current v%s)', $status->installedVersion ?? '?', $status->currentVersion),
+            AgentPlatformStatus::UNSTAMPED => 'unstamped',
+            AgentPlatformStatus::NOT_INSTALLED => 'not installed',
+            default => $status->state,
+        };
     }
 
     private function runCheck(OutputInterface $output, string $projectRoot, AgentVersionStamper $stamper): int

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -25,7 +25,11 @@ use function file_put_contents;
 use function implode;
 use function is_dir;
 use function is_file;
+use function rename;
+use function rmdir;
 use function sprintf;
+use function str_repeat;
+use function unlink;
 
 final class AgentInstallCommand extends Command
 {
@@ -42,6 +46,8 @@ final class AgentInstallCommand extends Command
     private const string OPT_CHECK = 'check';
 
     private const string OPT_LIST = 'list';
+
+    private const string OPT_UNINSTALL = 'uninstall';
 
     private const string AGENTS_DIR = '.agents';
 
@@ -71,7 +77,8 @@ final class AgentInstallCommand extends Command
             ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to ' . self::BACKUP_SUFFIX . ')')
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
             ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift')
-            ->addOption(self::OPT_LIST, null, InputOption::VALUE_NONE, 'List supported platforms with source template, install target, and current state');
+            ->addOption(self::OPT_LIST, null, InputOption::VALUE_NONE, 'List supported platforms with source template, install target, and current state')
+            ->addOption(self::OPT_UNINSTALL, null, InputOption::VALUE_NONE, 'Remove installed skill file(s); restores ' . self::BACKUP_SUFFIX . ' if present');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -96,6 +103,18 @@ final class AgentInstallCommand extends Command
         $dryRun = (bool) $input->getOption(self::OPT_DRY_RUN);
         $force = (bool) $input->getOption(self::OPT_FORCE);
 
+        if ((bool) $input->getOption(self::OPT_UNINSTALL)) {
+            foreach ($platforms as $platformKey) {
+                $this->uninstallPlatform($output, $projectRoot, $this->registry->get($platformKey), $dryRun);
+            }
+
+            if ((bool) $input->getOption(self::OPT_WITH_DOCS)) {
+                $this->removeDocs($output, $projectRoot, $dryRun);
+            }
+
+            return Command::SUCCESS;
+        }
+
         foreach ($platforms as $platformKey) {
             $this->installPlatform($output, $sourceRoot, $projectRoot, $this->registry->get($platformKey), $force, $dryRun, $stamper);
         }
@@ -105,6 +124,69 @@ final class AgentInstallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function uninstallPlatform(OutputInterface $output, string $projectRoot, AgentPlatform $platform, bool $dryRun): void
+    {
+        $dst = $projectRoot . '/' . $platform->target;
+        $backup = $dst . self::BACKUP_SUFFIX;
+
+        if (!is_file($dst)) {
+            $output->writeln(sprintf('  %-8s not installed; skip', $platform->key));
+            return;
+        }
+
+        if ($dryRun) {
+            $output->writeln(sprintf('[dry-run] remove %s', $dst));
+            if (is_file($backup)) {
+                $output->writeln(sprintf('[dry-run] restore %s -> %s', $backup, $dst));
+            }
+
+            return;
+        }
+
+        unlink($dst);
+        if (is_file($backup)) {
+            rename($backup, $dst);
+            $output->writeln(sprintf('<info>Restored backup</info> %s', $dst));
+            return;
+        }
+
+        $output->writeln(sprintf('<info>Removed</info> %s skill: %s', $platform->key, $dst));
+    }
+
+    private function removeDocs(OutputInterface $output, string $projectRoot, bool $dryRun): void
+    {
+        $dst = $projectRoot . '/' . self::AGENTS_DIR;
+        if (!is_dir($dst)) {
+            return;
+        }
+
+        if ($dryRun) {
+            $output->writeln(sprintf('[dry-run] remove %s', $dst));
+            return;
+        }
+
+        $this->recursiveRemove($dst);
+        $output->writeln(sprintf('<info>Removed docs tree</info> %s', $dst));
+    }
+
+    private function recursiveRemove(string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($dir);
     }
 
     private function runList(OutputInterface $output, string $projectRoot, AgentVersionStamper $stamper): int

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Phel\Run\Infrastructure\Command;
 
 use FilesystemIterator;
+use Phel\Run\Application\Agent\AgentInstallStatusInspector;
+use Phel\Run\Application\Agent\AgentVersionStamper;
+use Phel\Run\Domain\Agent\AgentPlatform;
+use Phel\Run\Domain\Agent\AgentPlatformRegistry;
+use Phel\Run\Domain\Agent\AgentPlatformStatus;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,12 +22,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function dirname;
 use function file_get_contents;
 use function file_put_contents;
+use function implode;
 use function is_dir;
 use function is_file;
-use function preg_replace;
-use function rtrim;
 use function sprintf;
-use function trim;
 
 final class AgentInstallCommand extends Command
 {
@@ -37,71 +39,58 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_DRY_RUN = 'dry-run';
 
-    private const string AGENTS_DIR = '.agents';
+    private const string OPT_CHECK = 'check';
 
-    private const string VERSION_FILE = 'VERSION';
+    private const string AGENTS_DIR = '.agents';
 
     private const string BACKUP_SUFFIX = '.pre-phel.bak';
 
-    private const string STAMP_PATTERN = '/\n?<!-- phel-agents v[^>]*-->\s*$/';
+    private readonly AgentPlatformRegistry $registry;
 
-    /** @var array<string, array{source: string, target: string}> */
-    private const array PLATFORMS = [
-        'claude' => [
-            'source' => 'skills/claude/phel-lang/SKILL.md',
-            'target' => '.claude/skills/phel-lang/SKILL.md',
-        ],
-        'cursor' => [
-            'source' => 'skills/cursor/phel.mdc',
-            'target' => '.cursor/rules/phel.mdc',
-        ],
-        'codex' => [
-            'source' => 'skills/codex/AGENTS.md',
-            'target' => 'AGENTS.md',
-        ],
-        'gemini' => [
-            'source' => 'skills/gemini/GEMINI.md',
-            'target' => 'GEMINI.md',
-        ],
-        'copilot' => [
-            'source' => 'skills/copilot/copilot-instructions.md',
-            'target' => '.github/copilot-instructions.md',
-        ],
-        'aider' => [
-            'source' => 'skills/aider/CONVENTIONS.md',
-            'target' => 'CONVENTIONS.md',
-        ],
-    ];
+    public function __construct()
+    {
+        $this->registry = new AgentPlatformRegistry();
+        parent::__construct();
+    }
 
     protected function configure(): void
     {
+        $platformList = implode(', ', $this->registry->keys());
+
         $this->setName('agent-install')
             ->setDescription('Install agent skill files (Claude, Cursor, Codex, Gemini, Copilot, Aider) into the current project')
             ->addArgument(
                 self::ARG_PLATFORM,
                 InputArgument::OPTIONAL,
-                sprintf('Platform: %s', implode(', ', array_keys(self::PLATFORMS))),
+                sprintf('Platform: %s', $platformList),
             )
             ->addOption(self::OPT_ALL, null, InputOption::VALUE_NONE, 'Install all supported platforms')
             ->addOption(self::OPT_WITH_DOCS, null, InputOption::VALUE_NONE, 'Also copy the bundled agent docs tree to .agents/')
             ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to ' . self::BACKUP_SUFFIX . ')')
-            ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files');
+            ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
+            ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $sourceRoot = $this->agentsRoot();
+        $projectRoot = (string) getcwd();
+        $stamper = new AgentVersionStamper($sourceRoot);
+
+        if ((bool) $input->getOption(self::OPT_CHECK)) {
+            return $this->runCheck($output, $projectRoot, $stamper);
+        }
+
         $platforms = $this->selectPlatforms($input, $output);
         if ($platforms === null) {
             return Command::INVALID;
         }
 
-        $sourceRoot = $this->agentsRoot();
-        $projectRoot = (string) getcwd();
         $dryRun = (bool) $input->getOption(self::OPT_DRY_RUN);
         $force = (bool) $input->getOption(self::OPT_FORCE);
 
-        foreach ($platforms as $platform) {
-            $this->installPlatform($output, $sourceRoot, $projectRoot, $platform, $force, $dryRun);
+        foreach ($platforms as $platformKey) {
+            $this->installPlatform($output, $sourceRoot, $projectRoot, $this->registry->get($platformKey), $force, $dryRun, $stamper);
         }
 
         if ((bool) $input->getOption(self::OPT_WITH_DOCS)) {
@@ -109,6 +98,37 @@ final class AgentInstallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function runCheck(OutputInterface $output, string $projectRoot, AgentVersionStamper $stamper): int
+    {
+        $inspector = new AgentInstallStatusInspector($this->registry, $stamper);
+        $statuses = $inspector->inspect($projectRoot);
+
+        $output->writeln(sprintf('phel-agents target version: <info>%s</info>', $stamper->currentVersion() ?? 'unknown'));
+        $output->writeln('');
+
+        $hasDrift = false;
+        foreach ($statuses as $status) {
+            $output->writeln($this->formatStatusLine($status));
+            $hasDrift = $hasDrift || $status->isDrift();
+        }
+
+        return $hasDrift ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function formatStatusLine(AgentPlatformStatus $status): string
+    {
+        $key = $status->platform->key;
+        $installed = $status->installedVersion ?? '?';
+
+        return match ($status->state) {
+            AgentPlatformStatus::CURRENT => sprintf('  <info>✓</info> %-8s v%s', $key, $installed),
+            AgentPlatformStatus::STALE => sprintf('  <comment>!</comment> %-8s v%s (current v%s) — run `agent-install %s --force` to refresh', $key, $installed, $status->currentVersion, $key),
+            AgentPlatformStatus::UNSTAMPED => sprintf('  <comment>?</comment> %-8s file exists but has no version stamp — run `agent-install %s --force` to refresh', $key, $key),
+            AgentPlatformStatus::NOT_INSTALLED => sprintf('    %-8s not installed', $key),
+            default => sprintf('  %-8s unknown state: %s', $key, $status->state),
+        };
     }
 
     /**
@@ -120,16 +140,16 @@ final class AgentInstallCommand extends Command
         $installAll = (bool) $input->getOption(self::OPT_ALL);
 
         if ($installAll) {
-            return array_keys(self::PLATFORMS);
+            return $this->registry->keys();
         }
 
         if ($platform === null) {
             $output->writeln('<error>Provide a platform or use --all</error>');
-            $output->writeln(sprintf('Platforms: %s', implode(', ', array_keys(self::PLATFORMS))));
+            $output->writeln(sprintf('Platforms: %s', implode(', ', $this->registry->keys())));
             return null;
         }
 
-        if (!isset(self::PLATFORMS[$platform])) {
+        if (!$this->registry->has($platform)) {
             $output->writeln(sprintf('<error>Unknown platform: %s</error>', $platform));
             return null;
         }
@@ -141,13 +161,13 @@ final class AgentInstallCommand extends Command
         OutputInterface $output,
         string $sourceRoot,
         string $projectRoot,
-        string $platform,
+        AgentPlatform $platform,
         bool $force,
         bool $dryRun,
+        AgentVersionStamper $stamper,
     ): void {
-        $spec = self::PLATFORMS[$platform];
-        $src = $sourceRoot . '/' . $spec['source'];
-        $dst = $projectRoot . '/' . $spec['target'];
+        $src = $sourceRoot . '/' . $platform->source;
+        $dst = $projectRoot . '/' . $platform->target;
 
         if (!is_file($src)) {
             throw new RuntimeException(sprintf('Source skill file not found: %s', $src));
@@ -162,8 +182,8 @@ final class AgentInstallCommand extends Command
         $this->backupIfExists($output, $dst, $force);
 
         $contents = (string) file_get_contents($src);
-        file_put_contents($dst, $this->stampVersion($contents, $sourceRoot));
-        $output->writeln(sprintf('<info>Installed</info> %s skill: %s', $platform, $dst));
+        file_put_contents($dst, $stamper->stamp($contents));
+        $output->writeln(sprintf('<info>Installed</info> %s skill: %s', $platform->key, $dst));
     }
 
     private function backupIfExists(OutputInterface $output, string $dst, bool $force): void
@@ -175,22 +195,6 @@ final class AgentInstallCommand extends Command
         $backup = $dst . self::BACKUP_SUFFIX;
         copy($dst, $backup);
         $output->writeln(sprintf('Backed up existing -> %s', $backup));
-    }
-
-    private function stampVersion(string $contents, string $sourceRoot): string
-    {
-        $versionFile = $sourceRoot . '/' . self::VERSION_FILE;
-        if (!is_file($versionFile)) {
-            return $contents;
-        }
-
-        $version = trim((string) file_get_contents($versionFile));
-        if ($version === '') {
-            return $contents;
-        }
-
-        $stripped = (string) preg_replace(self::STAMP_PATTERN, '', $contents);
-        return rtrim($stripped) . sprintf("\n\n<!-- phel-agents v%s -->\n", $version);
     }
 
     private function copyDocs(

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Infrastructure\Command;
 
 use FilesystemIterator;
 use Phel\Run\Application\Agent\AgentInstallStatusInspector;
+use Phel\Run\Application\Agent\AgentPlatformDetector;
 use Phel\Run\Application\Agent\AgentVersionStamper;
 use Phel\Run\Domain\Agent\AgentPlatform;
 use Phel\Run\Domain\Agent\AgentPlatformRegistry;
@@ -49,6 +50,8 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_UNINSTALL = 'uninstall';
 
+    private const string OPT_AUTO = 'auto';
+
     private const string AGENTS_DIR = '.agents';
 
     private const string BACKUP_SUFFIX = '.pre-phel.bak';
@@ -78,7 +81,8 @@ final class AgentInstallCommand extends Command
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
             ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift')
             ->addOption(self::OPT_LIST, null, InputOption::VALUE_NONE, 'List supported platforms with source template, install target, and current state')
-            ->addOption(self::OPT_UNINSTALL, null, InputOption::VALUE_NONE, 'Remove installed skill file(s); restores ' . self::BACKUP_SUFFIX . ' if present');
+            ->addOption(self::OPT_UNINSTALL, null, InputOption::VALUE_NONE, 'Remove installed skill file(s); restores ' . self::BACKUP_SUFFIX . ' if present')
+            ->addOption(self::OPT_AUTO, null, InputOption::VALUE_NONE, 'Auto-detect agents already present in the project (.claude/, .cursor/, AGENTS.md, ...) and install for them');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -257,12 +261,31 @@ final class AgentInstallCommand extends Command
     {
         $platform = $input->getArgument(self::ARG_PLATFORM);
         $installAll = (bool) $input->getOption(self::OPT_ALL);
+        $auto = (bool) $input->getOption(self::OPT_AUTO);
+
+        if ($auto) {
+            $detected = new AgentPlatformDetector($this->registry)->detect((string) getcwd());
+            if ($detected === []) {
+                $output->writeln('<comment>No agent traces detected; nothing to install. Use --all or pass a platform.</comment>');
+                return null;
+            }
+
+            $output->writeln(sprintf('Detected: <info>%s</info>', implode(', ', $detected)));
+            return $detected;
+        }
 
         if ($installAll) {
             return $this->registry->keys();
         }
 
         if ($platform === null) {
+            $detected = new AgentPlatformDetector($this->registry)->detect((string) getcwd());
+            if ($detected !== []) {
+                $output->writeln(sprintf('Detected installed agents: <info>%s</info>', implode(', ', $detected)));
+                $output->writeln('Run <comment>agent-install --auto</comment> to install skills for detected agents, or <comment>--all</comment> for every platform.');
+                return null;
+            }
+
             $output->writeln('<error>Provide a platform or use --all</error>');
             $output->writeln(sprintf('Platforms: %s', implode(', ', $this->registry->keys())));
             return null;

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -259,35 +259,17 @@ final class AgentInstallCommand extends Command
      */
     private function selectPlatforms(InputInterface $input, OutputInterface $output): ?array
     {
-        $platform = $input->getArgument(self::ARG_PLATFORM);
-        $installAll = (bool) $input->getOption(self::OPT_ALL);
-        $auto = (bool) $input->getOption(self::OPT_AUTO);
-
-        if ($auto) {
-            $detected = new AgentPlatformDetector($this->registry)->detect((string) getcwd());
-            if ($detected === []) {
-                $output->writeln('<comment>No agent traces detected; nothing to install. Use --all or pass a platform.</comment>');
-                return null;
-            }
-
-            $output->writeln(sprintf('Detected: <info>%s</info>', implode(', ', $detected)));
-            return $detected;
+        if ((bool) $input->getOption(self::OPT_AUTO)) {
+            return $this->selectAutoDetected($output);
         }
 
-        if ($installAll) {
+        if ((bool) $input->getOption(self::OPT_ALL)) {
             return $this->registry->keys();
         }
 
+        $platform = $input->getArgument(self::ARG_PLATFORM);
         if ($platform === null) {
-            $detected = new AgentPlatformDetector($this->registry)->detect((string) getcwd());
-            if ($detected !== []) {
-                $output->writeln(sprintf('Detected installed agents: <info>%s</info>', implode(', ', $detected)));
-                $output->writeln('Run <comment>agent-install --auto</comment> to install skills for detected agents, or <comment>--all</comment> for every platform.');
-                return null;
-            }
-
-            $output->writeln('<error>Provide a platform or use --all</error>');
-            $output->writeln(sprintf('Platforms: %s', implode(', ', $this->registry->keys())));
+            $this->reportMissingPlatform($output);
             return null;
         }
 
@@ -297,6 +279,42 @@ final class AgentInstallCommand extends Command
         }
 
         return [$platform];
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function selectAutoDetected(OutputInterface $output): ?array
+    {
+        $detected = $this->detectAgents();
+        if ($detected === []) {
+            $output->writeln('<comment>No agent traces detected; nothing to install. Use --all or pass a platform.</comment>');
+            return null;
+        }
+
+        $output->writeln(sprintf('Detected: <info>%s</info>', implode(', ', $detected)));
+        return $detected;
+    }
+
+    private function reportMissingPlatform(OutputInterface $output): void
+    {
+        $detected = $this->detectAgents();
+        if ($detected !== []) {
+            $output->writeln(sprintf('Detected installed agents: <info>%s</info>', implode(', ', $detected)));
+            $output->writeln('Run <comment>agent-install --auto</comment> to install skills for detected agents, or <comment>--all</comment> for every platform.');
+            return;
+        }
+
+        $output->writeln('<error>Provide a platform or use --all</error>');
+        $output->writeln(sprintf('Platforms: %s', implode(', ', $this->registry->keys())));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function detectAgents(): array
+    {
+        return new AgentPlatformDetector($this->registry)->detect((string) getcwd());
     }
 
     private function installPlatform(

--- a/src/php/Run/Infrastructure/Command/DoctorCommand.php
+++ b/src/php/Run/Infrastructure/Command/DoctorCommand.php
@@ -9,11 +9,18 @@ use Gacela\Framework\Health\HealthChecker;
 use Gacela\Framework\Health\HealthStatus;
 use Phel\Build\BuildFacade;
 use Phel\Filesystem\FilesystemFacade;
+use Phel\Run\Application\Agent\AgentInstallStatusInspector;
+use Phel\Run\Application\Agent\AgentVersionStamper;
+use Phel\Run\Domain\Agent\AgentPlatformRegistry;
+use Phel\Run\Domain\Agent\AgentPlatformStatus;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function dirname;
 use function extension_loaded;
+use function getcwd;
+use function is_dir;
 use function sprintf;
 
 final class DoctorCommand extends Command
@@ -28,6 +35,7 @@ final class DoctorCommand extends Command
     {
         $systemOk = $this->checkSystemRequirements($output);
         $modulesOk = $this->checkModuleHealth($output);
+        $this->reportAgentInstallStatus($output);
 
         if ($systemOk && $modulesOk) {
             $output->writeln('<info>Your system meets all requirements.</info>');
@@ -38,6 +46,64 @@ final class DoctorCommand extends Command
         $output->writeln('<error>Your system does not meet all requirements.</error>');
 
         return Command::FAILURE;
+    }
+
+    private function reportAgentInstallStatus(OutputInterface $output): void
+    {
+        $sourceRoot = $this->agentsRoot();
+        if ($sourceRoot === null) {
+            return;
+        }
+
+        $stamper = new AgentVersionStamper($sourceRoot);
+        $inspector = new AgentInstallStatusInspector(new AgentPlatformRegistry(), $stamper);
+        $statuses = $inspector->inspect((string) getcwd());
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            'AI agent skills (phel-agents v%s):',
+            $stamper->currentVersion() ?? 'unknown',
+        ));
+
+        $installedCount = 0;
+        foreach ($statuses as $status) {
+            if ($status->state === AgentPlatformStatus::NOT_INSTALLED) {
+                continue;
+            }
+
+            ++$installedCount;
+            $output->writeln(sprintf(
+                ' - %-8s %s',
+                $status->platform->key,
+                $this->formatAgentState($status),
+            ));
+        }
+
+        if ($installedCount === 0) {
+            $output->writeln(' - none installed; run <comment>phel agent-install --auto</comment>');
+        }
+    }
+
+    private function formatAgentState(AgentPlatformStatus $status): string
+    {
+        return match ($status->state) {
+            AgentPlatformStatus::CURRENT => sprintf('<info>OK</info> v%s', $status->installedVersion ?? '?'),
+            AgentPlatformStatus::STALE => sprintf('<comment>STALE</comment> v%s (current v%s) — refresh with `agent-install %s --force`', $status->installedVersion ?? '?', $status->currentVersion, $status->platform->key),
+            AgentPlatformStatus::UNSTAMPED => sprintf('<comment>UNSTAMPED</comment> — refresh with `agent-install %s --force`', $status->platform->key),
+            default => $status->state,
+        };
+    }
+
+    private function agentsRoot(): ?string
+    {
+        foreach ([5, 4, 6] as $levels) {
+            $candidate = dirname(__DIR__, $levels) . '/resources/agents';
+            if (is_dir($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     private function checkSystemRequirements(OutputInterface $output): bool

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -159,6 +159,54 @@ final class AgentInstallCommandTest extends TestCase
         self::assertStringContainsString('quick-syntax.md', $content);
     }
 
+    public function test_check_reports_not_installed_for_fresh_project(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        $rendered = $output->fetch();
+        self::assertStringContainsString('claude   not installed', $rendered);
+        self::assertStringContainsString('cursor   not installed', $rendered);
+    }
+
+    public function test_check_reports_current_for_freshly_installed(): void
+    {
+        $this->install(['platform' => 'aider']);
+
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertMatchesRegularExpression('/aider\s+v\d+\.\d+\.\d+/', $output->fetch());
+    }
+
+    public function test_check_returns_failure_when_stamp_is_stale(): void
+    {
+        $this->install(['platform' => 'aider']);
+        $path = $this->testDir . '/CONVENTIONS.md';
+        $original = (string) file_get_contents($path);
+        file_put_contents($path, preg_replace('/<!-- phel-agents v[^>]*-->/', '<!-- phel-agents v0.0.1 -->', $original));
+
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::FAILURE, $result);
+        self::assertStringContainsString('v0.0.1', $output->fetch());
+    }
+
+    public function test_check_reports_unstamped_when_file_has_no_stamp(): void
+    {
+        mkdir($this->testDir . '/.github', 0o755, true);
+        file_put_contents($this->testDir . '/.github/copilot-instructions.md', "# manual content\nno stamp here\n");
+
+        $output = new BufferedOutput();
+        $result = $this->install(['--check' => true], $output);
+
+        self::assertSame(Command::FAILURE, $result);
+        self::assertStringContainsString('copilot  file exists but has no version stamp', $output->fetch());
+    }
+
     /**
      * @param array<string, mixed> $args
      */

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -195,6 +195,31 @@ final class AgentInstallCommandTest extends TestCase
         self::assertStringContainsString('v0.0.1', $output->fetch());
     }
 
+    public function test_list_shows_all_supported_platforms_with_targets(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['--list' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        $rendered = $output->fetch();
+        foreach (['claude', 'cursor', 'codex', 'gemini', 'copilot', 'aider'] as $key) {
+            self::assertStringContainsString($key, $rendered);
+        }
+
+        self::assertStringContainsString('.claude/skills/phel-lang/SKILL.md', $rendered);
+        self::assertStringContainsString('not installed', $rendered);
+    }
+
+    public function test_list_reflects_installed_state(): void
+    {
+        $this->install(['platform' => 'aider']);
+
+        $output = new BufferedOutput();
+        $this->install(['--list' => true], $output);
+
+        self::assertMatchesRegularExpression('/aider\s+.+\s+current \(v\d+\.\d+\.\d+\)/', $output->fetch());
+    }
+
     public function test_check_reports_unstamped_when_file_has_no_stamp(): void
     {
         mkdir($this->testDir . '/.github', 0o755, true);

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -266,6 +266,44 @@ final class AgentInstallCommandTest extends TestCase
         self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
     }
 
+    public function test_auto_installs_only_for_detected_agents(): void
+    {
+        mkdir($this->testDir . '/.claude', 0o755, true);
+        mkdir($this->testDir . '/.cursor', 0o755, true);
+
+        $output = new BufferedOutput();
+        $result = $this->install(['--auto' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertFileExists($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
+        self::assertFileExists($this->testDir . '/.cursor/rules/phel.mdc');
+        self::assertFileDoesNotExist($this->testDir . '/AGENTS.md');
+        self::assertFileDoesNotExist($this->testDir . '/GEMINI.md');
+        self::assertStringContainsString('Detected:', $output->fetch());
+    }
+
+    public function test_auto_with_no_detection_returns_invalid(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['--auto' => true], $output);
+
+        self::assertSame(Command::INVALID, $result);
+        self::assertStringContainsString('No agent traces detected', $output->fetch());
+    }
+
+    public function test_no_args_suggests_auto_when_agents_detected(): void
+    {
+        mkdir($this->testDir . '/.claude', 0o755, true);
+
+        $output = new BufferedOutput();
+        $result = $this->install([], $output);
+
+        self::assertSame(Command::INVALID, $result);
+        $rendered = $output->fetch();
+        self::assertStringContainsString('Detected installed agents', $rendered);
+        self::assertStringContainsString('agent-install --auto', $rendered);
+    }
+
     public function test_uninstall_on_unknown_platform_is_noop(): void
     {
         $output = new BufferedOutput();

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -220,6 +220,61 @@ final class AgentInstallCommandTest extends TestCase
         self::assertMatchesRegularExpression('/aider\s+.+\s+current \(v\d+\.\d+\.\d+\)/', $output->fetch());
     }
 
+    public function test_uninstall_removes_skill_file_when_no_backup(): void
+    {
+        $this->install(['platform' => 'aider', '--force' => true]);
+        self::assertFileExists($this->testDir . '/CONVENTIONS.md');
+
+        $this->install(['platform' => 'aider', '--uninstall' => true]);
+
+        self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md');
+    }
+
+    public function test_uninstall_restores_backup_when_present(): void
+    {
+        file_put_contents($this->testDir . '/CONVENTIONS.md', 'user-original');
+        $this->install(['platform' => 'aider']);
+
+        $this->install(['platform' => 'aider', '--uninstall' => true]);
+
+        self::assertSame('user-original', file_get_contents($this->testDir . '/CONVENTIONS.md'));
+        self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md.pre-phel.bak');
+    }
+
+    public function test_uninstall_all_removes_every_installed_file(): void
+    {
+        $this->install(['--all' => true]);
+
+        $this->install(['--all' => true, '--uninstall' => true]);
+
+        foreach (['AGENTS.md', 'GEMINI.md', 'CONVENTIONS.md'] as $f) {
+            self::assertFileDoesNotExist($this->testDir . '/' . $f);
+        }
+
+        self::assertFileDoesNotExist($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
+        self::assertFileDoesNotExist($this->testDir . '/.cursor/rules/phel.mdc');
+        self::assertFileDoesNotExist($this->testDir . '/.github/copilot-instructions.md');
+    }
+
+    public function test_uninstall_with_docs_removes_agents_tree(): void
+    {
+        $this->install(['platform' => 'claude', '--with-docs' => true]);
+        self::assertDirectoryExists($this->testDir . '/.agents');
+
+        $this->install(['platform' => 'claude', '--uninstall' => true, '--with-docs' => true]);
+
+        self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
+    }
+
+    public function test_uninstall_on_unknown_platform_is_noop(): void
+    {
+        $output = new BufferedOutput();
+        $result = $this->install(['platform' => 'aider', '--uninstall' => true], $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertStringContainsString('aider    not installed', $output->fetch());
+    }
+
     public function test_check_reports_unstamped_when_file_has_no_stamp(): void
     {
         mkdir($this->testDir . '/.github', 0o755, true);

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -43,6 +43,18 @@ final class DoctorCommandTest extends TestCase
         );
     }
 
+    public function test_doctor_includes_agent_install_section(): void
+    {
+        $command = new DoctorCommand();
+
+        $this->expectOutputRegex('/AI agent skills \(phel-agents v/');
+
+        $command->run(
+            $this->createStub(InputInterface::class),
+            $this->stubOutput(),
+        );
+    }
+
     private function stubOutput(): OutputInterface
     {
         $output = $this->createStub(OutputInterface::class);


### PR DESCRIPTION
## 🤔 Background

PR #1966 made the 6 agent skill files lean and consistent. Day-to-day usage still needed answers to: "is my install up to date?", "what's available?", "how do I undo?", and "which agents does this project actually use?". This PR adds those pieces and surfaces them where users already look.

## 💡 Goal

Make `phel agent-install` and `phel doctor` answer every reasonable question about agent skills without grepping files or rerunning installs.

## 🔖 Changes (7 iterations)

1. **`--check`** — reads `<!-- phel-agents vX.Y.Z -->` stamps from installed files, compares to `resources/agents/VERSION`, reports per-platform state (current / stale / unstamped / not installed). Exit 1 on drift.
2. **`--list`** — table view: platform, source template, install target, current state.
3. **`--uninstall`** — removes installed skill file(s); restores `.pre-phel.bak` when present. `--with-docs` also drops `.agents/`.
4. **`--auto`** — detects `.claude/`, `.cursor/`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `CONVENTIONS.md`, `.aider.conf.yml` and installs only for agents the project already uses. With no args, the command now suggests `--auto` instead of just erroring.
5. **`phel doctor` integration** — surfaces installed agent skills + drift in the existing health report.
6. **`INSTALL.md`** — flag reference, recommended setup, detection-signal column.
7. **`ref` polish** — extracted `AgentPlatformRegistry`, `AgentVersionStamper`, `AgentInstallStatusInspector`, `AgentPlatformDetector` under `Run/Application/Agent` + `Run/Domain/Agent`; `selectPlatforms` split into `selectAutoDetected` / `reportMissingPlatform` / `detectAgents` helpers.

## Tests

- `AgentInstallCommandTest`: 26 tests covering install, check, list, uninstall, auto, with-docs, dry-run, force/backup, version stamping.
- `DoctorCommandTest`: new assertion that the doctor report includes the agent skills section.

## Why

One command, one workflow: detect → install → verify → uninstall. Doctor becomes the single "is everything wired" spot. New users can `agent-install --auto --with-docs` and stop thinking about it; upgraders run `agent-install --check` in CI to catch drift.