### PR TITLE
docs(agents): optimize resources/agents — trim dups, fill task gaps, normalize cross-refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - `phel agent-install --uninstall` removes skill file(s) and restores `.pre-phel.bak` if present; `--with-docs` also drops `.agents/`
 - `phel agent-install --auto` installs skills only for agents already used in the project (detects `.claude/`, `.cursor/`, `AGENTS.md`, `GEMINI.md`, etc.)
 - `phel doctor` now reports installed agent skills and surfaces stale versions in one place
+- New agent task recipes: `tasks/async.md`, `tasks/memoize.md`, `tasks/write-macros.md`; common-gotchas trimmed to non-duplicative items; module table cross-links to tasks
 - Runtime state (cache, REPL history, error log) consolidated under `.phel/`; relocate via `withPhelDir()` or `PHEL_DIR` env (#1954)
 - Module boundary tightening: `Munge`, `CompileOptions`, `PhelProjectDirectory`, `VersionFinder` moved to `Phel\Shared`; `GlobalEnvironment`, `DebugLineTap` exposed via `CompilerFacade` (#1963, #1964)
 - `PhelConfig` immutable via `withX()` chain; build/export fields flat on root; old `setX()` shims deprecated

--- a/resources/agents/README.md
+++ b/resources/agents/README.md
@@ -5,8 +5,7 @@ Agent-agnostic docs for AI assistants building apps **with** Phel.
 This tree is source material for `phel agent-install`. In user projects, `--with-docs` installs it as `.agents/`, so
 references inside adapter files intentionally point to `.agents/...`.
 
-Repo-maintenance guidance for phel-lang itself lives in the root `AGENTS.md`, `.codex/`, `.claude/`, `.agents/`, and
-`src/php/**/CLAUDE.md`.
+Repo-maintenance guidance for phel-lang itself lives in the root `AGENTS.md`, `.codex/`, `.claude/`, and `src/php/**/CLAUDE.md`.
 
 ## Install
 

--- a/resources/agents/index.md
+++ b/resources/agents/index.md
@@ -11,24 +11,24 @@ Rules + CLI: [`RULES.md`](RULES.md).
 | CLI tool | [`tasks/cli-tool.md`](tasks/cli-tool.md) | `docs/php-interop.md` |
 | Add tests | [`tasks/add-tests.md`](tasks/add-tests.md) | `src/phel/test.phel`, `docs/mocking-guide.md` |
 | REPL | [`tasks/repl-workflow.md`](tasks/repl-workflow.md) | `src/phel/repl.phel` |
-| Find core fn | [`tasks/use-core-lib.md`](tasks/use-core-lib.md) | `(phel doc <fn>)`, `docs/patterns.md` |
+| Find core fn | [`tasks/use-core-lib.md`](tasks/use-core-lib.md) | `phel doc <fn>`, `docs/patterns.md` |
 | Type a fn (params + return) | [`tasks/typed-defn.md`](tasks/typed-defn.md) | `docs/quickstart.md`, `docs/schema-guide.md` |
 | Debug errors | [`tasks/debug-errors.md`](tasks/debug-errors.md) | `docs/patterns.md` § Error Handling |
 | Profile hot paths | [`tasks/typed-defn.md`](tasks/typed-defn.md) § Find hot paths | `phel profile <path>` |
-| Async / fibers | — | `docs/async-guide.md`, `src/phel/async.phel` |
-| Memoize | — | `(doc memoize)`, `(doc memoize-lru)` |
+| Async / fibers | [`tasks/async.md`](tasks/async.md) | `docs/async-guide.md`, `src/phel/async.phel` |
+| Memoize | [`tasks/memoize.md`](tasks/memoize.md) | `phel doc memoize`, `phel doc memoize-lru` |
+| Write macros | [`tasks/write-macros.md`](tasks/write-macros.md) | `docs/patterns.md` § Writing Macros |
 | Common pitfalls | [`tasks/common-gotchas.md`](tasks/common-gotchas.md) | `RULES.md` § Gotchas |
 | Use a PHP library | [`tasks/use-php-libs.md`](tasks/use-php-libs.md) | `docs/php-interop.md` |
 | Validate data | [`tasks/validate-with-schema.md`](tasks/validate-with-schema.md) | `src/phel/schema.phel`, `docs/schema-guide.md` |
 | Pattern match | [`tasks/pattern-match.md`](tasks/pattern-match.md) | `src/phel/match.phel`, `docs/match-guide.md` |
 | Lint code | — | `docs/lint-guide.md` |
-| Editor integration | — | `docs/lsp-guide.md`, `docs/nrepl-guide.md` |
+| Editor / nREPL | — | `docs/lsp-guide.md`, `docs/nrepl-guide.md` |
 | Hot-reload | — | `docs/watch-guide.md` |
 | Syntax reference | [`quick-syntax.md`](quick-syntax.md) | `docs/quickstart.md`, `docs/reader-shortcuts.md` |
 | Idioms | — | `docs/patterns.md`, `docs/examples/` |
 | Call Phel from PHP | — | `docs/framework-integration.md` |
-| Data structures | — | `docs/data-structures-guide.md`, `docs/lazy-sequences.md` |
-| Macros | — | `docs/patterns.md` § Writing Macros |
+| Data structures | — | `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md` |
 
 ## Examples
 

--- a/resources/agents/tasks/add-tests.md
+++ b/resources/agents/tasks/add-tests.md
@@ -108,6 +108,8 @@ Full: `docs/mocking-guide.md`.
 - No `:reload`. Restart REPL or run `phel test`.
 - Typed fn under test: literal arg mismatch is now a compile error in the test file too. Cast or use a non-literal binding to test runtime paths.
 
-## Next
+## See also
 
-`src/phel/test.phel`, `docs/mocking-guide.md`, `tests/phel/*.phel`, `tasks/typed-defn.md`
+- `tasks/typed-defn.md` — typed fns under test
+- `docs/mocking-guide.md`
+- `src/phel/test.phel`, `tests/phel/*.phel`

--- a/resources/agents/tasks/async.md
+++ b/resources/agents/tasks/async.md
@@ -1,0 +1,54 @@
+# Async / fibers
+
+`phel\async` wraps AMPHP fibers. Use for I/O concurrency (HTTP, file, sleep), not CPU work.
+
+## Basic
+
+```phel
+(ns my-app\main
+  (:require phel\async :refer [async await delay future]))
+
+(defn fetch-slow [url]
+  (delay 200)                          ; simulate latency
+  (str "got " url))
+
+(defn ^:async fetch-pair []
+  (let [a (future #(fetch-slow "/a"))
+        b (future #(fetch-slow "/b"))]
+    [(await a) (await b)]))             ; concurrent, total ~200ms
+```
+
+`^:async defn` wraps the body in `async`; the function returns an `Amp\Future`.
+
+## Building blocks
+
+| Form | Returns | Purpose |
+|------|---------|---------|
+| `(async (fn [] body))` | `Amp\Future` | Run body in a fiber |
+| `(future #(work))` | `Amp\Future` | Sugar for the common case |
+| `(await fut)` | result | Block current fiber until done |
+| `(delay ms)` | nil | Cooperative sleep |
+
+## Outside an async context
+
+`await` from synchronous code throws. Wrap callers in `async` or `^:async defn`, or call `(.await fut)` only inside a fiber.
+
+## Combine with `^:memoize`
+
+```phel
+(defn ^:async ^:memoize fetch-user [^int id]
+  (await (http-get (str "/users/" id))))
+```
+
+Cache hits skip the fiber entirely.
+
+## Gotchas
+
+- CPU-bound code (parsing, math) gains nothing — fibers are cooperative, single-threaded.
+- `(async ...)` returns immediately; ignoring the future swallows errors. `await` or store it.
+- `^:async ^{:async false}` — opt-out without removing the meta key (e.g. when bench-comparing).
+
+## See also
+
+- `docs/async-guide.md`
+- `tasks/typed-defn.md` for combining `^:async` with `:tag` (`^"\\Amp\\Future"` return tag)

--- a/resources/agents/tasks/cli-tool.md
+++ b/resources/agents/tasks/cli-tool.md
@@ -214,6 +214,8 @@ For a trivial script without subcommands, drop `phel\cli`:
 
 Example: `.agents/examples/cli-wordcount/`.
 
-## Next
+## See also
 
-`docs/cli-guide.md`, `src/phel/cli.phel`, `tasks/add-tests.md`, `docs/framework-integration.md`
+- `tasks/add-tests.md` — test fixtures for handler fns
+- `docs/cli-guide.md`, `docs/framework-integration.md`
+- `src/phel/cli.phel`

--- a/resources/agents/tasks/common-gotchas.md
+++ b/resources/agents/tasks/common-gotchas.md
@@ -1,143 +1,88 @@
 # Common gotchas
 
-Pitfalls encountered during real-world Phel app development. Read before writing your first app.
+Pitfalls hit during real-world Phel app development. Read before writing your first app. Rules in [`RULES.md`](../RULES.md); this file adds the example each rule's one-liner doesn't show.
 
 ## 1. CLI argument access
 
-**Wrong** — `php/$argv` is `null` inside `phel run`:
+`php/$argv` is `null` inside `phel run`. Use `*argv*`:
 
 ```phel
-;; DON'T: this fails at runtime
-(let [args php/$argv] ...)
-```
-
-**Right** — use `*argv*`, which returns a Phel vector of strings (args after the script path):
-
-```phel
-(let [args *argv*]
+(let [args *argv*]                ; Phel vector of strings after the script path
   (println "First arg:" (first args)))
 ```
 
-For the full `phel\cli` module (subcommands, options, prompts), see `tasks/cli-tool.md`.
+Full CLI: `tasks/cli-tool.md`.
 
 ## 2. `transduce` with `max` / `min`
 
-`max` and `min` don't support 0-arity (no identity value), so they can't be used as bare reducing functions with `transduce`:
+`max` and `min` lack a 0-arity init. Wrap and pass an explicit seed:
 
 ```phel
-;; DON'T: fails — max needs 2 args, transduce calls (max) for init
+;; bad
 (transduce (map :score) max items)
-
-;; DO: wrap and provide init
+;; good
 (transduce (map :score) (fn [a b] (max a b)) 0 items)
 ```
 
 ## 3. `for` vs `doseq`
 
-`for` is a **list comprehension** — it builds a lazy sequence. `doseq` is for **side effects**.
+`for` builds a lazy sequence; `doseq` runs for side effects.
 
 ```phel
-;; DON'T: for returns a sequence, side effects are incidental
-(for [t :in todos] (println t))
-
-;; DO: doseq when you want side effects
-(doseq [t :in todos] (println t))
-
-;; DO: for when you want to build a collection
-(for [x :in xs :when (odd? x)] (* x x))
+(doseq [t :in todos] (println t))            ; side effects
+(for   [x :in xs :when (odd? x)] (* x x))    ; build a collection
 ```
 
-## 4. `phel.string` (not `phel.str`)
+## 4. Top-level side effects break `phel build`
 
-Since v0.33, the string module is `phel.string`:
-
-```phel
-;; DON'T
-(:require phel.str :as str)
-
-;; DO
-(:require phel.string :as string)
-```
-
-(`\` separator still parses but is deprecated.)
-
-## 5. Namespace segment count
-
-Namespaces need at least 2 segments. Single-segment namespaces cause a compile error:
+Top-level code runs at compile time. Guard:
 
 ```phel
-;; DON'T
-(ns main)
-
-;; DO
-(ns my-app\main)
-```
-
-## 6. Top-level side effects and `phel build`
-
-Code at the top level runs during compilation. Wrap side effects:
-
-```phel
-;; DON'T: breaks phel build
-(println "starting...")
-(start-server)
-
-;; DO
 (when-not *build-mode*
-  (println "starting...")
   (start-server))
 ```
 
-## 7. Converting PHP arrays to Phel collections
+## 5. PHP arrays vs Phel collections
 
-PHP arrays from interop are not Phel collections. Convert them:
+PHP interop returns raw PHP arrays, not Phel collections. Convert:
 
 ```phel
-;; PHP array → Phel vector
-(vec (php/explode "," "a,b,c"))
-
-;; Phel collection → PHP array (for passing to PHP functions)
-(to-php-array ["a" "b" "c"])
+(vec (php/explode "," "a,b,c"))   ; PHP array  → Phel vector
+(to-php-array ["a" "b" "c"])      ; Phel vec   → PHP indexed array
+(php-array-to-map arr)            ; PHP assoc  → Phel map
 ```
 
-Don't try `to-list` (doesn't exist) or `to-vec` (doesn't exist). Use `vec`.
+`to-list` and `to-vec` don't exist. Use `vec` / `to-php-array`.
 
-## 8. Record fields are accessed with `get`
-
-`defrecord` fields use keyword access via `get`, not dot notation:
+## 6. Record fields use `get`, not `.-prop`
 
 ```phel
 (defrecord Point [x y])
 (let [p (->Point 1 2)]
-  ;; DON'T: (.-x p); this is PHP property access
-  ;; DO:
-  (get p :x))
+  (get p :x))                     ; not (.-x p) — that's PHP property access
 ```
 
-## 9. `:tag` literal-arg mismatch is a compile error
+## 7. `:tag` literal mismatch is a compile error
 
 ```phel
 (defn ^int square [^int x] (* x x))
-
-;; DON'T: literal mismatch fails at compile time, not runtime
-(square "abc")
-
-;; DO: pass an int, or widen the tag
-(square 7)
-(defn ^int square [^"int|string" x] ...)   ; if you really want both
+(square "abc")                    ; :phel/static-type at compile time, not runtime
 ```
 
-Same for `recur` args vs. binding tags and tail literal vs. declared return tag. See `tasks/typed-defn.md`.
+Same for `recur` args vs binding tags and tail literal vs declared return tag. See `tasks/typed-defn.md`.
 
-## 10. `^` tags one symbol; map form for unusual types
+## 8. `^` tags one symbol; map form for unusual types
 
 ```phel
-;; DON'T: ^?int parses as a symbol named "?int"
-(defn parse [^?int s] ...)
-
-;; DO: quote the type string
-(defn parse [^"?int" s] ...)
-(defn parse [^{:tag "?int"} s] ...)
+(defn parse [^"?int" s] ...)              ; quote the type string
+(defn parse [^{:tag "?int"} s] ...)       ; map form
+(defn now   [^"\\DateTimeImmutable"] ...) ; class FQN needs leading \\
 ```
 
-Class FQNs need leading `\\`: `^"\\App\\User"`.
+`^?int` parses as a symbol named `?int`, not a nullable-int tag.
+
+## See also
+
+- [`RULES.md`](../RULES.md) for the one-liner rule each gotcha references.
+- [`tasks/debug-errors.md`](debug-errors.md) — error categories and fixes.
+- [`tasks/typed-defn.md`](typed-defn.md) — typing rules in depth.

--- a/resources/agents/tasks/debug-errors.md
+++ b/resources/agents/tasks/debug-errors.md
@@ -106,6 +106,7 @@ Check `~`, `` ` ``, auto-gensym `name#`.
 - PHP fatal errors bypass Phel `catch`.
 - `"a\\b"` is `a\b`.
 
-## Next
+## See also
 
-`docs/patterns.md` § Error Handling, `docs/php-interop.md` § Error Handling, `tasks/repl-workflow.md`, `tasks/typed-defn.md`
+- `tasks/repl-workflow.md`, `tasks/typed-defn.md`, `tasks/write-macros.md`
+- `docs/patterns.md` § Error Handling, `docs/php-interop.md` § Error Handling

--- a/resources/agents/tasks/http-app.md
+++ b/resources/agents/tasks/http-app.md
@@ -177,6 +177,8 @@ Swap `\Phel::run(...)` for `require` of compiled boot file.
 - Nil response from a matched handler triggers `:not-acceptable` (HTTP 406).
 - `:default-handler` is a fallback for any 404/405/406 not covered by a specific override.
 
-## Next
+## See also
 
-`src/phel/router.phel`, `src/phel/http.phel`, `src/phel/http-client.phel`, `tasks/use-php-libs.md`, `docs/framework-integration.md`
+- `tasks/use-php-libs.md`, `tasks/add-tests.md`
+- `src/phel/router.phel`, `src/phel/http.phel`, `src/phel/http-client.phel`
+- `docs/framework-integration.md`

--- a/resources/agents/tasks/memoize.md
+++ b/resources/agents/tasks/memoize.md
@@ -1,0 +1,47 @@
+# Memoize
+
+Opt-in caching via `defn` metadata. Cache key is the full positional arg vector.
+
+## Forms
+
+```phel
+(defn ^:memoize slow-hash [s] (php/sha1 (str s)))
+
+(defn ^{:memoize-lru 256} fib [^int n]
+  (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+
+(defn ^{:memoize false} sometimes-cached [...] ...)   ; opt-out flag
+```
+
+| Meta | Cache | Bound |
+|------|-------|-------|
+| `^:memoize` | unbounded | grows for life of process |
+| `^{:memoize-lru N}` | LRU | last `N` distinct arg vectors |
+| `^{:memoize false}` | none | escape hatch with meta intact |
+
+Combine with `:tag` for static type checks + JIT hints:
+
+```phel
+(defn ^{:memoize-lru 1024 :tag "int"} parse-id [^string s]
+  (php/intval s))
+```
+
+## When NOT to memoize
+
+- Side-effecting fn (the second call returns the first call's stale result; effects skipped).
+- Args contain mutable refs (atoms, PHP objects) — identity, not value, is the key.
+- Hot path with low cache-hit ratio — pure overhead.
+
+## Inspect
+
+```phel
+(phel doc memoize)
+(phel doc memoize-lru)
+```
+
+Manual cache reset isn't part of the public API; recreate the var by re-`def`/reload to clear.
+
+## See also
+
+- `tasks/typed-defn.md` for combining `:tag` + `:memoize`
+- `tasks/async.md` for `^:async ^:memoize` patterns

--- a/resources/agents/tasks/repl-workflow.md
+++ b/resources/agents/tasks/repl-workflow.md
@@ -70,6 +70,7 @@ Errors print trace and keep REPL alive. `(try expr (catch php\Foo e (.getMessage
 
 Per-fn call counts and self/total/avg/max plus compile-phase costs. Use to pick fns worth tagging (`tasks/typed-defn.md`).
 
-## Next
+## See also
 
-`tasks/use-core-lib.md`, `tasks/debug-errors.md`, `tasks/typed-defn.md`, `src/phel/repl.phel`
+- `tasks/use-core-lib.md`, `tasks/debug-errors.md`, `tasks/typed-defn.md`
+- `src/phel/repl.phel`, `docs/nrepl-guide.md`

--- a/resources/agents/tasks/scaffold-project.md
+++ b/resources/agents/tasks/scaffold-project.md
@@ -39,6 +39,6 @@ Namespaces need ≥ 2 segments (`my-app\main`, not `main`).
 
 Installs `.agents/` rules + task recipes + examples into your project so the assistant has Phel context.
 
-## Next
+## See also
 
-`tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/add-tests.md`, `tasks/use-core-lib.md`
+- `tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/add-tests.md`, `tasks/use-core-lib.md`

--- a/resources/agents/tasks/use-core-lib.md
+++ b/resources/agents/tasks/use-core-lib.md
@@ -102,24 +102,26 @@ Core: `(str a b c)`, `(name :k)`, `(keyword "x")`, `(symbol "x")`.
 
 ## Bundled modules
 
-| Module | Purpose |
-|--------|---------|
-| `phel\core` | collections, threading, state, predicates |
-| `phel\string` (`:as str`) | string ops |
-| `phel\json` | encode / decode |
-| `phel\pprint` | pretty-print |
-| `phel\walk` | tree traversal |
-| `phel\base64` | base64 encode/decode (URL-safe variants) |
-| `phel\http` | request/response structs, `request-from-globals`, `emit-response` |
-| `phel\router` | nested routes, middleware, URL gen, `compiled-router` |
-| `phel\http-client` | outbound HTTP: `get`, `post`, `put`, `patch`, `delete`, `head` |
-| `phel\cli` | Symfony-console wrapper — see `tasks/cli-tool.md` |
-| `phel\html` | HTML templating |
-| `phel\test` | `deftest`, `is`, `are`, `testing`, fixtures |
-| `phel\mock` | `with-mocks`, `mock`, `spy`, `called-with?` |
-| `phel\async` | `future`, `async`, `await`, `delay` (AMPHP-backed fibers) |
-| `phel\ai` | LLM client (`complete`, `chat`, `configure`) |
-| `phel\repl` | REPL utilities |
+| Module | Purpose | Task |
+|--------|---------|------|
+| `phel\core` | collections, threading, state, predicates | — |
+| `phel\string` (`:as str`) | string ops | — |
+| `phel\json` | encode / decode | — |
+| `phel\pprint` | pretty-print | — |
+| `phel\walk` | tree traversal | — |
+| `phel\base64` | base64 encode/decode (URL-safe variants) | — |
+| `phel\http` | request/response structs, `request-from-globals`, `emit-response` | [`http-app.md`](http-app.md) |
+| `phel\router` | nested routes, middleware, URL gen, `compiled-router` | [`http-app.md`](http-app.md) |
+| `phel\http-client` | outbound HTTP: `get`, `post`, `put`, `patch`, `delete`, `head` | [`http-app.md`](http-app.md) § Outbound |
+| `phel\cli` | Symfony-console wrapper | [`cli-tool.md`](cli-tool.md) |
+| `phel\html` | HTML templating | — |
+| `phel\test` | `deftest`, `is`, `are`, `testing`, fixtures | [`add-tests.md`](add-tests.md) |
+| `phel\mock` | `with-mocks`, `mock`, `spy`, `called-with?` | [`add-tests.md`](add-tests.md) § Mocking |
+| `phel\async` | `future`, `async`, `await`, `delay` (AMPHP-backed fibers) | [`async.md`](async.md) |
+| `phel\match` | data-shape pattern matching | [`pattern-match.md`](pattern-match.md) |
+| `phel\schema` | validate / coerce / generate | [`validate-with-schema.md`](validate-with-schema.md) |
+| `phel\ai` | LLM client (`complete`, `chat`, `configure`) | — |
+| `phel\repl` | REPL utilities | [`repl-workflow.md`](repl-workflow.md) |
 
 ## When to use what
 
@@ -153,6 +155,7 @@ Hot or public `defn`: tag params + return. PHP type emission, JIT-friendly call 
 
 Detail: [`tasks/typed-defn.md`](typed-defn.md). Find candidates: `phel profile <path>`.
 
-## Next
+## See also
 
-`docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`, `docs/cli-guide.md`, `tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/typed-defn.md`
+- `tasks/typed-defn.md`, `tasks/http-app.md`, `tasks/cli-tool.md`, `tasks/async.md`, `tasks/memoize.md`
+- `docs/patterns.md`, `docs/data-structures-guide.md`, `docs/lazy-sequences.md`, `docs/transducers.md`

--- a/resources/agents/tasks/use-php-libs.md
+++ b/resources/agents/tasks/use-php-libs.md
@@ -81,6 +81,6 @@ composer require guzzlehttp/guzzle
 - PHP warnings don't throw; `(php/error_get_last)` to check.
 - Hot loops: prefer `php/array_map` over round-tripping.
 
-## Next
+## See also
 
-`docs/php-interop.md`, `docs/framework-integration.md`
+- `docs/php-interop.md`, `docs/framework-integration.md`

--- a/resources/agents/tasks/write-macros.md
+++ b/resources/agents/tasks/write-macros.md
@@ -1,0 +1,80 @@
+# Write macros
+
+`defmacro` runs at expand time; body returns a form, not a value. Only quasiquoted (`` ` ``) content survives to runtime.
+
+## Basic
+
+```phel
+(defmacro unless [test & body]
+  `(if (not ~test) (do ~@body)))
+
+(unless false (println "fires"))   ; expands to (if (not false) (do (println ...)))
+```
+
+| Reader | Meaning |
+|--------|---------|
+| `` ` `` | quasiquote — emit form as data, but allow splicing |
+| `~x` | unquote — splice value of `x` |
+| `~@xs` | unquote-splice — splice each element of `xs` |
+| `name#` | auto-gensym — fresh symbol unique to this expansion |
+
+## Inspect expansions
+
+```phel
+(macroexpand-1 '(unless flag (print 1)))
+(macroexpand   '(-> x f g))
+```
+
+## Hygiene rules
+
+Phel macros are **non-hygienic**. Two failure modes:
+
+### 1. Local `let` shadows a referenced global
+
+```phel
+;; BAD: local `memoize-lru` shadows core fn
+(defmacro defn-builder [name meta & fdecl]
+  (let [memoize-lru (php/aget meta :memoize-lru)]
+    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru))))
+
+;; GOOD: role-suffix local names
+(defmacro defn-builder [name meta & fdecl]
+  (let [memoize-lru-arg (php/aget meta :memoize-lru)]
+    `(def ~name ~meta (memoize-lru (fn ~@fdecl) ~memoize-lru-arg))))
+```
+
+Convention: suffix macro-local bindings with `-arg`, `-flag`, `-val`, `-sym`, `-form`.
+
+### 2. Introduced symbols capture caller bindings
+
+```phel
+;; BAD: user's `acc` gets clobbered
+(defmacro with-acc [& body] `(let [acc 0] ~@body))
+
+;; GOOD: auto-gensym
+(defmacro with-acc [& body] `(let [acc# 0] ~@body))
+```
+
+Hygiene checklist:
+
+- List every `let`-binding name in the macro body.
+- Grep each against in-scope globals (own ns, `phel\core`, `:use`d modules).
+- Collision → suffix.
+- New scope-introduced symbol → `name#`.
+- Add a test exercising recursion / self-reference where shadowing diverges from the global.
+
+## Expand-time vs runtime
+
+```phel
+(defmacro log-and [expr]
+  (println "expanding" expr)    ; runs at compile time, prints once
+  `(do (println "running" '~expr) ~expr))
+```
+
+Anything outside `` ` `` is evaluated when the macro fires, not when the caller runs.
+
+## See also
+
+- `docs/patterns.md` § Writing Macros
+- `tasks/debug-errors.md` § Macro surprises
+- `RULES.md` § New features (records / protocols / multimethods as alternatives when a fn or protocol would suffice)


### PR DESCRIPTION
## 🤔 Background

`resources/agents/` is the source for every installed AI skill. After the last two PRs (skill files + agent-install DX), the docs themselves had three issues:

- Same rule explained in 2–4 places (`phel.string`, ns segments, `*build-mode*`).
- `index.md` listed Async / Memoize / Macros with no recipe (`tasks/foo.md = —`).
- Tail sections drifted between `## Next` (mostly comma list) and `## See also` (bullet list); cross-refs to module tasks were missing.

## 💡 Goal

Tighter token cost per agent session, one source of truth per rule, every intent in `index.md` resolves to a recipe.

## 🔖 Changes

- **New recipes**: `tasks/async.md`, `tasks/memoize.md`, `tasks/write-macros.md` — fill the three `—` slots in `index.md`. Each ~50 lines, focused on the failure modes agents hit (hygiene, cache vs side effects, `^:async` boundaries).
- **`common-gotchas.md` trim**: drop items already stated as one-line rules in `RULES.md` (`phel.str` → `phel.string`, ns segment count). Keep only items with examples that the rule itself can't show. 144 → 78 lines.
- **Unify tail section**: every task file now ends with `## See also` (bullet list). No more mixed `Next` / `See also`.
- **`use-core-lib.md` module table**: added Task column linking each bundled module (`phel\async` → `tasks/async.md`, `phel\test` → `tasks/add-tests.md`, etc.). Added `phel\match` + `phel\schema` rows.
- **`index.md`**: fixed `(phel doc <fn>)` → `phel doc <fn>` (was wrong syntax); routed Async / Memoize / Macros to the new recipes; merged data-structures row.
- **`README.md`**: dropped stale `.agents/` self-reference from the repo-maintenance line (only repo-root agent dirs are `.codex/`, `.claude/`, `AGENTS.md`).

## Verification

- `agent-install --all --with-docs` smoke-installed in tmp; all 15 task files present (was 12).
- `agent-install --check` reports all platforms current.
- `composer test-quality` green; no PHP changes.