### PR TITLE
ref(run): drop dead FACADE_FORMATTER + FACADE_INTEROP from RunProvider

### DIFF
--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -7,7 +7,7 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and al
 - **Facade**: `RunFacade` implements `RunFacadeInterface`
 - **Factory**: `RunFactory` extends `AbstractFactory<RunConfig>`
 - **Config**: `RunConfig` — REPL history path, startup file path
-- **Provider**: `RunProvider` — injects 7 facades: `CommandFacade`, `CompilerFacade`, `FormatterFacade`, `InteropFacade`, `BuildFacade`, `ApiFacade`, `ConsoleFacade`
+- **Provider**: `RunProvider` — injects 5 facades: `CommandFacade`, `CompilerFacade`, `BuildFacade`, `ApiFacade`, `ConsoleFacade`
 
 ## Public API (Facade)
 
@@ -41,8 +41,6 @@ Runtime execution: runs Phel namespaces/files, REPL, evaluation, testing, and al
 - **Command** (`CommandFacade`) — directories, error formatting
 - **Console** (`ConsoleFacade`) — version info
 - **Api** (`ApiFacade`) — REPL autocompletion
-- **Formatter** (`FormatterFacade`) — declared but currently unused
-- **Interop** (`InteropFacade`) — declared but currently unused
 
 ## Structure
 

--- a/src/php/Run/RunProvider.php
+++ b/src/php/Run/RunProvider.php
@@ -12,18 +12,12 @@ use Phel\Build\BuildFacade;
 use Phel\Command\CommandFacade;
 use Phel\Compiler\CompilerFacade;
 use Phel\Console\ConsoleFacade;
-use Phel\Formatter\FormatterFacade;
-use Phel\Interop\InteropFacade;
 
 final class RunProvider extends AbstractProvider
 {
     public const string FACADE_COMMAND = 'FACADE_COMMAND';
 
     public const string FACADE_COMPILER = 'FACADE_COMPILER';
-
-    public const string FACADE_FORMATTER = 'FACADE_FORMATTER';
-
-    public const string FACADE_INTEROP = 'FACADE_INTEROP';
 
     public const string FACADE_BUILD = 'FACADE_BUILD';
 
@@ -41,18 +35,6 @@ final class RunProvider extends AbstractProvider
     public function compilerFacade(Container $container): CompilerFacade
     {
         return $container->getLocator()->getRequired(CompilerFacade::class);
-    }
-
-    #[Provides(self::FACADE_FORMATTER)]
-    public function formatterFacade(Container $container): FormatterFacade
-    {
-        return $container->getLocator()->getRequired(FormatterFacade::class);
-    }
-
-    #[Provides(self::FACADE_INTEROP)]
-    public function interopFacade(Container $container): InteropFacade
-    {
-        return $container->getLocator()->getRequired(InteropFacade::class);
     }
 
     #[Provides(self::FACADE_BUILD)]


### PR DESCRIPTION
## 🤔 Background

Module-architecture audit of \`src/php/*\` flagged \`Run/RunProvider\` as the highest-fan-out provider in the codebase (7 facades). Two of those (\`FormatterFacade\`, \`InteropFacade\`) were marked "declared but currently unused" in \`Run/CLAUDE.md\` itself. Grep across \`src/php/Run/\` confirms zero consumers (no \`getFormatterFacade\`/\`getInteropFacade\`, no \`FACADE_FORMATTER\`/\`FACADE_INTEROP\` reads).

## 💡 Goal

Match wiring to reality. Lower Run's fan-out from 7 → 5 with zero behavior change.

## 🔖 Changes

- Remove \`FormatterFacade\` + \`InteropFacade\` constants, \`#[Provides]\` methods, and \`use\` imports from \`Run/RunProvider.php\`.
- Update \`Run/CLAUDE.md\`: 7 → 5 facades; drop the two "declared but currently unused" bullets.

## Verification

- \`composer test-quality\`: clean
- \`composer test-compiler\`: 3309 tests, all green