### PR TITLE
ref(build): add CompiledCodeCacheInterface in Domain/Cache

### DIFF
--- a/src/php/Build/Application/FileEvaluator.php
+++ b/src/php/Build/Application/FileEvaluator.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Phel\Build\Application;
 
 use ParseError;
+use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 use Phel\Build\Domain\Cache\DependencyTrackerInterface;
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\FirstFormExtractor;
 use Phel\Build\Domain\Extractor\NamespaceExtractorInterface;
-use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
-use Phel\Build\Infrastructure\Cache\DependencyTracker;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Parser\ParserNode\NodeInterface;
 use Phel\Compiler\Domain\Parser\ParserNode\TriviaNodeInterface;
@@ -36,7 +35,7 @@ final class FileEvaluator
     public function __construct(
         private readonly CompilerFacadeInterface $compilerFacade,
         private readonly NamespaceExtractorInterface $namespaceExtractor,
-        private readonly ?CompiledCodeCache $compiledCodeCache = null,
+        private readonly ?CompiledCodeCacheInterface $compiledCodeCache = null,
         private readonly FirstFormExtractor $firstFormExtractor = new FirstFormExtractor(),
         private readonly ?DependencyTrackerInterface $dependencyTracker = null,
     ) {}
@@ -65,7 +64,7 @@ final class FileEvaluator
         $namespaceInfo = $this->namespaceExtractor->getNamespaceFromFile($src);
         $namespace = $namespaceInfo->getNamespace();
 
-        if ($this->compiledCodeCache instanceof CompiledCodeCache) {
+        if ($this->compiledCodeCache instanceof CompiledCodeCacheInterface) {
             $sourceHash = md5($code);
             $cachedPath = $this->compiledCodeCache->get($src, $sourceHash);
 
@@ -94,7 +93,7 @@ final class FileEvaluator
                     $this->compiledCodeCache->invalidate($src);
                     throw $e;
                 }
-            } elseif ($this->dependencyTracker instanceof DependencyTracker
+            } elseif ($this->dependencyTracker instanceof DependencyTrackerInterface
                 && $this->compiledCodeCache->has($src)
             ) {
                 // Stale cache entry — source changed. Cascade invalidation to dependents.

--- a/src/php/Build/Domain/Cache/CompiledCodeCacheInterface.php
+++ b/src/php/Build/Domain/Cache/CompiledCodeCacheInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Build\Domain\Cache;
+
+/**
+ * Contract for the compiled-code cache. Lives in Domain so Application
+ * collaborators (FileEvaluator, SecondaryFileHarvester, DependencyTracker)
+ * can depend on the abstraction instead of the Infrastructure concrete.
+ */
+interface CompiledCodeCacheInterface
+{
+    /**
+     * Path of the cached compiled PHP file if it exists and matches the
+     * source hash; null otherwise.
+     */
+    public function get(string $sourcePath, string $sourceHash): ?string;
+
+    /**
+     * True when an entry exists for this source file, regardless of
+     * whether its hash matches. Distinguishes "first build" from
+     * "stale cache entry".
+     */
+    public function has(string $sourcePath): bool;
+
+    public function put(string $sourcePath, string $namespace, string $sourceHash, string $phpCode): void;
+
+    public function getCompiledPath(string $sourcePath, string $namespace): string;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getEnvironment(string $namespace): ?array;
+
+    /**
+     * @param array<string, mixed> $envData
+     */
+    public function putEnvironment(string $namespace, array $envData): void;
+
+    public function invalidate(string $sourcePath): void;
+
+    public function clear(): void;
+}

--- a/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
+++ b/src/php/Build/Domain/Cache/DependencyTrackerInterface.php
@@ -10,4 +10,11 @@ interface DependencyTrackerInterface
      * @param list<string> $dependencies
      */
     public function registerDependencies(string $sourcePath, string $namespace, array $dependencies): void;
+
+    /**
+     * Invalidate every compiled file that depends on `$namespace`.
+     *
+     * @return list<string> source paths whose cache entries were invalidated
+     */
+    public function invalidateDependentsOf(string $namespace, CompiledCodeCacheInterface $compiledCodeCache): array;
 }

--- a/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
+++ b/src/php/Build/Domain/Compile/SecondaryFileHarvester.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Phel\Build\Domain\Compile;
 
+use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Build\Domain\IO\FileIoInterface;
-use Phel\Build\Infrastructure\Cache\CompiledCodeCache;
 use RuntimeException;
 
 use function dirname;
@@ -29,7 +29,7 @@ use function sprintf;
 final readonly class SecondaryFileHarvester
 {
     public function __construct(
-        private CompiledCodeCache $compiledCodeCache,
+        private CompiledCodeCacheInterface $compiledCodeCache,
         private CompiledTargetPathResolver $targetPathResolver,
         private FileIoInterface $fileIo,
     ) {}

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Build\Infrastructure\Cache;
 
 use ParseError;
+use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 
 use function array_key_exists;
 use function count;
@@ -24,7 +25,7 @@ use const TOKEN_PARSE;
  * Environment data (refers/aliases) is keyed by namespace because it
  * is shared across all files of the namespace.
  */
-final class CompiledCodeCache
+final class CompiledCodeCache implements CompiledCodeCacheInterface
 {
     private const string VERSION = '1.2';
 

--- a/src/php/Build/Infrastructure/Cache/DependencyTracker.php
+++ b/src/php/Build/Infrastructure/Cache/DependencyTracker.php
@@ -7,6 +7,7 @@ namespace Phel\Build\Infrastructure\Cache;
 use Gacela\Framework\Cache\CycleDetectedException;
 use Gacela\Framework\Cache\FileCache;
 use Gacela\Framework\Cache\ScopedCache;
+use Phel\Build\Domain\Cache\CompiledCodeCacheInterface;
 use Phel\Build\Domain\Cache\DependencyTrackerInterface;
 
 use function is_string;
@@ -83,7 +84,7 @@ final readonly class DependencyTracker implements DependencyTrackerInterface
      *
      * @return list<string> Source paths of invalidated dependents
      */
-    public function invalidateDependentsOf(string $namespace, CompiledCodeCache $compiledCodeCache): array
+    public function invalidateDependentsOf(string $namespace, CompiledCodeCacheInterface $compiledCodeCache): array
     {
         $nsKey = $this->nsKey($namespace);
         if (!$this->cache->has($nsKey)) {


### PR DESCRIPTION
## 🤔 Background

Architecture audit found `Build/Application/FileEvaluator.php` importing `Phel\Build\Infrastructure\Cache\CompiledCodeCache` directly and `instanceof`-checking the concrete on lines 68 and 97. `SecondaryFileHarvester` (Domain) and `DependencyTracker::invalidateDependentsOf` did the same. Application/Domain leaked into Infrastructure for a stateful collaborator that already deserved an interface.

## 💡 Goal

Type the dependency by abstraction. Application stops knowing about Infrastructure for cache access; `instanceof` against a concrete becomes a clean null check (rector keeps it as `instanceof <interface>`, semantically identical).

## 🔖 Changes

- **New**: `src/php/Build/Domain/Cache/CompiledCodeCacheInterface.php` — listing `get`, `has`, `put`, `getCompiledPath`, `getEnvironment`, `putEnvironment`, `invalidate`, `clear`.
- `CompiledCodeCache` implements it (no behavior change).
- `FileEvaluator`, `SecondaryFileHarvester` typed against the interface; concrete `use` import removed.
- `DependencyTrackerInterface` gains `invalidateDependentsOf(string, CompiledCodeCacheInterface): array` so Application no longer relies on the concrete tracker either.

## Verification

- `composer test-quality`: clean
- `composer test-compiler`: 3309 tests, all green