### PR TITLE
ref(compiler): split global env state into Domain registry + DI manager (closes #1973)

### DIFF
--- a/src/php/Compiler/Application/GlobalEnvironmentManager.php
+++ b/src/php/Compiler/Application/GlobalEnvironmentManager.php
@@ -4,38 +4,60 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Application;
 
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
-use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentManagerInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentRegistry;
+use Phel\Compiler\Domain\Evaluator\RequireEvaluator;
 
-final class GlobalEnvironmentManager
+final class GlobalEnvironmentManager implements GlobalEnvironmentManagerInterface
 {
-    public function initialize(): void
+    public function initialize(): GlobalEnvironmentInterface
     {
-        GlobalEnvironmentSingleton::ensureInitialized();
+        $existing = GlobalEnvironmentRegistry::get();
+        if ($existing instanceof GlobalEnvironmentInterface) {
+            return $existing;
+        }
+
+        return $this->initializeNew();
     }
 
     public function reset(): void
     {
-        GlobalEnvironmentSingleton::reset();
+        GlobalEnvironmentRegistry::set(null);
     }
 
     public function isInitialized(): bool
     {
-        return GlobalEnvironmentSingleton::isInitialized();
+        return GlobalEnvironmentRegistry::has();
     }
 
     public function getInstance(): GlobalEnvironmentInterface
     {
-        return GlobalEnvironmentSingleton::getInstance();
+        $existing = GlobalEnvironmentRegistry::get();
+        if ($existing instanceof GlobalEnvironmentInterface) {
+            return $existing;
+        }
+
+        $env = new GlobalEnvironment();
+        GlobalEnvironmentRegistry::set($env);
+
+        return $env;
     }
 
     public function initializeNew(): GlobalEnvironmentInterface
     {
-        return GlobalEnvironmentSingleton::initializeNew();
+        Phel::clear();
+        RequireEvaluator::clearCache();
+        $env = new GlobalEnvironment();
+        GlobalEnvironmentRegistry::set($env);
+
+        return $env;
     }
 
     public function setInstance(GlobalEnvironmentInterface $env): void
     {
-        GlobalEnvironmentSingleton::setInstance($env);
+        GlobalEnvironmentRegistry::set($env);
     }
 }

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -58,14 +58,14 @@ Core compilation pipeline: Phel source -> tokens -> AST -> analyzed nodes -> PHP
 Compiler/
 ├── Application/        Analyzer, CodeCompiler, EvalCompiler, GlobalEnvironmentManager, Lexer, Parser, Reader, MacroExpander
 ├── Domain/
-│   ├── Analyzer/       AST nodes, special form handlers, environments
+│   ├── Analyzer/       AST nodes, special form handlers, environments, GlobalEnvironmentManagerInterface + GlobalEnvironmentRegistry
 │   ├── Compiler/       CodeCompilerInterface, EvalCompilerInterface
 │   ├── Emitter/        OutputEmitter, FileEmitter, StatementEmitter, node emitters
 │   ├── Evaluator/      InMemoryEvaluator, RequireEvaluator (cross-module exceptions live in Phel\Shared\Exceptions)
 │   ├── Lexer/          Token, TokenStream
 │   ├── Parser/         NodeInterface, ExpressionParserFactory (CodeSnippet lives in Phel\Shared\Parser\ReadModel)
 │   └── Reader/         ReaderInterface, QuasiquoteTransformer
-├── Infrastructure/     CompileOptions, GlobalEnvironmentSingleton
+├── Infrastructure/     CompileOptions, GlobalEnvironmentSingleton (ABI-compat shim for emitted PHP)
 └── Gacela files
 ```
 
@@ -76,7 +76,14 @@ Compiler/
 - Emitter must handle every node type — missing cases must throw, not silently skip
 - Special forms are registered centrally — no ad-hoc handling in the analyzer loop
 - Source locations must propagate through all phases for error reporting
-- `GlobalEnvironmentSingleton` manages the single global compile-time environment
+
+## Global Environment
+
+The single compile-time `GlobalEnvironmentInterface` is owned by `Application/GlobalEnvironmentManager` (implements `Domain/Analyzer/Environment/GlobalEnvironmentManagerInterface`). New collaborators inject the interface and call instance methods (`initialize()`, `getInstance()`, `reset()`).
+
+State lives in `Domain/Analyzer/Environment/GlobalEnvironmentRegistry` (process-wide static slot). Both the Application manager and the legacy `Infrastructure/GlobalEnvironmentSingleton` read/write the same slot, so neither layer imports the other.
+
+`GlobalEnvironmentSingleton` is retained because the emitter writes literal `\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()` calls into generated PHP — cached `.phel` artefacts depend on that exact FQN. Every static method on the singleton forwards to the registry.
 
 ## Namespace Encoding
 

--- a/src/php/Compiler/CompilerFactory.php
+++ b/src/php/Compiler/CompilerFactory.php
@@ -41,7 +41,6 @@ use Phel\Compiler\Domain\Parser\ParserInterface;
 use Phel\Compiler\Domain\Reader\ExpressionReaderFactory;
 use Phel\Compiler\Domain\Reader\QuasiquoteTransformer;
 use Phel\Compiler\Domain\Reader\ReaderInterface;
-use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
 use Phel\Filesystem\FilesystemFacadeInterface;
 use Phel\Lang\TagHandlers\BuiltinTagHandlers;
 use Phel\Lang\TagRegistry;
@@ -217,10 +216,6 @@ final class CompilerFactory extends AbstractFactory
 
     private function getGlobalEnvironment(): GlobalEnvironmentInterface
     {
-        if (!GlobalEnvironmentSingleton::isInitialized()) {
-            return GlobalEnvironmentSingleton::initializeNew();
-        }
-
-        return GlobalEnvironmentSingleton::getInstance();
+        return $this->createGlobalEnvironmentManager()->initialize();
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentManagerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentManagerInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+/**
+ * Manages the single `GlobalEnvironmentInterface` instance shared by the
+ * compiler pipeline within a process. Owns the slot, the lifecycle, and
+ * the lazy-construction policy.
+ *
+ * Application and Infrastructure both depend on this contract; the legacy
+ * static accessor in `Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton`
+ * is now a thin forwarder onto the same registry, preserved only for the
+ * compiled-PHP ABI (the emitter writes literal references to it into
+ * generated code).
+ */
+interface GlobalEnvironmentManagerInterface
+{
+    /**
+     * Ensures the global environment is initialized. Returns the existing
+     * instance when one is present; otherwise builds a new one (which also
+     * clears the Phel runtime registry).
+     */
+    public function initialize(): GlobalEnvironmentInterface;
+
+    /**
+     * Drops the global environment. Next access lazily creates a fresh one.
+     */
+    public function reset(): void;
+
+    public function isInitialized(): bool;
+
+    /**
+     * Returns the singleton, lazy-constructing a fresh `GlobalEnvironment`
+     * when none exists — without clearing the Phel registry. This keeps
+     * compiled artefacts usable when required outside a full compiler
+     * bootstrap.
+     */
+    public function getInstance(): GlobalEnvironmentInterface;
+
+    /**
+     * Builds a new global environment, clearing the Phel runtime registry
+     * and the require cache as a side effect. Returns the new instance.
+     */
+    public function initializeNew(): GlobalEnvironmentInterface;
+
+    /**
+     * Replaces the singleton with a previously captured environment. Used
+     * to restore state after a transient operation that needed a clean
+     * environment (e.g. documentation/completion loading).
+     */
+    public function setInstance(GlobalEnvironmentInterface $env): void;
+}

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentRegistry.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\Environment;
+
+/**
+ * Process-wide slot for the single `GlobalEnvironmentInterface` shared by the
+ * compiler pipeline. Owned by Domain so both Application and Infrastructure
+ * collaborators can read/write the same state without forming a layer
+ * dependency on each other.
+ *
+ * No business logic: side effects (Phel registry clearing, require-cache
+ * eviction) live in the Application manager and Infrastructure singleton.
+ *
+ * @internal use `GlobalEnvironmentManagerInterface` from collaborators
+ */
+final class GlobalEnvironmentRegistry
+{
+    private static ?GlobalEnvironmentInterface $instance = null;
+
+    public static function get(): ?GlobalEnvironmentInterface
+    {
+        return self::$instance;
+    }
+
+    public static function set(?GlobalEnvironmentInterface $env): void
+    {
+        self::$instance = $env;
+    }
+
+    public static function has(): bool
+    {
+        return self::$instance instanceof GlobalEnvironmentInterface;
+    }
+}

--- a/src/php/Compiler/Infrastructure/GlobalEnvironmentSingleton.php
+++ b/src/php/Compiler/Infrastructure/GlobalEnvironmentSingleton.php
@@ -7,21 +7,29 @@ namespace Phel\Compiler\Infrastructure;
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentRegistry;
 use Phel\Compiler\Domain\Analyzer\Exceptions\GlobalEnvironmentAlreadyInitializedException;
 use Phel\Compiler\Domain\Evaluator\RequireEvaluator;
 
+/**
+ * Static accessor preserved for the compiled-PHP ABI: the emitter writes
+ * literal `\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()`
+ * calls into generated code, so cached `.phel` artefacts depend on this
+ * exact FQN. State now lives in `Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentRegistry`;
+ * each method here is a thin forwarder.
+ *
+ * For new code prefer injecting `GlobalEnvironmentManagerInterface`.
+ */
 final class GlobalEnvironmentSingleton
 {
-    private static ?GlobalEnvironmentInterface $instance = null;
-
     public static function reset(): void
     {
-        self::$instance = null;
+        GlobalEnvironmentRegistry::set(null);
     }
 
     public static function isInitialized(): bool
     {
-        return self::$instance instanceof GlobalEnvironmentInterface;
+        return GlobalEnvironmentRegistry::has();
     }
 
     /**
@@ -31,15 +39,16 @@ final class GlobalEnvironmentSingleton
      */
     public static function ensureInitialized(): GlobalEnvironmentInterface
     {
-        if (self::$instance instanceof GlobalEnvironmentInterface) {
-            return self::$instance;
+        $existing = GlobalEnvironmentRegistry::get();
+        if ($existing instanceof GlobalEnvironmentInterface) {
+            return $existing;
         }
 
         return self::initializeNew();
     }
 
     /**
-     * Returns the singleton. Auto-creates a fresh `GlobalEnvironment`
+     * Returns the singleton, auto-creating a fresh `GlobalEnvironment`
      * when none exists — without clearing the Phel registry, unlike
      * `initializeNew()`. This keeps compiled artifacts usable when
      * required outside a full compiler bootstrap: their emitted
@@ -48,11 +57,15 @@ final class GlobalEnvironmentSingleton
      */
     public static function getInstance(): GlobalEnvironmentInterface
     {
-        if (!self::$instance instanceof GlobalEnvironmentInterface) {
-            self::$instance = new GlobalEnvironment();
+        $existing = GlobalEnvironmentRegistry::get();
+        if ($existing instanceof GlobalEnvironmentInterface) {
+            return $existing;
         }
 
-        return self::$instance;
+        $env = new GlobalEnvironment();
+        GlobalEnvironmentRegistry::set($env);
+
+        return $env;
     }
 
     /**
@@ -60,13 +73,14 @@ final class GlobalEnvironmentSingleton
      */
     public static function initialize(): GlobalEnvironmentInterface
     {
-        if (self::$instance instanceof GlobalEnvironmentInterface) {
+        if (GlobalEnvironmentRegistry::has()) {
             throw new GlobalEnvironmentAlreadyInitializedException();
         }
 
-        self::$instance = new GlobalEnvironment();
+        $env = new GlobalEnvironment();
+        GlobalEnvironmentRegistry::set($env);
 
-        return self::$instance;
+        return $env;
     }
 
     /**
@@ -76,9 +90,10 @@ final class GlobalEnvironmentSingleton
     {
         Phel::clear();
         RequireEvaluator::clearCache();
-        self::$instance = new GlobalEnvironment();
+        $env = new GlobalEnvironment();
+        GlobalEnvironmentRegistry::set($env);
 
-        return self::$instance;
+        return $env;
     }
 
     /**
@@ -90,6 +105,6 @@ final class GlobalEnvironmentSingleton
      */
     public static function setInstance(GlobalEnvironmentInterface $env): void
     {
-        self::$instance = $env;
+        GlobalEnvironmentRegistry::set($env);
     }
 }


### PR DESCRIPTION
## 🤔 Background

Architecture audit (#1973) flagged `Phel\Compiler\Application\GlobalEnvironmentManager:8` importing `Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton` — Application reaching into Infrastructure for a stateful collaborator. The manager was a 30-line forwarder over six static methods on the singleton, untestable in isolation because the singleton owned the only mutable slot.

Constraint that shaped the fix: the emitter writes literal `\Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton::getInstance()` calls into generated PHP. Cached `.phel` artefacts under `tests/php/Integration/**/.phel/cache/` and external user installations reference that exact FQN. The class cannot disappear without breaking the compiled-output ABI.

## 💡 Goal

Move state ownership into Domain so neither Application nor Infrastructure imports the other. Keep `GlobalEnvironmentSingleton` at its FQN as a compat shim. New code injects a Domain interface; old code keeps working.

## 🔖 Changes

**New Domain layer**

- `Compiler/Domain/Analyzer/Environment/GlobalEnvironmentManagerInterface` — instance methods: `initialize`, `reset`, `isInitialized`, `getInstance`, `initializeNew`, `setInstance`.
- `Compiler/Domain/Analyzer/Environment/GlobalEnvironmentRegistry` — process-wide static slot (`get`/`set`/`has`). No business logic; just storage.

**Application**

- `GlobalEnvironmentManager` implements `GlobalEnvironmentManagerInterface`. Manages lifecycle through `GlobalEnvironmentRegistry`. No more `use Phel\Compiler\Infrastructure\...` import.
- `Phel::clear()` + `RequireEvaluator::clearCache()` calls in `initializeNew()` stay (load-bearing for REPL bootstrap).

**Infrastructure**

- `GlobalEnvironmentSingleton` becomes a thin static forwarder onto `GlobalEnvironmentRegistry`. Same 6-method API; same FQN. Marked the singleton's docblock to prefer injecting `GlobalEnvironmentManagerInterface` for new code.

**Factory**

- `CompilerFactory::getGlobalEnvironment()` now delegates to `$this->createGlobalEnvironmentManager()->initialize()`. The unused `use ... GlobalEnvironmentSingleton` import is gone.

**Docs**

- `Compiler/CLAUDE.md` gains a `Global Environment` section explaining the ownership split and the ABI rationale for keeping the singleton.

## Verification

- `composer test-quality`: clean
- `composer test-compiler`: 3309/3309 green
- `grep 'Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton' src/php/Compiler/Application src/php/Compiler/Domain` → empty
- Cached compiled PHP under `tests/php/**/.phel/cache/` still references the singleton at the old FQN and resolves through the forwarder.

## Out of scope

- Replacing the process-level slot entirely (multi-environment compilation): separate architectural decision.
- Migrating test files that still call `GlobalEnvironmentSingleton::*` directly: not required for the audit fix; the static API is unchanged.

Sibling issues: #1972 ✅ merged, #1974 (Printer + facade internal types).