### PR TITLE
feat(compiler): extend ParamTypeInferrer for broader type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+#### Compiler
+- `ParamTypeInferrer` cross-fn channels: callee `:param-tags` propagation (Step 1), PHP host fn signature table (`random_int`, `intdiv`, `strlen`, `mb_strlen`, `str_repeat`, `count`) (Step 2), expected-type back-pressure into nested numeric calls (Step 3), `:int-stable` allowlist on `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) propagating `int` when an `int` expectation flows from above and bailing on `BigInteger` / `Rational` / float literal siblings (Step 4) (#1978)
+- `ReturnTypeInferrer` recognises `random_int` and `intdiv` as `int`-returning
+- Both inferrers skip self-references against the def being analyzed so a redefinition cannot inherit stale `:tag` / `:param-tags` carried in the runtime registry
+
 ## [0.37.0](https://github.com/phel-lang/phel-lang/compare/v0.36.0...v0.37.0) - 2026-05-12
 
 ### Added

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -83,7 +83,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             // body manipulates them, so a primitive-op observation in
             // the macro body must not type-narrow the runtime signature.
             if (!$isMacro) {
-                $this->graftInferredParamTags($initNode, $skip);
+                $this->graftInferredParamTags($initNode, $skip, $namespace, $nameSymbol->getName());
             }
 
             $metaMap = $metaMap->put('min-arity', max(0, $initNode->getMinArity() - $skip));
@@ -405,8 +405,12 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
      * locals and the fn surfaces a return-type declaration when it
      * could not before.
      */
-    private function graftInferredParamTags(FnNode $fnNode, int $skipFirst = 0): void
-    {
+    private function graftInferredParamTags(
+        FnNode $fnNode,
+        int $skipFirst = 0,
+        ?string $selfNamespace = null,
+        ?string $selfName = null,
+    ): void {
         $params = $this->scalarParamSlice($fnNode, $skipFirst);
         if ($params === []) {
             return;
@@ -416,6 +420,8 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $fnNode->getBody(),
             $params,
             $fnNode->isVariadic(),
+            $selfNamespace,
+            $selfName,
         );
 
         if ($inferred === []) {
@@ -448,6 +454,8 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
                     $fnNode->getBody(),
                     $fnNode->getParams(),
                     $fnNode->isVariadic(),
+                    $selfNamespace,
+                    $selfName,
                 ),
             );
         }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -165,11 +165,14 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
             }
         }
 
+        [$selfNs, $selfNameStr] = $this->splitBoundTo($env->getBoundTo());
         $returnType = $declaredReturnType
             ?? $this->returnTypeInferrer->infer(
                 $body,
                 $fnSymbolTuple->params(),
                 $fnSymbolTuple->isVariadic(),
+                $selfNs,
+                $selfNameStr,
             );
 
         return new FnNode(
@@ -183,6 +186,34 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
             $effectiveName,
             $returnType,
         );
+    }
+
+    /**
+     * Splits a `boundTo` string of the form `"namespace\\name"` (set by
+     * `DefSymbol` when analyzing a `(defn ...)` body) into the analyzer's
+     * dot-separated namespace + bare name. Returns `[null, null]` when
+     * the fn is anonymous: cross-fn self-skip needs both halves to fire.
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function splitBoundTo(string $boundTo): array
+    {
+        if ($boundTo === '') {
+            return [null, null];
+        }
+
+        $pos = strrpos($boundTo, '\\');
+        if ($pos === false) {
+            return [null, null];
+        }
+
+        $ns = str_replace('\\', '.', substr($boundTo, 0, $pos));
+        $name = substr($boundTo, $pos + 1);
+        if ($ns === '' || $name === '') {
+            return [null, null];
+        }
+
+        return [$ns, $name];
     }
 
     private function extractReturnType(mixed $paramVector): ?string

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -309,7 +309,7 @@ final class ParamTypeInferrer
         $this->walk($fn);
 
         if ($fn instanceof GlobalVarNode && $this->isGuardGlobal($fn)) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->markGuarded($a));
+            $this->walkArgsAsGuarded($node);
             return;
         }
 
@@ -326,9 +326,7 @@ final class ParamTypeInferrer
         // Unknown call position (call against a literal, vector, etc.):
         // walk args plainly so any nested operator still observes its
         // locals.
-        foreach ($node->getArguments() as $arg) {
-            $this->walk($arg);
-        }
+        $this->walkArgsExpecting($node, null);
     }
 
     private function walkPhpCall(CallNode $node, PhpVarNode $fn, ?string $expected): void
@@ -336,15 +334,12 @@ final class ParamTypeInferrer
         $op = $fn->getName();
 
         if (in_array($op, self::GUARD_PHP_FNS, true)) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->markGuarded($a));
+            $this->walkArgsAsGuarded($node);
             return;
         }
 
         if ($op === self::STRING_CONCAT_OP) {
-            foreach ($node->getArguments() as $arg) {
-                $this->walk($arg, 'string');
-            }
-
+            $this->walkArgsExpecting($node, 'string');
             return;
         }
 
@@ -364,25 +359,20 @@ final class ParamTypeInferrer
         }
 
         if (isset(self::PHP_FN_SIGNATURES[$op])) {
-            $this->walkPhpFnBySignature($node, self::PHP_FN_SIGNATURES[$op]);
+            $this->walkArgsBySignature($node, self::PHP_FN_SIGNATURES[$op]);
             return;
         }
 
         // Everything else (`aget`, unknown PHP fns) walks arg expressions
         // for nested operators without constraining the local: unknown
         // functions could accept anything.
-        foreach ($node->getArguments() as $arg) {
-            $this->walk($arg);
-        }
+        $this->walkArgsExpecting($node, null);
     }
 
     private function walkGlobalCall(CallNode $node, GlobalVarNode $fn, ?string $expected): void
     {
         if ($this->isSelfReference($fn)) {
-            foreach ($node->getArguments() as $arg) {
-                $this->walk($arg);
-            }
-
+            $this->walkArgsExpecting($node, null);
             return;
         }
 
@@ -390,17 +380,11 @@ final class ParamTypeInferrer
             && $this->isIntStableCoreFn($fn)
             && !$this->hasNonIntLiteralArg($node)
         ) {
-            foreach ($node->getArguments() as $arg) {
-                $this->walk($arg, 'int');
-            }
-
+            $this->walkArgsExpecting($node, 'int');
             return;
         }
 
-        $expectations = $this->calleeParamExpectations($fn);
-        foreach ($node->getArguments() as $i => $arg) {
-            $this->walk($arg, $expectations[$i] ?? null);
-        }
+        $this->walkArgsBySignature($node, $this->calleeParamExpectations($fn));
     }
 
     private function isSelfReference(GlobalVarNode $fn): bool
@@ -449,18 +433,6 @@ final class ParamTypeInferrer
     }
 
     /**
-     * @param list<?string> $paramTypes
-     */
-    private function walkPhpFnBySignature(CallNode $node, array $paramTypes): void
-    {
-        $count = count($paramTypes);
-        foreach ($node->getArguments() as $i => $arg) {
-            $argExpected = $i < $count ? $paramTypes[$i] : null;
-            $this->walk($arg, $argExpected);
-        }
-    }
-
-    /**
      * `(php/=== x nil)` and friends are how Phel code type-discriminates
      * before concatenating or arithmetic'ing the value. When a param is
      * compared to `nil`, `true`, or `false`, the body branches that
@@ -471,19 +443,18 @@ final class ParamTypeInferrer
      */
     private function walkIdentityCall(CallNode $node): void
     {
-        $args = $node->getArguments();
         $hasNullableLiteral = array_any(
-            $args,
+            $node->getArguments(),
             static fn(AbstractNode $a): bool => $a instanceof LiteralNode
                 && self::isNullableLiteral($a->getValue()),
         );
 
         if ($hasNullableLiteral) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->markGuarded($a));
+            $this->walkArgsAsGuarded($node);
             return;
         }
 
-        $this->walkArgs($node);
+        $this->walkArgsExpecting($node, null);
     }
 
     private static function isNullableLiteral(mixed $value): bool
@@ -501,15 +472,8 @@ final class ParamTypeInferrer
      */
     private function walkOrderingCall(CallNode $node): void
     {
-        $args = $node->getArguments();
-        $type = $this->literalNumericType($args);
-
-        if ($type !== null) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->constrainArgAsScalar($a, $type));
-            return;
-        }
-
-        $this->walkArgs($node);
+        $type = $this->literalNumericType($node->getArguments());
+        $this->walkArgsExpecting($node, $type);
     }
 
     /**
@@ -556,36 +520,42 @@ final class ParamTypeInferrer
      */
     private function walkNumericCall(CallNode $node, ?string $expected = null): void
     {
-        $args = $node->getArguments();
-        $type = $this->literalNumericType($args);
-
+        $type = $this->literalNumericType($node->getArguments());
         if ($type === null && ($expected === 'int' || $expected === 'float')) {
             $type = $expected;
         }
 
-        if ($type !== null) {
-            foreach ($args as $arg) {
-                $this->walk($arg, $type);
-            }
+        $this->walkArgsExpecting($node, $type);
+    }
 
-            return;
-        }
-
-        foreach ($args as $arg) {
-            $this->walk($arg);
+    /**
+     * Walks every arg with the same expectation. `null` flows through
+     * unchanged so callers that just want to traverse nested operators
+     * without constraining a slot share the same path as callers that
+     * push a concrete primitive tag down.
+     */
+    private function walkArgsExpecting(CallNode $node, ?string $expected): void
+    {
+        foreach ($node->getArguments() as $arg) {
+            $this->walk($arg, $expected);
         }
     }
 
     /**
-     * @param (callable(AbstractNode): void)|null $observe
+     * @param list<?string> $expectations
      */
-    private function walkArgs(CallNode $node, ?callable $observe = null): void
+    private function walkArgsBySignature(CallNode $node, array $expectations): void
+    {
+        $count = count($expectations);
+        foreach ($node->getArguments() as $i => $arg) {
+            $this->walk($arg, $i < $count ? $expectations[$i] : null);
+        }
+    }
+
+    private function walkArgsAsGuarded(CallNode $node): void
     {
         foreach ($node->getArguments() as $arg) {
-            if ($observe !== null) {
-                $observe($arg);
-            }
-
+            $this->markGuarded($arg);
             $this->walk($arg);
         }
     }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -16,13 +16,18 @@ use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
 
 use function array_unique;
 use function count;
 use function in_array;
 use function is_float;
 use function is_int;
+use function is_object;
+use function is_string;
 use function strlen;
 
 /**
@@ -40,6 +45,20 @@ use function strlen;
  *   - identity comparisons against `nil`/`true`/`false`
  *   - disagreeing observations across branches (e.g. compared to int and
  *     concatenated as string)
+ *
+ * Three cross-fn propagation channels extend the basic primitive-op
+ * inference:
+ *   - callee `:param-tags` (Step 1): when the call target's params are
+ *     already tagged with a pure primitive, the matching call-site args
+ *     inherit that tag.
+ *   - PHP host signature table (Step 2): a curated allowlist of stdlib
+ *     functions whose arg types are stable across versions.
+ *   - expected-type back-pressure (Step 3): a tag flowing in from a
+ *     callee or signature table can push down into nested numeric ops,
+ *     so `(php/random_int 0 (php/- hi lo))` flows int into `hi`/`lo`.
+ *   - `:int-stable` core fns (Step 4): an allowlist of `phel.core`
+ *     arithmetic fns that, given an `int` expectation from above, behave
+ *     like a numeric op for the purposes of propagation.
  */
 final class ParamTypeInferrer
 {
@@ -55,6 +74,61 @@ final class ParamTypeInferrer
 
     /** @var list<string> */
     private const array ORDERING_OPS = ['<', '>', '<=', '>=', '<=>'];
+
+    /**
+     * Tags that translate directly to a single PHP scalar and therefore
+     * survive being grafted onto a param without losing valid runtime
+     * inputs. Nullable (`?int`), union (`int|null`), and FQN tags are
+     * deliberately excluded: tightening them to bare `int` rejects
+     * callers that the callee already accepts.
+     *
+     * @var list<string>
+     */
+    private const array PURE_PRIMITIVE_TAGS = ['int', 'float', 'string', 'bool', 'array'];
+
+    /**
+     * Curated allowlist of PHP stdlib fns whose arg types are stable
+     * across supported versions. Each entry's value lists the scalar tag
+     * inferred per positional arg (use `null` to skip a slot). Unions
+     * and nullable types stay out so the inferrer never tightens a slot
+     * the runtime accepts more loosely.
+     *
+     * @var array<string, list<?string>>
+     */
+    private const array PHP_FN_SIGNATURES = [
+        'random_int' => ['int', 'int'],
+        'intdiv' => ['int', 'int'],
+        'strlen' => ['string'],
+        'mb_strlen' => ['string'],
+        'str_repeat' => ['string', 'int'],
+        'count' => ['array'],
+    ];
+
+    /**
+     * `phel.core` arithmetic fns whose return is `int` when every arg
+     * is `int`. The inferrer treats them as conditional numeric ops:
+     * propagation only fires when an `int` expectation flows in from
+     * above. Without that expectation we leave the runtime contract
+     * permissive so `BigInteger` / `Rational` polymorphism keeps
+     * working at the call site.
+     *
+     * @var list<string>
+     */
+    private const array INT_STABLE_CORE_FNS = ['+', '-', '*', 'inc', 'dec'];
+
+    /**
+     * Static fallback for `phel.core` callees whose compile-time
+     * `:param-tags` channel is not available (the runtime registry is
+     * populated from a precompiled cache, so the analyzer never sees
+     * the sub-namespaces' defns and the `:param-tags` vector stays
+     * empty). The mapping mirrors the strict slot-by-slot
+     * primitive-tag contract that the runtime fn already enforces.
+     *
+     * @var array<string, list<?string>>
+     */
+    private const array CORE_FN_SIGNATURES = [
+        'rand-int' => ['int'],
+    ];
 
     /**
      * Globals that signal "the function defensively rejects bad inputs at
@@ -103,16 +177,36 @@ final class ParamTypeInferrer
     /** @var array<string, true> */
     private array $guarded = [];
 
+    private ?string $selfNamespace = null;
+
+    private ?string $selfName = null;
+
     /**
+     * `$selfNamespace` / `$selfName` short-circuit cross-fn propagation
+     * for the def currently being analyzed. The runtime registry may
+     * still hold meta from a previous compile/eval of the same name
+     * (the analyzer's compile-time meta has been cleared in
+     * `addDefinition`, but registry meta persists across compilations
+     * of the same singleton); treating any self-referencing call as
+     * untagged keeps the new definition from inheriting that stale
+     * signal.
+     *
      * @param list<Symbol> $params
      *
      * @return array<string, string>
      */
-    public function infer(AbstractNode $body, array $params, bool $isVariadic = false): array
-    {
+    public function infer(
+        AbstractNode $body,
+        array $params,
+        bool $isVariadic = false,
+        ?string $selfNamespace = null,
+        ?string $selfName = null,
+    ): array {
         $this->observations = [];
         $this->params = [];
         $this->guarded = [];
+        $this->selfNamespace = $selfNamespace;
+        $this->selfName = $selfName;
 
         $lastIndex = $isVariadic ? count($params) - 1 : count($params);
         for ($i = 0; $i < $lastIndex; ++$i) {
@@ -143,11 +237,19 @@ final class ParamTypeInferrer
         return $result;
     }
 
-    private function walk(AbstractNode $node): void
+    private function walk(AbstractNode $node, ?string $expected = null): void
     {
         if ($node instanceof FnNode) {
             // Closures own their own params; a `$x` inside is unrelated
             // to the outer fn's `$x`.
+            return;
+        }
+
+        if ($node instanceof LocalVarNode) {
+            if ($expected !== null) {
+                $this->constrainArgAsScalar($node, $expected);
+            }
+
             return;
         }
 
@@ -156,14 +258,14 @@ final class ParamTypeInferrer
                 $this->walk($stmt);
             }
 
-            $this->walk($node->getRet());
+            $this->walk($node->getRet(), $expected);
             return;
         }
 
         if ($node instanceof IfNode) {
             $this->walk($node->getTestExpr());
-            $this->walk($node->getThenExpr());
-            $this->walk($node->getElseExpr());
+            $this->walk($node->getThenExpr(), $expected);
+            $this->walk($node->getElseExpr(), $expected);
             return;
         }
 
@@ -172,7 +274,7 @@ final class ParamTypeInferrer
                 $this->walk($binding->getInitExpr());
             }
 
-            $this->walk($node->getBodyExpr());
+            $this->walk($node->getBodyExpr(), $expected);
             return;
         }
 
@@ -193,12 +295,12 @@ final class ParamTypeInferrer
         }
 
         if ($node instanceof CallNode) {
-            $this->walkCall($node);
+            $this->walkCall($node, $expected);
             return;
         }
     }
 
-    private function walkCall(CallNode $node): void
+    private function walkCall(CallNode $node, ?string $expected = null): void
     {
         $fn = $node->getFn();
         // Recurse into the callee position first: descending captures any
@@ -211,11 +313,26 @@ final class ParamTypeInferrer
             return;
         }
 
-        if (!$fn instanceof PhpVarNode) {
-            $this->walkArgs($node);
+        if ($fn instanceof PhpVarNode) {
+            $this->walkPhpCall($node, $fn, $expected);
             return;
         }
 
+        if ($fn instanceof GlobalVarNode) {
+            $this->walkGlobalCall($node, $fn, $expected);
+            return;
+        }
+
+        // Unknown call position (call against a literal, vector, etc.):
+        // walk args plainly so any nested operator still observes its
+        // locals.
+        foreach ($node->getArguments() as $arg) {
+            $this->walk($arg);
+        }
+    }
+
+    private function walkPhpCall(CallNode $node, PhpVarNode $fn, ?string $expected): void
+    {
         $op = $fn->getName();
 
         if (in_array($op, self::GUARD_PHP_FNS, true)) {
@@ -224,12 +341,15 @@ final class ParamTypeInferrer
         }
 
         if ($op === self::STRING_CONCAT_OP) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->constrainArgAsScalar($a, 'string'));
+            foreach ($node->getArguments() as $arg) {
+                $this->walk($arg, 'string');
+            }
+
             return;
         }
 
         if (in_array($op, self::NUMERIC_OPS, true)) {
-            $this->walkNumericCall($node);
+            $this->walkNumericCall($node, $expected);
             return;
         }
 
@@ -243,10 +363,101 @@ final class ParamTypeInferrer
             return;
         }
 
+        if (isset(self::PHP_FN_SIGNATURES[$op])) {
+            $this->walkPhpFnBySignature($node, self::PHP_FN_SIGNATURES[$op]);
+            return;
+        }
+
         // Everything else (`aget`, unknown PHP fns) walks arg expressions
         // for nested operators without constraining the local: unknown
         // functions could accept anything.
-        $this->walkArgs($node);
+        foreach ($node->getArguments() as $arg) {
+            $this->walk($arg);
+        }
+    }
+
+    private function walkGlobalCall(CallNode $node, GlobalVarNode $fn, ?string $expected): void
+    {
+        if ($this->isSelfReference($fn)) {
+            foreach ($node->getArguments() as $arg) {
+                $this->walk($arg);
+            }
+
+            return;
+        }
+
+        if ($expected === 'int'
+            && $this->isIntStableCoreFn($fn)
+            && !$this->hasNonIntLiteralArg($node)
+        ) {
+            foreach ($node->getArguments() as $arg) {
+                $this->walk($arg, 'int');
+            }
+
+            return;
+        }
+
+        $expectations = $this->calleeParamExpectations($fn);
+        foreach ($node->getArguments() as $i => $arg) {
+            $this->walk($arg, $expectations[$i] ?? null);
+        }
+    }
+
+    private function isSelfReference(GlobalVarNode $fn): bool
+    {
+        return $this->selfNamespace !== null
+            && $this->selfName !== null
+            && $fn->getNamespace() === $this->selfNamespace
+            && $fn->getName()->getName() === $this->selfName;
+    }
+
+    /**
+     * Builds a per-slot list of expected pure-primitive tags for the
+     * callee. Compile-time `:param-tags` win; if that channel is empty
+     * (e.g. core sub-namespaces loaded from a precompiled cache that
+     * the analyzer never sees), `phel.core` fns fall back to the
+     * `CORE_FN_SIGNATURES` allowlist so cross-namespace inference can
+     * still propagate.
+     *
+     * @return list<?string>
+     */
+    private function calleeParamExpectations(GlobalVarNode $fn): array
+    {
+        $paramTags = $fn->getMeta()->find(Keyword::create('param-tags'));
+        if ($paramTags instanceof PersistentVectorInterface && count($paramTags) > 0) {
+            $expectations = [];
+            $hasPrimitive = false;
+            foreach ($paramTags as $tag) {
+                if (is_string($tag) && in_array($tag, self::PURE_PRIMITIVE_TAGS, true)) {
+                    $expectations[] = $tag;
+                    $hasPrimitive = true;
+                } else {
+                    $expectations[] = null;
+                }
+            }
+
+            if ($hasPrimitive) {
+                return $expectations;
+            }
+        }
+
+        if ($fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return self::CORE_FN_SIGNATURES[$fn->getName()->getName()] ?? [];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<?string> $paramTypes
+     */
+    private function walkPhpFnBySignature(CallNode $node, array $paramTypes): void
+    {
+        $count = count($paramTypes);
+        foreach ($node->getArguments() as $i => $arg) {
+            $argExpected = $i < $count ? $paramTypes[$i] : null;
+            $this->walk($arg, $argExpected);
+        }
     }
 
     /**
@@ -336,23 +547,33 @@ final class ParamTypeInferrer
 
     /**
      * `(php/+ x ...)` and friends. We only commit to a numeric type when
-     * a literal in the same call disambiguates int vs float. Without
-     * that hint, mixing call expressions for both operands (e.g.
+     * a literal in the same call disambiguates int vs float, or when an
+     * `int` / `float` expectation flows in from above (Step 3). Without
+     * either signal, mixing call expressions for both operands (e.g.
      * `(php/+ (php/- zx2 zy2) cx)` in a float Mandelbrot kernel) would
      * over-narrow the param to int. Walking arg expressions still
      * captures any nested operator without polluting the local.
      */
-    private function walkNumericCall(CallNode $node): void
+    private function walkNumericCall(CallNode $node, ?string $expected = null): void
     {
         $args = $node->getArguments();
         $type = $this->literalNumericType($args);
 
+        if ($type === null && ($expected === 'int' || $expected === 'float')) {
+            $type = $expected;
+        }
+
         if ($type !== null) {
-            $this->walkArgs($node, fn(AbstractNode $a) => $this->constrainArgAsScalar($a, $type));
+            foreach ($args as $arg) {
+                $this->walk($arg, $type);
+            }
+
             return;
         }
 
-        $this->walkArgs($node);
+        foreach ($args as $arg) {
+            $this->walk($arg);
+        }
     }
 
     /**
@@ -407,5 +628,41 @@ final class ParamTypeInferrer
         // type-discriminating" (same intent as the explicit `assert*`
         // guards), so mark the arg guarded.
         return $name !== '' && $name[strlen($name) - 1] === '?';
+    }
+
+    /**
+     * Detects literal args that the int-stable core fns explicitly
+     * accept via runtime polymorphism (`BigInteger`, `Rational`,
+     * `BigDecimal`, floats). Their presence signals that the caller
+     * is deliberately routing through `NumericOperations`, so the
+     * sibling param's runtime contract must stay permissive even when
+     * an `int` expectation flows in from above.
+     */
+    private function hasNonIntLiteralArg(CallNode $node): bool
+    {
+        return array_any(
+            $node->getArguments(),
+            static function (AbstractNode $arg): bool {
+                if (!$arg instanceof LiteralNode) {
+                    return false;
+                }
+
+                $value = $arg->getValue();
+                if (is_int($value)) {
+                    return false;
+                }
+
+                return is_float($value) || is_object($value);
+            },
+        );
+    }
+
+    private function isIntStableCoreFn(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::INT_STABLE_CORE_FNS, true);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ReturnTypeInferrer.php
@@ -74,6 +74,8 @@ final class ReturnTypeInferrer
         'intval' => 'int',
         'mb_strlen' => 'int',
         'count' => 'int',
+        'random_int' => 'int',
+        'intdiv' => 'int',
         'floatval' => 'float',
         'doubleval' => 'float',
         'floor' => 'float',
@@ -112,15 +114,32 @@ final class ReturnTypeInferrer
      */
     private bool $sawOperator = false;
 
+    private ?string $selfNamespace = null;
+
+    private ?string $selfName = null;
+
     /**
+     * `$selfNamespace` / `$selfName` short-circuit `:tag` lookup for the
+     * def currently being analyzed. The runtime registry can still hold
+     * a `:tag` from a previous compile/eval of the same name; treating
+     * any self-referencing call as untagged keeps a redefinition from
+     * inheriting that stale signal.
+     *
      * @param list<Symbol> $params
      *
      * @psalm-suppress RedundantCondition `inferNode` mutates `sawOperator`
      */
-    public function infer(AbstractNode $body, array $params, bool $isVariadic = false): ?string
-    {
+    public function infer(
+        AbstractNode $body,
+        array $params,
+        bool $isVariadic = false,
+        ?string $selfNamespace = null,
+        ?string $selfName = null,
+    ): ?string {
         $paramTypes = $this->collectParamTypes($params, $isVariadic);
         $this->sawOperator = false;
+        $this->selfNamespace = $selfNamespace;
+        $this->selfName = $selfName;
         $type = $this->inferNode($body, $paramTypes);
 
         if (!$this->sawOperator) {
@@ -346,6 +365,14 @@ final class ReturnTypeInferrer
      */
     private function inferGlobalCall(GlobalVarNode $fn): ?string
     {
+        if ($this->selfNamespace !== null
+            && $this->selfName !== null
+            && $fn->getNamespace() === $this->selfNamespace
+            && $fn->getName()->getName() === $this->selfName
+        ) {
+            return null;
+        }
+
         $tag = $this->tagFromMeta($fn->getMeta());
         return $tag === null ? null : $this->publish($tag);
     }

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn rand-range [lo hi]
+  (+ lo (rand-int (- hi lo))))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rand-range",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rand_range";
+
+    public function __invoke(int $lo, int $hi) {
+      return (\Phel::getDefinition("phel.core", "+"))($lo, (\Phel::getDefinition("phel.core", "rand-int"))((\Phel::getDefinition("phel.core", "-"))($hi, $lo)));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rand-range lo hi)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-rand-range-fully-inferred.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Def/defn-rand-range-fully-inferred.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 30
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[lo hi]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -1,0 +1,60 @@
+--PHEL--
+(defn ^int sum [^int a ^int b] (php/+ a b))
+(defn add-pair [x y] (sum x y))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "sum",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\sum";
+
+    public function __invoke(int $a, int $b): int {
+      return ($a + $b);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("tag"), "int",
+    \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 43
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "add-pair",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add_pair";
+
+    public function __invoke(int $x, int $y): int {
+      return (\Phel::getDefinition("user", "sum"))($x, $y);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 31
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -1,0 +1,58 @@
+--PHEL--
+(defn typed [^"\\Phel\\Lang\\Symbol" s] s)
+(defn caller [x] (typed x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "typed",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\typed";
+
+    public function __invoke(\Phel\Lang\Symbol $s) {
+      return $s;
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(typed s)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 42
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[s]"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "caller",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\caller";
+
+    public function __invoke($x) {
+      return (\Phel::getDefinition("user", "typed"))($x);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 27
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -1,0 +1,58 @@
+--PHEL--
+(defn maybe [^?int a] a)
+(defn caller [x] (maybe x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "maybe",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\maybe";
+
+    public function __invoke(?int $a) {
+      return $a;
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(maybe a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 24
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "caller",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\caller";
+
+    public function __invoke($x) {
+      return (\Phel::getDefinition("user", "maybe"))($x);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 27
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -1,0 +1,58 @@
+--PHEL--
+(defn either [^"int|string" a] a)
+(defn caller [x] (either x))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "either",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\either";
+
+    public function __invoke(int|string $a) {
+      return $a;
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(either a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 33
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);
+\Phel::addDefinition(
+  "user",
+  "caller",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\caller";
+
+    public function __invoke($x) {
+      return (\Phel::getDefinition("user", "either"))($x);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 28
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn caller [x] (php/random_int 0 (+ x 99999999999999999999N)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "caller",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\caller";
+
+    public function __invoke($x): int {
+      return random_int(0, (\Phel::getDefinition("phel.core", "+"))($x, \Phel\Lang\BigInteger::fromString("99999999999999999999")));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-core-plus-bails-on-bigint-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-core-plus-bails-on-bigint-literal.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 64
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn add-pair [x y] (php/random_int 0 (+ x y)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add-pair",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add_pair";
+
+    public function __invoke(int $x, int $y): int {
+      return random_int(0, (\Phel::getDefinition("phel.core", "+"))($x, $y));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-core-plus-int-stable.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-core-plus-int-stable.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 48
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[x y]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn weird [a] (php/. a (php/random_int 0 a)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "weird",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\weird";
+
+    public function __invoke($a): string {
+      return ($a . random_int(0, $a));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(weird a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-bails-on-disagreement.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-bails-on-disagreement.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 47
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]",
+    \Phel::keyword("tag"), "string"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn rrange [lo hi] (php/random_int 0 (php/- hi lo)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rrange",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rrange";
+
+    public function __invoke(int $lo, int $hi): int {
+      return random_int(0, ($hi - $lo));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rrange lo hi)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-numeric.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-numeric.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 54
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[lo hi]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn rec [n] (php/random_int 0 (rec (php/- n 1))))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rec",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rec";
+
+    public function __invoke(int $n): int {
+      return random_int(0, $this(($n - 1)));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-recursion-cycle.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-expected-type-recursion-cycle.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 51
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[n]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn size [xs] (php/count xs))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "size",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\size";
+
+    public function __invoke(array $xs): int {
+      return count($xs);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(size xs)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-count-arg.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-count-arg.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 31
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[xs]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn div [a b] (php/intdiv a b))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "div",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\div";
+
+    public function __invoke(int $a, int $b): int {
+      return intdiv($a, $b);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(div a b)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-intdiv-args.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-intdiv-args.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 33
+    ),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]",
+    \Phel::keyword("tag"), "int"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -1,0 +1,31 @@
+--PHEL--
+(defn rrange [hi] (php/random_int 0 hi))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "rrange",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\rrange";
+
+    public function __invoke(int $hi): int {
+      return random_int(0, $hi);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(rrange hi)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-random-int-arg.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Fn/fn-infer-php-random-int-arg.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 40
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[hi]",
+    \Phel::keyword("tag"), "int"
+  )
+);


### PR DESCRIPTION
## 🤔 Background

`ParamTypeInferrer` (`src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php`) only stamped `:tag` onto fn params when the body used a `php/`-host operator with a disambiguating int/float literal. Most idiomatic Phel code (core `+`, `-`, `rand-int`, …) compiled to untyped PHP signatures, leaving OPcache JIT unable to specialise and forcing boxed `\Phel::getDefinition(...)` dispatch on every arithmetic call.

`DefSymbol` already stashes `:param-tags` per def via `setCompileTimeMeta()` and `InvokeSymbol::verifyArgsAgainstParamTags` already reads them for static type-check diagnostics — the inferrer just didn't.

## 💡 Goal

Stamp more concrete primitive `:tag`s without breaking existing permissive semantics (`BigInteger` / `Rational` / polymorphic callers).

## 🔖 Changes

Implements all four steps from #1978 in a single PR:

- **Step 1 — callee `:param-tags` propagation.** In `walkGlobalCall`, read the callee's compile-time `:param-tags` vector and walk each arg with that tag as the expected type. Only pure primitive tags propagate (`int`, `float`, `string`, `bool`, `array`); nullable, union, and FQN tags stay untouched.
- **Step 2 — PHP host fn signature table.** Curated allowlist (`random_int`, `intdiv`, `strlen`, `mb_strlen`, `str_repeat`, `count`) stamps observations per arg slot. `ReturnTypeInferrer` also learns that `random_int` / `intdiv` are `int`-returning.
- **Step 3 — expected-type back-pressure.** `walk(AbstractNode, ?string $expected)` threads expectations through `Do.ret`, `If.then`/`else`, `Let.body`, and `CallNode`. A callee tag pushes `int` down through nested `php/+ - * /` ops onto the underlying locals so `(php/random_int 0 (php/- hi lo))` flows `int` into `hi`/`lo`.
- **Step 4 — `:int-stable` core arith opt-in.** Allowlist `+ - * inc dec` on `phel.core` as conditional numeric ops: with an `int` expectation from above, propagate `int` to siblings; bail when any sibling is a `BigInteger` / `Rational` / float literal so polymorphic call sites stay permissive. `CORE_FN_SIGNATURES` covers `rand-int` since core sub-namespaces are loaded from a precompiled cache the analyzer never re-walks.

Both inferrers also accept the def's namespace + name and treat any self-referencing call as untagged, so a redefinition cannot inherit stale `:tag` / `:param-tags` from the runtime registry singleton.

Final commit is a refactor (`ref(compiler): consolidate ParamTypeInferrer arg-walking helpers`) that replaces the old `walkArgs($node, ?callable $observe)` callback pattern with three intent-named helpers (`walkArgsExpecting`, `walkArgsBySignature`, `walkArgsAsGuarded`) so every call site reads its semantics off the helper name. Net -30 lines.

### Fixtures

- `Fn/fn-infer-callee-param-tag-propagates.test`
- `Fn/fn-infer-callee-param-tag-skips-nullable.test`
- `Fn/fn-infer-callee-param-tag-skips-union.test`
- `Fn/fn-infer-callee-param-tag-skips-fqn.test`
- `Fn/fn-infer-php-random-int-arg.test`
- `Fn/fn-infer-php-intdiv-args.test`
- `Fn/fn-infer-php-count-arg.test`
- `Fn/fn-infer-expected-type-numeric.test`
- `Fn/fn-infer-expected-type-bails-on-disagreement.test`
- `Fn/fn-infer-expected-type-recursion-cycle.test`
- `Fn/fn-infer-core-plus-int-stable.test`
- `Fn/fn-infer-core-plus-bails-on-bigint-literal.test`
- `Def/defn-rand-range-fully-inferred.test`

Closes #1978