### PR TITLE
feat(core): add prefer-method for multimethod ambiguity resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - `ReturnTypeInferrer` recognises `random_int` and `intdiv` as `int`-returning
 - Both inferrers skip self-references against the def being analyzed so a redefinition cannot inherit stale `:tag` / `:param-tags` carried in the runtime registry
 
+#### Core
+- Multimethods: `prefer-method`, `prefers`, and `prefers?` for resolving ambiguous dispatch when multiple methods match via the hierarchy and neither is more specific. Preferences are transitive; cycles and self-preferences are rejected. Dispatch with truly ambiguous matches and no preference now throws a clear error instead of silently picking one (#1980)
+
 ## [0.37.0](https://github.com/phel-lang/phel-lang/compare/v0.36.0...v0.37.0) - 2026-05-12
 
 ### Added

--- a/src/phel/core/protocols.phel
+++ b/src/phel/core/protocols.phel
@@ -327,33 +327,64 @@
                            all-children)]
          (when (not (empty? result)) result))))))
 
+(defn prefers?
+  "Returns true if dispatch value `x` is preferred over `y` in `prefers-map`,
+  considering transitive preferences. Used by multimethod dispatch when
+  multiple methods match and the hierarchy does not pick a unique winner."
+  {:see-also ["prefer-method" "prefers"]}
+  [prefers-map x y]
+  (let [direct (get prefers-map x #{})]
+    (cond
+      (contains? direct y) true
+      (empty? direct)      false
+      :else                (boolean
+                             (some (fn [p] (prefers? prefers-map p y))
+                                   direct)))))
+
+(defn- dominates?
+  "Returns true when candidate `x` is more specific than `y` for multimethod
+  dispatch: either `x` derives from `y` in the hierarchy, or `x` is preferred
+  over `y` via `prefer-method`."
+  [prefers-map parents-map x y]
+  (or (isa-in? parents-map x y)
+      (prefers? prefers-map x y)))
+
 (defn find-hierarchy-method
   "Finds the best matching method for dispatch-val using the global hierarchy.
-  Returns the method function or nil. Used internally by defmulti."
-  [methods dispatch-val]
-  (let [parents-map (get @*hierarchy* :parents)
-        method-keys (keys methods)
-        candidates  (persistent
-                     (reduce
-                      (fn [acc k]
-                        (if (and (not= k :default)
-                                 (not= k dispatch-val)
-                                 (isa-in? parents-map dispatch-val k))
-                          (conj acc k)
-                          acc))
-                      (transient [])
-                      method-keys))]
-    (when (not (empty? candidates))
-      (if (= 1 (count candidates))
-        (get methods (first candidates))
-        (let [best (reduce
-                    (fn [best k]
-                      (if (isa-in? parents-map k best)
-                        k
-                        best))
-                    (first candidates)
-                    (rest candidates))]
-          (get methods best))))))
+  Returns the method function or nil. Used internally by defmulti. When
+  multiple methods match and none is more specific, consults `prefers-map`
+  (built by `prefer-method`); if still ambiguous, throws."
+  ([methods dispatch-val]
+   (find-hierarchy-method methods dispatch-val {}))
+  ([methods dispatch-val prefers-map]
+   (let [parents-map (get @*hierarchy* :parents)
+         method-keys (keys methods)
+         candidates  (persistent
+                      (reduce
+                       (fn [acc k]
+                         (if (and (not= k :default)
+                                  (not= k dispatch-val)
+                                  (isa-in? parents-map dispatch-val k))
+                           (conj acc k)
+                           acc))
+                       (transient [])
+                       method-keys))]
+     (when (not (empty? candidates))
+       (if (= 1 (count candidates))
+         (get methods (first candidates))
+         (let [best (reduce
+                     (fn [best k]
+                       (cond
+                         (dominates? prefers-map parents-map k best) k
+                         (dominates? prefers-map parents-map best k) best
+                         :else
+                         (throw (php/new \InvalidArgumentException
+                                         (str "Multiple methods match dispatch value: "
+                                              dispatch-val " -> " k " and " best
+                                              ", and neither is preferred")))))
+                     (first candidates)
+                     (rest candidates))]
+           (get methods best)))))))
 
 ;; ---------
 ;; Protocols
@@ -702,6 +733,7 @@
                            "' expects (defmulti name docstring? dispatch-fn), got "
                            (inc arg-count) " arguments."))))
     (let [methods-name  (php/:: Symbol (create (php/. (php/-> name (getName)) "-methods")))
+          prefers-name  (php/:: Symbol (create (php/. (php/-> name (getName)) "-prefers")))
           dispatch-name (php/:: Symbol (create (php/. (php/-> name (getName)) "-dispatch")))
           name-str      (php/-> name (getName))
           df-sym        (gensym)
@@ -711,7 +743,7 @@
                                method#       (get methods# dispatch-val#)]
                            (if method#
                              (apply method# ~args-sym)
-                             (let [hierarchy-method# (find-hierarchy-method methods# dispatch-val#)]
+                             (let [hierarchy-method# (find-hierarchy-method methods# dispatch-val# (deref ~prefers-name))]
                                (if hierarchy-method#
                                  (apply hierarchy-method# ~args-sym)
                                  (let [default-method# (get methods# :default)]
@@ -721,6 +753,7 @@
                                                      (str "No method for dispatch value: " dispatch-val#)))))))))]
       `(do
          (def ~methods-name (atom {}))
+         (def ~prefers-name (atom {}))
          (def ~dispatch-name {:private true}
            (let [~df-sym ~dispatch-fn]
              (when (and (string? ~df-sym) (not (php/is_callable ~df-sym)))
@@ -749,6 +782,48 @@
                                      multi-ns
                                      (php/. (php/-> multi-name (getName)) "-methods")))]
     `(swap! ~methods-name assoc ~dispatch-val (fn ~@fn-tail))))
+
+(defmacro prefer-method
+  "Causes the multimethod to prefer matches of `dispatch-val-x` over
+  `dispatch-val-y` when there is an ambiguity (both match via the hierarchy
+  and neither is more specific). Preferences are transitive.
+
+  Throws if the new preference would create a cycle, i.e. `y` is already
+  (transitively) preferred over `x`."
+  {:example "(prefer-method draw :drawable :shape)"
+   :see-also ["defmulti" "defmethod" "prefers"]}
+  [multi-name dispatch-val-x dispatch-val-y]
+  (let [multi-ns     (php/-> multi-name (getNamespace))
+        multi-str    (php/-> multi-name (getName))
+        prefers-name (php/:: Symbol (createForNamespace
+                                     multi-ns
+                                     (php/. multi-str "-prefers")))]
+    `(let [x#    ~dispatch-val-x
+           y#    ~dispatch-val-y
+           pmap# (deref ~prefers-name)]
+       (when (= x# y#)
+         (throw (php/new \InvalidArgumentException
+                         (str "prefer-method: cannot prefer dispatch value to itself: " x#))))
+       (when (prefers? pmap# y# x#)
+         (throw (php/new \InvalidArgumentException
+                         (str "Preference conflict: " y# " is already preferred to " x#
+                              " in multimethod '" ~multi-str "'"))))
+       (swap! ~prefers-name update x#
+              (fn [s#] (if s# (conj s# y#) (hash-set y#))))
+       nil)))
+
+(defmacro prefers
+  "Returns the preference map for a multimethod (built by `prefer-method`).
+  Keys are dispatch values; values are sets of dispatch values they are
+  preferred over (directly; preference is transitive when consulted)."
+  {:example "(prefers draw)"
+   :see-also ["prefer-method" "defmulti"]}
+  [multi-name]
+  (let [multi-ns     (php/-> multi-name (getNamespace))
+        prefers-name (php/:: Symbol (createForNamespace
+                                     multi-ns
+                                     (php/. (php/-> multi-name (getName)) "-prefers")))]
+    `(deref ~prefers-name)))
 
 (defmacro if-let
   "If test is true, evaluates then with binding-form bound to the value of test,

--- a/tests/phel/core/multimethods.phel
+++ b/tests/phel/core/multimethods.phel
@@ -96,3 +96,75 @@
     (is (not (= false err)) "throws when dispatch-fn missing (string as dispatch)")
     (is (php/str_contains err "requires a callable dispatch-fn")
         "error mentions callable dispatch-fn")))
+
+;; -------------------------------------------
+;; prefer-method: ambiguity resolution
+;; -------------------------------------------
+
+;; Distinct keyword prefixes per test to avoid hierarchy state leaking.
+
+(derive :pm1-rect :pm1-shape)
+(derive :pm1-rect :pm1-drawable)
+
+(defmulti pm1-render identity)
+(defmethod pm1-render :pm1-shape    [_] "shape")
+(defmethod pm1-render :pm1-drawable [_] "drawable")
+
+(deftest test-prefer-method-ambiguity-throws-without-preference
+  (let [err (try (pm1-render :pm1-rect) false
+                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+    (is (not (= false err)) "ambiguous dispatch throws")
+    (is (php/str_contains err "Multiple methods match dispatch value")
+        "error message identifies ambiguity")))
+
+(deftest test-prefer-method-resolves-ambiguity
+  (prefer-method pm1-render :pm1-drawable :pm1-shape)
+  (is (= "drawable" (pm1-render :pm1-rect))
+      "after prefer-method, ambiguous dispatch resolves to preferred branch"))
+
+(deftest test-prefers-returns-preference-map
+  (let [pmap (prefers pm1-render)]
+    (is (contains? pmap :pm1-drawable) "preference map contains preferred key")
+    (is (contains? (get pmap :pm1-drawable) :pm1-shape)
+        "preferred-over set contains the dominated key")))
+
+;; Transitive preference
+
+(derive :pm2-c :pm2-a)
+(derive :pm2-c :pm2-b)
+(derive :pm2-c :pm2-d)
+
+(defmulti pm2-pick identity)
+(defmethod pm2-pick :pm2-a [_] "a")
+(defmethod pm2-pick :pm2-b [_] "b")
+(defmethod pm2-pick :pm2-d [_] "d")
+
+(deftest test-prefer-method-transitive
+  (prefer-method pm2-pick :pm2-a :pm2-b)
+  (prefer-method pm2-pick :pm2-b :pm2-d)
+  (is (= "a" (pm2-pick :pm2-c))
+      "transitive preference: a > b > d => a wins"))
+
+;; Cycle detection
+
+(derive :pm3-c :pm3-a)
+(derive :pm3-c :pm3-b)
+
+(defmulti pm3-cycle identity)
+(defmethod pm3-cycle :pm3-a [_] "a")
+(defmethod pm3-cycle :pm3-b [_] "b")
+
+(deftest test-prefer-method-cycle-throws
+  (prefer-method pm3-cycle :pm3-a :pm3-b)
+  (let [err (try (prefer-method pm3-cycle :pm3-b :pm3-a) false
+                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+    (is (not (= false err)) "cycle creation throws")
+    (is (php/str_contains err "already preferred")
+        "error explains the cycle")))
+
+(deftest test-prefer-method-self-throws
+  (let [err (try (prefer-method pm3-cycle :pm3-a :pm3-a) false
+                 (catch \InvalidArgumentException e (php/-> e (getMessage))))]
+    (is (not (= false err)) "preferring value to itself throws")
+    (is (php/str_contains err "cannot prefer dispatch value to itself")
+        "error explains self-preference")))


### PR DESCRIPTION
## 🤔 Background

Phel multimethods already support `defmulti`/`defmethod`/`derive`/`isa?`. When a dispatch value matched two methods via independent hierarchy edges (e.g. `::rect` derives both `::shape` and `::drawable`, each with its own `defmethod`), `find-hierarchy-method` silently picked one via fold-left ordering — non-deterministic from the user's perspective and impossible to override.

Clojure resolves this with `prefer-method` (audit at #1980). It was the only missing piece in Phel's multimethod surface.

## 💡 Goal

Closes #1980

Add `prefer-method` so users can declare a preference between two dispatch values when the hierarchy alone is not enough, and make truly ambiguous dispatch throw a clear error instead of silently picking one branch.

## 🔖 Changes

- `src/phel/core/protocols.phel`
  - New `prefers?` public fn — transitive preference predicate
  - New private `dominates?` — `isa-in?` OR `prefers?`
  - `find-hierarchy-method` gains an optional `prefers-map` arg; on multiple-candidate ties it consults preferences and throws `InvalidArgumentException` when still ambiguous (previously silently fold-left selected)
  - `defmulti` now also defines a `~name-prefers` atom; the body passes it into `find-hierarchy-method`
  - New `prefer-method` macro — adds an edge `x -> #{y}` in the multimethod's prefer map; rejects self-preference and cycles (when `y` is already preferred over `x` transitively)
  - New `prefers` macro — returns the prefer map for inspection
- `tests/phel/core/multimethods.phel` — 6 new `deftest` cases:
  - Ambiguous dispatch throws when no preference set
  - `prefer-method` resolves ambiguity
  - `prefers` returns the prefer map
  - Transitive preference (`a > b > d` => `a` wins)
  - Cycle creation throws
  - Self-preference throws
- `CHANGELOG.md` — Unreleased / Core entry

## Notes

- Preference state is per-multimethod, stored in `~name-prefers` atom alongside the existing `~name-methods` atom, mirroring `defmethod`'s pattern.
- The previous silent fold-left behaviour was effectively undefined; the new "throw on ambiguity" matches Clojure semantics and is the only sound behaviour once `prefer-method` exists. Any code that relied on the old silent ordering was already non-deterministic.