### PR TITLE
feat(core): add eduction for deferred transducer application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 #### Core
 - Multimethods: `prefer-method`, `prefers`, and `prefers?` for resolving ambiguous dispatch when multiple methods match via the hierarchy and neither is more specific. Preferences are transitive; cycles and self-preferences are rejected. Dispatch with truly ambiguous matches and no preference now throws a clear error instead of silently picking one (#1980)
+- Transducers: `eduction` returns a reducible/iterable view that applies its transducer chain freshly on every consumption. Works with `into`, `reduce`, `doseq`/`foreach`, and short-circuits via `take`. Backed by a new `Phel\Lang\Eduction` PHP class implementing `IteratorAggregate` (#1981)
 
 ## [0.37.0](https://github.com/phel-lang/phel-lang/compare/v0.36.0...v0.37.0) - 2026-05-12
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -2,6 +2,7 @@
 
 (use InvalidArgumentException)
 (use Phel)
+(use Phel.Lang.Eduction)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
 (use Phel.Lang.Collections.HashSet.TransientHashSetInterface)
 (use Phel.Lang.Collections.LazySeq.LazySeq)
@@ -1233,6 +1234,21 @@
    :see-also ["transduce" "into"]}
   [xform coll]
   (into [] xform coll))
+
+(defn eduction
+  "Returns a reducible/iterable applying transducers to `coll`. The last
+  argument is the source collection; preceding arguments are transducers
+  composed left-to-right. The transformation is re-run on each consumption
+  (no caching), so the result is safe to reduce or iterate multiple times."
+  {:example "(reduce + (eduction (map inc) (filter odd?) [1 2 3 4])) ; => 8"
+   :see-also ["transduce" "into" "sequence"]}
+  [& args]
+  (let [coll  (last args)
+        xs    (butlast args)
+        xform (if (or (nil? xs) (empty? xs))
+                identity
+                (apply comp xs))]
+    (php/new Eduction xform coll)))
 
 (defn compact
   "Returns a lazy sequence with specified values removed from `coll`.

--- a/src/php/Lang/Eduction.php
+++ b/src/php/Lang/Eduction.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang;
+
+use Generator;
+use IteratorAggregate;
+
+use function array_shift;
+use function count;
+
+/**
+ * Holds a transducer plus a source collection. Each iteration applies the
+ * transducer freshly to the source, yielding transformed values. No caching:
+ * a second iteration re-runs the transducer chain from scratch.
+ *
+ * Constructed by phel.core/eduction.
+ *
+ * @implements IteratorAggregate<int, mixed>
+ */
+final class Eduction implements IteratorAggregate
+{
+    /** @var callable */
+    private $xform;
+
+    /**
+     * @param iterable<mixed> $coll
+     */
+    public function __construct(
+        callable $xform,
+        private readonly iterable $coll,
+    ) {
+        $this->xform = $xform;
+    }
+
+    public function getIterator(): Generator
+    {
+        $buffer = [];
+        $step = ($this->xform)(static function (mixed ...$args) use (&$buffer): mixed {
+            $count = count($args);
+            if ($count === 0) {
+                return null;
+            }
+
+            if ($count === 1) {
+                return $args[0];
+            }
+
+            $buffer[] = $args[1];
+            return $args[0];
+        });
+
+        $acc = null;
+        foreach ($this->coll as $x) {
+            $acc = $step($acc, $x);
+            $stop = $acc instanceof Reduced;
+            if ($stop) {
+                $acc = $acc->deref();
+            }
+
+            yield from $this->drain($buffer);
+            if ($stop) {
+                $step($acc);
+                yield from $this->drain($buffer);
+                return;
+            }
+        }
+
+        $step($acc);
+        yield from $this->drain($buffer);
+    }
+
+    /**
+     * @param list<mixed> $buffer
+     *
+     * @psalm-suppress TypeDoesNotContainType,NoValue
+     */
+    private function drain(array &$buffer): Generator
+    {
+        while ($buffer !== []) {
+            /** @psalm-suppress NoValue */
+            yield array_shift($buffer);
+        }
+    }
+}

--- a/tests/phel/core/transducers.phel
+++ b/tests/phel/core/transducers.phel
@@ -209,3 +209,44 @@
   (let [v (volatile! 10)]
     (vswap! v + 3 4)
     (is (= 17 @v) "vswap! passes extra args")))
+
+;; --------
+;; eduction
+;; --------
+
+(deftest test-eduction-into
+  (is (= [2 3 4] (into [] (eduction (map inc) [1 2 3])))
+      "single transducer + into"))
+
+(deftest test-eduction-composes-multiple-xforms
+  (is (= [3 5] (into [] (eduction (map inc) (filter odd?) [1 2 3 4])))
+      "multiple transducers compose left-to-right"))
+
+(deftest test-eduction-reduce
+  (is (= 8 (reduce + 0 (eduction (map inc) (filter odd?) [1 2 3 4])))
+      "reduce works on eduction"))
+
+(deftest test-eduction-doseq
+  (let [seen (atom [])]
+    (doseq [x (eduction (map inc) [10 20 30])]
+      (swap! seen conj x))
+    (is (= [11 21 31] @seen) "doseq iterates eduction")))
+
+(deftest test-eduction-reiterates-without-cache
+  (let [calls (atom 0)
+        ed    (eduction (map (fn [x] (swap! calls inc) (inc x))) [1 2 3])]
+    (into [] ed)
+    (into [] ed)
+    (is (= 6 @calls) "transducer runs fresh each consumption (no caching)")))
+
+(deftest test-eduction-no-xforms
+  (is (= [1 2 3] (into [] (eduction [1 2 3])))
+      "no xforms = identity, yields source elements"))
+
+(deftest test-eduction-take-short-circuits
+  (is (= [0 1 2] (into [] (eduction (take 3) (range))))
+      "take 3 over infinite range terminates"))
+
+(deftest test-eduction-with-filter-only
+  (is (= [2 4] (into [] (eduction (filter even?) [1 2 3 4])))
+      "single filter transducer"))


### PR DESCRIPTION
## 🤔 Background

Phel already has `transduce`, `into` (with xform), the 1-arity transducer-returning forms of `map`/`filter`/`take`/etc., and `sequence` (which eagerly realizes a transducer pipeline into a vector). The missing piece called out in #1981 was `eduction`: a value that *is* the transducer chain plus a source, that runs the chain fresh on every consumption without realizing it eagerly.

## 💡 Goal

Closes #1981

Add `phel.core/eduction`, mirroring Clojure's semantics: returns a reducible/iterable that re-applies its transducer chain to the source on each consumption (no caching). Useful for composing pipelines without committing to a concrete output type, and for one-shot streaming consumers (`doseq`, `reduce` with a sink).

## 🔖 Changes

- New `Phel\Lang\Eduction` PHP class (`src/php/Lang/Eduction.php`):
  - Implements `IteratorAggregate`, so it works with PHP `foreach`, Phel `doseq`, and Phel `reduce` (which iterates via `:in`).
  - On each `getIterator()` call, builds a fresh reducing fn that pushes values into a generator-yielded buffer, drives the source through the composed xform step-by-step, and respects `Reduced` for early termination. Calls the 1-arity completion to drain transducer state.
- New `phel.core/eduction` (`src/phel/core/seq-fns.phel`):
  - Variadic: `(eduction xform1 xform2 ... coll)`.
  - Composes transducers left-to-right via `comp`; with zero xforms, falls back to `identity`.
  - Returns a `Phel\Lang\Eduction` instance.
  - Placed in `seq-fns.phel` (not `transducers.phel`) because `last`/`butlast`/`comp` are defined there.
- Tests in `tests/phel/core/transducers.phel` covering:
  - Single xform via `into`
  - Multi-xform composition order
  - `reduce` over an eduction
  - `doseq` iteration
  - No caching (counter increments on each consumption)
  - Zero-xform identity case
  - `take` short-circuiting over an infinite `range`
  - Single-filter case
- `CHANGELOG.md` Unreleased / Core entry.

## Notes

- Each iteration is independent: a fresh internal buffer + a fresh xform-wrapped reducer per `getIterator()` call, so re-iterating an eduction never re-uses stale transducer state (e.g. `take`'s decrementing counter).
- Yields are streamed through the buffer: elements are emitted as soon as the inner xform produces them, so memory stays bounded for large/infinite sources.