### PR TITLE
fix(formatter): skip pair alignment when cond/case/condp key spans multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+#### Formatter
+- `AlignPairsRule` no longer pads `cond` / `case` / `condp` values when the test/key spans multiple lines, which previously inflated whitespace by hundreds of columns (#1986)
+
 ### Added
 
 #### Compiler

--- a/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
+++ b/src/php/Formatter/Domain/Rules/Pair/PairAligner.php
@@ -36,6 +36,9 @@ final readonly class PairAligner
         }
 
         $maxKeyWidth = $this->maxKeyWidth($children, $pairs);
+        if ($maxKeyWidth === null) {
+            return $children;
+        }
 
         return $this->rebuild($children, $pairs, $maxKeyWidth);
     }
@@ -94,11 +97,16 @@ final readonly class PairAligner
      * @param list<NodeInterface>   $children
      * @param list<array{int, int}> $pairs
      */
-    private function maxKeyWidth(array $children, array $pairs): int
+    private function maxKeyWidth(array $children, array $pairs): ?int
     {
         $max = 0;
         foreach ($pairs as [$keyIdx]) {
-            $width = strlen($children[$keyIdx]->getCode());
+            $code = $children[$keyIdx]->getCode();
+            if (str_contains($code, "\n")) {
+                return null;
+            }
+
+            $width = strlen($code);
             if ($width > $max) {
                 $max = $width;
             }

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -303,6 +303,40 @@ final class FormatterFacadeTest extends TestCase
             ],
         ];
 
+        yield 'Cond with multi-line key not aligned (regression #1986)' => [
+            [
+                '(cond',
+                '  (some (fn [k] (contains? query k)) ks) :set-op',
+                '  (and (contains? query :values)',
+                '       (not (contains? query :select))) :values-only',
+                '  :else :select)',
+            ],
+            [
+                '(cond',
+                '  (some (fn [k] (contains? query k)) ks) :set-op',
+                '  (and (contains? query :values)',
+                '       (not (contains? query :select))) :values-only',
+                '  :else :select)',
+            ],
+        ];
+
+        yield 'Case with multi-line key not aligned (regression #1986)' => [
+            [
+                '(case x',
+                '  (foo',
+                '   bar) :first',
+                '  :baz :second',
+                '  :default)',
+            ],
+            [
+                '(case x',
+                '  (foo',
+                '   bar) :first',
+                '  :baz :second',
+                '  :default)',
+            ],
+        ];
+
         yield 'Indent def block' => [
             [
                 '(def foo',


### PR DESCRIPTION
## 🤔 Background

`AlignPairsRule` aligns key/value pairs in `cond`, `case`, and `condp` so values line up under a common column. The width calculation used `strlen($node->getCode())`, which on a multi-line key node returns the full serialized source — newlines and inner-line indentation included. A `(and ...)` test spanning two lines could therefore inflate the column to ~200, padding every other pair with hundreds of spaces and rendering the file unreadable past the terminal width.

## 💡 Goal

Closes #1986. Stop producing broken output when any pair key contains a newline.

## 🔖 Changes

- `PairAligner::maxKeyWidth()` now returns `?int`. It bails out (returns `null`) the moment it sees a key whose serialized source contains a newline; `align()` then leaves children untouched. Single-line pairs continue to align as before.
- `FormatterFacadeTest`: regression cases for `cond` with a multi-line `(and ...)` test and for `case` with a multi-line `(foo bar)` test — both must round-trip unchanged through the formatter.
- CHANGELOG: Unreleased / Fixed / Formatter entry.