### PR TITLE
test: cover namespaced keyword alias resolution (`::alias/kw`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+#### Tests
+- Regression coverage for namespaced keyword alias resolution: `::foo` resolves to the current namespace, `::alias/bar` resolves through `(:require [other.ns :as alias])` to the aliased namespace, and `::unknown/bar` raises a clear `KeywordParserException`. Phel-level test exercises `name` / `namespace` / `full-name` round-trips and equality with the absolute keyword form (#1983)
+
 #### Compiler
 - `ParamTypeInferrer` cross-fn channels: callee `:param-tags` propagation (Step 1), PHP host fn signature table (`random_int`, `intdiv`, `strlen`, `mb_strlen`, `str_repeat`, `count`) (Step 2), expected-type back-pressure into nested numeric calls (Step 3), `:int-stable` allowlist on `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) propagating `int` when an `int` expectation flows from above and bailing on `BigInteger` / `Rational` / float literal siblings (Step 4) (#1978)
 - `ReturnTypeInferrer` recognises `random_int` and `intdiv` as `int`-returning

--- a/tests/phel/keyword-alias-resolution.phel
+++ b/tests/phel/keyword-alias-resolution.phel
@@ -1,0 +1,27 @@
+(ns phel-test.keyword-alias-resolution
+  (:require phel.string :as s)
+  (:require phel.test :refer [deftest is]))
+
+(deftest auto-ns-keyword-resolves-to-current-ns
+  (is (= "phel-test.keyword-alias-resolution" (namespace ::foo))
+      "::foo carries current ns")
+  (is (= "foo" (name ::foo))
+      "::foo name extracted")
+  (is (= "phel-test.keyword-alias-resolution/foo" (full-name ::foo))
+      "::foo full-name round-trip"))
+
+(deftest aliased-keyword-resolves-via-require-alias
+  (is (= "phel.string" (namespace ::s/blank))
+      "::s/blank resolves via require alias to phel.string")
+  (is (= "blank" (name ::s/blank))
+      "name on aliased keyword"))
+
+(deftest absolute-namespaced-keyword-preserves-namespace
+  (is (= "other.ns" (namespace :other.ns/bar))
+      "single-colon keyword uses literal namespace")
+  (is (= "bar" (name :other.ns/bar))
+      "name on absolute namespaced keyword"))
+
+(deftest aliased-keyword-equality
+  (is (= ::s/blank :phel.string/blank)
+      "::alias/kw is equal to expanded :ns/kw"))

--- a/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
+++ b/tests/php/Unit/Compiler/Parser/ExpressionParser/AtomParserTest.php
@@ -170,6 +170,22 @@ final class AtomParserTest extends TestCase
         );
     }
 
+    public function test_parse_keyword_with_unknown_alias_throws(): void
+    {
+        $this->expectException(KeywordParserException::class);
+        $this->expectExceptionMessage("Can not resolve alias 'missing' in keyword: ::missing/foo");
+
+        $env = new GlobalEnvironment();
+        $env->setNs('user');
+
+        $parser = new AtomParser($env);
+        $start = new SourceLocation('string', 0, 0);
+        $end = new SourceLocation('string', 0, 14);
+        $parser->parse(
+            new Token(Token::T_ATOM, '::missing/foo', $start, $end),
+        );
+    }
+
     public function test_parse_binary_number(): void
     {
         $parser = new AtomParser(new GlobalEnvironment());


### PR DESCRIPTION
## 🤔 Background

Closes #1983.

`AtomParser::parseKeyword()` already implements three forms of keyword namespacing:

1. `::foo` — auto-promote to the current namespace
2. `::alias/bar` — resolve `alias` through the current namespace's require map and qualify with the resolved namespace
3. `:other.ns/bar` — explicit absolute namespace, no resolution

Existing unit tests cover the happy paths but the **error path for an unknown alias** was untested, and there was no Phel-level integration test exercising the full `(ns ... (:require [other.ns :as alias]))` plumbing end to end. The acceptance criteria on the issue ask for both.

## 💡 Goal

Make the alias-resolution behaviour locked-down by tests so future regressions surface immediately, and confirm the unknown-alias error message is actionable.

## 🔖 Changes

- `AtomParserTest::test_parse_keyword_with_unknown_alias_throws` — `::missing/foo` against an env without that alias raises `KeywordParserException` with the message `Can not resolve alias 'missing' in keyword: ::missing/foo`.
- `tests/phel/keyword-alias-resolution.phel` — Phel test that uses `(:require phel.string :as s)` and asserts:
  - `(namespace ::foo)` returns the current ns
  - `(namespace ::s/blank)` returns `"phel.string"` and `(name ::s/blank)` returns `"blank"`
  - `(namespace :other.ns/bar)` honours the literal namespace
  - `::s/blank = :phel.string/blank` (alias and absolute forms produce equal keywords)
- CHANGELOG entry under Unreleased / Tests.

## 🔍 Audit notes

The integration fixture `tests/php/Integration/Fixtures/Keyword/keywords.test` already covers compilation of `::bar`, `::foo/bar`, and `:xyz\foo/bar` to the right `Phel::keyword` calls. With the new tests on top, every acceptance scenario in the issue is exercised at one of three layers (PHP unit on the parser, PHP integration on the emitted code, Phel runtime on the resulting keyword).