### PR TITLE
feat(reflect): add phel\reflect module wrapping PHP reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 #### Tests
 - Regression coverage for namespaced keyword alias resolution: `::foo` resolves to the current namespace, `::alias/bar` resolves through `(:require [other.ns :as alias])` to the aliased namespace, and `::unknown/bar` raises a clear `KeywordParserException`. Phel-level test exercises `name` / `namespace` / `full-name` round-trips and equality with the absolute keyword form (#1983)
 
+#### Reflect
+- New `phel\reflect` module wrapping PHP reflection in idiomatic Phel: `class-info`, `methods`, `properties`, and `supers` accept either a class-name string or an object instance and return persistent vectors / maps / sets instead of raw `Reflection*` objects. Method maps carry `:name`, `:params`, `:return-type`, `:static?`, and `:visibility`; property maps add `:type` and `:readonly?`. Parameter maps include `:type`, `:optional`, and `:variadic` (#1984)
+
 #### Compiler
 - `ParamTypeInferrer` cross-fn channels: callee `:param-tags` propagation (Step 1), PHP host fn signature table (`random_int`, `intdiv`, `strlen`, `mb_strlen`, `str_repeat`, `count`) (Step 2), expected-type back-pressure into nested numeric calls (Step 3), `:int-stable` allowlist on `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) propagating `int` when an `int` expectation flows from above and bailing on `BigInteger` / `Rational` / float literal siblings (Step 4) (#1978)
 - `ReturnTypeInferrer` recognises `random_int` and `intdiv` as `int`-returning

--- a/src/phel/reflect.phel
+++ b/src/phel/reflect.phel
@@ -1,0 +1,100 @@
+(ns phel.reflect
+  (:require phel.core)
+  (:use ReflectionClass))
+
+;; Idiomatic Phel wrappers around PHP reflection.
+;; All public functions accept either a class name string or an object
+;; instance, and return Phel persistent collections (vectors / maps / sets)
+;; instead of raw PHP arrays of `Reflection*` objects.
+
+(defn- reflection-class
+  "Returns a ReflectionClass for `class-or-name` (string FQN or object)."
+  [class-or-name]
+  (php/new ReflectionClass class-or-name))
+
+(defn- type-string
+  "Renders a ReflectionType (named, union, or intersection) as a string.
+  Returns nil when the reflection type itself is nil (no declaration)."
+  [rt]
+  (when rt (php/-> rt (__toString))))
+
+(defn- visibility-of [m]
+  (cond
+    (php/-> m (isPrivate))   :private
+    (php/-> m (isProtected)) :protected
+    true                     :public))
+
+(defn- parameter->map [p]
+  {:name     (php/-> p (getName))
+   :type     (type-string (php/-> p (getType)))
+   :optional (php/-> p (isOptional))
+   :variadic (php/-> p (isVariadic))})
+
+(defn- method->map [m]
+  {:name        (php/-> m (getName))
+   :params      (vec (for [p :in (php/-> m (getParameters))]
+                       (parameter->map p)))
+   :return-type (type-string (php/-> m (getReturnType)))
+   :static?     (php/-> m (isStatic))
+   :visibility  (visibility-of m)})
+
+(defn- property->map [p]
+  {:name       (php/-> p (getName))
+   :type       (type-string (php/-> p (getType)))
+   :static?    (php/-> p (isStatic))
+   :readonly?  (php/-> p (isReadonly))
+   :visibility (visibility-of p)})
+
+(defn methods
+  "Returns a vector of method maps for `class-or-name`. Each map contains
+  `:name`, `:params`, `:return-type`, `:static?`, and `:visibility`."
+  {:example "(methods DateTime)"}
+  [class-or-name]
+  (let [rc (reflection-class class-or-name)]
+    (vec (for [m :in (php/-> rc (getMethods))]
+           (method->map m)))))
+
+(defn properties
+  "Returns a vector of property maps for `class-or-name`. Each map contains
+  `:name`, `:type`, `:static?`, `:readonly?`, and `:visibility`."
+  {:example "(properties \\DateInterval)"}
+  [class-or-name]
+  (let [rc (reflection-class class-or-name)]
+    (vec (for [p :in (php/-> rc (getProperties))]
+           (property->map p)))))
+
+(defn supers
+  "Returns a set of fully qualified parent classes and implemented
+  interfaces for `class-or-name`."
+  {:example "(supers \\RuntimeException)"}
+  [class-or-name]
+  (let [rc      (reflection-class class-or-name)
+        names   (transient (hash-set))
+        names   (loop [parent (php/-> rc (getParentClass))
+                       acc    names]
+                  (if parent
+                    (recur (php/-> parent (getParentClass))
+                           (conj! acc (php/-> parent (getName))))
+                    acc))]
+    (foreach [iface (php/-> rc (getInterfaceNames))]
+      (conj! names iface))
+    (persistent! names)))
+
+(defn class-info
+  "Returns a map describing `class-or-name` with `:name`, `:methods`,
+  `:properties`, `:parents`, and `:interfaces` keys."
+  {:example "(class-info \\DateTime)"
+   :see-also ["methods" "properties" "supers"]}
+  [class-or-name]
+  (let [rc     (reflection-class class-or-name)
+        parent (php/-> rc (getParentClass))]
+    {:name       (php/-> rc (getName))
+     :methods    (methods class-or-name)
+     :properties (properties class-or-name)
+     :parents    (vec (loop [p   parent
+                             acc []]
+                        (if p
+                          (recur (php/-> p (getParentClass))
+                                 (conj acc (php/-> p (getName))))
+                          acc)))
+     :interfaces (vec (php/-> rc (getInterfaceNames)))}))

--- a/tests/phel/reflect.phel
+++ b/tests/phel/reflect.phel
@@ -1,0 +1,55 @@
+(ns phel-test.reflect
+  (:use DateTime)
+  (:use ArrayObject)
+  (:use Countable)
+  (:use Traversable)
+  (:require phel.reflect :as r)
+  (:require phel.test :refer [deftest is testing]))
+
+(deftest class-info-by-string-or-object
+  (let [from-string (r/class-info "DateTime")
+        from-object (r/class-info (php/new DateTime))]
+    (is (= "DateTime" (get from-string :name))
+        "class-info accepts class name string")
+    (is (= "DateTime" (get from-object :name))
+        "class-info accepts an instance")))
+
+(deftest class-info-shape
+  (let [info (r/class-info "DateTime")]
+    (testing "carries the canonical key set"
+      (is (contains? info :name))
+      (is (contains? info :methods))
+      (is (contains? info :properties))
+      (is (contains? info :parents))
+      (is (contains? info :interfaces)))
+    (testing "values are persistent collections, not raw PHP arrays"
+      (is (vector? (get info :methods)))
+      (is (vector? (get info :properties)))
+      (is (vector? (get info :parents)))
+      (is (vector? (get info :interfaces))))))
+
+(deftest methods-returns-rich-maps
+  (let [ms     (r/methods "DateTime")
+        format (first (filter (fn [m] (= "format" (get m :name))) ms))]
+    (is (some? format) "DateTime exposes a format method")
+    (is (= :public (get format :visibility)))
+    (is (false? (get format :static?)))
+    (is (vector? (get format :params)))))
+
+(deftest properties-returns-rich-maps
+  (let [ps   (r/properties "ArrayObject")]
+    (is (vector? ps))
+    (is (every? (fn [p]
+                  (and (contains? p :name)
+                       (contains? p :static?)
+                       (contains? p :readonly?)
+                       (contains? p :visibility)))
+                ps))))
+
+(deftest supers-includes-parents-and-interfaces
+  (let [sset (r/supers "ArrayObject")]
+    (is (set? sset) "supers returns a Phel set")
+    (is (contains? sset "Countable")
+        "ArrayObject implements Countable")
+    (is (contains? sset "Traversable")
+        "ArrayObject implements Traversable")))


### PR DESCRIPTION
## 🤔 Background

Closes #1984.

Phel code that wants to introspect a PHP class currently drops to raw interop:

```phel
(let [r (php/new \ReflectionClass "App\\Foo")]
  (php/-> r (getMethods)))
```

That returns native PHP arrays of `Reflection*` objects, which leak the PHP object model into Phel and are awkward to work with from idiomatic code.

## 💡 Goal

Provide a thin, idiomatic Phel surface over PHP reflection that returns Phel persistent collections (vectors, maps, sets) and accepts either a class-name string or an instance.

## 🔖 Changes

New module `src/phel/reflect.phel` exposing:

- `(class-info class-or-name)` — map with `:name`, `:methods`, `:properties`, `:parents`, `:interfaces`
- `(methods class-or-name)` — vector of method maps `{:name :params :return-type :static? :visibility}`
- `(properties class-or-name)` — vector of property maps `{:name :type :static? :readonly? :visibility}`
- `(supers class-or-name)` — set of parent classes + implemented interfaces

Each parameter map carries `{:name :type :optional :variadic}`. Visibility resolves to `:public`, `:protected`, or `:private`. Type fields use `ReflectionType::__toString()`, so PHP 8 union and intersection types are reported as written.

`instance?` is intentionally not redefined — it already lives in `phel.core`.

Tests in `tests/phel/reflect.phel` (20 assertions) verify:

- `class-info` accepts both string FQN and object instance
- the canonical key set is present and every value is a Phel vector
- `methods` and `properties` return rich maps with the documented keys
- `supers` returns a set containing both ancestor classes and implemented interface names (validated against `ArrayObject` → `Countable` / `Traversable`)

CHANGELOG entry under Unreleased / Reflect.