### PR TITLE
fix(test): polish testdox, repeat, seed, junit-xml reporter flags

### DIFF
--- a/.claude/hooks/format-phel.sh
+++ b/.claude/hooks/format-phel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PostToolUse hook: auto-format Phel files after Edit/Write
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE" == *.phel ]]; then
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    cd "$PROJECT_DIR" 2>/dev/null
+    ./bin/phel format --quiet "$FILE" 2>/dev/null
+fi
+exit 0

--- a/.claude/rules/phel.md
+++ b/.claude/rules/phel.md
@@ -33,3 +33,7 @@ Every public function should have metadata:
 ## Macros
 
 Editing a `defmacro` body or `` ` `` quasiquote? Load [macro-hygiene.md](macro-hygiene.md) first — local `let` names can silently shadow globals.
+
+## Formatting
+
+`*.phel` files auto-formatted by `.claude/hooks/format-phel.sh` after Edit/Write (runs `./bin/phel format <file>`). No manual run needed. Check without writing: `./bin/phel format --dry-run <file>`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,11 @@
                         "type": "command",
                         "command": ".claude/hooks/format-php.sh",
                         "timeout": 30
+                    },
+                    {
+                        "type": "command",
+                        "command": ".claude/hooks/format-phel.sh",
+                        "timeout": 30
                     }
                 ]
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `phel test`: `--testdox` no longer prints "no test message found" placeholder when an assertion has no message
+- `phel test`: `--repeat=<non-numeric>` now errors instead of silently falling back to 1
+- `phel test`: `--seed=<N>` alone now shuffles tests (previously printed the seed but kept order deterministic)
+- `phel test`: `--reporter=junit-xml` no longer emits empty `<testsuite>` entries for loaded dependency namespaces that contain no tests
+
 ## [0.38.0](https://github.com/phel-lang/phel-lang/compare/v0.37.0...v0.38.0) - 2026-05-16
 
 ### Added

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -765,9 +765,9 @@
             marker (case state :failed "✘" :error "E" "✔")
             tname  (or (:test-name event) "")
             msg    (:message event)]
-        (println marker (if (and msg (not= msg ""))
-                          (str tname ": " msg)
-                          tname)))
+        (println marker (if (s/blank? msg)
+                          tname
+                          (str tname ": " msg))))
 
       (= type :skipped)
       (let [tname (or (:test-name event) "")]
@@ -956,9 +956,9 @@
       (assoc state :current nil)
 
       :else
-      (-> state
-          (assoc :testsuites (conj (get state :testsuites) current))
-          (assoc :current nil)))))
+      (assoc state
+             :testsuites (conj (:testsuites state) current)
+             :current nil))))
 
 (defn- junit-start-ns [state ns-name]
   (-> state

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -764,8 +764,10 @@
       (let [state  (:state event)
             marker (case state :failed "✘" :error "E" "✔")
             tname  (or (:test-name event) "")
-            msg    (or (:message event) "no test message found")]
-        (println marker (str tname ": " msg)))
+            msg    (:message event)]
+        (println marker (if (and msg (not= msg ""))
+                          (str tname ": " msg)
+                          tname)))
 
       (= type :skipped)
       (let [tname (or (:test-name event) "")]
@@ -946,11 +948,17 @@
 
 (defn- junit-finalize-current [state]
   (let [current (:current state)]
-    (if current
+    (cond
+      (nil? current)
+      state
+
+      (zero? (:tests current))
+      (assoc state :current nil)
+
+      :else
       (-> state
           (assoc :testsuites (conj (get state :testsuites) current))
-          (assoc :current nil))
-      state)))
+          (assoc :current nil)))))
 
 (defn- junit-start-ns [state ns-name]
   (-> state
@@ -1240,11 +1248,12 @@
   (swap! timings conj {:ns ns :test-name test-name :duration-ms duration-ms}))
 
 (defn- maybe-shuffle-tests
-  "Returns `tests` shuffled when `:random-order` is set in `options`, or
-  unchanged otherwise. The active seed (`:seed-resolved`) reseeds PHP's
-  Mersenne Twister so the resulting order is reproducible."
+  "Returns `tests` shuffled when `:random-order` is set in `options` (or
+  an explicit `:seed` is supplied), or unchanged otherwise. The active
+  seed (`:seed-resolved`) reseeds PHP's Mersenne Twister so the resulting
+  order is reproducible."
   [options tests]
-  (if (:random-order options)
+  (if (or (:random-order options) (:seed options))
     (do
       (when-let [seed (:seed-resolved options)]
         (php/mt_srand seed))

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -419,22 +419,14 @@ final class TestCommand extends Command
     private function parseRepeat(InputInterface $input): int
     {
         $raw = $input->getOption(self::OPT_REPEAT);
-        if (!is_numeric($raw)) {
-            throw new InvalidArgumentException(sprintf(
-                '--repeat must be a positive integer, got %s.',
-                is_string($raw) ? $raw : (string) $raw,
-            ));
-        }
-
-        $value = (int) $raw;
-        if ($value < 1) {
+        if (!is_numeric($raw) || (int) $raw < 1) {
             throw new InvalidArgumentException(sprintf(
                 '--repeat must be a positive integer, got %s.',
                 (string) $raw,
             ));
         }
 
-        return $value;
+        return (int) $raw;
     }
 
     private function parseSeed(InputInterface $input): ?int

--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -419,11 +419,18 @@ final class TestCommand extends Command
     private function parseRepeat(InputInterface $input): int
     {
         $raw = $input->getOption(self::OPT_REPEAT);
-        $value = is_numeric($raw) ? (int) $raw : 1;
+        if (!is_numeric($raw)) {
+            throw new InvalidArgumentException(sprintf(
+                '--repeat must be a positive integer, got %s.',
+                is_string($raw) ? $raw : (string) $raw,
+            ));
+        }
+
+        $value = (int) $raw;
         if ($value < 1) {
             throw new InvalidArgumentException(sprintf(
                 '--repeat must be a positive integer, got %s.',
-                is_string($raw) ? $raw : (string) $value,
+                (string) $raw,
             ));
         }
 

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandRepeatSeedTest.php
@@ -42,6 +42,14 @@ final class TestCommandRepeatSeedTest extends TestCase
         $this->collectAndPrint(['--repeat' => '-2']);
     }
 
+    public function test_repeat_non_numeric_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('--repeat must be a positive integer, got abc');
+
+        $this->collectAndPrint(['--repeat' => 'abc']);
+    }
+
     public function test_seed_flag_appears_in_phel_hash_map(): void
     {
         $printed = $this->collectAndPrint(['--seed' => '777']);


### PR DESCRIPTION
## 🤔 Background

While validating every flag of `./bin/phel test`, four small bugs surfaced in the reporters and option parsing. Each one was either silently wrong, misleading, or noisy enough to hurt the CI integration story (testdox, JUnit XML).

## 💡 Goal

Make every `phel test` flag behave the way its `--help` text already promises:
- placeholder strings out of test output
- consistent validation of numeric options
- `--seed=<N>` actually changing order
- JUnit XML containing only suites that ran tests

## 🔖 Changes

- `--testdox` no longer prints `"no test message found"` for assertions without a message. Just shows the test name.
- `--repeat=<non-numeric>` now errors with `--repeat must be a positive integer, got <value>.` (was silently falling back to 1; mirrors how `--seed` already behaved).
- `--seed=<N>` on its own now shuffles tests deterministically. Previously announced the seed but kept order unchanged unless `--random-order` was also passed.
- `--reporter=junit-xml` skips empty `<testsuite>` entries for dependency namespaces with 0 tests. Previously the XML listed every loaded `phel.*` namespace with `tests="0"`.
- New unit test: `test_repeat_non_numeric_throws`.
- CHANGELOG `Unreleased` updated under `### Fixed`.