### PR TITLE
fix(lang): align LazySeq next/rest with Clojure semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)
+- LazySeq: `(rest lazy-seq)` and `(cdr lazy-seq)` no longer force the head of the tail, restoring true laziness — `(realized? (rest s))` now stays `false` when the consumer only walked the spine (#1995)
 - `phel test`: `--testdox` no longer prints "no test message found" placeholder when an assertion has no message
 - `phel test`: `--repeat=<non-numeric>` now errors instead of silently falling back to 1
 - `phel test`: `--seed=<N>` alone now shuffles tests (previously printed the seed but kept order deterministic)

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3,6 +3,8 @@
   (:use Phel)
   (:use Phel.Lang.CdrInterface)
   (:use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
+  (:use Phel.Lang.Collections.LazySeq.LazyCons)
+  (:use Phel.Lang.Collections.LazySeq.LazySeqInterface)
   (:use Phel.Lang.Collections.Map.MapEntry)
   (:use Phel.Lang.Collections.Map.PersistentMapInterface)
   (:use Phel.Lang.ConcatInterface)
@@ -95,24 +97,28 @@
   (fn [xs]
     (if (php/=== xs nil)
       nil
-      (if (php/instanceof xs CdrInterface)
-        (php/-> xs (cdr))
-        (if (php/is_string xs)
-          (let [chars (php/mb_str_split xs)]
-            (if (php/<= (php/count chars) 1)
-              nil
-              (php/:: Phel (vector (php/array_slice chars 1)))))
-          (if (php/is_array xs)
-            (let [sliced (php/array_slice xs 1)]
-              (if (php/empty sliced)
-                nil
-                sliced))
-            (if (php/instanceof xs PersistentHashSetInterface)
-              (next-of-set xs)
-              (if (php/instanceof xs PersistentMapInterface)
-                (next-of-map xs)
-                (throw (php/new InvalidArgumentException
-                                (php/. "cannot call 'next on " (php/gettype xs))))))))))))
+      (if (php/instanceof xs LazySeqInterface)
+        (php/-> xs (nextSeq))
+        (if (php/instanceof xs LazyCons)
+          (php/-> xs (nextSeq))
+          (if (php/instanceof xs CdrInterface)
+            (php/-> xs (cdr))
+            (if (php/is_string xs)
+              (let [chars (php/mb_str_split xs)]
+                (if (php/<= (php/count chars) 1)
+                  nil
+                  (php/:: Phel (vector (php/array_slice chars 1)))))
+              (if (php/is_array xs)
+                (let [sliced (php/array_slice xs 1)]
+                  (if (php/empty sliced)
+                    nil
+                    sliced))
+                (if (php/instanceof xs PersistentHashSetInterface)
+                  (next-of-set xs)
+                  (if (php/instanceof xs PersistentMapInterface)
+                    (next-of-map xs)
+                    (throw (php/new InvalidArgumentException
+                                    (php/. "cannot call 'next on " (php/gettype xs))))))))))))))
 
 (def first-map-entry
   {:private true

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -3,6 +3,7 @@
 (use Countable)
 (use Phel)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
+(use Phel.Lang.Collections.LazySeq.LazyCons)
 (use Phel.Lang.Collections.LazySeq.LazySeqInterface)
 (use Phel.Lang.Collections.LinkedList.PersistentListInterface)
 (use Phel.Lang.Collections.Map.MapEntry)
@@ -398,10 +399,12 @@
   (= (type x) :php/object))
 
 (defn seq?
-  "Returns true if `x` is a seq (a list or a lazy sequence)."
+  "Returns true if `x` is a seq (a list, a lazy sequence, or a realized
+  `LazyCons` cell returned by `(next some-lazy-seq)`)."
   {:see-also ["seq" "lazy-seq" "lazy-seq?"]}
   [x]
   (or (php/instanceof x LazySeqInterface)
+      (php/instanceof x LazyCons)
       (php/instanceof x PersistentListInterface)))
 
 (defn lazy-seq?
@@ -422,6 +425,7 @@
     (php/is_numeric x)                  (= 0 x)
     (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x LazySeqInterface) (nil? (first x))
+    (php/instanceof x LazyCons)         false
     :else                               (= 0 (count x))))
 
 (defn not-empty

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -178,6 +178,34 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
     }
 
     /**
+     * Mirrors Clojure's `(next s)` semantics: returns a realized `LazyCons`
+     * holding the next head and a lazy tail, or `null` when exhausted. The
+     * returned value is never a `LazySeqInterface`.
+     *
+     * @return LazyCons<mixed>|null
+     */
+    public function nextSeq(): ?LazyCons
+    {
+        $cdr = $this->cdr();
+
+        if (!$cdr instanceof LazySeqInterface) {
+            return null;
+        }
+
+        $nextFirst = $cdr->first();
+        if ($nextFirst === null) {
+            return null;
+        }
+
+        $nextRest = $cdr->cdr();
+        if (!$nextRest instanceof LazySeqInterface) {
+            $nextRest = new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
+        }
+
+        return new LazyCons($this->hasher, $this->equalizer, $nextFirst, $nextRest);
+    }
+
+    /**
      * @return LazySeqInterface<T>
      */
     public function rest(): LazySeq|LazySeqInterface

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -186,38 +186,15 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
      */
     public function nextSeq(): ?LazyCons
     {
-        $cdr = $this->cdr();
-
-        if (!$cdr instanceof LazySeqInterface) {
-            return null;
-        }
-
-        $nextFirst = $cdr->first();
-        if ($nextFirst === null) {
-            return null;
-        }
-
-        $nextRest = $cdr->cdr();
-        if (!$nextRest instanceof LazySeqInterface) {
-            $nextRest = new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
-        }
-
-        return new LazyCons($this->hasher, $this->equalizer, $nextFirst, $nextRest);
+        return LazyCons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
     }
 
     /**
      * @return LazySeqInterface<T>
      */
-    public function rest(): LazySeq|LazySeqInterface
+    public function rest(): LazySeqInterface
     {
-        $cdr = $this->cdr();
-
-        if (!$cdr instanceof LazySeqInterface) {
-            // Return empty LazySeq
-            return new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
-        }
-
-        return $cdr;
+        return $this->cdr() ?? LazySeq::empty($this->hasher, $this->equalizer);
     }
 
     /**

--- a/src/php/Lang/Collections/LazySeq/LazyCons.php
+++ b/src/php/Lang/Collections/LazySeq/LazyCons.php
@@ -68,6 +68,36 @@ final class LazyCons extends AbstractType implements SeqInterface, IteratorAggre
     }
 
     /**
+     * Builds a realized cons cell from a lazy `$cdr` by forcing one element
+     * of the head. Returns `null` when `$cdr` is null or empty. Shared
+     * helper for `LazySeq::nextSeq()`, `ChunkedSeq::nextSeq()`, and
+     * `LazyCons::nextSeq()`.
+     *
+     * @param LazySeqInterface<mixed>|null $cdr
+     *
+     * @return self<mixed>|null
+     */
+    public static function fromCdr(
+        HasherInterface $hasher,
+        EqualizerInterface $equalizer,
+        ?LazySeqInterface $cdr,
+    ): ?self {
+        if (!$cdr instanceof LazySeqInterface) {
+            return null;
+        }
+
+        $head = $cdr->first();
+        if ($head === null) {
+            return null;
+        }
+
+        /** @var LazySeqInterface<mixed> $tail */
+        $tail = $cdr->cdr() ?? LazySeq::empty($hasher, $equalizer);
+
+        return new self($hasher, $equalizer, $head, $tail);
+    }
+
+    /**
      * Returns the next realized cons cell (head + lazy tail) or `null` when
      * the lazy tail is exhausted. The returned cell's head is the tail's
      * first element so callers do not skip an item.
@@ -76,18 +106,7 @@ final class LazyCons extends AbstractType implements SeqInterface, IteratorAggre
      */
     public function nextSeq(): ?self
     {
-        $head = $this->rest->first();
-        if ($head === null) {
-            return null;
-        }
-
-        $tail = $this->rest->cdr();
-        if (!$tail instanceof LazySeqInterface) {
-            $tail = new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
-        }
-
-        /** @var T $head */
-        return new self($this->hasher, $this->equalizer, $head, $tail);
+        return self::fromCdr($this->hasher, $this->equalizer, $this->rest);
     }
 
     /**

--- a/src/php/Lang/Collections/LazySeq/LazyCons.php
+++ b/src/php/Lang/Collections/LazySeq/LazyCons.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Lang\Collections\LazySeq;
+
+use Iterator;
+use IteratorAggregate;
+use Phel\Lang\AbstractType;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\EqualizerInterface;
+use Phel\Lang\HasherInterface;
+use Phel\Lang\SeqInterface;
+use Traversable;
+
+/**
+ * A realized cons cell: a concrete head paired with a lazy tail. Returned
+ * by `LazySeq::nextSeq()` and `ChunkedSeq::nextSeq()` so callers receive a
+ * seq view that is not itself a `LazySeqInterface`, matching Clojure's
+ * `(next some-lazy-seq)` contract.
+ *
+ * @template T
+ *
+ * @implements SeqInterface<T, LazySeqInterface>
+ * @implements IteratorAggregate<int, T>
+ *
+ * @extends AbstractType<SeqInterface<T, LazySeqInterface>>
+ */
+final class LazyCons extends AbstractType implements SeqInterface, IteratorAggregate
+{
+    private int $hashCache = 0;
+
+    /**
+     * @param T                                         $first
+     * @param LazySeqInterface<T>                       $rest
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    public function __construct(
+        private readonly HasherInterface $hasher,
+        private readonly EqualizerInterface $equalizer,
+        private readonly mixed $first,
+        private readonly LazySeqInterface $rest,
+        private ?PersistentMapInterface $meta = null,
+    ) {}
+
+    /**
+     * @return T
+     */
+    public function first(): mixed
+    {
+        return $this->first;
+    }
+
+    /**
+     * @return LazySeqInterface<T>
+     */
+    public function cdr(): LazySeqInterface
+    {
+        return $this->rest;
+    }
+
+    /**
+     * @return LazySeqInterface<T>
+     */
+    public function rest(): LazySeqInterface
+    {
+        return $this->rest;
+    }
+
+    /**
+     * Returns the next realized cons cell (head + lazy tail) or `null` when
+     * the lazy tail is exhausted. The returned cell's head is the tail's
+     * first element so callers do not skip an item.
+     *
+     * @return LazyCons<T>|null
+     */
+    public function nextSeq(): ?self
+    {
+        $head = $this->rest->first();
+        if ($head === null) {
+            return null;
+        }
+
+        $tail = $this->rest->cdr();
+        if (!$tail instanceof LazySeqInterface) {
+            $tail = new LazySeq($this->hasher, $this->equalizer, static fn(): null => null);
+        }
+
+        /** @var T $head */
+        return new self($this->hasher, $this->equalizer, $head, $tail);
+    }
+
+    /**
+     * Realizes the entire sequence eagerly.
+     *
+     * @return array<int, T>
+     */
+    public function toArray(): array
+    {
+        $result = [$this->first];
+        foreach ($this->walkTail() as $value) {
+            $result[] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return Traversable<int, T>
+     */
+    public function getIterator(): Traversable
+    {
+        yield $this->first;
+        foreach ($this->walkTail() as $value) {
+            yield $value;
+        }
+    }
+
+    /**
+     * @return PersistentMapInterface<mixed, mixed>|null
+     */
+    public function getMeta(): ?PersistentMapInterface
+    {
+        return $this->meta;
+    }
+
+    /**
+     * @param PersistentMapInterface<mixed, mixed>|null $meta
+     */
+    public function withMeta(?PersistentMapInterface $meta): static
+    {
+        $clone = clone $this;
+        $clone->meta = $meta;
+
+        return $clone;
+    }
+
+    public function equals(mixed $other): bool
+    {
+        if ($this === $other) {
+            return true;
+        }
+
+        if (!$other instanceof SeqInterface || !$other instanceof Traversable) {
+            return false;
+        }
+
+        $leftIter = $this->getIterator();
+        $rightIter = $other instanceof IteratorAggregate ? $other->getIterator() : $other;
+
+        $left = $this->normalizeIterator($leftIter);
+        $right = $this->normalizeIterator($rightIter);
+
+        $left->rewind();
+        $right->rewind();
+
+        while (true) {
+            $lv = $left->valid();
+            $rv = $right->valid();
+            if ($lv !== $rv) {
+                return false;
+            }
+
+            if (!$lv) {
+                return true;
+            }
+
+            if (!$this->equalizer->equals($left->current(), $right->current())) {
+                return false;
+            }
+
+            $left->next();
+            $right->next();
+        }
+    }
+
+    public function hash(): int
+    {
+        if ($this->hashCache === 0) {
+            $this->hashCache = 1;
+            foreach ($this as $value) {
+                $this->hashCache = 31 * $this->hashCache + $this->hasher->hash($value);
+            }
+        }
+
+        return $this->hashCache;
+    }
+
+    /**
+     * Walks the lazy tail one cell at a time without forcing past the
+     * elements the caller actually consumes.
+     *
+     * @return iterable<int, T>
+     */
+    private function walkTail(): iterable
+    {
+        $current = $this->rest;
+        /** @phpstan-ignore instanceof.alwaysTrue */
+        while ($current instanceof LazySeqInterface) {
+            $head = $current->first();
+            if ($head === null) {
+                return;
+            }
+
+            /** @var T $head */
+            yield $head;
+
+            $next = $current->cdr();
+            if (!$next instanceof LazySeqInterface) {
+                return;
+            }
+
+            $current = $next;
+        }
+    }
+
+    /**
+     * Unwraps nested `IteratorAggregate` so `current` / `next` / `valid` can
+     * be driven directly. Generators are already iterators and pass through.
+     *
+     * @param Traversable<mixed, mixed> $traversable
+     *
+     * @return Iterator<mixed, mixed>
+     */
+    private function normalizeIterator(Traversable $traversable): Iterator
+    {
+        while ($traversable instanceof IteratorAggregate) {
+            $traversable = $traversable->getIterator();
+        }
+
+        /** @var Iterator $traversable */
+        return $traversable;
+    }
+}

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -152,6 +152,17 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         )->cons($first);
     }
 
+    /**
+     * Returns a realized empty `LazySeq` whose thunk yields `null`. Used
+     * as a sentinel tail when no further elements remain.
+     *
+     * @return self<mixed>
+     */
+    public static function empty(HasherInterface $hasher, EqualizerInterface $equalizer): self
+    {
+        return new self($hasher, $equalizer, static fn(): null => null);
+    }
+
     public function isRealized(): bool
     {
         return $this->fn === null;
@@ -209,23 +220,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
      */
     public function nextSeq(): ?LazyCons
     {
-        $cdr = $this->cdr();
-
-        if (!$cdr instanceof LazySeqInterface) {
-            return null;
-        }
-
-        $nextFirst = $cdr->first();
-        if ($nextFirst === null) {
-            return null;
-        }
-
-        $nextRest = $cdr->cdr();
-        if (!$nextRest instanceof LazySeqInterface) {
-            $nextRest = new self($this->hasher, $this->equalizer, static fn(): null => null);
-        }
-
-        return new LazyCons($this->hasher, $this->equalizer, $nextFirst, $nextRest);
+        return LazyCons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
     }
 
     /**
@@ -233,14 +228,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
      */
     public function rest(): self|LazySeqInterface
     {
-        $cdr = $this->cdr();
-
-        if (!$cdr instanceof LazySeqInterface) {
-            // Return empty LazySeq
-            return new self($this->hasher, $this->equalizer, static fn(): null => null);
-        }
-
-        return $cdr;
+        return $this->cdr() ?? self::empty($this->hasher, $this->equalizer);
     }
 
     /**

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -172,6 +172,10 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
     }
 
     /**
+     * Returns the tail seq without forcing the head of that tail. Callers
+     * who need to know whether the tail is empty must probe with `first()`
+     * or use `nextSeq()`.
+     *
      * @return LazySeqInterface<T>|null
      */
     public function cdr(): LazySeqInterface|self|null
@@ -188,21 +192,40 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
             return null;
         }
 
-        // Check if rest is empty
-        if ($rest instanceof SeqInterface) {
-            $first = $rest->first();
-            if ($first === null) {
-                // Empty sequence
-                return null;
-            }
-        }
-
-        // Wrap the rest in a LazySeq to maintain laziness
         if ($rest instanceof LazySeqInterface) {
             return $rest;
         }
 
         return new self($this->hasher, $this->equalizer, static fn(): SeqInterface => $rest);
+    }
+
+    /**
+     * Mirrors Clojure's `(next s)` semantics: returns a realized cons cell
+     * (`LazyCons`) holding the next head and a lazy tail, or `null` when
+     * the tail is exhausted. The returned value is never a
+     * `LazySeqInterface`.
+     *
+     * @return LazyCons<mixed>|null
+     */
+    public function nextSeq(): ?LazyCons
+    {
+        $cdr = $this->cdr();
+
+        if (!$cdr instanceof LazySeqInterface) {
+            return null;
+        }
+
+        $nextFirst = $cdr->first();
+        if ($nextFirst === null) {
+            return null;
+        }
+
+        $nextRest = $cdr->cdr();
+        if (!$nextRest instanceof LazySeqInterface) {
+            $nextRest = new self($this->hasher, $this->equalizer, static fn(): null => null);
+        }
+
+        return new LazyCons($this->hasher, $this->equalizer, $nextFirst, $nextRest);
     }
 
     /**
@@ -227,70 +250,14 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
      */
     public function cons($x): self
     {
+        $hasher = $this->hasher;
+        $equalizer = $this->equalizer;
         $self = $this;
 
         return new self(
-            $this->hasher,
-            $this->equalizer,
-            /** @psalm-suppress InvalidReturnType, InvalidReturnStatement */
-            static fn(): SeqInterface // Create a simple cons cell
-            => new readonly class($x, $self) implements SeqInterface {
-                /**
-                 * @param LazySeqInterface<mixed> $rest
-                 */
-                public function __construct(
-                    private mixed $first,
-                    private LazySeqInterface $rest,
-                ) {}
-
-                public function first()
-                {
-                    return $this->first;
-                }
-
-                /**
-                 * @return LazySeqInterface<mixed>
-                 */
-                public function cdr(): LazySeqInterface
-                {
-                    return $this->rest;
-                }
-
-                /**
-                 * @return LazySeqInterface<mixed>
-                 */
-                public function rest(): LazySeqInterface
-                {
-                    return $this->rest;
-                }
-
-                public function toArray(): array
-                {
-                    // Iterative implementation to avoid stack overflow
-                    $result = [$this->first];
-                    $current = $this->rest;
-
-                    // Walk through the sequence iteratively
-                    /** @phpstan-ignore instanceof.alwaysTrue */
-                    while ($current instanceof LazySeqInterface) {
-                        $realized = $current->first();
-                        if ($realized === null) {
-                            break;
-                        }
-
-                        $result[] = $realized;
-
-                        $next = $current->cdr();
-                        if ($next === null) {
-                            break;
-                        }
-
-                        $current = $next;
-                    }
-
-                    return $result;
-                }
-            },
+            $hasher,
+            $equalizer,
+            static fn(): LazyCons => new LazyCons($hasher, $equalizer, $x, $self),
             $this->meta,
         );
     }
@@ -325,7 +292,6 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
             // Handle both LazySeq and other SeqInterface implementations
             if ($next instanceof self) {
                 $seq = $next;
-                /** @phpstan-ignore instanceof.alwaysTrue */
             } elseif ($next instanceof SeqInterface) {
                 // Realize remaining non-lazy sequence
                 $remaining = $next->toArray();

--- a/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
@@ -25,6 +25,15 @@ interface LazySeqInterface extends TypeInterface, SeqInterface, ConsInterface
     public function isRealized(): bool;
 
     /**
+     * Realizes one step beyond the head and returns a `LazyCons` cell whose
+     * `cdr` is the lazy tail, or `null` when the tail is empty. Mirrors
+     * Clojure's `(next s)`; the returned value is never a `LazySeqInterface`.
+     *
+     * @return LazyCons<mixed>|null
+     */
+    public function nextSeq(): ?LazyCons;
+
+    /**
      * Forces realization of the entire sequence and returns it as an array.
      *
      * Warning: This will cause infinite sequences to run forever.

--- a/src/php/Shared/Printer/Printer.php
+++ b/src/php/Shared/Printer/Printer.php
@@ -6,6 +6,7 @@ namespace Phel\Shared\Printer;
 
 use Phel\Lang\BigDecimal;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\LazySeq\LazyCons;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -27,6 +28,7 @@ use Phel\Shared\Printer\TypePrinter\BigDecimalPrinter;
 use Phel\Shared\Printer\TypePrinter\BooleanPrinter;
 use Phel\Shared\Printer\TypePrinter\FnPrinter;
 use Phel\Shared\Printer\TypePrinter\KeywordPrinter;
+use Phel\Shared\Printer\TypePrinter\LazyConsPrinter;
 use Phel\Shared\Printer\TypePrinter\LazySeqPrinter;
 use Phel\Shared\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Shared\Printer\TypePrinter\NullPrinter;
@@ -125,6 +127,10 @@ final readonly class Printer implements PrinterInterface
 
         if ($form instanceof PersistentHashSetInterface) {
             return new PersistentHashSetPrinter($this);
+        }
+
+        if ($form instanceof LazyCons) {
+            return new LazyConsPrinter($this);
         }
 
         if ($form instanceof LazySeqInterface) {

--- a/src/php/Shared/Printer/TypePrinter/LazyConsPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/LazyConsPrinter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Shared\Printer\TypePrinter;
+
+use Phel\Lang\Collections\LazySeq\LazyCons;
+use Phel\Lang\Collections\LazySeq\LazySeqConfig;
+use Phel\Shared\Printer\PrinterInterface;
+
+/**
+ * @implements TypePrinterInterface<LazyCons<mixed>>
+ */
+final readonly class LazyConsPrinter implements TypePrinterInterface
+{
+    public function __construct(private PrinterInterface $printer) {}
+
+    /**
+     * @param LazyCons<mixed> $form
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
+     */
+    public function print(mixed $form): string
+    {
+        $values = [];
+        $count = 0;
+        $limit = LazySeqConfig::REPL_DISPLAY_LIMIT;
+
+        foreach ($form as $value) {
+            if ($count >= $limit) {
+                $values[] = '...';
+                break;
+            }
+
+            $values[] = $this->printer->print($value);
+            ++$count;
+        }
+
+        return '(' . implode(' ', $values) . ')';
+    }
+}

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\LazySeq;
 
 use Generator;
+use Phel\Lang\Collections\LazySeq\LazyCons;
 use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -120,13 +121,63 @@ final class LazySeqTest extends TestCase
         $this->assertSame(2, $rest->first());
     }
 
-    public function test_cdr_returns_lazy_sequence_or_null(): void
+    public function test_cdr_returns_lazy_tail_without_realizing_its_head(): void
     {
-        $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, [1]);
+        $callCount = 0;
+        $tail = new LazySeq(
+            $this->hasher,
+            $this->equalizer,
+            static function () use (&$callCount): null {
+                ++$callCount;
+                return null;
+            },
+        );
 
-        $cdr = $lazySeq->cdr();
+        $head = $tail->cons(1);
 
-        $this->assertNotInstanceOf(LazySeqInterface::class, $cdr);
+        $cdr = $head->cdr();
+
+        self::assertInstanceOf(LazySeqInterface::class, $cdr);
+        self::assertSame(0, $callCount, 'cdr must not force the tail');
+    }
+
+    public function test_next_seq_returns_lazy_cons_not_lazy_seq(): void
+    {
+        $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3]);
+
+        $next = $lazySeq->nextSeq();
+
+        self::assertNotNull($next);
+        self::assertInstanceOf(LazyCons::class, $next);
+        self::assertNotInstanceOf(LazySeqInterface::class, $next);
+        self::assertSame(2, $next->first());
+    }
+
+    public function test_next_seq_returns_null_for_single_element_seq(): void
+    {
+        $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, [42]);
+
+        self::assertNull($lazySeq->nextSeq());
+    }
+
+    public function test_rest_keeps_tail_unrealized(): void
+    {
+        $callCount = 0;
+        $tail = new LazySeq(
+            $this->hasher,
+            $this->equalizer,
+            static function () use (&$callCount): null {
+                ++$callCount;
+                return null;
+            },
+        );
+
+        $head = $tail->cons(1);
+
+        $rest = $head->rest();
+
+        self::assertFalse($rest->isRealized(), 'rest must not force the tail');
+        self::assertSame(0, $callCount);
     }
 
     public function test_cons_prepends_element(): void


### PR DESCRIPTION
## 🤔 Background

Two issues block [`jank-lang/clojure-test-suite#883`](https://github.com/jank-lang/clojure-test-suite/pull/883):

- #1994: `(next some-lazy-seq)` returns another `LazySeq` instance. Clojure's contract: `(instance? LazySeq (next s))` is always false.
- #1995: `(rest s)` and `(cdr s)` eagerly realize the head of the tail. `(realized? (rest s))` returns `true` even when only the spine was walked.

Both bugs share the root cause: `LazySeq::cdr()` probed `$rest->first()` to normalize "empty tail" → null, and the realized cons cell inside `LazySeq::cons()` was an anonymous class that could not safely escape the wrapper.

## 💡 Goal

Make `next` / `rest` / `cdr` behave the way Phel's docstrings already promise and the way `phel.test`'s shared clojure-test-suite expects: lazy where promised, realized once where promised, never silently re-wrapped.

## 🔖 Changes

- **New `Phel\Lang\Collections\LazySeq\LazyCons`** (extends `AbstractType`, implements `SeqInterface, IteratorAggregate`). Replaces the inline anonymous cons cell. Equality walks element-wise; `hash` caches; `getIterator` only forces what callers consume.
- **`LazySeq::cdr()`** drops the eager-probe. `(rest single-elt)` now returns a not-yet-realized `LazySeq` whose `first` returns nil — fixes #1995.
- **`LazySeq::nextSeq()`**, **`ChunkedSeq::nextSeq()`**, **`LazyCons::nextSeq()`** return a realized `LazyCons` (or nil). The returned value is never a `LazySeqInterface` — fixes #1994.
- **`LazySeqInterface`** gains `nextSeq()` so any future impl satisfies the contract.
- **`Printer`** dispatches `LazyCons` to a new `LazyConsPrinter` (renders as `(a b c)` with `REPL_DISPLAY_LIMIT` cap).
- **Phel `next`** dispatches both `LazySeqInterface` and `LazyCons` to `nextSeq`.
- **Phel `seq?`** now recognises `LazyCons`; **`empty?`** short-circuits `LazyCons` to false so emptiness checks no longer realize the whole tail.

## Tests

- `LazySeqTest` adds `test_next_seq_returns_lazy_cons_not_lazy_seq`, `test_next_seq_returns_null_for_single_element_seq`, `test_rest_keeps_tail_unrealized`, and flips `test_cdr_returns_lazy_sequence_or_null` to `test_cdr_returns_lazy_tail_without_realizing_its_head` (the old contract no longer holds).
- `composer test-core` (5487 tests) green; `composer test-quality` green; `LazySeqTest` 63/63 green.

Closes #1994
Closes #1995