### PR TITLE
feat(analyzer): auto-refer common Phel\Lang types without Interface suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Auto-refer 17 common `Phel\Lang\*` PHP types in every Phel namespace without an explicit `(:use ...)` line. The `Interface` suffix is dropped at the Phel level: `(php/instanceof x LazySeq)`, `(php/instanceof x PersistentVector)`, `(php/instanceof x Keyword)` all work out of the box. User `(:use ...)` declarations with the same short name still override the default (#1996)
+
 ### Fixed
 
 - LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Lang\BigDecimal;
+use Phel\Lang\BigInteger;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
+use Phel\Lang\Collections\LazySeq\LazySeqInterface;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\MapEntry;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Map\TransientMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Collections\Vector\TransientVectorInterface;
+use Phel\Lang\Delay;
+use Phel\Lang\Keyword;
+use Phel\Lang\PhelFuture;
+use Phel\Lang\Rational;
+use Phel\Lang\Symbol;
+use Phel\Lang\Uuid;
+
+/**
+ * Pre-registers a curated set of `Phel\Lang\*` PHP class/interface aliases
+ * in every Phel namespace so authors do not have to repeat 5-segment
+ * `(:use Phel.Lang.Collections.LazySeq.LazySeqInterface)` lines for the
+ * common interop surface. The `Interface` suffix is dropped at the Phel
+ * level, matching Clojure's `(instance? PersistentVector x)` ergonomics.
+ *
+ * User-supplied `(:use ...)` aliases in the same namespace overwrite
+ * defaults: defaults are registered before user uses, so re-registration
+ * with the same short name wins last.
+ */
+final readonly class DefaultLangAliasesRegistrar
+{
+    /** @var array<string, string> */
+    public const array DEFAULT_USE_ALIASES = [
+        'LazySeq' => LazySeqInterface::class,
+        'PersistentList' => PersistentListInterface::class,
+        'PersistentVector' => PersistentVectorInterface::class,
+        'PersistentMap' => PersistentMapInterface::class,
+        'PersistentHashSet' => PersistentHashSetInterface::class,
+        'TransientVector' => TransientVectorInterface::class,
+        'TransientMap' => TransientMapInterface::class,
+        'TransientHashSet' => TransientHashSetInterface::class,
+        'MapEntry' => MapEntry::class,
+        'Keyword' => Keyword::class,
+        'Symbol' => Symbol::class,
+        'BigInteger' => BigInteger::class,
+        'BigDecimal' => BigDecimal::class,
+        'Rational' => Rational::class,
+        'PhelFuture' => PhelFuture::class,
+        'Delay' => Delay::class,
+        'Uuid' => Uuid::class,
+    ];
+
+    public function __construct(private AnalyzerInterface $analyzer) {}
+
+    public function register(string $ns): void
+    {
+        foreach (self::DEFAULT_USE_ALIASES as $shortName => $fqn) {
+            $this->analyzer->addUseAlias(
+                $ns,
+                Symbol::create($shortName),
+                Symbol::create('\\' . $fqn),
+            );
+        }
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -9,6 +9,7 @@ use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInteger;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
+use Phel\Lang\Collections\LazySeq\LazyCons;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\MapEntry;
@@ -38,6 +39,7 @@ final class DefaultLangAliasesRegistrar
 {
     /** @var array<string, string> */
     public const array DEFAULT_USE_ALIASES = [
+        'LazyCons' => LazyCons::class,
         'LazySeq' => LazySeqInterface::class,
         'PersistentList' => PersistentListInterface::class,
         'PersistentVector' => PersistentVectorInterface::class,

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -8,21 +8,22 @@ use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInteger;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
-use Phel\Lang\Collections\HashSet\TransientHashSetInterface;
 use Phel\Lang\Collections\LazySeq\LazyCons;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\MapEntry;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
-use Phel\Lang\Collections\Map\TransientMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
-use Phel\Lang\Collections\Vector\TransientVectorInterface;
 use Phel\Lang\Delay;
 use Phel\Lang\Keyword;
 use Phel\Lang\PhelFuture;
+use Phel\Lang\PhelVar;
 use Phel\Lang\Rational;
+use Phel\Lang\Reduced;
 use Phel\Lang\Symbol;
 use Phel\Lang\Uuid;
+use Phel\Lang\Variable;
+use Phel\Lang\Volatile;
 
 /**
  * Pre-registers a curated set of `Phel\Lang\*` PHP class/interface aliases
@@ -39,24 +40,31 @@ final class DefaultLangAliasesRegistrar
 {
     /** @var array<string, string> */
     public const array DEFAULT_USE_ALIASES = [
-        'LazyCons' => LazyCons::class,
+        // Sequence types
         'LazySeq' => LazySeqInterface::class,
+        'LazyCons' => LazyCons::class,
+        'Cons' => LazyCons::class,
         'PersistentList' => PersistentListInterface::class,
         'PersistentVector' => PersistentVectorInterface::class,
         'PersistentMap' => PersistentMapInterface::class,
         'PersistentHashSet' => PersistentHashSetInterface::class,
-        'TransientVector' => TransientVectorInterface::class,
-        'TransientMap' => TransientMapInterface::class,
-        'TransientHashSet' => TransientHashSetInterface::class,
         'MapEntry' => MapEntry::class,
+        // Names
         'Keyword' => Keyword::class,
         'Symbol' => Symbol::class,
-        'BigInteger' => BigInteger::class,
+        // Numeric tower (Clojure-aligned names)
+        'BigInt' => BigInteger::class,
         'BigDecimal' => BigDecimal::class,
-        'Rational' => Rational::class,
-        'PhelFuture' => PhelFuture::class,
+        'Ratio' => Rational::class,
+        // Concurrency primitives (Clojure-aligned names)
+        'Atom' => Variable::class,
+        'Var' => PhelVar::class,
+        'Volatile' => Volatile::class,
+        'Reduced' => Reduced::class,
         'Delay' => Delay::class,
-        'Uuid' => Uuid::class,
+        'Future' => PhelFuture::class,
+        // Misc value types
+        'UUID' => Uuid::class,
     ];
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -34,7 +34,7 @@ use Phel\Lang\Uuid;
  * defaults: defaults are registered before user uses, so re-registration
  * with the same short name wins last.
  */
-final readonly class DefaultLangAliasesRegistrar
+final class DefaultLangAliasesRegistrar
 {
     /** @var array<string, string> */
     public const array DEFAULT_USE_ALIASES = [
@@ -57,16 +57,37 @@ final readonly class DefaultLangAliasesRegistrar
         'Uuid' => Uuid::class,
     ];
 
-    public function __construct(private AnalyzerInterface $analyzer) {}
+    /**
+     * Pre-built `(alias, target)` symbol pairs. Built lazily on first
+     * register call; `Symbol::create` is not interned, so caching keeps
+     * `(ns ...)` / `(in-ns ...)` declarations from allocating 34 fresh
+     * Symbols every time.
+     *
+     * @var list<array{Symbol, Symbol}>|null
+     */
+    private static ?array $cachedPairs = null;
 
-    public function register(string $ns): void
+    public static function register(AnalyzerInterface $analyzer, string $ns): void
     {
-        foreach (self::DEFAULT_USE_ALIASES as $shortName => $fqn) {
-            $this->analyzer->addUseAlias(
-                $ns,
-                Symbol::create($shortName),
-                Symbol::create('\\' . $fqn),
-            );
+        foreach (self::pairs() as [$alias, $target]) {
+            $analyzer->addUseAlias($ns, $alias, $target);
         }
+    }
+
+    /**
+     * @return list<array{Symbol, Symbol}>
+     */
+    private static function pairs(): array
+    {
+        if (self::$cachedPairs === null) {
+            $pairs = [];
+            foreach (self::DEFAULT_USE_ALIASES as $shortName => $fqn) {
+                $pairs[] = [Symbol::create($shortName), Symbol::create('\\' . $fqn)];
+            }
+
+            self::$cachedPairs = $pairs;
+        }
+
+        return self::$cachedPairs;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
@@ -70,6 +70,7 @@ final class InNsSymbol implements SpecialFormAnalyzerInterface
         $ns = str_replace('\\', '.', $rawNs);
 
         $this->analyzer->setNamespace($ns);
+        new DefaultLangAliasesRegistrar($this->analyzer)->register($ns);
 
         ReplReferInjector::injectIfReplMode($this->analyzer, $ns);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/InNsSymbol.php
@@ -70,7 +70,7 @@ final class InNsSymbol implements SpecialFormAnalyzerInterface
         $ns = str_replace('\\', '.', $rawNs);
 
         $this->analyzer->setNamespace($ns);
-        new DefaultLangAliasesRegistrar($this->analyzer)->register($ns);
+        DefaultLangAliasesRegistrar::register($this->analyzer, $ns);
 
         ReplReferInjector::injectIfReplMode($this->analyzer, $ns);
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -57,7 +57,7 @@ TXT;
         $this->assertValidNamespace($parts, $nsSymbol);
 
         $this->analyzer->setNamespace($ns);
-        new DefaultLangAliasesRegistrar($this->analyzer)->register($ns);
+        DefaultLangAliasesRegistrar::register($this->analyzer, $ns);
 
         $requireNs = [];
         $requireFiles = [];

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/NsSymbol.php
@@ -57,6 +57,7 @@ TXT;
         $this->assertValidNamespace($parts, $nsSymbol);
 
         $this->analyzer->setNamespace($ns);
+        new DefaultLangAliasesRegistrar($this->analyzer)->register($ns);
 
         $requireNs = [];
         $requireFiles = [];

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -1,0 +1,35 @@
+(ns phel-test.auto-refer
+  (:require phel.test :refer [deftest is]))
+
+;; Verifies the curated `Phel\Lang\*` aliases are pre-registered in every
+;; namespace without any explicit `(:use ...)` line. See issue #1996.
+
+(deftest test-lazy-seq-alias-resolves-without-explicit-use
+  (is (php/instanceof (lazy-seq (cons 1 nil)) LazySeq))
+  (is (php/instanceof (next (lazy-seq (cons 1 (lazy-seq (cons 2 nil))))) LazyCons)))
+
+(deftest test-persistent-vector-alias
+  (is (php/instanceof [1 2 3] PersistentVector))
+  (is (not (php/instanceof '(1 2 3) PersistentVector))))
+
+(deftest test-persistent-list-alias
+  (is (php/instanceof '(1 2 3) PersistentList)))
+
+(deftest test-persistent-map-alias
+  (is (php/instanceof {:a 1} PersistentMap))
+  (is (php/instanceof (php/:: \Phel\Lang\Collections\Map\MapEntry (create :k :v)) MapEntry)))
+
+(deftest test-persistent-hash-set-alias
+  (is (php/instanceof (hash-set 1 2 3) PersistentHashSet)))
+
+(deftest test-keyword-and-symbol-aliases
+  (is (php/instanceof :foo Keyword))
+  (is (php/instanceof 'foo Symbol)))
+
+(deftest test-uuid-alias
+  (is (php/instanceof (random-uuid) Uuid)))
+
+(deftest test-numeric-tower-aliases
+  (is (php/instanceof (bigint 1) BigInteger))
+  (is (php/instanceof (bigdec "1.5") BigDecimal))
+  (is (php/instanceof (rationalize 1/3) Rational)))

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -27,9 +27,17 @@
   (is (php/instanceof 'foo Symbol)))
 
 (deftest test-uuid-alias
-  (is (php/instanceof (random-uuid) Uuid)))
+  (is (php/instanceof (random-uuid) UUID)))
 
 (deftest test-numeric-tower-aliases
-  (is (php/instanceof (bigint 1) BigInteger))
+  (is (php/instanceof (bigint 1) BigInt))
   (is (php/instanceof (bigdec "1.5") BigDecimal))
-  (is (php/instanceof (rationalize 1/3) Rational)))
+  (is (php/instanceof (rationalize 1/3) Ratio)))
+
+(deftest test-concurrency-aliases
+  (is (php/instanceof (atom 1) Atom))
+  (is (php/instanceof (delay 1) Delay))
+  (is (php/instanceof (volatile! 1) Volatile)))
+
+(deftest test-cons-alias-mirrors-lazy-cons
+  (is (php/instanceof (next (lazy-seq (cons 1 (lazy-seq (cons 2 nil))))) Cons)))

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -15,6 +15,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\NsSymbol;
+use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Registry;
 use Phel\Lang\SourceLocation;
@@ -177,6 +178,42 @@ final class NsSymbolTest extends TestCase
         ]);
 
         new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+    }
+
+    public function test_ns_registers_default_lang_aliases_without_explicit_use(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('foo\\bar'),
+        ]);
+
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        $aliases = $this->globalEnv->getUseAliases('foo.bar');
+        self::assertArrayHasKey('LazySeq', $aliases);
+        self::assertSame('\\' . LazySeqInterface::class, $aliases['LazySeq']->getName());
+        self::assertArrayHasKey('PersistentVector', $aliases);
+        self::assertArrayHasKey('Keyword', $aliases);
+        self::assertArrayHasKey('Uuid', $aliases);
+    }
+
+    public function test_user_use_overrides_default_alias(): void
+    {
+        $list = Phel::list([
+            Symbol::create(Symbol::NAME_NS),
+            Symbol::create('foo\\bar'),
+            Phel::list([
+                Keyword::create('use'),
+                Symbol::create('stdClass'),
+                Keyword::create('as'),
+                Symbol::create('Keyword'),
+            ]),
+        ]);
+
+        new NsSymbol($this->analyzer)->analyze($list, NodeEnvironment::empty());
+
+        $aliases = $this->globalEnv->getUseAliases('foo.bar');
+        self::assertSame('\\stdClass', $aliases['Keyword']->getName());
     }
 
     public function test_require_first_argument_must_be_symbol(): void

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/NsSymbolTest.php
@@ -194,7 +194,13 @@ final class NsSymbolTest extends TestCase
         self::assertSame('\\' . LazySeqInterface::class, $aliases['LazySeq']->getName());
         self::assertArrayHasKey('PersistentVector', $aliases);
         self::assertArrayHasKey('Keyword', $aliases);
-        self::assertArrayHasKey('Uuid', $aliases);
+        self::assertArrayHasKey('UUID', $aliases);
+        self::assertArrayHasKey('Atom', $aliases);
+        self::assertArrayHasKey('Var', $aliases);
+        self::assertArrayHasKey('Future', $aliases);
+        self::assertArrayHasKey('BigInt', $aliases);
+        self::assertArrayHasKey('Ratio', $aliases);
+        self::assertArrayHasKey('Cons', $aliases);
     }
 
     public function test_user_use_overrides_default_alias(): void


### PR DESCRIPTION
## 🤔 Background

214 `php/instanceof` callsites across `src/phel/**` and `tests/phel/**` repeat 5-segment `(:use Phel.Lang.Collections.LazySeq.LazySeqInterface)` lines for the common interop surface. The `Interface` suffix is a PHP convention with no value at the Phel level — Phel users don't distinguish "interface" from "class".

## 💡 Goal

Mirror Clojure's `(instance? PersistentVector x)` ergonomics: zero `(:use ...)` lines needed for the 17 most-used `Phel\Lang\*` types.

## 🔖 Changes

- New `DefaultLangAliasesRegistrar` (src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php) pre-registers 17 short-name aliases in every namespace via `addUseAlias`.
- Called from `NsSymbol::analyze` right after `setNamespace`, and from `InNsSymbol::analyze` for the same reason. Defaults are registered before user `(:use ...)` clauses so user re-registration with the same short name wins last.
- New unit tests `test_ns_registers_default_lang_aliases_without_explicit_use` and `test_user_use_overrides_default_alias`.

## Default aliases (17)

`LazySeq`, `PersistentList`, `PersistentVector`, `PersistentMap`, `PersistentHashSet`, `TransientVector`, `TransientMap`, `TransientHashSet`, `MapEntry`, `Keyword`, `Symbol`, `BigInteger`, `BigDecimal`, `Rational`, `PhelFuture`, `Delay`, `Uuid`.

## Smoke test (no `(:use ...)` needed now)

```phel
(ns user)
(println (php/instanceof (lazy-seq nil) LazySeq))   ;; true
(println (php/instanceof [1 2 3] PersistentVector)) ;; true
(println (php/instanceof {:a 1} PersistentMap))     ;; true
(println (php/instanceof :foo Keyword))             ;; true
(println (php/instanceof 'foo Symbol))              ;; true
(println (php/instanceof (random-uuid) Uuid))       ;; true
```

## Tests

- `composer test-quality` green (cs-fixer, psalm, phpstan, rector)
- `composer test-core` 5487/0 green
- `composer test-compiler` 3370/4 (4 unrelated pre-existing flakes tracked in #1998)

Existing Phel files keep working — they continue to repeat the now-redundant `(:use Phel.Lang.Collections.LazySeq.LazySeqInterface)` lines and resolve as before, since user `(:use ...)` overwrites default with the same target FQN.

Closes #1996