### PR TITLE
ref(lang): rename Variable to Atom (#2000 step 1/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Auto-refer 17 common `Phel\Lang\*` PHP types in every Phel namespace without an explicit `(:use ...)` line. The `Interface` suffix is dropped at the Phel level: `(php/instanceof x LazySeq)`, `(php/instanceof x PersistentVector)`, `(php/instanceof x Keyword)` all work out of the box. User `(:use ...)` declarations with the same short name still override the default (#1996)
 
+### Changed
+
+- BC break: rename `Phel\Lang\Variable` to `Phel\Lang\Atom` (and `Phel\Shared\Printer\TypePrinter\VariablePrinter` to `AtomPrinter`) to match the Clojure-aligned default alias added in #1996; the public static helper `\Phel::variable(...)` is now `\Phel::atom(...)`. Phel sources that still write `(:use Phel.Lang.Variable)` or `(php/instanceof x Variable)` need to switch to `Atom` (or drop the `(:use ...)` line — `Atom` is auto-referred) (#2000)
+
 ### Fixed
 
 - LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -18,7 +18,7 @@ Every directory under `src/php/` is a [Gacela](https://gacela-project.com/) modu
 
 | Module | Purpose |
 |--------|---------|
-| `Lang/` | Runtime types: persistent collections, `Symbol`, `Keyword`, `Variable`, `Registry`. Foundational, no facade. |
+| `Lang/` | Runtime types: persistent collections, `Symbol`, `Keyword`, `Atom`, `Registry`. Foundational, no facade. |
 | `Compiler/` | Lex → Parse → Read → Analyze → Emit → Eval. See [compiler.md](compiler.md). |
 | `Printer/` | Render Phel values. |
 | `Run/` | `phel run`, REPL (`Run/Domain/Repl/`), namespace bootstrap (`Run/Runtime/PhelSourceLoader.php`). |

--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -18,7 +18,7 @@ Grouped by reader.
 
 ## Coming from Clojure
 
-**Missing features.** No agents, no STM/refs (use `Variable` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (use `definterface`), no records (use `defstruct`).
+**Missing features.** No agents, no STM/refs (use `Atom` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (use `definterface`), no records (use `defstruct`).
 
 **Real persistent collections?** Yes. `PersistentVector` (32-way trie), `PersistentHashMap` (HAMT), `LazySeq` (per-element realisation). Under `Lang/Collections/`.
 

--- a/docs/internals/macros.md
+++ b/docs/internals/macros.md
@@ -4,7 +4,7 @@ Compile-time function. Takes Phel forms, returns Phel forms. Analyzer replaces t
 
 ## Mechanism
 
-`(defmacro when [test & body] ...)` is a `def` whose `Variable` carries `:macro true`. At runtime it is a function. At compile time, the analyzer:
+`(defmacro when [test & body] ...)` is a `def` whose `Atom` carries `:macro true`. At runtime it is a function. At compile time, the analyzer:
 
 1. Sees `(when x y)`.
 2. Resolves head to `GlobalVarNode`.

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -21,7 +21,7 @@ Three concerns: types, per-namespace `Registry`, value equality + hashing.
 |------|-------|
 | `Symbol` | Identifier with optional ns. `NAME_*` constants name special forms. |
 | `Keyword` | Interned `:foo`. Implements `FnInterface`, so `(:foo m)` is a map lookup. |
-| `Variable` | Mutable cell with watches/validators. `def` wraps values in one. |
+| `Atom` | Mutable cell with watches/validators. `(atom v)` and `swap!`/`reset!` produce/mutate it. |
 | `Delay` | One-shot lazy value (not a sequence). |
 | `Volatile` | Mutable box for transducer state. |
 | `Reduced` | Early-termination sentinel for `reduce`/`transduce`. |

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Phel\Lang\Atom;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -13,7 +14,6 @@ use Phel\Lang\PhelVarStateRegistry;
 use Phel\Lang\Registry;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeFactory;
-use Phel\Lang\Variable;
 use Phel\Phel as InternalPhel;
 
 /**
@@ -377,14 +377,14 @@ final class Phel extends InternalPhel
     /**
      * @template T
      *
-     * @param T                                         $value The initial value of the variable
+     * @param T                                         $value The initial value of the atom
      * @param PersistentMapInterface<mixed, mixed>|null $meta
      *
-     * @return Variable<T>
+     * @return Atom<T>
      */
-    public static function variable($value, ?PersistentMapInterface $meta = null): Variable
+    public static function atom($value, ?PersistentMapInterface $meta = null): Atom
     {
-        return new Variable($meta, $value);
+        return new Atom($meta, $value);
     }
 
     public static function symbol(string $name): Symbol

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -8,7 +8,7 @@
 (use Phel.Lang.Hasher)
 (use Phel.Lang.PhelVar)
 (use Phel.Lang.Seq)
-(use Phel.Lang.Variable)
+(use Phel.Lang.Atom)
 
 ;; Mutable reference cells (`atom`), first-class `Var` handles for global
 ;; definitions, their mutation protocol (`reset!`, `swap!`, `deref`,
@@ -33,14 +33,14 @@
   (let [pairs (apply hash-map opts)
         m     (get pairs :meta)
         vf    (get pairs :validator)
-        v     (php/:: Phel (variable value m))]
+        v     (php/:: Phel (atom value m))]
     (when vf (php/-> v (setValidator vf)))
     v))
 
 (defn atom?
   "Returns true if the given value is an atom."
   [x]
-  (php/instanceof x Variable))
+  (php/instanceof x Atom))
 
 (defn var?
   "Returns true if the given value is a `Var`, the first-class handle to a

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -24,7 +24,7 @@
 (use Phel.Lang.PhelVar)
 (use Phel.Lang.Rational)
 (use Phel.Lang.Symbol)
-(use Phel.Lang.Variable)
+(use Phel.Lang.Atom)
 
 ;; Type-dispatch primitives: the `type` function and every `*?` predicate
 ;; (`vector?`, `map?`, `list?`, `set?`, `keyword?`, `symbol?`, `int?`,
@@ -76,7 +76,7 @@
     (php/instanceof x PersistentQueue)            :queue
     (php/instanceof x Keyword)                    :keyword
     (php/instanceof x Symbol)                     :symbol
-    (php/instanceof x Variable)                   :atom
+    (php/instanceof x Atom)                       :atom
     (php/instanceof x PhelVar)                    :var
     (php/instanceof x Rational)                   :ratio
     (php/instanceof x BigInteger)                 :bigint

--- a/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/SymbolResolver.php
@@ -201,7 +201,7 @@ final readonly class SymbolResolver
     /**
      * Maps `clojure.lang.X` references to the matching Phel runtime class.
      * Auto-resolves when `\Phel\Lang\X` exists (covers `Symbol`, `Keyword`,
-     * `Variable`, etc.); a small rename table handles cases where Phel
+     * `Atom`, etc.); a small rename table handles cases where Phel
      * diverged from the Clojure name (`BigInt` vs `BigInteger`, `Ratio` vs
      * `Rational`). Returns null when no Phel counterpart exists.
      */

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Lang\Atom;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInteger;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
@@ -22,7 +23,6 @@ use Phel\Lang\Rational;
 use Phel\Lang\Reduced;
 use Phel\Lang\Symbol;
 use Phel\Lang\Uuid;
-use Phel\Lang\Variable;
 use Phel\Lang\Volatile;
 
 /**
@@ -57,7 +57,7 @@ final class DefaultLangAliasesRegistrar
         'BigDecimal' => BigDecimal::class,
         'Ratio' => Rational::class,
         // Concurrency primitives (Clojure-aligned names)
-        'Atom' => Variable::class,
+        'Atom' => Atom::class,
         'Var' => PhelVar::class,
         'Volatile' => Volatile::class,
         'Reduced' => Reduced::class,

--- a/src/php/Lang/Atom.php
+++ b/src/php/Lang/Atom.php
@@ -12,7 +12,7 @@ use Phel\Lang\Collections\Map\PersistentMapInterface;
  *
  * @extends AbstractType<T>
  */
-final class Variable extends AbstractType
+final class Atom extends AbstractType
 {
     use MetaTrait;
 
@@ -100,7 +100,7 @@ final class Variable extends AbstractType
     {
         $fn = $validator ?? $this->validator;
         if ($fn !== null && !Truthy::isTruthy($fn($value))) {
-            throw new InvalidArgumentException('Variable validator rejected the value');
+            throw new InvalidArgumentException('Atom validator rejected the value');
         }
     }
 

--- a/src/php/Lang/CLAUDE.md
+++ b/src/php/Lang/CLAUDE.md
@@ -10,7 +10,7 @@ This is a **foundational module** with no Facade, Factory, or DependencyProvider
 
 - **Symbol** : names with optional namespace; special constants for language forms (`def`, `fn`, `if`, etc.)
 - **Keyword** : interned with pool; callable as functions to access map values (implements `FnInterface`)
-- **Variable** : mutable box (atom) with watches, validators, deref
+- **Atom** : mutable box with watches, validators, deref (Clojure-aligned name; was `Variable`)
 - **PhelVar** : first-class handle to a global definition (`def`); produced by `Registry::addDefinition`/`getVar` and the `(var sym)` / `#'sym` forms; offers `deref`, `meta`, `alterRoot`, `addWatch`/`removeWatch`, `alterMeta`/`resetMeta`, and cached `isDynamic`; implements `FnInterface` so handles are callable (`__invoke` forwards to the current root value)
 - **PhelVarStateRegistry** : singleton side table for per-var watches, metadata overrides, and dynamic-flag cache keyed by `(ns, name)`; lets `PhelVar` stay `readonly` while `alter-meta!` / `add-watch` mutate canonical state
 - **BigInteger** : pure-PHP arbitrary-precision signed integer (`final readonly`); base-10^9 magnitude with sign; `fromInt`, `fromFloat` (truncate toward zero, reject NaN/Inf), `fromString`, `add/subtract/multiply/divide/mod/gcd/pow/negate/abs`, `compareTo/equals`, `hash`, `toInt`/`fitsInPhpInt`. Implements `TypeInterface` (with optional source location and meta) so `N`-suffix literals beyond `PHP_INT_MAX` flow through reader/analyzer/emitter as first-class values. No I/O, no static state.
@@ -69,6 +69,6 @@ Every module: Compiler (AST representation), Printer (value display), Build (nam
 - All collection types are **persistent** (immutable) with transient variants for bulk building
 - `Keyword` uses an intern pool for memory efficiency : identical keywords share the same instance
 - `Registry` is a singleton; `TypeFactory` is a singleton : both use `getInstance()`
-- Keyword callability, ex-info exceptions, atom-style mutation on `Variable`, first-class `PhelVar` for global defs
+- Keyword callability, ex-info exceptions, atom-style mutation on `Atom`, first-class `PhelVar` for global defs
 - Source locations must be preserved via `SourceLocationInterface` for error reporting
 - `Registry` keys are dot-separated: `phel.core`, `my-app.lib` (after `-` → `_` munge → `my_app.lib`). Compiler emitters and analyzer feed the registry through `Munge::encodeRegistryKey`. `Symbol::getFullName` returns the dot form for Phel symbols; symbols whose namespace is a PHP class FQN (leading `\`) keep backslash so static-method shorthand still resolves.

--- a/src/php/Lang/Volatile.php
+++ b/src/php/Lang/Volatile.php
@@ -6,7 +6,7 @@ namespace Phel\Lang;
 
 /**
  * A lightweight mutable container for transducer state.
- * Unlike Variable, has no watches or validators.
+ * Unlike Atom, has no watches or validators.
  *
  * @template T
  */

--- a/src/php/Shared/Printer/CLAUDE.md
+++ b/src/php/Shared/Printer/CLAUDE.md
@@ -31,7 +31,7 @@ Each implements `TypePrinterInterface`. Selected at runtime based on value type:
 | `RationalPrinter` | Rational numbers (`n/d`) |
 | `BigDecimalPrinter` | BigDecimal values (appends the `M` suffix so the readable form round-trips through the reader) |
 | `UuidPrinter` | UUID values (rendered as `#uuid "..."`) |
-| `VariablePrinter` | Variable objects (recursive) |
+| `AtomPrinter` | Atom objects (recursive) |
 | `VarPrinter` | `PhelVar` handles, rendered as `#'ns/name` |
 | `PersistentListPrinter` | Lists (recursive) |
 | `PersistentVectorPrinter` | Vectors (recursive) |
@@ -50,7 +50,7 @@ Each implements `TypePrinterInterface`. Selected at runtime based on value type:
 
 ## Dependencies
 
-- **Lang** : `Keyword`, `Symbol`, `Variable`, `FnInterface`, all collection interfaces
+- **Lang** : `Keyword`, `Symbol`, `Atom`, `FnInterface`, all collection interfaces
 
 ## Structure
 

--- a/src/php/Shared/Printer/Printer.php
+++ b/src/php/Shared/Printer/Printer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer;
 
+use Phel\Lang\Atom;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LazySeq\LazyCons;
@@ -21,9 +22,9 @@ use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
 use Phel\Lang\TypeStringifier;
 use Phel\Lang\Uuid;
-use Phel\Lang\Variable;
 use Phel\Shared\Printer\TypePrinter\AnonymousClassPrinter;
 use Phel\Shared\Printer\TypePrinter\ArrayPrinter;
+use Phel\Shared\Printer\TypePrinter\AtomPrinter;
 use Phel\Shared\Printer\TypePrinter\BigDecimalPrinter;
 use Phel\Shared\Printer\TypePrinter\BooleanPrinter;
 use Phel\Shared\Printer\TypePrinter\FnPrinter;
@@ -47,7 +48,6 @@ use Phel\Shared\Printer\TypePrinter\SymbolPrinter;
 use Phel\Shared\Printer\TypePrinter\ToStringPrinter;
 use Phel\Shared\Printer\TypePrinter\TypePrinterInterface;
 use Phel\Shared\Printer\TypePrinter\UuidPrinter;
-use Phel\Shared\Printer\TypePrinter\VariablePrinter;
 use Phel\Shared\Printer\TypePrinter\VarPrinter;
 use ReflectionClass;
 use RuntimeException;
@@ -149,8 +149,8 @@ final readonly class Printer implements PrinterInterface
             return new SymbolPrinter($this->withColor);
         }
 
-        if ($form instanceof Variable) {
-            return new VariablePrinter($this);
+        if ($form instanceof Atom) {
+            return new AtomPrinter($this);
         }
 
         if ($form instanceof PhelVar) {

--- a/src/php/Shared/Printer/TypePrinter/AtomPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/AtomPrinter.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
-use Phel\Lang\Variable;
+use Phel\Lang\Atom;
 use Phel\Shared\Printer\PrinterInterface;
 
 /**
- * @implements TypePrinterInterface<Variable<mixed>>
+ * @implements TypePrinterInterface<Atom<mixed>>
  */
-final readonly class VariablePrinter implements TypePrinterInterface
+final readonly class AtomPrinter implements TypePrinterInterface
 {
     public function __construct(
         private PrinterInterface $printer,
     ) {}
 
     /**
-     * @param Variable<mixed> $form
+     * @param Atom<mixed> $form
      */
     public function print(mixed $form): string
     {
-        return '(var ' . $this->printer->print($form->deref()) . ')';
+        return '(atom ' . $this->printer->print($form->deref()) . ')';
     }
 }

--- a/tests/php/Integration/Fixtures/Ns/use-dot-syntax.test
+++ b/tests/php/Integration/Fixtures/Ns/use-dot-syntax.test
@@ -1,6 +1,6 @@
 --PHEL--
 (ns test
-  (:use Phel.Lang.SourceLocation Phel.Lang.Variable :as V))
+  (:use Phel.Lang.SourceLocation Phel.Lang.Atom :as V))
 
 (php/new SourceLocation "f" 1 1)
 (php/new V nil 42)
@@ -17,4 +17,4 @@ require_once __DIR__ . '/phel/core.php';
   "*ns*",
   "test"
 );
-(new \Phel\Lang\SourceLocation("f", 1, 1));(new \Phel\Lang\Variable(null, 42));
+(new \Phel\Lang\SourceLocation("f", 1, 1));(new \Phel\Lang\Atom(null, 42));

--- a/tests/php/Unit/Lang/AtomTest.php
+++ b/tests/php/Unit/Lang/AtomTest.php
@@ -5,33 +5,33 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang;
 
 use InvalidArgumentException;
-use Phel\Lang\Variable;
+use Phel\Lang\Atom;
 use PHPUnit\Framework\TestCase;
 
-final class VariableTest extends TestCase
+final class AtomTest extends TestCase
 {
     public function test_deref(): void
     {
-        $v = new Variable(null, 10);
+        $v = new Atom(null, 10);
         $this->assertSame(10, $v->deref());
     }
 
     public function test_set(): void
     {
-        $v = new Variable(null, 10);
+        $v = new Atom(null, 10);
         $v->set(20);
         $this->assertSame(20, $v->deref());
     }
 
     public function test_set_returns_new_value(): void
     {
-        $v = new Variable(null, 10);
+        $v = new Atom(null, 10);
         $this->assertSame(20, $v->set(20));
     }
 
     public function test_set_returns_value_after_watch_runs(): void
     {
-        $v = new Variable(null, 1);
+        $v = new Atom(null, 1);
         $called = false;
         $v->addWatch('w', static function () use (&$called): void {
             $called = true;
@@ -43,7 +43,7 @@ final class VariableTest extends TestCase
 
     public function test_set_throws_when_validator_rejects(): void
     {
-        $v = new Variable(null, 1);
+        $v = new Atom(null, 1);
         $v->setValidator(static fn($value): bool => $value > 0);
 
         $this->expectException(InvalidArgumentException::class);
@@ -52,8 +52,8 @@ final class VariableTest extends TestCase
 
     public function test_equals(): void
     {
-        $v1 = new Variable(null, 10);
-        $v2 = new Variable(null, 10);
+        $v1 = new Atom(null, 10);
+        $v2 = new Atom(null, 10);
 
         $this->assertTrue($v1->equals($v1));
         $this->assertFalse($v1->equals($v2));
@@ -62,7 +62,7 @@ final class VariableTest extends TestCase
 
     public function test_hash(): void
     {
-        $v1 = new Variable(null, 10);
+        $v1 = new Atom(null, 10);
 
         $this->assertSame(crc32(spl_object_hash($v1)), $v1->hash());
     }


### PR DESCRIPTION
## 🤔 Background

#1996 added Clojure-aligned default aliases so Phel users write `(php/instanceof x Atom)` instead of `(php/instanceof x Variable)`. The runtime class behind that alias still lives under the old name `Phel\Lang\Variable`, which is the first of six classes flagged for renaming in #2000.

## 💡 Goal

Step 1/6 of #2000: align the runtime class name with the auto-refer alias so the PHP class, the Phel alias, the `:atom` type tag, and the `(atom v)` constructor all share the same identifier.

## 🔖 Changes

- Rename `Phel\Lang\Variable` → `Phel\Lang\Atom`
- Rename `Phel\Shared\Printer\TypePrinter\VariablePrinter` → `AtomPrinter`
- Rename `Phel::variable(...)` static helper → `Phel::atom(...)`
- Default alias map: `'Atom' => Phel\Lang\Atom::class` (was `Variable::class`)
- `core/atoms.phel` and `core/predicates.phel` switch their `(:use Phel.Lang.Variable)` import to `Atom`
- Refresh CLAUDE.md docs (`Lang`, `Shared/Printer`) and internal docs (`architecture.md`, `runtime.md`, `faq.md`, `macros.md`)
- Update integration fixture `Ns/use-dot-syntax.test` to use `Phel.Lang.Atom`
- Test: `tests/php/Unit/Lang/VariableTest.php` → `AtomTest.php`

### BC break

Any caller importing `\Phel\Lang\Variable`, calling `\Phel::variable(...)`, or writing `(:use Phel.Lang.Variable)` in a Phel ns form must switch to `Atom` (or drop the `(:use ...)` line, since `Atom` has been auto-referred since #1996).

Related to #2000