### PR TITLE
ref(lang): rename PhelFuture to Future (#2000 step 6/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - BC break: rename `Phel\Lang\Uuid` to `Phel\Lang\UUID` (plus `UuidPrinter` → `UUIDPrinter` and `UuidTagHandler` → `UUIDTagHandler`) so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.Uuid)` need to switch to `UUID` (or drop the `(:use ...)` line — `UUID` is auto-referred) (#2000)
 - BC break: rename `Phel\Lang\BigInteger` to `Phel\Lang\BigInt` so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.BigInteger)` or `(php/instanceof x BigInteger)` need to switch to `BigInt` (or drop the `(:use ...)` line — `BigInt` is auto-referred) (#2000)
 - BC break: rename `Phel\Lang\Rational` to `Phel\Lang\Ratio` (plus `RationalPrinter` → `RatioPrinter`) so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.Rational)` or `(php/instanceof x Rational)` need to switch to `Ratio` (or drop the `(:use ...)` line — `Ratio` is auto-referred) (#2000)
+- BC break: rename `Phel\Lang\PhelFuture` to `Phel\Lang\Future` so the PHP class name matches the Clojure-aligned alias from #1996. The unrelated `Phel\Fiber\Domain\Future` keeps its FQN (different namespace). Phel sources that still write `(:use Phel.Lang.PhelFuture)` or `(php/instanceof x PhelFuture)` need to switch to `Future` (or drop the `(:use ...)` line — `Future` is auto-referred) (#2000)
 
 ### Fixed
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -40,7 +40,7 @@ Schedules `body` on the AMPHP event loop in a fresh fiber. Returns `Amp\Future`.
 (await future)
 ```
 
-Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `PhelFuture` wrapper. Must be called from inside a fiber.
+Blocks the current fiber until the Future resolves, then returns its value. Accepts a raw `Amp\Future` or a `Future` wrapper. Must be called from inside a fiber.
 
 ### `^:async` on `defn`
 
@@ -105,7 +105,7 @@ Concurrent `map` via fibers; results in input order. PHP fibers are cooperative 
 (future body...)
 ```
 
-Wraps `body` in `Amp\Future`, returns a `PhelFuture` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, `future-done?`. Requires a fiber context (call inside `async` or an AMPHP loop).
+Wraps `body` in `Amp\Future`, returns a `Future` supporting `deref`, `realized?`, 3-arg `deref` timeouts, `future-cancel`, `future-cancelled?`, `future-done?`. Requires a fiber context (call inside `async` or an AMPHP loop).
 
 ```phel
 (async
@@ -176,7 +176,7 @@ Macro over `future-call`. Write `@(future-fiber (expensive))` without an outer `
 (future? x)
 ```
 
-Returns `true` if `x` is a fiber-future or `PhelFuture`. Useful when receiving Futures from code that may use either layer.
+Returns `true` if `x` is a fiber-future or `Future`. Useful when receiving Futures from code that may use either layer.
 
 ## Shared primitives
 
@@ -186,7 +186,7 @@ Returns `true` if `x` is a fiber-future or `PhelFuture`. Useful when receiving F
 |------|----------|
 | `(deref x)` / `@x` | Block until realized. Fiber path suspends cooperatively; AMPHP path awaits via the event loop |
 | `(deref x timeout-ms timeout-val)` | Return `timeout-val` if not realized within `timeout-ms`. Fiber path uses a deadline poll; AMPHP path uses `Future::await` with `TimeoutCancellation` |
-| `(realized? x)` | `true` once a value is available. Works for promises, fiber futures, `PhelFuture` |
+| `(realized? x)` | `true` once a value is available. Works for promises, fiber futures, `Future` |
 | `(future-done? x)` | For fiber futures, checks `isDone`; otherwise falls back to `realized?`. Use for "terminal state including cancellation", not just "value present" |
 
 ## Error and cancellation model

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -25,7 +25,7 @@ Three concerns: types, per-namespace `Registry`, value equality + hashing.
 | `Delay` | One-shot lazy value (not a sequence). |
 | `Volatile` | Mutable box for transducer state. |
 | `Reduced` | Early-termination sentinel for `reduce`/`transduce`. |
-| `PhelFuture` | Promise/future for `Fiber/`. |
+| `Future` | Promise/future for `Fiber/`. |
 | `SourceLocation` | File + line + column on every readable form. |
 
 All types implement `TypeInterface` (composes `MetaInterface`, `SourceLocationInterface`, `EqualsInterface`, `HashableInterface`).

--- a/src/phel/core/async.phel
+++ b/src/phel/core/async.phel
@@ -3,7 +3,7 @@
 ;; AMPHP-backed and fiber-backed async primitives, kept in core so that
 ;; `.cljc` portable code mirrors `clojure.core`'s default availability
 ;; (see #1537 for the analogous `future` move). The classes referenced
-;; below (`\Phel\Fiber\FiberFacade`, `\Phel\Lang\PhelFuture`, `Amp\\…`)
+;; below (`\Phel\Fiber\FiberFacade`, `\Phel\Lang\Future`, `Amp\\…`)
 ;; are autoloaded only when these functions are actually called, so
 ;; namespaces that don't use them pay no runtime cost.
 ;;
@@ -39,16 +39,16 @@
         (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))))
 
 (defn- unwrap-future
-  "Returns the raw Amp\\Future for either a `PhelFuture` wrapper or
+  "Returns the raw Amp\\Future for either a `Future` wrapper or
   a bare `Amp\\Future`."
   [future]
-  (if (php/instanceof future \Phel\Lang\PhelFuture)
+  (if (php/instanceof future \Phel\Lang\Future)
     (php/-> future (unwrap))
     future))
 
 (defn await
   "Blocks the current fiber until the Future resolves and returns its value.
-  Accepts either a raw `Amp\\Future` or a `PhelFuture` wrapper."
+  Accepts either a raw `Amp\\Future` or a `Future` wrapper."
   {:example "(await (async (+ 1 2)))"
    :see-also ["async" "await-all" "await-any"]}
   [future]
@@ -56,7 +56,7 @@
 
 (defn await-all
   "Awaits all Futures in the given collection. Returns a vector of results.
-  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
+  Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
   {:example "(await-all [(async 1) (async 2)])"
    :see-also ["await" "await-any" "pmap"]}
   [futures]
@@ -66,7 +66,7 @@
 
 (defn await-any
   "Awaits the first Future to resolve. Returns its value.
-  Accepts a mix of raw `Amp\\Future` and `PhelFuture` wrappers."
+  Accepts a mix of raw `Amp\\Future` and `Future` wrappers."
   {:example "(await-any [(async 1) (async 2)])"
    :see-also ["await" "await-all"]}
   [futures]
@@ -118,7 +118,7 @@
 
   Dispatches on type: for a `\\Phel\\Fiber\\Domain\\Future` (fiber-backed)
   it calls `isDone`; for any other value it falls back to `realized?`.
-  This lets the same predicate serve both the AMPHP `PhelFuture` wrapper
+  This lets the same predicate serve both the AMPHP `Future` wrapper
   and the cooperative fiber future."
   {:example "(future-done? f)"
    :see-also ["realized?" "future-cancel" "future" "future-fiber"]}
@@ -185,9 +185,9 @@
 
 (defn future?
   "Returns true if `x` is a fiber-future (from `future-call`/`future-fiber`)
-  or a `PhelFuture` (from the AMPHP-backed `future` macro)."
+  or a `Future` (from the AMPHP-backed `future` macro)."
   {:example "(future? (future-call (fn [] 1))) ; => true"
    :see-also ["future" "future-call" "future-fiber"]}
   [x]
   (or (php/instanceof x \Phel\Fiber\Domain\Future)
-      (php/instanceof x \Phel\Lang\PhelFuture)))
+      (php/instanceof x \Phel\Lang\Future)))

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -71,7 +71,7 @@
   (case (count args)
     0 (php/-> variable (deref))
     2 (cond
-        (php/instanceof variable \Phel\Lang\PhelFuture)
+        (php/instanceof variable \Phel\Lang\Future)
         (php/-> variable (derefWithTimeout (first args) (get args 1)))
         (php/instanceof variable \Phel\Fiber\Domain\Future)
         (php/-> variable (derefWithTimeout (first args) (get args 1)))

--- a/src/phel/core/futures.phel
+++ b/src/phel/core/futures.phel
@@ -1,13 +1,13 @@
 (in-ns phel.core)
 
 ;; Core `future`: starts `body` asynchronously and returns a
-;; `PhelFuture`. Kept in core so it mirrors Clojure, where `future`
+;; `Future`. Kept in core so it mirrors Clojure, where `future`
 ;; is available without an explicit require. The fiber-backed
 ;; `future-fiber`, `future-call`, `promise`, and the rest of the
 ;; Clojure-parity async surface live alongside in `core/async.phel`.
 
 (defmacro future
-  "Starts evaluating `body` asynchronously and returns a `PhelFuture`
+  "Starts evaluating `body` asynchronously and returns a `Future`
   that can be `deref`ed (blocks the current fiber until the value is
   available) or checked with `realized?`.
 
@@ -22,7 +22,7 @@
    :see-also ["realized?" "deref"]}
   [& body]
   `(let [frame# (php/:: \Phel (snapshotDynamicBindings))]
-     (php/new \Phel\Lang\PhelFuture
+     (php/new \Phel\Lang\Future
               (php/amp\async
                (fn []
                  (php/:: \Phel (withDynamicBindings frame# (fn [] ~@body)))))

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -1087,7 +1087,7 @@
     (php/instanceof coll LazySeqInterface) (php/-> coll (isRealized))
     (php/instanceof coll PersistentListInterface) true
     (php/instanceof coll Delay) (php/-> coll (isRealized))
-    (php/instanceof coll \Phel\Lang\PhelFuture) (php/-> coll (isRealized))
+    (php/instanceof coll \Phel\Lang\Future) (php/-> coll (isRealized))
     (php/instanceof coll \Phel\Fiber\Domain\Future) (php/-> coll (isRealized))
     (php/instanceof coll \Phel\Fiber\Domain\Promise) (php/-> coll (isRealized))
     true))

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -16,8 +16,8 @@ use Phel\Lang\Collections\Map\MapEntry;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Delay;
+use Phel\Lang\Future;
 use Phel\Lang\Keyword;
-use Phel\Lang\PhelFuture;
 use Phel\Lang\PhelVar;
 use Phel\Lang\Ratio;
 use Phel\Lang\Reduced;
@@ -62,7 +62,7 @@ final class DefaultLangAliasesRegistrar
         'Volatile' => Volatile::class,
         'Reduced' => Reduced::class,
         'Delay' => Delay::class,
-        'Future' => PhelFuture::class,
+        'Future' => Future::class,
         // Misc value types
         'UUID' => UUID::class,
     ];

--- a/src/php/Lang/Future.php
+++ b/src/php/Lang/Future.php
@@ -7,7 +7,7 @@ namespace Phel\Lang;
 use Amp\CancelledException;
 use Amp\CompositeCancellation;
 use Amp\DeferredCancellation;
-use Amp\Future;
+use Amp\Future as AmpFuture;
 use Amp\TimeoutCancellation;
 
 /**
@@ -21,7 +21,7 @@ use Amp\TimeoutCancellation;
  *
  * Note: `deref` must be called from inside a fiber (an `async` block or the event
  * loop), matching Amphp's cooperative-concurrency model. Calling `deref` on a
- * PhelFuture outside a fiber context is an Amphp runtime error by design.
+ * Future outside a fiber context is an Amphp runtime error by design.
  *
  * Cancellation semantics: `cancel()` signals the internal Amphp `DeferredCancellation`
  * token. Any pending or subsequent `deref()` call raises `CancelledException`, and
@@ -31,15 +31,15 @@ use Amp\TimeoutCancellation;
  * the underlying work may still complete in the background. This differs slightly
  * from Clojure's JVM-thread interrupt semantics.
  */
-final class PhelFuture
+final class Future
 {
     private bool $cancelled = false;
 
     /**
-     * @param Future<mixed> $future
+     * @param AmpFuture<mixed> $future
      */
     public function __construct(
-        private readonly Future $future,
+        private readonly AmpFuture $future,
         private readonly DeferredCancellation $cancellation,
     ) {}
 
@@ -103,9 +103,9 @@ final class PhelFuture
      * Exposes the underlying Amp\Future for interop with code that expects
      * the raw Amphp type (e.g. `await-all`, `await-any`).
      *
-     * @return Future<mixed>
+     * @return AmpFuture<mixed>
      */
-    public function unwrap(): Future
+    public function unwrap(): AmpFuture
     {
         return $this->future;
     }

--- a/tests/phel/async.phel
+++ b/tests/phel/async.phel
@@ -100,8 +100,8 @@
 
 (deftest test-future-returns-phel-future
   (let [f (await (async (future 42)))]
-    (is (= true (php/instanceof f \Phel\Lang\PhelFuture))
-        "future returns a PhelFuture wrapper")))
+    (is (= true (php/instanceof f \Phel\Lang\Future))
+        "future returns a Future wrapper")))
 
 (deftest test-future-deref
   (let [result (await (async (deref (future 42))))]
@@ -148,11 +148,11 @@
 
 (deftest test-future-interops-with-await-all
   (let [result (await (async (await-all [(future 1) (future 2) (future 3)])))]
-    (is (= [1 2 3] result) "await-all transparently unwraps PhelFutures")))
+    (is (= [1 2 3] result) "await-all transparently unwraps Futures")))
 
 (deftest test-future-interops-with-await
   (let [result (await (async (await (future 99))))]
-    (is (= 99 result) "await accepts a PhelFuture wrapper")))
+    (is (= 99 result) "await accepts a Future wrapper")))
 
 ;; --- 3-arg deref / future-cancel / future-done? tests ---
 

--- a/tests/phel/core/future-in-core.phel
+++ b/tests/phel/core/future-in-core.phel
@@ -8,8 +8,8 @@
 (deftest test-future-macro-is-available-without-require
   (let [expanded (macroexpand '(future 42))
         source   (print-str expanded)]
-    (is (php/str_contains source "Phel\\Lang\\PhelFuture")
-        "future expansion constructs a PhelFuture")
+    (is (php/str_contains source "Phel\\Lang\\Future")
+        "future expansion constructs a Future")
     (is (php/str_contains source "amp\\async")
         "future expansion delegates to amp\\async")
     (is (php/str_contains source "snapshotDynamicBindings")
@@ -17,5 +17,5 @@
 
 (deftest test-future-returns-phel-future-without-require
   (let [f (future 1)]
-    (is (= true (php/instanceof f \Phel\Lang\PhelFuture))
-        "future produces a PhelFuture instance at the top level")))
+    (is (= true (php/instanceof f \Phel\Lang\Future))
+        "future produces a Future instance at the top level")))

--- a/tests/php/Unit/Lang/FutureTest.php
+++ b/tests/php/Unit/Lang/FutureTest.php
@@ -6,42 +6,42 @@ namespace PhelTest\Unit\Lang;
 
 use Amp\DeferredCancellation;
 use Amp\DeferredFuture;
-use Amp\Future;
-use Phel\Lang\PhelFuture;
+use Amp\Future as AmpFuture;
+use Phel\Lang\Future;
 use PHPUnit\Framework\TestCase;
 use Revolt\EventLoop;
 use RuntimeException;
 
 use function Amp\async;
 
-final class PhelFutureTest extends TestCase
+final class FutureTest extends TestCase
 {
     public function test_is_realized_returns_false_for_incomplete_future(): void
     {
         $deferred = new DeferredFuture();
-        $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+        $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
 
         self::assertFalse($phelFuture->isRealized());
     }
 
     public function test_is_realized_returns_true_for_complete_future(): void
     {
-        $phelFuture = new PhelFuture(Future::complete(42), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete(42), new DeferredCancellation());
 
         self::assertTrue($phelFuture->isRealized());
     }
 
     public function test_deref_returns_underlying_value(): void
     {
-        $phelFuture = new PhelFuture(Future::complete('hello'), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete('hello'), new DeferredCancellation());
 
         self::assertSame('hello', $phelFuture->deref());
     }
 
     public function test_deref_propagates_underlying_exception(): void
     {
-        $phelFuture = new PhelFuture(
-            Future::error(new RuntimeException('boom')),
+        $phelFuture = new Future(
+            AmpFuture::error(new RuntimeException('boom')),
             new DeferredCancellation(),
         );
 
@@ -53,36 +53,36 @@ final class PhelFutureTest extends TestCase
 
     public function test_unwrap_returns_inner_future(): void
     {
-        $inner = Future::complete(1);
-        $phelFuture = new PhelFuture($inner, new DeferredCancellation());
+        $inner = AmpFuture::complete(1);
+        $phelFuture = new Future($inner, new DeferredCancellation());
 
         self::assertSame($inner, $phelFuture->unwrap());
     }
 
     public function test_deref_with_timeout_returns_value_when_future_completes_in_time(): void
     {
-        $phelFuture = new PhelFuture(Future::complete(42), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete(42), new DeferredCancellation());
 
         self::assertSame(42, $phelFuture->derefWithTimeout(1000, 'fallback'));
     }
 
     public function test_deref_with_timeout_zero_returns_fallback_immediately(): void
     {
-        $phelFuture = new PhelFuture(Future::complete(42), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete(42), new DeferredCancellation());
 
         self::assertSame('fallback', $phelFuture->derefWithTimeout(0, 'fallback'));
     }
 
     public function test_deref_with_timeout_negative_returns_fallback_immediately(): void
     {
-        $phelFuture = new PhelFuture(Future::complete(42), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete(42), new DeferredCancellation());
 
         self::assertSame('fallback', $phelFuture->derefWithTimeout(-1, 'fallback'));
     }
 
     public function test_is_cancelled_false_initially(): void
     {
-        $phelFuture = new PhelFuture(Future::complete(1), new DeferredCancellation());
+        $phelFuture = new Future(AmpFuture::complete(1), new DeferredCancellation());
 
         self::assertFalse($phelFuture->isCancelled());
     }
@@ -90,7 +90,7 @@ final class PhelFutureTest extends TestCase
     public function test_cancel_sets_cancelled_flag(): void
     {
         $deferred = new DeferredFuture();
-        $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+        $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
 
         $phelFuture->cancel();
 
@@ -100,7 +100,7 @@ final class PhelFutureTest extends TestCase
     public function test_cancel_is_idempotent(): void
     {
         $deferred = new DeferredFuture();
-        $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+        $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
 
         $phelFuture->cancel();
         $phelFuture->cancel();
@@ -111,7 +111,7 @@ final class PhelFutureTest extends TestCase
     public function test_is_realized_true_when_cancelled(): void
     {
         $deferred = new DeferredFuture();
-        $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+        $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
 
         self::assertFalse($phelFuture->isRealized());
 
@@ -123,7 +123,7 @@ final class PhelFutureTest extends TestCase
     public function test_deref_with_timeout_returns_fallback_when_cancelled(): void
     {
         $deferred = new DeferredFuture();
-        $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+        $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
 
         $phelFuture->cancel();
 
@@ -140,7 +140,7 @@ final class PhelFutureTest extends TestCase
         try {
             $result = async(static function (): mixed {
                 $deferred = new DeferredFuture();
-                $phelFuture = new PhelFuture($deferred->getFuture(), new DeferredCancellation());
+                $phelFuture = new Future($deferred->getFuture(), new DeferredCancellation());
                 return $phelFuture->derefWithTimeout(10, 'timed-out');
             })->await();
 


### PR DESCRIPTION
## 🤔 Background

Final step of #2000. #1996 added the Clojure-aligned default alias `Future`. The runtime PHP class still lives under `Phel\Lang\PhelFuture`. The unrelated `Phel\Fiber\Domain\Future` keeps its FQN — namespace isolation prevents collision.

(Step 2 — `PhelVar → Var` — remains blocked because `Var` is a PHP reserved keyword.)

## 💡 Goal

Align the PHP class name with the auto-refer alias so `(php/get_class (future ...))` reports `\Phel\Lang\Future`.

## 🔖 Changes

- Rename `Phel\Lang\PhelFuture` → `Phel\Lang\Future`
- Rename test `PhelFutureTest` → `FutureTest`
- Default alias map: `'Future' => Phel\Lang\Future::class`
- Phel core sources updated: `core/futures.phel`, `core/seq-fns.phel`, `core/atoms.phel`, `core/async.phel`
- Refresh `docs/internals/runtime.md`, `docs/async-guide.md`
- `Phel\Lang\Future` and the new `FutureTest` alias their `Amp\Future` import as `AmpFuture` to disambiguate from the new local class

### BC break

Any caller importing `\Phel\Lang\PhelFuture` or writing `(:use Phel.Lang.PhelFuture)` in a Phel ns form must switch to `Future` (or drop the `(:use ...)` line, since `Future` is auto-referred since #1996).

Closes #2000