### PR TITLE
ref(lang): rename ExInfoException to ExceptionInfo for Clojure-aligned naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BC break: rename `Phel\Lang\Variable` to `Phel\Lang\Atom` (and `Phel\Shared\Printer\TypePrinter\VariablePrinter` to `AtomPrinter`) to match the Clojure-aligned default alias added in #1996; the public static helper `\Phel::variable(...)` is now `\Phel::atom(...)`. Phel sources that still write `(:use Phel.Lang.Variable)` or `(php/instanceof x Variable)` need to switch to `Atom` (or drop the `(:use ...)` line — `Atom` is auto-referred) (#2000)
-- BC break: rename `Phel\Lang\Uuid` to `Phel\Lang\UUID` (plus `UuidPrinter` → `UUIDPrinter` and `UuidTagHandler` → `UUIDTagHandler`) so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.Uuid)` need to switch to `UUID` (or drop the `(:use ...)` line — `UUID` is auto-referred) (#2000)
-- BC break: rename `Phel\Lang\BigInteger` to `Phel\Lang\BigInt` so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.BigInteger)` or `(php/instanceof x BigInteger)` need to switch to `BigInt` (or drop the `(:use ...)` line — `BigInt` is auto-referred) (#2000)
-- BC break: rename `Phel\Lang\Rational` to `Phel\Lang\Ratio` (plus `RationalPrinter` → `RatioPrinter`) so the PHP class name matches the Clojure-aligned alias from #1996. Phel sources that still write `(:use Phel.Lang.Rational)` or `(php/instanceof x Rational)` need to switch to `Ratio` (or drop the `(:use ...)` line — `Ratio` is auto-referred) (#2000)
-- BC break: rename `Phel\Lang\PhelFuture` to `Phel\Lang\Future` so the PHP class name matches the Clojure-aligned alias from #1996. The unrelated `Phel\Fiber\Domain\Future` keeps its FQN (different namespace). Phel sources that still write `(:use Phel.Lang.PhelFuture)` or `(php/instanceof x PhelFuture)` need to switch to `Future` (or drop the `(:use ...)` line — `Future` is auto-referred) (#2000)
+- BC break: rename `Phel\Lang\*` types to match Clojure-aligned aliases from #1996. Each new short name is auto-referred (drop the `(:use ...)` line or rewrite to the new name):
+  - `Variable` → `Atom` (also `VariablePrinter` → `AtomPrinter`, `\Phel::variable` → `\Phel::atom`) (#2000)
+  - `Uuid` → `UUID` (also `UuidPrinter` → `UUIDPrinter`, `UuidTagHandler` → `UUIDTagHandler`) (#2002)
+  - `BigInteger` → `BigInt` (#2003)
+  - `Rational` → `Ratio` (also `RationalPrinter` → `RatioPrinter`) (#2004)
+  - `PhelFuture` → `Future` (unrelated `Phel\Fiber\Domain\Future` keeps its FQN) (#2005)
+  - `ExInfoException` → `ExceptionInfo` (matches `clojure.lang.ExceptionInfo` thrown by `ex-info`)
 
 ### Fixed
 

--- a/docs/migration/backslash-to-dot.md
+++ b/docs/migration/backslash-to-dot.md
@@ -37,7 +37,7 @@ Symbols flowing through the analyzer's `SymbolResolver` or the `ns`-form analyze
 - **Namespace declarations** (Phase 1b): `(ns phel\foo)` becomes `(ns phel.foo)`
 - **`:require` targets** (Phase 1b, flat and `[ns :as alias]` vector forms): `(:require phel\walk)` becomes `(:require phel.walk)`
 - **Fully-qualified call sites** (Phase 1a): `(phel\core/map inc xs)` becomes `(phel.core/map inc xs)`
-- **Leading-backslash class FQNs** (Phase 1a): `\Phel\Lang\ExInfoException` becomes `Phel.Lang.ExInfoException`. Dot alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553).
+- **Leading-backslash class FQNs** (Phase 1a): `\Phel\Lang\ExceptionInfo` becomes `Phel.Lang.ExceptionInfo`. Dot alias landed in [#1553](https://github.com/phel-lang/phel-lang/issues/1553).
 - **`:use` targets**: `(:use Phel\Lang\Foo)` becomes `(:use Phel.Lang.Foo)`. The analyzer already accepted the dot form; the warning makes the migration target explicit.
 
 ## What is NOT yet detected

--- a/src/phel/core/exceptions.phel
+++ b/src/phel/core/exceptions.phel
@@ -1,11 +1,10 @@
 (in-ns phel.core)
 
 (use Phel)
-(use Phel.Lang.ExInfoException)
 
 ;; Structured exceptions: the `ex-info` constructor and the `ex-data` /
 ;; `ex-message` / `ex-cause` accessors for carrying a data map alongside
-;; a thrown error. Thin wrapper over `Phel\Lang\ExInfoException`.
+;; a thrown error. Thin wrapper over `Phel\Lang\ExceptionInfo`.
 
 ;; --- Rich exceptions ---
 
@@ -14,15 +13,15 @@
   {:example "(throw (ex-info \"Invalid input\" {:field :email}))"
    :see-also ["ex-data" "ex-message" "ex-cause"]}
   ([msg data]
-   (php/new \Phel\Lang\ExInfoException msg data))
+   (php/new \Phel\Lang\ExceptionInfo msg data))
   ([msg data cause]
-   (php/new \Phel\Lang\ExInfoException msg data cause)))
+   (php/new \Phel\Lang\ExceptionInfo msg data cause)))
 
 (defn ex-data
-  "Returns the data map from an ex-info exception, or nil if not an ExInfoException."
+  "Returns the data map from an ex-info exception, or nil if not an ExceptionInfo."
   {:see-also ["ex-info" "ex-message" "ex-cause"]}
   [ex]
-  (when (php/instanceof ex ExInfoException)
+  (when (php/instanceof ex ExceptionInfo)
     (php/-> ex (getData))))
 
 (defn ex-message

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -16,6 +16,7 @@ use Phel\Lang\Collections\Map\MapEntry;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Delay;
+use Phel\Lang\ExceptionInfo;
 use Phel\Lang\Future;
 use Phel\Lang\Keyword;
 use Phel\Lang\PhelVar;
@@ -42,7 +43,6 @@ final class DefaultLangAliasesRegistrar
     public const array DEFAULT_USE_ALIASES = [
         // Sequence types
         'LazySeq' => LazySeqInterface::class,
-        'LazyCons' => LazyCons::class,
         'Cons' => LazyCons::class,
         'PersistentList' => PersistentListInterface::class,
         'PersistentVector' => PersistentVectorInterface::class,
@@ -52,11 +52,11 @@ final class DefaultLangAliasesRegistrar
         // Names
         'Keyword' => Keyword::class,
         'Symbol' => Symbol::class,
-        // Numeric tower (Clojure-aligned names)
+        // Numeric tower
         'BigInt' => BigInt::class,
         'BigDecimal' => BigDecimal::class,
         'Ratio' => Ratio::class,
-        // Concurrency primitives (Clojure-aligned names)
+        // Concurrency primitives
         'Atom' => Atom::class,
         'Var' => PhelVar::class,
         'Volatile' => Volatile::class,
@@ -65,6 +65,8 @@ final class DefaultLangAliasesRegistrar
         'Future' => Future::class,
         // Misc value types
         'UUID' => UUID::class,
+        // Exceptions
+        'ExceptionInfo' => ExceptionInfo::class,
     ];
 
     /**

--- a/src/php/Lang/ExceptionInfo.php
+++ b/src/php/Lang/ExceptionInfo.php
@@ -11,7 +11,7 @@ use Throwable;
 /**
  * Exception that carries a data map, matching Clojure's ex-info semantics.
  */
-final class ExInfoException extends Exception
+final class ExceptionInfo extends Exception
 {
     /**
      * @param PersistentMapInterface<mixed, mixed> $data

--- a/src/php/Lang/ExceptionInfo.php
+++ b/src/php/Lang/ExceptionInfo.php
@@ -8,9 +8,6 @@ use Exception;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Throwable;
 
-/**
- * Exception that carries a data map, matching Clojure's ex-info semantics.
- */
 final class ExceptionInfo extends Exception
 {
     /**

--- a/tests/phel/auto-refer.phel
+++ b/tests/phel/auto-refer.phel
@@ -6,7 +6,7 @@
 
 (deftest test-lazy-seq-alias-resolves-without-explicit-use
   (is (php/instanceof (lazy-seq (cons 1 nil)) LazySeq))
-  (is (php/instanceof (next (lazy-seq (cons 1 (lazy-seq (cons 2 nil))))) LazyCons)))
+  (is (php/instanceof (next (lazy-seq (cons 1 (lazy-seq (cons 2 nil))))) Cons)))
 
 (deftest test-persistent-vector-alias
   (is (php/instanceof [1 2 3] PersistentVector))
@@ -39,5 +39,3 @@
   (is (php/instanceof (delay 1) Delay))
   (is (php/instanceof (volatile! 1) Volatile)))
 
-(deftest test-cons-alias-mirrors-lazy-cons
-  (is (php/instanceof (next (lazy-seq (cons 1 (lazy-seq (cons 2 nil))))) Cons)))

--- a/tests/phel/core/ex-info.phel
+++ b/tests/phel/core/ex-info.phel
@@ -32,7 +32,7 @@
 
 (deftest test-ex-data-on-regular-exception
   (let [ex (php/new \Exception "plain")]
-    (is (nil? (ex-data ex)) "ex-data returns nil for non-ExInfoException")))
+    (is (nil? (ex-data ex)) "ex-data returns nil for non-ExceptionInfo")))
 
 (deftest test-ex-message-on-regular-exception
   (let [ex (php/new \Exception "hello")]


### PR DESCRIPTION
## 🤔 Background

Continuation of the Clojure-alignment series (#2001-#2005 renamed `Variable→Atom`, `Uuid→UUID`, `BigInteger→BigInt`, `Rational→Ratio`, `PhelFuture→Future`). `Phel\Lang\ExInfoException` is the PHP class thrown by `(ex-info ...)`. Clojure's equivalent is `clojure.lang.ExceptionInfo`. The current name also duplicates information (`Exception` suffix is redundant since the class already `extends Exception`).

## 💡 Goal

Rename `Phel\Lang\ExInfoException` → `Phel\Lang\ExceptionInfo` for Clojure parity and add the short name `ExceptionInfo` to the default auto-refer set so users can write `(php/instanceof e ExceptionInfo)` without an explicit `(:use ...)` line.

## 🔖 Changes

- Rename `src/php/Lang/ExInfoException.php` → `src/php/Lang/ExceptionInfo.php` (class declaration updated).
- Add `'ExceptionInfo' => ExceptionInfo::class` to `DefaultLangAliasesRegistrar::DEFAULT_USE_ALIASES`.
- Drop the redundant `'LazyCons' => LazyCons::class` alias (kept `'Cons'`, which is the Clojure-aligned name; Clojure has no `LazyCons`).
- Update `src/phel/core/exceptions.phel`: drop the explicit `(use Phel.Lang.ExInfoException)` line (now auto-referred), point `php/new` and `php/instanceof` at the new FQN/short name.
- Update `tests/phel/auto-refer.phel` to use `Cons` instead of `LazyCons`.
- Update `tests/phel/core/ex-info.phel` and `docs/migration/backslash-to-dot.md` docstring references.
- Simplify the `## Unreleased` `### Changed` section in `CHANGELOG.md` to a single bulleted list of the renames in this series.