### PR TITLE
fix(build): stop cascade invalidation from unlinking secondary cache files (#1998)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `bin/phel build`: secondary `(in-ns ...)` files are no longer dropped from the build output when the `.phel/cache` index references compiled files that have been deleted out-of-band. `CompiledCodeCache` now tracks per-process invalidation tombstones so the disk merge in `saveEntries()` cannot resurrect entries that a cascade `invalidate()` removed, which previously caused each `(load ...)` to re-run the cascade and unlink the prior secondary's freshly compiled file (#1998)
+- `bin/phel build`: secondary `(in-ns ...)` files are no longer dropped from the build output when stale `.phel/cache` entries trigger cascade invalidation. `CompiledCodeCache` now tombstones invalidated keys so the disk merge in `saveEntries()` cannot resurrect them, which previously caused each `(load ...)` to re-run the cascade and unlink the prior secondary's freshly compiled file (#1998)
 - LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)
 - LazySeq: `(rest lazy-seq)` and `(cdr lazy-seq)` no longer force the head of the tail, restoring true laziness — `(realized? (rest s))` now stays `false` when the consumer only walked the spine (#1995)
 - `phel test`: `--testdox` no longer prints "no test message found" placeholder when an assertion has no message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `bin/phel build`: secondary `(in-ns ...)` files are no longer dropped from the build output when the `.phel/cache` index references compiled files that have been deleted out-of-band. `CompiledCodeCache` now tracks per-process invalidation tombstones so the disk merge in `saveEntries()` cannot resurrect entries that a cascade `invalidate()` removed, which previously caused each `(load ...)` to re-run the cascade and unlink the prior secondary's freshly compiled file (#1998)
 - LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)
 - LazySeq: `(rest lazy-seq)` and `(cdr lazy-seq)` no longer force the head of the tail, restoring true laziness — `(realized? (rest s))` now stays `false` when the consumer only walked the spine (#1995)
 - `phel test`: `--testdox` no longer prints "no test message found" placeholder when an assertion has no message

--- a/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
+++ b/src/php/Build/Infrastructure/Cache/CompiledCodeCache.php
@@ -32,6 +32,15 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
     /** @var array<string, array{namespace: string, source_hash: string, compiled_path: string, last_accessed: int}> */
     private array $entries = [];
 
+    /**
+     * Source paths invalidated in this process that have not been re-`put`.
+     * Used as tombstones so the disk-merge in `saveEntries()` cannot
+     * resurrect entries that downstream cascades meant to remove.
+     *
+     * @var array<string, true>
+     */
+    private array $tombstones = [];
+
     private bool $loaded = false;
 
     /**
@@ -127,6 +136,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
             'compiled_path' => $compiledPath,
             'last_accessed' => time(),
         ];
+        unset($this->tombstones[$sourcePath]);
 
         $this->evictLRU();
         $this->saveEntries();
@@ -209,6 +219,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         }
 
         unset($this->entries[$sourcePath]);
+        $this->tombstones[$sourcePath] = true;
         $this->saveEntries();
     }
 
@@ -228,6 +239,7 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         }
 
         $this->entries = [];
+        $this->tombstones = [];
         $this->saveEntries();
         $this->envMemo = [];
     }
@@ -341,6 +353,9 @@ final class CompiledCodeCache implements CompiledCodeCacheInterface
         }
 
         $diskEntries = $this->parseIndexContent($currentContent);
+        foreach (array_keys($this->tombstones) as $tombstoned) {
+            unset($diskEntries[$tombstoned]);
+        }
 
         return array_merge($diskEntries, $this->entries);
     }

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -113,6 +113,39 @@ final class CompiledCodeCacheTest extends TestCase
         self::assertNotNull($cache->get($fileB, 'hashB'));
     }
 
+    public function test_invalidate_then_put_other_file_does_not_resurrect_invalidated_entry(): void
+    {
+        $cache = new CompiledCodeCache($this->cacheDir);
+        $fileA = $this->cacheDir . '/a.phel';
+        $fileB = $this->cacheDir . '/b.phel';
+        $cache->put($fileA, 'shared\\ns', 'hashA', '// A');
+        $cache->put($fileB, 'shared\\ns', 'hashB', '// B');
+
+        $cache->invalidate($fileA);
+        $cache->put($fileB, 'shared\\ns', 'hashB2', '// B2');
+
+        // After invalidating A and putting B again, A must stay invalidated —
+        // earlier the disk merge in saveEntries() would resurrect A's entry.
+        self::assertFalse($cache->has($fileA));
+        self::assertNull($cache->get($fileA, 'hashA'));
+    }
+
+    public function test_invalidated_entry_does_not_resurrect_across_new_instance_after_put(): void
+    {
+        $cache1 = new CompiledCodeCache($this->cacheDir);
+        $fileA = $this->cacheDir . '/a.phel';
+        $fileB = $this->cacheDir . '/b.phel';
+        $cache1->put($fileA, 'shared\\ns', 'hashA', '// A');
+        $cache1->put($fileB, 'shared\\ns', 'hashB', '// B');
+        $cache1->invalidate($fileA);
+        $cache1->put($fileB, 'shared\\ns', 'hashB2', '// B2');
+
+        $cache2 = new CompiledCodeCache($this->cacheDir);
+
+        self::assertFalse($cache2->has($fileA));
+        self::assertNotNull($cache2->get($fileB, 'hashB2'));
+    }
+
     public function test_clear_removes_all_entries(): void
     {
         $cache = new CompiledCodeCache($this->cacheDir);

--- a/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
+++ b/tests/php/Unit/Build/Infrastructure/Cache/CompiledCodeCacheTest.php
@@ -124,7 +124,7 @@ final class CompiledCodeCacheTest extends TestCase
         $cache->invalidate($fileA);
         $cache->put($fileB, 'shared\\ns', 'hashB2', '// B2');
 
-        // After invalidating A and putting B again, A must stay invalidated —
+        // After invalidating A and putting B again, A must stay invalidated;
         // earlier the disk merge in saveEntries() would resurrect A's entry.
         self::assertFalse($cache->has($fileA));
         self::assertNull($cache->get($fileA, 'hashA'));


### PR DESCRIPTION
## 🤔 Background

`BuildCommand` was dropping most secondary `(in-ns ...)` files from the build output when the `.phel/cache` index referenced compiled artefacts that no longer existed on disk. The failure surfaced as four integration tests breaking and a runtime `Cannot locate core/meta for (load ...)` from the deployed artefact.

Root cause: `CompiledCodeCache::saveEntries()` merges in-memory entries with whatever is on disk so concurrent writers cannot truncate each other. After `invalidate()` unset an entry in memory, the next `put()`'s save resurrected that entry from disk. The following `(load ...)` then re-saw a stale-entry-with-missing-file, re-triggered `invalidateDependentsOf(phel.core)`, and that cascade `unlink()`ed the prior secondary's freshly compiled file. Only the last `(load ...)` per primary survived in cache, so the harvester only copied that one file into the build output.

## 💡 Goal

Make `bin/phel build` produce a complete set of secondary `.php` files even when the on-disk cache index points at compiled artefacts that have been deleted out-of-band.

## 🔖 Changes

- `CompiledCodeCache` tracks per-process invalidation tombstones; `mergeWithDiskEntries()` excludes tombstoned keys so disk merge cannot resurrect entries removed in this process. `put()` clears the tombstone for a re-validated key; `clear()` resets the set.
- Two new unit tests pin the contract: after `invalidate(A)` + `put(B)`, `A` stays gone (same instance and across a fresh `new CompiledCodeCache` reading the same directory).
- Changelog entry under `## Unreleased` → `### Fixed`.

Closes #1998