### PR TITLE
ref(lang): rename LazyCons to Cons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ All notable changes to this project will be documented in this file.
   - `Rational` → `Ratio` (also `RationalPrinter` → `RatioPrinter`) (#2004)
   - `PhelFuture` → `Future` (unrelated `Phel\Fiber\Domain\Future` keeps its FQN) (#2005)
   - `ExInfoException` → `ExceptionInfo` (matches `clojure.lang.ExceptionInfo` thrown by `ex-info`)
+  - `LazyCons` → `Cons` (also `LazyConsPrinter` → `ConsPrinter`; matches `clojure.lang.Cons`. The class is a realized cons cell, not itself lazy)
 
 ### Fixed
 
 - `bin/phel build`: secondary `(in-ns ...)` files are no longer dropped from the build output when stale `.phel/cache` entries trigger cascade invalidation. `CompiledCodeCache` now tombstones invalidated keys so the disk merge in `saveEntries()` cannot resurrect them, which previously caused each `(load ...)` to re-run the cascade and unlink the prior secondary's freshly compiled file (#1998)
-- LazySeq: `(next lazy-seq)` now returns a realized `LazyCons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)
+- LazySeq: `(next lazy-seq)` now returns a realized `Cons` cell (or nil) instead of another `LazySeq`, matching Clojure's `(next s)` contract `(not (lazy-seq? (next s)))` (#1994)
 - LazySeq: `(rest lazy-seq)` and `(cdr lazy-seq)` no longer force the head of the tail, restoring true laziness — `(realized? (rest s))` now stays `false` when the consumer only walked the spine (#1995)
 - `phel test`: `--testdox` no longer prints "no test message found" placeholder when an assertion has no message
 - `phel test`: `--repeat=<non-numeric>` now errors instead of silently falling back to 1

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -3,7 +3,7 @@
   (:use Phel)
   (:use Phel.Lang.CdrInterface)
   (:use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
-  (:use Phel.Lang.Collections.LazySeq.LazyCons)
+  (:use Phel.Lang.Collections.LazySeq.Cons)
   (:use Phel.Lang.Collections.LazySeq.LazySeqInterface)
   (:use Phel.Lang.Collections.Map.MapEntry)
   (:use Phel.Lang.Collections.Map.PersistentMapInterface)
@@ -99,7 +99,7 @@
       nil
       (if (php/instanceof xs LazySeqInterface)
         (php/-> xs (nextSeq))
-        (if (php/instanceof xs LazyCons)
+        (if (php/instanceof xs Cons)
           (php/-> xs (nextSeq))
           (if (php/instanceof xs CdrInterface)
             (php/-> xs (cdr))

--- a/src/phel/core/predicates.phel
+++ b/src/phel/core/predicates.phel
@@ -3,7 +3,7 @@
 (use Countable)
 (use Phel)
 (use Phel.Lang.Collections.HashSet.PersistentHashSetInterface)
-(use Phel.Lang.Collections.LazySeq.LazyCons)
+(use Phel.Lang.Collections.LazySeq.Cons)
 (use Phel.Lang.Collections.LazySeq.LazySeqInterface)
 (use Phel.Lang.Collections.LinkedList.PersistentListInterface)
 (use Phel.Lang.Collections.Map.MapEntry)
@@ -400,11 +400,11 @@
 
 (defn seq?
   "Returns true if `x` is a seq (a list, a lazy sequence, or a realized
-  `LazyCons` cell returned by `(next some-lazy-seq)`)."
+  `Cons` cell returned by `(next some-lazy-seq)`)."
   {:see-also ["seq" "lazy-seq" "lazy-seq?"]}
   [x]
   (or (php/instanceof x LazySeqInterface)
-      (php/instanceof x LazyCons)
+      (php/instanceof x Cons)
       (php/instanceof x PersistentListInterface)))
 
 (defn lazy-seq?
@@ -425,7 +425,7 @@
     (php/is_numeric x)                  (= 0 x)
     (php/is_string x)                   (true? (php/empty x))
     (php/instanceof x LazySeqInterface) (nil? (first x))
-    (php/instanceof x LazyCons)         false
+    (php/instanceof x Cons)         false
     :else                               (= 0 (count x))))
 
 (defn not-empty

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefaultLangAliasesRegistrar.php
@@ -9,7 +9,7 @@ use Phel\Lang\Atom;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\BigInt;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
-use Phel\Lang\Collections\LazySeq\LazyCons;
+use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\MapEntry;
@@ -43,7 +43,7 @@ final class DefaultLangAliasesRegistrar
     public const array DEFAULT_USE_ALIASES = [
         // Sequence types
         'LazySeq' => LazySeqInterface::class,
-        'Cons' => LazyCons::class,
+        'Cons' => Cons::class,
         'PersistentList' => PersistentListInterface::class,
         'PersistentVector' => PersistentVectorInterface::class,
         'PersistentMap' => PersistentMapInterface::class,

--- a/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
+++ b/src/php/Lang/Collections/LazySeq/ChunkedSeq.php
@@ -178,15 +178,15 @@ final class ChunkedSeq extends AbstractType implements LazySeqInterface, Countab
     }
 
     /**
-     * Mirrors Clojure's `(next s)` semantics: returns a realized `LazyCons`
+     * Mirrors Clojure's `(next s)` semantics: returns a realized `Cons`
      * holding the next head and a lazy tail, or `null` when exhausted. The
      * returned value is never a `LazySeqInterface`.
      *
-     * @return LazyCons<mixed>|null
+     * @return Cons<mixed>|null
      */
-    public function nextSeq(): ?LazyCons
+    public function nextSeq(): ?Cons
     {
-        return LazyCons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
+        return Cons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
     }
 
     /**

--- a/src/php/Lang/Collections/LazySeq/Cons.php
+++ b/src/php/Lang/Collections/LazySeq/Cons.php
@@ -14,10 +14,10 @@ use Phel\Lang\SeqInterface;
 use Traversable;
 
 /**
- * A realized cons cell: a concrete head paired with a lazy tail. Returned
- * by `LazySeq::nextSeq()` and `ChunkedSeq::nextSeq()` so callers receive a
- * seq view that is not itself a `LazySeqInterface`, matching Clojure's
- * `(next some-lazy-seq)` contract.
+ * A realized cons cell: a concrete head paired with a lazy tail, matching
+ * Clojure's `clojure.lang.Cons` and `(next some-lazy-seq)` contract.
+ * Returned by `LazySeq::nextSeq()` and `ChunkedSeq::nextSeq()` so callers
+ * receive a seq view that is not itself a `LazySeqInterface`.
  *
  * @template T
  *
@@ -26,7 +26,7 @@ use Traversable;
  *
  * @extends AbstractType<SeqInterface<T, LazySeqInterface>>
  */
-final class LazyCons extends AbstractType implements SeqInterface, IteratorAggregate
+final class Cons extends AbstractType implements SeqInterface, IteratorAggregate
 {
     private int $hashCache = 0;
 
@@ -71,7 +71,7 @@ final class LazyCons extends AbstractType implements SeqInterface, IteratorAggre
      * Builds a realized cons cell from a lazy `$cdr` by forcing one element
      * of the head. Returns `null` when `$cdr` is null or empty. Shared
      * helper for `LazySeq::nextSeq()`, `ChunkedSeq::nextSeq()`, and
-     * `LazyCons::nextSeq()`.
+     * `Cons::nextSeq()`.
      *
      * @param LazySeqInterface<mixed>|null $cdr
      *
@@ -102,7 +102,7 @@ final class LazyCons extends AbstractType implements SeqInterface, IteratorAggre
      * the lazy tail is exhausted. The returned cell's head is the tail's
      * first element so callers do not skip an item.
      *
-     * @return LazyCons<T>|null
+     * @return Cons<T>|null
      */
     public function nextSeq(): ?self
     {

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -212,15 +212,15 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
 
     /**
      * Mirrors Clojure's `(next s)` semantics: returns a realized cons cell
-     * (`LazyCons`) holding the next head and a lazy tail, or `null` when
+     * (`Cons`) holding the next head and a lazy tail, or `null` when
      * the tail is exhausted. The returned value is never a
      * `LazySeqInterface`.
      *
-     * @return LazyCons<mixed>|null
+     * @return Cons<mixed>|null
      */
-    public function nextSeq(): ?LazyCons
+    public function nextSeq(): ?Cons
     {
-        return LazyCons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
+        return Cons::fromCdr($this->hasher, $this->equalizer, $this->cdr());
     }
 
     /**
@@ -245,7 +245,7 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         return new self(
             $hasher,
             $equalizer,
-            static fn(): LazyCons => new LazyCons($hasher, $equalizer, $x, $self),
+            static fn(): Cons => new Cons($hasher, $equalizer, $x, $self),
             $this->meta,
         );
     }

--- a/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeqInterface.php
@@ -25,13 +25,13 @@ interface LazySeqInterface extends TypeInterface, SeqInterface, ConsInterface
     public function isRealized(): bool;
 
     /**
-     * Realizes one step beyond the head and returns a `LazyCons` cell whose
+     * Realizes one step beyond the head and returns a `Cons` cell whose
      * `cdr` is the lazy tail, or `null` when the tail is empty. Mirrors
      * Clojure's `(next s)`; the returned value is never a `LazySeqInterface`.
      *
-     * @return LazyCons<mixed>|null
+     * @return Cons<mixed>|null
      */
-    public function nextSeq(): ?LazyCons;
+    public function nextSeq(): ?Cons;
 
     /**
      * Forces realization of the entire sequence and returns it as an array.

--- a/src/php/Shared/Printer/Printer.php
+++ b/src/php/Shared/Printer/Printer.php
@@ -7,7 +7,7 @@ namespace Phel\Shared\Printer;
 use Phel\Lang\Atom;
 use Phel\Lang\BigDecimal;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
-use Phel\Lang\Collections\LazySeq\LazyCons;
+use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -27,9 +27,9 @@ use Phel\Shared\Printer\TypePrinter\ArrayPrinter;
 use Phel\Shared\Printer\TypePrinter\AtomPrinter;
 use Phel\Shared\Printer\TypePrinter\BigDecimalPrinter;
 use Phel\Shared\Printer\TypePrinter\BooleanPrinter;
+use Phel\Shared\Printer\TypePrinter\ConsPrinter;
 use Phel\Shared\Printer\TypePrinter\FnPrinter;
 use Phel\Shared\Printer\TypePrinter\KeywordPrinter;
-use Phel\Shared\Printer\TypePrinter\LazyConsPrinter;
 use Phel\Shared\Printer\TypePrinter\LazySeqPrinter;
 use Phel\Shared\Printer\TypePrinter\NonPrintableClassPrinter;
 use Phel\Shared\Printer\TypePrinter\NullPrinter;
@@ -129,8 +129,8 @@ final readonly class Printer implements PrinterInterface
             return new PersistentHashSetPrinter($this);
         }
 
-        if ($form instanceof LazyCons) {
-            return new LazyConsPrinter($this);
+        if ($form instanceof Cons) {
+            return new ConsPrinter($this);
         }
 
         if ($form instanceof LazySeqInterface) {

--- a/src/php/Shared/Printer/TypePrinter/ConsPrinter.php
+++ b/src/php/Shared/Printer/TypePrinter/ConsPrinter.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Phel\Shared\Printer\TypePrinter;
 
-use Phel\Lang\Collections\LazySeq\LazyCons;
+use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeqConfig;
 use Phel\Shared\Printer\PrinterInterface;
 
 /**
- * @implements TypePrinterInterface<LazyCons<mixed>>
+ * @implements TypePrinterInterface<Cons<mixed>>
  */
-final readonly class LazyConsPrinter implements TypePrinterInterface
+final readonly class ConsPrinter implements TypePrinterInterface
 {
     public function __construct(private PrinterInterface $printer) {}
 
     /**
-     * @param LazyCons<mixed> $form
+     * @param Cons<mixed> $form
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */

--- a/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
+++ b/tests/php/Unit/Lang/Collections/LazySeq/LazySeqTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\LazySeq;
 
 use Generator;
-use Phel\Lang\Collections\LazySeq\LazyCons;
+use Phel\Lang\Collections\LazySeq\Cons;
 use Phel\Lang\Collections\LazySeq\LazySeq;
 use Phel\Lang\Collections\LazySeq\LazySeqInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -141,14 +141,14 @@ final class LazySeqTest extends TestCase
         self::assertSame(0, $callCount, 'cdr must not force the tail');
     }
 
-    public function test_next_seq_returns_lazy_cons_not_lazy_seq(): void
+    public function test_next_seq_returns_cons_not_lazy_seq(): void
     {
         $lazySeq = LazySeq::fromArray($this->hasher, $this->equalizer, [1, 2, 3]);
 
         $next = $lazySeq->nextSeq();
 
         self::assertNotNull($next);
-        self::assertInstanceOf(LazyCons::class, $next);
+        self::assertInstanceOf(Cons::class, $next);
         self::assertNotInstanceOf(LazySeqInterface::class, $next);
         self::assertSame(2, $next->first());
     }


### PR DESCRIPTION
## 🤔 Background

The Lang module has been progressively aligning class names with Clojure's `clojure.lang.*` types: `BigInteger` to `BigInt` (#2003), `Rational` to `Ratio` (#2004), `PhelFuture` to `Future` (#2005), `ExInfoException` to `ExceptionInfo` (#2006). One remaining mismatch is `LazyCons`.

The class is a realized cons cell: a head value paired with a lazy tail seq, returned by `LazySeq::nextSeq()` and `ChunkedSeq::nextSeq()`. The cell itself is not lazy (its head is realized when the cell is constructed); only the tail it carries is. Clojure exposes the same concept as `clojure.lang.Cons`, with no `Lazy` prefix.

## 💡 Goal

Rename `LazyCons` to `Cons` (and `LazyConsPrinter` to `ConsPrinter`) so the type name reflects what the class actually is, and to keep the Lang module aligned with Clojure's naming.

## 🔖 Changes

- `Phel\Lang\Collections\LazySeq\LazyCons` to `Cons`
- `Phel\Shared\Printer\TypePrinter\LazyConsPrinter` to `ConsPrinter`
- Updated all internal references: `LazySeq`, `ChunkedSeq`, `LazySeqInterface`, `Printer`, `DefaultLangAliasesRegistrar`, and the Phel core sources (`core.phel`, `core/predicates.phel`)
- Updated unit test `LazySeqTest` (import, assertion, method name)
- Refreshed the class docblock to mention the Clojure parallel and emphasise the "realized cell, lazy tail" distinction
- `CHANGELOG.md`: added bullet under Unreleased BC-break renames, and updated the pre-existing "Fixed" entry that mentioned `LazyCons` to use `Cons`

The auto-referred alias keeps the Phel-side identifier as `Cons` (it already was), so user code that does `(php/instanceof x Cons)` is unaffected.