### PR TITLE
feat(edn): add phel.edn namespace for EDN read/write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `phel.edn` namespace: read and write [Extensible Data Notation](https://github.com/edn-format/edn) without going through `eval`. Public API: `read-string`, `read-string-all`, `write-string`, `write-string-all`. Supports per-call `:readers` for custom tag handlers and an `:eof` option for empty input. (#2008)
+- Lexer: tagged literals now accept namespaced symbols (`#my.app/Person`, `#myapp/double`) and dot-separated namespaces (`#my.app.module`), matching EDN's tag grammar. Unqualified tags (`#uuid`, `#inst`) continue to work unchanged.
+
 ## [0.39.0](https://github.com/phel-lang/phel-lang/compare/v0.38.0...v0.39.0) - 2026-05-19
 
 ### Added

--- a/src/phel/edn.phel
+++ b/src/phel/edn.phel
@@ -1,0 +1,162 @@
+(ns phel.edn
+  (:use Phel.Compiler.CompilerFacade)
+  (:use Phel.Compiler.Domain.Parser.ParserNode.TriviaNodeInterface)
+  (:use Phel.Lang.TagRegistry)
+  (:use Phel.Shared.Printer.Printer))
+
+;; phel.edn: read and write Extensible Data Notation (EDN).
+;;
+;; Spec: https://github.com/edn-format/edn
+;;
+;; The Phel reader already accepts EDN syntax for nil, booleans, integers,
+;; floats, strings, characters, keywords, symbols, lists, vectors, maps,
+;; sets, the `#_` discard, `;` comments, and tagged literals. This module
+;; wraps that reader so EDN data can be exchanged with other Clojure-aligned
+;; runtimes without going through `eval`.
+;;
+;; Public API:
+;;   (read-string s)          (read-string s opts)
+;;   (read-string-all s)      (read-string-all s opts)
+;;   (write-string v)
+;;   (write-string-all xs)
+;;
+;; Options map:
+;;   :readers  -> {tag-sym fn}   per-call reader tag handlers
+;;   :eof      -> any            value returned when input is empty
+;;                               (default nil)
+
+(defn- compiler-facade []
+  (php/new CompilerFacade))
+
+(defn- tag-registry []
+  (php/:: TagRegistry (getInstance)))
+
+(defn- tag-key
+  "Normalises a tag from a symbol, keyword, or string to the string key
+  used by the global `TagRegistry`."
+  [tag]
+  (cond
+    (string? tag)  tag
+    (symbol? tag)  (full-name tag)
+    (keyword? tag) (name tag)
+    :else          (throw (php/new \InvalidArgumentException
+                          (str "EDN reader tag must be a symbol, keyword, or string, got: "
+                               (php/gettype tag))))))
+
+(defn- snapshot-tags
+  "Captures the existing handler for each tag key so it can be restored
+  after the call. Returns a map `{tag-key handler-or-nil}`."
+  [reg tag-keys]
+  (let [acc (transient {})]
+    (foreach [k tag-keys]
+      (php/-> acc (put k (php/-> reg (get k)))))
+    (persistent acc)))
+
+(defn- install-readers
+  "Registers each `tag -> fn` from `readers` on the registry."
+  [reg readers]
+  (foreach [tag handler readers]
+    (php/-> reg (register (tag-key tag) handler))))
+
+(defn- restore-tags
+  "Reinstates the original handlers captured by `snapshot-tags`. When a
+  tag had no prior handler, it is unregistered so the registry returns to
+  its earlier shape."
+  [reg snapshot]
+  (foreach [k handler snapshot]
+    (if (php/=== handler nil)
+      (php/-> reg (unregister k))
+      (php/-> reg (register k handler)))))
+
+(defn- with-readers*
+  "Runs `thunk` with `readers` temporarily installed on the tag registry.
+  Restores prior state in a `finally` so exceptions still clean up."
+  [readers thunk]
+  (if (or (php/=== readers nil) (zero? (count readers)))
+    (thunk)
+    (let [reg      (tag-registry)
+          tag-keys (for [tag :keys readers] (tag-key tag))
+          snapshot (snapshot-tags reg tag-keys)]
+      (install-readers reg readers)
+      (try
+        (thunk)
+        (finally
+          (restore-tags reg snapshot))))))
+
+(defn- read-next
+  "Reads the next form from the open `token-stream` using `cf`. Skips
+  whitespace, comments, and other trivia parser nodes that precede the
+  next data form. Returns nil when the stream is exhausted."
+  [cf token-stream]
+  (loop []
+    (let [node (php/-> cf (parseNext token-stream))]
+      (cond
+        (php/=== nil node)                       nil
+        (php/instanceof node TriviaNodeInterface) (recur)
+        :else (php/-> (php/-> cf (read node)) (getAst))))))
+
+(defn- parse-one [s]
+  (let [cf           (compiler-facade)
+        token-stream (php/-> cf (lexString s))]
+    (read-next cf token-stream)))
+
+(defn- parse-all [s]
+  (let [cf           (compiler-facade)
+        token-stream (php/-> cf (lexString s))]
+    (loop [acc (transient [])]
+      (let [form (read-next cf token-stream)]
+        (if (php/=== form nil)
+          (persistent acc)
+          (recur (conj! acc form)))))))
+
+(defn read-string
+  "Reads one EDN value from string `s`.
+
+  When `s` is empty or only whitespace/comments, returns the `:eof` value
+  from `opts` (default nil).
+
+  Options:
+    :readers  map of tag (symbol, keyword, or string) to 1-arg handler fn
+    :eof      value returned for empty input"
+  {:example "(read-string \"{:a 1 :b 2}\") ; => {:a 1 :b 2}"
+   :see-also ["read-string-all" "write-string"]}
+  ([s] (read-string s {}))
+  ([s opts]
+   (let [readers (get opts :readers)
+         eof     (get opts :eof)
+         result  (with-readers* readers #(parse-one s))]
+     (if (php/=== result nil) eof result))))
+
+(defn read-string-all
+  "Reads every EDN value from string `s` and returns them as a vector.
+
+  Options:
+    :readers  map of tag (symbol, keyword, or string) to 1-arg handler fn"
+  {:example "(read-string-all \"1 2 3\") ; => [1 2 3]"
+   :see-also ["read-string" "write-string-all"]}
+  ([s] (read-string-all s {}))
+  ([s opts]
+   (let [readers (get opts :readers)]
+     (with-readers* readers #(parse-all s)))))
+
+(defn write-string
+  "Serialises `value` to its EDN string representation. Uses Phel's
+  readable printer so the output round-trips through `read-string` for
+  all EDN-compatible values (nil, booleans, numbers, strings, keywords,
+  symbols, lists, vectors, maps, sets, and built-in tagged literals
+  such as `#uuid`)."
+  {:example "(write-string {:a 1}) ; => \"{:a 1}\""
+   :see-also ["read-string" "write-string-all"]}
+  [value]
+  (let [printer (php/:: Printer (readable))]
+    (php/-> printer (print value))))
+
+(defn write-string-all
+  "Serialises a sequence of values to EDN, separating top-level forms
+  with a single space. Inverse of `read-string-all`."
+  {:example "(write-string-all [1 2 3]) ; => \"1 2 3\""
+   :see-also ["read-string-all" "write-string"]}
+  [xs]
+  (php/implode " "
+               (apply php-indexed-array
+                      (for [x :in xs] (write-string x)))))

--- a/src/phel/edn.phel
+++ b/src/phel/edn.phel
@@ -40,8 +40,8 @@
     (symbol? tag)  (full-name tag)
     (keyword? tag) (name tag)
     :else          (throw (php/new \InvalidArgumentException
-                          (str "EDN reader tag must be a symbol, keyword, or string, got: "
-                               (php/gettype tag))))))
+                                   (str "EDN reader tag must be a symbol, keyword, or string, got: "
+                                        (php/gettype tag))))))
 
 (defn- snapshot-tags
   "Captures the existing handler for each tag key so it can be restored
@@ -72,7 +72,7 @@
   "Runs `thunk` with `readers` temporarily installed on the tag registry.
   Restores prior state in a `finally` so exceptions still clean up."
   [readers thunk]
-  (if (or (php/=== readers nil) (zero? (count readers)))
+  (if (empty? readers)
     (thunk)
     (let [reg      (tag-registry)
           tag-keys (for [tag :keys readers] (tag-key tag))
@@ -91,9 +91,9 @@
   (loop []
     (let [node (php/-> cf (parseNext token-stream))]
       (cond
-        (php/=== nil node)                       nil
+        (php/=== nil node)                        nil
         (php/instanceof node TriviaNodeInterface) (recur)
-        :else (php/-> (php/-> cf (read node)) (getAst))))))
+        :else                                     (php/-> (php/-> cf (read node)) (getAst))))))
 
 (defn- parse-one [s]
   (let [cf           (compiler-facade)
@@ -139,6 +139,8 @@
    (let [readers (get opts :readers)]
      (with-readers* readers #(parse-all s)))))
 
+(def- readable-printer (php/:: Printer (readable)))
+
 (defn write-string
   "Serialises `value` to its EDN string representation. Uses Phel's
   readable printer so the output round-trips through `read-string` for
@@ -148,8 +150,7 @@
   {:example "(write-string {:a 1}) ; => \"{:a 1}\""
    :see-also ["read-string" "write-string-all"]}
   [value]
-  (let [printer (php/:: Printer (readable))]
-    (php/-> printer (print value))))
+  (php/-> readable-printer (print value)))
 
 (defn write-string-all
   "Serialises a sequence of values to EDN, separating top-level forms

--- a/src/php/Compiler/Application/Lexer.php
+++ b/src/php/Compiler/Application/Lexer.php
@@ -51,7 +51,7 @@ final class Lexer implements LexerInterface
         '(#\?\()', // reader conditional (index: 25 = T_READER_COND)
         '(#\?@\()', // reader conditional splicing (index: 26 = T_READER_COND_SPLICING)
         '(##(?:-?Inf|NaN)(?![A-Za-z0-9_\-]))', // symbolic number literal (index: 27 = T_SYMBOLIC_NUMBER) - Clojure-style ##Inf, ##-Inf, ##NaN
-        '(#[A-Za-z][A-Za-z0-9_\-]*)', // tagged literal start (index: 28 = T_TAGGED_LITERAL) - e.g. #cpp, #uuid, #inst
+        '(#[A-Za-z][A-Za-z0-9_\-]*(?:\.[A-Za-z0-9_\-]+)*(?:\/[A-Za-z][A-Za-z0-9_\-]*(?:\.[A-Za-z0-9_\-]+)*)?)', // tagged literal start (index: 28 = T_TAGGED_LITERAL) - e.g. #cpp, #uuid, #inst, #my.app/Person (EDN-style namespaced tags)
         "(#')", // var-quote prefix (index: 29 = T_VAR_QUOTE) - `#'foo` expands to `(var foo)` in the reader, yielding a `PhelVar` handle to the named definition
     ];
 

--- a/tests/phel/edn/read.phel
+++ b/tests/phel/edn/read.phel
@@ -1,0 +1,90 @@
+(ns phel-test.edn.read
+  (:require phel.edn)
+  (:require phel.test :refer [deftest is]))
+
+(deftest test-read-nil
+  (is (= nil (edn/read-string "nil")) "nil literal")
+  (is (= nil (edn/read-string "")) "empty input returns nil")
+  (is (= :eof (edn/read-string "" {:eof :eof})) "empty input honors :eof option"))
+
+(deftest test-read-booleans
+  (is (= true (edn/read-string "true")))
+  (is (= false (edn/read-string "false"))))
+
+(deftest test-read-numbers
+  (is (= 42 (edn/read-string "42")))
+  (is (= -7 (edn/read-string "-7")))
+  (is (= 3.14 (edn/read-string "3.14")))
+  (is (= -1.5 (edn/read-string "-1.5"))))
+
+(deftest test-read-strings
+  (is (= "hello" (edn/read-string "\"hello\"")))
+  (is (= "with \"quote\"" (edn/read-string "\"with \\\"quote\\\"\""))))
+
+(deftest test-read-keywords
+  (is (= :foo (edn/read-string ":foo")))
+  (is (= :ns/foo (edn/read-string ":ns/foo"))))
+
+(deftest test-read-symbols
+  (is (= 'foo (edn/read-string "foo")))
+  (is (= 'ns/foo (edn/read-string "ns/foo"))))
+
+(deftest test-read-list
+  (is (= '(1 2 3) (edn/read-string "(1 2 3)")))
+  (is (= '() (edn/read-string "()"))))
+
+(deftest test-read-vector
+  (is (= [1 2 3] (edn/read-string "[1 2 3]")))
+  (is (= [] (edn/read-string "[]"))))
+
+(deftest test-read-map
+  (is (= {:a 1 :b 2} (edn/read-string "{:a 1 :b 2}")))
+  (is (= {} (edn/read-string "{}"))))
+
+(deftest test-read-set
+  (is (= #{1 2 3} (edn/read-string "#{1 2 3}")))
+  (is (= #{} (edn/read-string "#{}"))))
+
+(deftest test-read-nested
+  (is (= {:users [{:name "Alice" :age 30}
+                  {:name "Bob"   :age 25}]}
+         (edn/read-string
+          "{:users [{:name \"Alice\" :age 30} {:name \"Bob\" :age 25}]}"))))
+
+(deftest test-read-discard
+  (is (= [1 3] (edn/read-string "[1 #_2 3]")) "#_ discards next form"))
+
+(deftest test-read-comments
+  (is (= 1 (edn/read-string "; comment\n1"))))
+
+(deftest test-read-string-all
+  (is (= [1 2 3] (edn/read-string-all "1 2 3")))
+  (is (= [] (edn/read-string-all "")))
+  (is (= [:a {:b 1} [2 3]] (edn/read-string-all ":a {:b 1} [2 3]"))))
+
+(deftest test-read-builtin-tags
+  (let [uuid (edn/read-string "#uuid \"550e8400-e29b-41d4-a716-446655440000\"")]
+    (is (php/instanceof uuid \Phel\Lang\UUID) "#uuid returns UUID")
+    (is (= "550e8400-e29b-41d4-a716-446655440000" (php/-> uuid (__toString))))))
+
+(deftest test-read-custom-tag
+  (is (= 84
+         (edn/read-string "#myapp/double 42"
+                          {:readers {'myapp/double (fn [v] (* v 2))}}))
+      ":readers handler runs for tagged value")
+  (is (= [84]
+         (edn/read-string "[#myapp/double 42]"
+                          {:readers {'myapp/double (fn [v] (* v 2))}}))
+      "custom tag inside collection"))
+
+(deftest test-read-custom-tag-by-string
+  (is (= 6 (edn/read-string "#triple 2"
+                            {:readers {"triple" (fn [v] (* v 3))}}))
+      ":readers accepts string keys"))
+
+(deftest test-read-readers-restored-after-call
+  (edn/read-string "1" {:readers {'myapp/x (fn [v] v)}})
+  (is (false?
+       (php/-> (php/:: \Phel\Lang\TagRegistry (getInstance))
+               (has "myapp/x")))
+      "custom reader unregistered after call"))

--- a/tests/phel/edn/write.phel
+++ b/tests/phel/edn/write.phel
@@ -1,0 +1,58 @@
+(ns phel-test.edn.write
+  (:require phel.edn)
+  (:require phel.test :refer [deftest is]))
+
+(deftest test-write-nil
+  (is (= "nil" (edn/write-string nil))))
+
+(deftest test-write-booleans
+  (is (= "true"  (edn/write-string true)))
+  (is (= "false" (edn/write-string false))))
+
+(deftest test-write-numbers
+  (is (= "42"   (edn/write-string 42)))
+  (is (= "-7"   (edn/write-string -7)))
+  (is (= "3.14" (edn/write-string 3.14))))
+
+(deftest test-write-string
+  (is (= "\"hello\"" (edn/write-string "hello"))))
+
+(deftest test-write-keyword
+  (is (= ":foo"    (edn/write-string :foo)))
+  (is (= ":ns/foo" (edn/write-string :ns/foo))))
+
+(deftest test-write-symbol
+  (is (= "foo" (edn/write-string 'foo))))
+
+(deftest test-write-vector
+  (is (= "[1 2 3]" (edn/write-string [1 2 3])))
+  (is (= "[]"      (edn/write-string []))))
+
+(deftest test-write-list
+  (is (= "(1 2 3)" (edn/write-string '(1 2 3)))))
+
+(deftest test-write-map-round-trip
+  (is (= {:a 1 :b 2}
+         (edn/read-string (edn/write-string {:a 1 :b 2})))))
+
+(deftest test-write-set-round-trip
+  (is (= #{1 2 3}
+         (edn/read-string (edn/write-string #{1 2 3})))))
+
+(deftest test-write-uuid-round-trip
+  (let [u             (php/:: \Phel\Lang\UUID (fromString "550e8400-e29b-41d4-a716-446655440000"))
+        round-tripped (edn/read-string (edn/write-string u))]
+    (is (php/instanceof round-tripped \Phel\Lang\UUID))
+    (is (= (str u) (str round-tripped)) "UUID round-trips through EDN")))
+
+(deftest test-write-string-all
+  (is (= "1 2 3" (edn/write-string-all [1 2 3])))
+  (is (= ""      (edn/write-string-all [])))
+  (is (= ":a {:b 1}"
+         (edn/write-string-all [:a {:b 1}]))))
+
+(deftest test-round-trip-complex
+  (let [v {:users [{:id 1 :name "Alice"}
+                   {:id 2 :name "Bob"}]
+           :total 2}]
+    (is (= v (edn/read-string (edn/write-string v))))))


### PR DESCRIPTION
## 🤔 Background

[EDN](https://github.com/edn-format/edn) is the Clojure-aligned data transfer format. Phel's reader already accepts every EDN data form (nil, booleans, numbers, strings, keywords, symbols, lists, vectors, maps, sets, `#_`, comments, tagged literals), but those values were only reachable through `eval`. There was no safe, eval-free entry point for round-tripping data with other Clojure-family runtimes.

Closes #2008

## 💡 Goal

Expose a small `phel.edn` API that reads and writes EDN without going through the compiler/evaluator, and make Phel's lexer accept EDN's full tag grammar (`#my.app/Person`) so user-defined tagged literals are usable from both Phel source and `phel.edn/read-string`.

## 🔖 Changes

- **New `phel.edn` namespace** with `read-string`, `read-string-all`, `write-string`, `write-string-all`. Reads delegate to Phel's reader (so EDN data is consumed without `eval`); writes use the existing readable printer so output round-trips back through `read-string`.
- **`:readers` option** on `read-string` / `read-string-all`: a per-call `{tag-sym fn}` map. Keys may be symbols, keywords, or strings; the registry is snapshotted before the call and restored in a `finally`, so exceptions still leave the global `TagRegistry` clean.
- **`:eof` option** on `read-string` returns the supplied sentinel for empty / whitespace-only input.
- **Lexer:** widen the `T_TAGGED_LITERAL` regex to accept namespaced and dot-separated symbols (`#my.app/Person`, `#myapp/double`, `#my.app.module`). Unqualified tags (`#uuid`, `#inst`, `#regex`) continue to lex unchanged. Without this, `#myapp/double` was tokenised as the bare tag `myapp` followed by `/double`, which made registered namespaced tags unreachable from the reader.
- **Tests:** `tests/phel/edn/read.phel` and `tests/phel/edn/write.phel` cover scalars, every EDN collection, nested structures, `#_` discards, `;` comments, multi-form `read-string-all`, the built-in `#uuid` tag, custom tag handlers (symbol and string keys), and registry restoration.
- **CHANGELOG.md:** entries under `## Unreleased`.