### PR TITLE
feat(transit): add phel.transit namespace for Transit+JSON-Verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `phel.edn` namespace: read and write [Extensible Data Notation](https://github.com/edn-format/edn) without going through `eval`. Public API: `read-string`, `read-string-all`, `write-string`, `write-string-all`. Supports per-call `:readers` for custom tag handlers and an `:eof` option for empty input. (#2008)
 - Lexer: tagged literals now accept namespaced symbols (`#my.app/Person`, `#myapp/double`) and dot-separated namespaces (`#my.app.module`), matching EDN's tag grammar. Unqualified tags (`#uuid`, `#inst`) continue to work unchanged.
+- `phel.transit` namespace: read and write [Transit+JSON-Verbose](https://github.com/cognitect/transit-format). Public API: `read-string`, `write-string`. Type-mapping covers nil, booleans, numbers, strings (with `~`/`^`/`` ` `` escaping), keywords (`~:`), symbols (`~$`), UUIDs (`~u`), `DateTimeImmutable` (`~t`), vectors, lists (`~#list`), sets (`~#set`), and maps (string-keyed maps as JSON objects, composite-key maps as `~#cmap`). Reader extensibility via `:handlers` (`{tag-string fn}`) and `:default-handler` `(fn [tag rep] …)` for unknown tags. (#2009)
 
 ## [0.39.0](https://github.com/phel-lang/phel-lang/compare/v0.38.0...v0.39.0) - 2026-05-19
 

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -46,9 +46,14 @@
 ;; Writer extensibility is intentionally left out of this first
 ;; iteration to keep the surface small.
 
+;; Transit reserves three leading characters in JSON strings:
+;;   `~` opens a tag (`~:foo`, `~#set`, `~~` escape)
+;;   `^` is the cache marker in non-verbose mode
+;;   `` ` `` is reserved for future use
+;; A plain Phel string starting with any of them must be re-escaped on
+;; write so the reader does not mistake it for a tag.
 (def- ESC "~")
-(def- SUB "^")
-(def- RESERVED-LETTERS #{"#" SUB "`"})
+(def- RESERVED-LETTERS #{"~" "^" "`"})
 
 (def- json-flags
   (bit-or JSON_UNESCAPED_SLASHES JSON_UNESCAPED_UNICODE))
@@ -105,9 +110,8 @@
   [pairs opts]
   (let [acc (transient {})]
     (loop [items pairs]
-      (cond
-        (or (php/=== items nil) (zero? (count items))) (persistent acc)
-        :else
+      (if (empty? items)
+        (persistent acc)
         (let [k (decode (first items) opts)
               v (decode (first (next items)) opts)]
           (php/-> acc (put k v))
@@ -157,18 +161,17 @@
   "Recursive Transit decoder over a `json_decode` result tree."
   [x opts]
   (cond
-    (php/=== x nil)         nil
-    (php/is_bool x)         x
-    (php/is_int x)          x
-    (php/is_float x)        x
-    (and (php/is_string x)
-         (starts-with? x ESC)) (decode-tagged-scalar x opts)
-    (php/is_string x)       x
+    (nil? x)                     nil
+    (php/is_bool x)              x
+    (php/is_int x)               x
+    (php/is_float x)             x
+    (starts-with? x ESC)         (decode-tagged-scalar x opts)
+    (php/is_string x)            x
     ;; PHP's json_decode with assoc=true returns associative or indexed
     ;; PHP arrays. `array_is_list` distinguishes them.
     (and (php/is_array x)
-         (php/array_is_list x)) (decode-array x opts)
-    (php/is_array x)        (decode-object x opts)
+         (php/array_is_list x))  (decode-array x opts)
+    (php/is_array x)             (decode-object x opts)
     :else
     (throw (php/new \InvalidArgumentException
                     (str "Cannot decode Transit value of type "
@@ -204,10 +207,9 @@
   "Escapes a plain Phel string so that an existing leading `~`, `^`, or
   `` ` `` is not mistaken for a Transit tag by the reader."
   [s]
-  (let [head (php/substr s 0 1)]
-    (if (or (php/=== ESC head) (contains? RESERVED-LETTERS head))
-      (str ESC s)
-      s)))
+  (if (contains? RESERVED-LETTERS (php/substr s 0 1))
+    (str ESC s)
+    s))
 
 (defn- encode-keyword [k]
   (str "~:" (full-name k)))
@@ -224,11 +226,7 @@
 (defn- string-keys?
   "True when every key in `m` is a plain Phel string."
   [m]
-  (let [ok (atom true)]
-    (foreach [k _ m]
-      (when-not (php/is_string k)
-        (reset! ok false)))
-    @ok))
+  (every? string? (keys m)))
 
 (defn- encode-map [m]
   (if (string-keys? m)

--- a/src/phel/transit.phel
+++ b/src/phel/transit.phel
@@ -1,0 +1,291 @@
+(ns phel.transit
+  (:use Phel.Lang.Keyword)
+  (:use Phel.Lang.Symbol)
+  (:use Phel.Lang.UUID)
+  (:use \JSON_UNESCAPED_SLASHES)
+  (:use \JSON_UNESCAPED_UNICODE))
+
+;; phel.transit: read and write Transit+JSON-Verbose data.
+;;
+;; Spec: https://github.com/cognitect/transit-format
+;;
+;; Transit is a Clojure-aligned data transfer format that layers a
+;; semantic type system on top of JSON. This module implements the
+;; "JSON-Verbose" encoding (no key caching, maps with string keys
+;; emitted as standard JSON objects), which is what Transit's
+;; reference documentation uses for examples and what is easiest to
+;; debug.
+;;
+;; Type mapping (Phel <-> Transit):
+;;
+;;   nil          <-> null
+;;   bool         <-> true / false
+;;   int          <-> JSON number
+;;   float        <-> JSON number
+;;   string       <-> JSON string (with `~` escape)
+;;   keyword      <-> "~:name"
+;;   symbol       <-> "~$name"
+;;   UUID         <-> "~uXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+;;   DateTime     <-> "~tISO-8601"
+;;   vector       <-> JSON array  [a, b, c]
+;;   list         <-> ["~#list", [a, b, c]]
+;;   set          <-> ["~#set", [a, b, c]]
+;;   map          <-> JSON object when every key is a string; otherwise
+;;                    ["~#cmap", [k1, v1, k2, v2, …]]
+;;
+;; Reader extensibility:
+;;
+;;   (read-string s {:handlers {"point" (fn [rep] ...)}
+;;                   :default-handler (fn [tag rep] ...)})
+;;
+;;   `:handlers` maps tag strings (without the leading "~#" or "~")
+;;   to a 1-arg fn receiving the already-decoded representation. The
+;;   `:default-handler` is invoked for unknown tags with `[tag rep]`
+;;   and may return any Phel value; if absent, unknown tags throw.
+;;
+;; Writer extensibility is intentionally left out of this first
+;; iteration to keep the surface small.
+
+(def- ESC "~")
+(def- SUB "^")
+(def- RESERVED-LETTERS #{"#" SUB "`"})
+
+(def- json-flags
+  (bit-or JSON_UNESCAPED_SLASHES JSON_UNESCAPED_UNICODE))
+
+;; ---------------------------------------------------------------------------
+;; Reading
+;; ---------------------------------------------------------------------------
+
+(declare decode)
+
+(defn- starts-with?
+  "True when `s` begins with the single character `c`."
+  [s c]
+  (and (php/is_string s)
+       (php/=== c (php/substr s 0 1))))
+
+(defn- tag-string
+  "Returns the tag portion of a `~#tag`-encoded array marker, or nil
+  when `s` is not such a marker."
+  [s]
+  (when (and (php/is_string s)
+             (php/=== "~#" (php/substr s 0 2)))
+    (php/substr s 2)))
+
+(defn- decode-tagged-scalar
+  "Decodes a `~`-prefixed string. Returns the decoded value, or the
+  original string when the prefix is one of the escape forms."
+  [s opts]
+  (let [marker (php/substr s 1 1)
+        rep    (php/substr s 2)]
+    (case marker
+      ":" (keyword rep)
+      "$" (symbol rep)
+      "u" (php/:: UUID (fromString rep))
+      "t" (php/new \DateTimeImmutable rep)
+      "?" (php/=== rep "t")
+      "i" (php/intval rep)
+      "d" (php/floatval rep)
+      "s" rep
+      "~" (str "~" rep)
+      "^" (str "^" rep)
+      "`" (str "`" rep)
+      ;; Fallback: hand off to the user-supplied :default-handler if
+      ;; present; otherwise throw with a clear message.
+      (let [default (get opts :default-handler)]
+        (if default
+          (default (str marker) rep)
+          (throw (php/new \InvalidArgumentException
+                          (str "Unknown Transit scalar tag '~" marker "'"))))))))
+
+(defn- decode-cmap
+  "Decodes a `~#cmap` payload — a flat sequence of alternating key/value
+  representations — into a persistent map."
+  [pairs opts]
+  (let [acc (transient {})]
+    (loop [items pairs]
+      (cond
+        (or (php/=== items nil) (zero? (count items))) (persistent acc)
+        :else
+        (let [k (decode (first items) opts)
+              v (decode (first (next items)) opts)]
+          (php/-> acc (put k v))
+          (recur (next (next items))))))))
+
+(defn- decode-tagged-array
+  "Decodes a `[\"~#tag\", rep]` array. Handles built-in collection tags
+  (`set`, `list`, `cmap`) and falls back to `:handlers` / `:default-handler`."
+  [tag rep opts]
+  (case tag
+    "set"  (apply hash-set (for [x :in (decode rep opts)] x))
+    "list" (apply list     (for [x :in (decode rep opts)] x))
+    "cmap" (decode-cmap rep opts)
+    (let [handlers (or (get opts :handlers) {})
+          handler  (get handlers tag)
+          default  (get opts :default-handler)]
+      (cond
+        handler (handler (decode rep opts))
+        default (default tag (decode rep opts))
+        :else
+        (throw (php/new \InvalidArgumentException
+                        (str "Unknown Transit tag '~#" tag "'")))))))
+
+(defn- decode-array
+  "Decodes a JSON array. Detects `[\"~#tag\", rep]` markers before
+  falling back to a positional vector decode."
+  [arr opts]
+  (let [head (php/aget arr 0)
+        tag  (tag-string head)]
+    (if tag
+      (decode-tagged-array tag (php/aget arr 1) opts)
+      (let [acc (transient [])]
+        (foreach [x arr]
+          (conj! acc (decode x opts)))
+        (persistent acc)))))
+
+(defn- decode-object
+  "Decodes a JSON object (as PHP associative array) into a Phel map.
+  String keys may themselves be Transit-encoded (e.g. `\"~:foo\"`)."
+  [obj opts]
+  (let [acc (transient {})]
+    (foreach [k v obj]
+      (php/-> acc (put (decode k opts) (decode v opts))))
+    (persistent acc)))
+
+(defn- decode
+  "Recursive Transit decoder over a `json_decode` result tree."
+  [x opts]
+  (cond
+    (php/=== x nil)         nil
+    (php/is_bool x)         x
+    (php/is_int x)          x
+    (php/is_float x)        x
+    (and (php/is_string x)
+         (starts-with? x ESC)) (decode-tagged-scalar x opts)
+    (php/is_string x)       x
+    ;; PHP's json_decode with assoc=true returns associative or indexed
+    ;; PHP arrays. `array_is_list` distinguishes them.
+    (and (php/is_array x)
+         (php/array_is_list x)) (decode-array x opts)
+    (php/is_array x)        (decode-object x opts)
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "Cannot decode Transit value of type "
+                         (php/gettype x))))))
+
+(defn read-string
+  "Reads one Transit+JSON-Verbose value from string `s`.
+
+  Options:
+    :handlers         map of tag-string to 1-arg fn for `~#tag` extensions
+    :default-handler  2-arg fn `(fn [tag rep] ...)` invoked for any
+                      unknown tag (both scalar and array forms). Receives
+                      the bare tag name (e.g. \"point\", \":\", \"~\") and
+                      the already-decoded representation."
+  {:example "(read-string \"[\\\"~:foo\\\", 1]\") ; => [:foo 1]"
+   :see-also ["write-string"]}
+  ([s] (read-string s {}))
+  ([s opts]
+   (let [raw (php/json_decode s true)
+         err (php/json_last_error)]
+     (when-not (zero? err)
+       (throw (php/new \InvalidArgumentException
+                       (str "Invalid Transit JSON: " (php/json_last_error_msg)))))
+     (decode raw opts))))
+
+;; ---------------------------------------------------------------------------
+;; Writing
+;; ---------------------------------------------------------------------------
+
+(declare encode)
+
+(defn- escape-string
+  "Escapes a plain Phel string so that an existing leading `~`, `^`, or
+  `` ` `` is not mistaken for a Transit tag by the reader."
+  [s]
+  (let [head (php/substr s 0 1)]
+    (if (or (php/=== ESC head) (contains? RESERVED-LETTERS head))
+      (str ESC s)
+      s)))
+
+(defn- encode-keyword [k]
+  (str "~:" (full-name k)))
+
+(defn- encode-symbol [s]
+  (str "~$" (full-name s)))
+
+(defn- encode-uuid [u]
+  (str "~u" (str u)))
+
+(defn- encode-datetime [d]
+  (str "~t" (php/-> d (format "Y-m-d\\TH:i:s.vP"))))
+
+(defn- string-keys?
+  "True when every key in `m` is a plain Phel string."
+  [m]
+  (let [ok (atom true)]
+    (foreach [k _ m]
+      (when-not (php/is_string k)
+        (reset! ok false)))
+    @ok))
+
+(defn- encode-map [m]
+  (if (string-keys? m)
+    (let [obj (php/array)]
+      (foreach [k v m]
+        (php/aset obj k (encode v)))
+      obj)
+    (let [pairs (php/array)]
+      (foreach [k v m]
+        (php/apush pairs (encode k))
+        (php/apush pairs (encode v)))
+      (php-indexed-array "~#cmap" pairs))))
+
+(defn- encode-vector [v]
+  (let [arr (php/array)]
+    (foreach [x v]
+      (php/apush arr (encode x)))
+    arr))
+
+(defn- encode-set [s]
+  (let [arr (php/array)]
+    (foreach [x s]
+      (php/apush arr (encode x)))
+    (php-indexed-array "~#set" arr)))
+
+(defn- encode-list [l]
+  (let [arr (php/array)]
+    (foreach [x l]
+      (php/apush arr (encode x)))
+    (php-indexed-array "~#list" arr)))
+
+(defn- encode
+  "Encodes a Phel value into the PHP-array shape consumed by
+  `json_encode`. Strings carrying a Transit-sensitive prefix are
+  escaped with a leading `~`."
+  [x]
+  (cond
+    (nil? x)                              nil
+    (php/is_bool x)                       x
+    (php/is_int x)                        x
+    (php/is_float x)                      x
+    (keyword? x)                          (encode-keyword x)
+    (symbol? x)                           (encode-symbol x)
+    (php/instanceof x UUID)               (encode-uuid x)
+    (php/instanceof x \DateTimeInterface) (encode-datetime x)
+    (php/is_string x)                     (escape-string x)
+    (set? x)                              (encode-set x)
+    (vector? x)                           (encode-vector x)
+    (list? x)                             (encode-list x)
+    (map? x)                              (encode-map x)
+    :else
+    (throw (php/new \InvalidArgumentException
+                    (str "Cannot encode value of type " (php/gettype x) " to Transit")))))
+
+(defn write-string
+  "Serialises `value` to a Transit+JSON-Verbose string."
+  {:example "(write-string {:a 1}) ; => \"{\\\"~:a\\\":1}\""
+   :see-also ["read-string"]}
+  [value]
+  (php/json_encode (encode value) json-flags))

--- a/tests/phel/transit/read.phel
+++ b/tests/phel/transit/read.phel
@@ -1,0 +1,73 @@
+(ns phel-test.transit.read
+  (:require phel.transit :as transit)
+  (:require phel.test :refer [deftest is]))
+
+(deftest test-read-scalars
+  (is (= nil   (transit/read-string "null")))
+  (is (= true  (transit/read-string "true")))
+  (is (= false (transit/read-string "false")))
+  (is (= 42    (transit/read-string "42")))
+  (is (= -7    (transit/read-string "-7")))
+  (is (= 3.14  (transit/read-string "3.14")))
+  (is (= "hi"  (transit/read-string "\"hi\""))))
+
+(deftest test-read-keyword
+  (is (= :foo (transit/read-string "\"~:foo\"")))
+  (is (= :ns/foo (transit/read-string "\"~:ns/foo\""))))
+
+(deftest test-read-symbol
+  (is (= 'bar (transit/read-string "\"~$bar\""))))
+
+(deftest test-read-uuid
+  (let [u (transit/read-string "\"~u550e8400-e29b-41d4-a716-446655440000\"")]
+    (is (php/instanceof u \Phel\Lang\UUID))
+    (is (= "550e8400-e29b-41d4-a716-446655440000" (str u)))))
+
+(deftest test-read-instant
+  (let [d (transit/read-string "\"~t2026-05-19T12:00:00+00:00\"")]
+    (is (php/instanceof d \DateTimeImmutable))
+    (is (= "2026-05-19T12:00:00+00:00" (php/-> d (format "c"))))))
+
+(deftest test-read-vector
+  (is (= [1 2 3] (transit/read-string "[1,2,3]")))
+  (is (= [] (transit/read-string "[]")))
+  (is (= [:a :b] (transit/read-string "[\"~:a\",\"~:b\"]"))))
+
+(deftest test-read-set
+  (is (= #{1 2 3} (transit/read-string "[\"~#set\",[1,2,3]]")))
+  (is (= #{} (transit/read-string "[\"~#set\",[]]"))))
+
+(deftest test-read-list
+  (is (= '(1 2 3) (transit/read-string "[\"~#list\",[1,2,3]]"))))
+
+(deftest test-read-map-string-keys
+  (is (= {"a" 1 "b" 2} (transit/read-string "{\"a\":1,\"b\":2}"))))
+
+(deftest test-read-map-keyword-keys
+  (is (= {:a 1 :b 2} (transit/read-string "{\"~:a\":1,\"~:b\":2}"))))
+
+(deftest test-read-cmap
+  (let [m (transit/read-string "[\"~#cmap\",[\"~:a\",1,[1,2],\"vec-key\"]]")]
+    (is (= 1 (get m :a)))
+    (is (= "vec-key" (get m [1 2])))))
+
+(deftest test-read-escaped-strings
+  (is (= "~hello" (transit/read-string "\"~~hello\"")) "~~ unescapes to ~")
+  (is (= "^foo" (transit/read-string "\"~^foo\"")) "~^ unescapes to ^"))
+
+(deftest test-read-custom-handler
+  (is (= "Point[1,2]"
+         (transit/read-string "[\"~#point\",[1,2]]"
+                              {:handlers {"point" (fn [rep]
+                                                    (str "Point[" (first rep) "," (second rep) "]"))}}))))
+
+(deftest test-read-default-handler
+  (is (= [:unknown "myapp/Person" [1 2]]
+         (transit/read-string "[\"~#myapp/Person\",[1,2]]"
+                              {:default-handler (fn [tag rep] [:unknown tag rep])}))))
+
+(deftest test-read-nested
+  (is (= {:users [{:name "Alice" :tags #{:admin :active}}
+                  {:name "Bob"   :tags #{:guest}}]}
+         (transit/read-string
+          "{\"~:users\":[{\"~:name\":\"Alice\",\"~:tags\":[\"~#set\",[\"~:admin\",\"~:active\"]]},{\"~:name\":\"Bob\",\"~:tags\":[\"~#set\",[\"~:guest\"]]}]}"))))

--- a/tests/phel/transit/write.phel
+++ b/tests/phel/transit/write.phel
@@ -1,0 +1,54 @@
+(ns phel-test.transit.write
+  (:require phel.transit :as transit)
+  (:require phel.test :refer [deftest is]))
+
+(deftest test-write-scalars
+  (is (= "null"  (transit/write-string nil)))
+  (is (= "true"  (transit/write-string true)))
+  (is (= "false" (transit/write-string false)))
+  (is (= "42"    (transit/write-string 42)))
+  (is (= "3.14"  (transit/write-string 3.14)))
+  (is (= "\"hi\"" (transit/write-string "hi"))))
+
+(deftest test-write-keyword
+  (is (= "\"~:foo\"" (transit/write-string :foo)))
+  (is (= "\"~:ns/foo\"" (transit/write-string :ns/foo))))
+
+(deftest test-write-symbol
+  (is (= "\"~$bar\"" (transit/write-string 'bar))))
+
+(deftest test-write-uuid
+  (let [u (php/:: \Phel\Lang\UUID (fromString "550e8400-e29b-41d4-a716-446655440000"))]
+    (is (= "\"~u550e8400-e29b-41d4-a716-446655440000\"" (transit/write-string u)))))
+
+(deftest test-write-vector
+  (is (= "[1,2,3]" (transit/write-string [1 2 3])))
+  (is (= "[]"      (transit/write-string [])))
+  (is (= "[\"~:a\",\"~:b\"]" (transit/write-string [:a :b]))))
+
+(deftest test-write-set-round-trip
+  (is (= #{1 2 3} (transit/read-string (transit/write-string #{1 2 3})))))
+
+(deftest test-write-list-round-trip
+  (is (= '(1 2 3) (transit/read-string (transit/write-string '(1 2 3))))))
+
+(deftest test-write-map-string-keys
+  (is (= "{\"a\":1}" (transit/write-string {"a" 1}))))
+
+(deftest test-write-map-keyword-keys-round-trip
+  (is (= {:a 1 :b 2}
+         (transit/read-string (transit/write-string {:a 1 :b 2})))))
+
+(deftest test-write-cmap-round-trip
+  (let [m {[1 2] "vec-key" :a 1}]
+    (is (= m (transit/read-string (transit/write-string m))))))
+
+(deftest test-write-escapes-prefix-strings
+  (is (= "~hello" (transit/read-string (transit/write-string "~hello"))))
+  (is (= "^foo"   (transit/read-string (transit/write-string "^foo")))))
+
+(deftest test-round-trip-complex
+  (let [v {:users [{:name "Alice" :tags #{:admin :active}}
+                   {:name "Bob"   :tags #{:guest}}]
+           :total 2}]
+    (is (= v (transit/read-string (transit/write-string v))))))


### PR DESCRIPTION
## 🤔 Background

[Transit](https://github.com/cognitect/transit-format) layers a semantic type system on top of JSON / MessagePack so Phel can exchange typed data (keywords, sets, instants, UUIDs, …) with other Clojure-family runtimes (Clojure, ClojureScript, Java, Ruby, Python). Without it, anything beyond the JSON-native types has to be hand-marshalled at the boundary.

The issue prioritised EDN (#2008, now merged) and called out Transit as the follow-up.

Closes #2009

## 💡 Goal

Land an eval-free, well-typed Transit reader and writer. Scope this first iteration to **Transit+JSON-Verbose**: maps with string keys serialise to ordinary JSON objects (no key caching), which is what the spec's reference examples use and what is easiest to debug.

## 🔖 Changes

- **New `phel.transit` namespace** with two public fns:
  - `(read-string s)` / `(read-string s opts)`
  - `(write-string v)`
- **Phel ↔ Transit mapping** covers nil, booleans, integers, floats, strings (with `~`/`^`/`` ` `` escaping), keywords (`~:`), symbols (`~$`), `Phel\Lang\UUID` (`~u`), `DateTimeImmutable` (`~t`), vectors, lists (`~#list`), sets (`~#set`), maps (string-keyed maps → JSON objects, composite-key maps → `~#cmap`).
- **Reader extensibility**: `:handlers` accepts a `{tag-string fn}` map for `~#tag` extensions, `:default-handler` is `(fn [tag rep] …)` for unknown tags (both scalar and array forms). Without a handler, unknown tags throw an `InvalidArgumentException` quoting the tag.
- **Round-trip safety**: plain Phel strings whose first character is `~`, `^`, or `` ` `` are escaped on write so the reader does not mistake them for tags.
- **Tests** (`tests/phel/transit/read.phel`, `tests/phel/transit/write.phel`): scalars, every collection shape, tagged scalars (keyword, symbol, UUID, instant), tagged collections (`~#set`, `~#list`, `~#cmap`), escape sequences, custom and default handlers, full round-trip of nested data.
- **CHANGELOG.md**: entry under `## Unreleased`.