### PR TITLE
docs: condense Unreleased changelog and add data-formats guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `phel.edn` namespace: read and write [Extensible Data Notation](https://github.com/edn-format/edn) without going through `eval`. Public API: `read-string`, `read-string-all`, `write-string`, `write-string-all`. Supports per-call `:readers` for custom tag handlers and an `:eof` option for empty input. (#2008)
-- Lexer: tagged literals now accept namespaced symbols (`#my.app/Person`, `#myapp/double`) and dot-separated namespaces (`#my.app.module`), matching EDN's tag grammar. Unqualified tags (`#uuid`, `#inst`) continue to work unchanged.
-- `phel.transit` namespace: read and write [Transit+JSON-Verbose](https://github.com/cognitect/transit-format). Public API: `read-string`, `write-string`. Type-mapping covers nil, booleans, numbers, strings (with `~`/`^`/`` ` `` escaping), keywords (`~:`), symbols (`~$`), UUIDs (`~u`), `DateTimeImmutable` (`~t`), vectors, lists (`~#list`), sets (`~#set`), and maps (string-keyed maps as JSON objects, composite-key maps as `~#cmap`). Reader extensibility via `:handlers` (`{tag-string fn}`) and `:default-handler` `(fn [tag rep] …)` for unknown tags. (#2009)
+- `phel.edn`: eval-free EDN read/write. See [docs/data-formats.md](docs/data-formats.md). (#2008)
+- `phel.transit`: Transit+JSON-Verbose read/write. See [docs/data-formats.md](docs/data-formats.md). (#2009)
+- Lexer: tagged literals accept namespaced symbols (`#my.app/Person`).
 
 ## [0.39.0](https://github.com/phel-lang/phel-lang/compare/v0.38.0...v0.39.0) - 2026-05-19
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Coming from Clojure? Read [Clojure Migration](clojure-migration.md).
 - [Async](async-guide.md): fibers, promises, futures, AMPHP
 - [Schema](schema-guide.md): validate, coerce, generate
 - [AI](ai-guide.md): `chat-with-tools`, OpenAI tool use
+- [Data Interchange Formats](data-formats.md): `phel.edn`, `phel.transit`
 
 ## Apps
 

--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -1,0 +1,135 @@
+# Data Interchange Formats
+
+Phel ships two eval-free interchange modules for talking to other Clojure-aligned runtimes (or to itself across process boundaries):
+
+- [`phel.edn`](#phel-edn): [Extensible Data Notation](https://github.com/edn-format/edn), the Clojure-native subset of reader syntax.
+- [`phel.transit`](#phel-transit): [Transit](https://github.com/cognitect/transit-format) layered on top of JSON.
+
+Neither module goes through `eval`, so they are safe to point at untrusted input.
+
+## `phel.edn`
+
+### Public API
+
+| Function | Purpose |
+|---|---|
+| `(read-string s)` / `(read-string s opts)` | Read the first EDN form from `s`. |
+| `(read-string-all s)` / `(read-string-all s opts)` | Read every form, returns a vector. |
+| `(write-string v)` | Serialise `v` to EDN. |
+| `(write-string-all xs)` | Serialise a sequence; values joined by a single space. |
+
+### Options map
+
+| Key | Value | Behaviour |
+|---|---|---|
+| `:readers` | `{tag fn}` | Per-call tag handlers. Tags may be symbols, keywords, or strings. The handler receives the already-parsed form. The global `TagRegistry` is snapshotted before the call and restored in a `finally`. |
+| `:eof` | any | Returned by `read-string` when input is empty / whitespace-only / comment-only (default `nil`). |
+
+### Type mapping
+
+`phel.edn` delegates reading to Phel's own reader and writing to `Printer::readable()`, so every value Phel can print readably round-trips. That includes nil, booleans, integers, floats, strings, characters, keywords, symbols, lists, vectors, maps, sets, the `#_` discard form, `;` comments, and built-in tagged literals (`#uuid`, `#inst`, `#regex`).
+
+### Examples
+
+```phel
+(ns my-app.config
+  (:require phel.edn :as edn))
+
+(edn/read-string "{:host \"localhost\" :port 4000}")
+;; => {:host "localhost" :port 4000}
+
+(edn/read-string-all "1 2 3")
+;; => [1 2 3]
+
+(edn/write-string {:users [{:name "Alice"} {:name "Bob"}]})
+;; => "{:users [{:name \"Alice\"} {:name \"Bob\"}]}"
+
+;; Custom tag: register a handler for #my.app/Point literals
+(edn/read-string "#my.app/Point [1 2]"
+                 {:readers {'my.app/Point (fn [[x y]] {:x x :y y})}})
+;; => {:x 1 :y 2}
+
+;; Empty input with a sentinel
+(edn/read-string "" {:eof :no-data})
+;; => :no-data
+```
+
+### Namespaced tags
+
+The lexer accepts EDN's full tag grammar, so `#my.app/Person`, `#myapp/double`, and `#my.app.module` lex as a single tag. Unqualified tags (`#uuid`, `#inst`) continue to work unchanged.
+
+## `phel.transit`
+
+### Public API
+
+| Function | Purpose |
+|---|---|
+| `(read-string s)` / `(read-string s opts)` | Decode one Transit+JSON-Verbose value. |
+| `(write-string v)` | Encode `v` to a Transit+JSON-Verbose string. |
+
+This first iteration implements **JSON-Verbose** only: maps with string keys serialise to ordinary JSON objects (no key caching), composite-key maps to `~#cmap`.
+
+### Options map
+
+| Key | Value | Behaviour |
+|---|---|---|
+| `:handlers` | `{tag-string fn}` | Decoder for `~#tag` arrays. The handler receives the already-decoded representation. |
+| `:default-handler` | `(fn [tag rep] …)` | Fallback for any unknown tag (scalar or array). Receives the bare tag name and decoded rep. Without it, unknown tags throw `InvalidArgumentException`. |
+
+### Type mapping
+
+| Phel | Transit JSON-Verbose |
+|---|---|
+| `nil` | `null` |
+| bool | `true` / `false` |
+| int, float | JSON number |
+| string | JSON string (with `~`/`^`/`` ` `` escape) |
+| keyword | `"~:name"` |
+| symbol | `"~$name"` |
+| `Phel\Lang\UUID` | `"~uXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"` |
+| `DateTimeImmutable` | `"~tISO-8601"` |
+| vector | JSON array `[…]` |
+| list | `["~#list", [...]]` |
+| set | `["~#set", [...]]` |
+| map (string keys) | JSON object `{...}` |
+| map (composite keys) | `["~#cmap", [k1, v1, k2, v2, …]]` |
+
+Plain Phel strings whose first character is `~`, `^`, or `` ` `` are escaped on write with a leading `~`, so the reader does not mistake them for a Transit tag.
+
+### Examples
+
+```phel
+(ns my-app.api
+  (:require phel.transit :as transit))
+
+(transit/write-string {:users [{:name "Alice" :tags #{:admin}}]})
+;; => "{\"~:users\":[{\"~:name\":\"Alice\",\"~:tags\":[\"~#set\",[\"~:admin\"]]}]}"
+
+(transit/read-string "{\"~:status\":\"~:ok\",\"~:count\":42}")
+;; => {:status :ok :count 42}
+
+;; Custom extension type (read-side)
+(transit/read-string "[\"~#point\",[1,2]]"
+                     {:handlers {"point" (fn [[x y]] {:x x :y y})}})
+;; => {:x 1 :y 2}
+
+;; Catch-all for unknown tags
+(transit/read-string "[\"~#myapp/Foo\",[1,2]]"
+                     {:default-handler (fn [tag rep] [:unknown tag rep])})
+;; => [:unknown "myapp/Foo" [1 2]]
+```
+
+### What is intentionally out of scope (for now)
+
+- **Cached keys** (the non-verbose Transit+JSON encoding with `^` cache markers).
+- **Transit+MessagePack**.
+- **Write-side extension hooks**: there is no symmetric `:handlers` map on `write-string` yet. Encode custom types yourself before handing them to `write-string`.
+
+## Choosing between EDN and Transit
+
+| Need | Use |
+|---|---|
+| Phel-to-Phel config files, source-like data | EDN |
+| Talking to Clojure/Java/JS over HTTP, MessagePack-ready wire format | Transit |
+| Human-edited input with comments and `#_` discards | EDN |
+| Round-tripping JSON-shaped data with rich types | Transit |


### PR DESCRIPTION
## 🤔 Background

The `## Unreleased` entries for #2008 (EDN) and #2009 (Transit) carried the full API surface, option maps, and type-mapping tables inline. That is changelog noise — the same content is more useful as a stable reference.

## 💡 Goal

Move the detail to a dedicated guide and leave one-line pointers in the changelog.

## 🔖 Changes

- New `docs/data-formats.md`: covers `phel.edn` and `phel.transit` — public API, option maps, type-mapping tables, runnable examples, and an explicit note on what is intentionally out of scope for Transit (cache markers, MessagePack, write-side handlers).
- `docs/README.md`: link the new guide under the Modules section.
- `CHANGELOG.md`: collapse the three Unreleased entries into three short lines, each linking the guide where relevant.