### PR TITLE
docs: trim redundancy from patterns and data-structures guides

### DIFF
--- a/docs/data-structures-guide.md
+++ b/docs/data-structures-guide.md
@@ -1,30 +1,6 @@
 # Data Structures Manipulation Guide
 
-Functions for manipulating Phel's immutable data structures: vectors, maps, sets, and lists.
-
-## Contents
-
-- [Introduction](#introduction)
-- [String Iteration](#string-iteration)
-- [Adding & Building Collections](#adding--building-collections)
-- [Accessing Elements](#accessing-elements)
-- [Modifying Collections](#modifying-collections)
-- [Combining Maps](#combining-maps)
-- [Analysis Functions](#analysis-functions)
-- [Working with Nested Structures](#working-with-nested-structures)
-- [Transient Collections](#transient-collections)
-- [Phel-Specific Extensions](#phel-specific-extensions)
-- [Quick Reference](#quick-reference)
-- [Deprecated Functions](#deprecated-functions)
-- [Summary](#summary)
-
-## Introduction
-
-Phel's data structures are **immutable** and **persistent**. Operations return new versions while sharing structure with the original. Reads stay O(1) amortized; updates cost log32(n).
-
-Function names follow common Lisp conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, ...). See the [quick reference](#quick-reference).
-
----
+Functions for manipulating Phel's immutable, persistent data structures: vectors, maps, sets, lists. Operations return new versions while sharing structure with the original. Reads stay O(1) amortized; updates cost log32(n). Function names follow Clojure conventions (`conj`, `assoc`, `dissoc`, `merge`, `update`, `get`, `keys`, `vals`, `into`, `group-by`, `frequencies`, …). See the [quick reference](#quick-reference).
 
 ## String Iteration
 
@@ -705,13 +681,4 @@ Signatures and behavior are identical; replace the name.
 
 ---
 
-## Summary
-
-- `conj`: universal add
-- `assoc`: set key-value
-- `*-in`: nested operations
-- `deep-merge`, `dissoc-in`: Phel extensions for nested work
-- Transients: batch update performance
-- Migrate deprecated names to Clojure-compatible ones
-
-See `docs/examples/05_data-structures.phel`.
+See `docs/examples/05_data-structures.phel` for runnable code.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,19 +1,5 @@
 # Common Patterns and Idioms
 
-## Table of Contents
-
-- [Working with Nil](#working-with-nil)
-- [Collection Transformations](#collection-transformations)
-- [Threading Macros](#threading-macros)
-- [Pattern Matching](#pattern-matching)
-- [Error Handling](#error-handling)
-- [State Management](#state-management)
-- [Recursion and Looping](#recursion-and-looping)
-- [Destructuring](#destructuring)
-- [Data Validation](#data-validation)
-- [Writing Macros](#writing-macros)
-- [Build-safe Entry Points](#build-safe-entry-points)
-
 ## Working with Nil
 
 ### Safe Navigation
@@ -622,64 +608,6 @@ Every `defmacro` body has two implicit symbols:
 When the dispatch symbol has no registered method (e.g. `(is (= 1 1))`), the `:default` arm handles binary equality and predicate forms.
 
 > Cross-namespace registration must use fully-qualified `phel.test/assert-expr` so the methods table resolves in `phel.test`, not the local namespace.
-
-## Tips for Writing Idiomatic Phel
-
-### Prefer Higher-Order Functions
-
-```phel
-;; Loop
-(loop [coll [1 2 3 4] result []]
-  (if (empty? coll)
-    result
-    (recur (rest coll) (conj result (* 2 (first coll))))))
-
-;; map
-(map #(* % 2) [1 2 3 4])
-```
-
-### Use Threading for Readability
-
-```phel
-;; Hard to read
-(reduce + (map #(* % 2) (filter even? numbers)))
-
-;; Pipeline
-(->> numbers
-     (filter even?)
-     (map #(* % 2))
-     (reduce +))
-```
-
-### Keep Functions Small
-
-```phel
-(defn process-order [order]
-  (-> order
-      validate-order
-      calculate-total
-      apply-discounts
-      generate-invoice
-      send-confirmation))
-```
-
-### Use Descriptive Names
-
-```phel
-;; Good
-(defn find-active-users [users]
-  (filter :active users))
-
-;; Better
-(defn active-users [users]
-  (filter :active users))
-
-;; Best (with docstring)
-(defn active-users
-  "Returns only active users from the collection."
-  [users]
-  (filter :active users))
-```
 
 ## Build-safe Entry Points
 


### PR DESCRIPTION
## 🤔 Background

`patterns.md` and `data-structures-guide.md` are the two largest docs in `docs/`. Both carry redundant scaffolding that adds line count without adding signal: in-file Tables of Contents (just a list of the headers below), Introduction paragraphs that the lead sentence already covers, trailing Summary sections that restate the body, and generic best-practice tips that the rest of the guide already demonstrates.

## 💡 Goal

Remove the redundant scaffolding. Keep every piece of substantive content.

## 🔖 Changes

- **patterns.md**: drop the in-file Table of Contents and the trailing `Tips for Writing Idiomatic Phel` section (generic prefer-HoF / use-threading / keep-functions-small / use-descriptive-names — already covered by Collection Transformations and Threading Macros sections above).
- **data-structures-guide.md**: drop the in-file Contents, merge the one-paragraph Introduction into the lead, drop the trailing Summary that listed `conj` / `assoc` / `*-in` / transients again. The pointer to `docs/examples/05_data-structures.phel` is retained.

Net: 107 lines removed, no information lost.