### PR TITLE
test: mock claude CLI in upgrade-ecosystem bash tests

### DIFF
--- a/tools/upgrade-ecosystem-test.sh
+++ b/tools/upgrade-ecosystem-test.sh
@@ -17,12 +17,32 @@ SCRIPT="$SCRIPT_DIR/upgrade-ecosystem.sh"
 source "$SCRIPT_DIR/upgrade-ecosystem-lib.sh"
 
 TEMP_DIR=""
+ORIGINAL_PATH=""
+
+# Install a no-op stub for the named binary in $TEMP_DIR/bin and prepend it
+# to PATH. Lets the script's preflight `command -v <bin>` checks pass in
+# environments (such as the CI runner) where the real binary is not
+# installed. The stub exits 0 immediately; tests never exercise code paths
+# that actually invoke claude.
+function _stub_bin() {
+    local name="$1"
+    cat > "$TEMP_DIR/bin/$name" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$TEMP_DIR/bin/$name"
+}
 
 function set_up() {
     TEMP_DIR="$(mktemp -d)"
+    ORIGINAL_PATH="$PATH"
+    mkdir -p "$TEMP_DIR/bin"
+    _stub_bin claude
+    PATH="$TEMP_DIR/bin:$PATH"
 }
 
 function tear_down() {
+    PATH="$ORIGINAL_PATH"
     [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
 }
 


### PR DESCRIPTION
## 🤔 Background

The CI `Bash tests` job has been red on main since `tools/upgrade-ecosystem.sh` started preflight-checking for the `claude` binary on PATH. CI runners do not have `claude` installed, so 10 CLI smoke tests in `tools/upgrade-ecosystem-test.sh` fail with:

```
ERROR: claude CLI not found in PATH
```

## 💡 Goal

Make the upgrade-ecosystem tests hermetic: they should not depend on the real `claude` CLI being installed on the runner.

## 🔖 Changes

- `set_up()` now creates an executable no-op stub at `$TEMP_DIR/bin/claude` and prepends it to `PATH`, so the script's `command -v claude` check passes.
- `tear_down()` restores the original `PATH` and removes the temp directory.
- Added a `_stub_bin <name>` helper for future stubs (e.g. if `gh` is removed from runners).

Locally: `tools/bashunit tools/upgrade-ecosystem-test.sh --simple` → 45 passed, 0 failed.