### PR TITLE
chore: update maintainer email to phel@chemaclass.com

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         },
         {
             "name": "Jose M. Valera Reales",
-            "email": "phel@chemaclass.es",
+            "email": "phel@chemaclass.com",
             "homepage": "https://chemaclass.com"
         }
     ],


### PR DESCRIPTION
## 🤔 Background

The maintainer mailbox `phel@chemaclass.es` is no longer the canonical address.

## 💡 Goal

Point Packagist, Composer metadata, and downstream tooling at the active domain.

## 🔖 Changes

- `composer.json`: `phel@chemaclass.es` → `phel@chemaclass.com` in the maintainer entry.