### PR TITLE
fix(lint): unused-binding false positive in sequential let bindings

### DIFF
--- a/tests/php/Integration/Lint/Fixtures/let_sequential_binding.phel
+++ b/tests/php/Integration/Lint/Fixtures/let_sequential_binding.phel
@@ -1,0 +1,6 @@
+(ns fixtures\let-sequential-binding)
+
+(defn foo []
+  (let [n   (+ 1 2)
+        msg (str "n=" n)]
+    (println msg)))


### PR DESCRIPTION
## 🤔 Background

When using sequential `let` bindings where an earlier binding is referenced only in a later binding's value expression, the linter incorrectly flagged the earlier binding as unused.

```phel
(let [n   (+ 1 2)
      msg (str "n=" n)]  ;; n is used here
  (println msg))
```

`n` would be reported as `phel/unused-binding` despite being used in the value expression of `msg`.

Closes #2018

## 💡 Goal

Fix `UnusedBindingRule` so that a binding is only considered unused if it appears in neither (a) any later binding value expression in the same binding vector, nor (b) the `let` body.

## 🔖 Changes

- **`UnusedBindingRule`**: for each binding symbol at vector position `i`, the usage scan now also walks all subsequent binding values (odd indices `> i` in the binding vector) in addition to the body forms. Previously only body forms (indices `>= 2` in the outer `let` list) were scanned.
- **Unit tests** (`UnusedBindingRuleTest`): added three new test cases:
  - `test_it_does_not_flag_binding_used_in_subsequent_let_binding` — the exact minimal repro from the issue
  - `test_it_flags_binding_unused_in_both_later_bindings_and_body` — ensures genuinely unused bindings still get flagged
  - `test_it_does_not_flag_binding_used_only_in_later_binding_value` — covers a chain where the intermediate binding is used only in the next value
- **Integration test** (`LintCommandTest`): added `test_it_does_not_flag_binding_used_in_subsequent_let_binding` using a new fixture `let_sequential_binding.phel` that mirrors the issue's minimal repro.