### PR TITLE
fix(doctor): bootstrap temp dir before filesystem check

### DIFF
--- a/src/php/Filesystem/Application/TempDirHealthCheck.php
+++ b/src/php/Filesystem/Application/TempDirHealthCheck.php
@@ -10,6 +10,7 @@ use Override;
 
 use function is_dir;
 use function is_writable;
+use function mkdir;
 use function sprintf;
 
 final readonly class TempDirHealthCheck implements ModuleHealthCheckInterface
@@ -28,10 +29,12 @@ final readonly class TempDirHealthCheck implements ModuleHealthCheckInterface
     public function checkHealth(): HealthStatus
     {
         if (!is_dir($this->tempDir)) {
-            return HealthStatus::unhealthy(
-                sprintf('Temp dir does not exist: %s', $this->tempDir),
-                ['path' => $this->tempDir],
-            );
+            if (!@mkdir($this->tempDir, 0777, true) && !is_dir($this->tempDir)) {
+                return HealthStatus::unhealthy(
+                    sprintf('Temp dir could not be created: %s', $this->tempDir),
+                    ['path' => $this->tempDir],
+                );
+            }
         }
 
         if (!is_writable($this->tempDir)) {

--- a/src/php/Filesystem/Application/TempDirHealthCheck.php
+++ b/src/php/Filesystem/Application/TempDirHealthCheck.php
@@ -28,13 +28,11 @@ final readonly class TempDirHealthCheck implements ModuleHealthCheckInterface
     #[Override]
     public function checkHealth(): HealthStatus
     {
-        if (!is_dir($this->tempDir)) {
-            if (!@mkdir($this->tempDir, 0777, true) && !is_dir($this->tempDir)) {
-                return HealthStatus::unhealthy(
-                    sprintf('Temp dir could not be created: %s', $this->tempDir),
-                    ['path' => $this->tempDir],
-                );
-            }
+        if (!is_dir($this->tempDir) && (!@mkdir($this->tempDir, 0777, true) && !is_dir($this->tempDir))) {
+            return HealthStatus::unhealthy(
+                sprintf('Temp dir could not be created: %s', $this->tempDir),
+                ['path' => $this->tempDir],
+            );
         }
 
         if (!is_writable($this->tempDir)) {

--- a/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
+++ b/tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php
@@ -43,6 +43,31 @@ final class DoctorCommandTest extends TestCase
         );
     }
 
+    public function test_doctor_succeeds_when_temp_dir_does_not_exist_yet(): void
+    {
+        $this->resetContainer();
+        $nonExistentTempDir = sys_get_temp_dir() . '/phel-doctor-fresh-' . uniqid('', true);
+
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($nonExistentTempDir): void {
+            $config->addAppConfigKeyValue(PhelConfig::TEMP_DIR, $nonExistentTempDir);
+        });
+
+        self::assertDirectoryDoesNotExist($nonExistentTempDir);
+
+        $command = new DoctorCommand();
+        $exitCode = $command->run(
+            $this->createStub(InputInterface::class),
+            $this->stubOutput(),
+        );
+
+        // Cleanup the bootstrapped dir before assertions can fail
+        if (is_dir($nonExistentTempDir)) {
+            rmdir($nonExistentTempDir);
+        }
+
+        self::assertSame(0, $exitCode, 'doctor should exit 0 even when temp dir did not exist beforehand');
+    }
+
     public function test_doctor_includes_agent_install_section(): void
     {
         $command = new DoctorCommand();

--- a/tests/php/Unit/Filesystem/Application/TempDirHealthCheckTest.php
+++ b/tests/php/Unit/Filesystem/Application/TempDirHealthCheckTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Filesystem\Application;
+
+use Phel\Filesystem\Application\TempDirHealthCheck;
+use PHPUnit\Framework\TestCase;
+
+final class TempDirHealthCheckTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/phel-health-check-test-' . uniqid('', true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+    }
+
+    public function test_it_is_healthy_when_temp_dir_exists_and_is_writable(): void
+    {
+        mkdir($this->tempDir, 0777, true);
+
+        $healthCheck = new TempDirHealthCheck($this->tempDir);
+        $status = $healthCheck->checkHealth();
+
+        self::assertTrue($status->isHealthy());
+    }
+
+    public function test_it_bootstraps_missing_temp_dir_and_reports_healthy(): void
+    {
+        self::assertDirectoryDoesNotExist($this->tempDir);
+
+        $healthCheck = new TempDirHealthCheck($this->tempDir);
+        $status = $healthCheck->checkHealth();
+
+        self::assertTrue($status->isHealthy(), $status->message);
+        self::assertDirectoryExists($this->tempDir);
+    }
+
+    public function test_it_is_unhealthy_when_temp_dir_cannot_be_created(): void
+    {
+        $nonCreatableDir = '/root/phel-health-check-no-permission-' . uniqid('', true);
+
+        // Skip test if running as root (where all dirs are creatable)
+        if (posix_getuid() === 0) {
+            self::markTestSkipped('Cannot test permission failures when running as root.');
+        }
+
+        $healthCheck = new TempDirHealthCheck($nonCreatableDir);
+        $status = $healthCheck->checkHealth();
+
+        self::assertFalse($status->isHealthy());
+    }
+
+    public function test_it_is_unhealthy_when_temp_dir_is_not_writable(): void
+    {
+        // Skip test if running as root (where all dirs are writable)
+        if (posix_getuid() === 0) {
+            self::markTestSkipped('Cannot test permission failures when running as root.');
+        }
+
+        mkdir($this->tempDir, 0555, true);
+
+        $healthCheck = new TempDirHealthCheck($this->tempDir);
+        $status = $healthCheck->checkHealth();
+
+        self::assertFalse($status->isHealthy());
+
+        chmod($this->tempDir, 0755);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel doctor` is the recommended first step to verify a Phel installation. On a fresh checkout or after any temp-dir cleanup (common on CI runners), the configured temp dir (`/tmp/phel/tmp` by default) does not yet exist. Every other phel command creates it lazily, but `TempDirHealthCheck` was doing a bare `is_dir` check without any bootstrap attempt, causing doctor to exit 1 with _"Temp dir does not exist"_ before a single other command had run.

Closes #2020

## 💡 Goal

Make `phel doctor` self-healing for the temp dir: attempt `mkdir -p` before checking existence and writability, matching the lazy-creation behaviour already present in `TempDirFinder`. If creation fails (e.g. permission denied), the check still reports FAIL with an actionable message.

## 🔖 Changes

- `src/php/Filesystem/Application/TempDirHealthCheck.php`: attempt `@mkdir(..., 0777, true)` before the `is_dir` guard; fall through to the existing writability check unchanged. If mkdir fails and the dir still does not exist, return an unhealthy status with the message _"Temp dir could not be created: …"_.
- `tests/php/Unit/Filesystem/Application/TempDirHealthCheckTest.php` _(new)_: four unit tests covering healthy-existing, healthy-bootstrapped-from-nothing, unhealthy-cannot-create, and unhealthy-not-writable scenarios.
- `tests/php/Integration/Run/Command/Doctor/DoctorCommandTest.php`: added `test_doctor_succeeds_when_temp_dir_does_not_exist_yet` — boots Gacela with a non-existent temp dir path and asserts the command returns exit code 0.