### PR TITLE
fix(run): normalize backslash namespaces in Phel::run() facade

### DIFF
--- a/src/php/Run/Application/NamespaceRunner.php
+++ b/src/php/Run/Application/NamespaceRunner.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Resolver\LoadClasspath;
 use Phel\Run\Domain\Runner\NamespaceRunnerInterface;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
+use Phel\Shared\Munge;
 
 final readonly class NamespaceRunner implements NamespaceRunnerInterface
 {
@@ -18,6 +19,10 @@ final readonly class NamespaceRunner implements NamespaceRunnerInterface
 
     public function run(string $namespace): void
     {
+        // Normalize backslash form (e.g. `foo\bar`) to dot form (`foo.bar`) so
+        // that both separators work consistently, matching the CLI RunCommand.
+        $namespace = Munge::canonicalNs($namespace);
+
         $srcDirectories = [
             ...$this->commandFacade->getSourceDirectories(),
             ...$this->commandFacade->getVendorSourceDirectories(),

--- a/tests/php/Unit/Run/Application/NamespaceRunnerTest.php
+++ b/tests/php/Unit/Run/Application/NamespaceRunnerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Application;
+
+use Phel\Build\Domain\Compile\CompiledFile;
+use Phel\Run\Application\NamespaceRunner;
+use Phel\Shared\Facade\BuildFacadeInterface;
+use Phel\Shared\Facade\CommandFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class NamespaceRunnerTest extends TestCase
+{
+    public function test_it_normalizes_backslash_namespace_to_dot_form_before_resolving_dependencies(): void
+    {
+        $capturedNamespaces = [];
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getDependenciesForNamespace')
+            ->willReturnCallback(static function (array $dirs, array $ns) use (&$capturedNamespaces): array {
+                $capturedNamespaces = $ns;
+                return [];
+            });
+        $buildFacade->method('evalFile')
+            ->willReturn(new CompiledFile('', '', '', false));
+
+        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade->method('getSourceDirectories')->willReturn([]);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
+
+        $runner = new NamespaceRunner($commandFacade, $buildFacade);
+        $runner->run('cli-skeleton\\modules\\adder-module');
+
+        self::assertContains(
+            'cli-skeleton.modules.adder-module',
+            $capturedNamespaces,
+            'Backslash namespace must be normalized to dot form before getDependenciesForNamespace is called',
+        );
+        self::assertNotContains(
+            'cli-skeleton\\modules\\adder-module',
+            $capturedNamespaces,
+            'Raw backslash namespace must not be passed to getDependenciesForNamespace',
+        );
+    }
+
+    public function test_it_passes_dot_form_namespace_unchanged(): void
+    {
+        $capturedNamespaces = [];
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getDependenciesForNamespace')
+            ->willReturnCallback(static function (array $dirs, array $ns) use (&$capturedNamespaces): array {
+                $capturedNamespaces = $ns;
+                return [];
+            });
+        $buildFacade->method('evalFile')
+            ->willReturn(new CompiledFile('', '', '', false));
+
+        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade->method('getSourceDirectories')->willReturn([]);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
+
+        $runner = new NamespaceRunner($commandFacade, $buildFacade);
+        $runner->run('cli-skeleton.modules.adder-module');
+
+        self::assertContains(
+            'cli-skeleton.modules.adder-module',
+            $capturedNamespaces,
+            'Dot-form namespace must pass through unchanged',
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`Phel::run($root, $namespace)` and `phel run <ns>` both accept namespace strings, but only the CLI was normalizing backslash separators to dot form before resolving dependencies. When a caller passed the backslash form (the exact text from a `(ns ...)` header, e.g. `cli-skeleton\modules\adder-module`), `NamespaceRunner::run()` forwarded it unchanged to `getDependenciesForNamespace()`, which keys on dot-form. The result: zero deps resolved, zero files loaded, no error, and any subsequent `Phel::getDefinition()` returned `null` — crashing `PhelCallerTrait::callPhel()` with "Value of type null is not callable".

Closes #2021

## 💡 Goal

Make `Phel::run()` (and the `NamespaceRunner` it delegates to) accept both `foo\bar` and `foo.bar` namespace forms, consistent with the CLI `RunCommand` path.

## 🔖 Changes

- `src/php/Run/Application/NamespaceRunner.php`: call `Munge::canonicalNs()` at the top of `run()` to normalize `\` → `.` before any dependency lookup, mirroring what `RunCommand` already does via the same utility.
- `tests/php/Unit/Run/Application/NamespaceRunnerTest.php`: two new unit tests covering the normalization behaviour (RED → GREEN driven):
  - `test_it_normalizes_backslash_namespace_to_dot_form_before_resolving_dependencies`
  - `test_it_passes_dot_form_namespace_unchanged`