### PR TITLE
fix(format): append trailing newline to formatted files

### DIFF
--- a/src/php/Formatter/Application/Formatter.php
+++ b/src/php/Formatter/Application/Formatter.php
@@ -31,8 +31,9 @@ final readonly class Formatter implements FormatterInterface
     {
         $tokenStream = $this->compilerFacade->lexString($string, $source);
         $fileNode = $this->compilerFacade->parseAll($tokenStream);
+        $formatted = $this->formatNode($fileNode)->getCode();
 
-        return $this->formatNode($fileNode)->getCode();
+        return rtrim($formatted, "\n") . "\n";
     }
 
     /**

--- a/tests/php/Integration/Formatter/FormatterFacadeTest.php
+++ b/tests/php/Integration/Formatter/FormatterFacadeTest.php
@@ -31,7 +31,7 @@ final class FormatterFacadeTest extends TestCase
             ->createFormatter()
             ->format(implode("\n", $actualLines));
 
-        self::assertEquals($expectedLines, explode("\n", $formatted));
+        self::assertEquals($expectedLines, explode("\n", rtrim($formatted, "\n")));
     }
 
     public static function providerIndent(): Generator
@@ -473,6 +473,26 @@ final class FormatterFacadeTest extends TestCase
             ],
             ['(foo)'],
         ];
+    }
+
+    public function test_format_appends_trailing_newline_when_missing(): void
+    {
+        $formatted = $this->formatterFactory
+            ->createFormatter()
+            ->format("(ns demo)\n(defn foo []\n  (println 1))");
+
+        self::assertStringEndsWith("\n", $formatted);
+    }
+
+    public function test_format_does_not_double_trailing_newline_when_already_present(): void
+    {
+        $source = "(ns demo)\n(defn foo []\n  (println 1))\n";
+        $formatted = $this->formatterFactory
+            ->createFormatter()
+            ->format($source);
+
+        self::assertStringEndsWith("\n", $formatted);
+        self::assertStringEndsNotWith("\n\n", $formatted);
     }
 
     public static function providerRemoveTrailingWhitespaceRule(): Generator


### PR DESCRIPTION
## 🤔 Background

`phel format` rewrites indentation correctly but never ensured the output ends with a newline. Files lacking a trailing `\n` before formatting still lacked one after, producing POSIX violations, EditorConfig `insert_final_newline = true` violations, and `\ No newline at end of file` noise in every git diff.

Closes #2022

## 💡 Goal

`phel format` should behave like `gofmt`, `rustfmt`, `prettier`, `phpcs --fix`, and `cljfmt`: always emit exactly one trailing newline, regardless of whether the input had one.

## 🔖 Changes

- `Formatter::format()` now strips any trailing newlines from the formatted output and appends exactly one `\n` before returning, so callers (file writer and in-memory `formatString`) both benefit automatically.
- Updated `FormatterFacadeTest::test_format()` to `rtrim` before splitting on `\n`, keeping the data-provider cases focused on indentation/whitespace rules rather than trailing-newline behaviour.
- Added two dedicated tests:
  - `test_format_appends_trailing_newline_when_missing` — guards the bug fix (was the failing RED test).
  - `test_format_does_not_double_trailing_newline_when_already_present` — guards against double-newline regression.