### PR TITLE
fix(test): non-zero exit when --filter matches zero tests

### DIFF
--- a/src/php/Run/Infrastructure/Command/TestCommand.php
+++ b/src/php/Run/Infrastructure/Command/TestCommand.php
@@ -253,7 +253,16 @@ final class TestCommand extends Command
                 return self::FAILURE;
             }
 
-            return ($result) ? self::SUCCESS : self::FAILURE;
+            $successful = (bool) $result[0];
+            $total = (int) $result[1];
+
+            if ($this->isNoMatchWithSelectors($total, $options)) {
+                $output->writeln('<error>No tests matched the given selectors.</error>');
+
+                return self::FAILURE;
+            }
+
+            return $successful ? self::SUCCESS : self::FAILURE;
         } catch (CompilerException $e) {
             $this->getFacade()->writeLocatedException($output, $e);
         } catch (Throwable $e) {
@@ -261,6 +270,33 @@ final class TestCommand extends Command
         }
 
         return self::FAILURE;
+    }
+
+    /**
+     * Returns true when at least one test-narrowing selector was active AND zero tests ran.
+     * Only selectors that narrow the test set are checked (--filter, --ns, --include,
+     * --exclude, --last-failed / --only-tests). Structural options (--fail-fast, --reporter,
+     * etc.) are ignored.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function isNoMatchWithSelectors(int $total, array $options): bool
+    {
+        if ($total > 0) {
+            return false;
+        }
+
+        $filters = $options[TestCommandOptions::FILTERS] ?? [];
+        $nsPatterns = $options[TestCommandOptions::NS_PATTERNS] ?? [];
+        $includes = $options[TestCommandOptions::INCLUDE] ?? [];
+        $excludes = $options[TestCommandOptions::EXCLUDE] ?? [];
+        $onlyTests = $options[TestCommandOptions::ONLY_TESTS] ?? [];
+
+        return $filters !== []
+            || $nsPatterns !== []
+            || $includes !== []
+            || $excludes !== []
+            || $onlyTests !== [];
     }
 
     /**
@@ -294,7 +330,7 @@ final class TestCommand extends Command
     private function generatePhelTestCodeFromOptions(array $options, array $namespacesInformation): string
     {
         return sprintf(
-            '(do (phel\test/run-tests %s %s) (phel\test/successful?))',
+            '(do (phel\test/run-tests %s %s) [(phel\test/successful?) (get (get (phel\test/get-stats) :counts) :total)])',
             TestCommandOptions::fromArray($options)->asPhelHashMap(),
             $this->namespacesAsString($namespacesInformation),
         );

--- a/tests/php/Unit/Run/Infrastructure/Command/TestCommandFilterNoMatchesTest.php
+++ b/tests/php/Unit/Run/Infrastructure/Command/TestCommandFilterNoMatchesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Run\Infrastructure\Command;
+
+use Phel\Run\Domain\Test\TestCommandOptions;
+use Phel\Run\Infrastructure\Command\TestCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+
+final class TestCommandFilterNoMatchesTest extends TestCase
+{
+    // --- isNoMatchWithSelectors ---
+
+    public function test_no_selector_zero_total_is_not_a_no_match(): void
+    {
+        self::assertFalse($this->isNoMatch(0, []));
+    }
+
+    public function test_filter_selector_zero_total_is_a_no_match(): void
+    {
+        self::assertTrue($this->isNoMatch(0, [
+            TestCommandOptions::FILTERS => ['zzz-no-such-test'],
+        ]));
+    }
+
+    public function test_ns_selector_zero_total_is_a_no_match(): void
+    {
+        self::assertTrue($this->isNoMatch(0, [
+            TestCommandOptions::NS_PATTERNS => ['zzz.**'],
+        ]));
+    }
+
+    public function test_include_selector_zero_total_is_a_no_match(): void
+    {
+        self::assertTrue($this->isNoMatch(0, [
+            TestCommandOptions::INCLUDE => ['integration'],
+        ]));
+    }
+
+    public function test_exclude_selector_zero_total_is_a_no_match(): void
+    {
+        self::assertTrue($this->isNoMatch(0, [
+            TestCommandOptions::EXCLUDE => ['slow'],
+        ]));
+    }
+
+    public function test_only_tests_selector_zero_total_is_a_no_match(): void
+    {
+        self::assertTrue($this->isNoMatch(0, [
+            TestCommandOptions::ONLY_TESTS => ['some-ns/some-test'],
+        ]));
+    }
+
+    public function test_filter_selector_nonzero_total_is_not_a_no_match(): void
+    {
+        self::assertFalse($this->isNoMatch(3, [
+            TestCommandOptions::FILTERS => ['my-test'],
+        ]));
+    }
+
+    public function test_structural_options_only_zero_total_is_not_a_no_match(): void
+    {
+        self::assertFalse($this->isNoMatch(0, [
+            TestCommandOptions::TESTDOX => true,
+            TestCommandOptions::FAIL_FAST => true,
+            TestCommandOptions::REPORTERS => ['dot'],
+        ]));
+    }
+
+    // --- exit-code constants are self::FAILURE on no-match ---
+
+    public function test_failure_constant_is_non_zero(): void
+    {
+        self::assertSame(Command::FAILURE, 1);
+    }
+
+    // --- helpers ---
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function isNoMatch(int $total, array $options): bool
+    {
+        $method = new ReflectionMethod(TestCommand::class, 'isNoMatchWithSelectors');
+
+        return (bool) $method->invoke(new TestCommand(), $total, $options);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`phel test --filter zzz-no-such-test` exits 0 even when zero tests match the pattern. CI treats this as a green build, silently masking typos in filter patterns or path-based test selection that misfires.

Closes #2023

## 💡 Goal

Exit non-zero (1) and print `No tests matched the given selectors.` whenever a narrowing selector (`--filter`, `--ns`, `--include`, `--exclude`, `--last-failed`) is active and zero tests actually ran. Runs with no selectors keep the existing exit-0 behaviour.

## 🔖 Changes

- **`TestCommand::generatePhelTestCodeFromOptions`**: changed the Phel eval snippet return value from `(successful?)` (bool) to `[(successful?) total]` (vector), so PHP can inspect the run count without a second eval call.
- **`TestCommand::isNoMatchWithSelectors`**: new private pure method — returns `true` when `$total === 0` AND at least one narrowing selector was present. Structural options (`--fail-fast`, `--reporter`, etc.) are not counted as selectors.
- **`TestCommand::execute`**: checks `isNoMatchWithSelectors` after the run; on match writes the error message to output and returns `self::FAILURE`.
- **`TestCommandFilterNoMatchesTest`** (unit): 9 tests covering every selector type (filter, ns, include, exclude, only-tests), the non-zero-total short-circuit, the structural-options-only case, and the FAILURE constant value.