### PR TITLE
fix(lint): invalidate cache when phel-lint.phel changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `phel lint`: cache fingerprint now includes the resolved `RuleSettings` (severities + exclude patterns), so editing `phel-lint.phel` automatically invalidates stale cache entries without requiring `--no-cache`. (#2027)
+
 ### Added
 
 - `phel.edn`: eval-free EDN read/write. See [docs/data-formats.md](docs/data-formats.md). (#2008)

--- a/src/php/Lint/Application/Config/RuleSettings.php
+++ b/src/php/Lint/Application/Config/RuleSettings.php
@@ -9,6 +9,11 @@ use Phel\Api\Transfer\Diagnostic;
 use function array_key_exists;
 use function fnmatch;
 use function in_array;
+use function json_encode;
+use function ksort;
+use function md5;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Per-rule severities plus opt-out patterns. Values are the constants
@@ -35,6 +40,22 @@ final readonly class RuleSettings
         public array $severities,
         public array $excludeGlobs = [],
     ) {}
+
+    /**
+     * Deterministic hash of the effective settings (severities + exclude
+     * patterns). Used by LintCache to detect config changes independently of
+     * which rule codes are registered.
+     */
+    public function fingerprint(): string
+    {
+        $severities = $this->severities;
+        ksort($severities);
+
+        $globs = $this->excludeGlobs;
+        ksort($globs);
+
+        return md5(json_encode([$severities, $globs], JSON_THROW_ON_ERROR));
+    }
 
     /**
      * @param array<string, string> $map

--- a/src/php/Lint/CLAUDE.md
+++ b/src/php/Lint/CLAUDE.md
@@ -15,7 +15,7 @@ Read-only semantic linter built on top of `ApiFacade`: emits diagnostics on Phel
 - `loadSettings(string $configPath, RuleSettings $defaults): RuleSettings`
 - `defaultSettings(): RuleSettings`
 - `formatters(): FormatterRegistry`
-- `createCache(string $baseDir): LintCache`
+- `createCache(string $baseDir, RuleSettings $settings): LintCache`
 
 ## CLI Command
 
@@ -92,6 +92,6 @@ Lint/
 - Semantic diagnostics (`unresolved-symbol`, analyzer-detected `arity-mismatch`) are fetched via `ApiFacade::analyzeSource` and shared across rules through `FileAnalysis::$semanticDiagnostics` so the analyzer runs once per file
 - Rule pipeline is open/closed: `LintFactory::createRules()` is the only edit point to add a rule
 - `FormatterRegistry` is also open/closed: register new formatter names without editing existing ones
-- `LintCache` fingerprint is derived from `RuleRegistry::allCodes()` : adding/removing rules auto-invalidates the cache
+- `LintCache` fingerprint combines `RuleRegistry::allCodes()` with `RuleSettings::fingerprint()` (severities + exclude patterns): adding/removing rules OR editing `phel-lint.phel` auto-invalidates the cache
 - Failing rules are isolated in `RulePipeline`: one bad rule never kills the run
 - `DuplicateKeyRule` scans the parse tree (not read forms) because the reader silently de-duplicates map literals

--- a/src/php/Lint/Infrastructure/Command/LintCommand.php
+++ b/src/php/Lint/Infrastructure/Command/LintCommand.php
@@ -115,7 +115,7 @@ final class LintCommand extends Command
         }
 
         $settings = $this->loadSettings($input);
-        $cache = $this->maybeCache($input);
+        $cache = $this->maybeCache($input, $settings);
 
         // Load phel core so analyzeSource() resolves core symbols like
         // `defn`, `let`, etc. Without this the linter's first diagnostic
@@ -184,7 +184,7 @@ final class LintCommand extends Command
         return rtrim($cwd, '/') . '/' . LintConfig::defaultConfigFilename();
     }
 
-    private function maybeCache(InputInterface $input): ?LintCache
+    private function maybeCache(InputInterface $input, RuleSettings $settings): ?LintCache
     {
         if ($input->getOption(self::OPT_NO_CACHE)) {
             return null;
@@ -198,6 +198,6 @@ final class LintCommand extends Command
         PhelProjectDirectory::ensure($cwd);
         $cacheDir = PhelProjectDirectory::path($cwd, LintConfig::CACHE_SUBPATH);
 
-        return $this->getFacade()->createCache($cacheDir);
+        return $this->getFacade()->createCache($cacheDir, $settings);
     }
 }

--- a/src/php/Lint/LintFacade.php
+++ b/src/php/Lint/LintFacade.php
@@ -42,8 +42,8 @@ final class LintFacade extends AbstractFacade
         return $this->getFactory()->createFormatterRegistry();
     }
 
-    public function createCache(string $baseDir): LintCache
+    public function createCache(string $baseDir, RuleSettings $settings): LintCache
     {
-        return $this->getFactory()->createLintCache($baseDir);
+        return $this->getFactory()->createLintCache($baseDir, $settings);
     }
 }

--- a/src/php/Lint/LintFactory.php
+++ b/src/php/Lint/LintFactory.php
@@ -107,9 +107,9 @@ final class LintFactory extends AbstractFactory
         return new FileCollector();
     }
 
-    public function createLintCache(string $cacheDir): LintCache
+    public function createLintCache(string $cacheDir, RuleSettings $settings): LintCache
     {
-        return new LintCache($cacheDir, $this->ruleFingerprint());
+        return new LintCache($cacheDir, $this->ruleFingerprint($settings));
     }
 
     public function getApiFacade(): ApiFacade
@@ -133,14 +133,15 @@ final class LintFactory extends AbstractFactory
     }
 
     /**
-     * Deterministic fingerprint covering the rule set. Drives cache
-     * invalidation when rules are added, removed, or reordered.
+     * Deterministic fingerprint covering the rule set AND the resolved
+     * settings (severities + exclude patterns). Drives cache invalidation
+     * when rules are added/removed OR when phel-lint.phel is edited.
      */
-    private function ruleFingerprint(): string
+    private function ruleFingerprint(RuleSettings $settings): string
     {
         $codes = RuleRegistry::allCodes();
         sort($codes);
 
-        return md5(implode('|', $codes));
+        return md5(implode('|', $codes) . '|' . $settings->fingerprint());
     }
 }

--- a/tests/php/Integration/Lint/LintCacheFingerprintTest.php
+++ b/tests/php/Integration/Lint/LintCacheFingerprintTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Lint;
+
+use Phel;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Lint\Infrastructure\Command\LintCommand;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_map;
+use function chdir;
+use function file_put_contents;
+use function getcwd;
+use function is_dir;
+use function json_decode;
+use function mkdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Verifies that changing phel-lint.phel config (severities or exclude
+ * patterns) invalidates the cache so a second run without --no-cache
+ * reflects the updated config.
+ */
+final class LintCacheFingerprintTest extends TestCase
+{
+    private string $projectRoot;
+
+    private string $configPath;
+
+    private string|false $originalCwd;
+
+    protected function setUp(): void
+    {
+        $this->originalCwd = getcwd();
+        $this->projectRoot = sys_get_temp_dir() . '/phel-lint-fp-' . uniqid('', true);
+        $this->configPath = $this->projectRoot . '/phel-lint.phel';
+        mkdir($this->projectRoot, 0o777, true);
+
+        file_put_contents(
+            $this->projectRoot . '/unused_binding.phel',
+            "(ns fixtures\\unused-binding)\n\n(defn demo []\n  (let [x 1\n        y 2]\n    y))\n",
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalCwd !== false) {
+            chdir($this->originalCwd);
+        }
+
+        $this->removeDir($this->projectRoot);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_cache_is_invalidated_when_severity_changes_to_off(): void
+    {
+        chdir($this->projectRoot);
+        $this->bootstrap();
+
+        $fixture = $this->projectRoot . '/unused_binding.phel';
+
+        // First run: default config — unused-binding should produce a warning
+        $firstResult = $this->runLint($fixture);
+        $codes = array_map(static fn(array $d): string => $d['code'], $firstResult);
+        self::assertContains(
+            'phel/unused-binding',
+            $codes,
+            'First run must report unused-binding diagnostic',
+        );
+
+        // Change config: disable unused-binding entirely
+        file_put_contents($this->configPath, "{:rules {:phel/unused-binding :off}}\n");
+
+        // Second run WITHOUT --no-cache — must reflect the new config
+        $secondResult = $this->runLint($fixture, $this->configPath);
+        $codes = array_map(static fn(array $d): string => $d['code'], $secondResult);
+        self::assertNotContains(
+            'phel/unused-binding',
+            $codes,
+            'Second run must not report unused-binding after config sets it to :off — cache must have been invalidated',
+        );
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_cache_is_invalidated_when_exclude_pattern_added(): void
+    {
+        chdir($this->projectRoot);
+        $this->bootstrap();
+
+        $fixture = $this->projectRoot . '/unused_binding.phel';
+
+        // First run: no exclusions — expect the warning
+        $firstResult = $this->runLint($fixture);
+        $codes = array_map(static fn(array $d): string => $d['code'], $firstResult);
+        self::assertContains(
+            'phel/unused-binding',
+            $codes,
+            'First run must report unused-binding diagnostic',
+        );
+
+        // Add an :exclude pattern that matches the fixture file
+        file_put_contents(
+            $this->configPath,
+            "{:exclude {:phel/unused-binding [\"*/unused_binding.phel\"]}}\n",
+        );
+
+        // Second run WITHOUT --no-cache — must respect the exclude
+        $secondResult = $this->runLint($fixture, $this->configPath);
+        $codes = array_map(static fn(array $d): string => $d['code'], $secondResult);
+        self::assertNotContains(
+            'phel/unused-binding',
+            $codes,
+            'Second run must suppress unused-binding after exclude pattern added — cache must have been invalidated',
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function runLint(string $fixture, ?string $configPath = null): array
+    {
+        $args = [
+            'paths' => [$fixture],
+            '--format' => 'json',
+        ];
+        if ($configPath !== null) {
+            $args['--config'] = $configPath;
+        }
+
+        $tester = new CommandTester(new LintCommand());
+        $tester->execute($args);
+
+        $payload = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($payload, 'Lint output must be a JSON array. Got: ' . $tester->getDisplay());
+
+        return $payload;
+    }
+
+    private function bootstrap(): void
+    {
+        Phel::bootstrap($this->projectRoot);
+        Phel::clear();
+        Symbol::resetGen();
+        GlobalEnvironmentSingleton::initializeNew();
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir) ?: [];
+        foreach ($entries as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+            if ($entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/php/Integration/Lint/LintCacheFingerprintTest.php
+++ b/tests/php/Integration/Lint/LintCacheFingerprintTest.php
@@ -166,9 +166,11 @@ final class LintCacheFingerprintTest extends TestCase
             if ($entry === '.') {
                 continue;
             }
+
             if ($entry === '..') {
                 continue;
             }
+
             $path = $dir . '/' . $entry;
             if (is_dir($path)) {
                 $this->removeDir($path);

--- a/tests/php/Unit/Lint/Application/Config/RuleSettingsTest.php
+++ b/tests/php/Unit/Lint/Application/Config/RuleSettingsTest.php
@@ -71,4 +71,43 @@ final class RuleSettingsTest extends TestCase
         self::assertSame(RuleSettings::SEVERITY_OFF, $settings->severityFor('phel/nope'));
         self::assertFalse($settings->isEnabled('phel/nope'));
     }
+
+    public function test_fingerprint_is_stable_for_identical_settings(): void
+    {
+        $a = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: [RuleRegistry::UNUSED_BINDING => ['src/*.phel']],
+        );
+        $b = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: [RuleRegistry::UNUSED_BINDING => ['src/*.phel']],
+        );
+
+        self::assertSame($a->fingerprint(), $b->fingerprint());
+    }
+
+    public function test_fingerprint_changes_when_severity_changes(): void
+    {
+        $base = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+        );
+        $changed = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => RuleSettings::SEVERITY_OFF],
+        );
+
+        self::assertNotSame($base->fingerprint(), $changed->fingerprint());
+    }
+
+    public function test_fingerprint_changes_when_exclude_pattern_added(): void
+    {
+        $base = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+        );
+        $withExclude = new RuleSettings(
+            severities: [RuleRegistry::UNUSED_BINDING => Diagnostic::SEVERITY_WARNING],
+            excludeGlobs: [RuleRegistry::UNUSED_BINDING => ['src/*.phel']],
+        );
+
+        self::assertNotSame($base->fingerprint(), $withExclude->fingerprint());
+    }
 }


### PR DESCRIPTION
## 🤔 Background

`phel lint` stores per-file diagnostics in `.phel/lint-cache/index.json`. Each entry is keyed by the file's MD5 hash and a fingerprint that previously only covered `RuleRegistry::allCodes()`. Editing `phel-lint.phel` (changing a severity to `:off`, or adding an `:exclude` pattern) did not change the fingerprint, so the cache returned stale results on the next run — users saw identical diagnostics until they either passed `--no-cache`, edited a source file, or added/removed a rule.

## 💡 Goal

Make `phel lint` automatically honour any change to `phel-lint.phel` by including the resolved `RuleSettings` (effective severities + exclude patterns) in the cache fingerprint.

Closes #2027

## 🔖 Changes

- **`RuleSettings::fingerprint()`** (new method): deterministic MD5 of the ksorted severities and excludeGlobs maps. Lives in the domain object so it is independent of file I/O and trivially unit-testable.
- **`LintFactory::ruleFingerprint(RuleSettings)`**: combines the existing rule-codes hash with `$settings->fingerprint()`. The parameter is threaded from `createLintCache()`.
- **`LintFacade::createCache(string, RuleSettings)`**: updated signature — callers must now supply the resolved settings.
- **`LintCommand::maybeCache(InputInterface, RuleSettings)`**: `execute()` resolves settings first, then passes them to `maybeCache()`, which forwards to the facade. No behavioural change on the happy path — settings were already loaded before the cache was consulted.
- **Two integration tests** (`LintCacheFingerprintTest`): run lint twice on the same fixture without `--no-cache`; mutate the config between runs; assert the second run reflects the updated config. Cover both the severity→`:off` case and the `:exclude` pattern case.
- **Three unit tests** added to `RuleSettingsTest`: stability (same settings → same hash), severity change, and exclude-pattern change.
- **`src/php/Lint/CLAUDE.md`**: updated `createCache` signature and cache fingerprint description.
- **`CHANGELOG.md`**: entry added under `## Unreleased → Fixed`.

**Refactor pass findings**: zero naming drift or SOLID violations found in touched production code. The only changes in the `ref` commit are the three new `fingerprint()` unit tests (missing coverage on a new public method) and the CLAUDE.md doc update (stale API signature).