### PR TITLE
fix(cli): use Application::addCommand() when available (Symfony 8 compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel.cli`: `application` now calls `Application::addCommand()` (Symfony 8 compat) instead of the deprecated `add()` (#2033)
 - `phel lint`: cache invalidates when `phel-lint.phel` changes (#2027)
 - `phel lint`: `unused-binding` no longer flags symbols used in later let bindings (#2018)
 - `phel doctor`: auto-bootstraps temp dir; passes on fresh installs (#2020)

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -431,8 +431,12 @@
               (fn? (get spec :on-error)))
       (php/-> app (setDispatcher (build-dispatcher spec))))
     (register-signals app (or (get spec :on-signal) {}))
-    (foreach [c (get spec :commands [])]
-      (php/-> app (add (command c))))
+    (let [has-add-command (php/method_exists app "addCommand")]
+      (foreach [c (get spec :commands [])]
+        (let [cmd (command c)]
+          (if has-add-command
+            (php/-> app (addCommand cmd))
+            (php/-> app (add cmd))))))
     (when-let [d (get spec :default)]
       (php/-> app (setDefaultCommand d)))
     app))

--- a/tests/phel/cli.phel
+++ b/tests/phel/cli.phel
@@ -157,3 +157,25 @@
 (deftest test-output-contains-with-string
   (is (cli/output-contains? "foo bar baz" "bar"))
   (is (not (cli/output-contains? "foo bar baz" "qux"))))
+
+;; ---------------------------------------------------------------------------
+;; Symfony 8 compatibility: addCommand() preferred over deprecated add()
+;; ---------------------------------------------------------------------------
+
+(deftest test-application-uses-addcommand-when-available
+  ; Symfony 7.4 deprecated add() in favour of addCommand().
+  ; Capture any deprecation triggered while building the application and
+  ; assert that none mention Application::add().
+  ; Use an atom so the error-handler closure captures a reference-stable cell.
+  (let [deprecations (atom [])
+        _            (php/set_error_handler
+                      (fn [_ msg _ _]
+                        (swap! deprecations conj msg)
+                        true))
+        _            (cli/application {:name "t"
+                                       :commands [{:name "hi"
+                                                   :run  (fn [_] 0)}]})
+        _            (php/restore_error_handler)
+        found        (filter (fn [msg] (php/str_contains msg "Application::add()"))
+                             @deprecations)]
+    (is (= [] found) "no deprecation for Application::add() — addCommand() used instead")))


### PR DESCRIPTION
## 🤔 Background

`symfony/console` 7.4 deprecated `Application::add()` with a `#[Deprecated]` annotation and 8.0 removed it entirely. Any project that lets Composer resolve `symfony/console:^8.0` hits:

```
Call to undefined method Symfony\Component\Console\Application::add()
```

The current `composer.json` constraint is `^6.0|^7.0|^8.0`, so both old and new versions must be handled at runtime.

## 💡 Goal

Replace the `add()` call in `phel.cli/application` with `addCommand()` when it exists (Symfony ≥7.4), falling back to `add()` for Symfony 6–7.3.

## 🔖 Changes

- `src/phel/cli.phel` — in the `application` function, detect `addCommand` once via `php/method_exists` (hoisted outside the command loop), then dispatch to either `addCommand` or `add`.
- `tests/phel/cli.phel` — new `test-application-uses-addcommand-when-available`: installs a PHP error handler via an atom-backed closure (to avoid the PHP pass-by-value capture trap), builds an application with one command, and asserts no deprecation mentioning `Application::add()` was raised. This test is **RED** on the pre-fix code and **GREEN** after.
- `CHANGELOG.md` — entry under `## Unreleased → ### Fixed`.

**Refactor pass**: the `method_exists` check was already hoisted outside the loop in the same pass as the fix; no structural issues remain in the touched files. No separate `ref:` commit was needed.

Closes #2033