### PR TITLE
feat(ci): run clojure-test-suite against dev HEAD

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -1,0 +1,63 @@
+name: clojure-test-suite
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      suite-ref:
+        description: 'Ref of phel-lang/clojure-test-suite to run'
+        required: false
+        default: 'main'
+
+jobs:
+  run-clojure-test-suite:
+    name: Run clojure-test-suite (PHP 8.4)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout phel-lang
+        uses: actions/checkout@v4
+        with:
+          path: phel
+
+      - name: Checkout clojure-test-suite
+        uses: actions/checkout@v4
+        with:
+          repository: phel-lang/clojure-test-suite
+          ref: ${{ github.event.inputs.suite-ref || 'main' }}
+          path: clojure-test-suite
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          coverage: none
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-suite-${{ hashFiles('clojure-test-suite/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-suite-
+
+      - name: Point suite at local Phel checkout
+        working-directory: clojure-test-suite
+        run: |
+          composer config repositories.phel-local path ../phel
+          composer config minimum-stability dev
+          composer config prefer-stable true
+          composer require --no-update phel-lang/phel-lang:@dev
+
+      - name: Install suite dependencies
+        working-directory: clojure-test-suite
+        run: composer update --no-interaction --no-ansi --no-progress
+
+      - name: Run clojure-test-suite
+        working-directory: clojure-test-suite
+        run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `tools/upgrade-ecosystem.sh`: bumps phel-lang across sibling repos via Claude Code
 - `composer test-tools`: bashunit runner for `tools/*-test.sh`
 - `CITATION.cff` for academic citation (#2016)
+- CI: `clojure-test-suite` workflow runs `phel-lang/clojure-test-suite` against dev HEAD on every PR (non-blocking) (#2036)
 
 ### Changed
 


### PR DESCRIPTION
## 🤔 Background

[`jank-lang/clojure-test-suite`](https://github.com/jank-lang/clojure-test-suite) is the cross-dialect Clojure compliance suite. A Phel fork lives at [`phel-lang/clojure-test-suite`](https://github.com/phel-lang/clojure-test-suite). Today the fork's own CI only validates Phel **releases** (via `phel-lang/phel-lang: ^0.39` on Packagist), so dev-HEAD regressions slip through until they ship.

Upstream jank's CI currently disables the Phel job while parity reporting is sorted out, so the burden falls on this repo to catch regressions early. This implements **option B** from #2036: pull the suite into Phel's CI so every PR exercises it against the working tree.

## 💡 Goal

Catch regressions against the `clojure-test-suite` Phel fork on every PR / push to `main`, without letting external suite drift break unrelated PRs.

## 🔖 Changes

- New workflow `.github/workflows/run-clojure-test-suite.yml`:
  - Triggers on `pull_request`, `push: [main]`, and `workflow_dispatch` (with an optional `suite-ref` input for ad-hoc runs against a specific suite ref)
  - Checks out `phel-lang/phel-lang` and `phel-lang/clojure-test-suite` side-by-side
  - Points the suite's composer at the local Phel via `composer config repositories.phel-local path ../phel` + `phel-lang/phel-lang:@dev`
  - Runs `composer test` (PHP 8.4)
  - `continue-on-error: true` — failures show in logs/summary but do **not** block unrelated PRs. Tighten later once parity stabilises.
- `CHANGELOG.md` — `## Unreleased` → `### Added` entry.

### Verification

Local dry-run (`composer require @dev` path-repo wiring, then `composer test`) against the current `main` HEAD: **4692 passed, 0 failed, 0 errors** in ~14s.

### Final review pass

Re-reviewed the diff: no duplication, no dead branches, action versions match the surrounding `ci.yml` (`actions/checkout@v4`, `shivammathur/setup-php@v2`, `actions/cache@v4`). No `ref:` polish commit needed.

### Out of scope

- Splitting `ci.yml` into per-job files (separate refactor).
- Tightening to a hard fail once the suite stays green long enough.
- Parity-reporting (pass/fail counts per namespace) — track upstream solution.

Closes #2036