### PR TITLE
ref(ci): extract composite action + split ci.yml into quality/tests/smoke

### DIFF
--- a/.github/actions/setup-phel/action.yml
+++ b/.github/actions/setup-phel/action.yml
@@ -1,0 +1,48 @@
+name: Setup Phel
+description: Checkout repo, install PHP, restore Composer cache, install dependencies.
+
+inputs:
+  php-version:
+    description: PHP version to install
+    required: false
+    default: "8.4"
+  coverage:
+    description: PHP coverage driver (none, xdebug, pcov)
+    required: false
+    default: none
+  ini-values:
+    description: Comma-separated php.ini values
+    required: false
+    default: ""
+  composer-args:
+    description: Extra arguments for composer install
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        coverage: ${{ inputs.coverage }}
+        ini-values: ${{ inputs.ini-values }}
+        tools: composer
+
+    - name: Get composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-php${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php${{ inputs.php-version }}-composer-
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      shell: bash
+      run: composer install --no-interaction --no-ansi --no-progress ${{ inputs.composer-args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,26 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Run friendsofphp/php-cs-fixer
         run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --show-progress=dots --using-cache=no --verbose
@@ -59,26 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Run Psalm on internal code
         run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=${{ matrix.php }}
@@ -95,26 +57,9 @@ jobs:
         php: [ '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-phel
         with:
           php-version: ${{ matrix.php }}
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
 
       - name: Run unit tests to the compiler itself
         run: vendor/bin/phpunit --testsuite unit
@@ -131,26 +76,9 @@ jobs:
         php: [ '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-phel
         with:
           php-version: ${{ matrix.php }}
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
 
       - name: Run tests to the core library
         run: composer run-script test-core
@@ -160,26 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Run PHPBench
         run: vendor/bin/phpbench run --iterations=3 --warmup=1 --report=aggregate
@@ -189,26 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Run all example scripts
         run: |
@@ -227,26 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Validate .agents/ examples and core reference drift
         run: composer test-agents
@@ -256,27 +127,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-phel
         with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
           ini-values: phar.readonly=0
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
 
       - name: Build PHAR
         run: ./build/phar.sh
@@ -344,26 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+      - uses: ./.github/actions/setup-phel
 
       - name: Run Bashunit tests
         run: tools/bashunit tools/*-test.sh --simple

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,49 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+on:
+  - pull_request
+  - push
+
+name: Quality
+
+jobs:
+  composer-validate:
+    name: Validate composer configuration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          coverage: none
+          tools: composer
+
+      - name: Validate composer configuration
+        run: composer validate --strict --quiet --no-interaction --no-check-all --no-check-lock
+
+  coding-guidelines:
+    name: Coding Guidelines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+
+      - name: Run friendsofphp/php-cs-fixer
+        run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --show-progress=dots --using-cache=no --verbose
+
+      - name: Run rector/rector
+        run: ./vendor/bin/rector process --dry-run --config=rector.php
+
+  type-checker:
+    name: Type Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+
+      - name: Run Psalm on internal code
+        run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=${{ matrix.php }}
+
+      - name: Run PHPStan on internal code
+        run: ./vendor/bin/phpstan --memory-limit=516M --debug -vvv

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,10 +1,18 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
-on:
-  - pull_request
-  - push
-
 name: Quality
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   composer-validate:
@@ -43,7 +51,7 @@ jobs:
       - uses: ./.github/actions/setup-phel
 
       - name: Run Psalm on internal code
-        run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=${{ matrix.php }}
+        run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=8.4
 
       - name: Run PHPStan on internal code
         run: ./vendor/bin/phpstan --memory-limit=516M --debug -vvv

--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -11,6 +11,13 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: clojure-test-suite-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   run-clojure-test-suite:
     name: Run clojure-test-suite (PHP 8.4)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,95 +4,9 @@ on:
   - pull_request
   - push
 
-name: CI
+name: Smoke
 
 jobs:
-  composer-validate:
-    name: Validate composer configuration
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          coverage: none
-          tools: composer
-
-      - name: Validate composer configuration
-        run: composer validate --strict --quiet --no-interaction --no-check-all --no-check-lock
-
-  coding-guidelines:
-    name: Coding Guidelines
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-
-      - name: Run friendsofphp/php-cs-fixer
-        run: ./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --show-progress=dots --using-cache=no --verbose
-
-      - name: Run rector/rector
-        run: ./vendor/bin/rector process --dry-run --config=rector.php
-
-  type-checker:
-    name: Type Checker
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-
-      - name: Run Psalm on internal code
-        run: ./vendor/bin/psalm --config=psalm.xml --no-progress --shepherd --show-info=false --stats --php-version=${{ matrix.php }}
-
-      - name: Run PHPStan on internal code
-        run: ./vendor/bin/phpstan --memory-limit=516M --debug -vvv
-
-  compiler-tests:
-    name: Compiler tests on PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '8.4', '8.5' ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Run unit tests to the compiler itself
-        run: vendor/bin/phpunit --testsuite unit
-
-      - name: Run integration tests to the compiler itself
-        run: vendor/bin/phpunit --testsuite integration
-
-  core-tests:
-    name: Core tests on PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '8.4', '8.5' ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Run tests to the core library
-        run: composer run-script test-core
-
-  bench-tests:
-    name: Bench tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-
-      - name: Run PHPBench
-        run: vendor/bin/phpbench run --iterations=3 --warmup=1 --report=aggregate
-
   examples:
     name: Run examples
     runs-on: ubuntu-latest
@@ -110,7 +24,6 @@ jobs:
               echo "" || \
               (echo "❌ ERROR in {}" && exit 1)
             '
-
 
   agents-tests:
     name: Agent docs validation
@@ -191,13 +104,3 @@ jobs:
           echo "::group::phel analyze (JSON diagnostics)"
           "$PHAR" analyze src/main.phel > /tmp/analyze.json
           echo "::endgroup::"
-
-  bash-tests:
-    name: Bash tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-phel
-
-      - name: Run Bashunit tests
-        run: tools/bashunit tools/*-test.sh --simple

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,10 +1,18 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
-on:
-  - pull_request
-  - push
-
 name: Smoke
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   examples:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,63 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+on:
+  - pull_request
+  - push
+
+name: Tests
+
+jobs:
+  compiler-tests:
+    name: Compiler tests on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.4', '8.5' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Run unit tests to the compiler itself
+        run: vendor/bin/phpunit --testsuite unit
+
+      - name: Run integration tests to the compiler itself
+        run: vendor/bin/phpunit --testsuite integration
+
+  core-tests:
+    name: Core tests on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.4', '8.5' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Run tests to the core library
+        run: composer run-script test-core
+
+  bench-tests:
+    name: Bench tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+
+      - name: Run PHPBench
+        run: vendor/bin/phpbench run --iterations=3 --warmup=1 --report=aggregate
+
+  bash-tests:
+    name: Bash tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-phel
+
+      - name: Run Bashunit tests
+        run: tools/bashunit tools/*-test.sh --simple

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,18 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
-on:
-  - pull_request
-  - push
-
 name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   compiler-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
+- CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
 
 ### Fixed
 


### PR DESCRIPTION
## 🤔 Background

`ci.yml` had grown to 10 jobs and ~370 lines, with the checkout + setup-php + composer-cache + install block repeated almost verbatim across 9 of them. Editing a single boilerplate line meant touching 9 jobs. The single `CI` workflow also made path-based filtering or per-area triage harder than necessary.

We already moved `clojure-test-suite` into its own workflow file; this PR brings the rest of the CI surface in line with that convention while killing the duplicated boilerplate first.

## 💡 Goal

Make CI easier to evolve and cheaper to run by:

1. Removing duplicated setup boilerplate via a reusable composite action.
2. Splitting the monolithic `ci.yml` into focused workflows grouped by concern.
3. Adding concurrency cancellation, least-privilege token perms, and a tighter push trigger.

## 🔖 Changes

Three commits, intentionally separated for review:

### 1. `ref(ci): extract setup-phel composite action`
- New `.github/actions/setup-phel/action.yml` — single source of truth for setup-php + composer cache + install.
- `coding-guidelines`, `type-checker`, `compiler-tests`, `core-tests`, `bench-tests`, `examples`, `agents-tests`, `phar-smoke`, `bash-tests` all switched to `uses: ./.github/actions/setup-phel`.
- `composer-validate` keeps inline setup (does not need `composer install`).
- Cache key now includes the PHP version, so 8.4 and 8.5 no longer pollute each other's cache.

### 2. `ref(ci): split ci.yml into quality/tests/smoke workflows`
- `quality.yml` — `composer-validate`, `coding-guidelines`, `type-checker`
- `tests.yml` — `compiler-tests`, `core-tests`, `bench-tests`, `bash-tests`
- `smoke.yml` — `examples`, `agents-tests`, `phar-smoke`
- Deletes `ci.yml`.

### 3. `ref(ci): add concurrency, least-privilege perms, fix push trigger`
- `concurrency` group per workflow with `cancel-in-progress` on non-main refs — rapid pushes to a PR branch no longer pile up runners.
- `permissions: contents: read` on every workflow (least privilege for `GITHUB_TOKEN`).
- `push` trigger narrowed to `branches: [main]` so PR branches do not run every workflow twice (`pull_request` already covers them).
- Fixed pre-existing bug in `type-checker`: `--php-version=${{ matrix.php }}` referenced an undefined matrix and silently expanded to empty. Hardcoded `8.4`.
- Same `concurrency` + `permissions` block applied to `run-clojure-test-suite.yml` for consistency.

### Warning: branch protection

If branch protection currently requires a check named `CI`, it must be updated to require the new workflow names (`Quality`, `Tests`, `Smoke`) after merge.