### PR TITLE
fix(compiler): no backslash-deprecation for leading-only \\ PHP globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - `Phel::run()`: backslash namespaces normalize to dot-form, matching CLI (#2021)
 - `phel format`: appends trailing newline (POSIX / EditorConfig) (#2022)
 - `phel test`: non-zero exit when `--filter` matches zero tests (#2023)
+- `BackslashSeparatorDeprecator`: no longer false-warns on top-level PHP symbols with a leading-only `\` (e.g. `\JSON_UNESCAPED_SLASHES`, `\strlen`, `\DateTimeInterface`) (#2038)
 
 ## [0.39.0](https://github.com/phel-lang/phel-lang/compare/v0.38.0...v0.39.0) - 2026-05-19
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/BackslashSeparatorDeprecator.php
@@ -154,9 +154,15 @@ final class BackslashSeparatorDeprecator
             || str_starts_with($normalized, $stdlibRoot . '/');
     }
 
+    /**
+     * True only when `\` separates two non-empty segments. A leading-only `\`
+     * (PHP's global-namespace marker on top-level symbols like
+     * `\JSON_UNESCAPED_SLASHES`, `\strlen`, `\DateTimeInterface`) is not a
+     * Phel namespace separator and must not warn.
+     */
     private function containsBackslashSeparator(string $fullName): bool
     {
-        return str_contains($fullName, '\\');
+        return str_contains(ltrim($fullName, '\\'), '\\');
     }
 
     private function buildMessage(string $original, string $file, int $line): string

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -130,6 +130,16 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertSame([], $this->captured);
     }
 
+    public function test_emits_for_leading_backslash_when_internal_separator_present(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol(null, '\\Foo\\Bar', '/app/user.phel'));
+
+        self::assertCount(1, $this->captured);
+        self::assertStringContainsString("'\\Foo\\Bar'", $this->captured[0]);
+        self::assertStringContainsString("'Foo.Bar'", $this->captured[0]);
+    }
+
     public function test_suppresses_when_location_is_missing(): void
     {
         $deprecator = $this->deprecator(enabled: true);

--- a/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/BackslashSeparatorDeprecatorTest.php
@@ -106,6 +106,30 @@ final class BackslashSeparatorDeprecatorTest extends TestCase
         self::assertStringContainsString("'my.project'", $this->captured[0]);
     }
 
+    public function test_no_warning_for_leading_only_backslash_php_global_constant(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol(null, '\\JSON_UNESCAPED_SLASHES', '/app/user.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    public function test_no_warning_for_leading_only_backslash_php_global_function(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol(null, '\\strlen', '/app/user.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
+    public function test_no_warning_for_leading_only_backslash_top_level_class(): void
+    {
+        $deprecator = $this->deprecator(enabled: true);
+        $deprecator->maybeWarn($this->locatedSymbol(null, '\\DateTimeInterface', '/app/user.phel'));
+
+        self::assertSame([], $this->captured);
+    }
+
     public function test_suppresses_when_location_is_missing(): void
     {
         $deprecator = $this->deprecator(enabled: true);


### PR DESCRIPTION
## 🤔 Background

The new `clojure-test-suite` CI run on #2037 surfaced false-positive deprecations:

```
PHP Deprecated:  Backslash ('\') namespace separator in symbol '\JSON_UNESCAPED_SLASHES' at string:5 is deprecated; use dot ('.') instead — e.g. 'JSON_UNESCAPED_SLASHES'. The backslash form will be removed in a future release.
PHP Deprecated:  Backslash ('\') namespace separator in symbol '\JSON_UNESCAPED_UNICODE' at string:6 is deprecated; ...
```

`\JSON_UNESCAPED_SLASHES` is a top-level PHP constant; the leading `\` is PHP's global-namespace marker, not a Phel namespace separator. `BackslashSeparatorDeprecator` was incorrectly warning on it because `containsBackslashSeparator()` used a naive `str_contains($fullName, '\')` that returns true for any backslash, including the leading-only global marker.

## 💡 Goal

Stop emitting the backslash-separator deprecation when the symbol is a single PHP global identifier with only a leading `\` (no internal `\` separator).

## 🔖 Changes

- `BackslashSeparatorDeprecator::containsBackslashSeparator()` now `ltrim`s the leading `\` before checking for a separator, so it triggers only when `\` separates two non-empty segments.
- Behavior unchanged for `\Phel\Lang\Foo`, `phel\core/map`, and other multi-segment names.
- Three new unit tests cover the false-positive cases (`\JSON_UNESCAPED_SLASHES`, `\strlen`, `\DateTimeInterface`); all existing positive tests still pass.

## ✅ Verification

- `./vendor/bin/phpunit --filter=BackslashSeparatorDeprecatorTest` → 13/13 green
- `composer test-compiler` → 3402 tests pass
- Re-running `clojure-test-suite` after merge should no longer surface the deprecation lines for `\JSON_UNESCAPED_*`.

Closes #2038