### PR TITLE
fix(agent-install): copy .agents/ docs tree by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
+- `phel agent-install`: copy the `.agents/` docs tree by default; `--with-docs` is replaced by `--no-docs` to opt out
 
 ### Fixed
 

--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -6,10 +6,12 @@
 
 ```bash
 composer require phel-lang/phel-lang
-./vendor/bin/phel agent-install --all              # every platform
-./vendor/bin/phel agent-install claude             # single platform
-./vendor/bin/phel agent-install --all --with-docs  # also install docs into .agents/
+./vendor/bin/phel agent-install --all              # every platform + .agents/ docs
+./vendor/bin/phel agent-install claude             # single platform + .agents/ docs
+./vendor/bin/phel agent-install claude --no-docs   # skip the .agents/ docs tree
 ```
+
+`.agents/` (task recipes, examples, rules) is copied by default. Pass `--no-docs` to skip it.
 
 Platforms: `claude`, `cursor`, `codex`, `gemini`, `copilot`, `aider`.
 

--- a/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
+++ b/src/php/Run/Infrastructure/Command/AgentInstallCommand.php
@@ -38,7 +38,7 @@ final class AgentInstallCommand extends Command
 
     private const string OPT_ALL = 'all';
 
-    private const string OPT_WITH_DOCS = 'with-docs';
+    private const string OPT_NO_DOCS = 'no-docs';
 
     private const string OPT_FORCE = 'force';
 
@@ -76,7 +76,7 @@ final class AgentInstallCommand extends Command
                 sprintf('Platform: %s', $platformList),
             )
             ->addOption(self::OPT_ALL, null, InputOption::VALUE_NONE, 'Install all supported platforms')
-            ->addOption(self::OPT_WITH_DOCS, null, InputOption::VALUE_NONE, 'Also copy the bundled agent docs tree to .agents/')
+            ->addOption(self::OPT_NO_DOCS, null, InputOption::VALUE_NONE, 'Skip copying the bundled agent docs tree to .agents/ (copied by default)')
             ->addOption(self::OPT_FORCE, null, InputOption::VALUE_NONE, 'Overwrite existing files (default: backup to ' . self::BACKUP_SUFFIX . ')')
             ->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Print what would be written without changing files')
             ->addOption(self::OPT_CHECK, null, InputOption::VALUE_NONE, 'Report install status and version drift per platform; exit 1 if any drift')
@@ -107,12 +107,14 @@ final class AgentInstallCommand extends Command
         $dryRun = (bool) $input->getOption(self::OPT_DRY_RUN);
         $force = (bool) $input->getOption(self::OPT_FORCE);
 
+        $copyDocs = !(bool) $input->getOption(self::OPT_NO_DOCS);
+
         if ((bool) $input->getOption(self::OPT_UNINSTALL)) {
             foreach ($platforms as $platformKey) {
                 $this->uninstallPlatform($output, $projectRoot, $this->registry->get($platformKey), $dryRun);
             }
 
-            if ((bool) $input->getOption(self::OPT_WITH_DOCS)) {
+            if ($copyDocs) {
                 $this->removeDocs($output, $projectRoot, $dryRun);
             }
 
@@ -123,7 +125,7 @@ final class AgentInstallCommand extends Command
             $this->installPlatform($output, $sourceRoot, $projectRoot, $this->registry->get($platformKey), $force, $dryRun, $stamper);
         }
 
-        if ((bool) $input->getOption(self::OPT_WITH_DOCS)) {
+        if ($copyDocs) {
             $this->copyDocs($output, $sourceRoot, $projectRoot, $force, $dryRun);
         }
 

--- a/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
+++ b/tests/php/Integration/Run/Command/AgentInstall/AgentInstallCommandTest.php
@@ -45,7 +45,7 @@ final class AgentInstallCommandTest extends TestCase
 
     public function test_install_single_platform_only_creates_that_target(): void
     {
-        $this->install(['platform' => 'claude']);
+        $this->install(['platform' => 'claude', '--no-docs' => true]);
 
         self::assertFileExists($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
         self::assertFileDoesNotExist($this->testDir . '/AGENTS.md');
@@ -127,9 +127,9 @@ final class AgentInstallCommandTest extends TestCase
         );
     }
 
-    public function test_with_docs_copies_agents_tree(): void
+    public function test_install_copies_agents_tree_by_default(): void
     {
-        $this->install(['platform' => 'claude', '--with-docs' => true]);
+        $this->install(['platform' => 'claude']);
 
         self::assertDirectoryExists($this->testDir . '/.agents');
         self::assertFileExists($this->testDir . '/.agents/RULES.md');
@@ -139,13 +139,20 @@ final class AgentInstallCommandTest extends TestCase
         self::assertDirectoryExists($this->testDir . '/.agents/examples');
     }
 
-    public function test_with_docs_skips_when_agents_dir_already_exists(): void
+    public function test_no_docs_skips_agents_tree(): void
+    {
+        $this->install(['platform' => 'claude', '--no-docs' => true]);
+
+        self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
+    }
+
+    public function test_install_skips_docs_when_agents_dir_already_exists(): void
     {
         mkdir($this->testDir . '/.agents', 0o755, true);
         file_put_contents($this->testDir . '/.agents/marker.txt', 'keep me');
 
         $output = new BufferedOutput();
-        $this->install(['platform' => 'claude', '--with-docs' => true], $output);
+        $this->install(['platform' => 'claude'], $output);
 
         self::assertFileExists($this->testDir . '/.agents/marker.txt');
         self::assertStringContainsString('.agents/ already exists', $output->fetch());
@@ -153,7 +160,7 @@ final class AgentInstallCommandTest extends TestCase
 
     public function test_claude_skill_references_quick_syntax(): void
     {
-        $this->install(['platform' => 'claude']);
+        $this->install(['platform' => 'claude', '--no-docs' => true]);
 
         $content = (string) file_get_contents($this->testDir . '/.claude/skills/phel-lang/SKILL.md');
         self::assertStringContainsString('quick-syntax.md', $content);
@@ -222,10 +229,10 @@ final class AgentInstallCommandTest extends TestCase
 
     public function test_uninstall_removes_skill_file_when_no_backup(): void
     {
-        $this->install(['platform' => 'aider', '--force' => true]);
+        $this->install(['platform' => 'aider', '--force' => true, '--no-docs' => true]);
         self::assertFileExists($this->testDir . '/CONVENTIONS.md');
 
-        $this->install(['platform' => 'aider', '--uninstall' => true]);
+        $this->install(['platform' => 'aider', '--uninstall' => true, '--no-docs' => true]);
 
         self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md');
     }
@@ -233,9 +240,9 @@ final class AgentInstallCommandTest extends TestCase
     public function test_uninstall_restores_backup_when_present(): void
     {
         file_put_contents($this->testDir . '/CONVENTIONS.md', 'user-original');
-        $this->install(['platform' => 'aider']);
+        $this->install(['platform' => 'aider', '--no-docs' => true]);
 
-        $this->install(['platform' => 'aider', '--uninstall' => true]);
+        $this->install(['platform' => 'aider', '--uninstall' => true, '--no-docs' => true]);
 
         self::assertSame('user-original', file_get_contents($this->testDir . '/CONVENTIONS.md'));
         self::assertFileDoesNotExist($this->testDir . '/CONVENTIONS.md.pre-phel.bak');
@@ -243,9 +250,9 @@ final class AgentInstallCommandTest extends TestCase
 
     public function test_uninstall_all_removes_every_installed_file(): void
     {
-        $this->install(['--all' => true]);
+        $this->install(['--all' => true, '--no-docs' => true]);
 
-        $this->install(['--all' => true, '--uninstall' => true]);
+        $this->install(['--all' => true, '--uninstall' => true, '--no-docs' => true]);
 
         foreach (['AGENTS.md', 'GEMINI.md', 'CONVENTIONS.md'] as $f) {
             self::assertFileDoesNotExist($this->testDir . '/' . $f);
@@ -256,14 +263,24 @@ final class AgentInstallCommandTest extends TestCase
         self::assertFileDoesNotExist($this->testDir . '/.github/copilot-instructions.md');
     }
 
-    public function test_uninstall_with_docs_removes_agents_tree(): void
+    public function test_uninstall_removes_agents_tree_by_default(): void
     {
-        $this->install(['platform' => 'claude', '--with-docs' => true]);
+        $this->install(['platform' => 'claude']);
         self::assertDirectoryExists($this->testDir . '/.agents');
 
-        $this->install(['platform' => 'claude', '--uninstall' => true, '--with-docs' => true]);
+        $this->install(['platform' => 'claude', '--uninstall' => true]);
 
         self::assertDirectoryDoesNotExist($this->testDir . '/.agents');
+    }
+
+    public function test_uninstall_no_docs_keeps_agents_tree(): void
+    {
+        $this->install(['platform' => 'claude']);
+        self::assertDirectoryExists($this->testDir . '/.agents');
+
+        $this->install(['platform' => 'claude', '--uninstall' => true, '--no-docs' => true]);
+
+        self::assertDirectoryExists($this->testDir . '/.agents');
     }
 
     public function test_auto_installs_only_for_detected_agents(): void


### PR DESCRIPTION
## 🤔 Background

Running `phel agent-install claude` (or any single platform) only wrote the per-platform skill file (e.g. `.claude/skills/phel-lang/SKILL.md`). The `.agents/` docs tree — which the installed skill file routes to via `.agents/index.md` for task recipes, examples, `RULES.md`, and `quick-syntax.md` — was only copied when the user remembered to pass `--with-docs`.

Result: the freshly-installed skill referenced files the user didn't have. Users running `phel agent-install claude` reported "everything from `.agents/` is missing".

## 💡 Goal

Make `phel agent-install <platform>` install everything an agent needs in one shot. The `.agents/` tree should be present by default, with an explicit opt-out for users who don't want it.

## 🔖 Changes

- `phel agent-install`: copy the `.agents/` docs tree on every install by default.
- Replace `--with-docs` (opt-in) with `--no-docs` (opt-out).
- Symmetric for uninstall: `phel agent-install <platform> --uninstall` now also removes `.agents/`; pass `--no-docs` to keep the tree.
- Tests updated: existing `--with-docs` cases now assert the default-on behavior; added `--no-docs` cases for the opt-out path.
- `docs/agent-docs.md` + `CHANGELOG.md` updated to document the new default.