### PR TITLE
feat(compiler): hoist pure collection literals + PHP 8.5 dev fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,15 @@ All notable changes to this project will be documented in this file.
 
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
-- Compiler: pure vector/map/set literals inside a fn body are now hoisted to a per-fn `static` cache, so each invocation reuses the same persistent collection instead of rebuilding it
-- Compiler: `if` / `?:` skip the `Truthy::isTruthy` wrap when the test is a known-bool expression (literal `true`/`false`, infix comparison, `is_int`/`is_a`/etc.), emitting a direct PHP conditional and saving one assign + two comparisons per branch
-- Compiler: `recur` emits direct param assignments when no expression reads a recur param that an earlier expression has already overwritten, skipping the per-arg `$__phel_N` temp shuffle in the common case
+- Compiler: hoist pure vector/map/set literals to a per-fn `static` cache
+- Compiler: skip `Truthy::isTruthy` wrap in `if`/`?:` when the test is known-bool
+- Compiler: `recur` skips the `$__phel_N` temp shuffle when no aliasing is possible
 - `phel agent-install`: copy the `.agents/` docs tree by default; `--with-docs` is replaced by `--no-docs` to opt out
 
 ### Fixed
 
-- Dev: vendored Psalm 6.16.1 now patched on `composer install` / `composer update` to avoid the PHP 8.5 "NAN coerced to string" crash in `TLiteralFloat`
-- Compiler: `ConstantScope` uses `SplObjectStorage::offsetExists()` instead of the PHP 8.5-deprecated `contains()`, so deprecation notices no longer leak into emitted code
+- Dev: patch vendored Psalm 6.16.1 on install/update for PHP 8.5 NAN-coercion crash in `TLiteralFloat`
+- Compiler: use `SplObjectStorage::offsetExists()` in `ConstantScope` to silence PHP 8.5 deprecation in emitted code
 - `phel.cli`: `application` now calls `Application::addCommand()` (Symfony 8 compat) instead of the deprecated `add()` (#2033)
 - `phel lint`: cache invalidates when `phel-lint.phel` changes (#2027)
 - `phel lint`: `unused-binding` no longer flags symbols used in later let bindings (#2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
 - Compiler: pure vector/map/set literals inside a fn body are now hoisted to a per-fn `static` cache, so each invocation reuses the same persistent collection instead of rebuilding it
+- Compiler: `if` / `?:` skip the `Truthy::isTruthy` wrap when the test is a known-bool expression (literal `true`/`false`, infix comparison, `is_int`/`is_a`/etc.), emitting a direct PHP conditional and saving one assign + two comparisons per branch
 - `phel agent-install`: copy the `.agents/` docs tree by default; `--with-docs` is replaced by `--no-docs` to opt out
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
 - Compiler: pure vector/map/set literals inside a fn body are now hoisted to a per-fn `static` cache, so each invocation reuses the same persistent collection instead of rebuilding it
 - Compiler: `if` / `?:` skip the `Truthy::isTruthy` wrap when the test is a known-bool expression (literal `true`/`false`, infix comparison, `is_int`/`is_a`/etc.), emitting a direct PHP conditional and saving one assign + two comparisons per branch
+- Compiler: `recur` emits direct param assignments when no expression reads a recur param that an earlier expression has already overwritten, skipping the per-arg `$__phel_N` temp shuffle in the common case
 - `phel agent-install`: copy the `.agents/` docs tree by default; `--with-docs` is replaced by `--no-docs` to opt out
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ All notable changes to this project will be documented in this file.
 
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; add concurrency cancellation and least-privilege perms (#2039)
+- Compiler: pure vector/map/set literals inside a fn body are now hoisted to a per-fn `static` cache, so each invocation reuses the same persistent collection instead of rebuilding it
 
 ### Fixed
 
+- Dev: vendored Psalm 6.16.1 now patched on `composer install` / `composer update` to avoid the PHP 8.5 "NAN coerced to string" crash in `TLiteralFloat`
+- Compiler: `ConstantScope` uses `SplObjectStorage::offsetExists()` instead of the PHP 8.5-deprecated `contains()`, so deprecation notices no longer leak into emitted code
 - `phel.cli`: `application` now calls `Application::addCommand()` (Symfony 8 compat) instead of the deprecated `add()` (#2033)
 - `phel lint`: cache invalidates when `phel-lint.phel` changes (#2027)
 - `phel lint`: `unused-binding` no longer flags symbols used in later let bindings (#2018)

--- a/build/scripts/patch-psalm.php
+++ b/build/scripts/patch-psalm.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Composer post-install/post-update hook that patches a PHP 8.5
+ * incompatibility in the vendored Psalm release: `TLiteralFloat::getKey()`
+ * and `TLiteralFloat::getId()` coerce `$this->value` to a string via
+ * concatenation. When the literal float happens to be `NAN` (e.g. analysis
+ * of `##NaN` constants), PHP 8.5 raises an Error ("unexpected NAN value was
+ * coerced to string") and crashes the analyser.
+ *
+ * The fix is local and idempotent: wrap the coercion in an `is_nan()` /
+ * `is_infinite()` branch so NAN and Inf serialise to a readable token. The
+ * patch is reapplied on every Composer run so a fresh vendor/ install will
+ * not regress.
+ */
+
+declare(strict_types=1);
+
+$file = __DIR__ . '/../../vendor/vimeo/psalm/src/Psalm/Type/Atomic/TLiteralFloat.php';
+
+if (!is_file($file)) {
+    echo "patch-psalm: target file not present, skipping\n";
+    exit(0);
+}
+
+$source = file_get_contents($file);
+if ($source === false) {
+    fwrite(STDERR, "patch-psalm: unable to read {$file}\n");
+    exit(1);
+}
+
+if (str_contains($source, 'self::stringifyFloat(')) {
+    echo "patch-psalm: already patched\n";
+    exit(0);
+}
+
+$helperBlock = <<<'PHP'
+
+    /**
+     * NAN and Inf cannot be coerced to a string in PHP 8.5+, so this helper
+     * returns a stable, readable token for them.
+     */
+    private static function stringifyFloat(float $value): string
+    {
+        if (is_nan($value)) {
+            return 'NAN';
+        }
+
+        if (is_infinite($value)) {
+            return $value > 0 ? 'INF' : '-INF';
+        }
+
+        return (string) $value;
+    }
+}
+PHP;
+
+$patched = str_replace(
+    [
+        "return 'float(' . \$this->value . ')';",
+    ],
+    [
+        "return 'float(' . self::stringifyFloat(\$this->value) . ')';",
+    ],
+    $source,
+);
+
+// Replace the final closing brace of the class with the closing brace plus
+// the helper. The class is `final`, so there is exactly one matching brace
+// at the end of the file.
+$patched = preg_replace('/}\s*$/', $helperBlock . "\n", $patched, 1);
+
+if ($patched === $source) {
+    fwrite(STDERR, "patch-psalm: nothing to replace, file shape unexpected\n");
+    exit(1);
+}
+
+if (file_put_contents($file, $patched) === false) {
+    fwrite(STDERR, "patch-psalm: failed to write {$file}\n");
+    exit(1);
+}
+
+echo "patch-psalm: patched TLiteralFloat for PHP 8.5 compatibility\n";

--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,14 @@
         "phpbench": "./vendor/bin/phpbench run --report=aggregate --ansi",
         "phpbench-base": "./vendor/bin/phpbench run --tag=baseline --report=aggregate --progress=plain --ansi",
         "phpbench-ref": "./vendor/bin/phpbench run --ref=baseline --report=aggregate --progress=plain --ansi",
+        "patch-psalm": "@php build/scripts/patch-psalm.php",
         "phpstan": "./vendor/bin/phpstan --memory-limit=1G",
-        "psalm": "./vendor/bin/psalm --no-cache",
+        "post-install-cmd": "@patch-psalm",
+        "post-update-cmd": "@patch-psalm",
+        "psalm": [
+            "@patch-psalm",
+            "./vendor/bin/psalm --no-cache"
+        ],
         "rector": "./vendor/bin/rector process --dry-run",
         "rector:fix": "./vendor/bin/rector process",
         "static-clear-cache": [

--- a/composer.lock
+++ b/composer.lock
@@ -4396,11 +4396,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.50",
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
-                "reference": "d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -4445,7 +4445,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-17T13:10:32+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7989,5 +7989,5 @@
     "platform-overrides": {
         "php": "8.4.6"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
+use Rector\Php84\Rector\Foreach_\ForeachToArrayAllRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -25,6 +26,12 @@ return RectorConfig::configure()
         __DIR__ . '/tests/php/*/PhelGenerated/*',
         __DIR__ . '/tests/php/*/gacela-class-names.php',
         __DIR__ . '/tests/php/*/gacela-custom-services.php',
+        // The `foreach` here mutates a referenced `$names` parameter;
+        // converting to `array_all` with an arrow fn would silently
+        // drop the reference because arrow functions capture by value.
+        ForeachToArrayAllRector::class => [
+            __DIR__ . '/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php',
+        ],
         ReturnTypeFromReturnNewRector::class => [
             __DIR__ . '/tests/php/Unit/Interop/Generator/CompiledPhpMethodBuilderTest.php',
         ],

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\LiteralEmitter;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
@@ -16,7 +17,10 @@ use Phel\Lang\Symbol;
 use Phel\Shared\MungeInterface;
 use Phel\Shared\Printer\PrinterInterface;
 
+use function array_pop;
+use function array_values;
 use function count;
+use function end;
 use function is_null;
 use function strlen;
 
@@ -29,6 +33,9 @@ final class OutputEmitter implements OutputEmitterInterface
     /** @var array<int, string> */
     private array $indentCache = [];
 
+    /** @var list<ConstantScope> */
+    private array $constantScopes = [];
+
     public function __construct(
         private readonly bool $enableSourceMaps,
         private readonly NodeEmitterFactory $nodeEmitterFactory,
@@ -37,6 +44,25 @@ final class OutputEmitter implements OutputEmitterInterface
         private readonly SourceMapState $sourceMapState,
         private readonly OutputEmitterOptions $options,
     ) {}
+
+    public function pushConstantScope(ConstantScope $scope): void
+    {
+        $this->constantScopes[] = $scope;
+    }
+
+    public function popConstantScope(): void
+    {
+        array_pop($this->constantScopes);
+    }
+
+    public function currentConstantScope(): ?ConstantScope
+    {
+        if ($this->constantScopes === []) {
+            return null;
+        }
+
+        return end($this->constantScopes);
+    }
 
     public function getOptions(): OutputEmitterOptions
     {
@@ -135,10 +161,15 @@ final class OutputEmitter implements OutputEmitterInterface
     public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void
     {
         $this->emitStr('(function()', $sl);
-        if ($env->getLocals() !== []) {
+
+        $locals = array_values($env->getLocals());
+        $constantSlots = $this->currentConstantScope()?->count() ?? 0;
+
+        if ($locals !== [] || $constantSlots > 0) {
             $this->emitStr(' use(', $sl);
 
-            foreach (array_values($env->getLocals()) as $i => $l) {
+            $localsCount = count($locals);
+            foreach ($locals as $i => $l) {
                 $shadowed = $env->getShadowed($l);
                 if ($shadowed instanceof Symbol) {
                     $this->emitPhpVariable($shadowed, $sl);
@@ -146,7 +177,14 @@ final class OutputEmitter implements OutputEmitterInterface
                     $this->emitPhpVariable($l, $sl);
                 }
 
-                if ($i < count($env->getLocals()) - 1) {
+                if ($i < $localsCount - 1 || $constantSlots > 0) {
+                    $this->emitStr(',', $sl);
+                }
+            }
+
+            for ($i = 0; $i < $constantSlots; ++$i) {
+                $this->emitStr('&$__phel_const_' . $i, $sl);
+                if ($i < $constantSlots - 1) {
                     $this->emitStr(',', $sl);
                 }
             }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter.php
@@ -64,6 +64,28 @@ final class OutputEmitter implements OutputEmitterInterface
         return end($this->constantScopes);
     }
 
+    /**
+     * Opens a constant-cache wrap for `$node` and returns `true` when a
+     * slot was reserved for it. Callers must pair a `true` return with a
+     * matching {@see emitConstantSlotSuffix()} call after the inner
+     * expression has been emitted; a `false` return is a no-op.
+     */
+    public function emitConstantSlotPrefix(AbstractNode $node, ?SourceLocation $loc = null): bool
+    {
+        $slot = $this->currentConstantScope()?->lookup($node);
+        if ($slot === null) {
+            return false;
+        }
+
+        $this->emitStr('($__phel_const_' . $slot . ' ??= ', $loc);
+        return true;
+    }
+
+    public function emitConstantSlotSuffix(?SourceLocation $loc = null): void
+    {
+        $this->emitStr(')', $loc);
+    }
+
     public function getOptions(): OutputEmitterOptions
     {
         return $this->options;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
@@ -87,6 +87,13 @@ final readonly class BodyConstantScanner
     }
 
     /**
+     * Manual node-type registry. Any AST node added in the future that can
+     * contain a child collection literal must be listed here, otherwise the
+     * scanner silently produces no children for it and literals nested in
+     * the new node will never be hoisted (safe miss, not wrong code).
+     * Auditing the {@see \Phel\Compiler\Domain\Analyzer\Ast} namespace when
+     * introducing a new node type keeps this list current.
+     *
      * @return list<AbstractNode>
      */
     private function children(AbstractNode $node): array

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+
+/**
+ * Walks a fn body looking for *outermost* pure collection literals so the
+ * emitter can hoist them to a per-fn `static` cache. Stops at nested
+ * function boundaries (FnNode / MultiFnNode / ReifyNode method bodies)
+ * because each has its own static scope.
+ */
+final readonly class BodyConstantScanner
+{
+    public function scan(AbstractNode $body, ConstantScope $scope): void
+    {
+        $this->walk($body, $scope);
+    }
+
+    private function walk(AbstractNode $node, ConstantScope $scope): void
+    {
+        // Nested function bodies own their own scope; skip.
+        if ($node instanceof FnNode || $node instanceof MultiFnNode || $node instanceof ReifyNode) {
+            return;
+        }
+
+        if ($this->isCacheableCollection($node)) {
+            $scope->reserve($node);
+            return;
+        }
+
+        foreach ($this->children($node) as $child) {
+            $this->walk($child, $scope);
+        }
+    }
+
+    private function isCacheableCollection(AbstractNode $node): bool
+    {
+        if (!$node instanceof VectorNode && !$node instanceof MapNode && !$node instanceof SetNode) {
+            return false;
+        }
+
+        // Skip empty literals: \Phel::vector([]) already returns an empty
+        // singleton via the type factory, so caching adds no win.
+        if ($this->isEmpty($node)) {
+            return false;
+        }
+
+        return PureLiteralDetector::isPure($node);
+    }
+
+    private function isEmpty(AbstractNode $node): bool
+    {
+        return match (true) {
+            $node instanceof VectorNode => $node->getArgs() === [],
+            $node instanceof MapNode => $node->getKeyValues() === [],
+            $node instanceof SetNode => $node->getValues() === [],
+            default => false,
+        };
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private function children(AbstractNode $node): array
+    {
+        return match (true) {
+            $node instanceof CallNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof ApplyNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof IfNode => [$node->getTestExpr(), $node->getThenExpr(), $node->getElseExpr()],
+            $node instanceof DoNode => [...$node->getStmts(), $node->getRet()],
+            $node instanceof LetNode => $this->letChildren($node),
+            $node instanceof RecurNode => $node->getExpressions(),
+            $node instanceof TryNode => $this->tryChildren($node),
+            $node instanceof CatchNode => [$node->getBody()],
+            $node instanceof ThrowNode => [$node->getExceptionExpr()],
+            $node instanceof VectorNode => $node->getArgs(),
+            $node instanceof MapNode => $node->getKeyValues(),
+            $node instanceof SetNode => $node->getValues(),
+            $node instanceof DefNode => [$node->getMeta(), $node->getInit()],
+            $node instanceof SetVarNode => [$node->getSymbol(), $node->getValueExpr()],
+            $node instanceof ForeachNode => [$node->getListExpr(), $node->getBodyExpr()],
+            $node instanceof PhpNewNode => [$node->getClassExpr(), ...$node->getArgs()],
+            $node instanceof PhpObjectCallNode => [$node->getTargetExpr(), $node->getCallExpr()],
+            $node instanceof PhpObjectSetNode => [$node->getLeftExpr(), $node->getRightExpr()],
+            $node instanceof PhpArrayGetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            $node instanceof PhpArraySetNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayPushNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayUnsetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private function letChildren(LetNode $node): array
+    {
+        $children = [];
+        foreach ($node->getBindings() as $binding) {
+            $children[] = $binding->getInitExpr();
+        }
+
+        $children[] = $node->getBodyExpr();
+        return $children;
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private function tryChildren(TryNode $node): array
+    {
+        $children = [$node->getBody(), ...$node->getCatches()];
+        $finally = $node->getFinally();
+        if ($finally instanceof AbstractNode) {
+            $children[] = $finally;
+        }
+
+        return $children;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+
+use function in_array;
+use function is_bool;
+use function str_starts_with;
+use function substr;
+
+/**
+ * Recognises AST nodes whose runtime value is guaranteed to be a PHP
+ * `bool`. The `IfEmitter` uses this to skip the `Truthy::isTruthy()`
+ * dance (the `($__truthy = …) !== null && $__truthy !== false` wrap) and
+ * emit a direct ternary / `if` test, which saves an assignment plus two
+ * comparisons per check.
+ *
+ * Conservative on purpose: only forms with a hard PHP-level bool
+ * guarantee are recognised. Anything else routes through the legacy
+ * truthy wrap to preserve `nil`/`false`/anything-else semantics.
+ */
+final class BooleanExprDetector
+{
+    /**
+     * PHP infix comparison/identity operators that always yield bool.
+     * Subset of {@see PhpVarNode::INFIX_OPERATORS}; arithmetic / bitwise
+     * operators are excluded.
+     */
+    private const array BOOL_INFIX = [
+        '===',
+        '!==',
+        '==',
+        '!=',
+        '<',
+        '>',
+        '<=',
+        '>=',
+        'instanceof',
+    ];
+
+    /**
+     * PHP built-in callables that always return bool. Restricted to the
+     * common type predicates to keep the recogniser self-evidently safe.
+     */
+    private const array BOOL_PHP_FUNCTIONS = [
+        'array_is_list',
+        'array_key_exists',
+        'in_array',
+        'is_a',
+        'is_array',
+        'is_bool',
+        'is_callable',
+        'is_countable',
+        'is_float',
+        'is_int',
+        'is_iterable',
+        'is_null',
+        'is_numeric',
+        'is_object',
+        'is_resource',
+        'is_string',
+        'is_subclass_of',
+        'method_exists',
+        'property_exists',
+    ];
+
+    public static function isBool(AbstractNode $node): bool
+    {
+        if ($node instanceof LiteralNode) {
+            return is_bool($node->getValue());
+        }
+
+        if (!$node instanceof CallNode) {
+            return false;
+        }
+
+        $fn = $node->getFn();
+        if (!$fn instanceof PhpVarNode) {
+            return false;
+        }
+
+        $name = $fn->getName();
+
+        if ($fn->isInfix() && in_array($name, self::BOOL_INFIX, true)) {
+            return true;
+        }
+
+        // Match both bare (`is_int`) and namespaced (`\is_int`) forms.
+        $bare = str_starts_with($name, '\\') ? substr($name, 1) : $name;
+        return in_array($bare, self::BOOL_PHP_FUNCTIONS, true);
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use SplObjectStorage;
+
+/**
+ * Per-fn-body scope tracking which pure collection literals will be
+ * hoisted to a `static` PHP variable. Each registered node is assigned a
+ * monotonically increasing slot id; the emitter renders the literal as
+ * `($__phel_const_<id> ??= ...)` and declares matching `static` lines at
+ * the top of the body.
+ */
+final class ConstantScope
+{
+    /** @var SplObjectStorage<AbstractNode, int> */
+    private SplObjectStorage $slots;
+
+    private int $nextId = 0;
+
+    public function __construct()
+    {
+        $this->slots = new SplObjectStorage();
+    }
+
+    public function reserve(AbstractNode $node): int
+    {
+        if (!$this->slots->contains($node)) {
+            $this->slots[$node] = $this->nextId++;
+        }
+
+        /** @var int $id */
+        $id = $this->slots[$node];
+        return $id;
+    }
+
+    public function lookup(AbstractNode $node): ?int
+    {
+        if (!$this->slots->contains($node)) {
+            return null;
+        }
+
+        /** @var int $id */
+        $id = $this->slots[$node];
+        return $id;
+    }
+
+    public function count(): int
+    {
+        return $this->nextId;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/ConstantScope.php
@@ -28,7 +28,7 @@ final class ConstantScope
 
     public function reserve(AbstractNode $node): int
     {
-        if (!$this->slots->contains($node)) {
+        if (!$this->slots->offsetExists($node)) {
             $this->slots[$node] = $this->nextId++;
         }
 
@@ -39,7 +39,7 @@ final class ConstantScope
 
     public function lookup(AbstractNode $node): ?int
     {
-        if (!$this->slots->contains($node)) {
+        if (!$this->slots->offsetExists($node)) {
             return null;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CatchNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
+use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+
+/**
+ * Collects the names of every `LocalVarNode` referenced anywhere inside
+ * a subtree, including nested function bodies (a closure that captures a
+ * local is still a real reference to that local).
+ *
+ * Used by `RecurEmitter` to decide whether a `recur` form can skip its
+ * temp-variable shuffle: if no expression reads a recur param that an
+ * earlier expression has already overwritten, the temps are unnecessary.
+ *
+ * Mirrors {@see BodyConstantScanner::children()} as a manual node-type
+ * registry; any AST node added in the future that can contain a
+ * `LocalVarNode` must be listed here, otherwise the recur optimisation
+ * may emit incorrect direct assignments. When in doubt, leave the new
+ * node out (the result is "always use temp vars", which is safe).
+ */
+final class LocalVarReferences
+{
+    /**
+     * @return list<string> the `Symbol::getName()` of every referenced local
+     */
+    public static function collect(AbstractNode $node): array
+    {
+        $names = [];
+        self::walk($node, $names);
+        return $names;
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    private static function walk(AbstractNode $node, array &$names): void
+    {
+        if ($node instanceof LocalVarNode) {
+            $names[] = $node->getName()->getName();
+            return;
+        }
+
+        foreach (self::children($node) as $child) {
+            self::walk($child, $names);
+        }
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private static function children(AbstractNode $node): array
+    {
+        return match (true) {
+            $node instanceof CallNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof ApplyNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof IfNode => [$node->getTestExpr(), $node->getThenExpr(), $node->getElseExpr()],
+            $node instanceof DoNode => [...$node->getStmts(), $node->getRet()],
+            $node instanceof LetNode => self::letChildren($node),
+            $node instanceof RecurNode => $node->getExpressions(),
+            $node instanceof TryNode => self::tryChildren($node),
+            $node instanceof CatchNode => [$node->getBody()],
+            $node instanceof ThrowNode => [$node->getExceptionExpr()],
+            $node instanceof VectorNode => $node->getArgs(),
+            $node instanceof MapNode => $node->getKeyValues(),
+            $node instanceof SetNode => $node->getValues(),
+            $node instanceof DefNode => [$node->getMeta(), $node->getInit()],
+            $node instanceof SetVarNode => [$node->getSymbol(), $node->getValueExpr()],
+            $node instanceof ForeachNode => [$node->getListExpr(), $node->getBodyExpr()],
+            $node instanceof PhpNewNode => [$node->getClassExpr(), ...$node->getArgs()],
+            $node instanceof PhpObjectCallNode => [$node->getTargetExpr(), $node->getCallExpr()],
+            $node instanceof PhpObjectSetNode => [$node->getLeftExpr(), $node->getRightExpr()],
+            $node instanceof PhpArrayGetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            $node instanceof PhpArraySetNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayPushNode => [$node->getArrayExpr(), ...$node->getAccessExprs(), $node->getValueExpr()],
+            $node instanceof PhpArrayUnsetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
+            $node instanceof FnNode => [$node->getBody()],
+            $node instanceof MultiFnNode => $node->getFnNodes(),
+            $node instanceof ReifyNode => [],
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private static function letChildren(LetNode $node): array
+    {
+        $children = [];
+        foreach ($node->getBindings() as $binding) {
+            $children[] = $binding->getInitExpr();
+        }
+
+        $children[] = $node->getBodyExpr();
+        return $children;
+    }
+
+    /**
+     * @return list<AbstractNode>
+     */
+    private static function tryChildren(TryNode $node): array
+    {
+        $children = [$node->getBody(), ...$node->getCatches()];
+        $finally = $node->getFinally();
+        if ($finally instanceof AbstractNode) {
+            $children[] = $finally;
+        }
+
+        return $children;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/LocalVarReferences.php
@@ -12,76 +12,111 @@ use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayPushNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArraySetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayUnsetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpNewNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectSetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ReifyNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
 use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 
 /**
- * Collects the names of every `LocalVarNode` referenced anywhere inside
- * a subtree, including nested function bodies (a closure that captures a
- * local is still a real reference to that local).
+ * Walks a subtree and returns the names of every `LocalVarNode` it
+ * references, or `null` when it cannot prove the subtree's reference set
+ * (an AST node type this scanner does not enumerate is treated as
+ * potentially referencing anything, including recur params).
  *
- * Used by `RecurEmitter` to decide whether a `recur` form can skip its
- * temp-variable shuffle: if no expression reads a recur param that an
- * earlier expression has already overwritten, the temps are unnecessary.
- *
- * Mirrors {@see BodyConstantScanner::children()} as a manual node-type
- * registry; any AST node added in the future that can contain a
- * `LocalVarNode` must be listed here, otherwise the recur optimisation
- * may emit incorrect direct assignments. When in doubt, leave the new
- * node out (the result is "always use temp vars", which is safe).
+ * `RecurEmitter` uses this to decide whether a `recur` form can skip
+ * its temp-variable shuffle. `null` always forces temps, which is
+ * always safe. So this scanner is opt-in per node type: new node types
+ * added to the analyzer in the future will fall into the `default`
+ * branch, return `null`, and the recur optimisation will conservatively
+ * keep the temps until the new node is explicitly added here.
  */
 final class LocalVarReferences
 {
     /**
-     * @return list<string> the `Symbol::getName()` of every referenced local
+     * @return list<string>|null `null` means "subtree contains nodes we
+     *                           don't recognise; assume worst case"
      */
-    public static function collect(AbstractNode $node): array
+    public static function collect(AbstractNode $node): ?array
     {
         $names = [];
-        self::walk($node, $names);
+        if (!self::walk($node, $names)) {
+            return null;
+        }
+
         return $names;
     }
 
     /**
      * @param list<string> $names
      */
-    private static function walk(AbstractNode $node, array &$names): void
+    private static function walk(AbstractNode $node, array &$names): bool
     {
         if ($node instanceof LocalVarNode) {
             $names[] = $node->getName()->getName();
-            return;
+            return true;
         }
 
-        foreach (self::children($node) as $child) {
-            self::walk($child, $names);
+        $children = self::children($node);
+        if ($children === null) {
+            return false;
         }
+
+        // Cannot be `array_all(...static fn... self::walk($child, $names))`:
+        // PHP arrow functions capture by value, so `$names` inside the
+        // closure would be a copy and accumulated references would be
+        // silently lost.
+        foreach ($children as $child) {
+            if (!self::walk($child, $names)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
-     * @return list<AbstractNode>
+     * @return list<AbstractNode>|null `null` for nodes whose shape is not
+     *                                 enumerated (forces a conservative
+     *                                 "assume references exist" result)
      */
-    private static function children(AbstractNode $node): array
+    private static function children(AbstractNode $node): ?array
     {
         return match (true) {
+            // Leaf nodes that cannot contain a LocalVarNode.
+            $node instanceof LiteralNode,
+            $node instanceof QuoteNode,
+            $node instanceof PhpVarNode,
+            $node instanceof PhpClassNameNode,
+            $node instanceof GlobalVarNode,
+            $node instanceof VarNode,
+            $node instanceof PropertyOrConstantAccessNode => [],
+
             $node instanceof CallNode => [$node->getFn(), ...$node->getArguments()],
             $node instanceof ApplyNode => [$node->getFn(), ...$node->getArguments()],
+            $node instanceof MethodCallNode => $node->getArgs(),
             $node instanceof IfNode => [$node->getTestExpr(), $node->getThenExpr(), $node->getElseExpr()],
             $node instanceof DoNode => [...$node->getStmts(), $node->getRet()],
             $node instanceof LetNode => self::letChildren($node),
@@ -104,8 +139,9 @@ final class LocalVarReferences
             $node instanceof PhpArrayUnsetNode => [$node->getArrayExpr(), ...$node->getAccessExprs()],
             $node instanceof FnNode => [$node->getBody()],
             $node instanceof MultiFnNode => $node->getFnNodes(),
-            $node instanceof ReifyNode => [],
-            default => [],
+            // ReifyNode bodies are their own scope; opt-out of the optimisation.
+            $node instanceof ReifyNode => null,
+            default => null,
         };
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/PureLiteralDetector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/PureLiteralDetector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\Cache;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+
+/**
+ * A pure literal is a leaf scalar/quote, or a collection literal whose
+ * children are all pure. Pure literals produce the same value on every
+ * evaluation, so the emitter can safely hoist them to a per-fn static
+ * cache and reuse the persistent collection across calls.
+ */
+final class PureLiteralDetector
+{
+    public static function isPure(AbstractNode $node): bool
+    {
+        return match (true) {
+            $node instanceof LiteralNode, $node instanceof QuoteNode => true,
+            $node instanceof VectorNode => self::allPure($node->getArgs()),
+            $node instanceof MapNode => self::allPure($node->getKeyValues()),
+            $node instanceof SetNode => self::allPure($node->getValues()),
+            default => false,
+        };
+    }
+
+    /**
+     * @param list<AbstractNode> $nodes
+     */
+    private static function allPure(array $nodes): bool
+    {
+        return array_all($nodes, static fn(AbstractNode $node): bool => self::isPure($node));
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
 use function assert;
@@ -28,29 +29,49 @@ final class IfEmitter implements NodeEmitterInterface
 
     private function emitTernaryCondition(IfNode $node): void
     {
-        $this->outputEmitter->emitStr('(($__truthy = ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($node->getTestExpr());
-        $this->outputEmitter->emitStr(') !== null && $__truthy !== false ? ', $node->getStartSourceLocation());
+        $loc = $node->getStartSourceLocation();
+        $isBool = BooleanExprDetector::isBool($node->getTestExpr());
+
+        if ($isBool) {
+            $this->outputEmitter->emitStr('((', $loc);
+            $this->outputEmitter->emitNode($node->getTestExpr());
+            $this->outputEmitter->emitStr(') ? ', $loc);
+        } else {
+            $this->outputEmitter->emitStr('(($__truthy = ', $loc);
+            $this->outputEmitter->emitNode($node->getTestExpr());
+            $this->outputEmitter->emitStr(') !== null && $__truthy !== false ? ', $loc);
+        }
+
         $this->outputEmitter->emitNode($node->getThenExpr());
-        $this->outputEmitter->emitStr(' : ', $node->getStartSourceLocation());
+        $this->outputEmitter->emitStr(' : ', $loc);
         $this->outputEmitter->emitNode($node->getElseExpr());
         $this->outputEmitter->emitStr(')');
     }
 
     private function emitIfElseCondition(IfNode $node): void
     {
-        $this->outputEmitter->emitStr('if (($__truthy = ', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($node->getTestExpr());
-        $this->outputEmitter->emitLine(') !== null && $__truthy !== false) {', $node->getStartSourceLocation());
+        $loc = $node->getStartSourceLocation();
+        $isBool = BooleanExprDetector::isBool($node->getTestExpr());
+
+        if ($isBool) {
+            $this->outputEmitter->emitStr('if ((', $loc);
+            $this->outputEmitter->emitNode($node->getTestExpr());
+            $this->outputEmitter->emitLine(')) {', $loc);
+        } else {
+            $this->outputEmitter->emitStr('if (($__truthy = ', $loc);
+            $this->outputEmitter->emitNode($node->getTestExpr());
+            $this->outputEmitter->emitLine(') !== null && $__truthy !== false) {', $loc);
+        }
+
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitNode($node->getThenExpr());
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine();
-        $this->outputEmitter->emitLine('} else {', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('} else {', $loc);
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitNode($node->getElseExpr());
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('}', $loc);
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -19,11 +19,30 @@ final class MapEmitter implements NodeEmitterInterface
     {
         assert($node instanceof MapNode);
 
+        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+
+        if ($slot !== null) {
+            $this->outputEmitter->emitStr(
+                '($__phel_const_' . $slot . ' ??= \Phel::map(',
+                $node->getStartSourceLocation(),
+            );
+            $this->emitEntries($node);
+            $this->outputEmitter->emitStr('))', $node->getStartSourceLocation());
+        } else {
+            $this->outputEmitter->emitStr('\Phel::map(', $node->getStartSourceLocation());
+            $this->emitEntries($node);
+            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+    }
+
+    private function emitEntries(MapNode $node): void
+    {
         $keyValues = $node->getKeyValues();
         $countKeyValues = count($keyValues);
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel::map(', $node->getStartSourceLocation());
         if ($countKeyValues > 0) {
             $this->outputEmitter->increaseIndentLevel();
             $this->outputEmitter->emitLine();
@@ -46,8 +65,5 @@ final class MapEmitter implements NodeEmitterInterface
         if ($countKeyValues > 0) {
             $this->outputEmitter->decreaseIndentLevel();
         }
-
-        $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -18,24 +18,18 @@ final class MapEmitter implements NodeEmitterInterface
     public function emit(AbstractNode $node): void
     {
         assert($node instanceof MapNode);
+        $loc = $node->getStartSourceLocation();
 
-        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-
-        if ($slot !== null) {
-            $this->outputEmitter->emitStr(
-                '($__phel_const_' . $slot . ' ??= \Phel::map(',
-                $node->getStartSourceLocation(),
-            );
-            $this->emitEntries($node);
-            $this->outputEmitter->emitStr('))', $node->getStartSourceLocation());
-        } else {
-            $this->outputEmitter->emitStr('\Phel::map(', $node->getStartSourceLocation());
-            $this->emitEntries($node);
-            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $loc);
+        $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
+        $this->outputEmitter->emitStr('\Phel::map(', $loc);
+        $this->emitEntries($node);
+        $this->outputEmitter->emitStr(')', $loc);
+        if ($cached) {
+            $this->outputEmitter->emitConstantSlotSuffix($loc);
         }
 
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $loc);
     }
 
     private function emitEntries(MapNode $node): void

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BodyConstantScanner;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
 use Phel\Compiler\Domain\Emitter\OutputEmitterInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function count;
+use function implode;
 use function is_string;
 
 final readonly class MethodEmitter
@@ -18,6 +21,7 @@ final readonly class MethodEmitter
     public function __construct(
         private OutputEmitterInterface $outputEmitter,
         private ClosureEmitterHelper $closureHelper,
+        private BodyConstantScanner $constantScanner = new BodyConstantScanner(),
     ) {}
 
     public function emit(string $methodName, FnNode $node): void
@@ -29,7 +33,7 @@ final readonly class MethodEmitter
         $this->emitMethodParametersExtraction($node);
         $this->emitSelfNameBinding($node);
         $this->emitMethodVariadicParameters($node);
-        $this->emitMethodBody($node);
+        $this->emitBodyWithConstantScope($node);
         $this->emitMethodEnd($node);
     }
 
@@ -84,7 +88,44 @@ final readonly class MethodEmitter
         }
 
         $this->emitMethodVariadicParameters($node);
-        $this->emitMethodBody($node);
+        $this->emitBodyWithConstantScope($node);
+    }
+
+    /**
+     * Wraps {@see emitMethodBody()} with a {@see ConstantScope} so the
+     * emitters for {@see VectorNode}, {@see MapNode}, and {@see SetNode}
+     * can hoist pure literals to per-fn `static` variables.
+     */
+    private function emitBodyWithConstantScope(FnNode $node): void
+    {
+        $scope = new ConstantScope();
+        $this->constantScanner->scan($node->getBody(), $scope);
+        $this->outputEmitter->pushConstantScope($scope);
+
+        try {
+            $this->emitConstantStatics($scope, $node);
+            $this->emitMethodBody($node);
+        } finally {
+            $this->outputEmitter->popConstantScope();
+        }
+    }
+
+    private function emitConstantStatics(ConstantScope $scope, FnNode $node): void
+    {
+        $count = $scope->count();
+        if ($count === 0) {
+            return;
+        }
+
+        $parts = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $parts[] = '$__phel_const_' . $i;
+        }
+
+        $this->outputEmitter->emitLine(
+            'static ' . implode(', ', $parts) . ';',
+            $node->getStartSourceLocation(),
+        );
     }
 
     private function extractTypeTag(mixed $meta): ?string

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
@@ -106,7 +106,15 @@ final class RecurEmitter implements NodeEmitterInterface
         }
 
         foreach ($node->getExpressions() as $i => $expr) {
-            foreach (LocalVarReferences::collect($expr) as $referencedName) {
+            $refs = LocalVarReferences::collect($expr);
+            if ($refs === null) {
+                // Scanner saw a node it does not enumerate; assume the
+                // expression could reference any param and fall back to
+                // the temp-var path.
+                return false;
+            }
+
+            foreach ($refs as $referencedName) {
                 $refIdx = array_search($referencedName, $paramNames, true);
                 if ($refIdx !== false && $refIdx < $i) {
                     return false;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/RecurEmitter.php
@@ -6,9 +6,11 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Symbol;
 
+use function array_search;
 use function assert;
 
 final class RecurEmitter implements NodeEmitterInterface
@@ -19,6 +21,42 @@ final class RecurEmitter implements NodeEmitterInterface
     {
         assert($node instanceof RecurNode);
 
+        if ($this->canSkipTempVars($node)) {
+            $this->emitDirect($node);
+        } else {
+            $this->emitViaTempVars($node);
+        }
+
+        $this->outputEmitter->emitLine('continue;', $node->getStartSourceLocation());
+    }
+
+    /**
+     * Direct path: each recur expression is assigned straight to its
+     * matching param. Safe only when no expression reads a param that an
+     * earlier expression has already overwritten.
+     */
+    private function emitDirect(RecurNode $node): void
+    {
+        $params = $node->getFrame()->getParams();
+        foreach ($node->getExpressions() as $i => $expr) {
+            $paramSym = $params[$i];
+            $shadowedSymbol = $node->getEnv()->getShadowed($paramSym);
+            $normalizedParam = $shadowedSymbol instanceof Symbol ? $shadowedSymbol : $paramSym;
+
+            $this->outputEmitter->emitPhpVariable($normalizedParam, $paramSym->getStartLocation());
+            $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($expr);
+            $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
+        }
+    }
+
+    /**
+     * Aliasing-safe path: evaluate every expression into a fresh temp,
+     * then assign each temp to its param. Handles patterns like
+     * `(recur b a)` (swap) where naive emission would clobber.
+     */
+    private function emitViaTempVars(RecurNode $node): void
+    {
         $tempSyms = [];
         foreach ($node->getExpressions() as $expr) {
             $tempSym = Symbol::gen();
@@ -42,7 +80,40 @@ final class RecurEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitPhpVariable($tempSym, $node->getStartSourceLocation());
             $this->outputEmitter->emitLine(';', $node->getStartSourceLocation());
         }
+    }
 
-        $this->outputEmitter->emitLine('continue;', $node->getStartSourceLocation());
+    /**
+     * Temp vars are only needed when an expression at index `i` reads a
+     * recur param at index `j` with `j < i`. That param has already been
+     * overwritten by the direct path's earlier assignment, so the read
+     * would return the new value instead of the original. Self-reference
+     * (`j == i`) is safe because PHP evaluates the RHS before the
+     * assignment; forward reference (`j > i`) is also safe because the
+     * later param hasn't been touched yet.
+     */
+    private function canSkipTempVars(RecurNode $node): bool
+    {
+        $env = $node->getEnv();
+
+        // For each param slot, the recur emit assigns to the *shadowed*
+        // PHP variable. Match against the same shadowed name that any
+        // `LocalVarNode` in the recur expressions will carry, so the
+        // detector compares apples to apples.
+        $paramNames = [];
+        foreach ($node->getFrame()->getParams() as $p) {
+            $shadow = $env->getShadowed($p);
+            $paramNames[] = $shadow instanceof Symbol ? $shadow->getName() : $p->getName();
+        }
+
+        foreach ($node->getExpressions() as $i => $expr) {
+            foreach (LocalVarReferences::collect($expr) as $referencedName) {
+                $refIdx = array_search($referencedName, $paramNames, true);
+                if ($refIdx !== false && $refIdx < $i) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
@@ -18,23 +18,17 @@ final class SetEmitter implements NodeEmitterInterface
     public function emit(AbstractNode $node): void
     {
         assert($node instanceof SetNode);
+        $loc = $node->getStartSourceLocation();
 
-        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-
-        if ($slot !== null) {
-            $this->outputEmitter->emitStr(
-                '($__phel_const_' . $slot . ' ??= \\' . Phel::class . '::set([',
-                $node->getStartSourceLocation(),
-            );
-            $this->outputEmitter->emitArgList($node->getValues(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr(']))', $node->getStartSourceLocation());
-        } else {
-            $this->outputEmitter->emitStr('\\' . Phel::class . '::set([', $node->getStartSourceLocation());
-            $this->outputEmitter->emitArgList($node->getValues(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $loc);
+        $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
+        $this->outputEmitter->emitStr('\\' . Phel::class . '::set([', $loc);
+        $this->outputEmitter->emitArgList($node->getValues(), $loc);
+        $this->outputEmitter->emitStr('])', $loc);
+        if ($cached) {
+            $this->outputEmitter->emitConstantSlotSuffix($loc);
         }
 
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $loc);
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
@@ -19,10 +19,22 @@ final class SetEmitter implements NodeEmitterInterface
     {
         assert($node instanceof SetNode);
 
+        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\\' . Phel::class . '::set([', $node->getStartSourceLocation());
-        $this->outputEmitter->emitArgList($node->getValues(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+
+        if ($slot !== null) {
+            $this->outputEmitter->emitStr(
+                '($__phel_const_' . $slot . ' ??= \\' . Phel::class . '::set([',
+                $node->getStartSourceLocation(),
+            );
+            $this->outputEmitter->emitArgList($node->getValues(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr(']))', $node->getStartSourceLocation());
+        } else {
+            $this->outputEmitter->emitStr('\\' . Phel::class . '::set([', $node->getStartSourceLocation());
+            $this->outputEmitter->emitArgList($node->getValues(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+        }
+
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -18,10 +18,22 @@ final class VectorEmitter implements NodeEmitterInterface
     {
         assert($node instanceof VectorNode);
 
+        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('\Phel::vector([', $node->getStartSourceLocation());
-        $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-        $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+
+        if ($slot !== null) {
+            $this->outputEmitter->emitStr(
+                '($__phel_const_' . $slot . ' ??= \Phel::vector([',
+                $node->getStartSourceLocation(),
+            );
+            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr(']))', $node->getStartSourceLocation());
+        } else {
+            $this->outputEmitter->emitStr('\Phel::vector([', $node->getStartSourceLocation());
+            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
+            $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+        }
+
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -17,23 +17,17 @@ final class VectorEmitter implements NodeEmitterInterface
     public function emit(AbstractNode $node): void
     {
         assert($node instanceof VectorNode);
+        $loc = $node->getStartSourceLocation();
 
-        $slot = $this->outputEmitter->currentConstantScope()?->lookup($node);
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
-
-        if ($slot !== null) {
-            $this->outputEmitter->emitStr(
-                '($__phel_const_' . $slot . ' ??= \Phel::vector([',
-                $node->getStartSourceLocation(),
-            );
-            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr(']))', $node->getStartSourceLocation());
-        } else {
-            $this->outputEmitter->emitStr('\Phel::vector([', $node->getStartSourceLocation());
-            $this->outputEmitter->emitArgList($node->getArgs(), $node->getStartSourceLocation());
-            $this->outputEmitter->emitStr('])', $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $loc);
+        $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
+        $this->outputEmitter->emitStr('\Phel::vector([', $loc);
+        $this->outputEmitter->emitArgList($node->getArgs(), $loc);
+        $this->outputEmitter->emitStr('])', $loc);
+        if ($cached) {
+            $this->outputEmitter->emitConstantSlotSuffix($loc);
         }
 
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $loc);
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Emitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\OutputEmitterOptions;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\SourceMap\SourceMapState;
 use Phel\Lang\SourceLocation;
@@ -13,6 +14,12 @@ use Phel\Lang\Symbol;
 
 interface OutputEmitterInterface
 {
+    public function pushConstantScope(ConstantScope $scope): void;
+
+    public function popConstantScope(): void;
+
+    public function currentConstantScope(): ?ConstantScope;
+
     public function resetIndentLevel(): void;
 
     public function resetSourceMapState(): void;

--- a/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitterInterface.php
@@ -20,6 +20,10 @@ interface OutputEmitterInterface
 
     public function currentConstantScope(): ?ConstantScope;
 
+    public function emitConstantSlotPrefix(AbstractNode $node, ?SourceLocation $loc = null): bool;
+
+    public function emitConstantSlotSuffix(?SourceLocation $loc = null): void;
+
     public function resetIndentLevel(): void;
 
     public function resetSourceMapState(): void;

--- a/tests/php/Integration/Compiler/ConstantHoistingRuntimeTest.php
+++ b/tests/php/Integration/Compiler/ConstantHoistingRuntimeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end check that pure collection literals inside a fn body are
+ * hoisted to a per-fn static cache: two invocations must return the same
+ * persistent value instance (identity, not just equality).
+ */
+final class ConstantHoistingRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_pure_vector_literal_is_shared_across_calls(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [] [1 2 3])', new CompileOptions());
+
+        $a = $fn();
+        $b = $fn();
+
+        self::assertSame($a, $b, 'pure vector literal must be cached across fn calls');
+    }
+
+    public function test_pure_map_literal_is_shared_across_calls(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [] {:a 1 :b 2})', new CompileOptions());
+
+        $a = $fn();
+        $b = $fn();
+
+        self::assertSame($a, $b, 'pure map literal must be cached across fn calls');
+    }
+
+    public function test_pure_set_literal_is_shared_across_calls(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [] #{1 2 3})', new CompileOptions());
+
+        $a = $fn();
+        $b = $fn();
+
+        self::assertSame($a, $b, 'pure set literal must be cached across fn calls');
+    }
+
+    public function test_impure_vector_still_allocates_per_call(): void
+    {
+        // The argument depends on the parameter so the literal is not
+        // pure and the optimization must skip it.
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] [x 2 3])', new CompileOptions());
+
+        $a = $fn(1);
+        $b = $fn(1);
+
+        self::assertEquals($a, $b);
+        self::assertNotSame($a, $b, 'literals depending on parameters must not be cached');
+    }
+
+    public function test_two_calls_with_different_args_keep_cache_unchanged(): void
+    {
+        /** @var callable $fn */
+        $fn = $this->compilerFacade->eval('(fn [x] [1 2 3])', new CompileOptions());
+
+        $first = $fn('ignored');
+        $second = $fn(42);
+
+        self::assertSame($first, $second);
+    }
+
+    public function test_nested_fn_has_independent_static_scope(): void
+    {
+        /** @var callable $outer */
+        $outer = $this->compilerFacade->eval(
+            '(fn [] (fn [] [1 2 3]))',
+            new CompileOptions(),
+        );
+
+        $innerA = $outer();
+        $innerB = $outer();
+
+        // Each call to the outer fn returns a fresh inner closure; their
+        // static caches are independent, but each inner cache is shared
+        // across its own invocations.
+        $innerAFirst = $innerA();
+        $innerASecond = $innerA();
+        self::assertSame($innerAFirst, $innerASecond);
+
+        $innerBFirst = $innerB();
+        self::assertEquals($innerAFirst, $innerBFirst);
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -8,7 +8,7 @@
     public const BOUND_TO = "user\\rec";
 
     public function __invoke(int $n) {
-      if (($__truthy = ($n == 0)) !== null && $__truthy !== false) {
+      if ((($n == 0))) {
         return $n;
       } else {
         return $this(($n - 1));

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -1,7 +1,5 @@
 --PHEL--
-(def x (fn []
-  (foreach [v [1 2 3]]
-    (php/+ v v))))
+(def x (fn [] {:a 1 :b 2}))
 --PHP--
 \Phel::addDefinition(
   "user",
@@ -11,24 +9,22 @@
 
     public function __invoke() {
       static $__phel_const_0;
-      return (function() use(&$__phel_const_0) {
-        foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $v) {
-          ($v + $v);
-        }
-        return null;
-      })();
+      return ($__phel_const_0 ??= \Phel::map(
+        \Phel::keyword("a"), 1,
+        \Phel::keyword("b"), 2
+      ));
     }
   },
   \Phel::map(
     \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
+      \Phel::keyword("file"), "ConstantHoisting/map-in-fn-body.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
     \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 18
+      \Phel::keyword("file"), "ConstantHoisting/map-in-fn-body.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 27
     ),
     "min-arity", 0,
     "is-variadic", false,

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -1,0 +1,36 @@
+--PHEL--
+(def f (fn [b]
+  (if b [1 2] [3 4])))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "f",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\f";
+
+    public function __invoke($b) {
+      static $__phel_const_0, $__phel_const_1;
+      if (($__truthy = $b) !== null && $__truthy !== false) {
+        return ($__phel_const_0 ??= \Phel::vector([1, 2]));
+      } else {
+        return ($__phel_const_1 ??= \Phel::vector([3, 4]));
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "ConstantHoisting/multiple-pure-literals.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "ConstantHoisting/multiple-pure-literals.test",
+      \Phel::keyword("line"), 2,
+      \Phel::keyword("column"), 22
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[b]"
+  )
+);

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -1,7 +1,5 @@
 --PHEL--
-(def x (fn []
-  (foreach [v [1 2 3]]
-    (php/+ v v))))
+(def x (fn [] #{1 2 3}))
 --PHP--
 \Phel::addDefinition(
   "user",
@@ -11,24 +9,19 @@
 
     public function __invoke() {
       static $__phel_const_0;
-      return (function() use(&$__phel_const_0) {
-        foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $v) {
-          ($v + $v);
-        }
-        return null;
-      })();
+      return ($__phel_const_0 ??= \Phel::set([1, 2, 3]));
     }
   },
   \Phel::map(
     \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
+      \Phel::keyword("file"), "ConstantHoisting/set-in-fn-body.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
     \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 18
+      \Phel::keyword("file"), "ConstantHoisting/set-in-fn-body.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 24
     ),
     "min-arity", 0,
     "is-variadic", false,

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -1,7 +1,5 @@
 --PHEL--
-(def x (fn []
-  (foreach [v [1 2 3]]
-    (php/+ v v))))
+(def x (fn [] [1 2 3]))
 --PHP--
 \Phel::addDefinition(
   "user",
@@ -11,24 +9,19 @@
 
     public function __invoke() {
       static $__phel_const_0;
-      return (function() use(&$__phel_const_0) {
-        foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $v) {
-          ($v + $v);
-        }
-        return null;
-      })();
+      return ($__phel_const_0 ??= \Phel::vector([1, 2, 3]));
     }
   },
   \Phel::map(
     \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
+      \Phel::keyword("file"), "ConstantHoisting/vector-in-fn-body.test",
       \Phel::keyword("line"), 1,
       \Phel::keyword("column"), 0
     ),
     \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 18
+      \Phel::keyword("file"), "ConstantHoisting/vector-in-fn-body.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 23
     ),
     "min-arity", 0,
     "is-variadic", false,

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -33,7 +33,7 @@ interface IPlayer {
     public const BOUND_TO = "interface_instance\\choose";
 
     public function __invoke($p) {
-      if (($__truthy = is_a($p, "interface_instance\\IPlayer")) !== null && $__truthy !== false) {
+      if ((is_a($p, "interface_instance\\IPlayer"))) {
         return (function() use($p) {
           $target_1 = $p;
           return $target_1->choose();
@@ -69,7 +69,7 @@ interface IPlayer {
     public const BOUND_TO = "interface_instance\\update_strategy";
 
     public function __invoke($p, $me, $you) {
-      if (($__truthy = is_a($p, "interface_instance\\IPlayer")) !== null && $__truthy !== false) {
+      if ((is_a($p, "interface_instance\\IPlayer"))) {
         return (function() use($p,$me,$you) {
           $target_2 = $p;
           return $target_2->update_strategy($me, $you);

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -31,7 +31,7 @@ interface IPlayer {
     public const BOUND_TO = "user\\choose";
 
     public function __invoke($p) {
-      if (($__truthy = is_a($p, "user\\IPlayer")) !== null && $__truthy !== false) {
+      if ((is_a($p, "user\\IPlayer"))) {
         return (function() use($p) {
           $target_1 = $p;
           return $target_1->choose();
@@ -67,7 +67,7 @@ interface IPlayer {
     public const BOUND_TO = "user\\update_strategy";
 
     public function __invoke($p, $me, $you) {
-      if (($__truthy = is_a($p, "user\\IPlayer")) !== null && $__truthy !== false) {
+      if ((is_a($p, "user\\IPlayer"))) {
         return (function() use($p,$me,$you) {
           $target_2 = $p;
           return $target_2->update_strategy($me, $you);

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -8,11 +8,12 @@
     public const BOUND_TO = "user\\f";
 
     public function __invoke() {
+      static $__phel_const_0;
       \Phel::addDefinition(
         "user",
         "x",
         1,
-        \Phel::map(
+        ($__phel_const_0 ??= \Phel::map(
           \Phel::keyword("start-location"), \Phel::map(
             \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
             \Phel::keyword("line"), 1,
@@ -23,7 +24,7 @@
             \Phel::keyword("line"), 1,
             \Phel::keyword("column"), 23
           )
-        )
+        ))
       );
 
       return \Phel::getDefinition("user", "x");

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
@@ -9,8 +9,7 @@
     if ((($acc_1 <= 1))) {
       return $acc_1;
     } else {
-      $__phel_2 = ("x" . $acc_1);
-      $acc_1 = $__phel_2;
+      $acc_1 = ("x" . $acc_1);
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-drift.test
@@ -6,7 +6,7 @@
 (function(int $n) {
   $acc_1 = $n;
   while (true) {
-    if (($__truthy = ($acc_1 <= 1)) !== null && $__truthy !== false) {
+    if ((($acc_1 <= 1))) {
       return $acc_1;
     } else {
       $__phel_2 = ("x" . $acc_1);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
@@ -6,7 +6,7 @@
 (function(int $n, $stop) {
   $acc_1 = $n;
   while (true) {
-    if (($__truthy = ($acc_1 <= 1)) !== null && $__truthy !== false) {
+    if ((($acc_1 <= 1))) {
       return $acc_1;
     } else {
       $__phel_2 = $stop;

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-loop-recur-unknown.test
@@ -9,8 +9,7 @@
     if ((($acc_1 <= 1))) {
       return $acc_1;
     } else {
-      $__phel_2 = $stop;
-      $acc_1 = $__phel_2;
+      $acc_1 = $stop;
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
@@ -2,7 +2,7 @@
 (fn [^int x] (if (php/< x 0) nil (php/+ x 1)))
 --PHP--
 (function(int $x) {
-  if (($__truthy = ($x < 0)) !== null && $__truthy !== false) {
+  if ((($x < 0))) {
     return null;
   } else {
     return ($x + 1);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -8,7 +8,7 @@
     public const BOUND_TO = "user\\fib";
 
     public function __invoke(int $n) {
-      if (($__truthy = ($n < 2)) !== null && $__truthy !== false) {
+      if ((($n < 2))) {
         return $n;
       } else {
         return ($this(($n - 1)) + $this(($n - 2)));

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
@@ -2,7 +2,7 @@
 (fn [^int x] (if (php/< x 0) 0 (php/+ x 1)))
 --PHP--
 (function(int $x): int {
-  if (($__truthy = ($x < 0)) !== null && $__truthy !== false) {
+  if ((($x < 0))) {
     return 0;
   } else {
     return ($x + 1);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-loop-factorial.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-loop-factorial.test
@@ -9,7 +9,7 @@
   $i_1 = $n;
   $acc_2 = 1;
   while (true) {
-    if (($__truthy = ($i_1 <= 1)) !== null && $__truthy !== false) {
+    if ((($i_1 <= 1))) {
       return $acc_2;
     } else {
       $__phel_3 = ($i_1 - 1);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
@@ -8,13 +8,13 @@
 (function(int $n): int {
   $outer_1 = $n;
   while (true) {
-    if (($__truthy = ($outer_1 <= 0)) !== null && $__truthy !== false) {
+    if ((($outer_1 <= 0))) {
       return $outer_1;
     } else {
       $__phel_3 = (function() use($n,$outer_1) {
         $inner_2 = $outer_1;
         while (true) {
-          if (($__truthy = ($inner_2 <= 1)) !== null && $__truthy !== false) {
+          if ((($inner_2 <= 1))) {
             return $inner_2;
           } else {
             $__phel_4 = ($inner_2 - 1);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-nested-loops.test
@@ -11,21 +11,19 @@
     if ((($outer_1 <= 0))) {
       return $outer_1;
     } else {
-      $__phel_3 = (function() use($n,$outer_1) {
+      $outer_1 = (function() use($n,$outer_1) {
         $inner_2 = $outer_1;
         while (true) {
           if ((($inner_2 <= 1))) {
             return $inner_2;
           } else {
-            $__phel_4 = ($inner_2 - 1);
-            $inner_2 = $__phel_4;
+            $inner_2 = ($inner_2 - 1);
             continue;
 
           }
           break;
         }
       })();
-      $outer_1 = $__phel_3;
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -5,9 +5,10 @@
       (println b))))
 --PHP--
 (function() {
+  static $__phel_const_0;
   $b_1 = 10;
-  return (function() use($b_1) {
-    foreach (\Phel\Lang\Seq::toIterable(\Phel::vector([1, 2, 3])) as $b) {
+  return (function() use($b_1,&$__phel_const_0) {
+    foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $b) {
       (\Phel::getDefinition("phel.core", "println"))($b);
     }
     return null;

--- a/tests/php/Integration/Fixtures/If/if-then-else-expr.test
+++ b/tests/php/Integration/Fixtures/If/if-then-else-expr.test
@@ -1,5 +1,5 @@
 --PHEL--
 (let [x (if true (php/+ 1 1) (php/+ 2 2))] x)
 --PHP--
-$x_1 = (($__truthy = true) !== null && $__truthy !== false ? (1 + 1) : (2 + 2));
+$x_1 = ((true) ? (1 + 1) : (2 + 2));
 $x_1;

--- a/tests/php/Integration/Fixtures/If/if-then-else.test
+++ b/tests/php/Integration/Fixtures/If/if-then-else.test
@@ -1,7 +1,7 @@
 --PHEL--
 (if true (php/+ 1 1) (php/+ 2 2))
 --PHP--
-if (($__truthy = true) !== null && $__truthy !== false) {
+if ((true)) {
   (1 + 1);
 } else {
   (2 + 2);

--- a/tests/php/Integration/Fixtures/If/if-then.test
+++ b/tests/php/Integration/Fixtures/If/if-then.test
@@ -1,7 +1,7 @@
 --PHEL--
 (if true (php/+ 1 1))
 --PHP--
-if (($__truthy = true) !== null && $__truthy !== false) {
+if ((true)) {
   (1 + 1);
 } else {
 

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -31,10 +31,8 @@ while (true) {
     if ((($x_11 == null))) {
       $sum_3;
     } else {
-      $__phel_14 = $xs_13;
-      $__phel_15 = ($sum_3 + $x_11);
-      $__phel_1_2 = $__phel_14;
-      $sum_3 = $__phel_15;
+      $__phel_1_2 = $xs_13;
+      $sum_3 = ($sum_3 + $x_11);
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -28,7 +28,7 @@ while (true) {
   $__phel_7_12 = $__phel_6_10;
   $xs_13 = $__phel_7_12;
   if (($__truthy = $x_11) !== null && $__truthy !== false) {
-    if (($__truthy = ($x_11 == null)) !== null && $__truthy !== false) {
+    if ((($x_11 == null))) {
       $sum_3;
     } else {
       $__phel_14 = $xs_13;

--- a/tests/php/Integration/Fixtures/Let/loop.test
+++ b/tests/php/Integration/Fixtures/Let/loop.test
@@ -6,7 +6,7 @@
 $n_1 = 10;
 $sum_2 = 0;
 while (true) {
-  if (($__truthy = ($n_1 <= 0)) !== null && $__truthy !== false) {
+  if ((($n_1 <= 0))) {
     $sum_2;
   } else {
     $__phel_3 = ($n_1 - 1);

--- a/tests/php/Integration/Fixtures/ReaderCond/inside-if.test
+++ b/tests/php/Integration/Fixtures/ReaderCond/inside-if.test
@@ -1,7 +1,7 @@
 --PHEL--
 (if #?(:phel true :clj false) (php/+ 1 1) (php/+ 2 2))
 --PHP--
-if (($__truthy = true) !== null && $__truthy !== false) {
+if ((true)) {
   (1 + 1);
 } else {
   (2 + 2);

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
@@ -9,8 +9,7 @@
     if ((($x == 0))) {
       return $x;
     } else {
-      $__phel_1 = ($x - 1);
-      $x = $__phel_1;
+      $x = ($x - 1);
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-one-arg.test
@@ -6,7 +6,7 @@
 --PHP--
 (function($x) {
   while (true) {
-    if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
+    if ((($x == 0))) {
       return $x;
     } else {
       $__phel_1 = ($x - 1);

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
@@ -6,7 +6,7 @@
 --PHP--
 (function($x, $y) {
   while (true) {
-    if (($__truthy = ($x == 0)) !== null && $__truthy !== false) {
+    if ((($x == 0))) {
       return $x;
     } else {
       $__phel_1 = ($x - 1);

--- a/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
+++ b/tests/php/Integration/Fixtures/Recur/recur-fn-two-args.test
@@ -9,10 +9,8 @@
     if ((($x == 0))) {
       return $x;
     } else {
-      $__phel_1 = ($x - 1);
-      $__phel_2 = ($y + 1);
-      $x = $__phel_1;
-      $y = $__phel_2;
+      $x = ($x - 1);
+      $y = ($y + 1);
       continue;
 
     }

--- a/tests/php/Integration/Fixtures/RecurElision/recur-aliasing-uses-temps.test
+++ b/tests/php/Integration/Fixtures/RecurElision/recur-aliasing-uses-temps.test
@@ -1,0 +1,19 @@
+--PHEL--
+(fn [a b]
+  (if (php/== a 0) b (recur (php/- a 1) (php/+ a b))))
+--PHP--
+(function($a, $b) {
+  while (true) {
+    if ((($a == 0))) {
+      return $b;
+    } else {
+      $__phel_1 = ($a - 1);
+      $__phel_2 = ($a + $b);
+      $a = $__phel_1;
+      $b = $__phel_2;
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Fixtures/RecurElision/recur-no-aliasing-direct.test
+++ b/tests/php/Integration/Fixtures/RecurElision/recur-no-aliasing-direct.test
@@ -1,0 +1,17 @@
+--PHEL--
+(fn [a b]
+  (if (php/== a 0) b (recur (php/- a 1) (php/+ b 1))))
+--PHP--
+(function($a, $b) {
+  while (true) {
+    if ((($a == 0))) {
+      return $b;
+    } else {
+      $a = ($a - 1);
+      $b = ($b + 1);
+      continue;
+
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -10,8 +10,9 @@
     public const BOUND_TO = "user\\yield_generator_array";
 
     public function __invoke() {
-      return (function() {
-        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(\Phel::vector([0, 3])))) as $i) {
+      static $__phel_const_0;
+      return (function() use(&$__phel_const_0) {
+        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_const_0 ??= \Phel::vector([0, 3]))))) as $i) {
           yield $i => 21;
         }
         return null;

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -10,8 +10,9 @@
     public const BOUND_TO = "user\\yield_generator_str";
 
     public function __invoke() {
-      return (function() {
-        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(\Phel::vector([0, 3])))) as $i) {
+      static $__phel_const_0;
+      return (function() use(&$__phel_const_0) {
+        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_const_0 ??= \Phel::vector([0, 3]))))) as $i) {
           yield $i;
         }
         return null;

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -10,8 +10,9 @@
     public const BOUND_TO = "user\\yield_generator_str";
 
     public function __invoke() {
-      return (function() {
-        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(\Phel::vector([0, 3])))) as $i) {
+      static $__phel_const_0;
+      return (function() use(&$__phel_const_0) {
+        foreach (\Phel\Lang\Seq::toIterable((\Phel::getDefinition("phel.core", "range"))(...\Phel\Lang\Seq::toApplyArguments(($__phel_const_0 ??= \Phel::vector([0, 3]))))) as $i) {
           yield $i;
         }
         return null;

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BodyConstantScannerTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BodyConstantScannerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BodyConstantScanner;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class BodyConstantScannerTest extends TestCase
+{
+    public function test_pure_vector_at_root_is_reserved(): void
+    {
+        $vector = $this->pureVector();
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($vector, $scope);
+
+        self::assertSame(0, $scope->lookup($vector));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_pure_map_at_root_is_reserved(): void
+    {
+        $map = new MapNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'k'),
+            new LiteralNode(NodeEnvironment::empty(), 'v'),
+        ]);
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($map, $scope);
+
+        self::assertSame(0, $scope->lookup($map));
+    }
+
+    public function test_pure_set_at_root_is_reserved(): void
+    {
+        $set = new SetNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($set, $scope);
+
+        self::assertSame(0, $scope->lookup($set));
+    }
+
+    public function test_empty_vector_is_not_reserved(): void
+    {
+        $empty = new VectorNode(NodeEnvironment::empty(), []);
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($empty, $scope);
+
+        self::assertNull($scope->lookup($empty));
+        self::assertSame(0, $scope->count());
+    }
+
+    public function test_descends_into_call_arguments(): void
+    {
+        $vector = $this->pureVector();
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(NodeEnvironment::empty(), 'phel.core', Symbol::create('print'), Phel::map()),
+            [$vector],
+        );
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($call, $scope);
+
+        self::assertSame(0, $scope->lookup($vector));
+    }
+
+    public function test_descends_into_if_branches(): void
+    {
+        $thenVec = $this->pureVector();
+        $elseVec = $this->pureVector();
+        $if = new IfNode(
+            NodeEnvironment::empty(),
+            new LiteralNode(NodeEnvironment::empty(), true),
+            $thenVec,
+            $elseVec,
+        );
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($if, $scope);
+
+        self::assertSame(0, $scope->lookup($thenVec));
+        self::assertSame(1, $scope->lookup($elseVec));
+    }
+
+    public function test_descends_into_let_bindings_and_body(): void
+    {
+        $initVec = $this->pureVector();
+        $bodyVec = $this->pureVector();
+        $let = new LetNode(
+            NodeEnvironment::empty(),
+            [
+                new BindingNode(
+                    NodeEnvironment::empty(),
+                    Symbol::create('x'),
+                    Symbol::create('x_1'),
+                    $initVec,
+                ),
+            ],
+            $bodyVec,
+            false,
+        );
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($let, $scope);
+
+        self::assertSame(0, $scope->lookup($initVec));
+        self::assertSame(1, $scope->lookup($bodyVec));
+    }
+
+    public function test_does_not_descend_into_nested_fn(): void
+    {
+        $innerVec = $this->pureVector();
+        $innerFn = new FnNode(
+            NodeEnvironment::empty(),
+            [],
+            $innerVec,
+            [],
+            false,
+            false,
+        );
+        $outerDo = new DoNode(NodeEnvironment::empty(), [], $innerFn);
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($outerDo, $scope);
+
+        self::assertNull($scope->lookup($innerVec));
+        self::assertSame(0, $scope->count());
+    }
+
+    public function test_outer_pure_literal_does_not_recurse_into_children(): void
+    {
+        $inner = $this->pureVector();
+        $outer = new VectorNode(NodeEnvironment::empty(), [$inner]);
+        $scope = new ConstantScope();
+
+        new BodyConstantScanner()->scan($outer, $scope);
+
+        // Only the outer literal is hoisted; inner allocates once inside it.
+        self::assertSame(0, $scope->lookup($outer));
+        self::assertNull($scope->lookup($inner));
+        self::assertSame(1, $scope->count());
+    }
+
+    private function pureVector(): VectorNode
+    {
+        return new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+            new LiteralNode(NodeEnvironment::empty(), 2),
+            new LiteralNode(NodeEnvironment::empty(), 3),
+        ]);
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/BooleanExprDetectorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanExprDetectorTest extends TestCase
+{
+    public function test_bool_literal_is_bool(): void
+    {
+        self::assertTrue(BooleanExprDetector::isBool(new LiteralNode(NodeEnvironment::empty(), true)));
+        self::assertTrue(BooleanExprDetector::isBool(new LiteralNode(NodeEnvironment::empty(), false)));
+    }
+
+    public function test_non_bool_literal_is_not_bool(): void
+    {
+        self::assertFalse(BooleanExprDetector::isBool(new LiteralNode(NodeEnvironment::empty(), 1)));
+        self::assertFalse(BooleanExprDetector::isBool(new LiteralNode(NodeEnvironment::empty(), 'x')));
+        self::assertFalse(BooleanExprDetector::isBool(new LiteralNode(NodeEnvironment::empty(), null)));
+    }
+
+    public function test_infix_comparison_is_bool(): void
+    {
+        foreach (['===', '!==', '==', '!=', '<', '>', '<=', '>='] as $op) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new PhpVarNode(NodeEnvironment::empty(), $op),
+                [
+                    new LiteralNode(NodeEnvironment::empty(), 1),
+                    new LiteralNode(NodeEnvironment::empty(), 2),
+                ],
+            );
+            self::assertTrue(BooleanExprDetector::isBool($call), $op . ' should be bool');
+        }
+    }
+
+    public function test_infix_arithmetic_is_not_bool(): void
+    {
+        foreach (['+', '-', '*', '/', '%', '.', '<<', '>>'] as $op) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new PhpVarNode(NodeEnvironment::empty(), $op),
+                [
+                    new LiteralNode(NodeEnvironment::empty(), 1),
+                    new LiteralNode(NodeEnvironment::empty(), 2),
+                ],
+            );
+            self::assertFalse(BooleanExprDetector::isBool($call), $op . ' should not be bool');
+        }
+    }
+
+    public function test_known_bool_php_function_is_bool(): void
+    {
+        foreach (['is_int', 'is_string', 'is_a', 'in_array', 'array_key_exists', 'method_exists'] as $fn) {
+            $call = new CallNode(
+                NodeEnvironment::empty(),
+                new PhpVarNode(NodeEnvironment::empty(), $fn),
+                [],
+            );
+            self::assertTrue(BooleanExprDetector::isBool($call), $fn . ' should be bool');
+        }
+    }
+
+    public function test_namespaced_known_bool_php_function_is_bool(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new PhpVarNode(NodeEnvironment::empty(), '\\is_int'),
+            [],
+        );
+        self::assertTrue(BooleanExprDetector::isBool($call));
+    }
+
+    public function test_unknown_php_function_is_not_bool(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new PhpVarNode(NodeEnvironment::empty(), 'strlen'),
+            [],
+        );
+        self::assertFalse(BooleanExprDetector::isBool($call));
+    }
+
+    public function test_global_var_call_is_not_bool(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(NodeEnvironment::empty(), 'phel.core', Symbol::create('foo'), Phel::map()),
+            [],
+        );
+        self::assertFalse(BooleanExprDetector::isBool($call));
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/ConstantScopeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\ConstantScope;
+use PHPUnit\Framework\TestCase;
+
+final class ConstantScopeTest extends TestCase
+{
+    public function test_starts_empty(): void
+    {
+        $scope = new ConstantScope();
+        self::assertSame(0, $scope->count());
+    }
+
+    public function test_reserve_assigns_sequential_ids(): void
+    {
+        $scope = new ConstantScope();
+        $a = new LiteralNode(NodeEnvironment::empty(), 1);
+        $b = new LiteralNode(NodeEnvironment::empty(), 2);
+
+        self::assertSame(0, $scope->reserve($a));
+        self::assertSame(1, $scope->reserve($b));
+        self::assertSame(2, $scope->count());
+    }
+
+    public function test_reserve_is_idempotent_per_node(): void
+    {
+        $scope = new ConstantScope();
+        $node = new LiteralNode(NodeEnvironment::empty(), 1);
+
+        self::assertSame(0, $scope->reserve($node));
+        self::assertSame(0, $scope->reserve($node));
+        self::assertSame(1, $scope->count());
+    }
+
+    public function test_lookup_returns_null_for_unknown_node(): void
+    {
+        $scope = new ConstantScope();
+        $node = new LiteralNode(NodeEnvironment::empty(), 1);
+
+        self::assertNull($scope->lookup($node));
+    }
+
+    public function test_lookup_returns_reserved_slot(): void
+    {
+        $scope = new ConstantScope();
+        $node = new LiteralNode(NodeEnvironment::empty(), 1);
+        $scope->reserve($node);
+
+        self::assertSame(0, $scope->lookup($node));
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/LocalVarReferencesTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/LocalVarReferencesTest.php
@@ -7,6 +7,8 @@ namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MethodCallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpObjectCallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
@@ -15,6 +17,26 @@ use PHPUnit\Framework\TestCase;
 
 final class LocalVarReferencesTest extends TestCase
 {
+    public function test_local_inside_method_call_is_collected(): void
+    {
+        // Mirrors `(-> more (get i))` from the `aset` macro body: a
+        // local nested in a `MethodCallNode` must still be reachable.
+        $methodCall = new MethodCallNode(
+            NodeEnvironment::empty(),
+            Symbol::create('get'),
+            [new LocalVarNode(NodeEnvironment::empty(), Symbol::create('i'))],
+        );
+        $objCall = new PhpObjectCallNode(
+            NodeEnvironment::empty(),
+            new LocalVarNode(NodeEnvironment::empty(), Symbol::create('more')),
+            $methodCall,
+            isStatic: false,
+            isMethodCall: true,
+        );
+
+        self::assertSame(['more', 'i'], LocalVarReferences::collect($objCall));
+    }
+
     public function test_collects_single_local_var(): void
     {
         $node = new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x'));

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/LocalVarReferencesTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/LocalVarReferencesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\LocalVarReferences;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class LocalVarReferencesTest extends TestCase
+{
+    public function test_collects_single_local_var(): void
+    {
+        $node = new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x'));
+
+        self::assertSame(['x'], LocalVarReferences::collect($node));
+    }
+
+    public function test_collects_no_locals_from_a_literal(): void
+    {
+        $node = new LiteralNode(NodeEnvironment::empty(), 1);
+
+        self::assertSame([], LocalVarReferences::collect($node));
+    }
+
+    public function test_collects_locals_in_call_arguments(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new PhpVarNode(NodeEnvironment::empty(), '+'),
+            [
+                new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x')),
+                new LocalVarNode(NodeEnvironment::empty(), Symbol::create('y')),
+            ],
+        );
+
+        self::assertSame(['x', 'y'], LocalVarReferences::collect($call));
+    }
+
+    public function test_collects_nested_references(): void
+    {
+        $inner = new CallNode(
+            NodeEnvironment::empty(),
+            new PhpVarNode(NodeEnvironment::empty(), '-'),
+            [
+                new LocalVarNode(NodeEnvironment::empty(), Symbol::create('x')),
+                new LiteralNode(NodeEnvironment::empty(), 1),
+            ],
+        );
+        $outer = new CallNode(
+            NodeEnvironment::empty(),
+            new PhpVarNode(NodeEnvironment::empty(), '+'),
+            [
+                $inner,
+                new LocalVarNode(NodeEnvironment::empty(), Symbol::create('y')),
+            ],
+        );
+
+        self::assertSame(['x', 'y'], LocalVarReferences::collect($outer));
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/PureLiteralDetectorTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/ConstantHoisting/PureLiteralDetectorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\ConstantHoisting;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\PureLiteralDetector;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class PureLiteralDetectorTest extends TestCase
+{
+    public function test_literal_is_pure(): void
+    {
+        $node = new LiteralNode(NodeEnvironment::empty(), 1);
+        self::assertTrue(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_quote_is_pure(): void
+    {
+        $node = new QuoteNode(NodeEnvironment::empty(), Symbol::create('x'));
+        self::assertTrue(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_vector_of_literals_is_pure(): void
+    {
+        $node = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+            new LiteralNode(NodeEnvironment::empty(), 2),
+        ]);
+        self::assertTrue(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_nested_vector_of_literals_is_pure(): void
+    {
+        $inner = new VectorNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        $outer = new VectorNode(NodeEnvironment::empty(), [$inner]);
+        self::assertTrue(PureLiteralDetector::isPure($outer));
+    }
+
+    public function test_map_of_literals_is_pure(): void
+    {
+        $node = new MapNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'k'),
+            new LiteralNode(NodeEnvironment::empty(), 'v'),
+        ]);
+        self::assertTrue(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_set_of_literals_is_pure(): void
+    {
+        $node = new SetNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 1),
+        ]);
+        self::assertTrue(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_vector_containing_a_call_is_not_pure(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(NodeEnvironment::empty(), 'phel.core', Symbol::create('inc'), Phel::map()),
+            [new LiteralNode(NodeEnvironment::empty(), 1)],
+        );
+        $node = new VectorNode(NodeEnvironment::empty(), [$call]);
+
+        self::assertFalse(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_map_with_dynamic_value_is_not_pure(): void
+    {
+        $call = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(NodeEnvironment::empty(), 'phel.core', Symbol::create('inc'), Phel::map()),
+            [],
+        );
+        $node = new MapNode(NodeEnvironment::empty(), [
+            new LiteralNode(NodeEnvironment::empty(), 'k'),
+            $call,
+        ]);
+
+        self::assertFalse(PureLiteralDetector::isPure($node));
+    }
+
+    public function test_call_node_is_not_pure(): void
+    {
+        $node = new CallNode(
+            NodeEnvironment::empty(),
+            new GlobalVarNode(NodeEnvironment::empty(), 'phel.core', Symbol::create('inc'), Phel::map()),
+            [],
+        );
+        self::assertFalse(PureLiteralDetector::isPure($node));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Pure collection literals (`[1 2 3]`, `{:a 1}`, `#{:x :y}`) built inside a fn body were being rebuilt on every call, even though `PersistentVector` / `PersistentHashMap` / `PersistentHashSet` are immutable.

## 🔖 Changes

- Hoist pure collection literals to a per-fn `static` cache. First call builds the persistent collection; later calls reuse the same instance.
- Implemented via `PureLiteralDetector` + `BodyConstantScanner` + `ConstantScope`; `MethodEmitter` emits `static $__phel_const_N;` and the literal emitters render `($__phel_const_N ??= \Phel::vector([...]))`.
- IIFE wrappers (`let`, `do`, `foreach`, … in expression context) get matching `use(&$__phel_const_N)` so nested scopes still hit the same slot.
- Tests: unit (detector + scope + scanner), 4 integration fixtures under `ConstantHoisting/`, and a runtime test (`ConstantHoistingRuntimeTest`) asserting `assertSame` across calls.

### Side fixes

- `build/scripts/patch-psalm.php` + composer post-install/update hook: patches vendored Psalm 6.16.1 for the PHP 8.5 *"NAN coerced to string"* crash (Psalm 7 fixes it upstream but reports 1650 new errors — out of scope here).
- `ConstantScope`: use `SplObjectStorage::offsetExists()` instead of PHP 8.5-deprecated `contains()` (the notice was leaking into emitted code).
- `phpstan` bumped 2.1.50 → 2.1.55 (patch).

## Test plan

- [x] `composer test-all` green on PHP 8.4 and 8.5
- [x] 5611 Phel core tests + 3436 PHPUnit tests pass