### PR TITLE
feat(cli): `phel compile` command to emit PHP from a Phel snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - `composer test-tools`: bashunit runner for `tools/*-test.sh`
 - `CITATION.cff` for academic citation (#2016)
 - CI: `clojure-test-suite` workflow runs `phel-lang/clojure-test-suite` against dev HEAD on every PR (non-blocking) (#2036)
+- `phel compile`: new CLI command emits PHP from a Phel snippet, file, or stdin without evaluating; `--target` option reserved for future `ast`/`tokens` dumps (#2043)
 
 ### Changed
 

--- a/src/php/Build/Infrastructure/Command/BuildCommand.php
+++ b/src/php/Build/Infrastructure/Command/BuildCommand.php
@@ -33,7 +33,6 @@ final class BuildCommand extends Command
     protected function configure(): void
     {
         $this->setName('build')
-            ->setAliases(['compile'])
             ->setDescription('Build the current project')
             ->addOption(self::OPTION_CACHE, null, InputOption::VALUE_NEGATABLE, 'Enable cache', true)
             ->addOption(self::OPTION_SOURCE_MAP, null, InputOption::VALUE_NEGATABLE, 'Enable source maps', true);

--- a/src/php/Console/Infrastructure/Command/RunCommands.php
+++ b/src/php/Console/Infrastructure/Command/RunCommands.php
@@ -6,6 +6,7 @@ namespace Phel\Console\Infrastructure\Command;
 
 use Phel\Console\Domain\ConsoleCommandProviderInterface;
 use Phel\Run\Infrastructure\Command\AgentInstallCommand;
+use Phel\Run\Infrastructure\Command\CompileCommand;
 use Phel\Run\Infrastructure\Command\DoctorCommand;
 use Phel\Run\Infrastructure\Command\EvalCommand;
 use Phel\Run\Infrastructure\Command\InitCommand;
@@ -25,6 +26,7 @@ final class RunCommands implements ConsoleCommandProviderInterface
             new NsCommand(),
             new ReplCommand(),
             new EvalCommand(),
+            new CompileCommand(),
             new RunCommand(),
             new TestCommand(),
             new TestWorkerCommand(),

--- a/src/php/Run/Application/CompileExecutor.php
+++ b/src/php/Run/Application/CompileExecutor.php
@@ -30,6 +30,10 @@ final readonly class CompileExecutor
      */
     public function execute(string $source, callable $stdout, callable $stderr): bool
     {
+        if ($source === '') {
+            return true;
+        }
+
         if (!$this->compilerFacade->hasBalancedParentheses($source)) {
             $stderr("Unbalanced parentheses.\n");
             return false;

--- a/src/php/Run/Application/CompileExecutor.php
+++ b/src/php/Run/Application/CompileExecutor.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Application;
+
+use Phel\Shared\CompileOptions;
+use Phel\Shared\Exceptions\CompilerException;
+use Phel\Shared\Facade\CompilerFacadeInterface;
+use Throwable;
+
+/**
+ * Compiles a Phel snippet to PHP without evaluating it.
+ *
+ * Powers the `phel compile` CLI command (issue #2043). The compiled
+ * PHP is written to `$stdout` on success; any error is written to
+ * `$stderr` and signalled via the return value.
+ */
+final readonly class CompileExecutor
+{
+    public function __construct(
+        private CompilerFacadeInterface $compilerFacade,
+    ) {}
+
+    /**
+     * @param callable(string): void $stdout
+     * @param callable(string): void $stderr
+     *
+     * @return bool `true` on successful compile
+     */
+    public function execute(string $source, callable $stdout, callable $stderr): bool
+    {
+        if (!$this->compilerFacade->hasBalancedParentheses($source)) {
+            $stderr("Unbalanced parentheses.\n");
+            return false;
+        }
+
+        try {
+            $result = $this->compilerFacade->compile($source, new CompileOptions());
+            $stdout($result->getPhpCode());
+            return true;
+        } catch (CompilerException $e) {
+            $nested = $e->getNestedException();
+            $stderr($nested->getMessage() . "\n");
+            return false;
+        } catch (Throwable $e) {
+            $stderr($e->getMessage() . "\n");
+            return false;
+        }
+    }
+}

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Run\Infrastructure\Command;
+
+use Gacela\Framework\ServiceResolver\ServiceMap;
+use Gacela\Framework\ServiceResolverAwareTrait;
+use Phel\Run\Domain\StdinReaderInterface;
+use Phel\Run\RunFacade;
+use Phel\Run\RunFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * `phel compile` — read a Phel snippet and print the emitted PHP.
+ *
+ * @method RunFacade   getFacade()
+ * @method RunFactory  getFactory()
+ */
+#[ServiceMap(method: 'getFacade', className: RunFacade::class)]
+#[ServiceMap(method: 'getFactory', className: RunFactory::class)]
+final class CompileCommand extends Command
+{
+    use ServiceResolverAwareTrait;
+
+    private const string STDIN_MARKER = '-';
+
+    private const string TARGET_PHP = 'php';
+
+    /** @var list<string> */
+    private const array SUPPORTED_TARGETS = [self::TARGET_PHP];
+
+    public function __construct(
+        private ?StdinReaderInterface $stdinReader = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('compile')
+            ->setDescription('Compile a Phel snippet and print the emitted PHP. Does not evaluate.')
+            ->addArgument(
+                'source',
+                InputArgument::OPTIONAL,
+                'Phel expression, path to a `.phel` file, or "-" to read from stdin.',
+            )
+            ->addOption(
+                'target',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Compilation target. Currently only "php" is supported.',
+                self::TARGET_PHP,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $stderr = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        $target = (string) $input->getOption('target');
+        if (!in_array($target, self::SUPPORTED_TARGETS, true)) {
+            $stderr->writeln(
+                sprintf('Unsupported target "%s". Supported: %s', $target, implode(', ', self::SUPPORTED_TARGETS)),
+            );
+            return self::FAILURE;
+        }
+
+        $this->getFacade()->loadPhelNamespaces();
+
+        $source = $this->resolveSource((string) ($input->getArgument('source') ?? ''));
+
+        $ok = $this->getFactory()
+            ->createCompileExecutor()
+            ->execute(
+                $source,
+                static function (string $chunk) use ($output): void {
+                    $output->write($chunk);
+                },
+                static function (string $chunk) use ($stderr): void {
+                    $stderr->write($chunk);
+                },
+            );
+
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * The positional argument can be an inline expression, the literal
+     * "-" for stdin, or a path to a `.phel` file. File path is
+     * preferred when the argument exactly matches an existing file so
+     * users can run `phel compile snippet.phel` without quoting.
+     */
+    private function resolveSource(string $arg): string
+    {
+        if ($arg === self::STDIN_MARKER) {
+            return ($this->stdinReader ?? $this->getFactory()->createStdinReader())->read();
+        }
+
+        if ($arg !== '' && is_file($arg)) {
+            $contents = file_get_contents($arg);
+            return $contents === false ? '' : $contents;
+        }
+
+        return $arg;
+    }
+}

--- a/src/php/Run/Infrastructure/Command/CompileCommand.php
+++ b/src/php/Run/Infrastructure/Command/CompileCommand.php
@@ -82,12 +82,8 @@ final class CompileCommand extends Command
             ->createCompileExecutor()
             ->execute(
                 $source,
-                static function (string $chunk) use ($output): void {
-                    $output->write($chunk);
-                },
-                static function (string $chunk) use ($stderr): void {
-                    $stderr->write($chunk);
-                },
+                static fn(string $chunk) => $output->write($chunk),
+                static fn(string $chunk) => $stderr->write($chunk),
             );
 
         return $ok ? self::SUCCESS : self::FAILURE;

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -6,6 +6,7 @@ namespace Phel\Run;
 
 use Gacela\Framework\AbstractFactory;
 use Phel\Run\Application\BundledNamespaces;
+use Phel\Run\Application\CompileExecutor;
 use Phel\Run\Application\EntryPointDetector;
 use Phel\Run\Application\EvalExecutor;
 use Phel\Run\Application\FileRunner;
@@ -173,6 +174,13 @@ class RunFactory extends AbstractFactory
             $this->createReplCommandIo(),
             $this->createColorStyle(),
             $this->createPrinter(),
+            $this->getCompilerFacade(),
+        );
+    }
+
+    public function createCompileExecutor(): CompileExecutor
+    {
+        return new CompileExecutor(
             $this->getCompilerFacade(),
         );
     }

--- a/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
+++ b/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Run\Command\Compile;
+
+use Phel\Phel;
+use Phel\Run\Infrastructure\Command\CompileCommand;
+use Phel\Run\Infrastructure\PhpStdinReader;
+use PhelTest\Integration\Run\Command\AbstractTestCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class CompileCommandTest extends AbstractTestCommand
+{
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+    }
+
+    public function test_compile_inline_expression_emits_php(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+        $tester->execute(['source' => '(php/+ 2 3)']);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertStringContainsString('(2 + 3)', $tester->getDisplay());
+    }
+
+    public function test_compile_known_core_call_uses_get_definition(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+        $tester->execute(['source' => '(+ 1 2)']);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertStringContainsString(\Phel::class . '::getDefinition("phel.core", "+"))(1, 2)', $tester->getDisplay());
+    }
+
+    public function test_compile_unbalanced_parentheses_fails(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+        $exitCode = $tester->execute(['source' => '(broken'], ['capture_stderr_separately' => true]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Unbalanced parentheses', $tester->getErrorOutput());
+    }
+
+    public function test_compile_unknown_target_fails(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+        $exitCode = $tester->execute([
+            'source' => '(+ 1 2)',
+            '--target' => 'ast',
+        ], ['capture_stderr_separately' => true]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Unsupported target "ast"', $tester->getErrorOutput());
+    }
+
+    public function test_compile_reads_from_stdin_when_dash_argument(): void
+    {
+        $command = new CompileCommand($this->stdinReader('(php/* 4 5)'));
+        $tester = new CommandTester($command);
+        $tester->execute(['source' => '-']);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertStringContainsString('(4 * 5)', $tester->getDisplay());
+    }
+
+    public function test_compile_reads_from_file_path(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'phel-compile-cmd-');
+        self::assertNotFalse($path);
+        file_put_contents($path, '(php/- 9 4)');
+
+        try {
+            $tester = new CommandTester(new CompileCommand());
+            $tester->execute(['source' => $path]);
+
+            $tester->assertCommandIsSuccessful();
+            self::assertStringContainsString('(9 - 4)', $tester->getDisplay());
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_compile_empty_source_succeeds_with_no_output(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertSame('', $tester->getDisplay());
+    }
+
+    private function stdinReader(string $contents): PhpStdinReader
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        return new PhpStdinReader($stream);
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Closes #2043.

Inspecting emitted PHP for a Phel snippet today means writing a fixture, running PHPUnit, or grepping `tests/php/Integration/Fixtures/`. Adds a dedicated CLI verb so emitter authors and contributors can ask the compiler what it produces.

## 💡 Goal

Add `phel compile` that reads Phel source (inline, file, or stdin) and prints PHP to stdout, without evaluating.

## 🔖 Changes

- `Phel\Run\Application\CompileExecutor` — wraps `CompilerFacade::compile(...)->getPhpCode()` with stdout/stderr callbacks. Empty input fast-paths to success with no output.
- `Phel\Run\Infrastructure\Command\CompileCommand` — Symfony command, accepts inline expression, `-` for stdin, or a `.phel` file path. Adds `--target` option (only `php` for now, groundwork for future `ast`/`tokens` targets per the issue's "extensible" rationale).
- `BuildCommand` lost its `compile` alias to free the verb. Project builds stay on `phel build`.
- `RunCommands` provider registers the new command.
- `RunFactory::createCompileExecutor()` wires the executor.

## Usage

```bash
phel compile "(defn f [x] (+ x 1))"        # inline expression
phel compile - < snippet.phel               # stdin
phel compile path/to/snippet.phel           # file path
phel compile "(+ 1 2)" --target=php         # explicit target (default)
```

Compile errors land on stderr and the command exits non-zero.

## Test plan

- [x] `composer test-all` green (5611 Phel core + 3453 PHPUnit + quality suite)
- [x] 7 new integration tests cover all input modes + error paths via Symfony `CommandTester`
- [x] Manual smoke: `./bin/phel compile "(+ 1 2)"` → `(\Phel::getDefinition(\"phel.core\", \"+\"))(1, 2);`
- [x] Manual smoke: stdin via `echo … | phel compile -`
- [x] Manual smoke: file path arg
- [x] `phel list` shows `compile` alongside other verbs
- [x] `phel build` still works after dropping the `compile` alias