### PR TITLE
perf(compiler): hoist keyword literals via per-fn static cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `phel compile`: new CLI command emits PHP from a Phel snippet, file, or stdin without evaluating; `--target` option reserved for future `ast`/`tokens` dumps (#2043)
 - Compiler: global fn call sites in build mode are hoisted to per-fn `static $__phel_call_N` slots, and known `AbstractFn` callees dispatch via the new non-magic `AbstractFn::call(...)`, skipping `__invoke` magic-method overhead on the hot path (#2044)
 - Compiler: constant folder evaluates pure `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) on literal-only args at analyse time and short-circuits `if` with a literal test to the surviving branch, so the runtime call disappears entirely (#2045)
+- Compiler: keyword literals (`:foo`, `:my.app/bar`) inside a fn body are hoisted to per-fn `static $__phel_const_N` slots, skipping the `Keyword` intern-pool lookup on every call after the first (#2046)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
@@ -14,6 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpArrayGetNode;
@@ -31,14 +32,15 @@ use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
 use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
+use Phel\Lang\Keyword;
 
 /**
- * Walks a fn body looking for *outermost* pure collection literals so the
- * emitter can hoist them to a per-fn `static` cache. Also reserves a
- * per-fn `static $__phel_call_N` slot for each global-fn call site when
- * call-site caching is enabled. Stops at nested function boundaries
- * (FnNode / MultiFnNode / ReifyNode method bodies) because each has its
- * own static scope.
+ * Walks a fn body looking for *outermost* pure collection literals plus
+ * `Keyword` literals so the emitter can hoist them to a per-fn `static`
+ * cache, and reserves a per-fn `static $__phel_call_N` slot for each
+ * global-fn call site when call-site caching is enabled. Stops at nested
+ * function boundaries (FnNode / MultiFnNode / ReifyNode method bodies)
+ * because each has its own static scope.
  */
 final readonly class BodyConstantScanner
 {
@@ -54,7 +56,7 @@ final readonly class BodyConstantScanner
             return;
         }
 
-        if ($this->isCacheableCollection($node)) {
+        if ($this->isCacheableCollection($node) || $this->isCacheableKeyword($node)) {
             $scope->reserve($node);
             return;
         }
@@ -82,6 +84,17 @@ final readonly class BodyConstantScanner
         }
 
         return PureLiteralDetector::isPure($node);
+    }
+
+    /**
+     * A `LiteralNode` whose value is a {@see Keyword} is identity-shared
+     * via the interpreter's intern pool, but every call site still hits
+     * `\Phel::keyword("…")` afresh. Caching the resolved instance in a
+     * per-fn `static` slot skips the intern-pool hash on subsequent calls.
+     */
+    private function isCacheableKeyword(AbstractNode $node): bool
+    {
+        return $node instanceof LiteralNode && $node->getValue() instanceof Keyword;
     }
 
     private function isEmpty(AbstractNode $node): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
@@ -23,8 +23,15 @@ final class LiteralEmitter implements NodeEmitterInterface
             return;
         }
 
-        $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitContextPrefix($node->getEnv(), $loc);
+
+        $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
         $this->outputEmitter->emitLiteral($node->getValue());
-        $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());
+        if ($cached) {
+            $this->outputEmitter->emitConstantSlotSuffix($loc);
+        }
+
+        $this->outputEmitter->emitContextSuffix($node->getEnv(), $loc);
     }
 }

--- a/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [m] [(:foo m) (:foo m) (:bar m)])
+--PHP--
+(function($m) {
+  static $__phel_const_0, $__phel_const_1, $__phel_const_2;
+  return \Phel::vector([(($__phel_const_0 ??= \Phel::keyword("foo")))($m), (($__phel_const_1 ??= \Phel::keyword("foo")))($m), (($__phel_const_2 ??= \Phel::keyword("bar")))($m)]);
+});

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -8,7 +8,8 @@
     public const BOUND_TO = "user\\ns_present?";
 
     public function __invoke($_AMPERSAND_form, $_AMPERSAND_env) {
-      if (($__truthy = (\Phel::keyword("ns"))($_AMPERSAND_env)) !== null && $__truthy !== false) {
+      static $__phel_const_0;
+      if (($__truthy = (($__phel_const_0 ??= \Phel::keyword("ns")))($_AMPERSAND_env)) !== null && $__truthy !== false) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
## 🤔 Background

`(fn [m] (:foo m))` compiles to a closure that calls `\Phel::keyword("foo")` on every invocation. Keywords are identity-shared via the intern pool, but each call still pays a hash-map lookup.

Closes #2046

## 💡 Goal

Extend the const-hoisting machinery from #2042 to cover keyword literals: reserve a per-fn `static $__phel_const_N` slot for each `LiteralNode` wrapping a `Keyword`, so the lookup happens once per slot lifetime.

## 🔖 Changes

- `BodyConstantScanner` reserves a slot for any `LiteralNode` whose value is a `Keyword`, alongside the existing collection-literal reservation. Numeric / string / bool / nil literals stay un-hoisted.
- `LiteralEmitter` wraps the emission with `emitConstantSlotPrefix` / `emitConstantSlotSuffix`, producing `($__phel_const_N ??= \Phel::keyword("…"))` when a slot is present. Slots are per-call-site so duplicate keyword occurrences each get their own slot — simpler and still strictly faster than the bare-call baseline.
- New `ConstantHoisting/keyword-in-fn-body.test` exercises the cached emission shape end-to-end.
- `MacroExpand/defmacro-env-form.test` regenerates: its body now caches the `:ns` keyword.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).