### PR TITLE
perf(compiler): skip Seq::toIterable / toApplyArguments when args are iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: global fn call sites in build mode are hoisted to per-fn `static $__phel_call_N` slots, and known `AbstractFn` callees dispatch via the new non-magic `AbstractFn::call(...)`, skipping `__invoke` magic-method overhead on the hot path (#2044)
 - Compiler: constant folder evaluates pure `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) on literal-only args at analyse time and short-circuits `if` with a literal test to the surviving branch, so the runtime call disappears entirely (#2045)
 - Compiler: keyword literals (`:foo`, `:my.app/bar`) inside a fn body are hoisted to per-fn `static $__phel_const_N` slots, skipping the `Keyword` intern-pool lookup on every call after the first (#2046)
+- Compiler: drop `Seq::toIterable` from `foreach` over Phel collection / `(php/array …)` literals and drop `Seq::toApplyArguments` from `apply` when the final arg is a `(php/array …)` result — the adapters were no-ops on those shapes (#2047)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/IterableTarget.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/IterableTarget.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+
+/**
+ * Syntactic predicate: can the emitter prove that a node produces a value
+ * already in a shape `foreach` (or PHP argument unpacking) accepts? Used
+ * by `ForeachEmitter` and `ApplyEmitter` to drop the `Seq::toIterable` /
+ * `Seq::toApplyArguments` adapter wrappers when they would be no-ops.
+ */
+final readonly class IterableTarget
+{
+    private function __construct() {}
+
+    /**
+     * A node whose value always implements `IteratorAggregate` or is a
+     * PHP array. Phel collection literals (vector / map / set) emit
+     * `\Phel::vector([...])`, `\Phel::map(...)`, `\Phel::set(...)`, each
+     * implementing PHP's iterable protocol. `(php/array …)` emits a PHP
+     * array directly. Both are safe for `foreach (… as $v)`.
+     */
+    public static function isIterable(AbstractNode $node): bool
+    {
+        return $node instanceof VectorNode
+            || $node instanceof MapNode
+            || $node instanceof SetNode
+            || self::isPhpArray($node);
+    }
+
+    /**
+     * A node whose emitted PHP expression evaluates to a native PHP array
+     * (not just an iterable). `(php/array a b c)` is currently the only
+     * source. Native arrays unpack into positional args without needing
+     * `Seq::toApplyArguments` to walk them.
+     */
+    public static function isPhpArray(AbstractNode $node): bool
+    {
+        if (!$node instanceof CallNode) {
+            return false;
+        }
+
+        $fn = $node->getFn();
+        return $fn instanceof PhpVarNode && $fn->getName() === 'array';
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\IterableTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Seq;
 
@@ -62,6 +63,15 @@ final class ApplyEmitter implements NodeEmitterInterface
 
     private function emitFinalArgument(ApplyNode $node, AbstractNode $arg): void
     {
+        // PHP `...$arr` spread already accepts native arrays positionally,
+        // so when the analyzer has proven the final arg is a `(php/array …)`
+        // result we drop the `Seq::toApplyArguments` walk entirely.
+        if (IterableTarget::isPhpArray($arg)) {
+            $this->outputEmitter->emitStr('...', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($arg);
+            return;
+        }
+
         $this->outputEmitter->emitStr('...\\' . Seq::class . '::toApplyArguments(', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($arg);
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
@@ -7,6 +7,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ForeachNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\IterableTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Lang\Seq;
 use Phel\Lang\Symbol;
@@ -26,9 +27,21 @@ final class ForeachEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
 
-        $this->outputEmitter->emitStr('foreach (\\' . Seq::class . '::toIterable(', $node->getStartSourceLocation());
-        $this->outputEmitter->emitNode($node->getListExpr());
-        $this->outputEmitter->emitStr(') as ', $node->getStartSourceLocation());
+        // `Seq::toIterable` is only needed to coerce `nil` to `[]` and
+        // unwrap strings; for nodes the emitter has already proven are
+        // iterable, the adapter call is a no-op we skip.
+        $listExpr = $node->getListExpr();
+        $useAdapter = !IterableTarget::isIterable($listExpr);
+
+        if ($useAdapter) {
+            $this->outputEmitter->emitStr('foreach (\\' . Seq::class . '::toIterable(', $node->getStartSourceLocation());
+        } else {
+            $this->outputEmitter->emitStr('foreach (', $node->getStartSourceLocation());
+        }
+
+        $this->outputEmitter->emitNode($listExpr);
+
+        $this->outputEmitter->emitStr($useAdapter ? ') as ' : ' as ', $node->getStartSourceLocation());
         if ($node->getKeySymbol() instanceof Symbol) {
             $this->outputEmitter->emitPhpVariable($node->getKeySymbol());
             $this->outputEmitter->emitStr(' => ', $node->getStartSourceLocation());

--- a/tests/php/Integration/Fixtures/Apply/apply-infix-array.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-infix-array.test
@@ -1,4 +1,4 @@
 --PHEL--
 (apply php/+ 1 2 (php/array 3))
 --PHP--
-array_reduce([1, 2, ...\Phel\Lang\Seq::toApplyArguments(array(3))], function($a, $b) { return ($a + $b); });
+array_reduce([1, 2, ...array(3)], function($a, $b) { return ($a + $b); });

--- a/tests/php/Integration/Fixtures/Apply/apply-php-array-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Apply/apply-php-array-skips-adapter.test
@@ -1,0 +1,4 @@
+--PHEL--
+(apply php/+ (php/array 1 2 3))
+--PHP--
+array_reduce([...array(1, 2, 3)], function($a, $b) { return ($a + $b); });

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -12,7 +12,7 @@
     public function __invoke() {
       static $__phel_const_0;
       return (function() use(&$__phel_const_0) {
-        foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $v) {
+        foreach (($__phel_const_0 ??= \Phel::vector([1, 2, 3])) as $v) {
           ($v + $v);
         }
         return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-issue-471.test
@@ -8,7 +8,7 @@
   static $__phel_const_0, $__phel_call_0;
   $b_1 = 10;
   return (function() use($b_1,&$__phel_const_0,&$__phel_call_0) {
-    foreach (\Phel\Lang\Seq::toIterable(($__phel_const_0 ??= \Phel::vector([1, 2, 3]))) as $b) {
+    foreach (($__phel_const_0 ??= \Phel::vector([1, 2, 3])) as $b) {
       ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "println"))->__invoke($b);
     }
     return null;

--- a/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-key-value.test
@@ -2,6 +2,6 @@
 (foreach [k v [1 2 3]]
   (php/+ k v))
 --PHP--
-foreach (\Phel\Lang\Seq::toIterable(\Phel::vector([1, 2, 3])) as $k => $v) {
+foreach (\Phel::vector([1, 2, 3]) as $k => $v) {
   ($k + $v);
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-skips-adapter-for-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-skips-adapter-for-vector-literal.test
@@ -1,0 +1,6 @@
+--PHEL--
+(foreach [x [1 2 3]] (println x))
+--PHP--
+foreach (\Phel::vector([1, 2, 3]) as $x) {
+  (\Phel::getDefinition("phel.core", "println"))->__invoke($x);
+}

--- a/tests/php/Integration/Fixtures/Foreach/foreach-value.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-value.test
@@ -2,6 +2,6 @@
 (foreach [v [1 2 3]]
   (php/+ v v))
 --PHP--
-foreach (\Phel\Lang\Seq::toIterable(\Phel::vector([1, 2, 3])) as $v) {
+foreach (\Phel::vector([1, 2, 3]) as $v) {
   ($v + $v);
 }


### PR DESCRIPTION
## 🤔 Background

`(foreach [v coll] …)` always wrapped its list expression in `\Phel\Lang\Seq::toIterable($coll)`. The adapter only matters for `nil`/string coercion; when the analyser already sees an iterable shape, the wrap is pure overhead.

`(apply f … xs)` similarly always passed `xs` through `Seq::toApplyArguments($xs)` to walk it into a positional array, even when `xs` is already a native PHP array.

Closes #2047

## 💡 Goal

Drop both adapter calls in the syntactic cases the emitter can prove safe.

## 🔖 Changes

- New `IterableTarget` predicate exposes two checks:
  - `isIterable`: vector / map / set literals + `(php/array …)` calls.
  - `isPhpArray`: only `(php/array …)` for now (the one shape PHP's `...` spread accepts without conversion).
- `ForeachEmitter` skips `Seq::toIterable` when the list expression matches `isIterable`.
- `ApplyEmitter::emitFinalArgument` skips `Seq::toApplyArguments` when the final arg matches `isPhpArray`.
- 5 existing fixtures regenerate to the unwrapped emission; 2 new fixtures lock the optimisation in.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).
- Scope is deliberately syntactic so the change lands without depending on #2052 (analyser type-inference propagation). Local-binding cases (`(let [v vec] (foreach [x v] …))`) stay un-optimised until the analyser carries the type.