### PR TITLE
perf(compiler): specialise (str ...) literals + (instanceof local local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: constant folder evaluates pure `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) on literal-only args at analyse time and short-circuits `if` with a literal test to the surviving branch, so the runtime call disappears entirely (#2045)
 - Compiler: keyword literals (`:foo`, `:my.app/bar`) inside a fn body are hoisted to per-fn `static $__phel_const_N` slots, skipping the `Keyword` intern-pool lookup on every call after the first (#2046)
 - Compiler: drop `Seq::toIterable` from `foreach` over Phel collection / `(php/array …)` literals and drop `Seq::toApplyArguments` from `apply` when the final arg is a `(php/array …)` result — the adapters were no-ops on those shapes (#2047)
+- Compiler: `(str ...)` with all-string-literal args emits a PHP `.` concat chain instead of dispatching through `phel.core/str`, and `(php/instanceof x c)` with two local-binding args drops the two-temp IIFE for a direct `($x instanceof $c)` expression (#2048)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -8,15 +8,19 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
 
 use function assert;
 use function count;
+use function is_string;
 
 final class CallEmitter implements NodeEmitterInterface
 {
@@ -93,6 +97,18 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        // Both args being local variables means re-emitting them is a
+        // free, side-effect-free PHP variable reference, so we skip the
+        // two-temp IIFE the generic path falls back to.
+        if ($value instanceof LocalVarNode && $class instanceof LocalVarNode) {
+            $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($value);
+            $this->outputEmitter->emitStr(' instanceof ', $node->getStartSourceLocation());
+            $this->outputEmitter->emitNode($class);
+            $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+            return;
+        }
+
         $valueSym = Symbol::gen('instanceof_value_');
         $classSym = Symbol::gen('instanceof_class_');
 
@@ -140,6 +156,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitStrConcat($node)) {
+            return;
+        }
+
         $useCallMethod = !$this->isSelfCall($node) && GlobalCallTarget::isGlobalFnCall($node);
 
         $this->emitDynamicFunctionName($node);
@@ -149,6 +169,52 @@ final class CallEmitter implements NodeEmitterInterface
         } else {
             $this->emitFunctionArguments($node);
         }
+    }
+
+    /**
+     * Specialise `(str "a" "b" "c")` to PHP `.` concatenation when every
+     * arg is a string literal. The runtime `phel.core/str` does a
+     * per-arg `val-to-str` dispatch plus a `StringBuilder`-style
+     * accumulator pass; for purely literal inputs the result is a
+     * compile-time constant string, so we emit a single `.` chain and
+     * skip both the registry lookup and the runtime walk.
+     */
+    private function tryEmitStrConcat(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'str'
+        ) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if ($args === []) {
+            return false;
+        }
+
+        foreach ($args as $arg) {
+            if (!$arg instanceof LiteralNode || !is_string($arg->getValue())) {
+                return false;
+            }
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        foreach ($args as $i => $arg) {
+            if ($i > 0) {
+                $this->outputEmitter->emitStr(' . ', $loc);
+            }
+
+            $this->outputEmitter->emitNode($arg);
+        }
+
+        $this->outputEmitter->emitStr(')', $loc);
+        return true;
     }
 
     private function emitPhpFunctionName(PhpVarNode $fnNode): void

--- a/tests/php/Integration/Fixtures/Call/instanceof-local-local-no-iife.test
+++ b/tests/php/Integration/Fixtures/Call/instanceof-local-local-no-iife.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [x c] (php/instanceof x c))
+--PHP--
+(function($x, $c): bool {
+  return ($x instanceof $c);
+});

--- a/tests/php/Integration/Fixtures/Call/str-all-literal-folds-to-concat.test
+++ b/tests/php/Integration/Fixtures/Call/str-all-literal-folds-to-concat.test
@@ -1,0 +1,4 @@
+--PHEL--
+(str "hello, " "world" "!")
+--PHP--
+("hello, " . "world" . "!");

--- a/tests/php/Integration/Fixtures/Inline/str.test
+++ b/tests/php/Integration/Fixtures/Inline/str.test
@@ -4,4 +4,4 @@
 (str "a" "b")
 (str "a" "b" "c")
 --PHP--
-(\Phel::getDefinition("phel.core", "str"))->__invoke();(\Phel::getDefinition("phel.core", "str"))->__invoke("a");(\Phel::getDefinition("phel.core", "str"))->__invoke("a", "b");(\Phel::getDefinition("phel.core", "str"))->__invoke("a", "b", "c");
+(\Phel::getDefinition("phel.core", "str"))->__invoke();("a");("a" . "b");("a" . "b" . "c");


### PR DESCRIPTION
## 🤔 Background

#2048 bundles three small emitter wins. Two of them can land without analyser type-inference propagation (#2052):

1. `(str "a" "b" "c")` dispatches through `phel.core/str` (runtime walk through `val-to-str` + accumulator) even when all args are already strings.
2. `(php/instanceof x c)` wraps the check in a two-temp IIFE whenever `c` is not a `PhpClassNameNode`, including the trivial case where both args are local-binding references.

Closes the analyser-independent half of #2048; the `(:k m)` → `$m->find(...)` specialisation stays open behind #2052.

## 💡 Goal

Drop both indirections when the emitter can prove they're no-ops.

## 🔖 Changes

- `CallEmitter::tryEmitStrConcat` intercepts a `phel.core/str` call when every arg is a `LiteralNode` carrying a PHP string, emitting `("a" . "b" . "c")` directly. Mixed-arg and zero-arg `(str)` calls keep the runtime path.
- `CallEmitter::emitInstanceof` adds a fast path: when both `value` and `class` arguments are `LocalVarNode`s, emit `($x instanceof $c)` directly, skipping the IIFE.
- Two new fixtures lock the optimisations in (`Call/str-all-literal-folds-to-concat.test`, `Call/instanceof-local-local-no-iife.test`); `Inline/str.test` regenerates to the folded form.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).