### PR TITLE
perf(compiler): multi-arity fn dispatch via match(count($args))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: keyword literals (`:foo`, `:my.app/bar`) inside a fn body are hoisted to per-fn `static $__phel_const_N` slots, skipping the `Keyword` intern-pool lookup on every call after the first (#2046)
 - Compiler: drop `Seq::toIterable` from `foreach` over Phel collection / `(php/array …)` literals and drop `Seq::toApplyArguments` from `apply` when the final arg is a `(php/array …)` result — the adapters were no-ops on those shapes (#2047)
 - Compiler: `(str ...)` with all-string-literal args emits a PHP `.` concat chain instead of dispatching through `phel.core/str`, and `(php/instanceof x c)` with two local-binding args drops the two-temp IIFE for a direct `($x instanceof $c)` expression (#2048)
+- Compiler: multi-arity fn dispatch emits a `match (\count($args)) { … }` jump table instead of the previous `switch` + post-`if` block; the variadic body folds into the `default` arm (#2049)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MultiFnAsClassEmitter.php
@@ -126,14 +126,21 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
     }
 
     /**
+     * Multi-arity dispatch via a `match` jump table instead of the
+     * previous `switch` + post-`if`. PHP compiles `match` to a single
+     * branchless table when every arm is a constant `int`, and the
+     * variadic tail collapses into the `default` arm — same semantics,
+     * fewer instructions on every call.
+     *
      * @param list<FnNode> $fnNodes
      */
     private function emitInvoke(MultiFnNode $node, array $fnNodes): void
     {
-        $this->outputEmitter->emitLine('public function __invoke(...$args) {', $node->getStartSourceLocation());
+        $loc = $node->getStartSourceLocation();
+
+        $this->outputEmitter->emitLine('public function __invoke(...$args) {', $loc);
         $this->outputEmitter->increaseIndentLevel();
-        $this->outputEmitter->emitLine('$argc = \count($args);', $node->getStartSourceLocation());
-        $this->outputEmitter->emitLine('switch ($argc) {', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('return match (\count($args)) {', $loc);
         $this->outputEmitter->increaseIndentLevel();
 
         $variadicIndex = null;
@@ -144,31 +151,36 @@ final readonly class MultiFnAsClassEmitter implements NodeEmitterInterface
             }
 
             $arity = count($fnNode->getParams());
-            $this->outputEmitter->emitLine('case ' . $arity . ':', $node->getStartSourceLocation());
-            $this->outputEmitter->increaseIndentLevel();
             $params = [];
             for ($p = 0; $p < $arity; ++$p) {
                 $params[] = '$args[' . $p . ']';
             }
 
-            $this->outputEmitter->emitLine('return ($this->fn' . $i . ')(' . implode(', ', $params) . ');', $node->getStartSourceLocation());
-            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitLine(
+                $arity . ' => ($this->fn' . $i . ')(' . implode(', ', $params) . '),',
+                $loc,
+            );
         }
-
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
 
         if ($variadicIndex !== null) {
             $min = $fnNodes[$variadicIndex]->getMinArity();
-            $this->outputEmitter->emitLine('if ($argc >= ' . $min . ') {', $node->getStartSourceLocation());
-            $this->outputEmitter->increaseIndentLevel();
-            $this->outputEmitter->emitLine('return ($this->fn' . $variadicIndex . ')(...$args);', $node->getStartSourceLocation());
-            $this->outputEmitter->decreaseIndentLevel();
-            $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+            $this->outputEmitter->emitLine(
+                'default => \count($args) >= ' . $min
+                . ' ? ($this->fn' . $variadicIndex . ')(...$args)'
+                . ' : throw new \\InvalidArgumentException("No matching function arity"),',
+                $loc,
+            );
+        } else {
+            $this->outputEmitter->emitLine(
+                'default => throw new \\InvalidArgumentException("No matching function arity"),',
+                $loc,
+            );
         }
 
-        $this->outputEmitter->emitLine('throw new \\InvalidArgumentException("No matching function arity");', $node->getStartSourceLocation());
         $this->outputEmitter->decreaseIndentLevel();
-        $this->outputEmitter->emitLine('}', $node->getStartSourceLocation());
+        $this->outputEmitter->emitLine('};', $loc);
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine('}', $loc);
     }
 
     private function emitClassEnd(MultiFnNode $node): void

--- a/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-multi-arity.test
@@ -18,13 +18,10 @@ new class() extends \Phel\Lang\AbstractFn {
   }
 
   public function __invoke(...$args) {
-    $argc = \count($args);
-    switch ($argc) {
-      case 1:
-        return ($this->fn0)($args[0]);
-      case 2:
-        return ($this->fn1)($args[0], $args[1]);
-      }
-      throw new \InvalidArgumentException("No matching function arity");
-    }
-  };
+    return match (\count($args)) {
+      1 => ($this->fn0)($args[0]),
+      2 => ($this->fn1)($args[0], $args[1]),
+      default => throw new \InvalidArgumentException("No matching function arity"),
+    };
+  }
+};

--- a/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-named-recursive-multi-arity.test
@@ -18,13 +18,10 @@ new class() extends \Phel\Lang\AbstractFn {
   }
 
   public function __invoke(...$args) {
-    $argc = \count($args);
-    switch ($argc) {
-      case 1:
-        return ($this->fn0)($args[0]);
-      case 2:
-        return ($this->fn1)($args[0], $args[1]);
-      }
-      throw new \InvalidArgumentException("No matching function arity");
-    }
-  };
+    return match (\count($args)) {
+      1 => ($this->fn0)($args[0]),
+      2 => ($this->fn1)($args[0], $args[1]),
+      default => throw new \InvalidArgumentException("No matching function arity"),
+    };
+  }
+};

--- a/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-return-type-multi-arity.test
@@ -18,13 +18,10 @@ new class() extends \Phel\Lang\AbstractFn {
   }
 
   public function __invoke(...$args) {
-    $argc = \count($args);
-    switch ($argc) {
-      case 1:
-        return ($this->fn0)($args[0]);
-      case 2:
-        return ($this->fn1)($args[0], $args[1]);
-      }
-      throw new \InvalidArgumentException("No matching function arity");
-    }
-  };
+    return match (\count($args)) {
+      1 => ($this->fn0)($args[0]),
+      2 => ($this->fn1)($args[0], $args[1]),
+      default => throw new \InvalidArgumentException("No matching function arity"),
+    };
+  }
+};


### PR DESCRIPTION
## 🤔 Background

`MultiFnAsClassEmitter::emitInvoke` emitted a `switch ($argc)` + post-`if` block to dispatch a multi-arity fn to the right per-arity closure.

Closes #2049

## 💡 Goal

Rewrite the dispatch as a `match` expression. PHP compiles `match` on constant `int` arms to a single jump table — fewer instructions than the chained `switch` + post-`if` and friendlier to the opcache / JIT. Variadic body folds into the `default` arm.

## 🔖 Changes

- `MultiFnAsClassEmitter::emitInvoke` now emits:

```php
public function __invoke(...$args) {
    return match (\count($args)) {
        1 => ($this->fn0)($args[0]),
        2 => ($this->fn1)($args[0], $args[1]),
        default => \count($args) >= $min
            ? ($this->fnVariadic)(...$args)
            : throw new \InvalidArgumentException("No matching function arity"),
    };
}
```

- When the fn has no variadic arity, `default` collapses to a direct `throw` expression.
- Three existing multi-arity fixtures (`fn-named-multi-arity`, `fn-return-type-multi-arity`, `fn-named-recursive-multi-arity`) regenerate to the new shape.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).