### PR TITLE
perf(compiler): expose analyser :tag meta to emitter via LocalVarNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: `(str ...)` with all-string-literal args emits a PHP `.` concat chain instead of dispatching through `phel.core/str`, and `(php/instanceof x c)` with two local-binding args drops the two-temp IIFE for a direct `($x instanceof $c)` expression (#2048)
 - Compiler: multi-arity fn dispatch emits a `match (\count($args)) { … }` jump table instead of the previous `switch` + post-`if` block; the variadic body folds into the `default` arm (#2049)
 - Runtime: persistent collection `hash()` switches its memo sentinel from `0` to `null`, so empty maps / sets and the rare `hash == 0` value reuse the cached result on subsequent calls instead of recomputing (#2050)
+- Compiler: `LocalVarNode::getInferredType()` exposes the analyser's `:tag` meta to the emitter; `IterableTarget` consumes it so a `(defn f [^"array" arr] (foreach [x arr] …))` style annotation unlocks the same `foreach` / `apply` adapter skips as a literal would (#2052)
 
 ### Changed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -89,6 +89,16 @@ Compiler/
 - Special forms are registered centrally : no ad-hoc handling in the analyzer loop
 - Source locations must propagate through all phases for error reporting
 
+## Inferred-type plumbing
+
+The analyser already tracks param types (`ParamTypeInferrer`), return types (`ReturnTypeInferrer`), and grafts them onto each binding `Symbol`'s `:tag` meta. Emitters that want to specialise on a known type read that meta via:
+
+- `LocalVarNode::getInferredType(): ?string` resolves the binding's tag by name walk through `NodeEnvironment::getLocals()`. Returns `null` for bindings without a tag.
+- `GlobalVarNode::getMeta()` carries `arglists` / `tag` for `defn`s — `GlobalCallTarget::isGlobalFnCall()` and `ConstantFolder` consume it directly.
+- `IterableTarget::isIterable` / `::isPhpArray` already consume the local tag for `foreach` / `apply` adapter skips.
+
+Add new consumers by extending those predicates (or adding a sibling under `Compiler/Domain/Emitter/OutputEmitter/`). The contract is: never fabricate a type — propagate only what the analyser already published.
+
 ## Global Environment
 
 State lives in `Domain/Analyzer/Environment/GlobalEnvironmentRegistry` (process-wide static). The Application's `GlobalEnvironmentManager` and the infrastructure's `GlobalEnvironmentSingleton` both read/write the same slot.

--- a/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\Ast;
 
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
+
+use function is_string;
 
 final class LocalVarNode extends AbstractNode
 {
@@ -21,5 +25,41 @@ final class LocalVarNode extends AbstractNode
     public function getName(): Symbol
     {
         return $this->name;
+    }
+
+    /**
+     * Inferred type for this reference, derived from the binding's `:tag`
+     * meta (set by `defn` param tags, `let` `^Type` annotations, and the
+     * `ParamTypeInferrer` pass). Returns `null` when the binding has no
+     * known type — the call site falls back to runtime dispatch.
+     *
+     * `AnalyzeSymbol` builds the `LocalVarNode`'s own `Symbol` from the
+     * call-site syntax, which has no tag of its own, so the lookup walks
+     * the current environment's locals by name to find the typed binding.
+     */
+    public function getInferredType(): ?string
+    {
+        $name = $this->name->getName();
+        foreach ($this->getEnv()->getLocals() as $local) {
+            if ($local->getName() === $name) {
+                return $this->tagOf($local->getMeta());
+            }
+        }
+
+        return null;
+    }
+
+    private function tagOf(mixed $meta): ?string
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        return is_string($tag) && $tag !== '' ? $tag : null;
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/IterableTarget.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/IterableTarget.php
@@ -6,19 +6,50 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+use function in_array;
 
 /**
  * Syntactic predicate: can the emitter prove that a node produces a value
  * already in a shape `foreach` (or PHP argument unpacking) accepts? Used
  * by `ForeachEmitter` and `ApplyEmitter` to drop the `Seq::toIterable` /
  * `Seq::toApplyArguments` adapter wrappers when they would be no-ops.
+ *
+ * Beyond the obvious literal-shape matches the predicate also consumes
+ * the analyser's inferred type for `LocalVarNode` (via
+ * {@see LocalVarNode::getInferredType()}), so `(defn f [^array xs] …)` or
+ * `(let [^"\Iterator" it expr] …)` style annotations unlock the same
+ * fast paths as a literal would.
  */
 final readonly class IterableTarget
 {
+    /**
+     * Iterable type tags the emitter trusts not to need
+     * `Seq::toIterable` coercion. `iterable` and `array` are PHP-native;
+     * the Phel persistent-collection interfaces all implement
+     * `IteratorAggregate`, which `foreach` accepts.
+     */
+    private const array ITERABLE_TAGS = [
+        'array',
+        'iterable',
+        'Iterator',
+        'Traversable',
+        'IteratorAggregate',
+        PersistentVectorInterface::class,
+        PersistentMapInterface::class,
+        PersistentHashSetInterface::class,
+        PersistentListInterface::class,
+    ];
+
     private function __construct() {}
 
     /**
@@ -26,29 +57,51 @@ final readonly class IterableTarget
      * PHP array. Phel collection literals (vector / map / set) emit
      * `\Phel::vector([...])`, `\Phel::map(...)`, `\Phel::set(...)`, each
      * implementing PHP's iterable protocol. `(php/array …)` emits a PHP
-     * array directly. Both are safe for `foreach (… as $v)`.
+     * array directly. Both are safe for `foreach (… as $v)`. A
+     * `LocalVarNode` whose binding carries an iterable `:tag` is also
+     * accepted via the analyser's inferred type.
      */
     public static function isIterable(AbstractNode $node): bool
     {
-        return $node instanceof VectorNode
+        if ($node instanceof VectorNode
             || $node instanceof MapNode
             || $node instanceof SetNode
-            || self::isPhpArray($node);
+        ) {
+            return true;
+        }
+
+        if (self::isPhpArray($node)) {
+            return true;
+        }
+
+        return $node instanceof LocalVarNode
+            && self::isIterableTag($node->getInferredType());
     }
 
     /**
      * A node whose emitted PHP expression evaluates to a native PHP array
-     * (not just an iterable). `(php/array a b c)` is currently the only
-     * source. Native arrays unpack into positional args without needing
-     * `Seq::toApplyArguments` to walk them.
+     * (not just an iterable). `(php/array a b c)` and any local whose
+     * binding carries the `array` tag both round-trip as a PHP `array`,
+     * so PHP's `...$arr` spread accepts them without conversion.
      */
     public static function isPhpArray(AbstractNode $node): bool
     {
-        if (!$node instanceof CallNode) {
+        if ($node instanceof CallNode) {
+            $fn = $node->getFn();
+            return $fn instanceof PhpVarNode && $fn->getName() === 'array';
+        }
+
+        return $node instanceof LocalVarNode
+            && $node->getInferredType() === 'array';
+    }
+
+    private static function isIterableTag(?string $tag): bool
+    {
+        if ($tag === null) {
             return false;
         }
 
-        $fn = $node->getFn();
-        return $fn instanceof PhpVarNode && $fn->getName() === 'array';
+        $normalised = ltrim($tag, '\\');
+        return in_array($normalised, self::ITERABLE_TAGS, true);
     }
 }

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -1,0 +1,36 @@
+--PHEL--
+(defn process [^"array" arr] (foreach [x arr] (println x)))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "process",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\process";
+
+    public function __invoke(array $arr) {
+      static $__phel_call_0;
+      return (function() use($arr,&$__phel_call_0) {
+        foreach ($arr as $x) {
+          ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "println"))->__invoke($x);
+        }
+        return null;
+      })();
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(process arr)\n```\n",
+    \Phel::keyword("start-location"), \Phel::map(
+      \Phel::keyword("file"), "Foreach/foreach-tagged-array-param-skips-adapter.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 0
+    ),
+    \Phel::keyword("end-location"), \Phel::map(
+      \Phel::keyword("file"), "Foreach/foreach-tagged-array-param-skips-adapter.test",
+      \Phel::keyword("line"), 1,
+      \Phel::keyword("column"), 59
+    ),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[arr]"
+  )
+);


### PR DESCRIPTION
## 🤔 Background

#2052 is an umbrella issue for "give the emitter access to the analyser's inferred type info." The analyser already tracks param tags (`ParamTypeInferrer`), return tags (`ReturnTypeInferrer`), and grafts them onto each binding `Symbol`'s `:tag` meta — but the emitter had no way to read them off a `LocalVarNode` reference.

Closes #2052

## 💡 Goal

Provide a single, narrow accessor so emitters that want to specialise on a known type can read it off a node, and prove the surface works by promoting #2047's `foreach` / `apply` adapter skips to fire on tagged params (not just literal shapes).

## 🔖 Changes

- `LocalVarNode::getInferredType(): ?string` walks the binding by name through `NodeEnvironment::getLocals()` and pulls `:tag` off the matching local. Returns `null` when no tag is known.
- `IterableTarget` consumes the tag: bindings tagged `array`, `iterable`, `Iterator`, `Traversable`, `IteratorAggregate`, or one of the Phel persistent-collection interfaces count as iterable; `array` also counts as PHP-array-shaped (so `apply` can spread without `toApplyArguments`).
- `src/php/Compiler/CLAUDE.md` gets a new `Inferred-type plumbing` section describing the contract — emitters read analyser-published tag meta, they never fabricate types.
- New `Foreach/foreach-tagged-array-param-skips-adapter.test` fixture proves `(defn process [^"array" arr] (foreach [x arr] …))` compiles to a bare `foreach ($arr as $x)` with no `Seq::toIterable` wrap.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).