### PR TITLE
perf(compiler): collapse defn location maps into single Phel::location call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Compiler: multi-arity fn dispatch emits a `match (\count($args)) { … }` jump table instead of the previous `switch` + post-`if` block; the variadic body folds into the `default` arm (#2049)
 - Runtime: persistent collection `hash()` switches its memo sentinel from `0` to `null`, so empty maps / sets and the rare `hash == 0` value reuse the cached result on subsequent calls instead of recomputing (#2050)
 - Compiler: `LocalVarNode::getInferredType()` exposes the analyser's `:tag` meta to the emitter; `IterableTarget` consumes it so a `(defn f [^"array" arr] (foreach [x arr] …))` style annotation unlocks the same `foreach` / `apply` adapter skips as a literal would (#2052)
+- Runtime + compiler: new `\Phel::location($file, $line, $column)` helper interns the `:file` / `:line` / `:column` keyword keys once per process; `MapEmitter` detects the synthesised `{:file <string> :line <int> :column <int>}` shape on every `addDefinition` site and emits a single `\Phel::location(...)` call instead of the three-entry `\Phel::map(…)`, shrinking compiled file size (#2053)
 
 ### Changed
 

--- a/src/Phel.php
+++ b/src/Phel.php
@@ -299,6 +299,26 @@ final class Phel extends InternalPhel
     }
 
     /**
+     * Source-location three-tuple used by `defn` / `def` to tag generated
+     * metadata. Centralised here so the compiler emits a single helper
+     * call per location, rather than three keyword interns plus a map
+     * allocation, on every `addDefinition` site. The keyword keys live in
+     * `static` slots so they intern once per process and are reused by
+     * every location map.
+     *
+     * @return PersistentMapInterface<mixed, mixed>
+     */
+    public static function location(string $file, int $line, int $column): PersistentMapInterface
+    {
+        static $kwFile, $kwLine, $kwColumn;
+        $kwFile ??= self::keyword('file');
+        $kwLine ??= self::keyword('line');
+        $kwColumn ??= self::keyword('column');
+
+        return self::map($kwFile, $file, $kwLine, $line, $kwColumn, $column);
+    }
+
+    /**
      * Create a persistent hash set from an array of values.
      *
      * @param list<mixed>|null $values

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
+use Phel\Lang\Keyword;
+use Phel\Lang\SourceLocation;
 
+use function array_key_exists;
 use function assert;
 use function count;
+use function is_int;
+use function is_string;
 
 final class MapEmitter implements NodeEmitterInterface
 {
@@ -22,14 +29,87 @@ final class MapEmitter implements NodeEmitterInterface
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $loc);
         $cached = $this->outputEmitter->emitConstantSlotPrefix($node, $loc);
-        $this->outputEmitter->emitStr('\Phel::map(', $loc);
-        $this->emitEntries($node);
-        $this->outputEmitter->emitStr(')', $loc);
+
+        $locationLiteral = $this->locationLiteral($node);
+        if ($locationLiteral !== null) {
+            $this->emitLocationHelper($locationLiteral, $loc);
+        } else {
+            $this->outputEmitter->emitStr('\Phel::map(', $loc);
+            $this->emitEntries($node);
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
         if ($cached) {
             $this->outputEmitter->emitConstantSlotSuffix($loc);
         }
 
         $this->outputEmitter->emitContextSuffix($node->getEnv(), $loc);
+    }
+
+    /**
+     * Detect the `{:file <string> :line <int> :column <int>}` shape that
+     * every `def`/`defn` synthesises for `:start-location` and
+     * `:end-location`. When found, the emitter swaps the three-entry
+     * `\Phel::map(\Phel::keyword("file"), …)` call for a single
+     * `\Phel::location("file", line, col)` helper invocation — same map
+     * at runtime, far less generated PHP per definition.
+     *
+     * @return array{file: string, line: int, column: int}|null
+     */
+    private function locationLiteral(MapNode $node): ?array
+    {
+        $entries = $node->getKeyValues();
+        if (count($entries) !== 6) {
+            return null;
+        }
+
+        $expected = ['file' => null, 'line' => null, 'column' => null];
+
+        for ($i = 0; $i < 6; $i += 2) {
+            $key = $entries[$i];
+            $value = $entries[$i + 1];
+
+            if (!$key instanceof LiteralNode || !$value instanceof LiteralNode) {
+                return null;
+            }
+
+            $keyword = $key->getValue();
+            if (!$keyword instanceof Keyword) {
+                return null;
+            }
+
+            $name = $keyword->getName();
+            if (!array_key_exists($name, $expected) || $expected[$name] !== null) {
+                return null;
+            }
+
+            $expected[$name] = $value->getValue();
+        }
+
+        if (!is_string($expected['file']) || !is_int($expected['line']) || !is_int($expected['column'])) {
+            return null;
+        }
+
+        return [
+            'file' => $expected['file'],
+            'line' => $expected['line'],
+            'column' => $expected['column'],
+        ];
+    }
+
+    /**
+     * @param array{file: string, line: int, column: int} $location
+     */
+    private function emitLocationHelper(array $location, ?SourceLocation $loc): void
+    {
+        $this->outputEmitter->emitStr(
+            '\Phel::location("'
+            . PhpStringEscape::doubleQuoted($location['file'])
+            . '", ' . $location['line']
+            . ', ' . $location['column']
+            . ')',
+            $loc,
+        );
     }
 
     private function emitEntries(MapNode $node): void

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -14,16 +14,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/global-call.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/global-call.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 18
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Call/global-call.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/global-call.test", 1, 18),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
+++ b/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
@@ -7,16 +7,8 @@
   "k",
   \Phel::keyword("a"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/non-fn-global-call-skipped.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/non-fn-global-call-skipped.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 10
-    )
+    \Phel::keyword("start-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10)
   )
 );
 (\Phel::getDefinition("user", "k"))(\Phel::map(

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -14,16 +14,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/php-fn-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/php-fn-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 37
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Call/php-fn-reference.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 37),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[f xs]"

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -7,16 +7,8 @@
   "arr",
   array(1, 2, 3),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/php-push-global-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/php-push-global-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    )
+    \Phel::keyword("start-location"), \Phel::location("Call/php-push-global-reference.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/php-push-global-reference.test", 1, 27)
   )
 );
 (\Phel::getDefinitionReference("user", "arr"))[] = 4;

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/self-call-direct.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/self-call-direct.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 22
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Call/self-call-direct.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/self-call-direct.test", 1, 22),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -18,16 +18,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/self-call-with-if.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Call/self-call-with-if.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 52
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Call/self-call-with-if.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/self-call-with-if.test", 1, 52),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -16,16 +16,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/map-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/map-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -19,16 +19,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/multiple-pure-literals.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/multiple-pure-literals.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 22
-    ),
+    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[b]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -13,16 +13,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/set-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/set-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 24
-    ),
+    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -13,16 +13,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/vector-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "ConstantHoisting/vector-in-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 23
-    ),
+    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -6,15 +6,7 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/basic-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/basic-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/basic-def.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/basic-def.test", 1, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigdec-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigdec-literal.test
@@ -6,15 +6,7 @@
   "x",
   \Phel\Lang\BigDecimal::fromString("1.5"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigdec-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigdec-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 12
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/bigdec-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/bigdec-literal.test", 1, 12)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
@@ -6,15 +6,7 @@
   "x",
   -123,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
@@ -6,15 +6,7 @@
   "x",
   \Phel\Lang\BigInt::fromString("9223372036854775808"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal-oversize.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal-oversize.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 28
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 28)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal.test
@@ -6,15 +6,7 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/bigint-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 10
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
@@ -6,15 +6,7 @@
   "x",
   "a",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-alpha.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-alpha.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 10
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-alpha.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-alpha.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
@@ -6,15 +6,7 @@
   "x",
   "\n",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-named-newline.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-named-newline.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 16
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 16)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
@@ -6,15 +6,7 @@
   "x",
   " ",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-named-space.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-named-space.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 14
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-named-space.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-named-space.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-octal.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-octal.test
@@ -6,15 +6,7 @@
   "x",
   "A",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-octal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-octal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-octal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-octal.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
@@ -6,15 +6,7 @@
   "x",
   "(",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-punctuation.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-punctuation.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 10
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
@@ -6,15 +6,7 @@
   "x",
   "Ω",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-unicode.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/char-literal-unicode.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 14
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-unicode.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-unicode.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-no-value.test
+++ b/tests/php/Integration/Fixtures/Def/def-no-value.test
@@ -6,15 +6,7 @@
   "baz",
   null,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-no-value.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-no-value.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/def-no-value.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/def-no-value.test", 1, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
@@ -8,16 +8,8 @@ PHPChildT
   "PHPChildT",
   \RecursiveArrayIterator::class,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-php-class-reference.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-php-class-reference.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 38
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/def-php-class-reference.test", 2, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/def-php-class-reference.test", 2, 38)
   )
 );
 \Phel::getDefinition("user", "PHPChildT");

--- a/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
@@ -6,15 +6,7 @@
   "uc",
   (function(...$args) { return \strtoupper(...$args);}),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-php-function-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-php-function-reference.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 24
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/def-php-function-reference.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/def-php-function-reference.test", 1, 24)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -6,15 +6,7 @@
   "a'",
   42,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-trailing-quote-in-name.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/def-trailing-quote-in-name.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 11
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -46,16 +46,8 @@ interface IPlayer {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface-instance-of.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface-instance-of.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[p]"
@@ -82,16 +74,8 @@ interface IPlayer {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface-instance-of.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface-instance-of.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
     "min-arity", 3,
     "is-variadic", false,
     "arglists", "[p me you]"

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -44,16 +44,8 @@ interface IPlayer {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/definterface.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/definterface.test", 5, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[p]"
@@ -80,16 +72,8 @@ interface IPlayer {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/definterface.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/definterface.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/definterface.test", 5, 31),
     "min-arity", 3,
     "is-variadic", false,
     "arglists", "[p me you]"

--- a/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-inferred-param-tag.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-inferred-param-tag.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -14,16 +14,8 @@
   \Phel::map(
     \Phel::keyword("export"), true,
     \Phel::keyword("doc"), "```phel\n(identity x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-meta.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-meta.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 36
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defn-meta.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defn-meta.test", 1, 36),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -15,16 +15,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rand-range lo hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-rand-range-fully-inferred.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-rand-range-fully-inferred.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 30
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[lo hi]"

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -14,16 +14,8 @@
   \Phel::map(
     \Phel::keyword("tag"), "int",
     \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-return-type-name.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-return-type-name.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 43
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defn-return-type-name.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defn-return-type-name.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]"

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-typed-params.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defn-typed-params.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 56
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defn-typed-params.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defn-typed-params.test", 1, 56),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -30,16 +30,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defstruct-inside-fn-body.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/defstruct-inside-fn-body.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 33
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -7,15 +7,7 @@
   1,
   \Phel::map(
     \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/doc-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/doc-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 21
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/doc-def.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/doc-def.test", 1, 21)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -6,15 +6,7 @@
   "arr",
   (\Phel::getDefinition("phel.core", "php-associative-array"))->__invoke("a", 1, "b", 2),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/hash-php-map-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/hash-php-map-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 28
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 28)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -6,15 +6,7 @@
   "arr",
   (\Phel::getDefinition("phel.core", "php-indexed-array"))->__invoke(1, 2, 3),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/hash-php-vector-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/hash-php-vector-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 22
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 22)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -20,15 +20,7 @@ require_once __DIR__ . '/../phel/core.php';
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/namespace-def.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/namespace-def.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/namespace-def.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/namespace-def.test", 3, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
+++ b/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
@@ -6,15 +6,7 @@
   "x",
   (-9223372036854775807 - 1),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/negative-hex-int-min.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/negative-hex-int-min.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -14,16 +14,8 @@
         "x",
         1,
         ($__phel_const_0 ??= \Phel::map(
-          \Phel::keyword("start-location"), \Phel::map(
-            \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
-            \Phel::keyword("line"), 1,
-            \Phel::keyword("column"), 14
-          ),
-          \Phel::keyword("end-location"), \Phel::map(
-            \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
-            \Phel::keyword("line"), 1,
-            \Phel::keyword("column"), 23
-          )
+          \Phel::keyword("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 14),
+          \Phel::keyword("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)
         ))
       );
 
@@ -31,16 +23,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/nested-def-inside-fn.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -8,15 +8,7 @@
   \Phel::map(
     \Phel::keyword("private"), true,
     \Phel::keyword("export"), true,
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-def-meta.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-def-meta.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 38
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/private-def-meta.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/private-def-meta.test", 1, 38)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -7,15 +7,7 @@
   1,
   \Phel::map(
     \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 18
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/private-def.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/private-def.test", 1, 18)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -8,15 +8,7 @@
   \Phel::map(
     \Phel::keyword("private"), true,
     \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-doc-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/private-doc-def.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 42
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/private-doc-def.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/private-doc-def.test", 1, 42)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-binary.test
+++ b/tests/php/Integration/Fixtures/Def/radix-binary.test
@@ -6,15 +6,7 @@
   "x",
   15,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-binary.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-binary.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 14
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/radix-binary.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/radix-binary.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-hex.test
+++ b/tests/php/Integration/Fixtures/Def/radix-hex.test
@@ -6,15 +6,7 @@
   "x",
   255,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-hex.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-hex.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/radix-hex.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/radix-hex.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-negative.test
+++ b/tests/php/Integration/Fixtures/Def/radix-negative.test
@@ -6,15 +6,7 @@
   "x",
   -15,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/radix-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 15
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/radix-negative.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/radix-negative.test", 1, 15)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
@@ -6,15 +6,7 @@
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("-3"), \Phel\Lang\BigInt::fromString("4")),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/ratio-literal-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/ratio-literal-negative.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 12
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 12)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal.test
@@ -6,15 +6,7 @@
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("1"), \Phel\Lang\BigInt::fromString("2")),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/ratio-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/ratio-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 11
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/ratio-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/ratio-literal.test", 1, 11)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
+++ b/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
@@ -6,15 +6,7 @@
   "x",
   " ",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/string-literal-unicode-escape.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/string-literal-unicode-escape.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 16
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
@@ -6,15 +6,7 @@
   "x",
   INF,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-inf.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-inf.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
@@ -6,15 +6,7 @@
   "x",
   NAN,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-nan.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-nan.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
@@ -6,15 +6,7 @@
   "x",
   -INF,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-neg-inf.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/symbolic-number-neg-inf.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 14
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
+++ b/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
@@ -6,15 +6,7 @@
   "x",
   42,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/tagged-literal-in-reader-conditional.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Def/tagged-literal-in-reader-conditional.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 54
-    )
+    \Phel::keyword("start-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54)
   )
 );

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -9,15 +9,7 @@
     return (3 + 4);
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Do/do-in-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Do/do-in-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 36
-    )
+    \Phel::keyword("start-location"), \Phel::location("Do/do-in-expr.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Do/do-in-expr.test", 1, 36)
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -18,16 +18,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(fib n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-bail-on-self-recursion.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-bail-on-self-recursion.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 82
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -15,16 +15,8 @@
   \Phel::map(
     \Phel::keyword("tag"), "int",
     \Phel::keyword("doc"), "```phel\n(produce a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-explicit-wins.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-explicit-wins.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 40
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(check x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-inferred-callee.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-inferred-callee.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -15,16 +15,8 @@
   \Phel::map(
     \Phel::keyword("tag"), "int",
     \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-tagged.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-tagged.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 43
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-untagged.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-call-global-untagged.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 38
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -15,16 +15,8 @@
   \Phel::map(
     \Phel::keyword("tag"), "int",
     \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 43
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]"
@@ -43,16 +35,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-propagates.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(typed s)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 42
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[s]"
@@ -42,16 +34,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-fqn.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(maybe a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 24
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -42,16 +34,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-nullable.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(either a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 33
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -42,16 +34,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-callee-param-tag-skips-union.test",
-      \Phel::keyword("line"), 2,
-      \Phel::keyword("column"), 28
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-core-plus-bails-on-bigint-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-core-plus-bails-on-bigint-literal.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 64
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-core-plus-int-stable.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-core-plus-int-stable.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 48
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(weird a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-bails-on-disagreement.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-bails-on-disagreement.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 47
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rrange lo hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-numeric.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-numeric.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 54
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[lo hi]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-recursion-cycle.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-expected-type-recursion-cycle.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 51
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(size xs)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-count-arg.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-count-arg.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 31
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[xs]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(div a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-intdiv-args.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-intdiv-args.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 33
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]",

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -13,16 +13,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(rrange hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-random-int-arg.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-infer-php-random-int-arg.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 40
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[hi]",

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -19,16 +19,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(mixed x flag)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-mixed-branches-bails.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-mixed-branches-bails.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 57
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x flag]"

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-numeric.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-numeric.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
@@ -14,16 +14,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(greet x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-string.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Fn/fn-param-infer-string.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 32
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -20,16 +20,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-expr.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 18
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Foreach/foreach-expr.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Foreach/foreach-expr.test", 3, 18),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -19,16 +19,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(process arr)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-tagged-array-param-skips-adapter.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Foreach/foreach-tagged-array-param-skips-adapter.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 59
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[arr]"

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -24,16 +24,8 @@ require_once __DIR__ . '/xyz/foo.php';
   "a",
   \Phel::keyword("bar"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 12
-    )
+    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 3, 12)
   )
 );
 \Phel::addDefinition(
@@ -41,16 +33,8 @@ require_once __DIR__ . '/xyz/foo.php';
   "b",
   \Phel::keyword("bar", "test"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 4,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 4,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 4, 0),
+    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 4, 13)
   )
 );
 \Phel::addDefinition(
@@ -58,16 +42,8 @@ require_once __DIR__ . '/xyz/foo.php';
   "c",
   \Phel::keyword("bar", "xyz.foo"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 17
-    )
+    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 5, 0),
+    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 5, 17)
   )
 );
 \Phel::addDefinition(
@@ -75,15 +51,7 @@ require_once __DIR__ . '/xyz/foo.php';
   "d",
   \Phel::keyword("bar", "xyz\\foo"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Keyword/keywords.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 20
-    )
+    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 6, 0),
+    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 6, 20)
   )
 );

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -10,15 +10,7 @@
     return ($x_1 + $y_2);
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Let/let-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Let/let-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 35
-    )
+    \Phel::keyword("start-location"), \Phel::location("Let/let-expr.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Let/let-expr.test", 1, 35)
   )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -20,16 +20,8 @@
   \Phel::map(
     \Phel::keyword("macro"), true,
     \Phel::keyword("doc"), "```phel\n(ns-present?)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/defmacro-env-form.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/defmacro-env-form.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 52
-    ),
+    \Phel::keyword("start-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -19,16 +19,8 @@
   },
   \Phel::map(
     \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/macro-expand.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/macro-expand.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 38
-    ),
+    \Phel::keyword("start-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 38),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -15,16 +15,8 @@
   },
   \Phel::map(
     \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/return-array.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/return-array.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 55
-    ),
+    \Phel::keyword("start-location"), \Phel::location("MacroExpand/return-array.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("MacroExpand/return-array.test", 1, 55),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"
@@ -35,15 +27,7 @@
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/return-array.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "MacroExpand/return-array.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 13
-    )
+    \Phel::keyword("start-location"), \Phel::location("MacroExpand/return-array.test", 3, 0),
+    \Phel::keyword("end-location"), \Phel::location("MacroExpand/return-array.test", 3, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -26,16 +26,8 @@ require_once __DIR__ . '/my_namespace/core.php';
   10,
   \Phel::map(
     \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 5,
-      \Phel::keyword("column"), 19
-    )
+    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 5, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 5, 19)
   )
 );
 if (!class_exists('hello_world\abc')) {
@@ -68,16 +60,8 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 19
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -97,16 +81,8 @@ class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/munge-ns.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 19
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Ns/require-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-multiple.test
@@ -27,16 +27,8 @@ require_once __DIR__ . '/xyz/core2.php';
   "kw",
   \Phel::keyword("f1", "xyz.core"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-multiple.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-multiple.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 15
-    )
+    \Phel::keyword("start-location"), \Phel::location("Ns/require-multiple.test", 6, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/require-multiple.test", 6, 15)
   )
 );
 \Phel::addDefinition(
@@ -44,15 +36,7 @@ require_once __DIR__ . '/xyz/core2.php';
   "kw2",
   \Phel::keyword("f3", "xyz.core2"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-multiple.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-multiple.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 17
-    )
+    \Phel::keyword("start-location"), \Phel::location("Ns/require-multiple.test", 7, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/require-multiple.test", 7, 17)
   )
 );

--- a/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
@@ -27,16 +27,8 @@ require_once __DIR__ . '/xyz/core2.php';
   "kw",
   \Phel::keyword("f1", "xyz.core"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-vector-multiple.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-vector-multiple.test",
-      \Phel::keyword("line"), 6,
-      \Phel::keyword("column"), 15
-    )
+    \Phel::keyword("start-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 15)
   )
 );
 \Phel::addDefinition(
@@ -44,15 +36,7 @@ require_once __DIR__ . '/xyz/core2.php';
   "kw2",
   \Phel::keyword("f3", "xyz.core2"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-vector-multiple.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Ns/require-vector-multiple.test",
-      \Phel::keyword("line"), 7,
-      \Phel::keyword("column"), 17
-    )
+    \Phel::keyword("start-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 0),
+    \Phel::keyword("end-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 17)
   )
 );

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -7,16 +7,8 @@
   "a",
   (new \stdClass()),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "PhpObjectSet/set-class-property.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "PhpObjectSet/set-class-property.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 27
-    )
+    \Phel::keyword("start-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27)
   )
 );
 (function() {

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -7,16 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "SetVar/set-var.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "SetVar/set-var.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("SetVar/set-var.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("SetVar/set-var.test", 1, 9)
   )
 );
 \Phel::setVar(

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -15,16 +15,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/throw-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/throw-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 56
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Try/throw-expr.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Try/throw-expr.test", 1, 56),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -17,15 +17,7 @@
     }
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/try-catch-finally-expr-throw.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/try-catch-finally-expr-throw.test",
-      \Phel::keyword("line"), 4,
-      \Phel::keyword("column"), 27
-    )
+    \Phel::keyword("start-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -17,15 +17,7 @@
     }
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/try-catch-finally-expr.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Try/try-catch-finally-expr.test",
-      \Phel::keyword("line"), 4,
-      \Phel::keyword("column"), 27
-    )
+    \Phel::keyword("start-location"), \Phel::location("Try/try-catch-finally-expr.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Try/try-catch-finally-expr.test", 4, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
@@ -7,16 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "VarQuote/var-quote-emits-get-var.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "VarQuote/var-quote-emits-get-var.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9)
   )
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
@@ -7,16 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "VarQuote/var-special-form.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "VarQuote/var-special-form.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 9
-    )
+    \Phel::keyword("start-location"), \Phel::location("VarQuote/var-special-form.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("VarQuote/var-special-form.test", 1, 9)
   )
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -21,16 +21,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_generator_array)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-array.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-array.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 26
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Yield/yield-array.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Yield/yield-array.test", 3, 26),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -21,16 +21,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-doseq-str.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-doseq-str.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 23
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Yield/yield-doseq-str.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Yield/yield-doseq-str.test", 3, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -16,16 +16,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_no_return)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-return-context.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-return-context.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 18
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Yield/yield-return-context.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Yield/yield-return-context.test", 3, 18),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -21,16 +21,8 @@
   },
   \Phel::map(
     \Phel::keyword("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel::keyword("start-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-str.test",
-      \Phel::keyword("line"), 1,
-      \Phel::keyword("column"), 0
-    ),
-    \Phel::keyword("end-location"), \Phel::map(
-      \Phel::keyword("file"), "Yield/yield-str.test",
-      \Phel::keyword("line"), 3,
-      \Phel::keyword("column"), 23
-    ),
+    \Phel::keyword("start-location"), \Phel::location("Yield/yield-str.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Yield/yield-str.test", 3, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"


### PR DESCRIPTION
## 🤔 Background

Every `defn` synthesises a six-entry nested map for both `:start-location` and `:end-location`:

```php
\Phel::map(
  \Phel::keyword("file"), "…",
  \Phel::keyword("line"), 1,
  \Phel::keyword("column"), 0
)
```

For `phel.core` (hundreds of defs) that means three keyword interns plus a map allocation per location, twice per def — and the same keyword keys are duplicated all over the compiled `.php` file.

Closes #2053

## 💡 Goal

Share the location-map shape behind a single helper, and emit the helper call instead of the nested `\Phel::map(...)` block.

## 🔖 Changes

- New `\Phel::location(string $file, int $line, int $column): PersistentMapInterface` interns the `:file`, `:line`, `:column` keyword keys in `static` slots and builds the small map.
- `MapEmitter::locationLiteral` detects the exact `{:file <string> :line <int> :column <int>}` shape (any order) on a `MapNode` whose entries are all `LiteralNode`s with primitive values. When matched, emits a single `\Phel::location("…", line, col)` call site instead of the three-entry `\Phel::map(\Phel::keyword(…), …)` form.
- The pattern match is conservative — non-literal values, missing keys, or extra entries fall through to the generic emission path.
- 47 existing fixtures regenerate to the helper form; semantics unchanged.

## ✅ Tests

- `composer test` green (5611 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).
- Compiled emission for `(def x 1)` drops from 25 lines to 11.