### PR TITLE
feat(lang): add defonce special form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Runtime: persistent collection `hash()` switches its memo sentinel from `0` to `null`, so empty maps / sets and the rare `hash == 0` value reuse the cached result on subsequent calls instead of recomputing (#2050)
 - Compiler: `LocalVarNode::getInferredType()` exposes the analyser's `:tag` meta to the emitter; `IterableTarget` consumes it so a `(defn f [^"array" arr] (foreach [x arr] …))` style annotation unlocks the same `foreach` / `apply` adapter skips as a literal would (#2052)
 - Runtime + compiler: new `\Phel::location($file, $line, $column)` helper interns the `:file` / `:line` / `:column` keyword keys once per process; `MapEmitter` detects the synthesised `{:file <string> :line <int> :column <int>}` shape on every `addDefinition` site and emits a single `\Phel::location(...)` call instead of the three-entry `\Phel::map(…)`, shrinking compiled file size (#2053)
+- Language: new `defonce` special form binds a global only when the name is not already defined in the registry — Clojure-aligned REPL convenience for state holders that must survive file reloads (#2055)
 
 ### Changed
 

--- a/src/php/Api/Infrastructure/PhelFnLoader.php
+++ b/src/php/Api/Infrastructure/PhelFnLoader.php
@@ -75,6 +75,16 @@ This special form binds a value to a global symbol.',
             'desc' => 'This special form binds a value to a global symbol.',
             'example' => '(def my-value 42)',
         ],
+        Symbol::NAME_DEF_ONCE => [
+            'doc' => '```phel
+(defonce name meta? value)
+```
+Like `def`, but only binds the value when `name` is not already defined in the registry. Useful in REPL workflows where re-evaluating a file should not reset stateful holders (atoms, connections, caches).',
+            'docUrl' => '/documentation/global-and-local-bindings/#definition-def',
+            'signatures' => ['(defonce name meta? value)'],
+            'desc' => 'Like `def`, but only binds the value when `name` is not already defined.',
+            'example' => '(defonce app-state (atom {}))',
+        ],
         Symbol::NAME_DO => [
             'doc' => '```phel
 (do expr*)

--- a/src/php/Compiler/Domain/Analyzer/Ast/DefNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/DefNode.php
@@ -17,6 +17,7 @@ final class DefNode extends AbstractNode
         private readonly MapNode $meta,
         private readonly AbstractNode $init,
         ?SourceLocation $sourceLocation = null,
+        private readonly bool $defonce = false,
     ) {
         parent::__construct($env, $sourceLocation);
     }
@@ -39,5 +40,16 @@ final class DefNode extends AbstractNode
     public function getInit(): AbstractNode
     {
         return $this->init;
+    }
+
+    /**
+     * `true` when the def came from a `defonce*` special form. The
+     * emitter wraps the `addDefinition` call so the binding is left
+     * untouched if it already exists in the registry — a no-op on
+     * subsequent file evaluations / REPL reloads.
+     */
+    public function isDefonce(): bool
+    {
+        return $this->defonce;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -304,6 +304,7 @@ final class AnalyzePersistentList
 
         $analyzer = match ($symbolName) {
             Symbol::NAME_DEF => new DefSymbol($this->analyzer),
+            Symbol::NAME_DEF_ONCE => new DefSymbol($this->analyzer, defonce: true),
             Symbol::NAME_NS => new NsSymbol($this->analyzer),
             Symbol::NAME_IN_NS => new InNsSymbol($this->analyzer),
             Symbol::NAME_USE => new UseSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm;
 
 use Phel;
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\DefNode;
 use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
@@ -12,7 +13,6 @@ use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
-use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
@@ -38,14 +38,23 @@ use function max;
  *
  * Defines a global variable in the current namespace.
  */
-final class DefSymbol implements SpecialFormAnalyzerInterface
+final readonly class DefSymbol implements SpecialFormAnalyzerInterface
 {
-    use WithAnalyzerTrait;
-
     private const array POSSIBLE_TUPLE_SIZES = [2, 3, 4];
 
     /** Number of implicit parameters (`&form` and `&env`) injected into macro fns. */
     private const int MACRO_IMPLICIT_PARAMS = 2;
+
+    /**
+     * `defonce`: `false` for the plain `def` special form (always
+     * overwrite the existing binding), `true` for `defonce*` (only
+     * initialise when the binding is absent — used by REPL workflows to
+     * keep stateful objects alive across file reloads).
+     */
+    public function __construct(
+        private AnalyzerInterface $analyzer,
+        private bool $defonce = false,
+    ) {}
 
     /**
      * @param PersistentListInterface<mixed> $list
@@ -124,6 +133,7 @@ final class DefSymbol implements SpecialFormAnalyzerInterface
             $meta,
             $initNode,
             $list->getStartLocation(),
+            $this->defonce,
         );
     }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -41,13 +41,25 @@ final class DefEmitter implements NodeEmitterInterface
         }
 
         $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
+
+        $ns = PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace()));
+        $name = PhpStringEscape::doubleQuoted($node->getName()->getName());
+
+        if ($node->isDefonce()) {
+            // `defonce` keeps the existing binding intact across re-eval
+            // — useful for REPL workflows where re-loading a file would
+            // otherwise reset stateful atoms / connections / caches.
+            $this->outputEmitter->emitLine('if (!\\Phel::hasDefinition("' . $ns . '", "' . $name . '")) {');
+            $this->outputEmitter->increaseIndentLevel();
+        }
+
         $this->outputEmitter->emitLine('\\Phel::addDefinition(');
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($this->outputEmitter->mungeEncodeRegistryKey($node->getNamespace())));
+        $this->outputEmitter->emitStr($ns);
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitStr('"');
-        $this->outputEmitter->emitStr(PhpStringEscape::doubleQuoted($node->getName()->getName()));
+        $this->outputEmitter->emitStr($name);
         $this->outputEmitter->emitLine('",');
         $this->outputEmitter->emitNode($node->getInit());
         if ($node->getMeta()->getKeyValues() !== []) {
@@ -58,5 +70,10 @@ final class DefEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitLine();
         $this->outputEmitter->decreaseIndentLevel();
         $this->outputEmitter->emitLine(');');
+
+        if ($node->isDefonce()) {
+            $this->outputEmitter->decreaseIndentLevel();
+            $this->outputEmitter->emitLine('}');
+        }
     }
 }

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -21,6 +21,8 @@ final class Symbol extends AbstractType implements IdenticalInterface, FnInterfa
 
     public const string NAME_DEF = 'def';
 
+    public const string NAME_DEF_ONCE = 'defonce';
+
     public const string NAME_DEF_STRUCT = 'defstruct*';
 
     public const string NAME_DO = 'do';

--- a/tests/phel/core/utility-functions.phel
+++ b/tests/phel/core/utility-functions.phel
@@ -220,3 +220,10 @@
 (deftest test-compile-form
   (is (= "" (compile '(+ 1 1)))
       "fold elides pure top-level arithmetic"))
+
+(deftest test-defonce
+  (defonce defonce-test-target 1)
+  (is (= 1 defonce-test-target) "defonce binds the initial value")
+  (defonce defonce-test-target 999)
+  (is (= 1 defonce-test-target)
+      "defonce leaves the existing binding intact on re-evaluation"))

--- a/tests/php/Integration/Fixtures/Def/defonce.test
+++ b/tests/php/Integration/Fixtures/Def/defonce.test
@@ -1,0 +1,14 @@
+--PHEL--
+(defonce counter 0)
+--PHP--
+if (!\Phel::hasDefinition("user", "counter")) {
+  \Phel::addDefinition(
+    "user",
+    "counter",
+    0,
+    \Phel::map(
+      \Phel::keyword("start-location"), \Phel::location("Def/defonce.test", 1, 0),
+      \Phel::keyword("end-location"), \Phel::location("Def/defonce.test", 1, 19)
+    )
+  );
+}


### PR DESCRIPTION
## 🤔 Background

Clojure's `defonce` binds a global only the first time it sees it — subsequent re-evaluations (REPL reload, file re-require) leave the existing binding untouched. That's exactly the contract you want for atoms, connection pools, caches, or anything else whose identity must survive a code reload.

Phel had no equivalent.

Closes #2055

## 💡 Goal

Add `(defonce name value)` with Clojure-aligned semantics: same shape as `def`, only-when-absent binding.

## 🔖 Changes

- `Symbol::NAME_DEF_ONCE = 'defonce'` joins the special-form name table.
- `DefSymbol` now takes a `bool $defonce` constructor flag; the registration in `AnalyzePersistentList::symbolAnalyzerCache` wires `defonce` to a `DefSymbol(defonce: true)` and otherwise shares every analysis path with plain `def` (meta extraction, return-type inference, param tags, compile-time meta stash).
- `DefNode` gains `isDefonce(): bool` so the emitter sees the flag.
- `DefEmitter` wraps the `\Phel::addDefinition(...)` call in `if (!\Phel::hasDefinition("ns","name")) { … }` for `defonce` nodes; plain `def` keeps its current always-overwrite emission.
- `PhelFnLoader` metadata table gets a `defonce` entry so REPL doc lookup / hover surfaces work the same as for other special forms.

## ✅ Tests

- New `Def/defonce.test` integration fixture pins the emit shape.
- New `test-defonce` core test exercises the runtime semantics: first evaluation binds, second evaluation is a no-op even with a different value expression.
- `composer test` green (5613 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).