### PR TITLE
fix(emitter): defonce uses isDefined, not hasDefinition, for nil bindings

### DIFF
--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefEmitter.php
@@ -49,7 +49,11 @@ final class DefEmitter implements NodeEmitterInterface
             // `defonce` keeps the existing binding intact across re-eval
             // — useful for REPL workflows where re-loading a file would
             // otherwise reset stateful atoms / connections / caches.
-            $this->outputEmitter->emitLine('if (!\\Phel::hasDefinition("' . $ns . '", "' . $name . '")) {');
+            // `isDefined` (not `hasDefinition`) is the correct guard: it
+            // routes to `Registry::isDefined`, which uses `array_key_exists`
+            // and so distinguishes a stored `null` from a missing entry.
+            // `hasDefinition` would overwrite `(defonce x nil)` on reload.
+            $this->outputEmitter->emitLine('if (!\\Phel::isDefined("' . $ns . '", "' . $name . '")) {');
             $this->outputEmitter->increaseIndentLevel();
         }
 

--- a/tests/phel/core/utility-functions.phel
+++ b/tests/phel/core/utility-functions.phel
@@ -227,3 +227,10 @@
   (defonce defonce-test-target 999)
   (is (= 1 defonce-test-target)
       "defonce leaves the existing binding intact on re-evaluation"))
+
+(deftest test-defonce-preserves-nil-binding
+  (defonce defonce-nil-target nil)
+  (is (nil? defonce-nil-target) "defonce can bind nil as the initial value")
+  (defonce defonce-nil-target :reloaded)
+  (is (nil? defonce-nil-target)
+      "defonce treats a stored nil as a present binding, never overwrites"))

--- a/tests/php/Integration/Fixtures/Def/defonce.test
+++ b/tests/php/Integration/Fixtures/Def/defonce.test
@@ -1,7 +1,7 @@
 --PHEL--
 (defonce counter 0)
 --PHP--
-if (!\Phel::hasDefinition("user", "counter")) {
+if (!\Phel::isDefined("user", "counter")) {
   \Phel::addDefinition(
     "user",
     "counter",


### PR DESCRIPTION
## 🤔 Background

Follow-up to [SauronBot's review on #2070](https://github.com/phel-lang/phel-lang/pull/2070#issuecomment-4508370023).

`Registry::hasDefinition()` uses `isset()`, which treats a stored `null` as missing. `DefEmitter` guarded `defonce` with `\Phel::hasDefinition`, so:

```phel
(defonce state nil)
(defonce state :reloaded)
```

ended up rebinding `state` to `:reloaded` — exact opposite of the contract.

## 💡 Goal

Switch the emitted guard to `\Phel::isDefined`, which routes to `Registry::isDefined()`. That implementation uses `array_key_exists()` and so distinguishes a stored `null` from a missing entry.

## 🔖 Changes

- `DefEmitter::emit` emits `\Phel::isDefined(...)` (was `hasDefinition`) for `defonce` nodes; comment explains why.
- `Def/defonce.test` fixture regenerated to the new guard.
- New `test-defonce-preserves-nil-binding` Phel test exercises the regression: would fail without the fix, passes with it.

## ✅ Tests

- `composer test` green (5615 Phel + PHPUnit + Psalm + PHPStan + Rector + CS-Fixer).