### PR TITLE
perf(compiler): type-known specialisations for str + (:k m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Hoist keyword literals inside a fn body to per-fn `static $__phel_const_N` slots — one intern-pool lookup per call site (#2046)
 - Drop `Seq::toIterable` / `Seq::toApplyArguments` adapter wraps when the source is already iterable or a PHP array (#2047)
 - Specialise `(str ...)` to PHP `.` concat for all-literal args; emit `(php/instanceof x c)` over local bindings without the two-temp IIFE (#2048)
+- Extend `(str ...)` `.`-concat specialisation to args tagged `^string`; specialise `(:k m)` to `$m->find(\Phel::keyword("k"))` when `m` is tagged `^"\Phel\Lang\Collections\Map\PersistentMapInterface"`; both consumers share `CallSpecialization` so the cache scanner no longer reserves an orphan `static $__phel_call_N` for the specialised call (#2048)
 - Multi-arity fn dispatch via `match (\count($args)) { … }` instead of `switch` + post-`if`; variadic body folds into `default` (#2049)
 - Persistent-collection `hash()` memo uses a `null` sentinel so empty maps / sets and `hash == 0` stop recomputing (#2050)
 - `LocalVarNode::getInferredType()` exposes the analyser `:tag` meta to the emitter; `IterableTarget` promotes #2047 to fire on `(defn f [^"array" arr] …)` annotations (#2052)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
@@ -31,6 +31,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\SetVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ThrowNode;
 use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Lang\Keyword;
 
@@ -61,7 +62,11 @@ final readonly class BodyConstantScanner
             return;
         }
 
-        if ($cacheCalls && $node instanceof CallNode && GlobalCallTarget::isGlobalFnCall($node)) {
+        if ($cacheCalls
+            && $node instanceof CallNode
+            && GlobalCallTarget::isGlobalFnCall($node)
+            && !CallSpecialization::isSpecialized($node)
+        ) {
             $scope->reserveCallSlot($node);
             // Fall through so child args are still scanned for nested literals/calls.
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+use function is_string;
+use function ltrim;
+
+/**
+ * Syntactic predicates for `CallNode` instances the `CallEmitter`
+ * specialises away from the generic dispatch path. The scanner and the
+ * emitter consult the same predicates so a specialised call never gets
+ * an orphan `static $__phel_call_N` declaration reserved by the cache
+ * scanner.
+ */
+final readonly class CallSpecialization
+{
+    private function __construct() {}
+
+    public static function isSpecialized(CallNode $node): bool
+    {
+        if (self::isStrConcat($node)) {
+            return true;
+        }
+
+        return self::isKeywordFind($node);
+    }
+
+    /**
+     * `(str ...)` whose every argument compiles to a string-typed
+     * expression: string literals or `LocalVarNode`s tagged `string`.
+     */
+    public static function isStrConcat(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'str'
+        ) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if ($args === []) {
+            return false;
+        }
+
+        return array_all($args, static fn(AbstractNode $arg): bool => self::isStringConcatable($arg));
+    }
+
+    /**
+     * `(:k m)` where the analyser has tagged `m` as `PersistentMapInterface`,
+     * so `Keyword::__invoke` reduces to a single `$m->find($k)` call.
+     */
+    public static function isKeywordFind(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof LiteralNode || !$fn->getValue() instanceof Keyword) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        $arg = $args[0];
+        return $arg instanceof LocalVarNode
+            && self::isPersistentMapTag($arg->getInferredType());
+    }
+
+    private static function isStringConcatable(AbstractNode $arg): bool
+    {
+        if ($arg instanceof LiteralNode && is_string($arg->getValue())) {
+            return true;
+        }
+
+        if (!$arg instanceof LocalVarNode) {
+            return false;
+        }
+
+        $tag = $arg->getInferredType();
+        return $tag !== null && ltrim($tag, '\\') === 'string';
+    }
+
+    private static function isPersistentMapTag(?string $tag): bool
+    {
+        return $tag !== null && ltrim($tag, '\\') === PersistentMapInterface::class;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -8,19 +8,17 @@ use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
-use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Lang\Symbol;
-use Phel\Shared\CompilerConstants;
 
 use function assert;
 use function count;
-use function is_string;
 
 final class CallEmitter implements NodeEmitterInterface
 {
@@ -156,6 +154,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitKeywordFind($node)) {
+            return;
+        }
+
         if ($this->tryEmitStrConcat($node)) {
             return;
         }
@@ -172,40 +174,26 @@ final class CallEmitter implements NodeEmitterInterface
     }
 
     /**
-     * Specialise `(str "a" "b" "c")` to PHP `.` concatenation when every
-     * arg is a string literal. The runtime `phel.core/str` does a
-     * per-arg `val-to-str` dispatch plus a `StringBuilder`-style
-     * accumulator pass; for purely literal inputs the result is a
-     * compile-time constant string, so we emit a single `.` chain and
-     * skip both the registry lookup and the runtime walk.
+     * Specialise `(str ...)` to PHP `.` concatenation when every arg
+     * compiles to a string-typed expression. The runtime `phel.core/str`
+     * does a per-arg `val-to-str` dispatch plus a `StringBuilder`-style
+     * accumulator pass; when every arg is already a string the result is
+     * the same plain `.` chain, so we emit it directly and skip both the
+     * registry lookup and the runtime walk.
+     *
+     * Eligibility lives on {@see CallSpecialization::isStrConcat()} so the
+     * cache scanner can skip reserving a `static $__phel_call_N` slot for
+     * the call we are about to specialise.
      */
     private function tryEmitStrConcat(CallNode $node): bool
     {
-        $fn = $node->getFn();
-        if (!$fn instanceof GlobalVarNode) {
+        if (!CallSpecialization::isStrConcat($node)) {
             return false;
-        }
-
-        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
-            || $fn->getName()->getName() !== 'str'
-        ) {
-            return false;
-        }
-
-        $args = $node->getArguments();
-        if ($args === []) {
-            return false;
-        }
-
-        foreach ($args as $arg) {
-            if (!$arg instanceof LiteralNode || !is_string($arg->getValue())) {
-                return false;
-            }
         }
 
         $loc = $node->getStartSourceLocation();
         $this->outputEmitter->emitStr('(', $loc);
-        foreach ($args as $i => $arg) {
+        foreach ($node->getArguments() as $i => $arg) {
             if ($i > 0) {
                 $this->outputEmitter->emitStr(' . ', $loc);
             }
@@ -214,6 +202,30 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         $this->outputEmitter->emitStr(')', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(:k m)` to `$m->find(\Phel::keyword("k"))` when the
+     * analyser has proved `m` to be a `PersistentMapInterface`. The
+     * runtime `Keyword::__invoke` dispatches on the target's runtime
+     * type to pick between `ArrayAccess`, `ContainsInterface`, and the
+     * `nil` fallback; a typed map collapses that dispatch to the single
+     * `find` call the map already exposes, returning `null` on miss to
+     * match the 1-arg keyword-accessor contract.
+     */
+    private function tryEmitKeywordFind(CallNode $node): bool
+    {
+        if (!CallSpecialization::isKeywordFind($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr('->find(', $loc);
+        $this->outputEmitter->emitNode($node->getFn());
+        $this->outputEmitter->emitStr('))', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/keyword-find-on-persistent-map-local.test
+++ b/tests/php/Integration/Fixtures/Call/keyword-find-on-persistent-map-local.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^"\\Phel\\Lang\\Collections\\Map\\PersistentMapInterface" m] (:k m))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  static $__phel_const_0;
+  return ($m->find(($__phel_const_0 ??= \Phel::keyword("k"))));
+});

--- a/tests/php/Integration/Fixtures/Call/str-inferred-string-locals-folds-to-concat.test
+++ b/tests/php/Integration/Fixtures/Call/str-inferred-string-locals-folds-to-concat.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^string a ^string b] (str "[" a b "]"))
+--PHP--
+(function(string $a, string $b) {
+  return ("[" . $a . $b . "]");
+});


### PR DESCRIPTION
## 🤔 Background

Issue #2048 bundled three small `CallEmitter` shortcuts gated on analyser type info. Two of them landed in #2060: `(str <literals>)` → `.`-concat, and `(instanceof local local)` skips the two-temp IIFE. This PR completes the bundle: extends the `str` shortcut to inferred-string locals and adds the `(:k m)` → `$m->find(...)` shortcut.

While wiring this up I also noticed that the existing literal-`str` shortcut leaves an orphan `static $__phel_call_0;` declaration when used inside a fn body: `BodyConstantScanner` reserves a call slot the emitter then specialises away. Factoring the predicates into a shared `CallSpecialization` helper teaches the scanner to skip those slots.

## 💡 Goal

Closes #2048. One PR, three changes that all live in the same `CallEmitter` / `BodyConstantScanner` area.

## 🔖 Changes

- **`str` inferred-string args.** `tryEmitStrConcat` now also accepts `LocalVarNode`s whose `:tag` resolves to `string` (already inferred by `ParamTypeInferrer` for params used under `php/.`, or set by hand). `(str "[" a b "]")` with `^string a ^string b` now compiles to `("[" . $a . $b . "]")`.
- **`(:k m)` → `$m->find(...)`.** New `tryEmitKeywordFind`: when the keyword-as-fn target is a `LocalVarNode` tagged `^"\Phel\Lang\Collections\Map\PersistentMapInterface"`, emit `$m->find(\Phel::keyword("k"))` directly. The 1-arg `Keyword::__invoke` contract returns the default (= `null`) on miss, which is what `PersistentMapInterface::find` already does, so the optimisation is semantics-preserving for the typed-map case.
- **`CallSpecialization` shared helper.** Predicates `isStrConcat` / `isKeywordFind` / `isSpecialized` live in one place so `CallEmitter` (skip the generic dispatch) and `BodyConstantScanner` (skip `reserveCallSlot`) stay in lockstep. Removes the orphan `static $__phel_call_N` decl that the pre-existing literal-`str` specialisation already left behind.

Tests: per-opt fixture under `tests/php/Integration/Fixtures/Call/`. Existing literal-`str` and `instanceof local local` fixtures continue to pass.

Final refactor pass: re-reviewed `CallEmitter`, `CallSpecialization`, `BodyConstantScanner` and the two new fixtures; no follow-up changes surfaced.

Closes #2048