### PR TITLE
feat(compiler): ^:by-ref parameter hint compiles to PHP &$param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `phel.transit` — Transit + JSON-Verbose read/write (#2009)
 - `phel compile` — emit PHP for a snippet / file / stdin without evaluating; `--target` reserved for future `ast` / `tokens` dumps (#2043)
 - `defonce` special form — bind a global only when the name is not already defined, surviving REPL file reloads (#2055)
+- `^:by-ref` parameter hint — compiles a Phel fn param to PHP `&$param` so `php/aset` / `php/array_push` mutations on `(php/array)` buffers propagate back to the caller; pairs with the existing `^int` / `^string` tags. The historical undocumented `^:reference` keeps working as an alias (#2065)
 - Lexer: namespaced tagged literals (`#my.app/Person`)
 - CI: `clojure-test-suite` workflow runs against dev HEAD on every PR, non-blocking (#2036)
 - `CITATION.cff` for academic citation (#2016)

--- a/src/phel/core/sequences.phel
+++ b/src/phel/core/sequences.phel
@@ -58,7 +58,7 @@
 
 (defn- pop*
   "Removes the last element of `coll`. Returns nil for nil or empty PHP arrays."
-  [^:reference coll]
+  [^:by-ref coll]
   (cond
     (nil? coll) nil
     (php-array? coll) (php/array_pop coll)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MethodEmitter.php
@@ -70,7 +70,7 @@ final readonly class MethodEmitter
             if ($isVariadicTail) {
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $asReference = false, $isVariadic = true);
             } else {
-                $isReference = $meta instanceof PersistentMapInterface && $meta->find(Keyword::create('reference')) === true;
+                $isReference = $this->isByRef($meta);
                 $this->outputEmitter->emitPhpVariable($symbol, $loc = null, $isReference);
             }
 
@@ -163,6 +163,26 @@ final readonly class MethodEmitter
         }
 
         return is_string($tag) && $tag !== '' ? $tag : null;
+    }
+
+    /**
+     * `^:by-ref` (and the historical `^:reference` alias used inside
+     * `phel.core`) compiles the param to PHP `&$param` so mutations via
+     * `php/aset`, `php/array_push`, etc. propagate back to the caller's
+     * binding. Surfaces the `(php/array)` mutation pattern at the Phel
+     * level without forcing buffer-return-rebind dances.
+     */
+    private function isByRef(mixed $meta): bool
+    {
+        if (!$meta instanceof PersistentMapInterface) {
+            return false;
+        }
+
+        if ($meta->find(Keyword::create('by-ref')) === true) {
+            return true;
+        }
+
+        return $meta->find(Keyword::create('reference')) === true;
     }
 
     /**

--- a/tests/phel/core/by-ref-param.phel
+++ b/tests/phel/core/by-ref-param.phel
@@ -1,0 +1,22 @@
+(ns phel-test.core.by-ref-param
+  (:require phel.test :refer [deftest is]))
+
+(defn- paint-overlay! [^:by-ref parts msg]
+  (php/array_push parts msg))
+
+(deftest test-by-ref-param-propagates-mutation
+  (let [parts (php/array)]
+    (paint-overlay! parts "hello")
+    (paint-overlay! parts "world")
+    (is (= 2 (php/count parts)) "mutations via &$arg propagate to caller")
+    (is (= "hello" (php/aget parts 0)))
+    (is (= "world" (php/aget parts 1)))))
+
+(defn- reset-counter! [^:by-ref counter]
+  (php/aset counter "n" 0))
+
+(deftest test-by-ref-param-on-assoc-array
+  (let [counter (php/array)]
+    (php/aset counter "n" 5)
+    (reset-counter! counter)
+    (is (= 0 (php/aget counter "n")) "php/aset under ^:by-ref mutates caller")))

--- a/tests/php/Integration/Fixtures/Fn/fn-param-by-ref-legacy-reference-alias.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-by-ref-legacy-reference-alias.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^:reference parts] (php/array_push parts "x"))
+--PHP--
+(function(&$parts) {
+  return array_push($parts, "x");
+});

--- a/tests/php/Integration/Fixtures/Fn/fn-param-by-ref.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-by-ref.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^:by-ref parts] (php/array_push parts "x"))
+--PHP--
+(function(&$parts) {
+  return array_push($parts, "x");
+});


### PR DESCRIPTION
## 🤔 Background

PHP arrays are pass-by-value across function boundaries. A Phel fn that mutates a `(php/array)` via `php/aset` / `php/array_push` silently throws those mutations away — the caller's binding is untouched. Today's workaround is to return the array and let the caller rebind. The issue body documents this biting twice in a week in [phel-doom](https://github.com/Chemaclass/phel-doom).

`MethodEmitter` already understood an internal `^:reference` meta key (used by `phel.core/pop*` to mutate its `php/array` arg). This PR turns that capability into a public `^:by-ref` hint.

## 💡 Goal

Closes #2065. Tiny compiler-surface change: a parameter-emission tweak that prepends `&` when `^:by-ref` is present.

## 🔖 Changes

- `MethodEmitter::isByRef` accepts the public `^:by-ref` keyword. Keeps the historical `^:reference` working so the single internal usage doesn't break in flight.
- Migrate `phel.core/pop*` to the new `^:by-ref` spelling so the public name is the one users see in core source.
- Integration fixtures `tests/php/Integration/Fixtures/Fn/fn-param-by-ref.test` and `fn-param-by-ref-legacy-reference-alias.test` lock the emit format.
- End-to-end test `tests/phel/core/by-ref-param.phel` exercises `php/aset` and `php/array_push` propagation so the runtime contract is covered, not just the emit shape.

## ✅ Acceptance criteria

```phel
(defn paint-overlay! [^:by-ref parts msg]
  (php/array_push parts msg))
```

compiles to:

```php
public function __invoke(&$parts, $msg) {
  return array_push($parts, $msg);
}
```

and the caller's `parts` reflects every `array_push`. Verified by the e2e Phel test.

Final refactor pass: re-reviewed `MethodEmitter`, `sequences.phel`, and the new fixtures; no follow-up changes surfaced.

Closes #2065