### PR TITLE
feat(compiler): better destructure error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Compiler: map destructure now surfaces a targeted "Did you mean" suggestion when a Clojure-style `{local :keyword}` pair is seen instead of `{:keyword local}`; `:keys` / `:strs` / `:syms` with a non-vector value report a one-line shape error rather than being silently dropped (#2066)
 - Dev: patch vendored Psalm 6.16.1 on install / update for PHP 8.5 NAN-coercion crash in `TLiteralFloat`
 - Compiler: `ConstantScope` uses `SplObjectStorage::offsetExists()` to silence a PHP 8.5 deprecation in emitted code
 - `phel.cli`: register commands via `Application::addCommand()` for Symfony 8 compat (#2033)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 
 use Phel;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -12,8 +13,10 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\TypeInterface;
+use Phel\Shared\Printer\Printer;
 
 use function array_key_exists;
+use function sprintf;
 
 final class MapBindingDeconstructor implements BindingDeconstructorInterface
 {
@@ -43,16 +46,19 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
 
         foreach ($binding as $key => $bindTo) {
             if ($key instanceof Keyword && $key->getName() === 'keys') {
+                $this->assertVectorOfSymbols($binding, $bindTo, ':keys');
                 $keys = $bindTo;
                 continue;
             }
 
             if ($key instanceof Keyword && $key->getName() === 'strs') {
+                $this->assertVectorOfSymbols($binding, $bindTo, ':strs');
                 $strs = $bindTo;
                 continue;
             }
 
             if ($key instanceof Keyword && $key->getName() === 'syms') {
+                $this->assertVectorOfSymbols($binding, $bindTo, ':syms');
                 $syms = $bindTo;
                 continue;
             }
@@ -67,6 +73,7 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
                 continue;
             }
 
+            $this->rejectReversedPair($binding, $key, $bindTo);
             $normalBindings[] = [$key, $bindTo];
         }
 
@@ -201,5 +208,58 @@ final class MapBindingDeconstructor implements BindingDeconstructorInterface
             $this->createAccessValue($binding, $key),
             $default,
         ])->copyLocationFrom($binding);
+    }
+
+    /**
+     * Catches Clojure-style `{local :keyword}` pairs at the top of map
+     * destructuring. Phel writes them the other way (`{:keyword local}`),
+     * so a `(Symbol, Keyword)` ordering is almost always a reflex typo
+     * from a Clojure user. Surface a targeted "did you mean" suggestion
+     * before downstream code blows up with the opaque
+     * "Cannot destructure Phel\\Lang\\Keyword".
+     *
+     * @param PersistentMapInterface<mixed, mixed> $binding
+     */
+    private function rejectReversedPair(
+        PersistentMapInterface $binding,
+        mixed $key,
+        mixed $bindTo,
+    ): void {
+        if (!$key instanceof Symbol || !$bindTo instanceof Keyword) {
+            return;
+        }
+
+        $flipped = Phel::map($bindTo, $key);
+        $message = sprintf(
+            'Cannot destructure: expected map destructure pattern {:keyword local}, '
+            . "got reversed pair starting with symbol '%s'.\n\n"
+            . "Did you mean:\n  %s\n\n"
+            . "(Phel's destructure order is :keyword first, then local — "
+            . "opposite of Clojure's {local :keyword}.)",
+            $key->getName(),
+            Printer::readable()->print($flipped),
+        );
+
+        throw AnalyzerException::withLocation($message, $binding);
+    }
+
+    /**
+     * `:keys`, `:strs`, `:syms` each take a vector of symbols. Anything
+     * else is rejected here with a one-line shape error rather than
+     * being silently dropped further down the deconstructor.
+     *
+     * @param PersistentMapInterface<mixed, mixed> $binding
+     */
+    private function assertVectorOfSymbols(
+        PersistentMapInterface $binding,
+        mixed $bindTo,
+        string $directive,
+    ): void {
+        if (!$bindTo instanceof PersistentVectorInterface) {
+            throw AnalyzerException::withLocation(
+                sprintf('`{%s [...]}` expects a vector of symbols', $directive),
+                $binding,
+            );
+        }
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/Binding/Deconstructor/MapBindingDeconstructorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Analyzer\SpecialForm\Binding\Deconstructor;
 
 use Phel;
+use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\BindingValidatorInterface;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\Binding\Deconstructor\MapBindingDeconstructor;
@@ -523,5 +524,87 @@ final class MapBindingDeconstructorTest extends TestCase
                 Symbol::create('__phel_2'),
             ],
         ], $bindings);
+    }
+
+    public function test_reversed_pair_suggests_did_you_mean(): void
+    {
+        // Clojure-style {local :keyword} should surface a targeted suggestion
+        // rather than the opaque "Cannot destructure Phel\\Lang\\Keyword".
+        $binding = Phel::map(
+            Symbol::create('tops'),
+            Keyword::create('tops'),
+        );
+
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage(
+            'Cannot destructure: expected map destructure pattern {:keyword local}, '
+            . "got reversed pair starting with symbol 'tops'.",
+        );
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+    }
+
+    public function test_reversed_pair_message_renders_flipped_pair(): void
+    {
+        $binding = Phel::map(
+            Symbol::create('tops'),
+            Keyword::create('tops'),
+        );
+
+        try {
+            $bindings = [];
+            $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+            self::fail('Expected AnalyzerException');
+        } catch (AnalyzerException $analyzerException) {
+            self::assertStringContainsString('{:tops tops}', $analyzerException->getMessage());
+            self::assertStringContainsString(
+                "Phel's destructure order is :keyword first, then local",
+                $analyzerException->getMessage(),
+            );
+        }
+    }
+
+    public function test_keys_directive_requires_a_vector(): void
+    {
+        // (let [{:keys foo} x]) — missing the vector around the keys.
+        $binding = Phel::map(
+            Keyword::create('keys'),
+            Symbol::create('foo'),
+        );
+
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('`{:keys [...]}` expects a vector of symbols');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+    }
+
+    public function test_strs_directive_requires_a_vector(): void
+    {
+        $binding = Phel::map(
+            Keyword::create('strs'),
+            Symbol::create('foo'),
+        );
+
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('`{:strs [...]}` expects a vector of symbols');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
+    }
+
+    public function test_syms_directive_requires_a_vector(): void
+    {
+        $binding = Phel::map(
+            Keyword::create('syms'),
+            Symbol::create('foo'),
+        );
+
+        $this->expectException(AnalyzerException::class);
+        $this->expectExceptionMessage('`{:syms [...]}` expects a vector of symbols');
+
+        $bindings = [];
+        $this->deconstructor->deconstruct($bindings, $binding, Symbol::create('x'));
     }
 }


### PR DESCRIPTION
## 🤔 Background

Phel's map destructure pattern is `{:keyword local}`. Clojure does it the other way (`{local :keyword}`). When a Clojure user writes Phel by reflex, the compiler responded with the opaque `Cannot destructure Phel\Lang\Keyword` from deep in the deconstructor — nothing in that message hinted at the key/local order.

The same module silently dropped `:keys foo` (missing vector) instead of telling the user the shape rule.

## 💡 Goal

Closes #2066. Turn two of the most common destructure typos into self-teaching errors before the user has to crawl Phel sources.

## 🔖 Changes

- `MapBindingDeconstructor::rejectReversedPair` detects the `(Symbol, Keyword)` shape on a normal binding pair and throws a targeted "Did you mean: {:tops tops}" message with the language-rule explanation. The suggested map is rendered via `Printer::readable()` so the user sees real Phel syntax.
- `MapBindingDeconstructor::assertVectorOfSymbols` rejects `{:keys foo}` / `{:strs foo}` / `{:syms foo}` with a one-line shape error. Previously these forms were silently ignored.
- Unit tests cover the new error paths in `MapBindingDeconstructorTest`.

The `:or` unbound-key follow-up the issue lists under "while we're in there" is genuinely cross-pair (needs to know every binding the destructure introduces); leaving it out of this PR to keep scope tight.

Final refactor pass: re-reviewed `MapBindingDeconstructor` and the new test methods; no follow-up changes surfaced.

Closes #2066