### PR TITLE
perf(compiler): specialise (get coll k) on typed collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Persistent-collection `hash()` memo uses a `null` sentinel so empty maps / sets and `hash == 0` stop recomputing (#2050)
 - `LocalVarNode::getInferredType()` exposes the analyser `:tag` meta to the emitter; `IterableTarget` promotes #2047 to fire on `(defn f [^"array" arr] …)` annotations (#2052)
 - Collapse synthesised `defn` location maps into a single `\Phel::location(file, line, col)` call, shrinking compiled file size (#2053)
+- Specialise `(get coll k)` to a direct `$coll->get($k)` (vector) or `$coll->find($k)` (map) method call when the analyser has tagged `coll` as `PersistentVectorInterface` / `PersistentMapInterface`, collapsing the `phel.core/get` cond chain for the hot indexed-access shape (#2067)
 
 ### Changed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -10,6 +10,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Shared\CompilerConstants;
 
@@ -34,7 +35,60 @@ final readonly class CallSpecialization
             return true;
         }
 
-        return self::isKeywordFind($node);
+        if (self::isKeywordFind($node)) {
+            return true;
+        }
+
+        return self::isTypedGetAccess($node);
+    }
+
+    /**
+     * `(get coll k)` with two args, where the analyser has tagged the
+     * target as either `PersistentVectorInterface` or
+     * `PersistentMapInterface`. The runtime `phel.core/get` body walks
+     * a `cond` chain covering nil, set, seq, and the generic
+     * `php/aget` fallback; for a typed indexed access every branch
+     * collapses to a single method call on the target collection.
+     */
+    public static function isTypedGetAccess(CallNode $node): bool
+    {
+        return self::typedGetAccessMethod($node) !== null;
+    }
+
+    /**
+     * Returns the PHP method name to call on the target collection for
+     * a `(get coll k)` call the emitter can specialise, or `null` when
+     * the call is not a typed get-access.
+     */
+    public static function typedGetAccessMethod(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'get'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        return match ($tag) {
+            PersistentVectorInterface::class => 'get',
+            PersistentMapInterface::class => 'find',
+            default => null,
+        };
     }
 
     /**
@@ -99,6 +153,11 @@ final readonly class CallSpecialization
 
     private static function isPersistentMapTag(?string $tag): bool
     {
-        return $tag !== null && ltrim($tag, '\\') === PersistentMapInterface::class;
+        return self::normalisedTag($tag) === PersistentMapInterface::class;
+    }
+
+    private static function normalisedTag(?string $tag): ?string
+    {
+        return $tag === null ? null : ltrim($tag, '\\');
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -162,6 +162,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedGetAccess($node)) {
+            return;
+        }
+
         $useCallMethod = !$this->isSelfCall($node) && GlobalCallTarget::isGlobalFnCall($node);
 
         $this->emitDynamicFunctionName($node);
@@ -225,6 +229,33 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr('->find(', $loc);
         $this->outputEmitter->emitNode($node->getFn());
+        $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(get coll k)` to a direct method call when the target
+     * carries a `PersistentVectorInterface` or `PersistentMapInterface`
+     * tag. Skips the cond chain in `phel.core/get`'s body (nil / set /
+     * seq / php-aget fallback) for the hot indexed-access shape.
+     *
+     * Two-arg form only: the three-arg `(get coll k default)` shape
+     * needs an explicit `contains?` probe to honour the default, so
+     * the cond chain is still the right path.
+     */
+    private function tryEmitTypedGetAccess(CallNode $node): bool
+    {
+        $method = CallSpecialization::typedGetAccessMethod($node);
+        if ($method === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->' . $method . '(', $loc);
+        $this->outputEmitter->emitNode($args[1]);
         $this->outputEmitter->emitStr('))', $loc);
         return true;
     }

--- a/tests/phel/core/get-typed-collection.phel
+++ b/tests/phel/core/get-typed-collection.phel
@@ -1,0 +1,16 @@
+(ns phel-test.core.get-typed-collection
+  (:require phel.test :refer [deftest is]))
+
+(defn- read-vec [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v ^int i]
+  (get v i))
+
+(defn- read-map [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m k]
+  (get m k))
+
+(deftest test-get-on-typed-vector
+  (is (= 10 (read-vec [10 20 30] 0)) "specialised get hits PersistentVector::get")
+  (is (= 30 (read-vec [10 20 30] 2)) "specialised get at tail index"))
+
+(deftest test-get-on-typed-map-miss-returns-nil
+  (is (= 1 (read-map {:a 1 :b 2} :a)) "specialised get hits PersistentMap::find")
+  (is (nil? (read-map {:a 1} :missing)) "specialised get returns nil for missing key"))

--- a/tests/php/Integration/Fixtures/Call/get-on-persistent-map-local.test
+++ b/tests/php/Integration/Fixtures/Call/get-on-persistent-map-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\\Phel\\Lang\\Collections\\Map\\PersistentMapInterface" m k] (get m k))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, $k) {
+  return ($m->find($k));
+});

--- a/tests/php/Integration/Fixtures/Call/get-on-persistent-vector-local.test
+++ b/tests/php/Integration/Fixtures/Call/get-on-persistent-vector-local.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface" v ^int i] (get v i))
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v, int $i) {
+  return ($v->get($i));
+});


### PR DESCRIPTION
## 🤔 Background

Issue #2067 documents the 682x gap between `(get v i)` and `(php/aget v i)` on a 180-element vector in a tight render loop. The runtime `phel.core/get` body walks a `cond` chain on every call (nil → set → seq → `php/aget` fallback) even when the analyser already knows the target is a vector / map.

The plumbing landed in #2063: `LocalVarNode::getInferredType()` surfaces the `:tag` meta to emitters. This PR adds the first concrete consumer for `get`.

## 💡 Goal

Closes #2067. Skip the cond chain in the hottest indexed-access shape when the analyser has proven the target's type.

## 🔖 Changes

- `CallSpecialization::typedGetAccessMethod` returns `'get'` for a `PersistentVectorInterface`-tagged target and `'find'` for a `PersistentMapInterface`-tagged target on a 2-arg `(get coll k)`. Otherwise returns `null`.
- `CallEmitter::tryEmitTypedGetAccess` consumes the method name, emitting `($coll->get($k))` or `($coll->find($k))`. Wired into `emitPhpVarNode` alongside the existing `tryEmitStrConcat` / `tryEmitKeywordFind` shortcuts.
- `CallSpecialization::isSpecialized` now reports the new shape, so `BodyConstantScanner` no longer reserves an orphan `static $__phel_call_N` for it.
- Integration fixtures: `Call/get-on-persistent-vector-local.test`, `Call/get-on-persistent-map-local.test`.
- End-to-end Phel test: `tests/phel/core/get-typed-collection.phel` covers hit + tail-index + map-miss-returns-nil.

## ✅ Acceptance criteria

```phel
(defn read-shade [^"\\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface" tbl ^int idx]
  (get tbl idx))
```

emits

```php
public function __invoke(\Phel\Lang\Collections\Vector\PersistentVectorInterface $tbl, int $idx) {
  return ($tbl->get($idx));
}
```

Exception semantics preserved: out-of-bounds still throws `IndexOutOfBoundsException` because `$v[$k]` (the path `php/aget` takes today) already routes through `PersistentVector::get()`.

3-arg `(get coll k default)` keeps routing through the runtime defn (the default arm needs an explicit `contains?` probe). Arithmetic / `count` / transient `assoc!` follow-ups from the issue are left for sibling PRs.

Final refactor pass: re-reviewed `CallSpecialization`, `CallEmitter::tryEmitTypedGetAccess`, fixtures, and the Phel e2e test; no follow-up changes surfaced.

Closes #2067