### PR TITLE
perf(runtime): transient vector assoc! mutates trie in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - `LocalVarNode::getInferredType()` exposes the analyser `:tag` meta to the emitter; `IterableTarget` promotes #2047 to fire on `(defn f [^"array" arr] …)` annotations (#2052)
 - Collapse synthesised `defn` location maps into a single `\Phel::location(file, line, col)` call, shrinking compiled file size (#2053)
 - Specialise `(get coll k)` to a direct `$coll->get($k)` (vector) or `$coll->find($k)` (map) method call when the analyser has tagged `coll` as `PersistentVectorInterface` / `PersistentMapInterface`, collapsing the `phel.core/get` cond chain for the hot indexed-access shape (#2067)
+- `TransientVector::update()` mutates the trie in place via a by-reference walk; indexed writes past the tail offset skip the per-level array-copy the previous `doUpdate` (a persistent-vector path-copy) carried on every `assoc!`. PHP COW still detaches trie nodes from the persistent ancestor on first write, so structural sharing semantics are preserved (#2069)
 
 ### Changed
 

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -156,7 +156,7 @@ final class TransientVector implements TransientVectorInterface, Stringable
                 return $this;
             }
 
-            $this->root = $this->doUpdate($this->shift, $this->root, $i, $value);
+            $this->updateInPlace($this->shift, $this->root, $i, $value);
             return $this;
         }
 
@@ -293,22 +293,28 @@ final class TransientVector implements TransientVectorInterface, Stringable
     }
 
     /**
+     * Walks the trie from `$node` (passed by reference) down to the leaf
+     * that owns index `$i` and mutates the leaf slot in place. PHP arrays
+     * are copy-on-write, so any path nodes still shared with the
+     * originating persistent vector get detached automatically on the
+     * first mutation at each level; subsequent writes from the same
+     * transient mutate directly without re-copying the path. This
+     * collapses the per-level array-copy cost the previous `doUpdate`
+     * (a persistent-vector path-copy that the persistent `update` uses
+     * verbatim) carried on every `assoc!` past the tail offset.
+     *
      * @param array<int, mixed> $node
      * @param T                 $value
-     *
-     * @return array<int, mixed>
      */
-    private function doUpdate(int $level, array $node, int $i, mixed $value): array
+    private function updateInPlace(int $level, array &$node, int $i, mixed $value): void
     {
-        $ret = $node;
         if ($level === 0) {
-            $ret[$i & self::INDEX_MASK] = $value;
-        } else {
-            $subIndex = ($i >> $level) & self::INDEX_MASK;
-            $ret[$subIndex] = $this->doUpdate($level - self::SHIFT, $node[$subIndex], $i, $value);
+            $node[$i & self::INDEX_MASK] = $value;
+            return;
         }
 
-        return $ret;
+        $subIndex = ($i >> $level) & self::INDEX_MASK;
+        $this->updateInPlace($level - self::SHIFT, $node[$subIndex], $i, $value);
     }
 
     /**

--- a/src/php/Lang/Collections/Vector/TransientVector.php
+++ b/src/php/Lang/Collections/Vector/TransientVector.php
@@ -153,10 +153,10 @@ final class TransientVector implements TransientVectorInterface, Stringable
         if ($i >= 0 && $i < $this->count) {
             if ($i >= $this->tailOffset()) {
                 $this->tail[$i & self::INDEX_MASK] = $value;
-                return $this;
+            } else {
+                $this->updateInPlace($this->shift, $this->root, $i, $value);
             }
 
-            $this->updateInPlace($this->shift, $this->root, $i, $value);
             return $this;
         }
 

--- a/tests/phel/core/transient-vector-assoc.phel
+++ b/tests/phel/core/transient-vector-assoc.phel
@@ -3,7 +3,7 @@
 
 (deftest test-assoc-bang-indexed-writes-survive-persistent
   ;; Build a 180-element vector, transient it, and overwrite every
-  ;; index. The persistent ancestor must stay untouched — the in-place
+  ;; index. The persistent ancestor must stay untouched: the in-place
   ;; transient update path relies on PHP COW to detach shared trie nodes.
   (let [base (apply vector (range 0 180))
         t    (transient base)]

--- a/tests/phel/core/transient-vector-assoc.phel
+++ b/tests/phel/core/transient-vector-assoc.phel
@@ -1,0 +1,29 @@
+(ns phel-test.core.transient-vector-assoc
+  (:require phel.test :refer [deftest is]))
+
+(deftest test-assoc-bang-indexed-writes-survive-persistent
+  ;; Build a 180-element vector, transient it, and overwrite every
+  ;; index. The persistent ancestor must stay untouched — the in-place
+  ;; transient update path relies on PHP COW to detach shared trie nodes.
+  (let [base (apply vector (range 0 180))
+        t    (transient base)]
+    (loop [i 0]
+      (when (< i 180)
+        (assoc! t i (* i 10))
+        (recur (+ i 1))))
+    (is (= 0 (get base 0)) "persistent ancestor unchanged at head")
+    (is (= 100 (get base 100)) "persistent ancestor unchanged in trie body")
+    (is (= 179 (get base 179)) "persistent ancestor unchanged at tail")
+    (let [final (persistent! t)]
+      (is (= 0 (get final 0)))
+      (is (= 1000 (get final 100)))
+      (is (= 1790 (get final 179))))))
+
+(deftest test-assoc-bang-repeated-writes-at-same-index
+  (let [base (apply vector (range 0 100))
+        t    (transient base)]
+    (loop [iter 0]
+      (when (< iter 5)
+        (assoc! t 50 (+ 1000 iter))
+        (recur (+ iter 1))))
+    (is (= 1004 (get (persistent! t) 50)))))

--- a/tests/php/Unit/Lang/Collections/Vector/TransientVectorTest.php
+++ b/tests/php/Unit/Lang/Collections/Vector/TransientVectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Lang\Collections\Vector;
 
 use Phel\Lang\Collections\Exceptions\IndexOutOfBoundsException;
+use Phel\Lang\Collections\Vector\PersistentVector;
 use Phel\Lang\Collections\Vector\TransientVector;
 use PhelTest\Unit\Lang\Collections\ModuloHasher;
 use PhelTest\Unit\Lang\Collections\SimpleEqualizer;
@@ -105,6 +106,48 @@ final class TransientVectorTest extends TestCase
         $this->assertCount(33, $v2);
         $this->assertSame(20, $v1->get(0));
         $this->assertSame(20, $v2->get(0));
+    }
+
+    public function test_update_past_tail_does_not_corrupt_persistent_ancestor(): void
+    {
+        // 180 elements forces ~148 indexed writes through the trie (the
+        // transient's tail holds at most 32). The in-place mutation path
+        // must rely on PHP COW to detach shared trie nodes from the
+        // persistent ancestor on first write at each level.
+        $persistent = PersistentVector::fromArray(
+            new ModuloHasher(),
+            new SimpleEqualizer(),
+            range(0, 179),
+        );
+        $transient = $persistent->asTransient();
+
+        for ($i = 0; $i < 180; ++$i) {
+            $transient->update($i, $i * 10);
+        }
+
+        $this->assertSame(0, $persistent->get(0), 'persistent[0] unchanged after transient mutation');
+        $this->assertSame(100, $persistent->get(100), 'persistent[100] unchanged after transient mutation');
+        $this->assertSame(179, $persistent->get(179), 'persistent tail unchanged after transient mutation');
+        $this->assertSame(0, $transient->get(0));
+        $this->assertSame(1000, $transient->get(100));
+        $this->assertSame(1790, $transient->get(179));
+    }
+
+    public function test_update_repeatedly_at_same_indexed_position_mutates_in_place(): void
+    {
+        // The in-place mutation path should be idempotent under repeated
+        // writes at the same index past the tail offset.
+        $transient = TransientVector::fromArray(
+            new ModuloHasher(),
+            new SimpleEqualizer(),
+            range(0, 99),
+        );
+        for ($iter = 0; $iter < 5; ++$iter) {
+            $transient->update(50, 1000 + $iter);
+        }
+
+        $this->assertSame(1004, $transient->get(50));
+        $this->assertCount(100, $transient);
     }
 
     public function test_get_out_of_range(): void


### PR DESCRIPTION
## 🤔 Background

Issue #2069 documents `assoc!` on a `TransientVector` being **13.5× slower than `php/aset`** for indexed writes past the tail offset, while `conj!` is within 1.3×. The `doUpdate` body that runs on every `assoc!` past the tail was a verbatim copy of the persistent-vector path-copy: each trie level allocated a fresh PHP array, recursed, and the parent reassigned the returned child. Allocation + reassignment dominated the work for transient builds that should be writing in place.

## 💡 Goal

Closes #2069. Walk the trie by reference and mutate the leaf slot directly. Keep structural-sharing guarantees with the persistent ancestor intact.

## 🔖 Changes

- `TransientVector::doUpdate` replaced by `TransientVector::updateInPlace`, a by-reference recursive walk that mutates the target leaf in place. `update()` no longer reassigns `$this->root` because there's nothing new to receive — the trie is mutated in situ.
- PHP arrays are copy-on-write: the first mutation at each level on a trie node still shared with the originating persistent vector detaches that node automatically. The persistent ancestor stays intact. New unit test
  `test_update_past_tail_does_not_corrupt_persistent_ancestor` locks this invariant by `asTransient`-ing a 180-element vector, overwriting every index, then asserting head / body / tail positions on the persistent ancestor are untouched.
- `test_update_repeatedly_at_same_indexed_position_mutates_in_place` covers the steady-state hot path (repeated `update()` at the same index doesn't accumulate state).
- End-to-end Phel test `tests/phel/core/transient-vector-assoc.phel` exercises `assoc!` against `transient` of a `vector` so the public API surface is covered, not just the PHP-level class.

## ✅ Acceptance criteria

- Existing transient vector tests still green (`./vendor/bin/phpunit tests/php --filter TransientVector`).
- New persistent-ancestor-integrity test passes.
- `composer test` green.

Bench numbers from the issue (`assoc!` past tail, 180 elements, 100 trials) are expected to drop from 13.5× to roughly the same neighborhood as `php/aset`; happy to share before/after numbers if the maintainer wants to add them to the perf docs.

Final refactor pass: re-reviewed `TransientVector::updateInPlace`, the new unit tests, and the Phel e2e test; no follow-up changes surfaced.

Closes #2069