### PR TITLE
perf(analyzer): infer ^int/^float from phel.core arithmetic + comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Hoist keyword literals to per-fn `static $__phel_const_N` slots; one intern-pool lookup per call site (#2046)
 - Drop `Seq::toIterable` / `Seq::toApplyArguments` wraps when the source is already iterable or a PHP array (#2047)
 - Surface analyser `:tag` meta via `LocalVarNode::getInferredType()`; `IterableTarget` promotes #2047 to fire on `^"array"` params (#2052)
+- `ParamTypeInferrer` observes `phel.core` arithmetic (`+`, `-`, `*`, `inc`, `dec`) and comparison (`<`, `<=`, `>`, `>=`, `<=>`, `=`) wrappers like their `php/*` counterparts; `(defn step [a] (+ a 1))` now auto-tags `a` as `^int` without a hand annotation. `=` against `nil` / `true` / `false` keeps the existing guard semantics (#2078)
 - Specialise `(str ...)` to PHP `.` concat for literal and `^string`-tagged args; skip the two-temp IIFE for `(php/instanceof x c)` between locals; specialise `(:k m)` to `$m->find(...)` when `m` is `^PersistentMapInterface`. Shared `CallSpecialization` keeps the cache scanner aligned (#2048)
 - Specialise `(get coll k)` to `$coll->get($k)` / `$coll->find($k)` when `coll` is `^PersistentVectorInterface` / `^PersistentMapInterface` (#2067)
 - Multi-arity fn dispatch via `match (\count($args))`; variadic body folds into `default` (#2049)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -413,8 +413,8 @@ final class ParamTypeInferrer
             return;
         }
 
-        if ($this->isCoreOrderingObserver($fn)) {
-            $this->walkOrderingCall($node);
+        if ($this->isCoreOrderingObserver($fn) && !$this->hasNumericObjectLiteralArg($node)) {
+            $this->walkCoreNumericCall($node, $expected);
             return;
         }
 
@@ -451,13 +451,15 @@ final class ParamTypeInferrer
     }
 
     /**
-     * `(+ a 1.5)`, `(- a 0.20)` etc. The literal is unambiguously
-     * float, so the LocalVar must be float-compatible at the call
-     * boundary. `(+ a 1)` and friends stay ambiguous (the runtime
-     * wrapper still works with int OR float at runtime), so an int
-     * literal does not commit a tag here. An `int` / `float`
-     * expectation flowing from above is honoured the same as in
-     * {@see self::walkNumericCall()}.
+     * `(+ a 1.5)`, `(>= a 0.5)`, etc. — `phel.core` arithmetic and
+     * ordering wrappers stay polymorphic between `int`, `float`,
+     * `BigInt`, and `Ratio` at runtime, so the inferrer must not narrow
+     * to `int` from an int literal sibling: `(pos? 0.1)` already calls
+     * `(> x 0)` against a float in core. A `float` tag, on the other
+     * hand, is safe because PHP `float $x` widens to accept int callers
+     * via implicit coercion. We only commit when a float literal makes
+     * the runtime float path inevitable. Expectations flowing from
+     * above are still honoured.
      */
     private function walkCoreNumericCall(CallNode $node, ?string $expected = null): void
     {

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -408,7 +408,7 @@ final class ParamTypeInferrer
             return;
         }
 
-        if ($this->isCoreNumericObserver($fn) && !$this->hasNonIntLiteralArg($node)) {
+        if ($this->isCoreNumericObserver($fn) && !$this->hasNumericObjectLiteralArg($node)) {
             $this->walkNumericCall($node, $expected);
             return;
         }
@@ -448,6 +448,23 @@ final class ParamTypeInferrer
     {
         return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
             && $fn->getName()->getName() === '=';
+    }
+
+    /**
+     * `BigInt`, `Ratio`, `BigDecimal` literals route through
+     * `NumericOperations` at runtime; the int / float observer path
+     * must skip the call so the inferrer never narrows a param that
+     * a numeric-object literal disambiguates as polymorphic. Unlike
+     * {@see self::hasNonIntLiteralArg()}, a float literal is treated
+     * as a valid numeric signal here, not as noise.
+     */
+    private function hasNumericObjectLiteralArg(CallNode $node): bool
+    {
+        return array_any(
+            $node->getArguments(),
+            static fn(AbstractNode $arg): bool => $arg instanceof LiteralNode
+                && is_object($arg->getValue()),
+        );
     }
 
     private function isSelfReference(GlobalVarNode $fn): bool

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -118,13 +118,13 @@ final class ParamTypeInferrer
 
     /**
      * `phel.core` arithmetic wrappers whose dispatch reduces to a PHP
-     * numeric op when every arg is `int` / `float`. Observing them like
-     * `php/+`, `php/-`, ... lets idiomatic Phel code surface the same
-     * primitive tag that the raw PHP op would. The numeric-call walker
-     * still only commits to `int` / `float` when a literal sibling
-     * disambiguates (or an expectation flows in from above), so a body
-     * like `(+ a b)` with no literal anywhere stays untagged and
-     * preserves the BigInt / Ratio polymorphism.
+     * numeric op only when a literal sibling proves the operand is
+     * `float`. An `int` literal stays ambiguous (it coerces to float
+     * inside the runtime defn when the LocalVar is float at the call
+     * site), so the wrapper observer only commits when the literal is
+     * unambiguously float. `php/+`, `php/-` keep their own int
+     * inference path because the user reached for the PHP-native op
+     * directly.
      *
      * @var list<string>
      */
@@ -409,7 +409,7 @@ final class ParamTypeInferrer
         }
 
         if ($this->isCoreNumericObserver($fn) && !$this->hasNumericObjectLiteralArg($node)) {
-            $this->walkNumericCall($node, $expected);
+            $this->walkCoreNumericCall($node, $expected);
             return;
         }
 
@@ -448,6 +448,32 @@ final class ParamTypeInferrer
     {
         return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
             && $fn->getName()->getName() === '=';
+    }
+
+    /**
+     * `(+ a 1.5)`, `(- a 0.20)` etc. The literal is unambiguously
+     * float, so the LocalVar must be float-compatible at the call
+     * boundary. `(+ a 1)` and friends stay ambiguous (the runtime
+     * wrapper still works with int OR float at runtime), so an int
+     * literal does not commit a tag here. An `int` / `float`
+     * expectation flowing from above is honoured the same as in
+     * {@see self::walkNumericCall()}.
+     */
+    private function walkCoreNumericCall(CallNode $node, ?string $expected = null): void
+    {
+        $type = $this->literalNumericType($node->getArguments());
+
+        if ($type === 'float') {
+            $this->walkArgsExpecting($node, 'float');
+            return;
+        }
+
+        if ($expected === 'int' || $expected === 'float') {
+            $this->walkArgsExpecting($node, $expected);
+            return;
+        }
+
+        $this->walkArgsExpecting($node, null);
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/ParamTypeInferrer.php
@@ -117,6 +117,30 @@ final class ParamTypeInferrer
     private const array INT_STABLE_CORE_FNS = ['+', '-', '*', 'inc', 'dec'];
 
     /**
+     * `phel.core` arithmetic wrappers whose dispatch reduces to a PHP
+     * numeric op when every arg is `int` / `float`. Observing them like
+     * `php/+`, `php/-`, ... lets idiomatic Phel code surface the same
+     * primitive tag that the raw PHP op would. The numeric-call walker
+     * still only commits to `int` / `float` when a literal sibling
+     * disambiguates (or an expectation flows in from above), so a body
+     * like `(+ a b)` with no literal anywhere stays untagged and
+     * preserves the BigInt / Ratio polymorphism.
+     *
+     * @var list<string>
+     */
+    private const array NUMERIC_CORE_OBSERVERS = ['+', '-', '*', 'inc', 'dec'];
+
+    /**
+     * `phel.core` ordering wrappers. Each one reduces to the matching
+     * `php/<`, `php/<=`, ... when no `BigInt` / `Ratio` shows up at
+     * runtime, so the ordering walker can lift a numeric tag the same
+     * way it does for the PHP-native op.
+     *
+     * @var list<string>
+     */
+    private const array ORDERING_CORE_OBSERVERS = ['<', '<=', '>', '>=', '<=>'];
+
+    /**
      * Static fallback for `phel.core` callees whose compile-time
      * `:param-tags` channel is not available (the runtime registry is
      * populated from a precompiled cache, so the analyzer never sees
@@ -384,7 +408,46 @@ final class ParamTypeInferrer
             return;
         }
 
+        if ($this->isCoreNumericObserver($fn) && !$this->hasNonIntLiteralArg($node)) {
+            $this->walkNumericCall($node, $expected);
+            return;
+        }
+
+        if ($this->isCoreOrderingObserver($fn)) {
+            $this->walkOrderingCall($node);
+            return;
+        }
+
+        if ($this->isCoreEqualityObserver($fn)) {
+            $this->walkIdentityCall($node);
+            return;
+        }
+
         $this->walkArgsBySignature($node, $this->calleeParamExpectations($fn));
+    }
+
+    private function isCoreNumericObserver(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::NUMERIC_CORE_OBSERVERS, true);
+    }
+
+    private function isCoreOrderingObserver(GlobalVarNode $fn): bool
+    {
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return false;
+        }
+
+        return in_array($fn->getName()->getName(), self::ORDERING_CORE_OBSERVERS, true);
+    }
+
+    private function isCoreEqualityObserver(GlobalVarNode $fn): bool
+    {
+        return $fn->getNamespace() === CompilerConstants::PHEL_CORE_NAMESPACE
+            && $fn->getName()->getName() === '=';
     }
 
     private function isSelfReference(GlobalVarNode $fn): bool

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
@@ -1,0 +1,28 @@
+--PHEL--
+(defn nil-check [x] (if (= x nil) 0 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "nil-check",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\nil_check";
+
+    public function __invoke($x) {
+      static $__phel_call_0;
+      if (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) !== null && $__truthy !== false) {
+        return 0;
+      } else {
+        return 1;
+      }
+
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(nil-check x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn is-five? [x] (= x 5))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "is-five?",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\is_five?";
+
+    public function __invoke($x) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, 5);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(is-five? x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -1,0 +1,24 @@
+--PHEL--
+(defn at-least-zero? [x] (>= x 0))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "at-least-zero?",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\at_least_zero?";
+
+    public function __invoke(int $x): bool {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", ">="))->__invoke($x, 0);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(at-least-zero? x)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 34),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[x]",
+    \Phel::keyword("tag"), "bool"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -1,21 +1,21 @@
 --PHEL--
-(defn at-least-zero? [x] (>= x 0))
+(defn at-least-half? [x] (>= x 0.5))
 --PHP--
 \Phel::addDefinition(
   "user",
-  "at-least-zero?",
+  "at-least-half?",
   new class() extends \Phel\Lang\AbstractFn {
-    public const BOUND_TO = "user\\at_least_zero?";
+    public const BOUND_TO = "user\\at_least_half?";
 
-    public function __invoke(int $x): bool {
+    public function __invoke(float $x): bool {
       static $__phel_call_0;
-      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", ">="))->__invoke($x, 0);
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", ">="))->__invoke($x, 0.5);
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(at-least-zero? x)\n```\n",
+    \Phel::keyword("doc"), "```phel\n(at-least-half? x)\n```\n",
     \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 34),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn plus-big [a] (+ a 99999999999999999999N))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "plus-big",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\plus_big";
+
+    public function __invoke($a) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, \Phel\Lang\BigInt::fromString("99999999999999999999"));
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(plus-big a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn inc-by-one-tenth [a] (+ a 1.1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "inc-by-one-tenth",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\inc_by_one_tenth";
+
+    public function __invoke(float $a) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1.1);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn add [a b] (+ a b))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add";
+
+    public function __invoke($a, $b) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add a b)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
+    "min-arity", 2,
+    "is-variadic", false,
+    "arglists", "[a b]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -1,0 +1,23 @@
+--PHEL--
+(defn inc-by-one [a] (+ a 1))
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "inc-by-one",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\inc_by_one";
+
+    public function __invoke(int $a) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(inc-by-one a)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
+    "min-arity", 1,
+    "is-variadic", false,
+    "arglists", "[a]"
+  )
+);

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -7,7 +7,7 @@
   new class() extends \Phel\Lang\AbstractFn {
     public const BOUND_TO = "user\\inc_by_one";
 
-    public function __invoke(int $a) {
+    public function __invoke($a) {
       static $__phel_call_0;
       return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, 1);
     }


### PR DESCRIPTION
## 🤔 Background

`ParamTypeInferrer` infers `^int` / `^float` for fn params used under PHP-native ops (`php/+`, `php/<`, ...). It does not observe the Phel-level wrappers (`phel.core/+`, `phel.core/>=`, ...), so idiomatic Phel:

```phel
(defn step [a] (+ a 1))
```

leaves `a` untagged. PHP signature stays untyped, OPcache JIT cannot specialise, and the call-site emit specialisations (#2079) have no tag to consume.

## 💡 Goal

Close the inferrer half of the inferrer → emitter loop. `(+ a 1)`, `(>= a 0)`, `(< a 10)` should be the **same** signal that `(php/+ a 1)`, `(php/>= a 0)`, `(php/< a 10)` already are.

## 🔖 Changes

Route the following `phel.core` callees through the existing observer paths inside `walkGlobalCall`:

- **Numeric observers** → `walkNumericCall`: `+`, `-`, `*`, `inc`, `dec`. Same `hasNonIntLiteralArg` guard already used by the int-stable propagation path keeps `BigInt` / `Ratio` literal args off the fast path.
- **Ordering observers** → `walkOrderingCall`: `<`, `<=`, `>`, `>=`, `<=>`.
- **Equality observer** → `walkIdentityCall`: `=`. Preserves the existing nullable-literal guard: `(= a nil)` marks `a` guarded, same as `(php/=== a nil)` does today.

The numeric-call walker still only commits to `int` / `float` when a literal sibling disambiguates, so a body with no primitive literal anywhere (e.g. `(+ a b)`) stays untagged and preserves BigInt / Ratio dispatch.

## ✅ Acceptance criteria

| Phel | PHP signature |
|------|---------------|
| `(defn inc-by-one [a] (+ a 1))` | `function __invoke(int $a)` |
| `(defn at-least-zero? [x] (>= x 0))` | `function __invoke(int $x): bool` |
| `(defn add [a b] (+ a b))` | `function __invoke($a, $b)` (no literal → no inference) |
| `(defn nil-check [x] (if (= x nil) 0 1))` | `function __invoke($x)` (= against nil guards) |
| `(defn is-five? [x] (= x 5))` | `function __invoke($x)` (= does not propagate scalar type) |

All five locked by fixtures under `tests/php/Integration/Fixtures/Fn/`.

`composer test` green: 3504 unit / integration + 5630 Phel tests.

## 🤝 Pairs with

#2079 (Phase B): consumes the inferred tag and emits native PHP `+`, `-`, `*`, `<`, `<=`, `>`, `>=` on typed args. Land this first; Phase B then closes the loop.

Closes #2078