### PR TITLE
docs: update internals for protocols and records

### DIFF
--- a/docs/internals/faq.md
+++ b/docs/internals/faq.md
@@ -18,7 +18,13 @@ Grouped by reader.
 
 ## Coming from Clojure
 
-**Missing features.** No agents, no STM/refs (use `Atom` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)), no protocols (use `definterface`), no records (use `defstruct`).
+**Missing features.** No agents, no STM/refs (use `Atom` + `swap!`), no `core.async` (Phel has fibers + futures via `Fiber/`, see [async-guide.md](../async-guide.md)).
+
+Phel does have Clojure-style protocols and record/type forms: `defprotocol`,
+`extend-type`, `extend-protocol`, `reify`, `defrecord`, and `deftype`. Records
+and types expand through Phel's native map-backed `defstruct`; use
+`definterface` when you need a PHP interface. See
+[Clojure Migration](../clojure-migration.md#defstruct-defrecord-and-deftype).
 
 **Real persistent collections?** Yes. `PersistentVector` (32-way trie), `PersistentHashMap` (HAMT), `LazySeq` (per-element realisation). Under `Lang/Collections/`.
 

--- a/docs/internals/special-forms.md
+++ b/docs/internals/special-forms.md
@@ -49,7 +49,10 @@ Each handler returns one `AbstractNode`. Emitter has 1:1 mapping to `*Emitter.ph
 
 ## Type definitions (low-level)
 
-Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexception`, `reify` expand into these.
+Trailing `*` means not user-facing. Macros `defstruct`, `definterface`,
+`defexception`, and `reify` expand into these directly. `defrecord` and
+`deftype` build on `defstruct`; the protocol macros register their dispatch
+tables through ordinary definitions and updates.
 
 | Form | Const | Handler | Node |
 |------|-------|---------|------|
@@ -75,7 +78,10 @@ Trailing `*` means not user-facing. Macros `defstruct`, `definterface`, `defexce
 ## Not special forms
 
 - `if-let`, `when`, `cond`, `case`, `match`, `->`, `->>`: macros in `phel.core`
-- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify`: macros over `*` forms
+- `defn`, `defmacro`, `defstruct`, `definterface`, `defexception`, `reify`:
+  macros over `*` forms
+- `defprotocol`, `extend-type`, `extend-protocol`, `defrecord`, `deftype`:
+  macros in `phel.core` that expand through definitions and the type macros
 - `+`, `-`, `=`, `map`, `filter`, ...: functions in `phel.core`
 
 Run `(macroexpand-1 'form)` to see the truth.


### PR DESCRIPTION
## 🤔 Background

The internals FAQ still described protocols and records as missing Clojure
features, while current Phel ships protocol macros plus `defrecord` and
`deftype` on top of `defstruct`.

## 💡 Goal

Keep the internals docs aligned with current `main` without changing runtime
behavior.

## 🔖 Changes

- remove the stale FAQ guidance that says Phel has no protocols or records
- point Clojure readers to the current record/type migration docs and clarify
  that PHP interfaces still use `definterface`
- expand the special-forms internals notes so the newer protocol and
  record/type macros are classified correctly

Potential follow-up for a later iteration: add benchmark-backed guidance for
choosing plain maps versus map-backed `defrecord`/`defstruct` values in hot,
evolving state aggregates before presenting either form as a performance win.
