### PR TITLE
fix(lint): count later let-binding-vector exprs as uses (#2018)

### DIFF
--- a/src/php/Lint/Application/Rule/UnusedBindingRule.php
+++ b/src/php/Lint/Application/Rule/UnusedBindingRule.php
@@ -69,42 +69,78 @@ final readonly class UnusedBindingRule implements LintRuleInterface
             return;
         }
 
-        $bindingSyms = [];
+        /** @var list<array{idx: int, sym: Symbol}> $bindingPairs */
+        $bindingPairs = [];
         $size = count($bindings);
         for ($i = 0; $i < $size; $i += 2) {
             $sym = $bindings->get($i);
             if ($sym instanceof Symbol && $this->trackable($sym->getName())) {
-                $bindingSyms[] = $sym;
+                $bindingPairs[] = ['idx' => $i, 'sym' => $sym];
             }
         }
 
-        if ($bindingSyms === []) {
+        if ($bindingPairs === []) {
             return;
         }
 
-        $usageCounts = [];
+        $bodyUsageCounts = [];
         $formSize = count($form);
         for ($i = 2; $i < $formSize; ++$i) {
             $body = $form->get($i);
-            FormWalker::walk($body, static function (mixed $val) use (&$usageCounts): void {
+            FormWalker::walk($body, static function (mixed $val) use (&$bodyUsageCounts): void {
                 if ($val instanceof Symbol && $val->getNamespace() === null) {
                     $name = $val->getName();
-                    $usageCounts[$name] = ($usageCounts[$name] ?? 0) + 1;
+                    $bodyUsageCounts[$name] = ($bodyUsageCounts[$name] ?? 0) + 1;
                 }
             });
         }
 
-        foreach ($bindingSyms as $sym) {
-            $name = $sym->getName();
-            if (!isset($usageCounts[$name])) {
-                $result[] = DiagnosticBuilder::fromForm(
-                    $this->code(),
-                    sprintf("Unused binding: '%s'.", $name),
-                    $uri,
-                    $sym,
-                );
+        foreach ($bindingPairs as $pair) {
+            $name = $pair['sym']->getName();
+            if (isset($bodyUsageCounts[$name])) {
+                continue;
+            }
+
+            if ($this->referencedInLaterBindingValues($bindings, $pair['idx'], $name, $size)) {
+                continue;
+            }
+
+            $result[] = DiagnosticBuilder::fromForm(
+                $this->code(),
+                sprintf("Unused binding: '%s'.", $name),
+                $uri,
+                $pair['sym'],
+            );
+        }
+    }
+
+    /**
+     * @param PersistentVectorInterface<mixed> $bindings
+     */
+    private function referencedInLaterBindingValues(
+        PersistentVectorInterface $bindings,
+        int $nameIdx,
+        string $name,
+        int $size,
+    ): bool {
+        $found = false;
+        for ($j = $nameIdx + 3; $j < $size; $j += 2) {
+            $value = $bindings->get($j);
+            FormWalker::walk($value, static function (mixed $val) use ($name, &$found): void {
+                if ($found) {
+                    return;
+                }
+
+                if ($val instanceof Symbol && $val->getNamespace() === null && $val->getName() === $name) {
+                    $found = true;
+                }
+            });
+            if ($found) {
+                return true;
             }
         }
+
+        return false;
     }
 
     private function trackable(string $name): bool

--- a/tests/php/Unit/Lint/Application/Rule/UnusedBindingRuleTest.php
+++ b/tests/php/Unit/Lint/Application/Rule/UnusedBindingRuleTest.php
@@ -44,4 +44,39 @@ final class UnusedBindingRuleTest extends RuleTestCase
 
         self::assertSame([], $rule->apply($analysis));
     }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_binding_consumed_only_by_later_sibling(): void
+    {
+        $rule = new UnusedBindingRule();
+        $analysis = $this->buildAnalysis("(let [n 1 msg (str n)] msg)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_does_not_flag_binding_consumed_through_chain_of_siblings(): void
+    {
+        $rule = new UnusedBindingRule();
+        $analysis = $this->buildAnalysis("(let [a 1 b (inc a) c (inc b)] c)\n");
+
+        self::assertSame([], $rule->apply($analysis));
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function test_it_flags_binding_referenced_only_in_earlier_sibling(): void
+    {
+        $rule = new UnusedBindingRule();
+        // `tail` is never read; the only reference appears in `head`,
+        // which is bound BEFORE `tail`, so it cannot resolve to it.
+        $analysis = $this->buildAnalysis("(let [head 1 tail 2] head)\n");
+
+        $diagnostics = $rule->apply($analysis);
+
+        self::assertCount(1, $diagnostics);
+        self::assertStringContainsString("'tail'", $diagnostics[0]->message);
+    }
 }


### PR DESCRIPTION
## Summary

`UnusedBindingRule` collected usages only from body forms (form indices `>= 2`). A binding whose only reference appears in a **later sibling binding-value** — e.g. `n` in `(let [n 1 msg (str n)] msg)` — was therefore incorrectly flagged as unused. Fixed by also walking binding values at vector indices `> nameIdx + 1`.

Earlier-sibling references stay ignored (they cannot resolve to the binding being checked), so genuinely unused bindings whose only "reference" appears in a binding-value *before* their own definition are still flagged.

Closes #2018.

## Test plan

- [x] `composer test` (3520 tests, 9360 assertions)
- [x] `composer test-quality` (psalm + phpstan + rector + gacela validate, all green)
- [x] Targeted unit test `UnusedBindingRuleTest`: 6 tests covering body-only flag, body-used positive, underscore ignore, single-sibling positive, sibling chain positive, earlier-sibling negative