### PR TITLE
docs(changelog): tighten agnostic-ai adoption entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Emit size:
 
 ### Changed
 
-- AI tooling: per-tool configs (`.claude/`, `.codex/`, `.gemini/`, ...) gitignored and regenerated from a single source under `.agnostic-ai/` via [agnostic-ai](https://github.com/Chemaclass/agnostic-ai). Run `agnostic-ai sync` after clone; CI gate blocks drift
+- AI tooling: gitignore `.<tool>/` dirs; regenerate via `agnostic-ai sync` from `.agnostic-ai/` source (#2085)
 - BC: release tooling moved from `build/` to `tools/`; `build/` is now phar-only
 - CI: split `ci.yml` into `quality.yml` / `tests.yml` / `smoke.yml` with a shared `setup-phel` composite action; concurrency cancellation + least-privilege perms (#2039)
 - Compiler: hoist pure vector / map / set literals to a per-fn `static` cache


### PR DESCRIPTION
## 🤔 Background

The Unreleased entry added by #2085 was 280+ chars, embedded a marketing-style \`via [agnostic-ai](...)\` link, included procedural setup instructions, and was missing the PR ref. Project changelog style caps bullets around 120 chars with the PR ref at the end and onboarding details left to the README.

## 💡 Goal

Conform to the project's CHANGELOG style rules without losing the user-facing summary.

## 🔖 Changes

\`\`\`
- AI tooling: gitignore \`.<tool>/\` dirs; regenerate via \`agnostic-ai sync\` from \`.agnostic-ai/\` source (#2085)
\`\`\`

- Drops the marketing link and the \"Run X after clone\" procedural sentence (already in README).
- Adds the PR ref \`(#2085)\`.
- Compresses three sibling \`.<tool>/\` examples into the \`<tool>\` placeholder pattern.