### PR TITLE
fix(compiler): defonce idempotent on same-file redefinition (#2096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `defonce`: same-file redefinition is now a silent no-op (matches the documented contract); previously the analyzer raised `DuplicateDefinitionException` (#2096)
+
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 
 ### Added

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -86,9 +86,9 @@ final class Analyzer implements AnalyzerInterface
         }
     }
 
-    public function addDefinition(string $ns, Symbol $symbol): void
+    public function addDefinition(string $ns, Symbol $symbol, bool $allowRedefinition = false): void
     {
-        $this->globalEnvironment->addDefinition($ns, $symbol);
+        $this->globalEnvironment->addDefinition($ns, $symbol, $allowRedefinition);
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -34,7 +34,7 @@ interface AnalyzerInterface
      */
     public function addRefers(string $ns, array $referSymbols, Symbol $nsSymbol): void;
 
-    public function addDefinition(string $ns, Symbol $symbol): void;
+    public function addDefinition(string $ns, Symbol $symbol, bool $allowRedefinition = false): void;
 
     /**
      * @param PersistentMapInterface<mixed, mixed> $meta

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -71,11 +71,17 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->ns = $ns;
     }
 
-    public function addDefinition(string $namespace, Symbol $name): void
+    public function addDefinition(string $namespace, Symbol $name, bool $allowRedefinition = false): void
     {
         $this->initializeNamespace($namespace);
 
         if ($this->shouldThrowOnDuplicateDefinition($namespace, $name)) {
+            if ($allowRedefinition) {
+                // `defonce` semantics: keep the existing binding,
+                // do not overwrite, do not raise.
+                return;
+            }
+
             throw DuplicateDefinitionException::forSymbol($namespace, $name);
         }
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -14,7 +14,7 @@ interface GlobalEnvironmentInterface
 
     public function setNs(string $ns): void;
 
-    public function addDefinition(string $namespace, Symbol $name): void;
+    public function addDefinition(string $namespace, Symbol $name, bool $allowRedefinition = false): void;
 
     /**
      * @param PersistentMapInterface<mixed, mixed> $meta

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -72,7 +72,7 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
 
         $namespace = $this->analyzer->getNamespace();
 
-        $this->analyzer->addDefinition($namespace, $nameSymbol);
+        $this->analyzer->addDefinition($namespace, $nameSymbol, $this->defonce);
 
         [$metaMap, $init] = $this->createMetaMapAndInit($list);
 

--- a/tests/php/Integration/Compiler/DefonceRedefineRuntimeTest.php
+++ b/tests/php/Integration/Compiler/DefonceRedefineRuntimeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Domain\Analyzer\Exceptions\DuplicateDefinitionException;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+final class DefonceRedefineRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_defonce_same_file_redefinition_is_idempotent(): void
+    {
+        $this->compilerFacade->compile(
+            '(defonce redefine-target 1) (defonce redefine-target 2)',
+            new CompileOptions(),
+        );
+
+        self::assertSame(1, Phel::getDefinition('user', 'redefine-target'));
+    }
+
+    public function test_def_after_def_still_throws(): void
+    {
+        $this->expectException(DuplicateDefinitionException::class);
+        $this->expectExceptionMessage('Symbol def-target is already bound in namespace user');
+
+        $this->compilerFacade->compile(
+            '(def def-target 1) (def def-target 2)',
+            new CompileOptions(),
+        );
+    }
+}

--- a/tests/php/Integration/Fixtures/Def/defonce-redefine.test
+++ b/tests/php/Integration/Fixtures/Def/defonce-redefine.test
@@ -1,0 +1,25 @@
+--PHEL--
+(defonce counter 0) (defonce counter 99)
+--PHP--
+if (!\Phel::isDefined("user", "counter")) {
+  \Phel::addDefinition(
+    "user",
+    "counter",
+    0,
+    \Phel::map(
+      \Phel::keyword("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 0),
+      \Phel::keyword("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 19)
+    )
+  );
+}
+if (!\Phel::isDefined("user", "counter")) {
+  \Phel::addDefinition(
+    "user",
+    "counter",
+    99,
+    \Phel::map(
+      \Phel::keyword("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 20),
+      \Phel::keyword("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 40)
+    )
+  );
+}


### PR DESCRIPTION
## 🤔 Background

`defonce` is documented (#2055, CHANGELOG v0.40.0) as: *bind a global only when not already defined; survives REPL file reloads*. In practice the analyzer's duplicate-definition guard treats the second `(defonce x ...)` exactly like a second `(def x ...)` and raises `DuplicateDefinitionException`, even though the runtime emitter is already idempotent (it wraps the binding in `if (!\Phel::isDefined(...))`).

Reproduction (v0.40.0 PHAR):

```phel
(ns app.duplicate)
(defonce my-state 0)
(defonce my-state 99) ; <- analyzer raises here
```

Closes #2096

## 💡 Goal

Make `defonce` idempotent across same-file redefinitions, matching the documented contract. Keep `def` strict.

## 🔖 Changes

- `AnalyzerInterface::addDefinition` / `Analyzer::addDefinition` / `GlobalEnvironment::addDefinition` gain an optional `bool $allowRedefinition = false` parameter. When `true` and the symbol is already bound, the call silently returns: the existing binding is preserved and no exception is raised.
- `DefSymbol::analyze` forwards `$this->defonce` as `$allowRedefinition`, so only `defonce` opts into idempotency; plain `def` still raises on duplicate.
- Integration test `DefonceRedefineRuntimeTest`: drives two same-file `(defonce x ...)` through `CompilerFacade::compile`, asserts the first value wins; control case for `(def x ...)` still raises.
- Integration fixture `Fixtures/Def/defonce-redefine.test`: documents the emitted PHP (two `if (!isDefined) { addDefinition }` blocks).
- `CHANGELOG.md` `## Unreleased` entry under `### Fixed`.

The refactor pass found nothing material to clean up beyond the fix itself, so there is no separate `ref(...)` commit on this branch.