### PR TITLE
fix(compile): emit-only mode for phel compile, no evaluation (#2095)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel compile`: dry-run respects its "Does not evaluate" contract. Side-effecting forms (e.g. `(println ...)`, `(php/print ...)`) no longer execute during compilation; `CompileOptions` gains an `emitOnly` flag that skips the evaluator step (#2095)
 - `defonce`: same-file redefinition is now a silent no-op (matches the documented contract); previously the analyzer raised `DuplicateDefinitionException` (#2096)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -144,6 +144,14 @@ final readonly class CodeCompiler implements CodeCompilerInterface
             ->emitNode($node, $compileOptions->isSourceMapsEnabled())
             ->getCodeWithSourceMap();
 
+        if ($compileOptions->isEmitOnly()) {
+            // `phel compile` advertises "Does not evaluate"; skipping the
+            // evaluator preserves the dry-run contract. Same-snippet
+            // defmacros will not be available to later forms in this
+            // mode, which is the documented trade-off.
+            return;
+        }
+
         $this->evaluator->eval($phpCode);
     }
 }

--- a/src/php/Run/Application/CompileExecutor.php
+++ b/src/php/Run/Application/CompileExecutor.php
@@ -40,7 +40,8 @@ final readonly class CompileExecutor
         }
 
         try {
-            $result = $this->compilerFacade->compile($source, new CompileOptions());
+            $options = new CompileOptions()->setEmitOnly(true);
+            $result = $this->compilerFacade->compile($source, $options);
             $stdout($result->getPhpCode());
             return true;
         } catch (CompilerException $e) {

--- a/src/php/Shared/CompileOptions.php
+++ b/src/php/Shared/CompileOptions.php
@@ -12,11 +12,15 @@ final class CompileOptions
 
     public const bool DEFAULT_ENABLE_SOURCE_MAPS = true;
 
+    public const bool DEFAULT_EMIT_ONLY = false;
+
     private string $source = self::DEFAULT_SOURCE;
 
     private int $startingLine = self::DEFAULT_STARTING_LINE;
 
     private bool $isEnableSourceMaps = self::DEFAULT_ENABLE_SOURCE_MAPS;
+
+    private bool $emitOnly = self::DEFAULT_EMIT_ONLY;
 
     public function getSource(): string
     {
@@ -50,6 +54,18 @@ final class CompileOptions
     public function setIsEnabledSourceMaps(bool $isEnableSourceMaps): self
     {
         $this->isEnableSourceMaps = $isEnableSourceMaps;
+
+        return $this;
+    }
+
+    public function isEmitOnly(): bool
+    {
+        return $this->emitOnly;
+    }
+
+    public function setEmitOnly(bool $emitOnly): self
+    {
+        $this->emitOnly = $emitOnly;
 
         return $this;
     }

--- a/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
+++ b/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
@@ -105,6 +105,19 @@ final class CompileCommandTest extends AbstractTestCommand
         self::assertSame('', $tester->getDisplay());
     }
 
+    public function test_compile_does_not_evaluate_side_effecting_forms(): void
+    {
+        $tester = new CommandTester(new CompileCommand());
+
+        ob_start();
+        $tester->execute(['source' => '(println "compile-time-leak")']);
+        $phpStdout = (string) ob_get_clean();
+
+        $tester->assertCommandIsSuccessful();
+        self::assertStringNotContainsString('compile-time-leak', $phpStdout);
+        self::assertStringContainsString('"println"', $tester->getDisplay());
+    }
+
     private function stdinReader(string $contents): PhpStdinReader
     {
         $stream = fopen('php://memory', 'r+');


### PR DESCRIPTION
## 🤔 Background

`phel compile` advertises in its help text:

> Compile a Phel snippet and print the emitted PHP. Does not evaluate.

In practice, `CodeCompiler::compileString` runs `$this->evaluator->eval(...)` on every emitted statement (originally to make in-snippet defmacros visible to later forms). For pure forms (`def`, `defn`) this is invisible. For side-effecting forms (`println`, `php/print`) the dry-run leaks runtime side effects:

```bash
$ ./phel.phar compile '(println "compile-time-leak")'
compile-time-leak
(\Phel::getDefinition("phel.core", "println"))->__invoke("compile-time-leak");
```

Closes #2095

## 💡 Goal

Make `phel compile` honour its dry-run contract: no evaluation, just emitted PHP.

## 🔖 Changes

- `Phel\Shared\CompileOptions`: new `emitOnly` flag (default `false`), with `isEmitOnly()` / `setEmitOnly(bool)` accessors.
- `Phel\Compiler\Application\CodeCompiler::emitNode`: short-circuits before `$this->evaluator->eval(...)` when `emitOnly` is true.
- `Phel\Run\Application\CompileExecutor::execute`: now constructs `CompileOptions` with `setEmitOnly(true)` so the `phel compile` CLI is the consumer that flips the flag.
- `tests/php/Integration/Run/Command/Compile/CompileCommandTest::test_compile_does_not_evaluate_side_effecting_forms`: buffers PHP stdout around the `CommandTester` run, asserts `compile-time-leak` never reaches stdout while the emitted PHP still contains the `"println"` registry lookup.
- `CHANGELOG.md` `## Unreleased` → `### Fixed` entry.

### Trade-off

Same-snippet defmacros are not registered at compile time in emit-only mode, so a later form in the same snippet cannot expand a macro defined earlier in that snippet. Documented inline next to the skip. Other paths (`phel run`, `phel eval`, `phel build`) keep the eval step and are unaffected.

The refactor pass found nothing material to clean up beyond the fix itself, so there is no separate `ref(...)` commit on this branch.