### PR TITLE
fix(cli): type Command::setCode closure for Symfony Console 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `phel.cli`: Symfony Console 8.0 compatibility. The handler closure registered via `Command::setCode` now carries explicit `InputInterface` / `OutputInterface` named types; previously Symfony 8 rejected the untyped `(fn [input output] ...)` lowering with `The parameter "$input" must have a named type`. Symfony 7.3 stops emitting the deprecation warning for the same reason (#2094)
 - `phel compile`: dry-run respects its "Does not evaluate" contract. Side-effecting forms (e.g. `(println ...)`, `(php/print ...)`) no longer execute during compilation; `CompileOptions` gains an `emitOnly` flag that skips the evaluator step (#2095)
 - `defonce`: same-file redefinition is now a silent no-op (matches the documented contract); previously the analyzer raised `DuplicateDefinitionException` (#2096)
 

--- a/src/phel/cli.phel
+++ b/src/phel/cli.phel
@@ -320,12 +320,17 @@
    :style     (php/new SymfonyStyle input output)})
 
 (defn- set-handler [cmd spec]
+  ;; Symfony 8 (and 7.3 as a deprecation) requires named PHP types on
+  ;; Command::setCode closure params. Tagging here lowers the underlying
+  ;; AbstractFn `__invoke` to a typed signature so Symfony's reflection
+  ;; check passes on every supported version.
   (let [handler (get spec :run)]
     (php/-> cmd
             (setCode
              (php/:: \Closure
                      (fromCallable
-                      (fn [input output]
+                      (fn [^"\\Symfony\\Component\\Console\\Input\\InputInterface" input
+                           ^"\\Symfony\\Component\\Console\\Output\\OutputInterface" output]
                         (let [ctx (build-ctx input output spec)]
                           (try
                             (let [result (handler ctx)]

--- a/tests/phel/cli.phel
+++ b/tests/phel/cli.phel
@@ -179,3 +179,23 @@
         found        (filter (fn [msg] (php/str_contains msg "Application::add()"))
                              @deprecations)]
     (is (= [] found) "no deprecation for Application::add() — addCommand() used instead")))
+
+(deftest test-handler-closure-has-typed-symfony-params
+  ; Symfony 8 enforces named types on Command::setCode closure params.
+  ; Phel `(fn [input output] ...)` would lower to an untyped __invoke;
+  ; reflect on the closure handed to setCode (exposed via Command::getCode)
+  ; and assert each param carries the Symfony interface as a named type.
+  (let [cmd     (cli/command {:name "x" :run (fn [_] 0)})
+        closure (php/-> cmd (getCode))
+        rf      (php/new \ReflectionFunction closure)
+        params  (php/-> rf (getParameters))
+        p0      (php/aget params 0)
+        p1      (php/aget params 1)
+        t0      (php/-> p0 (getType))
+        t1      (php/-> p1 (getType))]
+    (is (not (nil? t0)) "input param must declare a named type")
+    (is (not (nil? t1)) "output param must declare a named type")
+    (is (= "Symfony\\Component\\Console\\Input\\InputInterface"
+           (php/-> t0 (getName))))
+    (is (= "Symfony\\Component\\Console\\Output\\OutputInterface"
+           (php/-> t1 (getName))))))


### PR DESCRIPTION
## 🤔 Background

`phel.cli` was incompatible with `symfony/console ^8.0`. Any `(cli/application ...)` crashed on the first command invocation under Symfony 8 with:

```
The parameter "$input" must have a named type. Untyped, Union or Intersection types are not supported.
```

Symfony 8 hard-enforces typed parameters on `Command::setCode` closures (deprecation in 7.3, [error in 8.0](https://github.com/symfony/symfony/blob/8.0/UPGRADE-8.0.md)). Phel's `(fn [input output] ...)` lowered to an untyped `__invoke($input, $output)`, so `InvokableCommand::getParameters` rejected it.

## 💡 Goal

Make `phel.cli` apps run on `symfony/console ^7.3 || ^8.0` without changing the public Phel API or requiring users to tag their handlers.

## 🔖 Changes

- `src/phel/cli.phel` — `set-handler` tags the `(fn ...)` params with `^"\Symfony\Component\Console\Input\InputInterface"` / `^"\Symfony\Component\Console\Output\OutputInterface"`. Phel's `MethodEmitter::extractTypeTag` lowers these to PHP type hints on the generated `__invoke`, satisfying Symfony's reflection check on every supported version.
- `tests/phel/cli.phel` — reflection-based regression test pulls the closure off `Command::getCode()` and asserts both params declare the Symfony interface as a named type. Fails RED on `main` (untyped → `getType()` returns `null`), GREEN with the fix.
- `CHANGELOG.md` — entry under `## Unreleased > ### Fixed`.

Refactor pass: surface is 1 production line + 1 test + 1 changelog row; nothing to extract or de-duplicate, so no separate `ref(...)` commit was warranted.

Closes #2094