### PR TITLE
perf(compiler): fold phel.core comparison ops on numeric literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - CI: `announce-release.yml` workflow + `scripts/announce-release.mjs` build a copy-pasteable Twitter/X thread draft from the CHANGELOG section of the released tag. The workflow uploads `thread.md` and `thread.json` as artifacts; posting stays manual to avoid X API costs. Supports `workflow_dispatch` for back-fills
 
+### Performance
+
+- `ConstantFolder`: compile-time evaluate `phel.core` comparison ops (`=`, `not=`, `<`, `<=`, `>`, `>=`) on integer / float literals. Variadic semantics preserved (pairwise check, single-arg → `true`, empty → skip so the runtime arity error fires as before). `BigInt` / `Ratio` args stay un-folded to keep the runtime numeric dispatcher in charge (#2088)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compatibility. The handler closure registered via `Command::setCode` now carries explicit `InputInterface` / `OutputInterface` named types; previously Symfony 8 rejected the untyped `(fn [input output] ...)` lowering with `The parameter "$input" must have a named type`. Symfony 7.3 stops emitting the deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -120,7 +120,7 @@ final class ConstantFolder
     /**
      * @param list<float|int> $literals
      */
-    private function compute(string $fnName, array $literals): int|float|null
+    private function compute(string $fnName, array $literals): int|float|bool|null
     {
         if (isset(self::NUMERIC_REDUCERS[$fnName])) {
             return $this->reduce(self::NUMERIC_REDUCERS[$fnName], $literals);
@@ -130,8 +130,43 @@ final class ConstantFolder
             '-' => $this->minus($literals),
             'inc' => $this->shift($literals, +1),
             'dec' => $this->shift($literals, -1),
+            '=' => $this->compareAll($literals, static fn($a, $b): bool => $a === $b || (float) $a === (float) $b),
+            'not=' => $this->negate($this->compareAll($literals, static fn($a, $b): bool => $a === $b || (float) $a === (float) $b)),
+            '<' => $this->compareAll($literals, static fn($a, $b): bool => $a < $b),
+            '<=' => $this->compareAll($literals, static fn($a, $b): bool => $a <= $b),
+            '>' => $this->compareAll($literals, static fn($a, $b): bool => $a > $b),
+            '>=' => $this->compareAll($literals, static fn($a, $b): bool => $a >= $b),
             default => null,
         };
+    }
+
+    /**
+     * N-ary pairwise comparison. Phel mirrors Clojure: `(=)` is an arity
+     * error (skip), `(= x)` is `true`, otherwise consecutive pairs must
+     * all satisfy `cmp`.
+     *
+     * @param list<float|int>                      $literals
+     * @param callable(float|int, float|int): bool $cmp
+     */
+    private function compareAll(array $literals, callable $cmp): ?bool
+    {
+        $count = count($literals);
+        if ($count === 0) {
+            return null;
+        }
+
+        for ($i = 0; $i < $count - 1; ++$i) {
+            if (!$cmp($literals[$i], $literals[$i + 1])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function negate(?bool $value): ?bool
+    {
+        return $value === null ? null : !$value;
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -130,8 +130,11 @@ final class ConstantFolder
             '-' => $this->minus($literals),
             'inc' => $this->shift($literals, +1),
             'dec' => $this->shift($literals, -1),
-            '=' => $this->compareAll($literals, static fn($a, $b): bool => $a === $b || (float) $a === (float) $b),
-            'not=' => $this->negate($this->compareAll($literals, static fn($a, $b): bool => $a === $b || (float) $a === (float) $b)),
+            // Phel `=` is type-strict: `(= 1 1.0)` is `false`. Numeric
+            // promotion is reserved for `<` / `<=` / `>` / `>=` which
+            // compare values, not identities.
+            '=' => $this->compareAll($literals, static fn($a, $b): bool => $a === $b),
+            'not=' => $this->negate($this->compareAll($literals, static fn($a, $b): bool => $a === $b)),
             '<' => $this->compareAll($literals, static fn($a, $b): bool => $a < $b),
             '<=' => $this->compareAll($literals, static fn($a, $b): bool => $a <= $b),
             '>' => $this->compareAll($literals, static fn($a, $b): bool => $a > $b),

--- a/tests/php/Integration/Fixtures/ConstantFolding/comparison-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/comparison-fold.test
@@ -1,0 +1,12 @@
+--PHEL--
+(let [a (= 1 1)
+      b (< 1 2 3)
+      c (>= 3 3 2)
+      d (not= 1 2)]
+  [a b c d])
+--PHP--
+$a_1 = true;
+$b_2 = true;
+$c_3 = true;
+$d_4 = true;
+\Phel::vector([$a_1, $b_2, $c_3, $d_4]);

--- a/tests/php/Integration/Fixtures/Inline/bigger-equal.test
+++ b/tests/php/Integration/Fixtures/Inline/bigger-equal.test
@@ -1,6 +1,6 @@
 --PHEL--
-(< 1)
-(< 1 2)
-(< 1 2 3)
+(fn [^int a ^int b] (>= a b))
 --PHP--
-(\Phel::getDefinition("phel.core", "<"))->__invoke(1);(1 < 2);(\Phel::getDefinition("phel.core", "<"))->__invoke(1, 2, 3);
+(function(int $a, int $b): bool {
+  return ($a >= $b);
+});

--- a/tests/php/Integration/Fixtures/Inline/bigger.test
+++ b/tests/php/Integration/Fixtures/Inline/bigger.test
@@ -1,6 +1,6 @@
 --PHEL--
-(> 1)
-(> 1 2)
-(> 1 2 3)
+(fn [^int a ^int b] (> a b))
 --PHP--
-(\Phel::getDefinition("phel.core", ">"))->__invoke(1);(1 > 2);(\Phel::getDefinition("phel.core", ">"))->__invoke(1, 2, 3);
+(function(int $a, int $b): bool {
+  return ($a > $b);
+});

--- a/tests/php/Integration/Fixtures/Inline/smaller-equal.test
+++ b/tests/php/Integration/Fixtures/Inline/smaller-equal.test
@@ -1,6 +1,6 @@
 --PHEL--
-(<= 1)
-(<= 1 2)
-(<= 1 2 3)
+(fn [^int a ^int b] (<= a b))
 --PHP--
-(\Phel::getDefinition("phel.core", "<="))->__invoke(1);(1 <= 2);(\Phel::getDefinition("phel.core", "<="))->__invoke(1, 2, 3);
+(function(int $a, int $b): bool {
+  return ($a <= $b);
+});

--- a/tests/php/Integration/Fixtures/Inline/smaller.test
+++ b/tests/php/Integration/Fixtures/Inline/smaller.test
@@ -1,6 +1,6 @@
 --PHEL--
-(< 1)
-(< 1 2)
-(< 1 2 3)
+(fn [^int a ^int b] (< a b))
 --PHP--
-(\Phel::getDefinition("phel.core", "<"))->__invoke(1);(1 < 2);(\Phel::getDefinition("phel.core", "<"))->__invoke(1, 2, 3);
+(function(int $a, int $b): bool {
+  return ($a < $b);
+});

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -108,12 +108,13 @@ final class ConstantFolderTest extends TestCase
         self::assertFalse($folded->getValue());
     }
 
-    public function test_fold_eq_mixed_int_float_compares_numerically(): void
+    public function test_fold_eq_is_type_strict_for_mixed_int_float(): void
     {
+        // Phel `=` is type-strict: `(= 1 1.0)` is `false`.
         $folded = new ConstantFolder()->fold($this->coreCall('=', [1, 1.0]));
 
         self::assertInstanceOf(LiteralNode::class, $folded);
-        self::assertTrue($folded->getValue());
+        self::assertFalse($folded->getValue());
     }
 
     public function test_fold_eq_variadic_all_equal(): void

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -92,6 +92,127 @@ final class ConstantFolderTest extends TestCase
         self::assertNull(new ConstantFolder()->fold($node));
     }
 
+    public function test_fold_eq_two_equal_int_literals(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('=', [1, 1]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_eq_two_unequal_int_literals(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('=', [1, 2]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_eq_mixed_int_float_compares_numerically(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('=', [1, 1.0]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_eq_variadic_all_equal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('=', [3, 3, 3]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_eq_variadic_one_unequal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('=', [3, 3, 4]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_lt_strict_ascending(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('<', [1, 2, 3]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_lt_equal_pair_is_false(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('<', [1, 1]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_lte_non_strict(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('<=', [1, 1, 2]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_gt_descending(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('>', [3, 2, 1]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_gte_non_strict(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('>=', [3, 3, 2]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_not_eq_negates_equality(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('not=', [1, 2]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_comparison_single_arg_is_true(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('<', [42]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_comparison_skips_zero_args(): void
+    {
+        // (=) is a runtime arity error; preserve that timing.
+        self::assertNull(new ConstantFolder()->fold($this->coreCall('=', [])));
+    }
+
+    public function test_fold_comparison_skips_when_any_arg_not_literal(): void
+    {
+        $node = new CallNode(
+            NodeEnvironment::empty()->withExpressionContext(),
+            new GlobalVarNode(
+                NodeEnvironment::empty()->withExpressionContext(),
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create('='),
+                Phel::map(),
+            ),
+            [
+                new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 1),
+                $this->globalVar('x'),
+            ],
+        );
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
     public function test_fold_if_truthy_test_returns_then_branch(): void
     {
         $env = NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

#2088 (Phase 1 of the emitter optimisation roadmap #2087) groups six atoms that each extend `ConstantFolder` with one new family of compile-time evaluations. This PR delivers **atom 1**: comparison ops.

## 💡 Goal

Collapse `(= 1 1)`, `(< 1 2 3)`, `(>= 3 3 2)`, `(not= 1 2)`, etc. to a literal `bool` at analyser time so the AST that reaches the emitter no longer carries the runtime call or inline arithmetic node.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php`
  - widen `compute` return type to `int|float|bool|null`
  - add dispatch for `=`, `not=`, `<`, `<=`, `>`, `>=` via a new `compareAll` helper
  - n-ary pairwise semantics matching Phel core: `(=)` → skip (runtime arity error preserved), `(= x)` → `true`, otherwise consecutive pairs must satisfy `cmp`
  - `not=` reuses `=` then negates
- `tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php` — 12 new tests covering positive cases for each op, variadic, mixed int/float, single-arg, zero-arg-skip, and non-literal-arg-skip
- `tests/php/Integration/Fixtures/ConstantFolding/comparison-fold.test` — end-to-end fixture: `let` bindings of comparison results inside a vector all collapse to `true` literals
- `tests/php/Integration/Fixtures/Inline/{bigger,smaller,bigger-equal,smaller-equal}.test` — rewritten to use typed locals (`(fn [^int a ^int b] (> a b))`). The previous literal-arg cases now fold, so the inline emission path moved to typed-local args. Also fixes a pre-existing copy-paste bug where `bigger-equal.test` was an exact duplicate of `smaller.test`.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `vendor/bin/phpunit --testsuite=unit,integration` (3539 tests, 9414 assertions, 0 failures)
- `composer test-core` (5645 tests, 0 failures)
- `composer test-quality` exit 0

## Trade-offs / non-goals

- `BigInt` / `Ratio` literals are not foldable here: `extractNumericLiterals` only accepts native `int|float`. Folding numerics with arbitrary precision needs a Phel-side comparator and is out of scope for this atom.
- The inline arithmetic specialisation (#2079, v0.40.0) and the call-site cache (#2044) are now bypassed for pure-literal comparison calls; that's strictly better since the folded literal is a no-op in statement context.

Closes — see roadmap #2088 (1/6); related: #2087