### PR TITLE
perf(compiler): fold phel.core boolean predicates on literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Performance
 
 - `ConstantFolder`: compile-time evaluate `phel.core` comparison ops (`=`, `not=`, `<`, `<=`, `>`, `>=`) on integer / float literals. Variadic semantics preserved (pairwise check, single-arg → `true`, empty → skip so the runtime arity error fires as before). `BigInt` / `Ratio` args stay un-folded to keep the runtime numeric dispatcher in charge (#2088)
+- `ConstantFolder`: compile-time evaluate `phel.core` boolean predicates (`not`, `nil?`, `true?`, `false?`, `boolean`) when the single argument is any literal value. Phel truthiness preserved: only `nil` / `false` are falsy, so `(boolean 0)` and `(boolean "")` still fold to `true` (#2088)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -13,6 +13,7 @@ use Phel\Shared\CompilerConstants;
 
 use function array_shift;
 use function count;
+use function in_array;
 use function is_float;
 use function is_int;
 
@@ -52,6 +53,8 @@ final class ConstantFolder
         '*' => ['identity' => 1, 'op' => 'mul'],
     ];
 
+    private const array BOOL_PREDICATES = ['not', 'nil?', 'true?', 'false?', 'boolean'];
+
     public function fold(CallNode $node): ?AbstractNode
     {
         $fn = $node->getFn();
@@ -63,12 +66,23 @@ final class ConstantFolder
             return null;
         }
 
+        $fnName = $fn->getName()->getName();
+
+        if (in_array($fnName, self::BOOL_PREDICATES, true)) {
+            $result = $this->foldBoolPredicate($fnName, $node->getArguments());
+            if ($result === null) {
+                return null;
+            }
+
+            return new LiteralNode($node->getEnv(), $result, $node->getStartSourceLocation());
+        }
+
         $numbers = $this->extractNumericLiterals($node->getArguments());
         if ($numbers === null) {
             return null;
         }
 
-        $result = $this->compute($fn->getName()->getName(), $numbers);
+        $result = $this->compute($fnName, $numbers);
         if ($result === null) {
             return null;
         }
@@ -91,6 +105,36 @@ final class ConstantFolder
         $truthy = $value !== null && $value !== false;
 
         return $truthy ? $node->getThenExpr() : $node->getElseExpr();
+    }
+
+    /**
+     * Single-arg boolean predicates over any literal value. Phel truthiness:
+     * only `nil` and `false` are falsy; everything else (including `0`,
+     * `""`, empty collections) is truthy.
+     *
+     * @param list<AbstractNode> $args
+     */
+    private function foldBoolPredicate(string $fnName, array $args): ?bool
+    {
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $arg = $args[0];
+        if (!$arg instanceof LiteralNode) {
+            return null;
+        }
+
+        $value = $arg->getValue();
+
+        return match ($fnName) {
+            'not' => $value === null || $value === false,
+            'nil?' => $value === null,
+            'true?' => $value === true,
+            'false?' => $value === false,
+            'boolean' => $value !== null && $value !== false,
+            default => null,
+        };
     }
 
     /**

--- a/tests/php/Integration/Fixtures/ConstantFolding/bool-predicate-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/bool-predicate-fold.test
@@ -1,0 +1,14 @@
+--PHEL--
+(let [a (not nil)
+      b (nil? nil)
+      c (true? true)
+      d (false? false)
+      e (boolean 0)]
+  [a b c d e])
+--PHP--
+$a_1 = true;
+$b_2 = true;
+$c_3 = true;
+$d_4 = true;
+$e_5 = true;
+\Phel::vector([$a_1, $b_2, $c_3, $d_4, $e_5]);

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -214,6 +214,126 @@ final class ConstantFolderTest extends TestCase
         self::assertNull(new ConstantFolder()->fold($node));
     }
 
+    public function test_fold_not_on_truthy_literal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('not', [1]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_not_on_false_literal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('not', [false]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_not_on_nil_literal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('not', [null]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_nil_pred_on_nil(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('nil?', [null]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_nil_pred_on_int(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('nil?', [0]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_true_pred_strict_on_true(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('true?', [true]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_true_pred_rejects_truthy_non_true(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('true?', [1]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_false_pred_strict_on_false(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('false?', [false]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_false_pred_rejects_falsy_non_false(): void
+    {
+        // `nil` is falsy in Phel but `(false? nil)` is `false`.
+        $folded = new ConstantFolder()->fold($this->coreCall('false?', [null]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_boolean_truthy(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('boolean', [0]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_boolean_empty_string_is_truthy(): void
+    {
+        // Phel: only `nil` / `false` are falsy; `""` is truthy.
+        $folded = new ConstantFolder()->fold($this->coreCall('boolean', ['']));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertTrue($folded->getValue());
+    }
+
+    public function test_fold_boolean_falsy(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('boolean', [null]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertFalse($folded->getValue());
+    }
+
+    public function test_fold_bool_predicate_skips_when_arg_count_wrong(): void
+    {
+        self::assertNull(new ConstantFolder()->fold($this->coreCall('not', [])));
+        self::assertNull(new ConstantFolder()->fold($this->coreCall('not', [1, 2])));
+    }
+
+    public function test_fold_bool_predicate_skips_non_literal_arg(): void
+    {
+        $node = new CallNode(
+            NodeEnvironment::empty()->withExpressionContext(),
+            new GlobalVarNode(
+                NodeEnvironment::empty()->withExpressionContext(),
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create('not'),
+                Phel::map(),
+            ),
+            [$this->globalVar('x')],
+        );
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
     public function test_fold_if_truthy_test_returns_then_branch(): void
     {
         $env = NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

#2088 (Phase 1 of the emitter optimisation roadmap #2087) atom 2: boolean predicates.

## 💡 Goal

Collapse `(not nil)`, `(nil? 0)`, `(true? true)`, `(false? false)`, `(boolean "")` to a bool literal at analyser time so the AST that reaches the emitter no longer carries the runtime predicate call.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php` — new `foldBoolPredicate` path. Single-arg predicates dispatch before the numeric extractor so they accept any `LiteralNode` (bool, nil, int, float, string). Wrong arity → skip. Phel truthy semantics preserved: only `nil` / `false` are falsy; `true?` / `false?` stay strict (do not collapse on truthy / falsy non-bool values).
- `tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php` — 14 new tests covering each predicate's positive / negative branch, truthy non-bool (`(true? 1)` → false), Phel truthiness edge cases (`(boolean "")` → true, `(boolean 0)` → true), wrong arity, non-literal arg
- `tests/php/Integration/Fixtures/ConstantFolding/bool-predicate-fold.test` — one fixture with five let-binds, all collapse to true bools
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `vendor/bin/phpunit --testsuite=integration` 739 tests, 0 failures
- `composer test-core` (cache cleared) 5645 tests, 0 failures
- Unit suite for ConstantFolder: 38 tests, 0 failures

## Trade-offs / non-goals

- `(not (not x))` and other multi-call cancellations stay un-folded — that needs a separate pass (Phase 2 simplification).
- Predicates over collection literals (`(empty? [])`, `(count [])`) ship in atom 4.

Closes — see roadmap #2088 (2/6); related: #2087