### PR TITLE
perf(compiler): fold count / first / last / nth on literal collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - `ConstantFolder`: compile-time evaluate `phel.core` comparison ops (`=`, `not=`, `<`, `<=`, `>`, `>=`) on integer / float literals. Variadic semantics preserved (pairwise check, single-arg → `true`, empty → skip so the runtime arity error fires as before). `BigInt` / `Ratio` args stay un-folded to keep the runtime numeric dispatcher in charge (#2088)
 - `ConstantFolder`: compile-time evaluate `phel.core` boolean predicates (`not`, `nil?`, `true?`, `false?`, `boolean`) when the single argument is any literal value. Phel truthiness preserved: only `nil` / `false` are falsy, so `(boolean 0)` and `(boolean "")` still fold to `true` (#2088)
 - `ConstantFolder`: compile-time evaluate bitwise `php/` interop ops (`&`, `|`, `^`, `<<`, `>>`, `~`) on int literals. Covers user-written `(php/& 12 10)` and the `bit-and` / `bit-or` / `bit-xor` / `bit-shift-left` / `bit-shift-right` / `bit-not` core fns whose `:inline` lowers to those ops. Float args skip the fold (PHP would coerce; Phel core asserts int-only via `assert-non-nil`); negative shift amounts skip so the runtime `ArithmeticError` fires unchanged (#2088)
+- `ConstantFolder`: compile-time evaluate `count` on literal vector / map / set, plus `first` / `last` / `nth` on literal vectors whose elements are all literal. `nth` skips out-of-bounds and non-int / negative indices so the runtime `IndexOutOfBoundsException` keeps its trigger point (#2088)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -111,7 +111,7 @@ final class ConstantFolder
         }
 
         $accessorResult = $this->foldCollectionAccessor($fnName, $node);
-        if ($accessorResult !== null) {
+        if ($accessorResult instanceof AbstractNode) {
             return $accessorResult;
         }
 
@@ -270,13 +270,7 @@ final class ConstantFolder
      */
     private function allLiteralNodes(array $nodes): bool
     {
-        foreach ($nodes as $n) {
-            if (!$n instanceof LiteralNode) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($nodes, static fn($n): bool => $n instanceof LiteralNode);
     }
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -9,11 +9,15 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Shared\CompilerConstants;
 
 use function array_shift;
 use function array_slice;
+use function assert;
 use function count;
 use function in_array;
 use function is_float;
@@ -106,6 +110,11 @@ final class ConstantFolder
             return new LiteralNode($node->getEnv(), $result, $node->getStartSourceLocation());
         }
 
+        $accessorResult = $this->foldCollectionAccessor($fnName, $node);
+        if ($accessorResult !== null) {
+            return $accessorResult;
+        }
+
         $numbers = $this->extractNumericLiterals($node->getArguments());
         if ($numbers === null) {
             return null;
@@ -134,6 +143,140 @@ final class ConstantFolder
         $truthy = $value !== null && $value !== false;
 
         return $truthy ? $node->getThenExpr() : $node->getElseExpr();
+    }
+
+    /**
+     * Compile-time evaluation of `count` / `first` / `last` / `nth` against
+     * literal collection nodes:
+     *
+     *  - `(count [a b c])` and `(count {:k v})` and `(count #{a b})` always
+     *    fold to the element-count literal.
+     *  - `(first [...])` / `(last [...])` / `(nth [...] i)` only fold when
+     *    every vector element is itself a `LiteralNode` (so substituting the
+     *    target element cannot drop a side-effect).
+     *  - Out-of-bounds `nth` keeps the call: Phel raises at runtime and we
+     *    refuse to lift that exception to compile time.
+     */
+    private function foldCollectionAccessor(string $fnName, CallNode $node): ?AbstractNode
+    {
+        $args = $node->getArguments();
+
+        if ($fnName === 'count') {
+            return $this->foldCount($args, $node);
+        }
+
+        if ($fnName === 'first' || $fnName === 'last') {
+            return $this->foldVectorPick($fnName, $args, $node);
+        }
+
+        if ($fnName === 'nth') {
+            return $this->foldNth($args, $node);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function foldCount(array $args, CallNode $node): ?LiteralNode
+    {
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $arg = $args[0];
+        $size = match (true) {
+            $arg instanceof VectorNode => count($arg->getArgs()),
+            $arg instanceof SetNode => count($arg->getValues()),
+            $arg instanceof MapNode => intdiv(count($arg->getKeyValues()), 2),
+            default => null,
+        };
+
+        if ($size === null) {
+            return null;
+        }
+
+        return new LiteralNode($node->getEnv(), $size, $node->getStartSourceLocation());
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function foldVectorPick(string $fnName, array $args, CallNode $node): ?LiteralNode
+    {
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $arg = $args[0];
+        if (!$arg instanceof VectorNode) {
+            return null;
+        }
+
+        $elements = $arg->getArgs();
+        if (!$this->allLiteralNodes($elements)) {
+            return null;
+        }
+
+        if ($elements === []) {
+            // `(first [])` is `nil` in Phel; `(last [])` is `nil` too.
+            return new LiteralNode($node->getEnv(), null, $node->getStartSourceLocation());
+        }
+
+        $pick = $fnName === 'first' ? $elements[0] : $elements[count($elements) - 1];
+        assert($pick instanceof LiteralNode);
+
+        return new LiteralNode($node->getEnv(), $pick->getValue(), $node->getStartSourceLocation());
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function foldNth(array $args, CallNode $node): ?LiteralNode
+    {
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        [$target, $index] = $args;
+        if (!$target instanceof VectorNode || !$index instanceof LiteralNode) {
+            return null;
+        }
+
+        $idx = $index->getValue();
+        if (!is_int($idx) || $idx < 0) {
+            return null;
+        }
+
+        $elements = $target->getArgs();
+        if (!$this->allLiteralNodes($elements)) {
+            return null;
+        }
+
+        if ($idx >= count($elements)) {
+            // Out-of-bounds → Phel raises at runtime. Don't lift that.
+            return null;
+        }
+
+        $pick = $elements[$idx];
+        assert($pick instanceof LiteralNode);
+
+        return new LiteralNode($node->getEnv(), $pick->getValue(), $node->getStartSourceLocation());
+    }
+
+    /**
+     * @param list<AbstractNode> $nodes
+     */
+    private function allLiteralNodes(array $nodes): bool
+    {
+        foreach ($nodes as $n) {
+            if (!$n instanceof LiteralNode) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/ConstantFolding/collection-accessor-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/collection-accessor-fold.test
@@ -1,0 +1,16 @@
+--PHEL--
+(let [a (count [1 2 3])
+      b (count {:k 1 :v 2})
+      c (count #{1 2 3})
+      d (first [10 20 30])
+      e (last [10 20 30])
+      f (nth [10 20 30] 1)]
+  [a b c d e f])
+--PHP--
+$a_1 = 3;
+$b_2 = 2;
+$c_3 = 3;
+$d_4 = 10;
+$e_5 = 30;
+$f_6 = 20;
+\Phel::vector([$a_1, $b_2, $c_3, $d_4, $e_5, $f_6]);

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -9,7 +9,10 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
 use Phel\Lang\Symbol;
@@ -414,6 +417,109 @@ final class ConstantFolderTest extends TestCase
         self::assertNull(new ConstantFolder()->fold($this->phpInfixCall('&', [12])));
     }
 
+    public function test_fold_count_vector(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('count', [$this->vector([1, 2, 3])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(3, $folded->getValue());
+    }
+
+    public function test_fold_count_map_divides_by_two(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('count', [$this->map([1, 2, 3, 4])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(2, $folded->getValue());
+    }
+
+    public function test_fold_count_set(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('count', [$this->set([1, 2, 3])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(3, $folded->getValue());
+    }
+
+    public function test_fold_count_skips_non_collection_arg(): void
+    {
+        self::assertNull(new ConstantFolder()->fold($this->coreCall('count', [42])));
+    }
+
+    public function test_fold_first_returns_first_literal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('first', [$this->vector([10, 20, 30])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(10, $folded->getValue());
+    }
+
+    public function test_fold_first_empty_vector_is_nil(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('first', [$this->vector([])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertNull($folded->getValue());
+    }
+
+    public function test_fold_last_returns_last_literal(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs('last', [$this->vector([10, 20, 30])]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(30, $folded->getValue());
+    }
+
+    public function test_fold_first_skips_non_literal_element(): void
+    {
+        // Mixed: one non-literal child blocks the fold so side effects stay.
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $args = [
+            new LiteralNode($env, 10),
+            $this->globalVar('side-effect'),
+        ];
+        $vec = new VectorNode($env, $args);
+        $node = $this->coreCallWithArgs('first', [$vec]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_nth_in_bounds_returns_element(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCallWithArgs(
+            'nth',
+            [$this->vector([10, 20, 30]), $this->literal(1)],
+        ));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(20, $folded->getValue());
+    }
+
+    public function test_fold_nth_out_of_bounds_skips(): void
+    {
+        // Phel raises at runtime; preserve that timing.
+        self::assertNull(new ConstantFolder()->fold($this->coreCallWithArgs(
+            'nth',
+            [$this->vector([10, 20]), $this->literal(99)],
+        )));
+    }
+
+    public function test_fold_nth_negative_index_skips(): void
+    {
+        self::assertNull(new ConstantFolder()->fold($this->coreCallWithArgs(
+            'nth',
+            [$this->vector([10, 20]), $this->literal(-1)],
+        )));
+    }
+
+    public function test_fold_nth_non_literal_index_skips(): void
+    {
+        self::assertNull(new ConstantFolder()->fold($this->coreCallWithArgs(
+            'nth',
+            [$this->vector([10, 20]), $this->globalVar('i')],
+        )));
+    }
+
     public function test_fold_if_truthy_test_returns_then_branch(): void
     {
         $env = NodeEnvironment::empty()->withExpressionContext();
@@ -492,5 +598,73 @@ final class ConstantFolderTest extends TestCase
         }
 
         return new CallNode($env, new PhpVarNode($env, $op), $argNodes);
+    }
+
+    /**
+     * @param list<Phel\Compiler\Domain\Analyzer\Ast\AbstractNode> $argNodes
+     */
+    private function coreCallWithArgs(string $name, array $argNodes): CallNode
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+
+        return new CallNode(
+            $env,
+            new GlobalVarNode(
+                $env,
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create($name),
+                Phel::map(),
+            ),
+            $argNodes,
+        );
+    }
+
+    /**
+     * @param list<bool|float|int|string|null> $values
+     */
+    private function vector(array $values): VectorNode
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $nodes = [];
+        foreach ($values as $v) {
+            $nodes[] = new LiteralNode($env, $v);
+        }
+
+        return new VectorNode($env, $nodes);
+    }
+
+    /**
+     * @param list<bool|float|int|string|null> $values
+     */
+    private function set(array $values): SetNode
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $nodes = [];
+        foreach ($values as $v) {
+            $nodes[] = new LiteralNode($env, $v);
+        }
+
+        return new SetNode($env, $nodes);
+    }
+
+    /**
+     * Flat `[k0, v0, k1, v1, ...]` list of literals mirroring MapNode shape.
+     *
+     * @param list<bool|float|int|string|null> $flat
+     */
+    private function map(array $flat): MapNode
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $nodes = [];
+        foreach ($flat as $v) {
+            $nodes[] = new LiteralNode($env, $v);
+        }
+
+        return new MapNode($env, $nodes);
+    }
+
+    private function literal(bool|float|int|string|null $value): LiteralNode
+    {
+        return new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), $value);
     }
 }

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer;
 
 use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
@@ -601,7 +602,7 @@ final class ConstantFolderTest extends TestCase
     }
 
     /**
-     * @param list<Phel\Compiler\Domain\Analyzer\Ast\AbstractNode> $argNodes
+     * @param list<AbstractNode> $argNodes
      */
     private function coreCallWithArgs(string $name, array $argNodes): CallNode
     {


### PR DESCRIPTION
## 🤔 Background

#2088 (Phase 1 of the emitter optimisation roadmap #2087) atom 4: collection accessors.

## 💡 Goal

Collapse `count`, `first`, `last`, `nth` calls against literal `VectorNode` / `MapNode` / `SetNode` AST shapes to a literal so the runtime accessor call disappears.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php` — new `foldCollectionAccessor` path dispatching to `foldCount` / `foldVectorPick` / `foldNth`. `count` works on Vector / Map / Set; the positional accessors only fold over `VectorNode` (ordered) when every element is a `LiteralNode`, so no side effects are dropped. Out-of-bounds, negative, and non-int indices skip the fold so Phel's runtime `IndexOutOfBoundsException` fires unchanged.
- `tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php` — 12 new tests covering `count` on each collection kind, empty / single / multi-element first / last, in-bounds / out-of-bounds / negative / non-literal index `nth`, mixed literal + non-literal element skip
- `tests/php/Integration/Fixtures/ConstantFolding/collection-accessor-fold.test` — one fixture, six let-binds, each binding becomes an int / nil literal
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `vendor/bin/phpunit --testsuite=integration` 741 tests, 0 failures
- `composer test-core` (cache cleared) 5645 tests, 0 failures
- `composer phpstan` clean
- Unit suite for ConstantFolder: 61 tests, 0 failures

## Trade-offs / non-goals

- `first` / `last` / `nth` over `MapNode` / `SetNode` stay un-folded; ordering semantics there are unsafe to assume statically.
- Mixed literal + non-literal elements block positional folding so side effects in non-picked elements are not silently dropped.

Closes — see roadmap #2088 (4/6); related: #2087