### PR TITLE
perf(compiler): fold (str ...) on int / bool / string / nil literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - `ConstantFolder`: compile-time evaluate `phel.core` boolean predicates (`not`, `nil?`, `true?`, `false?`, `boolean`) when the single argument is any literal value. Phel truthiness preserved: only `nil` / `false` are falsy, so `(boolean 0)` and `(boolean "")` still fold to `true` (#2088)
 - `ConstantFolder`: compile-time evaluate bitwise `php/` interop ops (`&`, `|`, `^`, `<<`, `>>`, `~`) on int literals. Covers user-written `(php/& 12 10)` and the `bit-and` / `bit-or` / `bit-xor` / `bit-shift-left` / `bit-shift-right` / `bit-not` core fns whose `:inline` lowers to those ops. Float args skip the fold (PHP would coerce; Phel core asserts int-only via `assert-non-nil`); negative shift amounts skip so the runtime `ArithmeticError` fires unchanged (#2088)
 - `ConstantFolder`: compile-time evaluate `count` on literal vector / map / set, plus `first` / `last` / `nth` on literal vectors whose elements are all literal. `nth` skips out-of-bounds and non-int / negative indices so the runtime `IndexOutOfBoundsException` keeps its trigger point (#2088)
+- `ConstantFolder`: compile-time evaluate `(str ...)` when every argument is a literal `int`, `bool`, `string`, or `nil`. Phel's `val-to-str` semantics are preserved: `nil` becomes `""`, `false` / `true` render as `"false"` / `"true"`. Float arguments stay un-folded so the runtime's `NaN` / `±Infinity` / trailing-`.0` formatting keeps control (#2088)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -19,9 +19,11 @@ use function array_shift;
 use function array_slice;
 use function assert;
 use function count;
+use function implode;
 use function in_array;
 use function is_float;
 use function is_int;
+use function is_string;
 
 /**
  * Compile-time evaluation of pure core fns whose arguments are all literal.
@@ -113,6 +115,13 @@ final class ConstantFolder
         $accessorResult = $this->foldCollectionAccessor($fnName, $node);
         if ($accessorResult instanceof AbstractNode) {
             return $accessorResult;
+        }
+
+        if ($fnName === 'str') {
+            $strResult = $this->foldStr($node->getArguments());
+            if ($strResult !== null) {
+                return new LiteralNode($node->getEnv(), $strResult, $node->getStartSourceLocation());
+            }
         }
 
         $numbers = $this->extractNumericLiterals($node->getArguments());
@@ -271,6 +280,42 @@ final class ConstantFolder
     private function allLiteralNodes(array $nodes): bool
     {
         return array_all($nodes, static fn($n): bool => $n instanceof LiteralNode);
+    }
+
+    /**
+     * `(str ...)` over literal `int` / `bool` / `string` / `nil` args.
+     * Floats are skipped because Phel's `val-to-str` preserves trailing
+     * `.0`, handles `NaN` / `±Infinity` specially, and we don't want to
+     * duplicate that surface here.
+     *
+     * @param list<AbstractNode> $args
+     */
+    private function foldStr(array $args): ?string
+    {
+        $parts = [];
+        foreach ($args as $arg) {
+            if (!$arg instanceof LiteralNode) {
+                return null;
+            }
+
+            $value = $arg->getValue();
+            $part = match (true) {
+                $value === null => '',
+                $value === true => 'true',
+                $value === false => 'false',
+                is_int($value) => (string) $value,
+                is_string($value) => $value,
+                default => null,
+            };
+
+            if ($part === null) {
+                return null;
+            }
+
+            $parts[] = $part;
+        }
+
+        return implode('', $parts);
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Call/str-all-literal-folds-to-concat.test
+++ b/tests/php/Integration/Fixtures/Call/str-all-literal-folds-to-concat.test
@@ -1,4 +1,0 @@
---PHEL--
-(str "hello, " "world" "!")
---PHP--
-("hello, " . "world" . "!");

--- a/tests/php/Integration/Fixtures/ConstantFolding/str-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/str-fold.test
@@ -1,0 +1,14 @@
+--PHEL--
+(let [a (str)
+      b (str "hello")
+      c (str "a" "-" 1 "-" true)
+      d (str nil)
+      e (str false)]
+  [a b c d e])
+--PHP--
+$a_1 = "";
+$b_2 = "hello";
+$c_3 = "a-1-true";
+$d_4 = "";
+$e_5 = "false";
+\Phel::vector([$a_1, $b_2, $c_3, $d_4, $e_5]);

--- a/tests/php/Integration/Fixtures/Inline/str.test
+++ b/tests/php/Integration/Fixtures/Inline/str.test
@@ -1,7 +1,15 @@
 --PHEL--
-(str)
-(str "a")
-(str "a" "b")
-(str "a" "b" "c")
+(fn [^string a] (str))
+(fn [^string a] (str a))
+(fn [^string a ^string b] (str a b))
+(fn [^string a ^string b ^string c] (str a b c))
 --PHP--
-(\Phel::getDefinition("phel.core", "str"))->__invoke();("a");("a" . "b");("a" . "b" . "c");
+(function(string $a) {
+  return "";
+});(function(string $a) {
+  return ($a);
+});(function(string $a, string $b) {
+  return ($a . $b);
+});(function(string $a, string $b, string $c) {
+  return ($a . $b . $c);
+});

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -521,6 +521,72 @@ final class ConstantFolderTest extends TestCase
         )));
     }
 
+    public function test_fold_str_empty_returns_empty_string(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('str', []));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame('', $folded->getValue());
+    }
+
+    public function test_fold_str_single_string(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('str', ['hello']));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame('hello', $folded->getValue());
+    }
+
+    public function test_fold_str_concat_mixed_literals(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('str', ['a', '-', 1, '-', true]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame('a-1-true', $folded->getValue());
+    }
+
+    public function test_fold_str_nil_is_empty(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('str', [null]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame('', $folded->getValue());
+    }
+
+    public function test_fold_str_false_renders_as_false_keyword(): void
+    {
+        $folded = new ConstantFolder()->fold($this->coreCall('str', [false]));
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame('false', $folded->getValue());
+    }
+
+    public function test_fold_str_skips_float_arg(): void
+    {
+        // Float `val-to-str` semantics (NaN, Infinity, trailing .0) are
+        // intentionally not duplicated in the folder.
+        self::assertNull(new ConstantFolder()->fold($this->coreCall('str', [1.5])));
+    }
+
+    public function test_fold_str_skips_non_literal_arg(): void
+    {
+        $node = new CallNode(
+            NodeEnvironment::empty()->withExpressionContext(),
+            new GlobalVarNode(
+                NodeEnvironment::empty()->withExpressionContext(),
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create('str'),
+                Phel::map(),
+            ),
+            [
+                new LiteralNode(NodeEnvironment::empty()->withExpressionContext(), 'x'),
+                $this->globalVar('y'),
+            ],
+        );
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
     public function test_fold_if_truthy_test_returns_then_branch(): void
     {
         $env = NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

#2088 (Phase 1 of the emitter optimisation roadmap #2087) atom 5: `(str ...)` fold.

## 💡 Goal

Collapse `(str ...)` calls whose arguments are all literal primitives to a single string literal at analyser time so the inline PHP `.` concat chain no longer reaches the emitter.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php` — new `foldStr` path. Matches `phel.core/str` callees whose every argument is a `LiteralNode` of `int`, `bool`, `string`, or `nil`. Float args skip so Phel's `val-to-str` keeps owning `NaN` / `±Infinity` / trailing-`.0` formatting. `(str)` returns `""`; nil renders as `""`; booleans as `"true"` / `"false"`; ints via PHP cast.
- `tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php` — 7 new tests: empty, single-string, mixed-types concat, nil, false, float skip, non-literal skip
- `tests/php/Integration/Fixtures/ConstantFolding/str-fold.test` — end-to-end fixture; five `let` bindings, each becomes a string literal
- `tests/php/Integration/Fixtures/Inline/str.test` — rewritten to `^string` locals so the inline PHP `.` concat path stays covered. The previous literal-only forms now fold and would emit empty output in statement context.
- `tests/php/Integration/Fixtures/Call/str-all-literal-folds-to-concat.test` — removed as obsolete; the concern is now covered by the unit + ConstantFolding fixtures.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `vendor/bin/phpunit --testsuite=integration` 741 tests, 0 failures
- `composer test-core` (cache cleared) 5645 tests, 0 failures
- `composer phpstan` clean
- Unit suite for ConstantFolder: 68 tests, 0 failures

## Trade-offs / non-goals

- Float arguments stay un-folded. Reproducing `float-to-str` (which preserves trailing `.0` for integer-valued floats, special-cases `NaN` / `±Infinity`) would duplicate runtime semantics that are easy to drift from. Keep the source of truth in core.

Closes — see roadmap #2088 (5/6); related: #2087