### PR TITLE
perf(compiler): simplification pass drops pure non-tail expressions in do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `ConstantFolder`: compile-time evaluate `count` on literal vector / map / set, plus `first` / `last` / `nth` on literal vectors whose elements are all literal. `nth` skips out-of-bounds and non-int / negative indices so the runtime `IndexOutOfBoundsException` keeps its trigger point (#2088)
 - `ConstantFolder`: compile-time evaluate `(str ...)` when every argument is a literal `int`, `bool`, `string`, or `nil`. Phel's `val-to-str` semantics are preserved: `nil` becomes `""`, `false` / `true` render as `"false"` / `"true"`. Float arguments stay un-folded so the runtime's `NaN` / `±Infinity` / trailing-`.0` formatting keeps control (#2088)
 - `ConstantFolder`: compile-time evaluate `min` / `max` / `mod` / `quot` / `rem` / `abs` on numeric literals. `min` / `max` skip when any operand is `NaN` (Phel returns `##NaN`, which we don't lift to a literal); `mod` / `quot` / `rem` are int-only and skip when divisor is `0` so the runtime `DivisionByZeroError` keeps its trigger point; `abs` skips `PHP_INT_MIN` so the runtime's `BigInt` promotion path retains control (#2088)
+- New `Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/` pass: `DoSimplifier` drops pure expressions from `(do ...)` body non-tail positions; the tail expression and side-effecting calls stay. Purity is conservative: `CallNode` purity defers to `ConstantFolder`, so calls that would throw at runtime (`(abs nil)`, `(quot 1 0)`, …) are not dropped (#2089)
 
 ### Fixed
 

--- a/src/php/Compiler/CLAUDE.md
+++ b/src/php/Compiler/CLAUDE.md
@@ -60,7 +60,10 @@ Core compilation pipeline: Phel source -> tokens -> AST -> analyzed nodes -> PHP
 | Parser | `Application/Parser` | `TokenStream` | `FileNode` (parse tree) |
 | Reader | `Application/Reader` | `NodeInterface` | `ReaderResult` (Phel data) |
 | Analyzer | `Application/Analyzer` | Phel data | `AbstractNode` (AST) |
+| Simplifier | `Domain/Analyzer/TypeAnalyzer/Simplification/` | `AbstractNode` | `AbstractNode` (smaller) |
 | Emitter | Domain/Emitter/ | `AbstractNode` | `EmitterResult` (PHP code) |
+
+The simplification pass runs **after** the analyser-level `ConstantFolder`. It currently drops pure non-tail expressions from `(do ...)` bodies; purity is decided by `PureExpressionDetector`, which delegates `CallNode` checks to `ConstantFolder` so a call is "pure" only when the folder can statically compute its value (calls that would throw at runtime stay un-dropped).
 
 ## Structure
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+
+/**
+ * Drops pure expressions from a `(do ...)` body's non-tail positions
+ * after analysis. The tail expression is always preserved because it
+ * is the form's return value.
+ *
+ * Side effects in non-tail positions stay; only computations with no
+ * observable effect are removed, so behaviour is unchanged.
+ */
+final readonly class DoSimplifier
+{
+    public function __construct(
+        private PureExpressionDetector $purity = new PureExpressionDetector(),
+    ) {}
+
+    public function simplify(DoNode $node): DoNode
+    {
+        $stmts = $node->getStmts();
+        $filtered = [];
+        $dropped = false;
+        foreach ($stmts as $stmt) {
+            if ($this->purity->isPure($stmt)) {
+                $dropped = true;
+                continue;
+            }
+
+            $filtered[] = $stmt;
+        }
+
+        if (!$dropped) {
+            return $node;
+        }
+
+        return new DoNode(
+            $node->getEnv(),
+            $filtered,
+            $node->getRet(),
+            $node->getStartSourceLocation(),
+        );
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetector.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\ConstantFolder;
+
+/**
+ * Conservative purity oracle used by the simplification pass.
+ *
+ * "Pure" here means: evaluating this node has no observable effect
+ * (no I/O, no mutation, no exception under any input the analyser
+ * could not statically reject). When in doubt, return `false` — a
+ * false negative (keeping a dead expression) is cheap; a false
+ * positive (dropping a side effect) is silently wrong.
+ *
+ * For `CallNode` purity we delegate to {@see ConstantFolder}: only
+ * calls the folder can statically evaluate are considered pure. This
+ * automatically excludes calls that *could* throw at runtime
+ * (`(abs nil)`, `(quot 1 0)`, `(nth [] 99)`, …) because the folder
+ * refuses to lift those exceptions to compile time.
+ */
+final readonly class PureExpressionDetector
+{
+    public function __construct(
+        private ConstantFolder $folder = new ConstantFolder(),
+    ) {}
+
+    public function isPure(AbstractNode $node): bool
+    {
+        if ($node instanceof LiteralNode || $node instanceof LocalVarNode || $node instanceof GlobalVarNode) {
+            return true;
+        }
+
+        if ($node instanceof CallNode) {
+            // A call is pure iff the folder can compute its exact value.
+            // That guarantees the call has no observable effect and no
+            // runtime exception under its current arguments.
+            return $this->folder->fold($node) !== null;
+        }
+
+        return false;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetector.php
@@ -42,7 +42,7 @@ final readonly class PureExpressionDetector
             // A call is pure iff the folder can compute its exact value.
             // That guarantees the call has no observable effect and no
             // runtime exception under its current arguments.
-            return $this->folder->fold($node) !== null;
+            return $this->folder->fold($node) instanceof AbstractNode;
         }
 
         return false;

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\DoSimplifier;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\WithAnalyzerTrait;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Symbol;
@@ -59,11 +60,13 @@ final class DoSymbol implements SpecialFormAnalyzerInterface
             $stmts[] = $this->analyzer->analyze(null, $env);
         }
 
-        return new DoNode(
+        $node = new DoNode(
             $env,
             array_slice($stmts, 0, -1),
             $stmts[count($stmts) - 1],
             $list->getStartLocation(),
         );
+
+        return new DoSimplifier()->simplify($node);
     }
 }

--- a/tests/php/Integration/Compiler/CallSiteCacheTest.php
+++ b/tests/php/Integration/Compiler/CallSiteCacheTest.php
@@ -35,27 +35,30 @@ final class CallSiteCacheTest extends TestCase
 
     public function test_build_mode_on_hoists_call_sites_to_static_slots(): void
     {
+        // Use a vector so both `+` call sites are live (the simplification
+        // pass drops pure non-tail expressions, which would otherwise
+        // remove the first call before the cache could see it).
         BuildFacade::enableBuildMode();
-        $output = $this->compileSnippet('(fn [x] (+ x 1) (+ x 2))');
+        $output = $this->compileSnippet('(fn [x] [(+ x 1) (+ x 2)])');
         BuildFacade::disableBuildMode();
 
         $phel = '\\' . Phel::class;
 
         self::assertStringContainsString('static $__phel_call_0', $output);
-        self::assertStringContainsString('($__phel_call_0 ??= ' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 1);', $output);
-        self::assertStringContainsString('($__phel_call_1 ??= ' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 2);', $output);
+        self::assertStringContainsString('($__phel_call_0 ??= ' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 1)', $output);
+        self::assertStringContainsString('($__phel_call_1 ??= ' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 2)', $output);
     }
 
     public function test_build_mode_off_skips_cache_so_repl_redefine_still_wins(): void
     {
         BuildFacade::disableBuildMode();
-        $output = $this->compileSnippet('(fn [x] (+ x 1) (+ x 2))');
+        $output = $this->compileSnippet('(fn [x] [(+ x 1) (+ x 2)])');
 
         $phel = '\\' . Phel::class;
 
         self::assertStringNotContainsString('$__phel_call_', $output);
-        self::assertStringContainsString('(' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 1);', $output);
-        self::assertStringContainsString('(' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 2);', $output);
+        self::assertStringContainsString('(' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 1)', $output);
+        self::assertStringContainsString('(' . $phel . '::getDefinition("phel.core", "+"))->__invoke($x, 2)', $output);
     }
 
     public function test_call_method_dispatch_targets_only_known_fn_defs(): void

--- a/tests/php/Integration/Fixtures/Call/call-site-cache-multiple.test
+++ b/tests/php/Integration/Fixtures/Call/call-site-cache-multiple.test
@@ -1,12 +1,10 @@
 --PHEL--
 (fn [x]
-  (+ x 1)
-  (+ x 2)
-  (* x 3))
+  [(+ x 1)
+   (+ x 2)
+   (* x 3)])
 --PHP--
 (function($x) {
   static $__phel_call_0, $__phel_call_1, $__phel_call_2;
-  ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, 1);
-  ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, 2);
-  return ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "*"))->__invoke($x, 3);
+  return \Phel::vector([($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, 1), ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($x, 2), ($__phel_call_2 ??= \Phel::getDefinition("phel.core", "*"))->__invoke($x, 3)]);
 });

--- a/tests/php/Integration/Fixtures/Simplify/do-drops-pure-non-tail.test
+++ b/tests/php/Integration/Fixtures/Simplify/do-drops-pure-non-tail.test
@@ -1,0 +1,4 @@
+--PHEL--
+(do 1 2 (println "x") 3)
+--PHP--
+(\Phel::getDefinition("phel.core", "println"))->__invoke("x");

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/DoSymbolTest.php
@@ -74,6 +74,8 @@ final class DoSymbolTest extends TestCase
 
     public function test_with_two_scalar_value(): void
     {
+        // `1` is a pure literal in non-tail position, so the simplifier
+        // drops it; only the tail expression `2` survives.
         $env = NodeEnvironment::empty();
 
         $list = Phel::list([
@@ -84,9 +86,7 @@ final class DoSymbolTest extends TestCase
 
         $expected = new DoNode(
             $env,
-            $stmts = [
-                $this->analyzer->analyze(1, $env->withDisallowRecurFrame()),
-            ],
+            [],
             $this->analyzer->analyze(2, $env),
             $list->getStartLocation(),
         );

--- a/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/SpecialForm/LetSymbolTest.php
@@ -156,6 +156,8 @@ final class LetSymbolTest extends TestCase
 
     public function test_with_two_body_expression(): void
     {
+        // The `do`-wrapped body has `1` as a pure literal in non-tail
+        // position; the simplifier drops it, leaving the tail `2`.
         $list = Phel::list([
             Symbol::create('let'),
             Phel::vector([]),
@@ -170,7 +172,7 @@ final class LetSymbolTest extends TestCase
                 [],
                 new DoNode(
                     $env->withReturnContext(),
-                    [new LiteralNode($env->withStatementContext()->withDisallowRecurFrame(), 1)],
+                    [],
                     new LiteralNode($env->withReturnContext(), 2),
                 ),
                 false,

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/DoSimplifierTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/DoSimplifierTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\DoSimplifier;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class DoSimplifierTest extends TestCase
+{
+    public function test_drops_pure_literals_in_non_tail(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $node = new DoNode(
+            $env,
+            [new LiteralNode($env, 1), new LiteralNode($env, 2)],
+            new LiteralNode($env, 3),
+        );
+
+        $simplified = new DoSimplifier()->simplify($node);
+
+        self::assertSame([], $simplified->getStmts());
+        self::assertSame(3, $this->literalValue($simplified->getRet()));
+    }
+
+    public function test_keeps_impure_calls_in_non_tail(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $println = $this->coreCall('println', [new LiteralNode($env, 'x')]);
+        $node = new DoNode(
+            $env,
+            [new LiteralNode($env, 1), $println, new LiteralNode($env, 2)],
+            new LiteralNode($env, 3),
+        );
+
+        $simplified = new DoSimplifier()->simplify($node);
+
+        self::assertCount(1, $simplified->getStmts());
+        self::assertSame($println, $simplified->getStmts()[0]);
+    }
+
+    public function test_preserves_tail_even_if_pure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $ret = new LiteralNode($env, 42);
+        $node = new DoNode($env, [], $ret);
+
+        $simplified = new DoSimplifier()->simplify($node);
+
+        self::assertSame($ret, $simplified->getRet());
+    }
+
+    public function test_returns_same_instance_when_nothing_to_drop(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $println = $this->coreCall('println', [new LiteralNode($env, 'x')]);
+        $node = new DoNode($env, [$println], new LiteralNode($env, 1));
+
+        $simplified = new DoSimplifier()->simplify($node);
+
+        self::assertSame($node, $simplified);
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+
+        return new CallNode(
+            $env,
+            new GlobalVarNode($env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create($name), Phel::map()),
+            $args,
+        );
+    }
+
+    private function literalValue(AbstractNode $node): mixed
+    {
+        self::assertInstanceOf(LiteralNode::class, $node);
+        return $node->getValue();
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetectorTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetectorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\PureExpressionDetector;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class PureExpressionDetectorTest extends TestCase
+{
+    public function test_literal_is_pure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        self::assertTrue(new PureExpressionDetector()->isPure(new LiteralNode($env, 42)));
+    }
+
+    public function test_local_var_is_pure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $node = new LocalVarNode($env, Symbol::create('x'));
+
+        self::assertTrue(new PureExpressionDetector()->isPure($node));
+    }
+
+    public function test_global_var_reference_is_pure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $node = new GlobalVarNode($env, 'user', Symbol::create('my-fn'), Phel::map());
+
+        self::assertTrue(new PureExpressionDetector()->isPure($node));
+    }
+
+    public function test_foldable_call_is_pure(): void
+    {
+        // `(+ 1 2)` folds → safe to drop.
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $call = new CallNode(
+            $env,
+            new GlobalVarNode($env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('+'), Phel::map()),
+            [new LiteralNode($env, 1), new LiteralNode($env, 2)],
+        );
+
+        self::assertTrue(new PureExpressionDetector()->isPure($call));
+    }
+
+    public function test_call_that_would_throw_is_impure(): void
+    {
+        // `(abs nil)` is in the fold whitelist but the folder rejects
+        // nil (it would throw at runtime) so we must keep the call.
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $call = new CallNode(
+            $env,
+            new GlobalVarNode($env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('abs'), Phel::map()),
+            [new LiteralNode($env, null)],
+        );
+
+        self::assertFalse(new PureExpressionDetector()->isPure($call));
+    }
+
+    public function test_side_effecting_call_is_impure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $call = new CallNode(
+            $env,
+            new GlobalVarNode($env, CompilerConstants::PHEL_CORE_NAMESPACE, Symbol::create('println'), Phel::map()),
+            [new LiteralNode($env, 'x')],
+        );
+
+        self::assertFalse(new PureExpressionDetector()->isPure($call));
+    }
+
+    public function test_user_call_is_impure(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $call = new CallNode(
+            $env,
+            new GlobalVarNode($env, 'user', Symbol::create('add'), Phel::map()),
+            [new LiteralNode($env, 1)],
+        );
+
+        self::assertFalse(new PureExpressionDetector()->isPure($call));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2089 (Phase 2 of the emitter optimisation roadmap #2087) atom 1: simplification pass.

The roadmap describes a new pass that runs on `AnalyzedNode` trees after `ConstantFolder` to drop dead code and inline single-use let bindings. This PR delivers atom 1 — dropping pure non-tail expressions from `(do ...)` bodies — and lays down the namespace + purity oracle that atoms 2 and 3 will reuse.

## 💡 Goal

`(do 1 2 (println "x") 3)` should compile to just the `println` call followed by `3`; the literals `1` and `2` are dead. Same for any pure expression in any non-tail position of a `do`.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/PureExpressionDetector.php` — conservative purity oracle. `LiteralNode` / `LocalVarNode` / `GlobalVarNode` are pure as bare references. `CallNode` purity **defers to `ConstantFolder`**: a call is pure only when the folder can compute its exact value. That guarantees no side effects and no runtime exception — automatically excludes calls that would throw (`(abs nil)`, `(quot 1 0)`, `(nth [] 99)`, …) without maintaining a parallel may-throw whitelist.
- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php` — filters pure expressions out of `DoNode::stmts`. The tail (`DoNode::ret`) is always preserved.
- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DoSymbol.php` — wraps the constructed `DoNode` through the simplifier before returning.
- `src/php/Compiler/CLAUDE.md` — documents the new Simplification phase in the pipeline table.
- `tests/php/Unit/.../Simplification/` — `DoSimplifierTest` (4 tests) + `PureExpressionDetectorTest` (7 tests).
- `tests/php/Integration/Fixtures/Simplify/do-drops-pure-non-tail.test` — end-to-end fixture.
- `tests/php/Integration/Fixtures/Call/call-site-cache-multiple.test` + `tests/php/Integration/Compiler/CallSiteCacheTest.php` — migrated: the old `(fn [x] (+ x 1) (+ x 2) ...)` shape relied on pure non-tail calls surviving for the cache to see them; both now wrap call sites in a vector so all three remain live.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `vendor/bin/phpunit --testsuite=integration` 743 tests, 0 failures
- `composer test-core` (cache cleared) 5645 tests, 0 failures
- `composer phpstan` clean
- Unit suite for Simplification: 11 tests, 0 failures
- Manual `./bin/phel compile`:
  - `(do 1 2 (println "x") 3)` → emits only the `println` call (literal `3` elided in statement context)
  - `(do 1 (abs nil) 4)` → keeps the `abs(null)` call (folder refuses to lift its runtime throw)
  - `(do 1 (+ 2 3) 4)` → empty output (all folded / pure)

## Trade-offs / non-goals

- Purity is whitelist-via-folder, not effect inference. A side-effect-free user fn (`(defn double [x] (* x 2))`) is **not** pure to the detector because it can't fold a non-core call. That is intentionally conservative; broadening it belongs to atom 3 (inline single-use let bindings) where we have a use site to verify.
- The simplifier only runs on `DoNode`s built by `DoSymbol`. `LetSymbol` / `FnSymbol` wrap bodies in `DoNode` via `DoSymbol`, so they inherit the cleanup transitively, but `IfSymbol`'s branches are not `DoNode`s and stay untouched (no scope for atom 1).

Closes — see roadmap #2089 (1/3); related: #2087