### PR TITLE
ci(clojure-test-suite): pin PHEL_TEST_WORKERS=1 to fix red exit code

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -67,4 +67,11 @@ jobs:
 
       - name: Run clojure-test-suite
         working-directory: clojure-test-suite
+        # Pin to a single worker: the parallel orchestrator's spawned
+        # PHP 8.4 subprocesses currently exit non-zero after a clean
+        # run, which propagates up as `composer test` exit 1 even though
+        # every test passes. Serial mode bypasses that and keeps the
+        # check honest.
+        env:
+          PHEL_TEST_WORKERS: '1'
         run: composer test


### PR DESCRIPTION
## 🤔 Background

The `Run clojure-test-suite (PHP 8.4)` job has been red on every PR in the v0.41.0 epic (#2102 through #2110) and on the merge runs against `main`, despite every single suite test passing.

Sample CI tail (from PR #2110):

```
Passed: 4654
Failed: 0
Error: 0
Total: 4654
Time: 00:24.213, Memory: 267.82 MB
Script XDEBUG_MODE=off ./vendor/bin/phel test handling the test event returned with error code 1
```

Locally on PHP 8.5 the same suite against the same `phel-lang` HEAD exits **0**. The failure mode is CI-specific, on PHP 8.4 + parallel orchestrator path.

## 💡 Goal

Get a green check on the workflow without papering over real failures. The 4654 tests do pass — only the runner's exit propagation is wrong.

## 🔖 Changes

- `.github/workflows/run-clojure-test-suite.yml` — set `PHEL_TEST_WORKERS=1` for the `Run clojure-test-suite` step. The serial path runs every test in-process; the parallel orchestrator's worker subprocess exit code isn't currently being honoured cleanly.

## Validation

- Locally (PHP 8.5) with workers=1 the suite already exits 0.
- The CI rerun on this PR is the actual verification of the workaround.

## Trade-offs / non-goals

- This is a **workaround**, not a root-cause fix. A follow-up issue should track investigating `ParallelTestOrchestrator` worker exit propagation under PHP 8.4 (likely in `TestCommand` or the orchestrator's `proc_close` handling).
- The job still has `continue-on-error: true`, so this PR's own clojure-test-suite cell will tell us if the workaround works.