### PR TITLE
fix(compiler): narrow DoSimplifier to LiteralNode-only drops

### DIFF
--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php
@@ -5,28 +5,29 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
 
 use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 
 /**
- * Drops pure expressions from a `(do ...)` body's non-tail positions
- * after analysis. The tail expression is always preserved because it
- * is the form's return value.
+ * Drops `LiteralNode` expressions from a `(do ...)` body's non-tail
+ * positions after analysis. The tail expression is always preserved
+ * because it is the form's return value.
  *
- * Side effects in non-tail positions stay; only computations with no
- * observable effect are removed, so behaviour is unchanged.
+ * Scope is intentionally narrow — only literal nodes are stripped.
+ * Any other "pure" candidate (`LocalVarNode` references, foldable
+ * core calls, …) is kept, because the analyser is allowed to lower
+ * those into emitter shapes whose evaluation order or side effects
+ * the simplifier cannot statically prove harmless (e.g. registering a
+ * test assertion counter on a folded predicate).
  */
 final readonly class DoSimplifier
 {
-    public function __construct(
-        private PureExpressionDetector $purity = new PureExpressionDetector(),
-    ) {}
-
     public function simplify(DoNode $node): DoNode
     {
         $stmts = $node->getStmts();
         $filtered = [];
         $dropped = false;
         foreach ($stmts as $stmt) {
-            if ($this->purity->isPure($stmt)) {
+            if ($stmt instanceof LiteralNode) {
                 $dropped = true;
                 continue;
             }


### PR DESCRIPTION
## 🤔 Background

Phase 2 atom 1 (#2108) wired `DoSimplifier` to `DoSymbol::analyze` with the full purity oracle, which considers any whitelisted core call / `LocalVarNode` / `GlobalVarNode` reference "pure". Since that merge, every PR's `Run clojure-test-suite (PHP 8.4)` CI cell has reported:

```
Passed: 4654
Failed: 0
Error: 0
Total: 4654
Script XDEBUG_MODE=off ./vendor/bin/phel test handling the test event returned with error code 1
```

The same suite against the same `phel-lang` HEAD exits **0** locally on PHP 8.5.

## 💡 Goal

Restore green CI for the suite without giving up the win from #2108. Workaround attempt #2111 (`PHEL_TEST_WORKERS=1`) did not change the exit code, so the cause is not the parallel orchestrator.

## 🔖 Changes

- `src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/DoSimplifier.php` — drop only `LiteralNode` non-tail expressions. Everything else stays. The `PureExpressionDetector` collaborator is no longer used by this simplifier (it remains in use by `LetSimplifier`).

## Validation

- `composer test-core` 5645 tests, 0 failures.
- Local clojure-test-suite run: **4654 passed, 0 failed, exit 0**.
- The CI rerun on this PR is the actual verification on PHP 8.4.

## Trade-offs

- The original example from atom 1, `(do 1 2 (println "x") 3)`, still strips the unused literals — that's the high-value case anyway.
- Foldable core calls (`(do (+ 1 2) ...)`) and bare `GlobalVarNode` references stay in non-tail position. They cost a no-op emission each but cannot accidentally suppress a host-context side effect (e.g. a test framework's pure-looking probe).
- `LetSimplifier`'s drop / inline (atoms 2 / 3) still uses the full purity oracle locally on binding inits, where the analyser owns the host context.

Replaces / supersedes #2111.