### PR TITLE
perf(compiler): specialise nth / count on typed PersistentVector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - New `Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/` pass + `PureExpressionDetector` purity oracle (defers `CallNode` purity to `ConstantFolder` so calls that would throw at runtime are not considered safe to drop) (#2089)
 - `LetSimplifier`: drops `let` bindings whose shadow name is never referenced from any later init nor from the body, **when** the dropped init is pure. Loop bindings stay (recur can rebind them). Bindings whose body subtree emits a closure (`fn` / `multi-fn` / `foreach` / `try`) stay too — those nodes carry a `use(...)` capture list fixed at analysis time that would dangle on a dropped binding (#2089)
 - `LetSimplifier`: inline `(let […, x <literal>] x)` to the literal when the body's tail is a `LocalVarNode` whose shadow matches the last binding and the shadow has exactly one reference in the body. Limited to `LiteralNode` inits today because every other node type would need an env rebase on the let's outer context that the analyser doesn't yet expose safely (#2089)
+- `CallSpecialization`: `(count v)` and `(nth v i)` lower to direct `$v->count()` / `$v->get($i)` method calls when the analyser has tagged `v` as `PersistentVectorInterface`. The runtime `phel.core/nth` body walks a `cond` over set / seq / vector / map / php-array; the typed path collapses every branch (#2090)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -73,7 +73,61 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypedVectorAccessor($node)) {
+            return true;
+        }
+
         return self::isTypedBinaryOp($node);
+    }
+
+    /**
+     * `(nth v i)` / `(count v)` where the analyser has tagged the
+     * target as `PersistentVectorInterface`. The runtime `nth` body
+     * walks a `cond` over set / seq / vector / map / php-array; for a
+     * typed vector every branch collapses to a single method call.
+     *
+     * @return array{method: string, args: list<int>}|null list of arg
+     *                                                     indices to
+     *                                                     pass as
+     *                                                     method args
+     */
+    public static function typedVectorMethodCall(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        $target = $args[0] ?? null;
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        if (self::normalisedTag($target->getInferredType()) !== PersistentVectorInterface::class) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+
+        if ($name === 'count' && count($args) === 1) {
+            return ['method' => 'count', 'args' => []];
+        }
+
+        if ($name === 'nth' && count($args) === 2) {
+            return ['method' => 'get', 'args' => [1]];
+        }
+
+        return null;
+    }
+
+    public static function isTypedVectorAccessor(CallNode $node): bool
+    {
+        return self::typedVectorMethodCall($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -166,6 +166,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedVectorAccessor($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedBinaryOp($node)) {
             return;
         }
@@ -287,6 +291,37 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
         $this->outputEmitter->emitNode($args[1]);
+        $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(nth v i)` / `(count v)` to a direct method call on
+     * the tagged `PersistentVectorInterface` target. The runtime
+     * `phel.core/nth` body walks a `cond` over set / seq / vector /
+     * map / php-array; for a typed vector every branch collapses to
+     * a single method call.
+     */
+    private function tryEmitTypedVectorAccessor(CallNode $node): bool
+    {
+        $spec = CallSpecialization::typedVectorMethodCall($node);
+        if ($spec === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->' . $spec['method'] . '(', $loc);
+        $argCount = count($spec['args']);
+        foreach ($spec['args'] as $i => $argIndex) {
+            $this->outputEmitter->emitNode($args[$argIndex]);
+            if ($i < $argCount - 1) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+        }
+
         $this->outputEmitter->emitStr('))', $loc);
         return true;
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -314,6 +314,7 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(', $loc);
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $spec['method'] . '(', $loc);
+
         $argCount = count($spec['args']);
         foreach ($spec['args'] as $i => $argIndex) {
             $this->outputEmitter->emitNode($args[$argIndex]);

--- a/tests/php/Integration/Fixtures/Call/nth-count-typed-vector.test
+++ b/tests/php/Integration/Fixtures/Call/nth-count-typed-vector.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v] [(count v) (nth v 0)])
+--PHP--
+(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return \Phel::vector([($v->count()), ($v->get(0))]);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class CallSpecializationTest extends TestCase
+{
+    public function test_count_on_typed_vector_specialises_to_method_call(): void
+    {
+        $node = $this->coreCall('count', [$this->vectorLocal('v')]);
+
+        $spec = CallSpecialization::typedVectorMethodCall($node);
+
+        self::assertSame(['method' => 'count', 'args' => []], $spec);
+    }
+
+    public function test_nth_on_typed_vector_specialises_to_get(): void
+    {
+        $node = $this->coreCall('nth', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
+
+        $spec = CallSpecialization::typedVectorMethodCall($node);
+
+        self::assertSame(['method' => 'get', 'args' => [1]], $spec);
+    }
+
+    public function test_nth_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('nth', [
+            new LocalVarNode($env, Symbol::create('v')),
+            new LiteralNode($env, 0),
+        ]);
+
+        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
+    }
+
+    public function test_count_with_wrong_arity_skips(): void
+    {
+        $node = $this->coreCall('count', [$this->vectorLocal('v'), new LiteralNode($this->env(), 0)]);
+
+        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
+    }
+
+    public function test_other_core_fn_on_typed_vector_skips(): void
+    {
+        $node = $this->coreCall('inc', [$this->vectorLocal('v')]);
+
+        self::assertNull(CallSpecialization::typedVectorMethodCall($node));
+    }
+
+    private function env(): NodeEnvironment
+    {
+        return NodeEnvironment::empty()->withExpressionContext();
+    }
+
+    /**
+     * @param list<Phel\Compiler\Domain\Analyzer\Ast\AbstractNode> $args
+     */
+    private function coreCall(string $name, array $args): CallNode
+    {
+        return new CallNode(
+            $this->env(),
+            new GlobalVarNode(
+                $this->env(),
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create($name),
+                Phel::map(),
+            ),
+            $args,
+        );
+    }
+
+    private function vectorLocal(string $name): LocalVarNode
+    {
+        $sym = Symbol::create($name);
+        $tag = PersistentVectorInterface::class;
+        $meta = Phel::map(Keyword::create('tag'), $tag);
+        $locals = [$sym->withMeta($meta)];
+
+        $env = NodeEnvironment::empty()
+            ->withExpressionContext()
+            ->withMergedLocals($locals);
+
+        return new LocalVarNode($env, $sym);
+    }
+}

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter;
 
 use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
@@ -68,7 +69,7 @@ final class CallSpecializationTest extends TestCase
     }
 
     /**
-     * @param list<Phel\Compiler\Domain\Analyzer\Ast\AbstractNode> $args
+     * @param list<AbstractNode> $args
      */
     private function coreCall(string $name, array $args): CallNode
     {


### PR DESCRIPTION
## 🤔 Background

#2090 (Phase 3 of the emitter optimisation roadmap #2087) atom 2: `nth` / `count` on tagged `PersistentVectorInterface`.

Phase 3 atom 1 (variadic numeric chain) is deferred: PHP `*` does not promote int overflow to `BigInt`, so a 3-arg `(* huge huge huge)` would silently lose precision when specialised. The fix needs analyser-side overflow analysis that isn't in scope yet.

## 💡 Goal

`(nth v i)` and `(count v)` lower to a single PHP method call on the target collection when the analyser knows the target is a `PersistentVectorInterface`. Skip the runtime `cond` walk in `phel.core/nth` that handles set / seq / vector / map / php-array fallback.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php`
  - new `typedVectorMethodCall` predicate returns `{method, args}` for `count` / `nth` when the first arg is a vector-tagged `LocalVarNode`
  - wired into `isSpecialized` so the call-site cache scanner skips reserving a static slot
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php`
  - new `tryEmitTypedVectorAccessor` branch that emits `($v->count())` / `($v->get($i))`
- `tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php` — new file: 5 cases for positive / arity-skip / untyped fallback / unrelated-fn skip
- `tests/php/Integration/Fixtures/Call/nth-count-typed-vector.test` — end-to-end fixture
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `composer test-core` (cache cleared) 5645 tests, 0 failures
- `vendor/bin/phpunit --testsuite=integration` 745 tests, 0 failures
- `composer phpstan` clean

Refactor pass: ~90 added lines mirror the existing `typedGetAccessMethod` / `tryEmitTypedGetAccess` pair; nothing to extract or dedup.

## Trade-offs

- Specialisation requires a `LocalVarNode` target — chained calls (`(nth (foo) 0)`) keep the generic path because we have no analyser-published tag on the intermediate expression.
- `nth` 3-arg `(nth v i default)` is not specialised yet; the default branch needs a bounds-check that's not a single method call.

Closes — see roadmap #2090 (2/6); related: #2087