### PR TITLE
perf(compiler): specialise first / rest on tagged seq targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - `LetSimplifier`: drops `let` bindings whose shadow name is never referenced from any later init nor from the body, **when** the dropped init is pure. Loop bindings stay (recur can rebind them). Bindings whose body subtree emits a closure (`fn` / `multi-fn` / `foreach` / `try`) stay too — those nodes carry a `use(...)` capture list fixed at analysis time that would dangle on a dropped binding (#2089)
 - `LetSimplifier`: inline `(let […, x <literal>] x)` to the literal when the body's tail is a `LocalVarNode` whose shadow matches the last binding and the shadow has exactly one reference in the body. Limited to `LiteralNode` inits today because every other node type would need an env rebase on the let's outer context that the analyser doesn't yet expose safely (#2089)
 - `CallSpecialization`: `(count v)` and `(nth v i)` lower to direct `$v->count()` / `$v->get($i)` method calls when the analyser has tagged `v` as `PersistentVectorInterface`. The runtime `phel.core/nth` body walks a `cond` over set / seq / vector / map / php-array; the typed path collapses every branch (#2090)
+- `CallSpecialization`: `(first s)` and `(rest s)` lower to `$s->first()` / `$s->rest()` when the target is tagged as a `SeqInterface`, `PersistentVectorInterface`, or `PersistentListInterface`. `next` stays generic because it needs a runtime empty-rest check that a single method call cannot reproduce (#2090)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -57,6 +57,19 @@ final readonly class CallSpecialization
     /** @var list<string> */
     private const array EQUALITY_PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string'];
 
+    /** @var array<string, string> Phel core seq accessor → PHP method */
+    private const array SEQ_METHODS = [
+        'first' => 'first',
+        'rest' => 'rest',
+    ];
+
+    /** @var array<string, true> Tags whose runtime types implement SeqInterface */
+    private const array SEQ_TAGS = [
+        \Phel\Lang\SeqInterface::class => true,
+        PersistentVectorInterface::class => true,
+        \Phel\Lang\Collections\LinkedList\PersistentListInterface::class => true,
+    ];
+
     private function __construct() {}
 
     public static function isSpecialized(CallNode $node): bool
@@ -74,6 +87,10 @@ final readonly class CallSpecialization
         }
 
         if (self::isTypedVectorAccessor($node)) {
+            return true;
+        }
+
+        if (self::isTypedSeqAccessor($node)) {
             return true;
         }
 
@@ -128,6 +145,53 @@ final readonly class CallSpecialization
     public static function isTypedVectorAccessor(CallNode $node): bool
     {
         return self::typedVectorMethodCall($node) !== null;
+    }
+
+    /**
+     * `(first s)` / `(rest s)` where the analyser has tagged the
+     * target as a `SeqInterface` / `PersistentVectorInterface` /
+     * `PersistentListInterface`. The runtime body of each fn walks a
+     * cond chain that handles nil, strings, php-arrays, sets, etc.;
+     * for a tagged seq every branch collapses to `$s->first()` /
+     * `$s->rest()`.
+     */
+    public static function typedSeqMethodName(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!isset(self::SEQ_METHODS[$name])) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag === null || !isset(self::SEQ_TAGS[$tag])) {
+            return null;
+        }
+
+        return self::SEQ_METHODS[$name];
+    }
+
+    public static function isTypedSeqAccessor(CallNode $node): bool
+    {
+        return self::typedSeqMethodName($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -9,9 +9,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\SeqInterface;
 use Phel\Shared\CompilerConstants;
 
 use function count;
@@ -65,9 +67,9 @@ final readonly class CallSpecialization
 
     /** @var array<string, true> Tags whose runtime types implement SeqInterface */
     private const array SEQ_TAGS = [
-        \Phel\Lang\SeqInterface::class => true,
+        SeqInterface::class => true,
         PersistentVectorInterface::class => true,
-        \Phel\Lang\Collections\LinkedList\PersistentListInterface::class => true,
+        PersistentListInterface::class => true,
     ];
 
     private function __construct() {}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -170,6 +170,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedSeqAccessor($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedBinaryOp($node)) {
             return;
         }
@@ -292,6 +296,28 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
         $this->outputEmitter->emitNode($args[1]);
         $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(first s)` / `(rest s)` to a direct method call on
+     * the tagged seq target. The runtime `phel.core/first` and
+     * `phel.core/rest` bodies walk cond chains over nil / string /
+     * php-array / set / map / seq; for a known seq tag every branch
+     * collapses to `$s->first()` / `$s->rest()`.
+     */
+    private function tryEmitTypedSeqAccessor(CallNode $node): bool
+    {
+        $method = CallSpecialization::typedSeqMethodName($node);
+        if ($method === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->' . $method . '())', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/first-rest-typed-seq.test
+++ b/tests/php/Integration/Fixtures/Call/first-rest-typed-seq.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^"\Phel\Lang\SeqInterface" s] [(first s) (rest s)])
+--PHP--
+(function(\Phel\Lang\SeqInterface $s) {
+  return \Phel::vector([($s->first()), ($s->rest())]);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -14,6 +14,7 @@ use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
+use Phel\Lang\SeqInterface;
 use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 use PHPUnit\Framework\TestCase;
@@ -65,7 +66,7 @@ final class CallSpecializationTest extends TestCase
 
     public function test_first_on_typed_seq_specialises_to_first_method(): void
     {
-        $node = $this->coreCall('first', [$this->localWithTag('s', Phel\Lang\SeqInterface::class)]);
+        $node = $this->coreCall('first', [$this->localWithTag('s', SeqInterface::class)]);
 
         self::assertSame('first', CallSpecialization::typedSeqMethodName($node));
     }
@@ -90,7 +91,7 @@ final class CallSpecializationTest extends TestCase
         // `next` returns nil on empty rest; a bare method call cannot
         // reproduce that without a runtime probe, so the specialiser
         // stays out of it.
-        $node = $this->coreCall('next', [$this->localWithTag('s', Phel\Lang\SeqInterface::class)]);
+        $node = $this->coreCall('next', [$this->localWithTag('s', SeqInterface::class)]);
 
         self::assertNull(CallSpecialization::typedSeqMethodName($node));
     }

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -63,6 +63,38 @@ final class CallSpecializationTest extends TestCase
         self::assertNull(CallSpecialization::typedVectorMethodCall($node));
     }
 
+    public function test_first_on_typed_seq_specialises_to_first_method(): void
+    {
+        $node = $this->coreCall('first', [$this->localWithTag('s', Phel\Lang\SeqInterface::class)]);
+
+        self::assertSame('first', CallSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_rest_on_typed_vector_specialises_to_rest_method(): void
+    {
+        $node = $this->coreCall('rest', [$this->localWithTag('v', PersistentVectorInterface::class)]);
+
+        self::assertSame('rest', CallSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_first_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('first', [new LocalVarNode($env, Symbol::create('s'))]);
+
+        self::assertNull(CallSpecialization::typedSeqMethodName($node));
+    }
+
+    public function test_next_is_not_specialised(): void
+    {
+        // `next` returns nil on empty rest; a bare method call cannot
+        // reproduce that without a runtime probe, so the specialiser
+        // stays out of it.
+        $node = $this->coreCall('next', [$this->localWithTag('s', Phel\Lang\SeqInterface::class)]);
+
+        self::assertNull(CallSpecialization::typedSeqMethodName($node));
+    }
+
     private function env(): NodeEnvironment
     {
         return NodeEnvironment::empty()->withExpressionContext();
@@ -87,8 +119,12 @@ final class CallSpecializationTest extends TestCase
 
     private function vectorLocal(string $name): LocalVarNode
     {
+        return $this->localWithTag($name, PersistentVectorInterface::class);
+    }
+
+    private function localWithTag(string $name, string $tag): LocalVarNode
+    {
         $sym = Symbol::create($name);
-        $tag = PersistentVectorInterface::class;
         $meta = Phel::map(Keyword::create('tag'), $tag);
         $locals = [$sym->withMeta($meta)];
 


### PR DESCRIPTION
## 🤔 Background

#2090 (Phase 3 of the emitter optimisation roadmap #2087) atom 3: `first` / `rest` on tagged seq targets.

## 💡 Goal

`(first s)` and `(rest s)` lower to a single method call when the analyser knows the target is a seq.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php`
  - new `SEQ_METHODS` + `SEQ_TAGS` constants
  - new `typedSeqMethodName` predicate
  - wired into `isSpecialized`
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php`
  - new `tryEmitTypedSeqAccessor` branch
- `tests/php/Unit/.../CallSpecializationTest.php` — 4 new tests (first / rest specialise, untyped falls back, `next` deliberately not specialised)
- `tests/php/Integration/Fixtures/Call/first-rest-typed-seq.test`
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `composer test-core` 5645 tests, 0 failures
- `vendor/bin/phpunit --testsuite=integration` 746 tests, 0 failures
- `composer phpstan` clean

Refactor commit: re-bases `vectorLocal` in the unit test on a new generic `localWithTag` helper so future tag checks (atoms 4-6) can reuse it.

## Trade-offs / non-goals

- `next` stays generic. It returns `nil` on empty `rest`; a single method call can't reproduce that without a runtime probe.
- Specialisation requires the target to be a `LocalVarNode` with an `:inferred-type` tag matching one of the three seq interfaces. Chained calls or untyped locals keep the generic dispatch.

Closes — see roadmap #2090 (3/6); related: #2087