### PR TITLE
perf(compiler): specialise assoc / conj / dissoc on tagged persistents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - `LetSimplifier`: inline `(let […, x <literal>] x)` to the literal when the body's tail is a `LocalVarNode` whose shadow matches the last binding and the shadow has exactly one reference in the body. Limited to `LiteralNode` inits today because every other node type would need an env rebase on the let's outer context that the analyser doesn't yet expose safely (#2089)
 - `CallSpecialization`: `(count v)` and `(nth v i)` lower to direct `$v->count()` / `$v->get($i)` method calls when the analyser has tagged `v` as `PersistentVectorInterface`. The runtime `phel.core/nth` body walks a `cond` over set / seq / vector / map / php-array; the typed path collapses every branch (#2090)
 - `CallSpecialization`: `(first s)` and `(rest s)` lower to `$s->first()` / `$s->rest()` when the target is tagged as a `SeqInterface`, `PersistentVectorInterface`, or `PersistentListInterface`. `next` stays generic because it needs a runtime empty-rest check that a single method call cannot reproduce (#2090)
+- `CallSpecialization`: 3-arg `(assoc m k v)` / `(assoc v i x)`, 2-arg `(conj v x)`, and 2-arg `(dissoc m k)` lower to direct persistent-collection method calls: `$m->put(...)` / `$v->update(...)` / `$v->append(...)` / `$m->remove(...)`. Variadic forms keep the runtime path (#2090)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -96,6 +96,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypedAssocConjDissoc($node)) {
+            return true;
+        }
+
         return self::isTypedBinaryOp($node);
     }
 
@@ -194,6 +198,69 @@ final readonly class CallSpecialization
     public static function isTypedSeqAccessor(CallNode $node): bool
     {
         return self::typedSeqMethodName($node) !== null;
+    }
+
+    /**
+     * `(assoc coll k v)` 3-arg / `(conj coll x)` 2-arg / `(dissoc coll k)` 2-arg
+     * specialise to a direct method call when the target carries an
+     * inferred persistent-collection tag:
+     *
+     *  - `PersistentMapInterface`  → `put` / `cons` (n/a) / `remove`
+     *  - `PersistentVectorInterface` → `update` / `append` / (n/a)
+     *
+     * Skips variadic / extra-arg arities — those need a loop the runtime
+     * dispatch handles separately.
+     */
+    public static function typedAssocConjDissocMethod(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        $target = $args[0] ?? null;
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        $argCount = count($args);
+
+        if ($name === 'assoc' && $argCount === 3) {
+            return match ($tag) {
+                PersistentMapInterface::class => 'put',
+                PersistentVectorInterface::class => 'update',
+                default => null,
+            };
+        }
+
+        if ($name === 'conj' && $argCount === 2) {
+            return match ($tag) {
+                PersistentVectorInterface::class => 'append',
+                default => null,
+            };
+        }
+
+        if ($name === 'dissoc' && $argCount === 2 && $tag === PersistentMapInterface::class) {
+            return 'remove';
+        }
+
+        return null;
+    }
+
+    public static function isTypedAssocConjDissoc(CallNode $node): bool
+    {
+        return self::typedAssocConjDissocMethod($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -321,6 +321,7 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(', $loc);
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
+
         $rest = array_slice($args, 1);
         $count = count($rest);
         foreach ($rest as $i => $arg) {

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -17,6 +17,7 @@ use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\PhpStringEscape;
 use Phel\Lang\Symbol;
 
+use function array_slice;
 use function assert;
 use function count;
 
@@ -174,6 +175,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedAssocConjDissoc($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedBinaryOp($node)) {
             return;
         }
@@ -295,6 +300,36 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitNode($args[0]);
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
         $this->outputEmitter->emitNode($args[1]);
+        $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(assoc m k v)` / `(assoc v i x)` / `(conj v x)` /
+     * `(dissoc m k)` to a direct persistent-collection method when the
+     * target tag is known. Skips variadic forms.
+     */
+    private function tryEmitTypedAssocConjDissoc(CallNode $node): bool
+    {
+        $method = CallSpecialization::typedAssocConjDissocMethod($node);
+        if ($method === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->' . $method . '(', $loc);
+        $rest = array_slice($args, 1);
+        $count = count($rest);
+        foreach ($rest as $i => $arg) {
+            $this->outputEmitter->emitNode($arg);
+            if ($i < $count - 1) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+        }
+
         $this->outputEmitter->emitStr('))', $loc);
         return true;
     }

--- a/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
+++ b/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [^"\Phel\Lang\Collections\Map\PersistentMapInterface" m
+     ^"\Phel\Lang\Collections\Vector\PersistentVectorInterface" v]
+  [(assoc m :k 1) (conj v 99) (dissoc m :k)])
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, \Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  static $__phel_const_0, $__phel_const_1;
+  return \Phel::vector([($m->put(($__phel_const_0 ??= \Phel::keyword("k")), 1)), ($v->append(99)), ($m->remove(($__phel_const_1 ??= \Phel::keyword("k"))))]);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -96,6 +96,77 @@ final class CallSpecializationTest extends TestCase
         self::assertNull(CallSpecialization::typedSeqMethodName($node));
     }
 
+    public function test_assoc_on_typed_map_specialises_to_put(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            new LiteralNode($env, 'k'),
+            new LiteralNode($env, 1),
+        ]);
+
+        self::assertSame('put', CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_assoc_on_typed_vector_specialises_to_update(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->vectorLocal('v'),
+            new LiteralNode($env, 0),
+            new LiteralNode($env, 42),
+        ]);
+
+        self::assertSame('update', CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_conj_on_typed_vector_specialises_to_append(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('conj', [
+            $this->vectorLocal('v'),
+            new LiteralNode($env, 99),
+        ]);
+
+        self::assertSame('append', CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_dissoc_on_typed_map_specialises_to_remove(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('dissoc', [
+            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            new LiteralNode($env, 'k'),
+        ]);
+
+        self::assertSame('remove', CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_variadic_assoc_is_not_specialised(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('assoc', [
+            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            new LiteralNode($env, 'k1'),
+            new LiteralNode($env, 1),
+            new LiteralNode($env, 'k2'),
+            new LiteralNode($env, 2),
+        ]);
+
+        self::assertNull(CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
+    public function test_conj_on_untyped_local_falls_back(): void
+    {
+        $env = $this->env();
+        $node = $this->coreCall('conj', [
+            new LocalVarNode($env, Symbol::create('v')),
+            new LiteralNode($env, 99),
+        ]);
+
+        self::assertNull(CallSpecialization::typedAssocConjDissocMethod($node));
+    }
+
     private function env(): NodeEnvironment
     {
         return NodeEnvironment::empty()->withExpressionContext();

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
@@ -100,7 +101,7 @@ final class CallSpecializationTest extends TestCase
     {
         $env = $this->env();
         $node = $this->coreCall('assoc', [
-            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            $this->localWithTag('m', PersistentMapInterface::class),
             new LiteralNode($env, 'k'),
             new LiteralNode($env, 1),
         ]);
@@ -135,7 +136,7 @@ final class CallSpecializationTest extends TestCase
     {
         $env = $this->env();
         $node = $this->coreCall('dissoc', [
-            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            $this->localWithTag('m', PersistentMapInterface::class),
             new LiteralNode($env, 'k'),
         ]);
 
@@ -146,7 +147,7 @@ final class CallSpecializationTest extends TestCase
     {
         $env = $this->env();
         $node = $this->coreCall('assoc', [
-            $this->localWithTag('m', Phel\Lang\Collections\Map\PersistentMapInterface::class),
+            $this->localWithTag('m', PersistentMapInterface::class),
             new LiteralNode($env, 'k1'),
             new LiteralNode($env, 1),
             new LiteralNode($env, 'k2'),


### PR DESCRIPTION
## 🤔 Background

#2090 (Phase 3 of the emitter optimisation roadmap #2087) atom 4: `assoc` / `conj` / `dissoc` on tagged persistent collections.

## 💡 Goal

3-arg `(assoc m k v)` / `(assoc v i x)`, 2-arg `(conj v x)`, and 2-arg `(dissoc m k)` lower to a single PHP method call on the target when the analyser knows the target type.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php`
  - new `typedAssocConjDissocMethod` predicate covering 3 fns × 2 collection arms
  - wired into `isSpecialized`
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php`
  - new `tryEmitTypedAssocConjDissoc` branch that emits `($target->method(arg...))`
- `tests/php/Unit/.../CallSpecializationTest.php` — 6 new cases (assoc-map, assoc-vector, conj-vector, dissoc-map, variadic-assoc skip, untyped fallback)
- `tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test`
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `composer test-core` 5645 tests, 0 failures
- `vendor/bin/phpunit --testsuite=integration` 747 tests, 0 failures
- `composer phpstan` clean

Refactor pass: no new helpers needed; the existing `localWithTag` (introduced in #2115) covers the unit test surface.

## Trade-offs / non-goals

- Variadic `assoc` (`(assoc m k1 v1 k2 v2 ...)`) keeps the runtime loop.
- `conj` on `PersistentListInterface` / `PersistentHashSetInterface` is not specialised yet — those use different methods (`cons` / `add`) and add a second tag dimension; out of scope for atom 4.
- `dissoc` on vector is not a thing (`dissoc` is map-only in Phel).

Closes — see roadmap #2090 (4/6); related: #2087