### PR TITLE
perf(compiler): apply direct positional call on fixed-arity globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `CallSpecialization`: `(count v)` and `(nth v i)` lower to direct `$v->count()` / `$v->get($i)` method calls when the analyser has tagged `v` as `PersistentVectorInterface`. The runtime `phel.core/nth` body walks a `cond` over set / seq / vector / map / php-array; the typed path collapses every branch (#2090)
 - `CallSpecialization`: `(first s)` and `(rest s)` lower to `$s->first()` / `$s->rest()` when the target is tagged as a `SeqInterface`, `PersistentVectorInterface`, or `PersistentListInterface`. `next` stays generic because it needs a runtime empty-rest check that a single method call cannot reproduce (#2090)
 - `CallSpecialization`: 3-arg `(assoc m k v)` / `(assoc v i x)`, 2-arg `(conj v x)`, and 2-arg `(dissoc m k)` lower to direct persistent-collection method calls: `$m->put(...)` / `$v->update(...)` / `$v->append(...)` / `$m->remove(...)`. Variadic forms keep the runtime path (#2090)
+- `ApplyEmitter`: `(apply f [a b c])` lowers to a direct positional invocation `($f)->__invoke($a, $b, $c)` when `f` is a fixed-arity `GlobalVarNode` (per `min-arity` meta) and the final argument is a syntactic vector literal whose length matches the declared arity. Skips the `Seq::toApplyArguments` walk and `...` spread for that shape. Variadic fns or non-vector trailing args keep the generic spread path (#2090)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php
@@ -6,13 +6,18 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\ApplyNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\IterableTarget;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Lang\Keyword;
 use Phel\Lang\Seq;
 
+use function array_slice;
 use function assert;
 use function count;
+use function is_int;
 
 final class ApplyEmitter implements NodeEmitterInterface
 {
@@ -87,11 +92,80 @@ final class ApplyEmitter implements NodeEmitterInterface
 
     private function noPhpVarNode(ApplyNode $node): void
     {
+        if ($this->tryEmitDirectPositionalApply($node)) {
+            return;
+        }
+
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         $this->outputEmitter->emitNode($node->getFn());
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
         $this->outputEmitter->emitStr('(', $node->getStartSourceLocation());
         $this->emitArguments($node);
         $this->outputEmitter->emitStr(')', $node->getStartSourceLocation());
+    }
+
+    /**
+     * `(apply f [a b c])` where `f` is a fixed-arity `GlobalVarNode`
+     * whose declared `min-arity` matches `#leading + #vec-elements`
+     * lowers to a positional invocation. The vector literal is
+     * unfolded into individual arguments, skipping the
+     * `Seq::toApplyArguments` walk that the generic spread path
+     * would emit.
+     *
+     * Skips variadic fns (`is-variadic`) and any final argument that
+     * is not a syntactic `VectorNode`.
+     */
+    private function tryEmitDirectPositionalApply(ApplyNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        $arguments = $node->getArguments();
+        if ($arguments === []) {
+            return false;
+        }
+
+        $lastArg = $arguments[count($arguments) - 1];
+        if (!$lastArg instanceof VectorNode) {
+            return false;
+        }
+
+        $meta = $fn->getMeta();
+        $isVariadic = $meta->find('is-variadic') ?? $meta->find(Keyword::create('is-variadic'));
+        if ($isVariadic !== false) {
+            return false;
+        }
+
+        $minArity = $meta->find('min-arity') ?? $meta->find(Keyword::create('min-arity'));
+        if (!is_int($minArity)) {
+            return false;
+        }
+
+        $leading = count($arguments) - 1;
+        $vecElements = $lastArg->getArgs();
+        $expected = $leading + count($vecElements);
+        if ($minArity !== $expected) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($fn);
+        $this->outputEmitter->emitStr(')->__invoke(', $loc);
+
+        $leadingArgs = array_slice($arguments, 0, $leading);
+        $positional = [...$leadingArgs, ...$vecElements];
+        $total = count($positional);
+        foreach ($positional as $i => $arg) {
+            $this->outputEmitter->emitNode($arg);
+            if ($i < $total - 1) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+        }
+
+        $this->outputEmitter->emitStr(')', $loc);
+        return true;
     }
 }

--- a/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
+++ b/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
@@ -1,0 +1,25 @@
+--PHEL--
+(defn add3 [a b c] (+ a b c))
+(apply add3 [1 2 3])
+--PHP--
+\Phel::addDefinition(
+  "user",
+  "add3",
+  new class() extends \Phel\Lang\AbstractFn {
+    public const BOUND_TO = "user\\add3";
+
+    public function __invoke($a, $b, $c) {
+      static $__phel_call_0;
+      return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, $b, $c);
+    }
+  },
+  \Phel::map(
+    \Phel::keyword("doc"), "```phel\n(add3 a b c)\n```\n",
+    \Phel::keyword("start-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
+    \Phel::keyword("end-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
+    "min-arity", 3,
+    "is-variadic", false,
+    "arglists", "[a b c]"
+  )
+);
+(\Phel::getDefinition("user", "add3"))->__invoke(1, 2, 3);


### PR DESCRIPTION
## 🤔 Background

#2090 (Phase 3 of the emitter optimisation roadmap #2087) atom 5: direct positional `(apply f literal-vec)`.

The generic `ApplyEmitter` for `GlobalVarNode` targets emits `(\$f)(...\Phel\Lang\Seq::toApplyArguments(\$vec))`. The walk + spread overhead is pure waste when the analyser already knows the trailing argument is a syntactic vector literal and the fn's declared arity matches.

## 💡 Goal

`(apply add3 [1 2 3])` → `(\$f)->__invoke(1, 2, 3)`. No spread, no `Seq` walk, just a positional `__invoke`.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/ApplyEmitter.php`
  - new `tryEmitDirectPositionalApply` branch in `noPhpVarNode`
  - guarded by: `GlobalVarNode` callee, fixed-arity meta (`is-variadic: false`, integer `min-arity`), final `VectorNode` arg of matching length
- `tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test`
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`

## Validation

- `composer test-core` 5645 tests, 0 failures
- `vendor/bin/phpunit --testsuite=integration` 748 tests, 0 failures
- `composer phpstan` clean

## Trade-offs / non-goals

- Variadic targets keep the spread path — the trailing vector represents the rest-args bundle, not an unfolded positional list.
- Non-vector trailing arg keeps the generic path even if the arity would happen to match — the simplifier needs a syntactic `VectorNode` to unfold without a runtime probe.
- Multi-arity fns are skipped (analyser publishes a single `min-arity`; matching against multiple arities needs a richer specialiser).

Closes — see roadmap #2090 (5/6); related: #2087