### PR TITLE
perf(compiler): not-eq peephole over typed = specialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - `CallSpecialization`: `(first s)` and `(rest s)` lower to `$s->first()` / `$s->rest()` when the target is tagged as a `SeqInterface`, `PersistentVectorInterface`, or `PersistentListInterface`. `next` stays generic because it needs a runtime empty-rest check that a single method call cannot reproduce (#2090)
 - `CallSpecialization`: 3-arg `(assoc m k v)` / `(assoc v i x)`, 2-arg `(conj v x)`, and 2-arg `(dissoc m k)` lower to direct persistent-collection method calls: `$m->put(...)` / `$v->update(...)` / `$v->append(...)` / `$m->remove(...)`. Variadic forms keep the runtime path (#2090)
 - `ApplyEmitter`: `(apply f [a b c])` lowers to a direct positional invocation `($f)->__invoke($a, $b, $c)` when `f` is a fixed-arity `GlobalVarNode` (per `min-arity` meta) and the final argument is a syntactic vector literal whose length matches the declared arity. Skips the `Seq::toApplyArguments` walk and `...` spread for that shape. Variadic fns or non-vector trailing args keep the generic spread path (#2090)
+- `CallSpecialization`: `(not (= a b))` peephole emits `($a !== $b)` directly when the inner `=` is already specialisable to `===` (both operands typed primitives). Skips the `phel.core/not` dispatch and the `!` wrapper that would otherwise sit on top of the inline equality op (#2090)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -100,6 +100,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isNotEqPeephole($node)) {
+            return true;
+        }
+
         return self::isTypedBinaryOp($node);
     }
 
@@ -261,6 +265,50 @@ final readonly class CallSpecialization
     public static function isTypedAssocConjDissoc(CallNode $node): bool
     {
         return self::typedAssocConjDissocMethod($node) !== null;
+    }
+
+    /**
+     * `(not (= a b))` where the inner `=` is already typed-binary-op
+     * specialisable (`===` between two typed primitives). The
+     * peephole emits `($a !== $b)` directly, sparing the runtime
+     * `phel.core/not` dispatch and the `!` wrapper.
+     *
+     * Returns the inner `=` `CallNode` so the emitter can splice the
+     * args between `!==`.
+     */
+    public static function notEqPeepholeInner(CallNode $node): ?CallNode
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'not'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $inner = $args[0];
+        if (!$inner instanceof CallNode) {
+            return null;
+        }
+
+        if (self::typedBinaryOpName($inner) !== '===') {
+            return null;
+        }
+
+        return $inner;
+    }
+
+    public static function isNotEqPeephole(CallNode $node): bool
+    {
+        return self::notEqPeepholeInner($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -308,7 +308,7 @@ final readonly class CallSpecialization
 
     public static function isNotEqPeephole(CallNode $node): bool
     {
-        return self::notEqPeepholeInner($node) !== null;
+        return self::notEqPeepholeInner($node) instanceof CallNode;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -318,7 +318,7 @@ final class CallEmitter implements NodeEmitterInterface
     private function tryEmitNotEqPeephole(CallNode $node): bool
     {
         $inner = CallSpecialization::notEqPeepholeInner($node);
-        if ($inner === null) {
+        if (!$inner instanceof CallNode) {
             return false;
         }
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -179,6 +179,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitNotEqPeephole($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedBinaryOp($node)) {
             return;
         }
@@ -301,6 +305,30 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
         $this->outputEmitter->emitNode($args[1]);
         $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * `(not (= a b))` peephole over the typed-`=` specialiser:
+     * emits `($a !== $b)` directly, skipping both `phel.core/not`
+     * and the explicit `!(($a === $b))` wrapper.
+     *
+     * Eligibility lives on {@see CallSpecialization::notEqPeepholeInner()}.
+     */
+    private function tryEmitNotEqPeephole(CallNode $node): bool
+    {
+        $inner = CallSpecialization::notEqPeepholeInner($node);
+        if ($inner === null) {
+            return false;
+        }
+
+        $args = $inner->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr(' !== ', $loc);
+        $this->outputEmitter->emitNode($args[1]);
+        $this->outputEmitter->emitStr(')', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/not-eq-peephole.test
+++ b/tests/php/Integration/Fixtures/Call/not-eq-peephole.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int a ^int b] (not (= a b)))
+--PHP--
+(function(int $a, int $b) {
+  return ($a !== $b);
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -170,7 +170,7 @@ final class CallSpecializationTest extends TestCase
 
     public function test_not_eq_peephole_fires_when_inner_eq_is_typed(): void
     {
-        $env = $this->env();
+        $this->env();
         $inner = $this->coreCall('=', [
             $this->localWithTag('a', 'int'),
             $this->localWithTag('b', 'int'),
@@ -194,7 +194,7 @@ final class CallSpecializationTest extends TestCase
 
     public function test_not_eq_peephole_skips_when_outer_is_not_not(): void
     {
-        $env = $this->env();
+        $this->env();
         $inner = $this->coreCall('=', [
             $this->localWithTag('a', 'int'),
             $this->localWithTag('b', 'int'),

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/CallSpecializationTest.php
@@ -168,6 +168,42 @@ final class CallSpecializationTest extends TestCase
         self::assertNull(CallSpecialization::typedAssocConjDissocMethod($node));
     }
 
+    public function test_not_eq_peephole_fires_when_inner_eq_is_typed(): void
+    {
+        $env = $this->env();
+        $inner = $this->coreCall('=', [
+            $this->localWithTag('a', 'int'),
+            $this->localWithTag('b', 'int'),
+        ]);
+        $outer = $this->coreCall('not', [$inner]);
+
+        self::assertSame($inner, CallSpecialization::notEqPeepholeInner($outer));
+    }
+
+    public function test_not_eq_peephole_skips_when_inner_eq_is_untyped(): void
+    {
+        $env = $this->env();
+        $inner = $this->coreCall('=', [
+            new LocalVarNode($env, Symbol::create('a')),
+            new LocalVarNode($env, Symbol::create('b')),
+        ]);
+        $outer = $this->coreCall('not', [$inner]);
+
+        self::assertNull(CallSpecialization::notEqPeepholeInner($outer));
+    }
+
+    public function test_not_eq_peephole_skips_when_outer_is_not_not(): void
+    {
+        $env = $this->env();
+        $inner = $this->coreCall('=', [
+            $this->localWithTag('a', 'int'),
+            $this->localWithTag('b', 'int'),
+        ]);
+        $outer = $this->coreCall('inc', [$inner]);
+
+        self::assertNull(CallSpecialization::notEqPeepholeInner($outer));
+    }
+
     private function env(): NodeEnvironment
     {
         return NodeEnvironment::empty()->withExpressionContext();


### PR DESCRIPTION
## 🤔 Background

#2090 (Phase 3 of the emitter optimisation roadmap #2087) atom 6: `(not (= a b))` peephole.

Phase 3 atom 1 (variadic numeric chain) stays deferred (BigInt overflow correctness). With this atom merged Phase 3 is functionally complete: 5/6 atoms in main, 1 deferred.

## 💡 Goal

`(fn [^int a ^int b] (not (= a b)))` emits `(\$a !== \$b)` directly instead of routing through `phel.core/not` + the `\$a === \$b` specialiser.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php` — new `notEqPeepholeInner` predicate returns the inner `=` `CallNode` when both layers are specialisable; wired into `isSpecialized`.
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php` — new `tryEmitNotEqPeephole` branch emits `(\$a !== \$b)`.
- `tests/php/Unit/.../CallSpecializationTest.php` — 3 new cases (positive, untyped fallback, wrong outer fn).
- `tests/php/Integration/Fixtures/Call/not-eq-peephole.test`.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`.

## Validation

- `composer test-core` 5645 tests, 0 failures.
- `vendor/bin/phpunit --testsuite=integration` 749 tests, 0 failures.
- `composer phpstan` clean.
- Manual `./bin/phel compile`:
  - `(fn [^int a ^int b] (not (= a b)))` → `return (\$a !== \$b);`
  - `(fn [^int a ^int b] (not (= a 0)))` → `return (\$a !== 0);`
  - `(fn [a b] (not (= a b)))` → keeps runtime dispatch.

## Trade-offs / non-goals

- Peephole fires only when the inner `=` already qualifies for `===` specialisation (both operands typed `int`/`float`/`bool`/`string` per `EQUALITY_PRIMITIVE_TAGS`). Untyped operands keep the full `phel.core/not (= ...)` chain.
- `(not= a b)` is the user-facing core fn that already maps to `!==` directly through `ConstantFolder` for literals and through a future variadic atom for locals; the peephole here covers the idiomatic `(not (= …))` shape that survives macro expansion.

Closes — see roadmap #2090 (6/6 active, 1 deferred), Phase 3 functionally complete; related: #2087