### PR TITLE
feat(compiler): CompileOptions::setOptimizationLevel infra flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - `CallSpecialization`: 3-arg `(assoc m k v)` / `(assoc v i x)`, 2-arg `(conj v x)`, and 2-arg `(dissoc m k)` lower to direct persistent-collection method calls: `$m->put(...)` / `$v->update(...)` / `$v->append(...)` / `$m->remove(...)`. Variadic forms keep the runtime path (#2090)
 - `ApplyEmitter`: `(apply f [a b c])` lowers to a direct positional invocation `($f)->__invoke($a, $b, $c)` when `f` is a fixed-arity `GlobalVarNode` (per `min-arity` meta) and the final argument is a syntactic vector literal whose length matches the declared arity. Skips the `Seq::toApplyArguments` walk and `...` spread for that shape. Variadic fns or non-vector trailing args keep the generic spread path (#2090)
 - `CallSpecialization`: `(not (= a b))` peephole emits `($a !== $b)` directly when the inner `=` is already specialisable to `===` (both operands typed primitives). Skips the `phel.core/not` dispatch and the `!` wrapper that would otherwise sit on top of the inline equality op (#2090)
+- `CompileOptions::setOptimizationLevel(int)` flag (defaults `0`). Reserved for Phase 5 / 6 of the emitter optimisation roadmap: `1` = auto-inline private `defn-`, `2` = hoist loop-invariant exprs out of recur loops. Today no caller consults the flag; it ships as the wiring infrastructure those phases need (#2092)
 
 ### Fixed
 

--- a/src/php/Shared/CompileOptions.php
+++ b/src/php/Shared/CompileOptions.php
@@ -14,6 +14,20 @@ final class CompileOptions
 
     public const bool DEFAULT_EMIT_ONLY = false;
 
+    /**
+     * Roadmap of optimisation levels gated behind this option:
+     *
+     *  - `0` (default): every experimental optimisation phase is off
+     *  - `1`: Phase 5 — auto-inline single-expression private `defn-`
+     *  - `2`: Phase 6 — hoist loop-invariant exprs out of recur loops
+     *
+     * Phases that ship as default-on (e.g. `ConstantFolder`,
+     * `LetSimplifier`) do not consult this flag; only phases whose
+     * behaviour change is observable across stack traces / profiling
+     * output gate themselves here.
+     */
+    public const int DEFAULT_OPTIMIZATION_LEVEL = 0;
+
     private string $source = self::DEFAULT_SOURCE;
 
     private int $startingLine = self::DEFAULT_STARTING_LINE;
@@ -21,6 +35,8 @@ final class CompileOptions
     private bool $isEnableSourceMaps = self::DEFAULT_ENABLE_SOURCE_MAPS;
 
     private bool $emitOnly = self::DEFAULT_EMIT_ONLY;
+
+    private int $optimizationLevel = self::DEFAULT_OPTIMIZATION_LEVEL;
 
     public function getSource(): string
     {
@@ -66,6 +82,18 @@ final class CompileOptions
     public function setEmitOnly(bool $emitOnly): self
     {
         $this->emitOnly = $emitOnly;
+
+        return $this;
+    }
+
+    public function getOptimizationLevel(): int
+    {
+        return $this->optimizationLevel;
+    }
+
+    public function setOptimizationLevel(int $level): self
+    {
+        $this->optimizationLevel = max(0, $level);
 
         return $this;
     }

--- a/tests/php/Unit/Shared/CompileOptionsOptimizationLevelTest.php
+++ b/tests/php/Unit/Shared/CompileOptionsOptimizationLevelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Shared;
+
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+final class CompileOptionsOptimizationLevelTest extends TestCase
+{
+    public function test_default_optimization_level_is_zero(): void
+    {
+        self::assertSame(0, new CompileOptions()->getOptimizationLevel());
+    }
+
+    public function test_set_level_round_trips(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+
+        self::assertSame(2, $options->getOptimizationLevel());
+    }
+
+    public function test_negative_level_clamps_to_zero(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(-5);
+
+        self::assertSame(0, $options->getOptimizationLevel());
+    }
+
+    public function test_set_level_returns_same_instance(): void
+    {
+        $options = new CompileOptions();
+
+        self::assertSame($options, $options->setOptimizationLevel(1));
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2092 (Phase 5 of the emitter optimisation roadmap #2087) atom 1: the `optimizationLevel` infra flag.

Phases 5 and 6 of the roadmap change observable program behaviour beyond emitted PHP (stack traces, profile output, lazy-eval order). Those phases ship default-off, and the `--optimization-level N` knob is the future opt-in.

This PR lands the wiring only. No phase consumes the flag yet — Phase 4, 5 (atom 2), and 6 will all read it when their analyser passes are written.

## 💡 Goal

A single `CompileOptions::setOptimizationLevel(int)` setter + `getOptimizationLevel(): int` getter, defaulting to `0`, documented level semantics.

## 🔖 Changes

- `src/php/Shared/CompileOptions.php` — new `optimizationLevel` property + setter (clamps negative input to `0`) + getter. `DEFAULT_OPTIMIZATION_LEVEL` exposed as `public const`.
- `tests/php/Unit/Shared/CompileOptionsOptimizationLevelTest.php` — 4 cases: default, round-trip, negative clamp, fluent return.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`.

## Validation

- `composer test-core` 5645 tests, 0 failures.
- `vendor/bin/phpunit --testsuite=integration` 749 tests, 0 failures.
- `composer phpstan` clean.

Refactor pass: addition is a single property + accessor pair on an existing value object; nothing to extract or dedup.

## Trade-offs

- Default `0` keeps every consumer at current behaviour. Reading `getOptimizationLevel()` from a downstream is a 1-line `if` gate.
- Negative values clamp to `0` rather than throwing — callers passing user input (e.g. CLI flag) need not validate.

Closes — see roadmap #2092 (1/2, atom 2 follows); related: #2087