### PR TITLE
perf(compiler): lower case / cond chains to PHP match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - `ApplyEmitter`: `(apply f [a b c])` lowers to a direct positional invocation `($f)->__invoke($a, $b, $c)` when `f` is a fixed-arity `GlobalVarNode` (per `min-arity` meta) and the final argument is a syntactic vector literal whose length matches the declared arity. Skips the `Seq::toApplyArguments` walk and `...` spread for that shape. Variadic fns or non-vector trailing args keep the generic spread path (#2090)
 - `CallSpecialization`: `(not (= a b))` peephole emits `($a !== $b)` directly when the inner `=` is already specialisable to `===` (both operands typed primitives). Skips the `phel.core/not` dispatch and the `!` wrapper that would otherwise sit on top of the inline equality op (#2090)
 - `CompileOptions::setOptimizationLevel(int)` flag (defaults `0`). Reserved for Phase 5 / 6 of the emitter optimisation roadmap: `1` = auto-inline private `defn-`, `2` = hoist loop-invariant exprs out of recur loops. Today no caller consults the flag; it ships as the wiring infrastructure those phases need (#2092)
+- `LetEmitter`: lower a `case` / `cond` shape (nested `if` chain inside a `let` whose tests all compare the same shadow against primitive literal keys) to a single PHP `match` expression. Arm keys and arm bodies must reduce to primitive literals (`int` / `string` / `bool` / `Keyword`). Walks transitively through the per-arm let rebinds Phel's `case` macro generates. Skips `loop` lets and statement-context lets (#2091)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\QuoteNode;
+use Phel\Lang\Keyword;
+use Phel\Shared\CompilerConstants;
+
+use function count;
+use function in_array;
+use function is_bool;
+use function is_int;
+use function is_string;
+
+/**
+ * Detects the post-macroexpansion shape of a `case` / `cond`:
+ *
+ *   (let [g1 e]
+ *     (if (= g1 lit1) lit-then1
+ *       (let [g2 g1]
+ *         (if (= g2 lit2) lit-then2
+ *           ... lit-fallback))))
+ *
+ * where every test compares a (transitively rebound) shadow of the
+ * outer let's binding against a primitive literal. Phel's `case`
+ * macro is recursive and wraps each test in its own `let`, so the
+ * walker threads the active shadow through both `LetNode` and
+ * `IfNode` layers.
+ *
+ * Arm bodies and the fallback must reduce to primitive literal
+ * values (`LiteralNode` or `QuoteNode` wrapping an int / string /
+ * bool / Keyword) so the emitter can render them via `emitLiteral`
+ * directly — bypassing the context-prefix machinery that would
+ * inject `return …;` inside a match arm and break PHP syntax.
+ */
+final readonly class IfChainMatchLowerer
+{
+    /** @var list<string> */
+    private const array EQUALITY_FNS = ['=', 'equals1'];
+
+    /**
+     * Sentinel: returning `null` would collide with the legitimate
+     * `LiteralNode(null)` value (Phel's `nil`).
+     */
+    private const string NOT_FOLDABLE = "\0NOT_FOLDABLE\0";
+
+    /**
+     * @return array{init: AbstractNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed}|null
+     */
+    public static function analyse(LetNode $root): ?array
+    {
+        $bindings = $root->getBindings();
+        if ($root->isLoop() || count($bindings) !== 1) {
+            return null;
+        }
+
+        $binding = $bindings[0];
+        $body = $root->getBodyExpr();
+        if (!$body instanceof DoNode || $body->getStmts() !== []) {
+            return null;
+        }
+
+        $activeShadow = $binding->getShadow()->getName();
+        $current = $body->getRet();
+
+        $arms = [];
+        while (true) {
+            if ($current instanceof IfNode) {
+                $key = self::matchEqualityTest($current->getTestExpr(), $activeShadow);
+                if ($key === self::NOT_FOLDABLE) {
+                    return null;
+                }
+
+                $then = self::literalValue($current->getThenExpr());
+                if ($then === self::NOT_FOLDABLE) {
+                    return null;
+                }
+
+                $arms[] = ['key' => $key, 'expr' => $then];
+                $current = $current->getElseExpr();
+                continue;
+            }
+
+            if ($current instanceof LetNode && !$current->isLoop()) {
+                $innerBindings = $current->getBindings();
+                if (count($innerBindings) !== 1) {
+                    break;
+                }
+
+                $innerBinding = $innerBindings[0];
+                $innerInit = $innerBinding->getInitExpr();
+                if (!$innerInit instanceof LocalVarNode
+                    || $innerInit->getName()->getName() !== $activeShadow
+                ) {
+                    break;
+                }
+
+                $activeShadow = $innerBinding->getShadow()->getName();
+
+                $innerBody = $current->getBodyExpr();
+                if (!$innerBody instanceof DoNode || $innerBody->getStmts() !== []) {
+                    break;
+                }
+
+                $current = $innerBody->getRet();
+                continue;
+            }
+
+            break;
+        }
+
+        $fallback = self::literalValue($current);
+        if (count($arms) < 2 || $fallback === self::NOT_FOLDABLE) {
+            return null;
+        }
+
+        return [
+            'init' => $binding->getInitExpr(),
+            'arms' => $arms,
+            'fallback' => $fallback,
+        ];
+    }
+
+    private static function literalValue(AbstractNode $node): mixed
+    {
+        if ($node instanceof LiteralNode) {
+            $value = $node->getValue();
+            return self::isPrimitive($value) ? $value : self::NOT_FOLDABLE;
+        }
+
+        if ($node instanceof QuoteNode) {
+            $value = $node->getValue();
+            return self::isPrimitive($value) ? $value : self::NOT_FOLDABLE;
+        }
+
+        return self::NOT_FOLDABLE;
+    }
+
+    private static function matchEqualityTest(AbstractNode $test, string $activeShadow): mixed
+    {
+        if (!$test instanceof CallNode) {
+            return self::NOT_FOLDABLE;
+        }
+
+        $fn = $test->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return self::NOT_FOLDABLE;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || !in_array($fn->getName()->getName(), self::EQUALITY_FNS, true)
+        ) {
+            return self::NOT_FOLDABLE;
+        }
+
+        $args = $test->getArguments();
+        if (count($args) !== 2) {
+            return self::NOT_FOLDABLE;
+        }
+
+        [$lhs, $rhs] = $args;
+
+        if ($lhs instanceof LocalVarNode && $lhs->getName()->getName() === $activeShadow) {
+            return self::literalValue($rhs);
+        }
+
+        if ($rhs instanceof LocalVarNode && $rhs->getName()->getName() === $activeShadow) {
+            return self::literalValue($lhs);
+        }
+
+        return self::NOT_FOLDABLE;
+    }
+
+    private static function isPrimitive(mixed $value): bool
+    {
+        return is_int($value)
+            || is_string($value)
+            || is_bool($value)
+            || $value instanceof Keyword;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -19,6 +19,10 @@ final class LetEmitter implements NodeEmitterInterface
     {
         assert($node instanceof LetNode);
 
+        if ($this->tryEmitAsMatch($node)) {
+            return;
+        }
+
         $isWrapFn = $node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION);
         if ($isWrapFn) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
@@ -47,5 +51,48 @@ final class LetEmitter implements NodeEmitterInterface
         if ($isWrapFn) {
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
         }
+    }
+
+    /**
+     * Lower a `case` / `cond`-shaped `LetNode` to a single PHP `match`
+     * expression. See {@see IfChainMatchLowerer} for the detection
+     * rules.
+     *
+     * Only fires when the let is in expression / return context — PHP
+     * `match` always evaluates the dispatch, so dropping the result
+     * in statement context is wasted work the generic if/else path
+     * handles cheaper.
+     */
+    private function tryEmitAsMatch(LetNode $node): bool
+    {
+        $env = $node->getEnv();
+        if ($env->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
+            return false;
+        }
+
+        $shape = IfChainMatchLowerer::analyse($node);
+        if ($shape === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitContextPrefix($env, $loc);
+        $this->outputEmitter->emitStr('match (', $loc);
+        $this->outputEmitter->emitNode($shape['init']);
+        $this->outputEmitter->emitStr(') { ', $loc);
+
+        foreach ($shape['arms'] as $arm) {
+            $this->outputEmitter->emitLiteral($arm['key']);
+            $this->outputEmitter->emitStr(' => ', $loc);
+            $this->outputEmitter->emitLiteral($arm['expr']);
+            $this->outputEmitter->emitStr(', ', $loc);
+        }
+
+        $this->outputEmitter->emitStr('default => ', $loc);
+        $this->outputEmitter->emitLiteral($shape['fallback']);
+        $this->outputEmitter->emitStr(' }', $loc);
+        $this->outputEmitter->emitContextSuffix($env, $loc);
+
+        return true;
     }
 }

--- a/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (case x 1 :one 2 :two 3 :three :other))
+--PHP--
+(function($x) {
+  static $__phel_const_0, $__phel_const_1, $__phel_const_2, $__phel_const_3, $__phel_call_0, $__phel_call_1, $__phel_call_2;
+  return match ($x) { 1 => \Phel::keyword("one"), 2 => \Phel::keyword("two"), 3 => \Phel::keyword("three"), default => \Phel::keyword("other") };
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowererTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowererTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\IfChainMatchLowerer;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompilerConstants;
+use PHPUnit\Framework\TestCase;
+
+final class IfChainMatchLowererTest extends TestCase
+{
+    public function test_detects_two_arm_case_chain(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $shadow = Symbol::create('g_1');
+        $binding = new BindingNode($env, Symbol::create('g'), $shadow, new LocalVarNode($env, Symbol::create('x')));
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, $shadow, 1),
+            new LiteralNode($env, 'one'),
+            new IfNode(
+                $env,
+                $this->equalityTest($env, $shadow, 2),
+                new LiteralNode($env, 'two'),
+                new LiteralNode($env, 'other'),
+            ),
+        );
+        $let = new LetNode($env, [$binding], new DoNode($env, [], $chain), false);
+
+        $shape = IfChainMatchLowerer::analyse($let);
+
+        self::assertNotNull($shape);
+        self::assertCount(2, $shape['arms']);
+        self::assertSame(1, $shape['arms'][0]['key']);
+        self::assertSame('one', $shape['arms'][0]['expr']);
+        self::assertSame('other', $shape['fallback']);
+    }
+
+    public function test_rejects_single_arm_chain(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $shadow = Symbol::create('g_2');
+        $binding = new BindingNode($env, Symbol::create('g'), $shadow, new LocalVarNode($env, Symbol::create('x')));
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, $shadow, 1),
+            new LiteralNode($env, 'one'),
+            new LiteralNode($env, 'other'),
+        );
+        $let = new LetNode($env, [$binding], new DoNode($env, [], $chain), false);
+
+        self::assertNull(IfChainMatchLowerer::analyse($let));
+    }
+
+    public function test_rejects_loop_let(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $shadow = Symbol::create('g_3');
+        $binding = new BindingNode($env, Symbol::create('g'), $shadow, new LiteralNode($env, 1));
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, $shadow, 1),
+            new LiteralNode($env, 'one'),
+            new IfNode(
+                $env,
+                $this->equalityTest($env, $shadow, 2),
+                new LiteralNode($env, 'two'),
+                new LiteralNode($env, 'other'),
+            ),
+        );
+        $let = new LetNode($env, [$binding], new DoNode($env, [], $chain), true);
+
+        self::assertNull(IfChainMatchLowerer::analyse($let));
+    }
+
+    public function test_rejects_non_literal_arm_body(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $shadow = Symbol::create('g_4');
+        $binding = new BindingNode($env, Symbol::create('g'), $shadow, new LiteralNode($env, 1));
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, $shadow, 1),
+            new LocalVarNode($env, Symbol::create('non-literal')),
+            new IfNode(
+                $env,
+                $this->equalityTest($env, $shadow, 2),
+                new LiteralNode($env, 'two'),
+                new LiteralNode($env, 'other'),
+            ),
+        );
+        $let = new LetNode($env, [$binding], new DoNode($env, [], $chain), false);
+
+        self::assertNull(IfChainMatchLowerer::analyse($let));
+    }
+
+    private function equalityTest(NodeEnvironment $env, Symbol $shadow, int $key): CallNode
+    {
+        return new CallNode(
+            $env,
+            new GlobalVarNode(
+                $env,
+                CompilerConstants::PHEL_CORE_NAMESPACE,
+                Symbol::create('='),
+                Phel::map(),
+            ),
+            [
+                new LocalVarNode($env, $shadow),
+                new LiteralNode($env, $key),
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2091 (Phase 4 of #2087) atoms 1 + 2: detect the nested-`if` shape that `case` and shape-eligible `cond` expand to, and lower it to a single PHP `match` expression. Gives PHP an actual dispatch table and skips per-branch `phel.core/equals1` calls.

## 💡 Goal

`(fn [x] (case x 1 :one 2 :two 3 :three :other))` should compile to:

```php
(function(\$x) {
  static \$__phel_const_0, \$__phel_const_1, \$__phel_const_2, \$__phel_const_3, …;
  return match (\$x) {
    1 => \\Phel::keyword(\"one\"),
    2 => \\Phel::keyword(\"two\"),
    3 => \\Phel::keyword(\"three\"),
    default => \\Phel::keyword(\"other\"),
  };
});
```

instead of the nested `if (Phel::equals1(…))` chain that the macro expansion produces.

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php` — new pattern walker. Threads the active shadow through both `IfNode` and the per-arm `LetNode` rebinds Phel's `case` macro generates; validates that every test compares against the same shadow and that arm bodies / fallback reduce to primitive literals (`LiteralNode` or `QuoteNode` wrapping `int` / `string` / `bool` / `Keyword`).
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php` — new `tryEmitAsMatch` branch fires at the outermost `LetNode`. Emits `match (init) { key => value, … default => fallback }` directly via `emitLiteral`, sidestepping the context-prefix machinery that would inject `return …;` inside a match arm and break PHP syntax. Skips statement-context lets (match would discard its result) and `loop` lets (recur semantics).
- `tests/php/Unit/.../NodeEmitter/IfChainMatchLowererTest.php` — 4 cases: two-arm chain detection, single-arm rejection, loop-let rejection, non-literal arm rejection.
- `tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test` — end-to-end fixture.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`.

## Validation

- `composer test-core` 5645 tests, 0 failures.
- `vendor/bin/phpunit --testsuite=integration` 749 tests, 0 failures.
- `composer phpstan` clean.
- Manual `./bin/phel compile`:
  - `(case x 1 :one 2 :two :other)` → `match (\$x) { 1 => keyword(\"one\"), 2 => keyword(\"two\"), default => keyword(\"other\") }` ✓
  - `(cond (= x :a) 1 (= x :b) 2 :else 99)` keeps generic chain (no outer let; both atoms covered by the single PR — `cond` form requires no let rebind and the same walker would handle it once we hoist the entry point to `IfEmitter`. Tracked as a follow-up.)

## Trade-offs / non-goals

- Arm bodies / fallback restricted to primitive literals (`int`, `string`, `bool`, `Keyword`). Non-literal arm bodies need an env rebase to emit as expressions inside match arms; out of scope here.
- Statement-context `case` keeps the generic if/else chain — `match` would evaluate the dispatch only to throw the result away.
- `cond` shape without an outer `let` (where every test is `(= x …)` with the same `x`) is not yet detected; needs an `IfEmitter` entry point. Tracking as a follow-up while #2091 atom 2's stricter spec waits on it.

Closes — see roadmap #2091 (1/2 covered); related: #2087