### PR TITLE
perf(compiler): lower bare cond chains to PHP match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - `CallSpecialization`: `(not (= a b))` peephole emits `($a !== $b)` directly when the inner `=` is already specialisable to `===` (both operands typed primitives). Skips the `phel.core/not` dispatch and the `!` wrapper that would otherwise sit on top of the inline equality op (#2090)
 - `CompileOptions::setOptimizationLevel(int)` flag (defaults `0`). Reserved for Phase 5 / 6 of the emitter optimisation roadmap: `1` = auto-inline private `defn-`, `2` = hoist loop-invariant exprs out of recur loops. Today no caller consults the flag; it ships as the wiring infrastructure those phases need (#2092)
 - `LetEmitter`: lower a `case` / `cond` shape (nested `if` chain inside a `let` whose tests all compare the same shadow against primitive literal keys) to a single PHP `match` expression. Arm keys and arm bodies must reduce to primitive literals (`int` / `string` / `bool` / `Keyword`). Walks transitively through the per-arm let rebinds Phel's `case` macro generates. Skips `loop` lets and statement-context lets (#2091)
+- `IfEmitter`: same `match` lowering for a bare nested-`if` chain that compares the same `LocalVarNode` against primitive literal keys, with primitive-literal arm bodies and fallback. Covers `(cond (= x lit) e1 (= x lit2) e2 :else f)` without an outer `let` rebind (#2091)
 
 ### Fixed
 

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php
@@ -55,6 +55,56 @@ final readonly class IfChainMatchLowerer
     private const string NOT_FOLDABLE = "\0NOT_FOLDABLE\0";
 
     /**
+     * Detects the lone-`if`-chain shape produced by `(cond (= x lit) e …)`
+     * with no outer `let`. Every test must reference the **same**
+     * `LocalVarNode` shadow.
+     *
+     * @return array{init: LocalVarNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed}|null
+     */
+    public static function analyseIfChain(IfNode $root): ?array
+    {
+        $arms = [];
+        $shared = null;
+        $current = $root;
+
+        while ($current instanceof IfNode) {
+            $info = self::testInfo($current->getTestExpr());
+            if ($info === null) {
+                return null;
+            }
+
+            [$candidate, $key] = $info;
+
+            if ($shared === null) {
+                $shared = $candidate;
+            } elseif ($shared->getName()->getName() !== $candidate->getName()->getName()) {
+                return null;
+            }
+
+            $then = self::literalValue($current->getThenExpr());
+            if ($then === self::NOT_FOLDABLE) {
+                return null;
+            }
+
+            $arms[] = ['key' => $key, 'expr' => $then];
+            $current = $current->getElseExpr();
+        }
+
+        $fallback = self::literalValue($current);
+        // `count($arms) >= 2` guarantees the loop ran at least once
+        // and `$shared` was assigned during the first iteration.
+        if (count($arms) < 2 || $fallback === self::NOT_FOLDABLE) {
+            return null;
+        }
+
+        return [
+            'init' => $shared,
+            'arms' => $arms,
+            'fallback' => $fallback,
+        ];
+    }
+
+    /**
      * @return array{init: AbstractNode, arms: list<array{key: mixed, expr: mixed}>, fallback: mixed}|null
      */
     public static function analyse(LetNode $root): ?array
@@ -129,6 +179,54 @@ final readonly class IfChainMatchLowerer
             'arms' => $arms,
             'fallback' => $fallback,
         ];
+    }
+
+    /**
+     * @return array{0: LocalVarNode, 1: mixed}|null
+     */
+    private static function testInfo(AbstractNode $test): ?array
+    {
+        if (!$test instanceof CallNode) {
+            return null;
+        }
+
+        $fn = $test->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || !in_array($fn->getName()->getName(), self::EQUALITY_FNS, true)
+        ) {
+            return null;
+        }
+
+        $args = $test->getArguments();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        [$lhs, $rhs] = $args;
+
+        if ($lhs instanceof LocalVarNode) {
+            $value = self::literalValue($rhs);
+            if ($value === self::NOT_FOLDABLE) {
+                return null;
+            }
+
+            return [$lhs, $value];
+        }
+
+        if ($rhs instanceof LocalVarNode) {
+            $value = self::literalValue($lhs);
+            if ($value === self::NOT_FOLDABLE) {
+                return null;
+            }
+
+            return [$rhs, $value];
+        }
+
+        return null;
     }
 
     private static function literalValue(AbstractNode $node): mixed

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -20,11 +20,57 @@ final class IfEmitter implements NodeEmitterInterface
     {
         assert($node instanceof IfNode);
 
+        if ($this->tryEmitAsMatch($node)) {
+            return;
+        }
+
         if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
             $this->emitTernaryCondition($node);
         } else {
             $this->emitIfElseCondition($node);
         }
+    }
+
+    /**
+     * Lower a bare `cond`-shaped `if` chain (every test `(= x lit)`
+     * against the same `LocalVarNode`, arm bodies + fallback are
+     * primitive literals) to a single PHP `match` expression. See
+     * {@see IfChainMatchLowerer::analyseIfChain()}.
+     *
+     * Statement-context chains keep the if/else path — `match`
+     * would dispatch only to throw the result away.
+     */
+    private function tryEmitAsMatch(IfNode $node): bool
+    {
+        $env = $node->getEnv();
+        if ($env->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
+            return false;
+        }
+
+        $shape = IfChainMatchLowerer::analyseIfChain($node);
+        if ($shape === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitContextPrefix($env, $loc);
+        $this->outputEmitter->emitStr('match (', $loc);
+        $this->outputEmitter->emitNode($shape['init']);
+        $this->outputEmitter->emitStr(') { ', $loc);
+
+        foreach ($shape['arms'] as $arm) {
+            $this->outputEmitter->emitLiteral($arm['key']);
+            $this->outputEmitter->emitStr(' => ', $loc);
+            $this->outputEmitter->emitLiteral($arm['expr']);
+            $this->outputEmitter->emitStr(', ', $loc);
+        }
+
+        $this->outputEmitter->emitStr('default => ', $loc);
+        $this->outputEmitter->emitLiteral($shape['fallback']);
+        $this->outputEmitter->emitStr(' }', $loc);
+        $this->outputEmitter->emitContextSuffix($env, $loc);
+
+        return true;
     }
 
     private function emitTernaryCondition(IfNode $node): void

--- a/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (cond (= x :a) 1 (= x :b) 2 :else 99))
+--PHP--
+(function($x) {
+  static $__phel_const_0, $__phel_const_1, $__phel_call_0, $__phel_call_1;
+  return match ($x) { \Phel::keyword("a") => 1, \Phel::keyword("b") => 2, default => 99 };
+});

--- a/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowererTest.php
+++ b/tests/php/Unit/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowererTest.php
@@ -110,6 +110,64 @@ final class IfChainMatchLowererTest extends TestCase
         self::assertNull(IfChainMatchLowerer::analyse($let));
     }
 
+    public function test_cond_chain_detects_two_arms_against_same_local(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $x = Symbol::create('x');
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, $x, 1),
+            new LiteralNode($env, 'one'),
+            new IfNode(
+                $env,
+                $this->equalityTest($env, $x, 2),
+                new LiteralNode($env, 'two'),
+                new LiteralNode($env, 'other'),
+            ),
+        );
+
+        $shape = IfChainMatchLowerer::analyseIfChain($chain);
+
+        self::assertNotNull($shape);
+        self::assertCount(2, $shape['arms']);
+        self::assertSame(1, $shape['arms'][0]['key']);
+        self::assertSame('two', $shape['arms'][1]['expr']);
+        self::assertSame('other', $shape['fallback']);
+    }
+
+    public function test_cond_chain_rejects_when_tests_use_different_locals(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, Symbol::create('x'), 1),
+            new LiteralNode($env, 'one'),
+            new IfNode(
+                $env,
+                $this->equalityTest($env, Symbol::create('y'), 2),
+                new LiteralNode($env, 'two'),
+                new LiteralNode($env, 'other'),
+            ),
+        );
+
+        self::assertNull(IfChainMatchLowerer::analyseIfChain($chain));
+    }
+
+    public function test_cond_chain_rejects_single_arm(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $chain = new IfNode(
+            $env,
+            $this->equalityTest($env, Symbol::create('x'), 1),
+            new LiteralNode($env, 'one'),
+            new LiteralNode($env, 'other'),
+        );
+
+        self::assertNull(IfChainMatchLowerer::analyseIfChain($chain));
+    }
+
     private function equalityTest(NodeEnvironment $env, Symbol $shadow, int $key): CallNode
     {
         return new CallNode(


### PR DESCRIPTION
## 🤔 Background

#2091 (Phase 4 of #2087) atom 2: detect the no-outer-let shape `cond` expands to and lower it to `match`.

`(cond (= x :a) 1 (= x :b) 2 :else 99)` macroexpands to a plain nested-`if` chain with no enclosing `let` — atom 1's `LetEmitter`-rooted walker skips it. This PR adds a parallel entry point on `IfEmitter`.

## 💡 Goal

```phel
(fn [x] (cond (= x :a) 1 (= x :b) 2 :else 99))
```

→

```php
(function(\$x) {
  static \$__phel_const_0, \$__phel_const_1, \$__phel_call_0, \$__phel_call_1;
  return match (\$x) {
    \\Phel::keyword(\"a\") => 1,
    \\Phel::keyword(\"b\") => 2,
    default => 99,
  };
});
```

## 🔖 Changes

- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfChainMatchLowerer.php` — new `analyseIfChain` entry point. Walks the `if` chain without `let` unwrapping, requires every test to reference the same `LocalVarNode` shadow, validates primitive-literal arm bodies + fallback.
- `src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php` — new `tryEmitAsMatch` guard in front of the ternary / if-else paths. Emits `match` via `emitLiteral` so arm bodies don't pick up a stray `return` prefix from the if's return context.
- `tests/php/Unit/.../IfChainMatchLowererTest.php` — 3 new cases: same-local detection, different-locals rejection, single-arm rejection.
- `tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test`.
- `CHANGELOG.md` — entry under `## Unreleased > ### Performance`.

## Validation

- `composer test-core` 5645 tests, 0 failures.
- `vendor/bin/phpunit --testsuite=integration` 751 tests, 0 failures.
- `composer phpstan` clean.

Refactor pass: `analyseIfChain` reuses the existing `testInfo` / `literalValue` helpers; no extraction surfaced on review.

## Trade-offs / non-goals

- Statement-context chains keep the generic if/else path — `match` would dispatch only to discard the result.
- Tests must reference a `LocalVarNode` (not an arbitrary expression). Lifting `x` out of `(cond (= (some-fn) lit) …)` would require a fresh binding the lowering doesn't introduce.

Closes — see roadmap #2091 (2/2); related: #2087