### PR TITLE
fix: preserve REPL runtime namespace after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Control-flow lowering to PHP `match` (#2091):
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)
 - `phel compile`: dry-run no longer executes side-effecting forms; new `CompileOptions` `emitOnly` flag skips the evaluator step (#2095)
 - `defonce`: same-file redefinition is a silent no-op (was `DuplicateDefinitionException`) (#2096)
+- REPL startup now restores runtime `*ns*` to `user`, so `(require [phel.test :as t])` no longer leaves `*ns*` in the last loaded dependency namespace (#2125)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/php/Run/Application/NamespaceLoader.php
+++ b/src/php/Run/Application/NamespaceLoader.php
@@ -75,6 +75,7 @@ final class NamespaceLoader
     private function restoreStartupNamespace(string $namespace): void
     {
         $this->compilerFacade->getGlobalEnvironment()->setNs($namespace);
+        Phel::setVar(CompilerConstants::PHEL_CORE_NAMESPACE, '*ns*', $namespace);
     }
 
     /**

--- a/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
+++ b/tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php
@@ -92,6 +92,40 @@ final class ReplPromptNamespaceTest extends AbstractTestCommand
 
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
+    public function test_repl_require_preserves_current_runtime_namespace(): void
+    {
+        $io = $this->createReplTestIo();
+        $io->setInputs(
+            new InputLine('user:1> ', '*ns*'),
+            new InputLine('user:2> ', '(ns mordor.core)'),
+            new InputLine('mordor.core:3> ', '*ns*'),
+            new InputLine('mordor.core:4> ', '(require [phel.test :as t])'),
+            new InputLine('mordor.core:5> ', '*ns*'),
+            new InputLine('mordor.core:6> ', 'exit'),
+        );
+        $this->prepareRunFactory($io);
+
+        $replStartupFile = __DIR__ . '/../../../../../../resources/repl/startup.phel';
+        new ReplCommand()->setReplStartupFile($replStartupFile)->run(
+            $this->createStub(InputInterface::class),
+            $this->stubOutput(),
+        );
+
+        $outputs = $io->getRawOutputs();
+        self::assertSame('user:1> *ns*' . PHP_EOL, $outputs[2]);
+        self::assertSame('user', $outputs[3]);
+        self::assertSame('user:2> (ns mordor.core)' . PHP_EOL, $outputs[4]);
+        self::assertSame('nil', $outputs[5]);
+        self::assertSame('mordor.core:3> *ns*' . PHP_EOL, $outputs[6]);
+        self::assertSame('mordor.core', $outputs[7]);
+        self::assertSame('mordor.core:4> (require [phel.test :as t])' . PHP_EOL, $outputs[8]);
+        self::assertSame('phel.test', $outputs[9]);
+        self::assertSame('mordor.core:5> *ns*' . PHP_EOL, $outputs[10]);
+        self::assertSame('mordor.core', $outputs[11]);
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_test_runner_error_output_prints_empty_strings_readably(): void
     {
         $io = $this->createReplTestIo();


### PR DESCRIPTION
## 🤔 Background

`phel repl` restored the compiler namespace to `user` after loading the startup namespace and bundled dependencies, but the runtime `phel.core/*ns*` var still reflected the last dependency evaluated during startup. In the reported case, `(require [phel.test :as t])` made that visible as `phel.reflect`.

## 💡 Goal

Closes #2125. Keep the REPL runtime namespace aligned with the prompt/compiler namespace after startup and after requiring `phel.test`.

## 🔖 Changes

- Restore `phel.core/*ns*` alongside `GlobalEnvironment::setNs()` in `NamespaceLoader`.
- Add a REPL integration regression test for `*ns*`, `(require [phel.test :as t])`, then `*ns*` again.
- Document the fix in `CHANGELOG.md`.

Validation:

- `printf '%s\n' '*ns*' '(require [phel.test :as t])' '*ns*' 'exit' | ./bin/phel`
- `vendor/bin/phpunit tests/php/Integration/Run/Command/Repl/ReplPromptNamespaceTest.php`
- `vendor/bin/phpunit tests/php/Integration/Repl/RequireNamespaceTest.php`
- `composer csrun`
- `git diff --check`

Note: `composer test-compiler` still hits the suite's configured 512 MB PHPUnit memory cap on this machine before completion; the same happens when invoking PHPUnit with a higher CLI memory flag because `phpunit.xml.dist` sets `memory_limit=512M`.
