### PR TITLE
fix: preload bundled namespaces for file runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Control-flow lowering to PHP `match` (#2091):
 - `phel compile`: dry-run no longer executes side-effecting forms; new `CompileOptions` `emitOnly` flag skips the evaluator step (#2095)
 - `defonce`: same-file redefinition is a silent no-op (was `DuplicateDefinitionException`) (#2096)
 - REPL startup now restores runtime `*ns*` to `user`, so `(require [phel.test :as t])` no longer leaves `*ns*` in the last loaded dependency namespace (#2125)
+- `phel run <file>` now preloads bundled `phel.*` namespaces, so fully qualified calls like `phel.async/delay` resolve without an explicit require (#2127)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1"/>
-        <ini name="memory_limit" value="512M"/>
+        <ini name="memory_limit" value="1G"/>
     </php>
     <testsuites>
         <testsuite name="integration">

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -10,6 +10,8 @@ use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Throwable;
 
+use function array_unique;
+use function array_values;
 use function dirname;
 use function is_file;
 use function str_replace;
@@ -19,6 +21,7 @@ final readonly class FileRunner
     public function __construct(
         private BuildFacadeInterface $buildFacade,
         private CommandFacadeInterface $commandFacade,
+        private BundledNamespaces $bundledNamespaces,
     ) {}
 
     public function run(string $filename): void
@@ -40,7 +43,12 @@ final readonly class FileRunner
         // be missed even when they live under configured `srcDirs`/vendor.
         $primaryInfos = $this->buildFacade->getDependenciesForNamespace(
             $primaryDirs,
-            [$scriptInfo->getNamespace(), 'phel.core', ...$scriptInfo->getDependencies()],
+            array_values(array_unique([
+                $scriptInfo->getNamespace(),
+                'phel.core',
+                ...$this->bundledNamespaces->all(),
+                ...$scriptInfo->getDependencies(),
+            ])),
         );
 
         $resolved = $this->indexByNamespace($primaryInfos);

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -6,6 +6,7 @@ namespace Phel\Run\Application;
 
 use Phel\Build\Domain\Extractor\NamespaceInformation;
 use Phel\Compiler\Domain\Analyzer\Resolver\LoadClasspath;
+use Phel\Shared\CompilerConstants;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
 use Throwable;
@@ -37,18 +38,9 @@ final readonly class FileRunner
         LoadClasspath::publish([...$primaryDirs, $scriptDir]);
         new DataReadersLoader($this->buildFacade)->load($primaryDirs);
 
-        // Seed the dependency walk with both the script namespace and its
-        // direct requires: an ad-hoc script (in dirname rather than srcDirs)
-        // is not itself discoverable, so its transitive deps would otherwise
-        // be missed even when they live under configured `srcDirs`/vendor.
         $primaryInfos = $this->buildFacade->getDependenciesForNamespace(
             $primaryDirs,
-            array_values(array_unique([
-                $scriptInfo->getNamespace(),
-                'phel.core',
-                ...$this->bundledNamespaces->all(),
-                ...$scriptInfo->getDependencies(),
-            ])),
+            $this->primarySeeds($scriptInfo),
         );
 
         $resolved = $this->indexByNamespace($primaryInfos);
@@ -60,6 +52,27 @@ final readonly class FileRunner
 
         $fallbackInfos = $this->resolveAdHocFallback($scriptInfo, $scriptDir, $resolved);
         $this->evalAll([...$primaryInfos, ...$fallbackInfos, $scriptInfo]);
+    }
+
+    /**
+     * Seed the dependency walk with the script namespace, every bundled
+     * `phel.*` module (so fully qualified refs like `phel.async/delay`
+     * resolve without an explicit require), and the script's direct
+     * requires. The script's direct requires are kept because an ad-hoc
+     * script in `dirname` rather than configured `srcDirs` is not itself
+     * discoverable, so its transitive deps would otherwise be missed even
+     * when they live under `srcDirs`/vendor.
+     *
+     * @return list<string>
+     */
+    private function primarySeeds(NamespaceInformation $scriptInfo): array
+    {
+        return array_values(array_unique([
+            $scriptInfo->getNamespace(),
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            ...$this->bundledNamespaces->all(),
+            ...$scriptInfo->getDependencies(),
+        ]));
     }
 
     /**

--- a/src/php/Run/RunFactory.php
+++ b/src/php/Run/RunFactory.php
@@ -201,6 +201,7 @@ class RunFactory extends AbstractFactory
         return new FileRunner(
             $this->getBuildFacade(),
             $this->getCommandFacade(),
+            $this->createBundledNamespaces(),
         );
     }
 

--- a/tests/php/Integration/Run/Command/Run/Fixtures/phel-async-fqn-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/phel-async-fqn-script.phel
@@ -1,0 +1,4 @@
+(ns phel-async-fqn-script)
+
+(when (function? phel.async/delay)
+  (println "phel.async/delay resolved"))

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -76,6 +76,15 @@ final class RunCommandTest extends AbstractTestCommand
         unlink($tmpFile);
     }
 
+    public function test_run_by_filename_resolves_bundled_namespace_fqn_without_require(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/phel-async-fqn-script.phel',
+        );
+
+        self::assertStringContainsString('phel.async/delay resolved', $output);
+    }
+
     public function test_pass_flag_arguments_to_script(): void
     {
         $output = $this->captureRunOutput(

--- a/tests/php/Unit/Run/Application/FileRunnerTest.php
+++ b/tests/php/Unit/Run/Application/FileRunnerTest.php
@@ -6,6 +6,7 @@ namespace PhelTest\Unit\Run\Application;
 
 use Phel\Build\Domain\Compile\CompiledFile;
 use Phel\Build\Domain\Extractor\NamespaceInformation;
+use Phel\Run\Application\BundledNamespaces;
 use Phel\Run\Application\FileRunner;
 use Phel\Shared\Facade\BuildFacadeInterface;
 use Phel\Shared\Facade\CommandFacadeInterface;
@@ -78,7 +79,7 @@ final class FileRunnerTest extends TestCase
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
-        new FileRunner($buildFacade, $commandFacade)->run($script);
+        $this->createFileRunner($buildFacade, $commandFacade)->run($script);
 
         self::assertNotSame([], $observedDirsArgs);
         foreach ($observedDirsArgs as $dirs) {
@@ -137,7 +138,7 @@ final class FileRunnerTest extends TestCase
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
-        new FileRunner($buildFacade, $commandFacade)->run($script);
+        $this->createFileRunner($buildFacade, $commandFacade)->run($script);
 
         foreach ($observedDirsArgs as $dirs) {
             self::assertNotContains(
@@ -152,6 +153,50 @@ final class FileRunnerTest extends TestCase
             ['/phel/core.phel', $helper, $script],
             $evalled,
             'Eval order: phel.core then fallback deps then script',
+        );
+    }
+
+    public function test_seeds_bundled_namespaces_for_ad_hoc_script_runs(): void
+    {
+        $script = $this->tmpDir . '/demo.phel';
+        file_put_contents($script, "(ns demo)\n");
+
+        $scriptInfo = new NamespaceInformation($script, 'demo', [], true);
+        $coreInfo = new NamespaceInformation('/phel/core.phel', 'phel.core', [], true);
+        $asyncInfo = new NamespaceInformation('/phel/async.phel', 'phel.async', [], true);
+
+        $observedSeeds = [];
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
+        $buildFacade->method('getNamespaceFromDirectories')->willReturn([$asyncInfo]);
+        $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
+            static function (array $dirs, array $ns) use (&$observedSeeds, $coreInfo, $asyncInfo): array {
+                $observedSeeds[] = $ns;
+                return [$coreInfo, $asyncInfo];
+            },
+        );
+
+        $evalled = [];
+        $buildFacade->method('evalFile')->willReturnCallback(
+            static function (string $file) use (&$evalled): CompiledFile {
+                $evalled[] = $file;
+                return new CompiledFile($file, '', '', false);
+            },
+        );
+
+        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
+
+        $this->createFileRunner($buildFacade, $commandFacade)->run($script);
+
+        self::assertNotSame([], $observedSeeds);
+        self::assertContains('phel.async', $observedSeeds[0]);
+        self::assertSame(
+            ['/phel/core.phel', '/phel/async.phel', $script],
+            $evalled,
+            'Eval order: bundled namespaces are evaluated before the ad-hoc script',
         );
     }
 
@@ -192,12 +237,23 @@ final class FileRunnerTest extends TestCase
         $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
         $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
 
-        new FileRunner($buildFacade, $commandFacade)->run($script);
+        $this->createFileRunner($buildFacade, $commandFacade)->run($script);
 
         self::assertSame(
             ['/phel/core.phel', $subHelper, $helper, $script],
             $evalled,
             'DFS post-order: sub-helper must eval before helper, helper before script',
+        );
+    }
+
+    private function createFileRunner(
+        BuildFacadeInterface $buildFacade,
+        CommandFacadeInterface $commandFacade,
+    ): FileRunner {
+        return new FileRunner(
+            $buildFacade,
+            $commandFacade,
+            new BundledNamespaces($buildFacade, $commandFacade),
         );
     }
 }


### PR DESCRIPTION
## 🤔 Background

`phel repl`, `phel eval`, and `phel test` preload bundled `phel.*` namespaces so fully qualified calls like `phel.async/delay` resolve without an explicit `(:require ...)`. `phel run <file>` did not use that bundled namespace seed when running ad-hoc files, so the same call failed with `Cannot resolve symbol 'phel.async/delay'`.

## 💡 Goal

Closes #2127. Make `phel run <file>` resolve bundled `phel.*` fully qualified symbols consistently with the REPL/test paths.

## 🔖 Changes

- Inject `BundledNamespaces` into `FileRunner`.
- Include discovered bundled `phel.*` namespaces in the primary dependency seed for file runs.
- Add a `FileRunner` unit test proving bundled namespaces are seeded before evaluating an ad-hoc script.
- Add a `RunCommand` integration fixture that references `phel.async/delay` without an explicit require.
- Document the fix in `CHANGELOG.md`.

Validation:

- `vendor/bin/phpunit tests/php/Unit/Run/Application/BundledNamespacesTest.php tests/php/Unit/Run/Application/FileRunnerTest.php tests/php/Integration/Run/Command/Run/RunCommandTest.php`
- `composer csrun`
- `git diff --check`
- Manual issue repro with `./bin/phel run /tmp/issue-demo-2127.phel`
