### PR TITLE
perf(emitter): mark defstruct-generated classes as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Control-flow lowering to PHP `match` (#2091):
 - `LetEmitter`: `case` / `cond`-shaped nested `if` chain inside a `let` (tests compare the same shadow against primitive literal keys) → `match`. Arms restricted to primitive literals (`int` / `string` / `bool` / `Keyword`)
 - `IfEmitter`: same lowering for bare nested `if` chains comparing the same `LocalVarNode` against primitive literal keys
 
+- `DefStructEmitter`: emit `defstruct`-generated classes as `final` to let PHP OPcache / JIT monomorphise method dispatch. `def-exception` keeps non-final (parent class is user-specified, subclassing chains stay valid); fn-as-class / multi-fn / reify already emit anonymous classes which are implicitly final (#2137)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/DefStructEmitter.php
@@ -105,7 +105,7 @@ final readonly class DefStructEmitter implements NodeEmitterInterface
     private function emitClassHeader(DefStructNode $node): void
     {
         $this->outputEmitter->emitStr(
-            'class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
+            'final class ' . $this->outputEmitter->mungeEncode($node->getName()->getName()) . ' extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct',
             $node->getStartSourceLocation(),
         );
 

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -12,7 +12,7 @@
     public function __invoke() {
       if (!class_exists('user\foo_inside')) {
         eval('namespace user;
-      class foo_inside extends \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct {
+      final class foo_inside extends \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct {
 
         protected const array ALLOWED_KEYS = [\'a\'];
 

--- a/tests/php/Integration/Fixtures/Def/defstruct-interface-without-methods.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-interface-without-methods.test
@@ -9,7 +9,7 @@ interface MyInterfaceWithoutMethods {
 }
 }
 if (!class_exists('user\my_type_with_one_interface_without_methods')) {
-class my_type_with_one_interface_without_methods extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterfaceWithoutMethods {
+final class my_type_with_one_interface_without_methods extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterfaceWithoutMethods {
 
   protected const array ALLOWED_KEYS = ['v'];
 

--- a/tests/php/Integration/Fixtures/Def/defstruct-one-interface.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-one-interface.test
@@ -15,7 +15,7 @@ interface MyInterface {
 }
 }
 if (!class_exists('user\my_type_with_one_interface')) {
-class my_type_with_one_interface extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterface {
+final class my_type_with_one_interface extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyInterface {
 
   protected const array ALLOWED_KEYS = ['v'];
 

--- a/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-two-interfaces.test
@@ -25,7 +25,7 @@ interface MySecondInterface {
 }
 }
 if (!class_exists('user\my_type_with_two_interfaces')) {
-class my_type_with_two_interfaces extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyFirstInterface, \user\MySecondInterface {
+final class my_type_with_two_interfaces extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct implements \user\MyFirstInterface, \user\MySecondInterface {
 
   protected const array ALLOWED_KEYS = ['v'];
 

--- a/tests/php/Integration/Fixtures/Def/defstruct.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct.test
@@ -2,7 +2,7 @@
 (defstruct* my-type [a b c?])
 --PHP--
 if (!class_exists('user\my_type')) {
-class my_type extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+final class my_type extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
 
   protected const array ALLOWED_KEYS = ['a', 'b', 'c?'];
 

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -31,7 +31,7 @@ require_once __DIR__ . '/my_namespace/core.php';
   )
 );
 if (!class_exists('hello_world\abc')) {
-class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
+final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
 
   protected const array ALLOWED_KEYS = ['a'];
 


### PR DESCRIPTION
## 🤔 Background

Issue #2137 proposed marking emitter-generated classes (`fn-as-class`, `multi-fn`, `defstruct`, `def-exception`) as `final` so PHP OPcache and the JIT can monomorphise method dispatch.

While investigating, two constraints narrowed the scope:

- **Anonymous classes** (emitted by `FnAsClassEmitter`, `MultiFnAsClassEmitter`, `ReifyEmitter`) **already are implicitly final** — PHP rejects an explicit `final` modifier on them (`Cannot use the final modifier on an anonymous class`). No change needed.
- **`def-exception`** lets the user specify a parent class and supports chains like `(def-exception SubError MyError)`. Marking it `final` would break subclassing. Skipped.

That leaves **`defstruct`** as the only safe + meaningful target. Defstruct types are concrete value classes; `extend-type` / `extend-protocol` register external dispatch rather than creating subclasses, so no user code relies on subclassing them.

## 💡 Goal

Let PHP OPcache and JIT inline method calls on `defstruct` instances by marking the emitted class `final`.

Closes #2137

## 🔖 Changes

- `DefStructEmitter::emitClassHeader` now emits `final class Name extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct …`.
- Updated integration fixtures under `tests/php/Integration/Fixtures/Def/` and `Ns/munge-ns.test` to reflect the new `final` keyword.
- `CHANGELOG.md` — added entry under `Unreleased / Performance`.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green