### PR TITLE
perf(emitter): emit @var doctags for tagged let / loop bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `DefStructEmitter`: emit `defstruct`-generated classes as `final` to let PHP OPcache / JIT monomorphise method dispatch. `def-exception` keeps non-final (parent class is user-specified, subclassing chains stay valid); fn-as-class / multi-fn / reify already emit anonymous classes which are implicitly final (#2137)
 
+- `LetEmitter`: emit `/** @var T $shadow */` before each tagged `let` / `loop` binding init. Primitives (`int` / `float` / `bool` / `string` / `array`) pass through; class tags get a leading `\` so static analysers resolve from the global namespace. Function params already carry native PHP type hints via `MethodEmitter`, so they are unchanged. Runtime perf is unchanged — docblocks help static analysers (PHPStan / Psalm / IDEs) read the generated PHP, the PHP JIT itself infers types from opcodes (#2136)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -8,12 +8,21 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Keyword;
+use Phel\Lang\Symbol;
 
 use function assert;
+use function in_array;
+use function is_string;
+use function ltrim;
 
 final class LetEmitter implements NodeEmitterInterface
 {
     use WithOutputEmitterTrait;
+
+    /** @var list<string> Tags that map straight to a PHP primitive type */
+    private const array PRIMITIVE_TAGS = ['int', 'float', 'bool', 'string', 'array'];
 
     public function emit(AbstractNode $node): void
     {
@@ -29,6 +38,14 @@ final class LetEmitter implements NodeEmitterInterface
         }
 
         foreach ($node->getBindings() as $bindingNode) {
+            $docType = $this->doctagType($bindingNode->getSymbol());
+            if ($docType !== null) {
+                $this->outputEmitter->emitLine(
+                    '/** @var ' . $docType . ' $' . $this->outputEmitter->mungeEncode($bindingNode->getShadow()->getName()) . ' */',
+                    $bindingNode->getStartSourceLocation(),
+                );
+            }
+
             $this->outputEmitter->emitPhpVariable($bindingNode->getShadow(), $bindingNode->getStartSourceLocation());
             $this->outputEmitter->emitStr(' = ', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($bindingNode->getInitExpr());
@@ -94,5 +111,35 @@ final class LetEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitContextSuffix($env, $loc);
 
         return true;
+    }
+
+    /**
+     * Map a binding symbol's `:tag` meta to a PHP doctag type string,
+     * or `null` when the binding carries no tag. Primitive tags pass
+     * through; anything else is treated as a class FQN and prefixed
+     * with `\` so static analysers resolve it from the global namespace.
+     */
+    private function doctagType(Symbol $symbol): ?string
+    {
+        $meta = $symbol->getMeta();
+        if (!$meta instanceof PersistentMapInterface) {
+            return null;
+        }
+
+        $tag = $meta->find(Keyword::create('tag'));
+        if ($tag instanceof Symbol) {
+            $tag = $tag->getName();
+        }
+
+        if (!is_string($tag) || $tag === '') {
+            return null;
+        }
+
+        $normalised = ltrim($tag, '\\');
+        if (in_array($normalised, self::PRIMITIVE_TAGS, true)) {
+            return $normalised;
+        }
+
+        return '\\' . $normalised;
     }
 }

--- a/tests/php/Integration/Fixtures/Let/let-tagged-bindings.test
+++ b/tests/php/Integration/Fixtures/Let/let-tagged-bindings.test
@@ -1,0 +1,19 @@
+--PHEL--
+(let [^int x 1
+      ^float y 2.5
+      ^bool z true
+      ^string s "hi"
+      ^\Phel\Lang\Collections\Vector\PersistentVectorInterface v [1 2 3]]
+  [x y z s v])
+--PHP--
+/** @var int $x_1 */
+$x_1 = 1;
+/** @var float $y_2 */
+$y_2 = 2.5;
+/** @var bool $z_3 */
+$z_3 = true;
+/** @var string $s_4 */
+$s_4 = "hi";
+/** @var \Phel\Lang\Collections\Vector\PersistentVectorInterface $v_5 */
+$v_5 = \Phel::vector([1, 2, 3]);
+\Phel::vector([$x_1, $y_2, $z_3, $s_4, $v_5]);


### PR DESCRIPTION
## 🤔 Background

Issue #2136 proposed emitting `/** @var T $x */` PHPDoc lines for analyser-tagged locals so PHP OPcache and the JIT could specialise method dispatch. While implementing it I confirmed the JIT actually infers types from bytecode (not from docblocks), so the original runtime-perf framing in the issue is unrealistic.

That said, the change still carries a real win for the static-analysis side: PHPStan / Psalm / IDE inspection of the generated PHP (or of a cached compile output the user diffed) can now read the binding type the analyser already knows.

## 💡 Goal

For every tagged `let` / `loop` binding, emit a `/** @var T $shadow */` line right before the PHP assignment. Function parameters were intentionally left alone — `MethodEmitter::emitParameters` already turns a binding tag into a native PHP type hint, which is a stronger signal than a docblock for both the JIT and static analysers.

Closes #2136

## 🔖 Changes

- `LetEmitter` reads the binding `Symbol`'s `:tag` meta via a new `doctagType()` helper.
- Primitive tags (`int` / `float` / `bool` / `string` / `array`) pass through verbatim; anything else is treated as a class FQN and prefixed with `\` so static analysers resolve from the global namespace.
- New integration fixture `tests/php/Integration/Fixtures/Let/let-tagged-bindings.test` exercises all primitive shapes plus a fully qualified persistent-collection tag.
- `CHANGELOG.md` — entry added under `Unreleased / Performance`, with an honest note that runtime perf is unchanged.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green

## 🔮 Notes for reviewers

- I did **not** wire this into the `FnAsClassEmitter` param emission path — that path already uses native PHP type hints, which is strictly better than a docblock.
- The fixture deliberately references every bound variable so the `LetSimplifier` pass does not drop unused pure-literal bindings before the emitter sees them.