### PR TITLE
fix: propagate type tags through let/loop bindings (closes #2146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Control-flow lowering to PHP `match` (#2091):
 - `defonce`: same-file redefinition is a silent no-op (was `DuplicateDefinitionException`) (#2096)
 - REPL startup now restores runtime `*ns*` to `user`, so `(require [phel.test :as t])` no longer leaves `*ns*` in the last loaded dependency namespace (#2125)
 - `phel run <file>` now preloads bundled `phel.*` namespaces, so fully qualified calls like `phel.async/delay` resolve without an explicit require (#2127)
+- Type-tag plumbing: `^int` / `^float` / `^string` annotations on `let` and `loop` bindings now propagate to references in the body, so the typed-arithmetic specialiser fires inside `let` / `loop` the same way it already does for `fn` params. `(loop [^int i 0] (if (< i n) (recur (+ i 1)) i))` now emits native `($i < $n)` / `($i + 1)` instead of runtime `\Phel::getDefinition("phel.core", "+")->__invoke(...)` dispatch (#2146)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/LocalVarNode.php
@@ -29,13 +29,17 @@ final class LocalVarNode extends AbstractNode
 
     /**
      * Inferred type for this reference, derived from the binding's `:tag`
-     * meta (set by `defn` param tags, `let` `^Type` annotations, and the
-     * `ParamTypeInferrer` pass). Returns `null` when the binding has no
-     * known type — the call site falls back to runtime dispatch.
+     * meta (set by `defn` param tags, `let` / `loop` `^Type` annotations,
+     * and the `ParamTypeInferrer` pass). Returns `null` when the binding
+     * has no known type - the call site falls back to runtime dispatch.
      *
      * `AnalyzeSymbol` builds the `LocalVarNode`'s own `Symbol` from the
-     * call-site syntax, which has no tag of its own, so the lookup walks
-     * the current environment's locals by name to find the typed binding.
+     * call-site syntax. For `fn` params the symbol matches the binding
+     * name verbatim; for `let` / `loop` bindings the symbol carries the
+     * **shadowed** name (e.g. `a_3` for `(let [a 0] ...)`). We therefore
+     * try a direct name match first, then fall back to the env's reverse
+     * shadow lookup so a shadowed reference still resolves to the typed
+     * binding meta.
      */
     public function getInferredType(): ?string
     {
@@ -44,6 +48,11 @@ final class LocalVarNode extends AbstractNode
             if ($local->getName() === $name) {
                 return $this->tagOf($local->getMeta());
             }
+        }
+
+        $shadowedSource = $this->getEnv()->findLocalByShadowedName($name);
+        if ($shadowedSource instanceof Symbol) {
+            return $this->tagOf($shadowedSource->getMeta());
         }
 
         return null;

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironment.php
@@ -74,6 +74,21 @@ final class NodeEnvironment implements NodeEnvironmentInterface
         return array_key_exists($local->getName(), $this->shadowed);
     }
 
+    public function findLocalByShadowedName(string $shadowedName): ?Symbol
+    {
+        foreach ($this->shadowed as $originalName => $shadowSymbol) {
+            if ($shadowSymbol->getName() === $shadowedName) {
+                foreach ($this->locals as $local) {
+                    if ($local->getName() === $originalName) {
+                        return $local;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     public function isContext(string $context): bool
     {
         return $this->context === $context;

--- a/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/NodeEnvironmentInterface.php
@@ -26,6 +26,19 @@ interface NodeEnvironmentInterface extends ContextualEnvironmentInterface
     public function isShadowed(Symbol $local): bool;
 
     /**
+     * Reverse-lookup helper: given the **shadowed** name of a binding
+     * (e.g. `a_3` for `(let [a 0] ...)`), return the original user-facing
+     * local `Symbol` (with its `:tag` meta intact) when one exists in
+     * scope; otherwise `null`.
+     *
+     * Lets a reference whose AST stores the shadowed identifier (as
+     * produced by {@see \Phel\Compiler\Domain\Analyzer\TypeAnalyzer\AnalyzeSymbol})
+     * still recover the binding's analyser metadata - in particular the
+     * `^int` / `^float` tag the call-site specialisers consult.
+     */
+    public function findLocalByShadowedName(string $shadowedName): ?Symbol;
+
+    /**
      * @param array<int, Symbol> $locals
      */
     public function withMergedLocals(array $locals): self;

--- a/tests/php/Integration/Fixtures/Let/let-typed-binding-native-add.test
+++ b/tests/php/Integration/Fixtures/Let/let-typed-binding-native-add.test
@@ -2,6 +2,7 @@
 (fn [^int n] (let [^int a 0] (+ a n)))
 --PHP--
 (function(int $n) {
+  /** @var int $a_1 */
   $a_1 = 0;
   return ($a_1 + $n);
 });

--- a/tests/php/Integration/Fixtures/Let/let-typed-binding-native-add.test
+++ b/tests/php/Integration/Fixtures/Let/let-typed-binding-native-add.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^int n] (let [^int a 0] (+ a n)))
+--PHP--
+(function(int $n) {
+  $a_1 = 0;
+  return ($a_1 + $n);
+});

--- a/tests/php/Integration/Fixtures/Let/let-typed-binding-native-mul.test
+++ b/tests/php/Integration/Fixtures/Let/let-typed-binding-native-mul.test
@@ -2,6 +2,7 @@
 (fn [^float x] (let [^float a 2.0] (* a x)))
 --PHP--
 (function(float $x) {
+  /** @var float $a_1 */
   $a_1 = 2.0;
   return ($a_1 * $x);
 });

--- a/tests/php/Integration/Fixtures/Let/let-typed-binding-native-mul.test
+++ b/tests/php/Integration/Fixtures/Let/let-typed-binding-native-mul.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^float x] (let [^float a 2.0] (* a x)))
+--PHP--
+(function(float $x) {
+  $a_1 = 2.0;
+  return ($a_1 * $x);
+});

--- a/tests/php/Integration/Fixtures/Let/let-untyped-binding-bails.test
+++ b/tests/php/Integration/Fixtures/Let/let-untyped-binding-bails.test
@@ -1,0 +1,8 @@
+--PHEL--
+(fn [^int n] (let [a 0] (+ a n)))
+--PHP--
+(function(int $n) {
+  static $__phel_call_0;
+  $a_1 = 0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a_1, $n);
+});

--- a/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
+++ b/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
@@ -2,6 +2,7 @@
 (fn [^int n] (loop [^int i 0] (if (< i n) (recur (+ i 1)) i)))
 --PHP--
 (function(int $n) {
+  /** @var int $i_1 */
   $i_1 = 0;
   while (true) {
     if (($__truthy = ($i_1 < $n)) !== null && $__truthy !== false) {

--- a/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
+++ b/tests/php/Integration/Fixtures/Let/loop-typed-binding-native-arith.test
@@ -1,0 +1,16 @@
+--PHEL--
+(fn [^int n] (loop [^int i 0] (if (< i n) (recur (+ i 1)) i)))
+--PHP--
+(function(int $n) {
+  $i_1 = 0;
+  while (true) {
+    if (($__truthy = ($i_1 < $n)) !== null && $__truthy !== false) {
+      $i_1 = ($i_1 + 1);
+      continue;
+
+    } else {
+      return $i_1;
+    }
+    break;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #2146. `^int` / `^float` / `^string` annotations on `let` / `loop` bindings now propagate into the body, so the typed-arithmetic specialiser in `CallSpecialization` fires for references to those bindings the same way it already did for `fn` params.

## Root cause

`AnalyzeSymbol::createLocalVarNode` wraps a reference to a `let` / `loop` binding around the binding's **shadowed** symbol (e.g. `a_3` for `(let [a 0] ...)`). The env keeps the original binding under `a` with its `:tag` meta. `LocalVarNode::getInferredType` only walked `getLocals()` by name, so the shadowed name never matched and every typed-binding reference fell back to runtime dispatch.

`fn` params do not get shadowed, which is why `(defn f [^int a ^int b] (+ a b))` already emitted native PHP arithmetic.

## Fix

- Add `NodeEnvironment::findLocalByShadowedName` (and the interface method): reverse-lookup that returns the original local `Symbol` (with `:tag` meta) for a given shadowed name.
- Use it as a fallback in `LocalVarNode::getInferredType` after the direct name match misses.

## Before / after

`(fn [^int n] (let [^int a 0] (+ a n)))`

Before:
```php
(function(int $n) {
  static $__phel_call_0;
  $a_1 = 0;
  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a_1, $n);
});
```

After:
```php
(function(int $n) {
  $a_1 = 0;
  return ($a_1 + $n);
});
```

`(fn [^int n] (loop [^int i 0] (if (< i n) (recur (+ i 1)) i)))`

Before:
```php
(function(int $n) {
  static $__phel_call_0, $__phel_call_1;
  $i_1 = 0;
  while (true) {
    if (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "<"))->__invoke($i_1, $n)) !== null && $__truthy !== false) {
      $i_1 = ($__phel_call_1 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($i_1, 1);
      continue;
    } else {
      return $i_1;
    }
    break;
  }
});
```

After:
```php
(function(int $n) {
  $i_1 = 0;
  while (true) {
    if (($__truthy = ($i_1 < $n)) !== null && $__truthy !== false) {
      $i_1 = ($i_1 + 1);
      continue;
    } else {
      return $i_1;
    }
    break;
  }
});
```

Untyped bindings unchanged (`(let [a 0] (+ a n))` still runtime-dispatches).

## Scope

This is milestone 1 from the issue: honour explicit `^int` / `^float` hints on `let` / `loop` bindings. Milestone 2 (infer from literal initial values + monotonic `recur`) is **not** included; can land separately.

## Test plan

- [x] Four new integration fixtures under `tests/php/Integration/Fixtures/Let/`: typed-add, typed-mul, typed-loop, untyped-bails.
- [x] Full suite: `composer test-compiler` (3673 tests, 0 failures, same 2 warnings / 21 deprecations / 7 skips as baseline).
- [x] Quality: `composer test-quality` (php-cs-fixer dry-run, psalm, phpstan, rector dry-run, validate-config) all green.