### PR TITLE
perf(compiler): specialise (get arr k) on php-array tag to native subscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `LetEmitter`: emit `/** @var T $shadow */` before each tagged `let` / `loop` binding init. Primitives (`int` / `float` / `bool` / `string` / `array`) pass through; class tags get a leading `\` so static analysers resolve from the global namespace. Function params already carry native PHP type hints via `MethodEmitter`, so they are unchanged. Runtime perf is unchanged — docblocks help static analysers (PHPStan / Psalm / IDEs) read the generated PHP, the PHP JIT itself infers types from opcodes (#2136)
 
+- `CallSpecialization`: `(get arr k)` / `(get arr k default)` on a target tagged `array` → `($arr[$k] ?? $default)` native subscript. Skips the runtime `get` dispatch, the type guard cond chain, and the `php/aget` adapter. Matches the runtime semantics (both absent keys and explicit nulls fall through to the default) because the `:else` branch of the Phel `get` body is itself `(if (nil? res) opt res)` (#2139)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -88,6 +88,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypedPhpArrayGet($node)) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -459,6 +463,40 @@ final readonly class CallSpecialization
             PersistentMapInterface::class => 'find',
             default => null,
         };
+    }
+
+    /**
+     * `(get arr k)` or `(get arr k default)` where the analyser has
+     * tagged `arr` as a PHP `array`. The runtime `get` body for the
+     * `:else` branch is `(let [res (php/aget ds k)] (if (nil? res) opt res))`,
+     * which is semantically `$arr[$k] ?? $default` — both absent keys
+     * and explicit null values fall through to the default.
+     */
+    public static function isTypedPhpArrayGet(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'get'
+        ) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $argc = count($args);
+        if ($argc !== 2 && $argc !== 3) {
+            return false;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return false;
+        }
+
+        return self::normalisedTag($target->getInferredType()) === 'array';
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -167,6 +167,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedPhpArrayGet($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -354,6 +358,37 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('->' . $method . '(', $loc);
         $this->outputEmitter->emitNode($args[1]);
         $this->outputEmitter->emitStr('))', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise `(get arr k)` / `(get arr k default)` on a target
+     * tagged `array` to a native PHP subscript with the null-coalescing
+     * fallback. Matches the runtime `get` semantics for PHP arrays —
+     * `(php/aget ds k)` then "if nil return default" — because PHP's
+     * `??` treats both absent keys and explicit nulls as triggering
+     * the fallback.
+     */
+    private function tryEmitTypedPhpArrayGet(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTypedPhpArrayGet($node)) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('[', $loc);
+        $this->outputEmitter->emitNode($args[1]);
+        $this->outputEmitter->emitStr('] ?? ', $loc);
+        if (count($args) === 3) {
+            $this->outputEmitter->emitNode($args[2]);
+        } else {
+            $this->outputEmitter->emitStr('null', $loc);
+        }
+
+        $this->outputEmitter->emitStr(')', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/get-php-array-typed.test
+++ b/tests/php/Integration/Fixtures/Call/get-php-array-typed.test
@@ -1,0 +1,10 @@
+--PHEL--
+(fn [^array a] (get a "k"))
+(fn [^array a] (get a "k" :missing))
+--PHP--
+(function(array $a) {
+  return ($a["k"] ?? null);
+});(function(array $a) {
+  static $__phel_const_0;
+  return ($a["k"] ?? ($__phel_const_0 ??= \Phel::keyword("missing")));
+});


### PR DESCRIPTION
## 🤔 Background

The runtime `get` in `src/phel/core/sequences.phel` walks a `cond` over set / seq / vector / map / php-array shapes. For a target the analyser has already tagged `array`, the only branch that ever fires is the final `:else` clause:

```phel
(let [res (php/aget ds k)]
  (if (nil? res) opt res))
```

Which is the same thing PHP's null-coalescing `??` does — both absent keys and explicit nulls fall through to the default.

So an unspecialised `(get arr k)` call burns:

- a `\Phel::getDefinition("phel.core", "get")` lookup
- a frame for the `get` `__invoke`
- a cond chain that rejects every branch but the last
- a `php/aget` adapter

…just to do what `$arr[$k] ?? $default` does in one bytecode.

## 💡 Goal

Recognise the typed-`(get arr k)` shape in `CallSpecialization` and emit the native subscript directly. Cover both arities (2-arg defaults to `null`, 3-arg uses the provided default).

Closes #2139

## 🔖 Changes

- `CallSpecialization::isTypedPhpArrayGet` — new predicate. Accepts `(get arr k)` and `(get arr k default)` where `arr` is a `LocalVarNode` whose inferred tag normalises to `array`.
- Wired into `CallSpecialization::isSpecialized` next to `isTypedGetAccess` so the cache scanner does not allocate an orphan `$__phel_call_N` slot.
- `CallEmitter::tryEmitTypedPhpArrayGet` — emits `($arr[$k] ?? $default)`.
- Integration fixture `tests/php/Integration/Fixtures/Call/get-php-array-typed.test` covers both arities.
- `CHANGELOG.md` — `Unreleased / Performance` entry with the semantics justification.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green