### PR TITLE
perf(emitter): direct __invoke dispatch on tagged AbstractFn locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: `(get arr k)` / `(get arr k default)` on a target tagged `array` → `($arr[$k] ?? $default)` native subscript. Skips the runtime `get` dispatch, the type guard cond chain, and the `php/aget` adapter. Matches the runtime semantics (both absent keys and explicit nulls fall through to the default) because the `:else` branch of the Phel `get` body is itself `(if (nil? res) opt res)` (#2139)
 
+- `CallEmitter`: invoke calls on a `LocalVarNode` tagged `\Phel\Lang\AbstractFn` (or `\Phel\Lang\FnInterface`) now route through `$f->__invoke(...)` instead of the implicit `$f($args)` magic dispatch. Same code path the global-fn specialiser already uses — removes one magic-method resolution per call site (#2142)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -9,9 +9,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
 use Phel\Shared\CompilerConstants;
@@ -463,6 +465,36 @@ final readonly class CallSpecialization
             PersistentMapInterface::class => 'find',
             default => null,
         };
+    }
+
+    /**
+     * Call whose target is a `LocalVarNode` tagged with the abstract Phel
+     * fn base class (`\Phel\Lang\AbstractFn`) or the marker interface
+     * (`\Phel\Lang\FnInterface`). The generic dispatch path emits
+     * `($f)($args)`, which goes through PHP's `__invoke` magic call.
+     * When the tag asserts the value is an `AbstractFn` (or anything that
+     * implements `FnInterface`), the emitter can call `__invoke` directly
+     * and skip the magic-method resolution.
+     *
+     * The runtime contract is the same `__invoke` signature emitted by
+     * `FnAsClassEmitter`, so a tag mismatch becomes a method-not-found
+     * error at runtime instead of silent fallback — that is a deliberate
+     * trade-off: tags are user-asserted, the emitter trusts them.
+     */
+    public static function isTypedAFnLocal(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof LocalVarNode) {
+            return false;
+        }
+
+        $tag = self::normalisedTag($fn->getInferredType());
+        if ($tag === null) {
+            return false;
+        }
+
+        return $tag === AbstractFn::class
+            || $tag === FnInterface::class;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -195,7 +195,8 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
-        $useCallMethod = !$this->isSelfCall($node) && GlobalCallTarget::isGlobalFnCall($node);
+        $useCallMethod = !$this->isSelfCall($node)
+            && (GlobalCallTarget::isGlobalFnCall($node) || CallSpecialization::isTypedAFnLocal($node));
 
         $this->emitDynamicFunctionName($node);
 

--- a/tests/php/Integration/Fixtures/Call/typed-afn-local-invoke.test
+++ b/tests/php/Integration/Fixtures/Call/typed-afn-local-invoke.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [^\Phel\Lang\AbstractFn f x] (f x))
+(fn [^\Phel\Lang\FnInterface g a b] (g a b))
+--PHP--
+(function(\Phel\Lang\AbstractFn $f, $x) {
+  return ($f)->__invoke($x);
+});(function(\Phel\Lang\FnInterface $g, $a, $b) {
+  return ($g)->__invoke($a, $b);
+});


### PR DESCRIPTION
## 🤔 Background

The global-fn dispatch path in `CallEmitter` already emits `$target->__invoke(...)` rather than the implicit `$target($args)` syntax. That avoids the PHP `__invoke` magic resolution and preserves the concrete `__invoke($a, $b, …)` signature emitted by `FnAsClassEmitter`.

The same trick was missing for local-var call sites, even when the analyser had inferred that the local was an `AbstractFn` (or `FnInterface`) — e.g. a higher-order function receiving another fn as parameter:

```phel
(defn run [^\Phel\Lang\AbstractFn f x] (f x))
```

Without a specialiser this still emits `($f)($x)`, which goes through magic dispatch on every call.

## 💡 Goal

Recognise the typed-AFn-local call shape and route it through the existing `emitCallMethodArguments` path, which already emits `->__invoke(...)`.

Closes #2142

## 🔖 Changes

- `CallSpecialization::isTypedAFnLocal` — new predicate. Matches a `CallNode` whose target is a `LocalVarNode` whose normalised tag is `\Phel\Lang\AbstractFn` or `\Phel\Lang\FnInterface`.
- `CallEmitter::tryEmitCall` flips `$useCallMethod = true` when the predicate matches, so the dispatch path reaches `emitCallMethodArguments` instead of `emitFunctionArguments`.
- No `BodyConstantScanner` change — local-var calls were already excluded from `$__phel_call_N` cache reservation, so no orphan slot can appear.
- Integration fixture `tests/php/Integration/Fixtures/Call/typed-afn-local-invoke.test` covers both supported tags.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green