### PR TITLE
perf(emitter): batch assoc / conj chains on tagged persistents via transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallEmitter`: invoke calls on a `LocalVarNode` tagged `\Phel\Lang\AbstractFn` (or `\Phel\Lang\FnInterface`) now route through `$f->__invoke(...)` instead of the implicit `$f($args)` magic dispatch. Same code path the global-fn specialiser already uses — removes one magic-method resolution per call site (#2142)
 
+- `CallSpecialization`: detect nested `(assoc m k v)` / `(conj v x)` chains on a typed persistent target and emit them as a single transient round-trip — `($m->asTransient()->put($k1,$v1)->put($k2,$v2)->...->persistent())`. After thread-macro expansion `(-> m (assoc :a 1) (assoc :b 2) (assoc :c 3))` collapses to nested `CallNode`s with the leaf tagged `PersistentMapInterface`; previously each level created a new persistent map. Chains of length 1 stay on the existing single-call specialiser (no transient overhead). Same shape for `conj` chains on `PersistentVectorInterface` (#2143)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -18,6 +18,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
 use Phel\Shared\CompilerConstants;
 
+use function array_slice;
 use function count;
 use function in_array;
 use function is_bool;
@@ -103,6 +104,10 @@ final readonly class CallSpecialization
         }
 
         if (self::isTypedAssocConjDissoc($node)) {
+            return true;
+        }
+
+        if (self::isAssocConjChain($node)) {
             return true;
         }
 
@@ -275,6 +280,87 @@ final readonly class CallSpecialization
     public static function isTypedAssocConjDissoc(CallNode $node): bool
     {
         return self::typedAssocConjDissocMethod($node) !== null;
+    }
+
+    /**
+     * Detects an `(-> m (assoc k v) (assoc k v) ...)` or
+     * `(-> v (conj x) (conj y) ...)` chain — after thread-macro
+     * expansion these are nested `CallNode`s of the same op terminating
+     * at a `LocalVarNode` whose tag matches `PersistentMapInterface` or
+     * `PersistentVectorInterface`. A chain of length 1 is **not**
+     * batched: the existing single-call specialiser already lowers it
+     * to a direct method call, and a transient round-trip would just
+     * add work.
+     *
+     * Returns the leaf target, the transient method to spam, and the
+     * argument groups (`[k, v]` pairs for `assoc`, single-element
+     * `[x]` lists for `conj`) — `null` when the call is not a chain.
+     *
+     * @return array{
+     *     target: LocalVarNode,
+     *     method: 'append'|'put',
+     *     groups: list<list<AbstractNode>>
+     * }|null
+     */
+    public static function assocConjChain(CallNode $node): ?array
+    {
+        $shape = self::classifyChainHead($node);
+        if ($shape === null) {
+            return null;
+        }
+
+        [$opName, $expectedArgCount, $method, $expectedTag] = $shape;
+
+        $groups = [];
+        $current = $node;
+        while (true) {
+            $cFn = $current->getFn();
+            if (!$cFn instanceof GlobalVarNode) {
+                return null;
+            }
+
+            if ($cFn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+                || $cFn->getName()->getName() !== $opName
+            ) {
+                return null;
+            }
+
+            $cArgs = $current->getArguments();
+            if (count($cArgs) !== $expectedArgCount) {
+                return null;
+            }
+
+            array_unshift($groups, array_slice($cArgs, 1));
+
+            $target = $cArgs[0];
+            if ($target instanceof CallNode) {
+                $current = $target;
+                continue;
+            }
+
+            if (!$target instanceof LocalVarNode) {
+                return null;
+            }
+
+            if (self::normalisedTag($target->getInferredType()) !== $expectedTag) {
+                return null;
+            }
+
+            if (count($groups) < 2) {
+                return null;
+            }
+
+            return [
+                'target' => $target,
+                'method' => $method,
+                'groups' => $groups,
+            ];
+        }
+    }
+
+    public static function isAssocConjChain(CallNode $node): bool
+    {
+        return self::assocConjChain($node) !== null;
     }
 
     /**
@@ -575,6 +661,25 @@ final readonly class CallSpecialization
         $arg = $args[0];
         return $arg instanceof LocalVarNode
             && self::isPersistentMapTag($arg->getInferredType());
+    }
+
+    /**
+     * @return array{0: string, 1: int, 2: 'append'|'put', 3: class-string}|null
+     */
+    private static function classifyChainHead(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'assoc' => ['assoc', 3, 'put', PersistentMapInterface::class],
+            'conj' => ['conj', 2, 'append', PersistentVectorInterface::class],
+            default => null,
+        };
     }
 
     private static function isStringConcatable(AbstractNode $arg): bool

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -179,6 +179,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitAssocConjChain($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedAssocConjDissoc($node)) {
             return;
         }
@@ -414,6 +418,46 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr(' !== ', $loc);
         $this->outputEmitter->emitNode($args[1]);
         $this->outputEmitter->emitStr(')', $loc);
+        return true;
+    }
+
+    /**
+     * Specialise a chain of `(assoc m k v)` calls (or `(conj v x)`
+     * calls) on a typed persistent target — after thread-macro
+     * expansion these are nested `CallNode`s of the same op rooted at
+     * a `LocalVarNode`. The runtime path goes through one persistent
+     * `put` / `append` per chain step, each allocating a new persistent
+     * map / vector. The transient path opens one transient at the leaf
+     * target, mutates it once per chain step, and snapshots back to a
+     * persistent at the end — N-1 persistent intermediates collapse to
+     * one.
+     */
+    private function tryEmitAssocConjChain(CallNode $node): bool
+    {
+        $chain = CallSpecialization::assocConjChain($node);
+        if ($chain === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('((', $loc);
+        $this->outputEmitter->emitNode($chain['target']);
+        $this->outputEmitter->emitStr(')->asTransient()', $loc);
+
+        foreach ($chain['groups'] as $group) {
+            $this->outputEmitter->emitStr('->' . $chain['method'] . '(', $loc);
+            foreach ($group as $i => $arg) {
+                if ($i > 0) {
+                    $this->outputEmitter->emitStr(', ', $loc);
+                }
+
+                $this->outputEmitter->emitNode($arg);
+            }
+
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
+        $this->outputEmitter->emitStr('->persistent())', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/assoc-conj-chain-transient.test
+++ b/tests/php/Integration/Fixtures/Call/assoc-conj-chain-transient.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m]
+  (assoc (assoc (assoc m :a 1) :b 2) :c 3))
+(fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v]
+  (conj (conj v 1) 2))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  static $__phel_const_0, $__phel_const_1, $__phel_const_2;
+  return (($m)->asTransient()->put(($__phel_const_0 ??= \Phel::keyword("a")), 1)->put(($__phel_const_1 ??= \Phel::keyword("b")), 2)->put(($__phel_const_2 ??= \Phel::keyword("c")), 3)->persistent());
+});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return (($v)->asTransient()->append(1)->append(2)->persistent());
+});


### PR DESCRIPTION
## 🤔 Background

A common builder pattern in Phel:

```phel
(-> m (assoc :a 1) (assoc :b 2) (assoc :c 3))
```

After thread-macro expansion this is a nested `(assoc (assoc (assoc m :a 1) :b 2) :c 3)`. The single-call specialiser landed in #2116 lowers `(assoc m k v)` on a `LocalVarNode` tagged `PersistentMapInterface` to `$m->put($k, $v)`. But that predicate requires the target to be a `LocalVarNode`. In a chain only the inner-most call qualifies — the outer levels see a `CallNode` target, so they fall back to the runtime `assoc` dispatch, and each runtime `put` allocates a new persistent map. N steps → N persistent allocations.

The transient API on `PersistentMapInterface` / `PersistentVectorInterface` already exposes the right primitives (`asTransient` / `put` / `append` / `persistent`). We just need to recognise the chain shape and emit one transient round-trip instead.

## 💡 Goal

Detect the chain at the outer call, walk inside-out to collect the (key, value) groups, and emit a single transient build:

```php
(($m)->asTransient()->put($k1, $v1)->put($k2, $v2)->put($k3, $v3)->persistent())
```

Closes #2143

## 🔖 Changes

- `CallSpecialization::assocConjChain` — walks the chain inside-out. Every level must be the same op (`assoc` or `conj`) at the same arity, terminating at a `LocalVarNode` whose normalised tag matches `PersistentMapInterface` / `PersistentVectorInterface`. Chains of length 1 are excluded so the existing `tryEmitTypedAssocConjDissoc` path keeps handling them (single transient round-trip on one mutation is pure overhead).
- `CallSpecialization::isAssocConjChain` wired into `isSpecialized` so the cache scanner skips reserving a `static $__phel_call_N` slot for the chain head.
- `CallEmitter::tryEmitAssocConjChain` runs **before** `tryEmitTypedAssocConjDissoc` so a chain consumes the outer `CallNode` first; the inner levels become groups of `(k, v)` arguments rather than being visited as independent calls.
- Integration fixture `tests/php/Integration/Fixtures/Call/assoc-conj-chain-transient.test` covers both shapes (3-step assoc-on-map, 2-step conj-on-vector).
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green