### PR TITLE
perf(emitter): lower (or …) / (and …) in if-test position to native short-circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: detect nested `(assoc m k v)` / `(conj v x)` chains on a typed persistent target and emit them as a single transient round-trip — `($m->asTransient()->put($k1,$v1)->put($k2,$v2)->...->persistent())`. After thread-macro expansion `(-> m (assoc :a 1) (assoc :b 2) (assoc :c 3))` collapses to nested `CallNode`s with the leaf tagged `PersistentMapInterface`; previously each level created a new persistent map. Chains of length 1 stay on the existing single-call specialiser (no transient overhead). Same shape for `conj` chains on `PersistentVectorInterface` (#2143)
 
+- `IfEmitter`: lower the expanded `(or …)` / `(and …)` macro shapes to native PHP `||` / `&&` chains when consumed as an `if` test. The recursive `(let [v expr] (if v v rest))` (`or`) / `(let [v expr] (if v rest v))` (`and`) shape collapses to a flat short-circuit chain where each operand is guarded by the inline Phel truthy adapter `(($__truthy = expr) !== null && $__truthy !== false)`. Skips the per-chain IIFE the macro expansion previously forced. Restricted to chains whose every operand is a simple expression (`LocalVarNode` / `LiteralNode` / `GlobalVarNode` / `PhpVarNode` / nested `CallNode` of simple args), so we never need to swap the analyser env on a `LetNode` / `IfNode` operand (#2132)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/AndOrShortCircuitLowerer.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/AndOrShortCircuitLowerer.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\BindingNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+
+use function count;
+
+/**
+ * Detects the shape produced by the `(or …)` and `(and …)` macros after
+ * expansion. Each operand pushes another `(let [v expr] (if v …))`
+ * around the residual chain — so a 3-argument `(or a b c)` becomes
+ *
+ *     (let [v1 a] (if v1 v1 (let [v2 b] (if v2 v2 c))))
+ *
+ * and 3-argument `(and a b c)` is the mirror image, with the chain
+ * continuation as the `then` branch and the binding as the `else`.
+ *
+ * Returns a flat list of operand `AbstractNode`s in argument order, or
+ * `null` when the input does not match the shape, or when any argument
+ * is not a "simple" expression shape — emitting a `LetNode` or `IfNode`
+ * as a chain leaf in `IfEmitter` would require swapping its analyser
+ * env to `EXPRESSION`, which the AST is intentionally immutable about.
+ *
+ * Lowering only runs when the chain is consumed in test position
+ * (`IfEmitter`); native PHP `||` / `&&` collapse to a bool, so the
+ * value-semantics of the Phel forms (returning the first truthy / last
+ * falsy *value*, not a bool) would be broken in expression position.
+ */
+final class AndOrShortCircuitLowerer
+{
+    private const int SHAPE_OR = 1;
+
+    private const int SHAPE_AND = 2;
+
+    /**
+     * @return list<AbstractNode>|null
+     */
+    public static function extractOrChain(AbstractNode $node): ?array
+    {
+        return self::walk($node, self::SHAPE_OR);
+    }
+
+    /**
+     * @return list<AbstractNode>|null
+     */
+    public static function extractAndChain(AbstractNode $node): ?array
+    {
+        return self::walk($node, self::SHAPE_AND);
+    }
+
+    /**
+     * @return list<AbstractNode>|null
+     */
+    private static function walk(AbstractNode $node, int $shape): ?array
+    {
+        $args = self::collect($node, $shape);
+        if ($args === null) {
+            return null;
+        }
+
+        foreach ($args as $arg) {
+            if (!self::isSimpleArg($arg)) {
+                return null;
+            }
+        }
+
+        return $args;
+    }
+
+    /**
+     * @return list<AbstractNode>|null
+     */
+    private static function collect(AbstractNode $node, int $shape): ?array
+    {
+        if (!$node instanceof LetNode) {
+            return null;
+        }
+
+        $bindings = $node->getBindings();
+        if (count($bindings) !== 1) {
+            return null;
+        }
+
+        $binding = $bindings[0];
+
+        $body = $node->getBodyExpr();
+        if ($body instanceof DoNode && $body->getStmts() === []) {
+            $body = $body->getRet();
+        }
+
+        if (!$body instanceof IfNode) {
+            return null;
+        }
+
+        if (!self::referencesBinding($body->getTestExpr(), $binding)) {
+            return null;
+        }
+
+        $shadowExpr = $shape === self::SHAPE_OR ? $body->getThenExpr() : $body->getElseExpr();
+        if (!self::referencesBinding($shadowExpr, $binding)) {
+            return null;
+        }
+
+        $continuation = $shape === self::SHAPE_OR ? $body->getElseExpr() : $body->getThenExpr();
+        if ($continuation instanceof DoNode && $continuation->getStmts() === []) {
+            $continuation = $continuation->getRet();
+        }
+
+        $rest = self::collect($continuation, $shape);
+        if ($rest === null) {
+            $rest = [$continuation];
+        }
+
+        return [$binding->getInitExpr(), ...$rest];
+    }
+
+    private static function referencesBinding(AbstractNode $node, BindingNode $binding): bool
+    {
+        if (!$node instanceof LocalVarNode) {
+            return false;
+        }
+
+        $name = $node->getName()->getName();
+        if ($name === $binding->getShadow()->getName()) {
+            return true;
+        }
+
+        return $name === $binding->getSymbol()->getName();
+    }
+
+    /**
+     * Chain leaves are emitted directly into the surrounding `if (…)`
+     * test position, so each one must produce a PHP expression — not a
+     * sequence of statements wrapped in an IIFE. Accept the shapes the
+     * existing emitters render as a single expression irrespective of
+     * env context, plus `CallNode`s whose own arguments are also
+     * simple (the call itself is `($f)->__invoke($args)`, which is
+     * fine).
+     */
+    private static function isSimpleArg(AbstractNode $node): bool
+    {
+        if ($node instanceof LocalVarNode
+            || $node instanceof LiteralNode
+            || $node instanceof GlobalVarNode
+            || $node instanceof PhpVarNode
+        ) {
+            return true;
+        }
+
+        if ($node instanceof CallNode) {
+            return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::isSimpleArg($child));
+        }
+
+        return false;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -32,6 +32,94 @@ final class IfEmitter implements NodeEmitterInterface
     }
 
     /**
+     * Emit the `if` test expression: either as the lowered native
+     * `(a) || (b) || ...` / `(a) && (b) && ...` chain when the test
+     * is an expanded `(or …)` / `(and …)` form, or as the generic
+     * `($__truthy = expr) !== null && $__truthy !== false` adapter.
+     */
+    private function emitTestExpr(AbstractNode $testExpr): void
+    {
+        if ($this->tryEmitShortCircuitTest($testExpr, AndOrShortCircuitLowerer::extractOrChain($testExpr), '||')) {
+            return;
+        }
+
+        if ($this->tryEmitShortCircuitTest($testExpr, AndOrShortCircuitLowerer::extractAndChain($testExpr), '&&')) {
+            return;
+        }
+
+        $isBool = BooleanExprDetector::isBool($testExpr);
+        if ($isBool) {
+            $this->outputEmitter->emitStr('(', $testExpr->getStartSourceLocation());
+            $this->outputEmitter->emitNode($testExpr);
+            $this->outputEmitter->emitStr(')', $testExpr->getStartSourceLocation());
+            return;
+        }
+
+        $this->outputEmitter->emitStr('($__truthy = ', $testExpr->getStartSourceLocation());
+        $this->outputEmitter->emitNode($testExpr);
+        $this->outputEmitter->emitStr(') !== null && $__truthy !== false', $testExpr->getStartSourceLocation());
+    }
+
+    /**
+     * @param list<AbstractNode>|null $chain
+     */
+    private function tryEmitShortCircuitTest(AbstractNode $testExpr, ?array $chain, string $op): bool
+    {
+        if ($chain === null) {
+            return false;
+        }
+
+        $loc = $testExpr->getStartSourceLocation();
+        foreach ($chain as $i => $arg) {
+            if ($i > 0) {
+                $this->outputEmitter->emitStr(' ' . $op . ' ', $loc);
+            }
+
+            if (BooleanExprDetector::isBool($arg)) {
+                $this->outputEmitter->emitStr('(', $loc);
+                $this->emitNodeAsExpression($arg);
+                $this->outputEmitter->emitStr(')', $loc);
+                continue;
+            }
+
+            $this->outputEmitter->emitStr('(($__truthy = ', $loc);
+            $this->emitNodeAsExpression($arg);
+            $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        }
+
+        return true;
+    }
+
+    /**
+     * Emit a node and strip the analyser's `return ` prefix / trailing
+     * `;` from the captured output — the same node may sit deep inside
+     * a chain whose original env is RETURN, but our chunk is consumed
+     * as a bare expression in the surrounding `if (…)` test position,
+     * so the context decoration would produce invalid PHP.
+     */
+    private function emitNodeAsExpression(AbstractNode $node): void
+    {
+        ob_start();
+        try {
+            $this->outputEmitter->emitNode($node);
+        } finally {
+            $buf = (string) ob_get_clean();
+        }
+
+        $buf = preg_replace('/^return\s+/', '', $buf);
+        if ($buf === null) {
+            $buf = '';
+        }
+
+        $buf = rtrim($buf);
+        if ($buf !== '' && str_ends_with($buf, ';')) {
+            $buf = substr($buf, 0, -1);
+        }
+
+        $this->outputEmitter->emitStr($buf, $node->getStartSourceLocation());
+    }
+
+    /**
      * Lower a bare `cond`-shaped `if` chain (every test `(= x lit)`
      * against the same `LocalVarNode`, arm bodies + fallback are
      * primitive literals) to a single PHP `match` expression. See
@@ -76,18 +164,9 @@ final class IfEmitter implements NodeEmitterInterface
     private function emitTernaryCondition(IfNode $node): void
     {
         $loc = $node->getStartSourceLocation();
-        $isBool = BooleanExprDetector::isBool($node->getTestExpr());
-
-        if ($isBool) {
-            $this->outputEmitter->emitStr('((', $loc);
-            $this->outputEmitter->emitNode($node->getTestExpr());
-            $this->outputEmitter->emitStr(') ? ', $loc);
-        } else {
-            $this->outputEmitter->emitStr('(($__truthy = ', $loc);
-            $this->outputEmitter->emitNode($node->getTestExpr());
-            $this->outputEmitter->emitStr(') !== null && $__truthy !== false ? ', $loc);
-        }
-
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->emitTestExpr($node->getTestExpr());
+        $this->outputEmitter->emitStr(' ? ', $loc);
         $this->outputEmitter->emitNode($node->getThenExpr());
         $this->outputEmitter->emitStr(' : ', $loc);
         $this->outputEmitter->emitNode($node->getElseExpr());
@@ -97,17 +176,9 @@ final class IfEmitter implements NodeEmitterInterface
     private function emitIfElseCondition(IfNode $node): void
     {
         $loc = $node->getStartSourceLocation();
-        $isBool = BooleanExprDetector::isBool($node->getTestExpr());
-
-        if ($isBool) {
-            $this->outputEmitter->emitStr('if ((', $loc);
-            $this->outputEmitter->emitNode($node->getTestExpr());
-            $this->outputEmitter->emitLine(')) {', $loc);
-        } else {
-            $this->outputEmitter->emitStr('if (($__truthy = ', $loc);
-            $this->outputEmitter->emitNode($node->getTestExpr());
-            $this->outputEmitter->emitLine(') !== null && $__truthy !== false) {', $loc);
-        }
+        $this->outputEmitter->emitStr('if (', $loc);
+        $this->emitTestExpr($node->getTestExpr());
+        $this->outputEmitter->emitLine(') {', $loc);
 
         $this->outputEmitter->increaseIndentLevel();
         $this->outputEmitter->emitNode($node->getThenExpr());

--- a/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
+++ b/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
@@ -1,0 +1,21 @@
+--PHEL--
+(fn [a b c] (if (or a b c) :truthy :falsy))
+(fn [a b c] (if (and a b c) :truthy :falsy))
+--PHP--
+(function($a, $b, $c) {
+  static $__phel_const_0, $__phel_const_1;
+  if ((($__truthy = $a) !== null && $__truthy !== false) || (($__truthy = $b) !== null && $__truthy !== false) || (($__truthy = $c) !== null && $__truthy !== false)) {
+    return ($__phel_const_0 ??= \Phel::keyword("truthy"));
+  } else {
+    return ($__phel_const_1 ??= \Phel::keyword("falsy"));
+  }
+
+});(function($a, $b, $c) {
+  static $__phel_const_0, $__phel_const_1;
+  if ((($__truthy = $a) !== null && $__truthy !== false) && (($__truthy = $b) !== null && $__truthy !== false) && (($__truthy = $c) !== null && $__truthy !== false)) {
+    return ($__phel_const_0 ??= \Phel::keyword("truthy"));
+  } else {
+    return ($__phel_const_1 ??= \Phel::keyword("falsy"));
+  }
+
+});


### PR DESCRIPTION
## 🤔 Background

The `(or …)` and `(and …)` macros in `src/phel/core/booleans.phel` expand to nested `(let [v expr] (if v …))` chains. With the binding's body in expression context, the `LetEmitter` wraps the whole thing in an IIFE — so `(if (or a b c) X Y)` compiles to a `(function() use(…) { … })()` call inside the `if` test. That is a closure allocation, a use-clause capture, and a function-call frame per evaluation, all to compute a single boolean.

When the chain sits in an `if` test, only the final boolean matters: native PHP `||` / `&&` short-circuit on the same operand order and yield the same truthiness. Phel's truthy semantics (only `nil` and `false` count as falsy) need the existing inline truthy adapter per operand, but everything else collapses to a flat short-circuit expression.

## 💡 Goal

Recognise the expanded `or` / `and` shape in `IfEmitter`'s test slot and emit a flat short-circuit chain instead of the IIFE.

Closes #2132

## 🔖 Changes

- `AndOrShortCircuitLowerer` (new file in `Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/`) — walks the macro-expanded `LetNode → DoNode? → IfNode` chain inside-out. Recognises operand references via the binding's original symbol *or* its generated shadow (the analyser uses the shadow inside the body). `DoNode` wrapper is unwrapped when it has no statements (only a `ret`). Recursion stops at the trailing operand, which can be any AST node — but the whole chain is rejected unless every operand passes `isSimpleArg` (`LocalVarNode`, `LiteralNode`, `GlobalVarNode`, `PhpVarNode`, or a `CallNode` of simple args), so we never have to swap an immutable analyser env to render a `LetNode` / `IfNode` operand.
- `IfEmitter::emitTestExpr` (new) — consolidates the test-emit path so the ternary (`emitTernaryCondition`) and statement (`emitIfElseCondition`) forms share the same lowering. Tries `extractOrChain` first, then `extractAndChain`, then falls back to the existing bool / truthy adapter.
- `IfEmitter::tryEmitShortCircuitTest` — emits each operand into the chain. Bool-typed operands (per `BooleanExprDetector::isBool`) are emitted bare; others go through the inline truthy adapter `(($__truthy = expr) !== null && $__truthy !== false)`. `$__truthy` is reused between operands — the assignment is fully evaluated before the surrounding `||` / `&&` reads it.
- Integration fixture `tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test` covers 3-operand `or` and `and` in if-test position.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ⚠ Restriction & why

Value-position semantics differ between Phel and PHP: `(or 0 5)` returns `0` in Phel (`0` is truthy), but native `||` returns `true`. So lowering is **only** applied in `IfEmitter`'s test slot, where the surrounding `if (…)` discards everything except truthiness anyway.

The `isSimpleArg` gate exists because chain operands inherit their original analyser env (typically `RETURN`), and the corresponding emitters honour that — `LocalVarNode` in `RETURN` context emits `return $x;`. Capturing and stripping the `return ` / `;` decorations works for simple shapes but breaks when an operand is itself a `LetNode` or `IfNode` whose `RETURN`-context emission is multi-statement.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green