### PR TITLE
perf(emitter): emit keyword literals via Keyword::create directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `IfEmitter`: lower the expanded `(or …)` / `(and …)` macro shapes to native PHP `||` / `&&` chains when consumed as an `if` test. The recursive `(let [v expr] (if v v rest))` (`or`) / `(let [v expr] (if v rest v))` (`and`) shape collapses to a flat short-circuit chain where each operand is guarded by the inline Phel truthy adapter `(($__truthy = expr) !== null && $__truthy !== false)`. Skips the per-chain IIFE the macro expansion previously forced. Restricted to chains whose every operand is a simple expression (`LocalVarNode` / `LiteralNode` / `GlobalVarNode` / `PhpVarNode` / nested `CallNode` of simple args), so we never need to swap the analyser env on a `LetNode` / `IfNode` operand (#2132)
 
+- `LiteralEmitter`: emit keyword literals as `\Phel\Lang\Keyword::create("name")` directly instead of routing through the `\Phel::keyword(...)` facade. Same intern-pool semantics (identity is preserved), skips one static-call frame per cache miss and lets OPcache inline the factory (#2131)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/LiteralEmitter.php
@@ -185,12 +185,12 @@ final readonly class LiteralEmitter
     {
         if ($x->getNamespace() !== null) {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . PhpStringEscape::doubleQuoted($x->getName()) . '", "' . PhpStringEscape::doubleQuoted($x->getNamespace()) . '")',
+                '\Phel\Lang\Keyword::create("' . PhpStringEscape::doubleQuoted($x->getName()) . '", "' . PhpStringEscape::doubleQuoted($x->getNamespace()) . '")',
                 $x->getStartLocation(),
             );
         } else {
             $this->outputEmitter->emitStr(
-                '\Phel::keyword("' . PhpStringEscape::doubleQuoted($x->getName()) . '")',
+                '\Phel\Lang\Keyword::create("' . PhpStringEscape::doubleQuoted($x->getName()) . '")',
                 $x->getStartLocation(),
             );
         }

--- a/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
+++ b/tests/php/Integration/Fixtures/Call/apply-fixed-arity-direct.test
@@ -14,9 +14,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add3 a b c)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add3 a b c)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/apply-fixed-arity-direct.test", 1, 29),
     "min-arity", 3,
     "is-variadic", false,
     "arglists", "[a b c]"

--- a/tests/php/Integration/Fixtures/Call/assoc-conj-chain-transient.test
+++ b/tests/php/Integration/Fixtures/Call/assoc-conj-chain-transient.test
@@ -6,7 +6,7 @@
 --PHP--
 (function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
   static $__phel_const_0, $__phel_const_1, $__phel_const_2;
-  return (($m)->asTransient()->put(($__phel_const_0 ??= \Phel::keyword("a")), 1)->put(($__phel_const_1 ??= \Phel::keyword("b")), 2)->put(($__phel_const_2 ??= \Phel::keyword("c")), 3)->persistent());
+  return (($m)->asTransient()->put(($__phel_const_0 ??= \Phel\Lang\Keyword::create("a")), 1)->put(($__phel_const_1 ??= \Phel\Lang\Keyword::create("b")), 2)->put(($__phel_const_2 ??= \Phel\Lang\Keyword::create("c")), 3)->persistent());
 });(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
   return (($v)->asTransient()->append(1)->append(2)->persistent());
 });

--- a/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
+++ b/tests/php/Integration/Fixtures/Call/assoc-conj-dissoc-typed.test
@@ -5,5 +5,5 @@
 --PHP--
 (function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, \Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
   static $__phel_const_0, $__phel_const_1;
-  return \Phel::vector([($m->put(($__phel_const_0 ??= \Phel::keyword("k")), 1)), ($v->append(99)), ($m->remove(($__phel_const_1 ??= \Phel::keyword("k"))))]);
+  return \Phel::vector([($m->put(($__phel_const_0 ??= \Phel\Lang\Keyword::create("k")), 1)), ($v->append(99)), ($m->remove(($__phel_const_1 ??= \Phel\Lang\Keyword::create("k"))))]);
 });

--- a/tests/php/Integration/Fixtures/Call/get-php-array-typed.test
+++ b/tests/php/Integration/Fixtures/Call/get-php-array-typed.test
@@ -6,5 +6,5 @@
   return ($a["k"] ?? null);
 });(function(array $a) {
   static $__phel_const_0;
-  return ($a["k"] ?? ($__phel_const_0 ??= \Phel::keyword("missing")));
+  return ($a["k"] ?? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("missing")));
 });

--- a/tests/php/Integration/Fixtures/Call/global-call.test
+++ b/tests/php/Integration/Fixtures/Call/global-call.test
@@ -14,8 +14,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Call/global-call.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/global-call.test", 1, 18),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/global-call.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/global-call.test", 1, 18),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Call/keyword-find-on-persistent-map-local.test
+++ b/tests/php/Integration/Fixtures/Call/keyword-find-on-persistent-map-local.test
@@ -3,5 +3,5 @@
 --PHP--
 (function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
   static $__phel_const_0;
-  return ($m->find(($__phel_const_0 ??= \Phel::keyword("k"))));
+  return ($m->find(($__phel_const_0 ??= \Phel\Lang\Keyword::create("k"))));
 });

--- a/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
+++ b/tests/php/Integration/Fixtures/Call/non-fn-global-call-skipped.test
@@ -5,12 +5,12 @@
 \Phel::addDefinition(
   "user",
   "k",
-  \Phel::keyword("a"),
+  \Phel\Lang\Keyword::create("a"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/non-fn-global-call-skipped.test", 1, 10)
   )
 );
 (\Phel::getDefinition("user", "k"))(\Phel::map(
-  \Phel::keyword("a"), 1
+  \Phel\Lang\Keyword::create("a"), 1
 ));

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -14,8 +14,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Call/php-fn-reference.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 37),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-fn-reference.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 37),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[f xs]"

--- a/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-push-global-reference.test
@@ -7,8 +7,8 @@
   "arr",
   array(1, 2, 3),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Call/php-push-global-reference.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/php-push-global-reference.test", 1, 27)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-push-global-reference.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-push-global-reference.test", 1, 27)
   )
 );
 (\Phel::getDefinitionReference("user", "arr"))[] = 4;

--- a/tests/php/Integration/Fixtures/Call/self-call-direct.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-direct.test
@@ -12,9 +12,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Call/self-call-direct.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/self-call-direct.test", 1, 22),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/self-call-direct.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/self-call-direct.test", 1, 22),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -17,9 +17,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Call/self-call-with-if.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Call/self-call-with-if.test", 1, 52),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/self-call-with-if.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/self-call-with-if.test", 1, 52),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/keyword-in-fn-body.test
@@ -3,5 +3,5 @@
 --PHP--
 (function($m) {
   static $__phel_const_0, $__phel_const_1, $__phel_const_2;
-  return \Phel::vector([(($__phel_const_0 ??= \Phel::keyword("foo")))($m), (($__phel_const_1 ??= \Phel::keyword("foo")))($m), (($__phel_const_2 ??= \Phel::keyword("bar")))($m)]);
+  return \Phel::vector([(($__phel_const_0 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_1 ??= \Phel\Lang\Keyword::create("foo")))($m), (($__phel_const_2 ??= \Phel\Lang\Keyword::create("bar")))($m)]);
 });

--- a/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/map-in-fn-body.test
@@ -10,14 +10,14 @@
     public function __invoke() {
       static $__phel_const_0;
       return ($__phel_const_0 ??= \Phel::map(
-        \Phel::keyword("a"), 1,
-        \Phel::keyword("b"), 2
+        \Phel\Lang\Keyword::create("a"), 1,
+        \Phel\Lang\Keyword::create("b"), 2
       ));
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/map-in-fn-body.test", 1, 27),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/multiple-pure-literals.test
@@ -19,8 +19,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/multiple-pure-literals.test", 2, 22),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[b]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/set-in-fn-body.test
@@ -13,8 +13,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/set-in-fn-body.test", 1, 24),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
+++ b/tests/php/Integration/Fixtures/ConstantHoisting/vector-in-fn-body.test
@@ -13,8 +13,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("ConstantHoisting/vector-in-fn-body.test", 1, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/basic-def.test
+++ b/tests/php/Integration/Fixtures/Def/basic-def.test
@@ -6,7 +6,7 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/basic-def.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/basic-def.test", 1, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/basic-def.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/basic-def.test", 1, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigdec-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigdec-literal.test
@@ -6,7 +6,7 @@
   "x",
   \Phel\Lang\BigDecimal::fromString("1.5"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/bigdec-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/bigdec-literal.test", 1, 12)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigdec-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigdec-literal.test", 1, 12)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-negative.test
@@ -6,7 +6,7 @@
   "x",
   -123,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal-negative.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal-oversize.test
@@ -6,7 +6,7 @@
   "x",
   \Phel\Lang\BigInt::fromString("9223372036854775808"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 28)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal-oversize.test", 1, 28)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Def/bigint-literal.test
@@ -6,7 +6,7 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/bigint-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/bigint-literal.test", 1, 10)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/bigint-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/bigint-literal.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-alpha.test
@@ -6,7 +6,7 @@
   "x",
   "a",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-alpha.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-alpha.test", 1, 10)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-alpha.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-alpha.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-newline.test
@@ -6,7 +6,7 @@
   "x",
   "\n",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 16)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-named-newline.test", 1, 16)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-named-space.test
@@ -6,7 +6,7 @@
   "x",
   " ",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-named-space.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-named-space.test", 1, 14)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-named-space.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-named-space.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-octal.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-octal.test
@@ -6,7 +6,7 @@
   "x",
   "A",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-octal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-octal.test", 1, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-octal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-octal.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-punctuation.test
@@ -6,7 +6,7 @@
   "x",
   "(",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 10)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-punctuation.test", 1, 10)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
+++ b/tests/php/Integration/Fixtures/Def/char-literal-unicode.test
@@ -6,7 +6,7 @@
   "x",
   "Ω",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/char-literal-unicode.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/char-literal-unicode.test", 1, 14)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/char-literal-unicode.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/char-literal-unicode.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-no-value.test
+++ b/tests/php/Integration/Fixtures/Def/def-no-value.test
@@ -6,7 +6,7 @@
   "baz",
   null,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/def-no-value.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/def-no-value.test", 1, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-no-value.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-no-value.test", 1, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-class-reference.test
@@ -8,8 +8,8 @@ PHPChildT
   "PHPChildT",
   \RecursiveArrayIterator::class,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/def-php-class-reference.test", 2, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/def-php-class-reference.test", 2, 38)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-php-class-reference.test", 2, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-php-class-reference.test", 2, 38)
   )
 );
 \Phel::getDefinition("user", "PHPChildT");

--- a/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
+++ b/tests/php/Integration/Fixtures/Def/def-php-function-reference.test
@@ -6,7 +6,7 @@
   "uc",
   (function(...$args) { return \strtoupper(...$args);}),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/def-php-function-reference.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/def-php-function-reference.test", 1, 24)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-php-function-reference.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-php-function-reference.test", 1, 24)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
+++ b/tests/php/Integration/Fixtures/Def/def-trailing-quote-in-name.test
@@ -6,7 +6,7 @@
   "a'",
   42,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/def-trailing-quote-in-name.test", 1, 11)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
+++ b/tests/php/Integration/Fixtures/Def/definterface-instance-of.test
@@ -45,9 +45,9 @@ interface IPlayer {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[p]"
@@ -73,9 +73,9 @@ interface IPlayer {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface-instance-of.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface-instance-of.test", 5, 31),
     "min-arity", 3,
     "is-variadic", false,
     "arglists", "[p me you]"

--- a/tests/php/Integration/Fixtures/Def/definterface.test
+++ b/tests/php/Integration/Fixtures/Def/definterface.test
@@ -43,9 +43,9 @@ interface IPlayer {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(choose p)\n```\nChoose docs",
-    \Phel::keyword("start-location"), \Phel::location("Def/definterface.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/definterface.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(choose p)\n```\nChoose docs",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface.test", 5, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[p]"
@@ -71,9 +71,9 @@ interface IPlayer {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(update-strategy p me you)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/definterface.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/definterface.test", 5, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(update-strategy p me you)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/definterface.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/definterface.test", 5, 31),
     "min-arity", 3,
     "is-variadic", false,
     "arglists", "[p me you]"

--- a/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
+++ b/tests/php/Integration/Fixtures/Def/defn-inferred-param-tag.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-inferred-param-tag.test", 1, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Def/defn-meta.test
+++ b/tests/php/Integration/Fixtures/Def/defn-meta.test
@@ -12,10 +12,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("export"), true,
-    \Phel::keyword("doc"), "```phel\n(identity x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/defn-meta.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defn-meta.test", 1, 36),
+    \Phel\Lang\Keyword::create("export"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(identity x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-meta.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-meta.test", 1, 36),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
+++ b/tests/php/Integration/Fixtures/Def/defn-rand-range-fully-inferred.test
@@ -14,9 +14,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rand-range lo hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rand-range lo hi)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-rand-range-fully-inferred.test", 2, 30),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[lo hi]"

--- a/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
+++ b/tests/php/Integration/Fixtures/Def/defn-return-type-name.test
@@ -12,10 +12,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("tag"), "int",
-    \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/defn-return-type-name.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defn-return-type-name.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-return-type-name.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-return-type-name.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]"

--- a/tests/php/Integration/Fixtures/Def/defn-typed-params.test
+++ b/tests/php/Integration/Fixtures/Def/defn-typed-params.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Def/defn-typed-params.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defn-typed-params.test", 1, 56),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add x y)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defn-typed-params.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defn-typed-params.test", 1, 56),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Def/defonce-redefine.test
+++ b/tests/php/Integration/Fixtures/Def/defonce-redefine.test
@@ -7,8 +7,8 @@ if (!\Phel::isDefined("user", "counter")) {
     "counter",
     0,
     \Phel::map(
-      \Phel::keyword("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 0),
-      \Phel::keyword("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 19)
+      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 0),
+      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 19)
     )
   );
 }
@@ -18,8 +18,8 @@ if (!\Phel::isDefined("user", "counter")) {
     "counter",
     99,
     \Phel::map(
-      \Phel::keyword("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 20),
-      \Phel::keyword("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 40)
+      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce-redefine.test", 1, 20),
+      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce-redefine.test", 1, 40)
     )
   );
 }

--- a/tests/php/Integration/Fixtures/Def/defonce.test
+++ b/tests/php/Integration/Fixtures/Def/defonce.test
@@ -7,8 +7,8 @@ if (!\Phel::isDefined("user", "counter")) {
     "counter",
     0,
     \Phel::map(
-      \Phel::keyword("start-location"), \Phel::location("Def/defonce.test", 1, 0),
-      \Phel::keyword("end-location"), \Phel::location("Def/defonce.test", 1, 19)
+      \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defonce.test", 1, 0),
+      \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defonce.test", 1, 19)
     )
   );
 }

--- a/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
+++ b/tests/php/Integration/Fixtures/Def/defstruct-inside-fn-body.test
@@ -30,8 +30,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/defstruct-inside-fn-body.test", 3, 33),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/doc-def.test
@@ -6,8 +6,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::location("Def/doc-def.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/doc-def.test", 1, 21)
+    \Phel\Lang\Keyword::create("doc"), "my number",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/doc-def.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/doc-def.test", 1, 21)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-map-literal.test
@@ -6,7 +6,7 @@
   "arr",
   (\Phel::getDefinition("phel.core", "php-associative-array"))->__invoke("a", 1, "b", 2),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 28)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/hash-php-map-literal.test", 1, 28)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
+++ b/tests/php/Integration/Fixtures/Def/hash-php-vector-literal.test
@@ -6,7 +6,7 @@
   "arr",
   (\Phel::getDefinition("phel.core", "php-indexed-array"))->__invoke(1, 2, 3),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 22)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/hash-php-vector-literal.test", 1, 22)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -20,7 +20,7 @@ require_once __DIR__ . '/../phel/core.php';
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/namespace-def.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/namespace-def.test", 3, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/namespace-def.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/namespace-def.test", 3, 9)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
+++ b/tests/php/Integration/Fixtures/Def/negative-hex-int-min.test
@@ -6,7 +6,7 @@
   "x",
   (-9223372036854775807 - 1),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 27)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/negative-hex-int-min.test", 1, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
+++ b/tests/php/Integration/Fixtures/Def/nested-def-inside-fn.test
@@ -14,8 +14,8 @@
         "x",
         1,
         ($__phel_const_0 ??= \Phel::map(
-          \Phel::keyword("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 14),
-          \Phel::keyword("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)
+          \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 14),
+          \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 23)
         ))
       );
 
@@ -23,8 +23,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/nested-def-inside-fn.test", 1, 27),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Def/private-def-meta.test
+++ b/tests/php/Integration/Fixtures/Def/private-def-meta.test
@@ -6,9 +6,9 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("private"), true,
-    \Phel::keyword("export"), true,
-    \Phel::keyword("start-location"), \Phel::location("Def/private-def-meta.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/private-def-meta.test", 1, 38)
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("export"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-def-meta.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-def-meta.test", 1, 38)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-def.test
@@ -6,8 +6,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::location("Def/private-def.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/private-def.test", 1, 18)
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-def.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-def.test", 1, 18)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/private-doc-def.test
+++ b/tests/php/Integration/Fixtures/Def/private-doc-def.test
@@ -6,9 +6,9 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("private"), true,
-    \Phel::keyword("doc"), "my number",
-    \Phel::keyword("start-location"), \Phel::location("Def/private-doc-def.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/private-doc-def.test", 1, 42)
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("doc"), "my number",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/private-doc-def.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/private-doc-def.test", 1, 42)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-binary.test
+++ b/tests/php/Integration/Fixtures/Def/radix-binary.test
@@ -6,7 +6,7 @@
   "x",
   15,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/radix-binary.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/radix-binary.test", 1, 14)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-binary.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-binary.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-hex.test
+++ b/tests/php/Integration/Fixtures/Def/radix-hex.test
@@ -6,7 +6,7 @@
   "x",
   255,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/radix-hex.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/radix-hex.test", 1, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-hex.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-hex.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/radix-negative.test
+++ b/tests/php/Integration/Fixtures/Def/radix-negative.test
@@ -6,7 +6,7 @@
   "x",
   -15,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/radix-negative.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/radix-negative.test", 1, 15)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/radix-negative.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/radix-negative.test", 1, 15)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal-negative.test
@@ -6,7 +6,7 @@
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("-3"), \Phel\Lang\BigInt::fromString("4")),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 12)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/ratio-literal-negative.test", 1, 12)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/ratio-literal.test
+++ b/tests/php/Integration/Fixtures/Def/ratio-literal.test
@@ -6,7 +6,7 @@
   "x",
   \Phel\Lang\Ratio::create(\Phel\Lang\BigInt::fromString("1"), \Phel\Lang\BigInt::fromString("2")),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/ratio-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/ratio-literal.test", 1, 11)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/ratio-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/ratio-literal.test", 1, 11)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
+++ b/tests/php/Integration/Fixtures/Def/string-literal-unicode-escape.test
@@ -6,7 +6,7 @@
   "x",
   " ",
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/string-literal-unicode-escape.test", 1, 16)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-inf.test
@@ -6,7 +6,7 @@
   "x",
   INF,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-inf.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-nan.test
@@ -6,7 +6,7 @@
   "x",
   NAN,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-nan.test", 1, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
+++ b/tests/php/Integration/Fixtures/Def/symbolic-number-neg-inf.test
@@ -6,7 +6,7 @@
   "x",
   -INF,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/symbolic-number-neg-inf.test", 1, 14)
   )
 );

--- a/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
+++ b/tests/php/Integration/Fixtures/Def/tagged-literal-in-reader-conditional.test
@@ -6,7 +6,7 @@
   "x",
   42,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Def/tagged-literal-in-reader-conditional.test", 1, 54)
   )
 );

--- a/tests/php/Integration/Fixtures/Do/do-in-expr.test
+++ b/tests/php/Integration/Fixtures/Do/do-in-expr.test
@@ -9,7 +9,7 @@
     return (3 + 4);
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Do/do-in-expr.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Do/do-in-expr.test", 1, 36)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Do/do-in-expr.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Do/do-in-expr.test", 1, 36)
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
@@ -18,9 +18,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(nil-check x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(nil-check x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq-nil-stays-untagged.test", 1, 39),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(is-five? x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(is-five? x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-eq.test", 1, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-gte.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(at-least-half? x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(at-least-half? x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-gte.test", 1, 36),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "bool"
+    \Phel\Lang\Keyword::create("tag"), "bool"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-bigint-bails.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(plus-big a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(plus-big a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-bigint-bails.test", 1, 47),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-float.test
@@ -12,9 +12,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one-tenth a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-float.test", 1, 37),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-plus-without-literal-bails.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/defn-infer-phel-core-plus-without-literal-bails.test", 1, 24),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -17,9 +17,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(fib n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(fib n)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-bail-on-self-recursion.test", 1, 82),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-explicit-wins.test
@@ -13,10 +13,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("tag"), "int",
-    \Phel::keyword("doc"), "```phel\n(produce a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(produce a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-explicit-wins.test", 1, 40),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-inferred-callee.test
@@ -13,13 +13,13 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(check x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(check x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-inferred-callee.test", 1, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "bool"
+    \Phel\Lang\Keyword::create("tag"), "bool"
   )
 );
 (function($x): bool {

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-tagged.test
@@ -13,10 +13,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("tag"), "int",
-    \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-tagged.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-call-global-untagged.test
@@ -13,13 +13,13 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-call-global-untagged.test", 1, 38),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );
 (function(int $x): int {

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-propagates.test
@@ -13,10 +13,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("tag"), "int",
-    \Phel::keyword("doc"), "```phel\n(sum a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
+    \Phel\Lang\Keyword::create("tag"), "int",
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(sum a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 1, 43),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]"
@@ -34,12 +34,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-propagates.test", 2, 31),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-fqn.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(typed s)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(typed s)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 1, 42),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[s]"
@@ -33,9 +33,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-fqn.test", 2, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-nullable.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(maybe a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(maybe a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 1, 24),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -33,9 +33,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-nullable.test", 2, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-callee-param-tag-skips-union.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(either a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(either a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 1, 33),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -33,9 +33,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-callee-param-tag-skips-union.test", 2, 28),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-bails-on-bigint-literal.test
@@ -13,12 +13,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(caller x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(caller x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-core-plus-bails-on-bigint-literal.test", 1, 64),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-core-plus-int-stable.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add-pair x y)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add-pair x y)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-core-plus-int-stable.test", 1, 48),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x y]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-bails-on-disagreement.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(weird a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(weird a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-bails-on-disagreement.test", 1, 47),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]",
-    \Phel::keyword("tag"), "string"
+    \Phel\Lang\Keyword::create("tag"), "string"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-numeric.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rrange lo hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange lo hi)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-numeric.test", 1, 54),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[lo hi]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-expected-type-recursion-cycle.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rec n)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rec n)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-expected-type-recursion-cycle.test", 1, 51),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-phel-core-plus.test
@@ -13,9 +13,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(inc-by-one a)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(inc-by-one a)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-phel-core-plus.test", 1, 29),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-count-arg.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(size xs)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(size xs)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-count-arg.test", 1, 31),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[xs]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-intdiv-args.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(div a b)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(div a b)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-intdiv-args.test", 1, 33),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[a b]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-php-random-int-arg.test
@@ -12,12 +12,12 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(rrange hi)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(rrange hi)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-infer-php-random-int-arg.test", 1, 40),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[hi]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -18,9 +18,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(mixed x flag)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(mixed x flag)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-mixed-branches-bails.test", 1, 57),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[x flag]"

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-numeric.test
@@ -13,13 +13,13 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(add1 x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(add1 x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-numeric.test", 1, 27),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "int"
+    \Phel\Lang\Keyword::create("tag"), "int"
   )
 );
 (\Phel::getDefinition("user", "add1"))->__invoke(42);

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-string.test
@@ -13,13 +13,13 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(greet x)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(greet x)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Fn/fn-param-infer-string.test", 1, 32),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]",
-    \Phel::keyword("tag"), "string"
+    \Phel\Lang\Keyword::create("tag"), "string"
   )
 );
 (\Phel::getDefinition("user", "greet"))->__invoke("world");

--- a/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-expr.test
@@ -20,8 +20,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Foreach/foreach-expr.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Foreach/foreach-expr.test", 3, 18),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Foreach/foreach-expr.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Foreach/foreach-expr.test", 3, 18),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
+++ b/tests/php/Integration/Fixtures/Foreach/foreach-tagged-array-param-skips-adapter.test
@@ -18,9 +18,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(process arr)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(process arr)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Foreach/foreach-tagged-array-param-skips-adapter.test", 1, 59),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[arr]"

--- a/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
+++ b/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
@@ -5,17 +5,17 @@
 (function($a, $b, $c) {
   static $__phel_const_0, $__phel_const_1;
   if ((($__truthy = $a) !== null && $__truthy !== false) || (($__truthy = $b) !== null && $__truthy !== false) || (($__truthy = $c) !== null && $__truthy !== false)) {
-    return ($__phel_const_0 ??= \Phel::keyword("truthy"));
+    return ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy"));
   } else {
-    return ($__phel_const_1 ??= \Phel::keyword("falsy"));
+    return ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy"));
   }
 
 });(function($a, $b, $c) {
   static $__phel_const_0, $__phel_const_1;
   if ((($__truthy = $a) !== null && $__truthy !== false) && (($__truthy = $b) !== null && $__truthy !== false) && (($__truthy = $c) !== null && $__truthy !== false)) {
-    return ($__phel_const_0 ??= \Phel::keyword("truthy"));
+    return ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy"));
   } else {
-    return ($__phel_const_1 ??= \Phel::keyword("falsy"));
+    return ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy"));
   }
 
 });

--- a/tests/php/Integration/Fixtures/Keyword/keywords.test
+++ b/tests/php/Integration/Fixtures/Keyword/keywords.test
@@ -22,36 +22,36 @@ require_once __DIR__ . '/xyz/foo.php';
 \Phel::addDefinition(
   "test",
   "a",
-  \Phel::keyword("bar"),
+  \Phel\Lang\Keyword::create("bar"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 3, 12)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 3, 12)
   )
 );
 \Phel::addDefinition(
   "test",
   "b",
-  \Phel::keyword("bar", "test"),
+  \Phel\Lang\Keyword::create("bar", "test"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 4, 0),
-    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 4, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 4, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 4, 13)
   )
 );
 \Phel::addDefinition(
   "test",
   "c",
-  \Phel::keyword("bar", "xyz.foo"),
+  \Phel\Lang\Keyword::create("bar", "xyz.foo"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 5, 0),
-    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 5, 17)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 5, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 5, 17)
   )
 );
 \Phel::addDefinition(
   "test",
   "d",
-  \Phel::keyword("bar", "xyz\\foo"),
+  \Phel\Lang\Keyword::create("bar", "xyz\\foo"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Keyword/keywords.test", 6, 0),
-    \Phel::keyword("end-location"), \Phel::location("Keyword/keywords.test", 6, 20)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Keyword/keywords.test", 6, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Keyword/keywords.test", 6, 20)
   )
 );

--- a/tests/php/Integration/Fixtures/Let/let-expr.test
+++ b/tests/php/Integration/Fixtures/Let/let-expr.test
@@ -10,7 +10,7 @@
     return ($x_1 + $y_2);
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Let/let-expr.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Let/let-expr.test", 1, 35)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Let/let-expr.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Let/let-expr.test", 1, 35)
   )
 );

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -9,7 +9,7 @@
 
     public function __invoke($_AMPERSAND_form, $_AMPERSAND_env) {
       static $__phel_const_0;
-      if (($__truthy = (($__phel_const_0 ??= \Phel::keyword("ns")))($_AMPERSAND_env)) !== null && $__truthy !== false) {
+      if (($__truthy = (($__phel_const_0 ??= \Phel\Lang\Keyword::create("ns")))($_AMPERSAND_env)) !== null && $__truthy !== false) {
         return true;
       } else {
         return false;
@@ -18,10 +18,10 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("macro"), true,
-    \Phel::keyword("doc"), "```phel\n(ns-present?)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(ns-present?)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/defmacro-env-form.test", 1, 52),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/macro-expand.test
@@ -18,9 +18,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 38),
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/macro-expand.test", 1, 38),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[n]"

--- a/tests/php/Integration/Fixtures/MacroExpand/return-array.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/return-array.test
@@ -14,9 +14,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("macro"), true,
-    \Phel::keyword("start-location"), \Phel::location("MacroExpand/return-array.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("MacroExpand/return-array.test", 1, 55),
+    \Phel\Lang\Keyword::create("macro"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/return-array.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/return-array.test", 1, 55),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"
@@ -27,7 +27,7 @@
   "y",
   [0 => 1, 1 => 2, 2 => [0 => 3, 1 => 4]],
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("MacroExpand/return-array.test", 3, 0),
-    \Phel::keyword("end-location"), \Phel::location("MacroExpand/return-array.test", 3, 13)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("MacroExpand/return-array.test", 3, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("MacroExpand/return-array.test", 3, 13)
   )
 );

--- a/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
@@ -3,5 +3,5 @@
 --PHP--
 (function($x) {
   static $__phel_const_0, $__phel_const_1, $__phel_const_2, $__phel_const_3, $__phel_call_0, $__phel_call_1, $__phel_call_2;
-  return match ($x) { 1 => \Phel::keyword("one"), 2 => \Phel::keyword("two"), 3 => \Phel::keyword("three"), default => \Phel::keyword("other") };
+  return match ($x) { 1 => \Phel\Lang\Keyword::create("one"), 2 => \Phel\Lang\Keyword::create("two"), 3 => \Phel\Lang\Keyword::create("three"), default => \Phel\Lang\Keyword::create("other") };
 });

--- a/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
@@ -3,5 +3,5 @@
 --PHP--
 (function($x) {
   static $__phel_const_0, $__phel_const_1, $__phel_call_0, $__phel_call_1;
-  return match ($x) { \Phel::keyword("a") => 1, \Phel::keyword("b") => 2, default => 99 };
+  return match ($x) { \Phel\Lang\Keyword::create("a") => 1, \Phel\Lang\Keyword::create("b") => 2, default => 99 };
 });

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -25,9 +25,9 @@ require_once __DIR__ . '/my_namespace/core.php';
   "x",
   10,
   \Phel::map(
-    \Phel::keyword("private"), true,
-    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 5, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 5, 19)
+    \Phel\Lang\Keyword::create("private"), true,
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 5, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 5, 19)
   )
 );
 if (!class_exists('hello_world\abc')) {
@@ -59,9 +59,9 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
-    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc a)\n```\nCreates a new abc struct.",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[a]"
@@ -80,9 +80,9 @@ final class abc extends \Phel\Lang\Collections\Struct\AbstractPersistentStruct {
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
-    \Phel::keyword("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct.",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/munge-ns.test", 7, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/munge-ns.test", 7, 19),
     "min-arity", 1,
     "is-variadic", false,
     "arglists", "[x]"

--- a/tests/php/Integration/Fixtures/Ns/require-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-multiple.test
@@ -25,18 +25,18 @@ require_once __DIR__ . '/xyz/core2.php';
 \Phel::addDefinition(
   "test",
   "kw",
-  \Phel::keyword("f1", "xyz.core"),
+  \Phel\Lang\Keyword::create("f1", "xyz.core"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Ns/require-multiple.test", 6, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/require-multiple.test", 6, 15)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-multiple.test", 6, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-multiple.test", 6, 15)
   )
 );
 \Phel::addDefinition(
   "test",
   "kw2",
-  \Phel::keyword("f3", "xyz.core2"),
+  \Phel\Lang\Keyword::create("f3", "xyz.core2"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Ns/require-multiple.test", 7, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/require-multiple.test", 7, 17)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-multiple.test", 7, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-multiple.test", 7, 17)
   )
 );

--- a/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
+++ b/tests/php/Integration/Fixtures/Ns/require-vector-multiple.test
@@ -25,18 +25,18 @@ require_once __DIR__ . '/xyz/core2.php';
 \Phel::addDefinition(
   "test",
   "kw",
-  \Phel::keyword("f1", "xyz.core"),
+  \Phel\Lang\Keyword::create("f1", "xyz.core"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 15)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-vector-multiple.test", 6, 15)
   )
 );
 \Phel::addDefinition(
   "test",
   "kw2",
-  \Phel::keyword("f3", "xyz.core2"),
+  \Phel\Lang\Keyword::create("f3", "xyz.core2"),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 0),
-    \Phel::keyword("end-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 17)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Ns/require-vector-multiple.test", 7, 17)
   )
 );

--- a/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
+++ b/tests/php/Integration/Fixtures/PhpObjectSet/set-class-property.test
@@ -7,8 +7,8 @@
   "a",
   (new \stdClass()),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("PhpObjectSet/set-class-property.test", 1, 27)
   )
 );
 (function() {

--- a/tests/php/Integration/Fixtures/SetVar/set-var.test
+++ b/tests/php/Integration/Fixtures/SetVar/set-var.test
@@ -7,8 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("SetVar/set-var.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("SetVar/set-var.test", 1, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("SetVar/set-var.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("SetVar/set-var.test", 1, 9)
   )
 );
 \Phel::setVar(

--- a/tests/php/Integration/Fixtures/Simplify/do-empties-stmts-in-expression-context.test
+++ b/tests/php/Integration/Fixtures/Simplify/do-empties-stmts-in-expression-context.test
@@ -2,6 +2,6 @@
 (let [x (do 1 2 :foo)] x)
 --PHP--
 $x_1 = (function() {
-  return \Phel::keyword("foo");
+  return \Phel\Lang\Keyword::create("foo");
 })();
 $x_1;

--- a/tests/php/Integration/Fixtures/Try/throw-expr.test
+++ b/tests/php/Integration/Fixtures/Try/throw-expr.test
@@ -15,8 +15,8 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Try/throw-expr.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Try/throw-expr.test", 1, 56),
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/throw-expr.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/throw-expr.test", 1, 56),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -17,7 +17,7 @@
     }
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/try-catch-finally-expr-throw.test", 4, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Integration/Fixtures/Try/try-catch-finally-expr.test
@@ -17,7 +17,7 @@
     }
   })(),
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("Try/try-catch-finally-expr.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Try/try-catch-finally-expr.test", 4, 27)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Try/try-catch-finally-expr.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Try/try-catch-finally-expr.test", 4, 27)
   )
 );

--- a/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-quote-emits-get-var.test
@@ -7,8 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("VarQuote/var-quote-emits-get-var.test", 1, 9)
   )
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
+++ b/tests/php/Integration/Fixtures/VarQuote/var-special-form.test
@@ -7,8 +7,8 @@
   "x",
   1,
   \Phel::map(
-    \Phel::keyword("start-location"), \Phel::location("VarQuote/var-special-form.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("VarQuote/var-special-form.test", 1, 9)
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("VarQuote/var-special-form.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("VarQuote/var-special-form.test", 1, 9)
   )
 );
 \Phel\Lang\Registry::getInstance()->getVar("user", "x");

--- a/tests/php/Integration/Fixtures/Yield/yield-array.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-array.test
@@ -20,9 +20,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(yield_generator_array)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Yield/yield-array.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Yield/yield-array.test", 3, 26),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_array)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-array.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-array.test", 3, 26),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-doseq-str.test
@@ -20,9 +20,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Yield/yield-doseq-str.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Yield/yield-doseq-str.test", 3, 23),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-doseq-str.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-doseq-str.test", 3, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-return-context.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-return-context.test
@@ -15,9 +15,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(yield_no_return)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Yield/yield-return-context.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Yield/yield-return-context.test", 3, 18),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_no_return)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-return-context.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-return-context.test", 3, 18),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"

--- a/tests/php/Integration/Fixtures/Yield/yield-str.test
+++ b/tests/php/Integration/Fixtures/Yield/yield-str.test
@@ -20,9 +20,9 @@
     }
   },
   \Phel::map(
-    \Phel::keyword("doc"), "```phel\n(yield_generator_str)\n```\n",
-    \Phel::keyword("start-location"), \Phel::location("Yield/yield-str.test", 1, 0),
-    \Phel::keyword("end-location"), \Phel::location("Yield/yield-str.test", 3, 23),
+    \Phel\Lang\Keyword::create("doc"), "```phel\n(yield_generator_str)\n```\n",
+    \Phel\Lang\Keyword::create("start-location"), \Phel::location("Yield/yield-str.test", 1, 0),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Yield/yield-str.test", 3, 23),
     "min-arity", 0,
     "is-variadic", false,
     "arglists", "[]"


### PR DESCRIPTION
## 🤔 Background

`LiteralEmitter::emitKeyword` emits `\Phel::keyword("name")` at every literal keyword site. `\Phel::keyword(...)` is a one-line static facade defined in `src/Phel.php:415` that immediately calls `\Phel\Lang\Keyword::create(...)` — the intern-pool factory. The indirection costs one static-call frame per cache miss and stops OPcache from inlining the factory.

## 💡 Goal

Skip the facade and emit the factory call directly. Intern-pool semantics are unchanged because `\Phel::keyword` is itself a forwarder, so identity guarantees (`Keyword::create("a") === Keyword::create("a")`) hold.

Closes #2131

## 🔖 Changes

- `LiteralEmitter::emitKeyword` — emits `\Phel\Lang\Keyword::create("name")` (with the optional namespace arg when present) instead of `\Phel::keyword(...)`.
- 113 integration fixtures under `tests/php/Integration/Fixtures/` regenerated via `sed`.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green