### PR TITLE
perf(emitter): collapse tail if to ternary + drop nil else in stmt context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `LiteralEmitter`: emit keyword literals as `\Phel\Lang\Keyword::create("name")` directly instead of routing through the `\Phel::keyword(...)` facade. Same intern-pool semantics (identity is preserved), skips one static-call frame per cache miss and lets OPcache inline the factory (#2131)
 
+- `IfEmitter`: collapse `if (…) { return a; } else { return b; }` to `return (cond ? a : b);` when both branches are simple expressions (`LocalVarNode` / `LiteralNode` / `GlobalVarNode` / `PhpVarNode` / `CallNode` of simple args, optionally wrapped in a no-stmt `DoNode`). Smaller bytecode and one fewer basic block for the JIT (#2133)
+
+- `IfEmitter`: drop the redundant `else { null; }` branch when an `if` (e.g. expanded from `(when …)` / `(when-not …)`) is in statement context and the else branch is the `nil` literal. Saves three lines of generated PHP per call site (#2134)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\Cache\BooleanExprDetector;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
@@ -24,11 +30,108 @@ final class IfEmitter implements NodeEmitterInterface
             return;
         }
 
-        if ($node->getEnv()->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
+        $env = $node->getEnv();
+        if ($env->isContext(NodeEnvironment::CONTEXT_EXPRESSION)) {
             $this->emitTernaryCondition($node);
-        } else {
-            $this->emitIfElseCondition($node);
+            return;
         }
+
+        if ($this->tryEmitReturnTernary($node)) {
+            return;
+        }
+
+        if ($this->tryEmitStatementWithoutNilElse($node)) {
+            return;
+        }
+
+        $this->emitIfElseCondition($node);
+    }
+
+    /**
+     * In RETURN context, if both branches emit as bare PHP expressions
+     * we can collapse the whole `if (…) { return a; } else { return b; }`
+     * to a single `return (cond ? a : b);` statement. Smaller bytecode
+     * and one fewer basic block for the JIT.
+     */
+    private function tryEmitReturnTernary(IfNode $node): bool
+    {
+        if (!$node->getEnv()->isContext(NodeEnvironment::CONTEXT_RETURN)) {
+            return false;
+        }
+
+        $then = $node->getThenExpr();
+        $else = $node->getElseExpr();
+        if (!self::isSimpleExpressionNode($then) || !self::isSimpleExpressionNode($else)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('return (', $loc);
+        $this->emitTestExpr($node->getTestExpr());
+        $this->outputEmitter->emitStr(' ? ', $loc);
+        $this->emitNodeAsExpression($then);
+        $this->outputEmitter->emitStr(' : ', $loc);
+        $this->emitNodeAsExpression($else);
+        $this->outputEmitter->emitLine(');', $loc);
+
+        return true;
+    }
+
+    /**
+     * In statement context, drop the `else { … }` branch when it is
+     * just `nil` — that is the shape `(when …)` / `(when-not …)`
+     * expand to, and emitting `} else { null; }` is dead bytecode.
+     */
+    private function tryEmitStatementWithoutNilElse(IfNode $node): bool
+    {
+        if (!$node->getEnv()->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
+            return false;
+        }
+
+        $else = $node->getElseExpr();
+        if (!$else instanceof LiteralNode || $else->getValue() !== null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('if (', $loc);
+        $this->emitTestExpr($node->getTestExpr());
+        $this->outputEmitter->emitLine(') {', $loc);
+        $this->outputEmitter->increaseIndentLevel();
+        $this->outputEmitter->emitNode($node->getThenExpr());
+        $this->outputEmitter->decreaseIndentLevel();
+        $this->outputEmitter->emitLine();
+        $this->outputEmitter->emitLine('}', $loc);
+
+        return true;
+    }
+
+    /**
+     * Chain leaves and ternary branches are emitted directly into a
+     * surrounding expression context, so each one must render as a
+     * single PHP expression — `LetNode` / `IfNode` in `RETURN`
+     * context expand to multi-statement bodies that the strip helper
+     * cannot safely flatten.
+     */
+    private static function isSimpleExpressionNode(AbstractNode $node): bool
+    {
+        if ($node instanceof DoNode) {
+            return $node->getStmts() === [] && self::isSimpleExpressionNode($node->getRet());
+        }
+
+        if ($node instanceof LocalVarNode
+            || $node instanceof LiteralNode
+            || $node instanceof GlobalVarNode
+            || $node instanceof PhpVarNode
+        ) {
+            return true;
+        }
+
+        if ($node instanceof CallNode) {
+            return array_all([$node->getFn(), ...$node->getArguments()], static fn(AbstractNode $child): bool => self::isSimpleExpressionNode($child));
+        }
+
+        return false;
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Call/self-call-with-if.test
+++ b/tests/php/Integration/Fixtures/Call/self-call-with-if.test
@@ -8,11 +8,7 @@
     public const BOUND_TO = "user\\rec";
 
     public function __invoke(int $n) {
-      if ((($n == 0))) {
-        return $n;
-      } else {
-        return $this(($n - 1));
-      }
+      return ((($n == 0)) ? $n : $this(($n - 1)));
 
     }
   },

--- a/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
+++ b/tests/php/Integration/Fixtures/Fn/defn-infer-phel-core-eq-nil-stays-untagged.test
@@ -9,11 +9,7 @@
 
     public function __invoke($x) {
       static $__phel_call_0;
-      if (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) !== null && $__truthy !== false) {
-        return 0;
-      } else {
-        return 1;
-      }
+      return (($__truthy = ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "="))->__invoke($x, null)) !== null && $__truthy !== false ? 0 : 1);
 
     }
   },

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-mixed-branches.test
@@ -2,10 +2,6 @@
 (fn [^int x] (if (php/< x 0) nil (php/+ x 1)))
 --PHP--
 (function(int $x) {
-  if ((($x < 0))) {
-    return null;
-  } else {
-    return ($x + 1);
-  }
+  return ((($x < 0)) ? null : ($x + 1));
 
 });

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-bail-on-self-recursion.test
@@ -8,11 +8,7 @@
     public const BOUND_TO = "user\\fib";
 
     public function __invoke(int $n) {
-      if ((($n < 2))) {
-        return $n;
-      } else {
-        return ($this(($n - 1)) + $this(($n - 2)));
-      }
+      return ((($n < 2)) ? $n : ($this(($n - 1)) + $this(($n - 2))));
 
     }
   },

--- a/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-infer-return-if-merges.test
@@ -2,10 +2,6 @@
 (fn [^int x] (if (php/< x 0) 0 (php/+ x 1)))
 --PHP--
 (function(int $x): int {
-  if ((($x < 0))) {
-    return 0;
-  } else {
-    return ($x + 1);
-  }
+  return ((($x < 0)) ? 0 : ($x + 1));
 
 });

--- a/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
+++ b/tests/php/Integration/Fixtures/Fn/fn-param-infer-mixed-branches-bails.test
@@ -9,11 +9,7 @@
     public const BOUND_TO = "user\\mixed";
 
     public function __invoke($x, $flag) {
-      if (($__truthy = $flag) !== null && $__truthy !== false) {
-        return ($x + 1);
-      } else {
-        return ($x . "!");
-      }
+      return (($__truthy = $flag) !== null && $__truthy !== false ? ($x + 1) : ($x . "!"));
 
     }
   },

--- a/tests/php/Integration/Fixtures/If/if-return-ternary.test
+++ b/tests/php/Integration/Fixtures/If/if-return-ternary.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [x] (if x 1 2))
+--PHP--
+(function($x) {
+  return (($__truthy = $x) !== null && $__truthy !== false ? 1 : 2);
+
+});

--- a/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
+++ b/tests/php/Integration/Fixtures/If/if-test-and-or-lowering.test
@@ -4,18 +4,10 @@
 --PHP--
 (function($a, $b, $c) {
   static $__phel_const_0, $__phel_const_1;
-  if ((($__truthy = $a) !== null && $__truthy !== false) || (($__truthy = $b) !== null && $__truthy !== false) || (($__truthy = $c) !== null && $__truthy !== false)) {
-    return ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy"));
-  } else {
-    return ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy"));
-  }
+  return ((($__truthy = $a) !== null && $__truthy !== false) || (($__truthy = $b) !== null && $__truthy !== false) || (($__truthy = $c) !== null && $__truthy !== false) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy")));
 
 });(function($a, $b, $c) {
   static $__phel_const_0, $__phel_const_1;
-  if ((($__truthy = $a) !== null && $__truthy !== false) && (($__truthy = $b) !== null && $__truthy !== false) && (($__truthy = $c) !== null && $__truthy !== false)) {
-    return ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy"));
-  } else {
-    return ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy"));
-  }
+  return ((($__truthy = $a) !== null && $__truthy !== false) && (($__truthy = $b) !== null && $__truthy !== false) && (($__truthy = $c) !== null && $__truthy !== false) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("truthy")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("falsy")));
 
 });

--- a/tests/php/Integration/Fixtures/If/when-stmt-no-else.test
+++ b/tests/php/Integration/Fixtures/If/when-stmt-no-else.test
@@ -1,0 +1,10 @@
+--PHEL--
+(fn [x] (when x (php/print "hi")) 42)
+--PHP--
+(function($x) {
+  if (($__truthy = $x) !== null && $__truthy !== false) {
+    print("hi");
+  }
+
+  return 42;
+});

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -37,8 +37,6 @@ while (true) {
 
     }
 
-  } else {
-
   }
   break;
 }

--- a/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
+++ b/tests/php/Integration/Fixtures/MacroExpand/defmacro-env-form.test
@@ -9,11 +9,7 @@
 
     public function __invoke($_AMPERSAND_form, $_AMPERSAND_env) {
       static $__phel_const_0;
-      if (($__truthy = (($__phel_const_0 ??= \Phel\Lang\Keyword::create("ns")))($_AMPERSAND_env)) !== null && $__truthy !== false) {
-        return true;
-      } else {
-        return false;
-      }
+      return (($__truthy = (($__phel_const_0 ??= \Phel\Lang\Keyword::create("ns")))($_AMPERSAND_env)) !== null && $__truthy !== false ? true : false);
 
     }
   },


### PR DESCRIPTION
## 🤔 Background

Two complementary `IfEmitter` lowerings — combined into one PR because they touch the same `emitIfElseCondition` dispatch and would otherwise rebase against each other.

**#2133 — tail-position `if` → ternary in RETURN context.** Today an `if` in return position emits `if (test) { return a; } else { return b; }`. PHP's `return (test ? a : b);` is smaller and gives the JIT one fewer basic block. Safe whenever both branches emit as bare PHP expressions.

**#2134 — drop redundant `else { null; }` in statement context.** The `(when …)` and `(when-not …)` macros expand to `(if cond (do body) nil)`. In statement context the `else { null; }` branch is dead bytecode the runtime never observes.

Closes #2133
Closes #2134

## 🔖 Changes

- `IfEmitter::emit` now tries `tryEmitReturnTernary` and `tryEmitStatementWithoutNilElse` before falling back to the generic if/else path.
- `tryEmitReturnTernary` fires only when `env === RETURN` and both branches pass `isSimpleExpressionNode` (`LocalVarNode` / `LiteralNode` / `GlobalVarNode` / `PhpVarNode` / `CallNode` of simple args, optionally wrapped in a no-statement `DoNode`). Uses the existing `emitNodeAsExpression` ob_start helper to strip the analyser's `return ` / `;` decoration before splicing into the ternary.
- `tryEmitStatementWithoutNilElse` fires only when `env === STATEMENT` and `else` is `LiteralNode(null)`.
- Nine integration fixtures regenerated to reflect the new emission (`MacroExpand/defmacro-env-form`, `Call/self-call-with-if`, `Fn/defn-infer-phel-core-eq-nil-stays-untagged`, `Fn/fn-infer-return-if-merges`, `Fn/fn-param-infer-mixed-branches-bails`, `Fn/fn-infer-bail-on-mixed-branches`, `Fn/fn-infer-bail-on-self-recursion`, `Let/loop-destructure`, `If/if-test-and-or-lowering`).
- Two new fixtures (`If/if-return-ternary.test`, `If/when-stmt-no-else.test`) exercise each lowering directly.
- `CHANGELOG.md` — `Unreleased / Performance` entries for both issues.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green