### PR TITLE
chore(emitter): drop orphan $__phel_call_N / $__phel_const_N slots after match lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `IfEmitter`: drop the redundant `else { null; }` branch when an `if` (e.g. expanded from `(when …)` / `(when-not …)`) is in statement context and the else branch is the `nil` literal. Saves three lines of generated PHP per call site (#2134)
 
+- `BodyConstantScanner`: skip slot reservations for the cond-test calls and arm-key literals of any `LetNode` / `IfNode` that `IfChainMatchLowerer` will lower to a PHP `match`. Closes the orphan-slot path that left a `static $__phel_call_N` / `$__phel_const_N` declaration in the generated PHP without any `??=` initialiser to fill it. Added `OrphanCallSlotAuditTest` as a regression guard that walks every integration fixture's `--PHP--` block (#2144)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BodyConstantScanner.php
@@ -33,6 +33,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\TryNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\GlobalCallTarget;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\IfChainMatchLowerer;
 use Phel\Lang\Keyword;
 
 /**
@@ -62,6 +63,19 @@ final readonly class BodyConstantScanner
             return;
         }
 
+        // When a `LetNode` / `IfNode` will be lowered to a PHP `match`,
+        // its cond-test calls and arm-key literals are consumed by the
+        // lowerer (the arms are emitted via `emitLiteral`, never going
+        // through the per-fn cache). Reserving slots for them would
+        // leave orphan `$__phel_call_N` / `$__phel_const_N` declarations
+        // in the generated PHP — kept invisible by the runtime, but
+        // bloat in bytecode and OPcache.
+        $matchInit = $this->matchLoweredInit($node);
+        if ($matchInit instanceof AbstractNode) {
+            $this->walk($matchInit, $scope, $cacheCalls);
+            return;
+        }
+
         if ($cacheCalls
             && $node instanceof CallNode
             && GlobalCallTarget::isGlobalFnCall($node)
@@ -74,6 +88,29 @@ final readonly class BodyConstantScanner
         foreach ($this->children($node) as $child) {
             $this->walk($child, $scope, $cacheCalls);
         }
+    }
+
+    /**
+     * If `$node` will be lowered to a PHP `match` by
+     * `\Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter\IfChainMatchLowerer`,
+     * return the only sub-expression that still flows through the
+     * normal emit path — the matched init value. Everything else
+     * (cond tests, arm keys, arm bodies) is emitted via `emitLiteral`
+     * and never consumes a per-fn cache slot.
+     */
+    private function matchLoweredInit(AbstractNode $node): ?AbstractNode
+    {
+        if ($node instanceof LetNode) {
+            $shape = IfChainMatchLowerer::analyse($node);
+            return $shape['init'] ?? null;
+        }
+
+        if ($node instanceof IfNode) {
+            $shape = IfChainMatchLowerer::analyseIfChain($node);
+            return $shape['init'] ?? null;
+        }
+
+        return null;
     }
 
     private function isCacheableCollection(AbstractNode $node): bool

--- a/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/case-lit-keyword-arms.test
@@ -2,6 +2,5 @@
 (fn [x] (case x 1 :one 2 :two 3 :three :other))
 --PHP--
 (function($x) {
-  static $__phel_const_0, $__phel_const_1, $__phel_const_2, $__phel_const_3, $__phel_call_0, $__phel_call_1, $__phel_call_2;
   return match ($x) { 1 => \Phel\Lang\Keyword::create("one"), 2 => \Phel\Lang\Keyword::create("two"), 3 => \Phel\Lang\Keyword::create("three"), default => \Phel\Lang\Keyword::create("other") };
 });

--- a/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
+++ b/tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test
@@ -2,6 +2,5 @@
 (fn [x] (cond (= x :a) 1 (= x :b) 2 :else 99))
 --PHP--
 (function($x) {
-  static $__phel_const_0, $__phel_const_1, $__phel_call_0, $__phel_call_1;
   return match ($x) { \Phel\Lang\Keyword::create("a") => 1, \Phel\Lang\Keyword::create("b") => 2, default => 99 };
 });

--- a/tests/php/Integration/OrphanCallSlotAuditTest.php
+++ b/tests/php/Integration/OrphanCallSlotAuditTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_keys;
+use function count;
+use function file_get_contents;
+use function preg_match_all;
+use function preg_split;
+use function realpath;
+use function sprintf;
+use function str_ends_with;
+
+/**
+ * Walks every `--PHP--` block under `tests/php/Integration/Fixtures` and
+ * asserts that every `static $__phel_call_N` / `static $__phel_const_N`
+ * slot reserved in the body is actually written by an `??=`
+ * initialisation somewhere in the same body. An orphan slot is a
+ * signal that the `BodyConstantScanner` reserved a slot for a call
+ * that a specialiser later consumed without using it — invisible at
+ * runtime, but bloats the bytecode and the OPcache footprint.
+ */
+final class OrphanCallSlotAuditTest extends TestCase
+{
+    public function test_fixtures_contain_no_orphan_phel_call_or_const_slots(): void
+    {
+        $fixturesDir = realpath(__DIR__ . '/Fixtures');
+        self::assertIsString($fixturesDir);
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($fixturesDir),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $orphans = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!str_ends_with($file->getRealPath(), '.test')) {
+                continue;
+            }
+
+            $content = (string) file_get_contents($file->getRealPath());
+            $parts = preg_split('/^--PHP--\s*$/m', $content, 2);
+            if ($parts === false) {
+                continue;
+            }
+
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            $php = $parts[1];
+            $declared = $this->collectDeclaredSlots($php);
+            $used = $this->collectUsedSlots($php);
+
+            foreach (array_keys($declared) as $slot) {
+                if (!isset($used[$slot])) {
+                    $orphans[] = sprintf(
+                        '%s: %s declared but never written',
+                        str_replace($fixturesDir . '/', '', $file->getRealPath()),
+                        $slot,
+                    );
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            $orphans,
+            "Orphan slot declarations found in fixtures:\n  " . implode("\n  ", $orphans),
+        );
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function collectDeclaredSlots(string $php): array
+    {
+        $declared = [];
+        if (preg_match_all('/static\s+([^;]+);/', $php, $matches) === false) {
+            return [];
+        }
+
+        foreach ($matches[1] as $declList) {
+            if (preg_match_all('/\$(?:__phel_call_\d+|__phel_const_\d+|__phel_kw_\d+)/', $declList, $slots) === false) {
+                continue;
+            }
+
+            foreach ($slots[0] as $name) {
+                $declared[$name] = true;
+            }
+        }
+
+        return $declared;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function collectUsedSlots(string $php): array
+    {
+        $used = [];
+        if (preg_match_all('/\$(__phel_call_\d+|__phel_const_\d+|__phel_kw_\d+)\s*\?\?=/', $php, $matches) === false) {
+            return [];
+        }
+
+        foreach ($matches[1] as $name) {
+            $used['$' . $name] = true;
+        }
+
+        return $used;
+    }
+}


### PR DESCRIPTION
## 🤔 Background

`BodyConstantScanner` walks each fn body and reserves a per-fn cache slot (`static \$__phel_call_N` / `\$__phel_const_N` / `\$__phel_kw_N`) for every eligible call or pure literal it encounters. The slot is later filled by an `??=` initialiser emitted at the call/literal site.

`IfChainMatchLowerer` (added in #2091) collapses `(cond (= x :a) 1 (= x :b) 2 :else 99)` style shapes to a PHP `match` expression. The lowered output emits arm keys and bodies via `emitLiteral`, which goes directly to the literal renderer and never consumes a cache slot. Result: the scanner reserved a slot for every `(= x :a)` call and every `:a` keyword, but the lowered `match` never wrote to them, leaving orphan declarations on the fn signature.

A quick audit across `tests/php/Integration/Fixtures` found 5 orphan slots across 2 fixtures — invisible at runtime but pure bytecode + OPcache bloat.

## 💡 Goal

Teach the scanner to skip slot reservations for the sub-tree that the lowerer will consume, while still scanning the only sub-expression that survives — the matched init value.

Add a regression guard so the next emitter optimisation that inadvertently orphans a slot is caught immediately.

Closes #2144

## 🔖 Changes

- `BodyConstantScanner::matchLoweredInit` — probes `IfChainMatchLowerer::analyse` / `analyseIfChain` for each `LetNode` / `IfNode`. When the node will be lowered, scanning descends into the matched init value only; arms, keys, and cond-test calls are skipped.
- New test class `tests/php/Integration/OrphanCallSlotAuditTest` — walks every `--PHP--` block under the fixtures tree, extracts every `static \$__phel_*_N` declaration, and asserts a matching `\$__phel_*_N \?\?=` initialiser exists in the same body. Fails loudly with the orphan name + file when the invariant breaks.
- `tests/php/Integration/Fixtures/Match/cond-lit-keyword-arms.test` and `case-lit-keyword-arms.test` — regenerated to drop the orphan `static` declarations.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green (audit test included)
- `composer test-core` — green
- `composer test-quality` — green