### PR TITLE
perf(compiler): specialise nil? / some? / count on array tag to native ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `BodyConstantScanner`: skip slot reservations for the cond-test calls and arm-key literals of any `LetNode` / `IfNode` that `IfChainMatchLowerer` will lower to a PHP `match`. Closes the orphan-slot path that left a `static $__phel_call_N` / `$__phel_const_N` declaration in the generated PHP without any `??=` initialiser to fill it. Added `OrphanCallSlotAuditTest` as a regression guard that walks every integration fixture's `--PHP--` block (#2144)
 
+- `CallSpecialization`: lower `(nil? x)` and 1-arg `(some? x)` to the native `($x === null)` / `($x !== null)` comparisons, skipping the registry lookup + `id`/`not` adapters. Predicates this hot show up across virtually every Phel program (`(when (some? x) …)`, threaded `(when-let …)` chains, default-supplying `(if (nil? x) default …)`) (#2157)
+
+- `CallSpecialization`: lower 1-arg `(count arr)` on an `array`-tagged local to native `count($arr)`, matching the `(get arr k)` specialisation in #2139. The runtime cond chain over set / seq / vector / map collapses to the same `php/count` branch the native call already covers (#2158)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -95,6 +95,18 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypedPhpArrayCount($node)) {
+            return true;
+        }
+
+        if (self::isNilCheck($node)) {
+            return true;
+        }
+
+        if (self::isSomeCheck($node)) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -618,6 +630,60 @@ final readonly class CallSpecialization
     }
 
     /**
+     * `(count arr)` where the analyser has tagged `arr` as a PHP
+     * `array`. The runtime `count` body walks a cond chain over the
+     * standard collection shapes before reaching `(php/count ds)`; for
+     * an `array`-tagged target the only branch that ever fires is the
+     * native one.
+     */
+    public static function isTypedPhpArrayCount(CallNode $node): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'count'
+        ) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return false;
+        }
+
+        return self::normalisedTag($target->getInferredType()) === 'array';
+    }
+
+    /**
+     * `(nil? x)` — single-arg identity check against `nil`. The runtime
+     * body is `(id x nil)` which routes through the registry; the
+     * specialised emit is the literal `($x === null)`.
+     */
+    public static function isNilCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'nil?');
+    }
+
+    /**
+     * `(some? x)` (1-arg) — `(not (nil? x))`. Maps to `($x !== null)`.
+     * Skips the 2-arg overload (`(some? pred coll)`); that variant has
+     * a different shape and the specialised emit would not be a single
+     * native expression.
+     */
+    public static function isSomeCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'some?');
+    }
+
+    /**
      * `(str ...)` whose every argument compiles to a string-typed
      * expression: string literals or `LocalVarNode`s tagged `string`.
      */
@@ -661,6 +727,22 @@ final readonly class CallSpecialization
         $arg = $args[0];
         return $arg instanceof LocalVarNode
             && self::isPersistentMapTag($arg->getInferredType());
+    }
+
+    private static function isUnaryCoreCall(CallNode $node, string $name): bool
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        if ($fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== $name
+        ) {
+            return false;
+        }
+
+        return count($node->getArguments()) === 1;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -171,6 +171,18 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypedPhpArrayCount($node)) {
+            return;
+        }
+
+        if ($this->tryEmitNilCheck($node)) {
+            return;
+        }
+
+        if ($this->tryEmitSomeCheck($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -374,6 +386,59 @@ final class CallEmitter implements NodeEmitterInterface
      * `??` treats both absent keys and explicit nulls as triggering
      * the fallback.
      */
+    /**
+     * Specialise `(count arr)` on a target tagged `array` to a native
+     * `count(\$arr)` call. The runtime body would walk a cond chain
+     * over the standard collection shapes before reaching the same
+     * `php/count` branch.
+     */
+    private function tryEmitTypedPhpArrayCount(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTypedPhpArrayCount($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('count(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(')', $loc);
+        return true;
+    }
+
+    /**
+     * `(nil? x)` — emit `($x === null)` directly, bypassing the
+     * registry lookup and `id` adapter.
+     */
+    private function tryEmitNilCheck(CallNode $node): bool
+    {
+        if (!CallSpecialization::isNilCheck($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(' === null)', $loc);
+        return true;
+    }
+
+    /**
+     * `(some? x)` 1-arg — emit `($x !== null)` directly. The 2-arg
+     * overload `(some? pred coll)` keeps the runtime dispatch.
+     */
+    private function tryEmitSomeCheck(CallNode $node): bool
+    {
+        if (!CallSpecialization::isSomeCheck($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(' !== null)', $loc);
+        return true;
+    }
+
     private function tryEmitTypedPhpArrayGet(CallNode $node): bool
     {
         if (!CallSpecialization::isTypedPhpArrayGet($node)) {

--- a/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [x] (nil? x))
+(fn [x] (some? x))
+(fn [^array a] (count a))
+--PHP--
+(function($x) {
+  return ($x === null);
+});(function($x) {
+  return ($x !== null);
+});(function(array $a) {
+  return count($a);
+});


### PR DESCRIPTION
## 🤔 Background

Three call-site lowerings closing follow-up specialiser gaps:

- `(nil? x)` and 1-arg `(some? x)` are amongst the hottest predicates in any Phel program (every `(when (some? x) …)`, every `(if (nil? x) default …)`, every threaded `(when-let …)`). Today they go through `\Phel::getDefinition("phel.core", "nil?")->__invoke($x)` plus the `id` adapter, and `some?` also wraps through `not`.
- `(count arr)` on an `array`-tagged local hits the same problem #2139 solved for `get`: the runtime body walks a cond chain over set / seq / vector / map / php-array, and the only branch that ever fires for a tagged target is the native `php/count` one.

## 💡 Goal

Add three sibling specialisers next to the existing `isTypedPhpArrayGet`:

- `(nil? x)` → `($x === null)`
- 1-arg `(some? x)` → `($x !== null)` (2-arg `(some? pred coll)` keeps runtime dispatch)
- `(count arr)` on `^array`-tagged local → `count(\$arr)`

Closes #2157
Closes #2158

## 🔖 Changes

- `CallSpecialization::isNilCheck`, `isSomeCheck` — new predicates (shared `isUnaryCoreCall` helper).
- `CallSpecialization::isTypedPhpArrayCount` — predicate mirroring `isTypedPhpArrayGet`.
- All three wired into `isSpecialized` so the cache scanner skips reserving `$__phel_call_N` slots.
- `CallEmitter::tryEmitNilCheck`, `tryEmitSomeCheck`, `tryEmitTypedPhpArrayCount` — direct PHP emission.
- Integration fixture `tests/php/Integration/Fixtures/Call/nil-some-check-specialised.test` covers all three shapes.
- `CHANGELOG.md` — `Unreleased / Performance` entries.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green