### PR TITLE
perf(compiler): specialise true?/false?/truthy? + zero?/pos?/neg? predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower 1-arg `(count arr)` on an `array`-tagged local to native `count($arr)`, matching the `(get arr k)` specialisation in #2139. The runtime cond chain over set / seq / vector / map collapses to the same `php/count` branch the native call already covers (#2158)
 
+- `CallSpecialization`: lower identity-strict bool predicates (`(true? x)` → `($x === true)`, `(false? x)` → `($x === false)`), the Phel-truthy probe (`(truthy? x)` → `(($__truthy = $x) !== null && $__truthy !== false)`), and the numeric predicates on `^int`/`^float` tagged locals (`(zero? x)` → `($x === 0)`, `(pos? x)` → `($x > 0)`, `(neg? x)` → `($x < 0)`). `BigInt` / `Ratio` / `BigDecimal` shapes stay on the runtime `NumericOperations` dispatch (#2160)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -107,6 +107,22 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTrueCheck($node)) {
+            return true;
+        }
+
+        if (self::isFalseCheck($node)) {
+            return true;
+        }
+
+        if (self::isTruthyCheck($node)) {
+            return true;
+        }
+
+        if (self::isNumericPredicate($node) !== null) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -681,6 +697,72 @@ final readonly class CallSpecialization
     public static function isSomeCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'some?');
+    }
+
+    /**
+     * `(true? x)` — Phel `true?` is identity-strict (`(id x true)`),
+     * so the call collapses to `($x === true)` for any argument.
+     */
+    public static function isTrueCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'true?');
+    }
+
+    /**
+     * `(false? x)` — `(id x false)`, collapses to `($x === false)`.
+     */
+    public static function isFalseCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'false?');
+    }
+
+    /**
+     * `(truthy? x)` — Phel-truthy probe. The runtime body wraps
+     * `Truthy::isTruthy($x)`; the inline check is equivalent.
+     */
+    public static function isTruthyCheck(CallNode $node): bool
+    {
+        return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(zero? x)` / `(pos? x)` / `(neg? x)` on an `int` / `float`
+     * tagged local. Other numeric shapes (`BigInt`, `Ratio`,
+     * `BigDecimal`) need the runtime `NumericOperations` dispatch
+     * because the native operators do not honour their equality
+     * semantics. Returns the predicate name when eligible, `null`
+     * otherwise.
+     */
+    public static function isNumericPredicate(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!in_array($name, ['zero?', 'pos?', 'neg?'], true)) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag !== 'int' && $tag !== 'float') {
+            return null;
+        }
+
+        return $name;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -183,6 +183,22 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTrueCheck($node)) {
+            return;
+        }
+
+        if ($this->tryEmitFalseCheck($node)) {
+            return;
+        }
+
+        if ($this->tryEmitTruthyCheck($node)) {
+            return;
+        }
+
+        if ($this->tryEmitNumericPredicate($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -436,6 +452,76 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(' !== null)', $loc);
+        return true;
+    }
+
+    private function tryEmitTrueCheck(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTrueCheck($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(' === true)', $loc);
+        return true;
+    }
+
+    private function tryEmitFalseCheck(CallNode $node): bool
+    {
+        if (!CallSpecialization::isFalseCheck($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(' === false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(truthy? x)` — Phel-truthy probe inlined. Uses a fresh `$__truthy`
+     * binding so the result is a bool the caller can splice into any
+     * expression position.
+     */
+    private function tryEmitTruthyCheck(CallNode $node): bool
+    {
+        if (!CallSpecialization::isTruthyCheck($node)) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(($__truthy = ', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(zero? x)` / `(pos? x)` / `(neg? x)` on an `int` / `float`
+     * tagged local — emit the native comparison directly.
+     */
+    private function tryEmitNumericPredicate(CallNode $node): bool
+    {
+        $name = CallSpecialization::isNumericPredicate($node);
+        if ($name === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+
+        $op = match ($name) {
+            'zero?' => ' === 0',
+            'pos?' => ' > 0',
+            'neg?' => ' < 0',
+            default => ' === 0',
+        };
+
+        $this->outputEmitter->emitStr($op . ')', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/predicate-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/predicate-specialised.test
@@ -1,0 +1,21 @@
+--PHEL--
+(fn [x] (true? x))
+(fn [x] (false? x))
+(fn [x] (truthy? x))
+(fn [^int n] (zero? n))
+(fn [^int n] (pos? n))
+(fn [^float n] (neg? n))
+--PHP--
+(function($x) {
+  return ($x === true);
+});(function($x) {
+  return ($x === false);
+});(function($x) {
+  return (($__truthy = $x) !== null && $__truthy !== false);
+});(function(int $n) {
+  return ($n === 0);
+});(function(int $n): bool {
+  return ($n > 0);
+});(function(float $n): bool {
+  return ($n < 0);
+});


### PR DESCRIPTION
## 🤔 Background

Continuation of the predicate-specialiser series. `(nil? x)` and `(some? x)` landed in #2159; this PR adds the rest of the hot single-arg predicates that today still route through `\Phel::getDefinition(...)->__invoke($x)` for variable arguments.

Closes #2160

## 🔖 Changes

- `(true? x)` / `(false? x)` → `($x === true)` / `($x === false)`. Phel `true?`/`false?` are identity-strict (`(id x true|false)`).
- `(truthy? x)` → `(($__truthy = $x) !== null && $__truthy !== false)`. Same Phel-truthy adapter `IfEmitter` already emits, just inlined at the predicate call site.
- `(zero? x)` / `(pos? x)` / `(neg? x)` on `^int` / `^float` tagged locals → `($x === 0)` / `($x > 0)` / `($x < 0)`. `BigInt`, `Ratio`, `BigDecimal` shapes stay on the `NumericOperations` runtime dispatch because the native operators do not honour their equality semantics.
- All five wired into `CallSpecialization::isSpecialized` so the cache scanner skips reserving `$__phel_call_N` slots.
- One integration fixture `tests/php/Integration/Fixtures/Call/predicate-specialised.test` covers every shape.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green