### PR TITLE
perf(compiler): specialise int?/float?/string?/keyword?/symbol?/ratio? to native PHP checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower identity-strict bool predicates (`(true? x)` → `($x === true)`, `(false? x)` → `($x === false)`), the Phel-truthy probe (`(truthy? x)` → `(($__truthy = $x) !== null && $__truthy !== false)`), and the numeric predicates on `^int`/`^float` tagged locals (`(zero? x)` → `($x === 0)`, `(pos? x)` → `($x > 0)`, `(neg? x)` → `($x < 0)`). `BigInt` / `Ratio` / `BigDecimal` shapes stay on the runtime `NumericOperations` dispatch (#2160)
 
+- `CallSpecialization`: lower the 1-arg type predicates `int?` / `float?` / `double?` / `string?` / `keyword?` / `symbol?` / `ratio?` to their native PHP one-liners (`is_int`, `is_float`, `is_string`, `instanceof Keyword`, `instanceof Symbol`, `instanceof Ratio`). Predicates with multi-shape runtime bodies (`integer?` covering `int|BigInt`, `number?` covering four numeric types) stay on the runtime dispatch (#2162)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -123,6 +123,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isTypePredicate($node)) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -723,6 +727,47 @@ final readonly class CallSpecialization
     public static function isTruthyCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(int? x)` / `(float? x)` / `(double? x)` / `(string? x)` /
+     * `(keyword? x)` / `(symbol? x)` / `(ratio? x)` — single-arg
+     * type predicates whose runtime body is a one-liner native
+     * check. Returns the PHP expression fragment to splice between
+     * the surrounding parens, or `null` when the call is not one of
+     * these predicates.
+     *
+     * The fragment expects `%s` substitution for the (already-emitted)
+     * argument expression.
+     */
+    public static function typePredicateFragment(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'int?' => 'is_int(%s)',
+            'float?', 'double?' => 'is_float(%s)',
+            'string?' => 'is_string(%s)',
+            'keyword?' => '(%s instanceof \\Phel\\Lang\\Keyword)',
+            'symbol?' => '(%s instanceof \\Phel\\Lang\\Symbol)',
+            'ratio?' => '(%s instanceof \\Phel\\Lang\\Ratio)',
+            default => null,
+        };
+    }
+
+    public static function isTypePredicate(CallNode $node): bool
+    {
+        return self::typePredicateFragment($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -199,6 +199,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitTypePredicate($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -496,6 +500,28 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(($__truthy = ', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * Splice the argument into the native predicate fragment from
+     * `CallSpecialization::typePredicateFragment`. Used for `int?` /
+     * `float?` / `string?` / `keyword?` / `symbol?` / `ratio?`.
+     */
+    private function tryEmitTypePredicate(CallNode $node): bool
+    {
+        $fragment = CallSpecialization::typePredicateFragment($node);
+        if ($fragment === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $parts = explode('%s', $fragment, 2);
+        assert(count($parts) === 2);
+
+        $this->outputEmitter->emitStr($parts[0], $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr($parts[1], $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/type-predicate-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/type-predicate-specialised.test
@@ -1,0 +1,21 @@
+--PHEL--
+(fn [x] (int? x))
+(fn [x] (float? x))
+(fn [x] (string? x))
+(fn [x] (keyword? x))
+(fn [x] (symbol? x))
+(fn [x] (ratio? x))
+--PHP--
+(function($x): bool {
+  return is_int($x);
+});(function($x): bool {
+  return is_float($x);
+});(function($x): bool {
+  return is_string($x);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Keyword);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Symbol);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Ratio);
+});


### PR DESCRIPTION
## 🤔 Background

Continuation of the predicate-specialiser series (#2159, #2161). The 1-arg type predicates whose `phel.core` body is a single PHP one-liner today still go through `\Phel::getDefinition(…)->__invoke(…)`.

Closes #2162

## 🔖 Changes

- `CallSpecialization::typePredicateFragment` — table-driven map from predicate name to PHP fragment with `%s` substitution.
- `CallEmitter::tryEmitTypePredicate` — splices the argument into the fragment.
- Wired into `isSpecialized` so the cache scanner skips reserving `$__phel_call_N` slots.
- Integration fixture `tests/php/Integration/Fixtures/Call/type-predicate-specialised.test` covers each shape.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

| Predicate | Emitted |
|-----------|---------|
| `(int? x)` | `is_int($x)` |
| `(float? x)` / `(double? x)` | `is_float($x)` |
| `(string? x)` | `is_string($x)` |
| `(keyword? x)` | `($x instanceof \Phel\Lang\Keyword)` |
| `(symbol? x)` | `($x instanceof \Phel\Lang\Symbol)` |
| `(ratio? x)` | `($x instanceof \Phel\Lang\Ratio)` |

`integer?` (int|BigInt) and `number?` (four numeric types) stay on runtime dispatch — they would need an `or` chain that the current infrastructure does not generate.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green