### PR TITLE
perf(compiler): specialise (name x) / (namespace x) on tagged Keyword / Symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower the 1-arg type predicates `int?` / `float?` / `double?` / `string?` / `keyword?` / `symbol?` / `ratio?` to their native PHP one-liners (`is_int`, `is_float`, `is_string`, `instanceof Keyword`, `instanceof Symbol`, `instanceof Ratio`). Predicates with multi-shape runtime bodies (`integer?` covering `int|BigInt`, `number?` covering four numeric types) stay on the runtime dispatch (#2162)
 
+- `CallSpecialization`: lower `(name k)` and `(namespace k)` to the direct `$k->getName()` / `$k->getNamespace()` method call when the analyser has tagged `k` as `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`. Skips the runtime `(if (string? x) x (php/-> x (getName)))` cond chain (#2164)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -16,6 +16,7 @@ use Phel\Lang\Collections\Vector\PersistentVectorInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
+use Phel\Lang\Symbol;
 use Phel\Shared\CompilerConstants;
 
 use function array_slice;
@@ -124,6 +125,10 @@ final readonly class CallSpecialization
         }
 
         if (self::isTypePredicate($node)) {
+            return true;
+        }
+
+        if (self::isNamedAccessor($node)) {
             return true;
         }
 
@@ -727,6 +732,50 @@ final readonly class CallSpecialization
     public static function isTruthyCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(name x)` / `(namespace x)` on a target tagged
+     * `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`. The runtime body
+     * for `name` is `(if (string? x) x (php/-> x (getName)))`; the
+     * tagged target always hits the second branch. Returns the
+     * method name (`getName` / `getNamespace`) when eligible, `null`
+     * otherwise.
+     */
+    public static function namedAccessorMethod(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag !== Keyword::class && $tag !== Symbol::class) {
+            return null;
+        }
+
+        return match ($fn->getName()->getName()) {
+            'name' => 'getName',
+            'namespace' => 'getNamespace',
+            default => null,
+        };
+    }
+
+    public static function isNamedAccessor(CallNode $node): bool
+    {
+        return self::namedAccessorMethod($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -203,6 +203,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitNamedAccessor($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -500,6 +504,25 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(($__truthy = ', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(name x)` / `(namespace x)` on a target tagged
+     * `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol` — emit the direct
+     * method call, skipping the runtime cond chain.
+     */
+    private function tryEmitNamedAccessor(CallNode $node): bool
+    {
+        $method = CallSpecialization::namedAccessorMethod($node);
+        if ($method === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr('->' . $method . '())', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/name-namespace-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/name-namespace-tagged.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [^\Phel\Lang\Keyword k] (name k))
+(fn [^\Phel\Lang\Symbol s] (namespace s))
+--PHP--
+(function(\Phel\Lang\Keyword $k) {
+  return ($k->getName());
+});(function(\Phel\Lang\Symbol $s) {
+  return ($s->getNamespace());
+});


### PR DESCRIPTION
## 🤔 Background

Continuation of the call-site specialiser series. The `(name k)` / `(namespace k)` accessors today go through `\Phel::getDefinition(…)->__invoke(…)`. When the analyser has tagged `k` as `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`, the `(if (string? x) x …)` branch in the runtime body is dead and the whole call collapses to a single `\$k->getName()` / `\$k->getNamespace()` invocation.

Closes #2164

## 🔖 Changes

- `CallSpecialization::namedAccessorMethod` — returns `'getName'` / `'getNamespace'` when the call is eligible, `null` otherwise.
- `CallSpecialization::isNamedAccessor` wired into `isSpecialized`.
- `CallEmitter::tryEmitNamedAccessor` — emits the direct method call.
- Integration fixture `tests/php/Integration/Fixtures/Call/name-namespace-tagged.test`.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green