### PR TITLE
perf(compiler): specialise (empty? x) on tagged locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower `(name k)` and `(namespace k)` to the direct `$k->getName()` / `$k->getNamespace()` method call when the analyser has tagged `k` as `\Phel\Lang\Keyword` or `\Phel\Lang\Symbol`. Skips the runtime `(if (string? x) x (php/-> x (getName)))` cond chain (#2164)
 
+- `CallSpecialization`: lower `(empty? x)` to a tag-specific native check — `($x === [])` for `^array`, `($x === '')` for `^string`, `($x === 0)` for `^int`, `($x->count() === 0)` for `^PersistentMapInterface` / `^PersistentVectorInterface`. Skips the runtime cond chain over numeric / string / lazyseq / cons / fallback (#2166)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -132,6 +132,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isEmptyCheck($node)) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -732,6 +736,57 @@ final readonly class CallSpecialization
     public static function isTruthyCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(empty? x)` on a tagged local. Returns the PHP expression
+     * fragment with `%s` substitution for the (already-emitted)
+     * argument, or `null` when the call is not eligible.
+     *
+     *  - `^array x`                       → `(%s === [])`
+     *  - `^string x`                      → `(%s === '')`
+     *  - `^int x`                         → `(%s === 0)`
+     *  - `^PersistentMapInterface x`      → `(%s->count() === 0)`
+     *  - `^PersistentVectorInterface x`   → `(%s->count() === 0)`
+     */
+    public static function emptyCheckFragment(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'empty?'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        return match ($tag) {
+            'array' => '(%s === [])',
+            'string' => "(%s === '')",
+            'int' => '(%s === 0)',
+            PersistentMapInterface::class,
+            PersistentVectorInterface::class => '(%s->count() === 0)',
+            default => null,
+        };
+    }
+
+    public static function isEmptyCheck(CallNode $node): bool
+    {
+        return self::emptyCheckFragment($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -207,6 +207,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitEmptyCheck($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -504,6 +508,27 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(($__truthy = ', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(empty? x)` on a tagged local — emit the native check
+     * specific to the tag, skipping the runtime cond chain.
+     */
+    private function tryEmitEmptyCheck(CallNode $node): bool
+    {
+        $fragment = CallSpecialization::emptyCheckFragment($node);
+        if ($fragment === null) {
+            return false;
+        }
+
+        $loc = $node->getStartSourceLocation();
+        $parts = explode('%s', $fragment, 2);
+        assert(count($parts) === 2);
+
+        $this->outputEmitter->emitStr($parts[0], $loc);
+        $this->outputEmitter->emitNode($node->getArguments()[0]);
+        $this->outputEmitter->emitStr($parts[1], $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/empty-check-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/empty-check-tagged.test
@@ -1,0 +1,18 @@
+--PHEL--
+(fn [^array a] (empty? a))
+(fn [^string s] (empty? s))
+(fn [^int n] (empty? n))
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m] (empty? m))
+(fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v] (empty? v))
+--PHP--
+(function(array $a) {
+  return ($a === []);
+});(function(string $s) {
+  return ($s === '');
+});(function(int $n) {
+  return ($n === 0);
+});(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m) {
+  return ($m->count() === 0);
+});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v) {
+  return ($v->count() === 0);
+});


### PR DESCRIPTION
## 🤔 Background

`(empty? x)` walks a cond chain over numeric / string / lazyseq / cons / fallback at runtime. For analyser-tagged targets only one branch ever fires; the dispatch reduces to a single native check.

Closes #2166

## 🔖 Changes

- `CallSpecialization::emptyCheckFragment` — table-driven mapping from arg tag to PHP fragment with `%s` substitution.
- `CallSpecialization::isEmptyCheck` wired into `isSpecialized`.
- `CallEmitter::tryEmitEmptyCheck` — splices the argument into the fragment.
- Integration fixture `tests/php/Integration/Fixtures/Call/empty-check-tagged.test` covers all five shapes.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

| Tag | Emitted |
|-----|---------|
| `^array x` | `($x === [])` |
| `^string x` | `($x === '')` |
| `^int x` | `($x === 0)` |
| `^PersistentMapInterface x` | `($x->count() === 0)` |
| `^PersistentVectorInterface x` | `($x->count() === 0)` |

Untagged calls fall back to the runtime cond chain — necessary for the dynamic-dispatch shapes (`LazySeqInterface`, `Cons`) where no native short-circuit covers the semantics.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green