### PR TITLE
perf(compiler): extend type predicate table (struct?/set?/lazy-seq?/queue?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower `(empty? x)` to a tag-specific native check — `($x === [])` for `^array`, `($x === '')` for `^string`, `($x === 0)` for `^int`, `($x->count() === 0)` for `^PersistentMapInterface` / `^PersistentVectorInterface`. Skips the runtime cond chain over numeric / string / lazyseq / cons / fallback (#2166)
 
+- `CallSpecialization`: extend the type-predicate table with `struct?` / `set?` / `lazy-seq?` / `queue?`. All four runtime bodies are single `(php/instanceof x …)` expressions so they reduce to a direct `instanceof` check. Predicates with multi-condition bodies (`list?`, `seq?`, `map?`, `vector?`) stay on the runtime dispatch (#2168)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -865,6 +865,10 @@ final readonly class CallSpecialization
             'keyword?' => '(%s instanceof \\Phel\\Lang\\Keyword)',
             'symbol?' => '(%s instanceof \\Phel\\Lang\\Symbol)',
             'ratio?' => '(%s instanceof \\Phel\\Lang\\Ratio)',
+            'struct?' => '(%s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct)',
+            'set?' => '(%s instanceof \\Phel\\Lang\\Collections\\HashSet\\PersistentHashSetInterface)',
+            'lazy-seq?' => '(%s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface)',
+            'queue?' => '(%s instanceof \\Phel\\Lang\\Collections\\Queue\\PersistentQueue)',
             default => null,
         };
     }

--- a/tests/php/Integration/Fixtures/Call/type-predicate-extra-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/type-predicate-extra-specialised.test
@@ -1,0 +1,15 @@
+--PHEL--
+(fn [x] (struct? x))
+(fn [x] (set? x))
+(fn [x] (lazy-seq? x))
+(fn [x] (queue? x))
+--PHP--
+(function($x): bool {
+  return ($x instanceof \Phel\Lang\Collections\Struct\AbstractPersistentStruct);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Collections\HashSet\PersistentHashSetInterface);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Collections\LazySeq\LazySeqInterface);
+});(function($x): bool {
+  return ($x instanceof \Phel\Lang\Collections\Queue\PersistentQueue);
+});


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2162. Four more 1-arg type predicates whose `phel.core` body is a single `(php/instanceof x …)` get lowered directly at the call site.

Closes #2168

## 🔖 Changes

- `CallSpecialization::typePredicateFragment` — added four entries.
- Integration fixture `tests/php/Integration/Fixtures/Call/type-predicate-extra-specialised.test`.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

| Predicate | Emitted |
|-----------|---------|
| `(struct? x)` | `($x instanceof \Phel\Lang\Collections\Struct\AbstractPersistentStruct)` |
| `(set? x)` | `($x instanceof \Phel\Lang\Collections\HashSet\PersistentHashSetInterface)` |
| `(lazy-seq? x)` | `($x instanceof \Phel\Lang\Collections\LazySeq\LazySeqInterface)` |
| `(queue? x)` | `($x instanceof \Phel\Lang\Collections\Queue\PersistentQueue)` |

Predicates with multi-condition bodies (`list?`, `seq?`, `map?`, `vector?`) stay on the runtime dispatch — those need a richer lowerer than the single-fragment table.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green