### PR TITLE
perf(compiler): specialise (contains? coll k) on tagged target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: extend the type-predicate table with `struct?` / `set?` / `lazy-seq?` / `queue?`. All four runtime bodies are single `(php/instanceof x …)` expressions so they reduce to a direct `instanceof` check. Predicates with multi-condition bodies (`list?`, `seq?`, `map?`, `vector?`) stay on the runtime dispatch (#2168)
 
+- `CallSpecialization`: lower `(contains? coll k)` to the direct collection call when the target is tagged. `ContainsInterface`-implementing tags (`^PersistentMapInterface`, `^PersistentVectorInterface`, `^PersistentHashSetInterface`, `^ContainsInterface`) → `$coll->contains($k)`. `^array` → `array_key_exists($k, $coll)`. Untagged / string targets stay on the runtime cond chain (#2170)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -10,9 +10,11 @@ use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
 use Phel\Lang\AbstractFn;
+use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+use Phel\Lang\ContainsInterface;
 use Phel\Lang\FnInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SeqInterface;
@@ -133,6 +135,10 @@ final readonly class CallSpecialization
         }
 
         if (self::isEmptyCheck($node)) {
+            return true;
+        }
+
+        if (self::isContainsCheck($node)) {
             return true;
         }
 
@@ -736,6 +742,63 @@ final readonly class CallSpecialization
     public static function isTruthyCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(contains? coll k)` on a target tagged as a
+     * `\Phel\Lang\ContainsInterface`-implementing collection
+     * (PersistentMap / PersistentVector / PersistentHashSet) or as a
+     * PHP `array`. The runtime body walks
+     * `nil? → ContainsInterface → is_array → is_string → throw`; the
+     * tagged target collapses to one of the first two branches.
+     *
+     * Returns:
+     *  - `'method'` for ContainsInterface targets — emit `$coll->contains($k)`
+     *  - `'array'` for array tags                 — emit `array_key_exists($k, $coll)`
+     *  - `null` otherwise.
+     */
+    public static function containsCheckKind(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+            || $fn->getName()->getName() !== 'contains?'
+        ) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        $target = $args[0];
+        if (!$target instanceof LocalVarNode) {
+            return null;
+        }
+
+        $tag = self::normalisedTag($target->getInferredType());
+        if ($tag === null) {
+            return null;
+        }
+
+        if ($tag === 'array') {
+            return 'array';
+        }
+
+        $containsInterfaces = [
+            PersistentMapInterface::class,
+            PersistentVectorInterface::class,
+            PersistentHashSetInterface::class,
+            ContainsInterface::class,
+        ];
+
+        return in_array($tag, $containsInterfaces, true) ? 'method' : null;
+    }
+
+    public static function isContainsCheck(CallNode $node): bool
+    {
+        return self::containsCheckKind($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -211,6 +211,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitContainsCheck($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -508,6 +512,37 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(($__truthy = ', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(contains? coll k)` on a tagged target — emit the direct
+     * method or `array_key_exists` form.
+     */
+    private function tryEmitContainsCheck(CallNode $node): bool
+    {
+        $kind = CallSpecialization::containsCheckKind($node);
+        if ($kind === null) {
+            return false;
+        }
+
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+
+        if ($kind === 'array') {
+            $this->outputEmitter->emitStr('array_key_exists(', $loc);
+            $this->outputEmitter->emitNode($args[1]);
+            $this->outputEmitter->emitStr(', ', $loc);
+            $this->outputEmitter->emitNode($args[0]);
+            $this->outputEmitter->emitStr(')', $loc);
+            return true;
+        }
+
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->contains(', $loc);
+        $this->outputEmitter->emitNode($args[1]);
+        $this->outputEmitter->emitStr('))', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/contains-check-tagged.test
+++ b/tests/php/Integration/Fixtures/Call/contains-check-tagged.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [^\Phel\Lang\Collections\Map\PersistentMapInterface m k] (contains? m k))
+(fn [^\Phel\Lang\Collections\Vector\PersistentVectorInterface v i] (contains? v i))
+(fn [^array a k] (contains? a k))
+--PHP--
+(function(\Phel\Lang\Collections\Map\PersistentMapInterface $m, $k) {
+  return ($m->contains($k));
+});(function(\Phel\Lang\Collections\Vector\PersistentVectorInterface $v, $i) {
+  return ($v->contains($i));
+});(function(array $a, $k) {
+  return array_key_exists($k, $a);
+});


### PR DESCRIPTION
## 🤔 Background

`(contains? coll k)` walks a cond chain `nil? → ContainsInterface → is_array → is_string → throw` at runtime. When the analyser has tagged `coll`, the dispatch reduces to a single native call.

Closes #2170

## 🔖 Changes

- `CallSpecialization::containsCheckKind` — returns `'method'` for ContainsInterface tags, `'array'` for `^array`, `null` otherwise.
- `CallEmitter::tryEmitContainsCheck` — emits `$coll->contains($k)` or `array_key_exists($k, $coll)`.
- Wired into `isSpecialized`.
- Integration fixture `tests/php/Integration/Fixtures/Call/contains-check-tagged.test`.
- `CHANGELOG.md` — entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green