### PR TITLE
perf(emitter): BooleanExprDetector recognises specialised predicate calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower `(contains? coll k)` to the direct collection call when the target is tagged. `ContainsInterface`-implementing tags (`^PersistentMapInterface`, `^PersistentVectorInterface`, `^PersistentHashSetInterface`, `^ContainsInterface`) → `$coll->contains($k)`. `^array` → `array_key_exists($k, $coll)`. Untagged / string targets stay on the runtime cond chain (#2170)
 
+- `BooleanExprDetector`: recognise specialised predicate `CallNode`s (`nil?`, `some?`, `true?`, `false?`, `truthy?`, the numeric predicates on tagged numerics, the type predicates, `empty?`, `contains?`) as bool-returning. Lets `IfEmitter` splice the lowered expression straight into the `if` test slot without the Phel-truthy `($__truthy = …) !== null && $__truthy !== false` adapter — combined with the tail-ternary lowering, `(if (nil? x) a b)` becomes `return (($x === null) ? a : b);` (#2172)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/Cache/BooleanExprDetector.php
@@ -8,6 +8,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
 use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
+use Phel\Compiler\Domain\Emitter\OutputEmitter\CallSpecialization;
 
 use function in_array;
 use function is_bool;
@@ -81,18 +82,21 @@ final class BooleanExprDetector
         }
 
         $fn = $node->getFn();
-        if (!$fn instanceof PhpVarNode) {
-            return false;
+        if ($fn instanceof PhpVarNode) {
+            $name = $fn->getName();
+
+            if ($fn->isInfix() && in_array($name, self::BOOL_INFIX, true)) {
+                return true;
+            }
+
+            // Match both bare (`is_int`) and namespaced (`\is_int`) forms.
+            $bare = str_starts_with($name, '\\') ? substr($name, 1) : $name;
+            return in_array($bare, self::BOOL_PHP_FUNCTIONS, true);
         }
 
-        $name = $fn->getName();
-
-        if ($fn->isInfix() && in_array($name, self::BOOL_INFIX, true)) {
-            return true;
-        }
-
-        // Match both bare (`is_int`) and namespaced (`\is_int`) forms.
-        $bare = str_starts_with($name, '\\') ? substr($name, 1) : $name;
-        return in_array($bare, self::BOOL_PHP_FUNCTIONS, true);
+        // A `CallNode` that the `CallSpecialization` layer lowers to a
+        // bool-typed PHP expression is also a hard bool — `IfEmitter`
+        // can splice it into the test slot without the truthy adapter.
+        return CallSpecialization::isBoolReturningSpecialisation($node);
     }
 }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -80,6 +80,29 @@ final readonly class CallSpecialization
 
     private function __construct() {}
 
+    /**
+     * Subset of {@see self::isSpecialized()} that lowers to a bool-typed
+     * PHP expression. The `BooleanExprDetector` consults this so the
+     * `IfEmitter` can splice the call directly into the test slot
+     * without wrapping it in the Phel-truthy adapter.
+     */
+    public static function isBoolReturningSpecialisation(CallNode $node): bool
+    {
+        if (self::isNilCheck($node)
+            || self::isSomeCheck($node)
+            || self::isTrueCheck($node)
+            || self::isFalseCheck($node)
+            || self::isTruthyCheck($node)
+            || self::isTypePredicate($node)
+            || self::isEmptyCheck($node)
+            || self::isContainsCheck($node)
+        ) {
+            return true;
+        }
+
+        return self::isNumericPredicate($node) !== null;
+    }
+
     public static function isSpecialized(CallNode $node): bool
     {
         if (self::isStrConcat($node)) {

--- a/tests/php/Integration/Fixtures/If/specialised-predicate-bool-skips-truthy.test
+++ b/tests/php/Integration/Fixtures/If/specialised-predicate-bool-skips-truthy.test
@@ -1,0 +1,18 @@
+--PHEL--
+(fn [x] (if (nil? x) :yes :no))
+(fn [^int n] (if (zero? n) :z :nz))
+(fn [^array a] (if (empty? a) :e :ne))
+--PHP--
+(function($x) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($x === null)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("yes")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("no")));
+
+});(function(int $n) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($n === 0)) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("z")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("nz")));
+
+});(function(array $a) {
+  static $__phel_const_0, $__phel_const_1;
+  return ((($a === [])) ? ($__phel_const_0 ??= \Phel\Lang\Keyword::create("e")) : ($__phel_const_1 ??= \Phel\Lang\Keyword::create("ne")));
+
+});


### PR DESCRIPTION
## 🤔 Background

The predicate specialisers landed in #2159 / #2161 / #2162 / #2168 emit bool-typed expressions (`is_int($x)`, `($x === null)`, `($x instanceof …)`, etc.) but the underlying call is still syntactically a `CallNode` with a `GlobalVarNode` fn. `BooleanExprDetector::isBool` only recognised `CallNode` with a `PhpVarNode` fn, so `IfEmitter` kept wrapping the specialised calls in the Phel-truthy adapter `($__truthy = …) !== null && $__truthy !== false`.

Closes #2172

## 🔖 Changes

- `CallSpecialization::isBoolReturningSpecialisation` — enumerates the subset of specialisers that lower to a bool-typed expression (`nil?`, `some?`, `true?`, `false?`, `truthy?`, the numeric predicates on tagged numerics, the type-predicate table, `empty?`, `contains?`).
- `BooleanExprDetector::isBool` delegates to it for non-`PhpVarNode` calls.
- Integration fixture `tests/php/Integration/Fixtures/If/specialised-predicate-bool-skips-truthy.test` shows the combined effect on three shapes.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## 🔗 Effect

```php
// Before:
if (($__truthy = ($x === null)) !== null && $__truthy !== false) { return :yes; } else { return :no; }

// After (composes with #2155 tail-ternary):
return ((($x === null)) ? :yes : :no);
```

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green