### PR TITLE
perf(emitter): lower (or …) / (and …) value-position to nested ternary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `BooleanExprDetector`: recognise specialised predicate `CallNode`s (`nil?`, `some?`, `true?`, `false?`, `truthy?`, the numeric predicates on tagged numerics, the type predicates, `empty?`, `contains?`) as bool-returning. Lets `IfEmitter` splice the lowered expression straight into the `if` test slot without the Phel-truthy `($__truthy = …) !== null && $__truthy !== false` adapter — combined with the tail-ternary lowering, `(if (nil? x) a b)` becomes `return (($x === null) ? a : b);` (#2172)
 
+- `LetEmitter`: lower `(or …)` / `(and …)` in expression / return context to a nested PHP ternary that preserves the Phel value-semantics (return first truthy / last falsy value), skipping the IIFE wrap. Same restriction as the test-position lowerer in #2153: every operand must be a simple expression shape. `(or a b c)` returns the first truthy value through a `($__or = …)` cascade without allocating a closure (#2174)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -13,6 +13,7 @@ use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 
 use function assert;
+use function count;
 use function in_array;
 use function is_string;
 use function ltrim;
@@ -29,6 +30,10 @@ final class LetEmitter implements NodeEmitterInterface
         assert($node instanceof LetNode);
 
         if ($this->tryEmitAsMatch($node)) {
+            return;
+        }
+
+        if ($this->tryEmitAsShortCircuit($node)) {
             return;
         }
 
@@ -111,6 +116,95 @@ final class LetEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitContextSuffix($env, $loc);
 
         return true;
+    }
+
+    /**
+     * Lower the expanded `(or …)` / `(and …)` macro shapes to a
+     * nested PHP ternary that preserves the Phel value-semantics
+     * (return the first truthy value / last falsy, not a bool).
+     * Skips the IIFE wrap the generic let-in-expression path emits.
+     *
+     * Statement-context lets do not benefit (no value is consumed),
+     * so we keep the generic emit there.
+     */
+    private function tryEmitAsShortCircuit(LetNode $node): bool
+    {
+        $env = $node->getEnv();
+        if ($env->isContext(NodeEnvironment::CONTEXT_STATEMENT)) {
+            return false;
+        }
+
+        $chain = AndOrShortCircuitLowerer::extractOrChain($node);
+        if ($chain !== null) {
+            $this->emitValuePositionChain($node, $chain, true);
+            return true;
+        }
+
+        $chain = AndOrShortCircuitLowerer::extractAndChain($node);
+        if ($chain !== null) {
+            $this->emitValuePositionChain($node, $chain, false);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<AbstractNode> $operands
+     */
+    private function emitValuePositionChain(LetNode $node, array $operands, bool $isOr): void
+    {
+        $env = $node->getEnv();
+        $loc = $node->getStartSourceLocation();
+
+        $this->outputEmitter->emitContextPrefix($env, $loc);
+
+        $count = count($operands);
+        for ($i = 0; $i < $count - 1; ++$i) {
+            $this->outputEmitter->emitStr('((($__or = ', $loc);
+            $this->emitOperandAsExpression($operands[$i]);
+            $this->outputEmitter->emitStr(') !== null && $__or !== false) ? ', $loc);
+            if ($isOr) {
+                $this->outputEmitter->emitStr('$__or : ', $loc);
+            }
+        }
+
+        $this->emitOperandAsExpression($operands[$count - 1]);
+
+        $suffix = $isOr ? ')' : ' : $__or)';
+        for ($i = 0; $i < $count - 1; ++$i) {
+            $this->outputEmitter->emitStr($suffix, $loc);
+        }
+
+        $this->outputEmitter->emitContextSuffix($env, $loc);
+    }
+
+    /**
+     * Capture the emit output of a chain operand and strip the
+     * analyser's `return ` prefix / trailing `;` so the result fits
+     * inside the ternary expression. Same trick `IfEmitter` uses for
+     * test-position chains.
+     */
+    private function emitOperandAsExpression(AbstractNode $operand): void
+    {
+        ob_start();
+        try {
+            $this->outputEmitter->emitNode($operand);
+        } finally {
+            $buf = (string) ob_get_clean();
+        }
+
+        $stripped = preg_replace('/^return\s+/', '', $buf);
+        if ($stripped === null) {
+            $stripped = '';
+        }
+
+        $stripped = rtrim($stripped);
+        if ($stripped !== '' && str_ends_with($stripped, ';')) {
+            $stripped = substr($stripped, 0, -1);
+        }
+
+        $this->outputEmitter->emitStr($stripped, $operand->getStartSourceLocation());
     }
 
     /**

--- a/tests/php/Integration/Fixtures/Let/or-and-value-ternary.test
+++ b/tests/php/Integration/Fixtures/Let/or-and-value-ternary.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [a b c] (or a b c))
+(fn [a b c] (and a b c))
+--PHP--
+(function($a, $b, $c) {
+  return ((($__or = $a) !== null && $__or !== false) ? $__or : ((($__or = $b) !== null && $__or !== false) ? $__or : $c));
+});(function($a, $b, $c) {
+  return ((($__or = $a) !== null && $__or !== false) ? ((($__or = $b) !== null && $__or !== false) ? $c : $__or) : $__or);
+});


### PR DESCRIPTION
## 🤔 Background

#2153 lowered `(or …)` / `(and …)` macros to native `||` / `&&` only when consumed in test position. In expression / return position the macro-expanded `LetNode` still emits as an IIFE — closure allocation + use-clause + call frame per evaluation.

Native `||` / `&&` returns a bool, so it cannot substitute the macro semantics in value position (Phel `(or 0 5)` returns `0`, not `true`). A nested ternary that assigns each operand to `$__or` before testing preserves the value semantics without the IIFE.

Closes #2174

## 🔖 Changes

- `LetEmitter::tryEmitAsShortCircuit` — probes `AndOrShortCircuitLowerer::extractOrChain` / `extractAndChain` for the let. When the shape matches and we are in expression / return context, emit the nested ternary form instead of falling through to the IIFE.
- `LetEmitter::emitOperandAsExpression` — ob_capture + strip helper to drop the analyser's RETURN-context decoration on chain operands (same trick `IfEmitter` uses).
- Integration fixture `tests/php/Integration/Fixtures/Let/or-and-value-ternary.test` covers both shapes.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

| Form | Emitted |
|------|---------|
| `(or a b c)` | `((($__or = $a) ... ) ? $__or : ((($__or = $b) ... ) ? $__or : $c))` |
| `(and a b c)` | `((($__or = $a) ... ) ? ((($__or = $b) ... ) ? $c : $__or) : $__or)` |

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green