### PR TITLE
perf(compiler): specialise map?/vector?/seq? to multi-instanceof checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `LetEmitter`: lower `(or …)` / `(and …)` in expression / return context to a nested PHP ternary that preserves the Phel value-semantics (return first truthy / last falsy value), skipping the IIFE wrap. Same restriction as the test-position lowerer in #2153: every operand must be a simple expression shape. `(or a b c)` returns the first truthy value through a `($__or = …)` cascade without allocating a closure (#2174)
 
+- `CallSpecialization`: extend the type-predicate table with the multi-instanceof shapes `map?` / `vector?` / `seq?`. `(map? x)` → `(($x instanceof PersistentMapInterface) && !($x instanceof AbstractPersistentStruct))`, `(vector? x)` → `(($x instanceof PersistentVectorInterface) \|\| ($x instanceof MapEntry))`, `(seq? x)` → 3-way `\|\|` chain over `LazySeqInterface` / `Cons` / `PersistentListInterface`. `list?` keeps the runtime dispatch (it also calls `$x->isList()`) (#2177)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -955,6 +955,9 @@ final readonly class CallSpecialization
             'set?' => '(%s instanceof \\Phel\\Lang\\Collections\\HashSet\\PersistentHashSetInterface)',
             'lazy-seq?' => '(%s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface)',
             'queue?' => '(%s instanceof \\Phel\\Lang\\Collections\\Queue\\PersistentQueue)',
+            'map?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Map\\PersistentMapInterface) && !(%1$s instanceof \\Phel\\Lang\\Collections\\Struct\\AbstractPersistentStruct))',
+            'vector?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\Vector\\PersistentVectorInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\Map\\MapEntry))',
+            'seq?' => '((%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\LazySeqInterface) || (%1$s instanceof \\Phel\\Lang\\Collections\\LazySeq\\Cons) || (%1$s instanceof \\Phel\\Lang\\Collections\\LinkedList\\PersistentListInterface))',
             default => null,
         };
     }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -20,6 +20,7 @@ use Phel\Lang\Symbol;
 use function array_slice;
 use function assert;
 use function count;
+use function sprintf;
 
 final class CallEmitter implements NodeEmitterInterface
 {
@@ -588,8 +589,9 @@ final class CallEmitter implements NodeEmitterInterface
 
     /**
      * Splice the argument into the native predicate fragment from
-     * `CallSpecialization::typePredicateFragment`. Used for `int?` /
-     * `float?` / `string?` / `keyword?` / `symbol?` / `ratio?`.
+     * `CallSpecialization::typePredicateFragment`. The fragment uses
+     * `sprintf` placeholders so multi-instanceof predicates (`map?`,
+     * `vector?`, `seq?`) can reference the argument multiple times.
      */
     private function tryEmitTypePredicate(CallNode $node): bool
     {
@@ -599,12 +601,21 @@ final class CallEmitter implements NodeEmitterInterface
         }
 
         $loc = $node->getStartSourceLocation();
-        $parts = explode('%s', $fragment, 2);
-        assert(count($parts) === 2);
 
-        $this->outputEmitter->emitStr($parts[0], $loc);
-        $this->outputEmitter->emitNode($node->getArguments()[0]);
-        $this->outputEmitter->emitStr($parts[1], $loc);
+        ob_start();
+        try {
+            $this->outputEmitter->emitNode($node->getArguments()[0]);
+        } finally {
+            $argEmit = (string) ob_get_clean();
+        }
+
+        $argEmit = preg_replace('/^return\s+/', '', $argEmit) ?? '';
+        $argEmit = rtrim($argEmit);
+        if (str_ends_with($argEmit, ';')) {
+            $argEmit = substr($argEmit, 0, -1);
+        }
+
+        $this->outputEmitter->emitStr(sprintf($fragment, $argEmit), $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/multi-instanceof-predicate.test
+++ b/tests/php/Integration/Fixtures/Call/multi-instanceof-predicate.test
@@ -1,0 +1,12 @@
+--PHEL--
+(fn [x] (map? x))
+(fn [x] (vector? x))
+(fn [x] (seq? x))
+--PHP--
+(function($x) {
+  return (($x instanceof \Phel\Lang\Collections\Map\PersistentMapInterface) && !($x instanceof \Phel\Lang\Collections\Struct\AbstractPersistentStruct));
+});(function($x): bool {
+  return (($x instanceof \Phel\Lang\Collections\Vector\PersistentVectorInterface) || ($x instanceof \Phel\Lang\Collections\Map\MapEntry));
+});(function($x): bool {
+  return (($x instanceof \Phel\Lang\Collections\LazySeq\LazySeqInterface) || ($x instanceof \Phel\Lang\Collections\LazySeq\Cons) || ($x instanceof \Phel\Lang\Collections\LinkedList\PersistentListInterface));
+});


### PR DESCRIPTION
## 🤔 Background

Follow-up to #2162 / #2168. The remaining type predicates whose body is a compound of `instanceof` checks (no method calls):

- `(map? x)` — `(php/instanceof x PersistentMapInterface) AND NOT (php/instanceof x AbstractPersistentStruct)`
- `(vector? x)` — `(php/instanceof x PersistentVectorInterface) OR (php/instanceof x MapEntry)`
- `(seq? x)` — `(php/instanceof x LazySeqInterface) OR (php/instanceof x Cons) OR (php/instanceof x PersistentListInterface)`

`list?` keeps the runtime dispatch — its body also calls `$x->isList()`, which is not a pure instanceof check.

Closes #2177

## 🔖 Changes

- `CallSpecialization::typePredicateFragment` — three new entries using `sprintf` numeric placeholders (`%1$s`) so the arg can appear multiple times in the fragment.
- `CallEmitter::tryEmitTypePredicate` — captures the arg emit via ob_start, strips the analyser's RETURN-context decoration, then `sprintf`s the fragment.
- Integration fixture `tests/php/Integration/Fixtures/Call/multi-instanceof-predicate.test` covers all three shapes.
- `CHANGELOG.md` — `Unreleased / Performance` entry.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green