### PR TITLE
perf(compiler): specialise (deref x) / (reset! v val) to direct method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: extend the type-predicate table with the multi-instanceof shapes `map?` / `vector?` / `seq?`. `(map? x)` → `(($x instanceof PersistentMapInterface) && !($x instanceof AbstractPersistentStruct))`, `(vector? x)` → `(($x instanceof PersistentVectorInterface) \|\| ($x instanceof MapEntry))`, `(seq? x)` → 3-way `\|\|` chain over `LazySeqInterface` / `Cons` / `PersistentListInterface`. `list?` keeps the runtime dispatch (it also calls `$x->isList()`) (#2177)
 
+- `CallSpecialization`: lower `(deref x)` (1-arg) and `(reset! v val)` to direct method calls (`$x->deref()` and `$v->set($val)`), skipping the registry lookup. The runtime fn body is itself a single `php/->` call, so the failure mode (method not found) is identical. The 3-arg `deref` overload (future / promise timeout) keeps the runtime dispatch (#2179)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -165,6 +165,10 @@ final readonly class CallSpecialization
             return true;
         }
 
+        if (self::isAtomMethodCall($node)) {
+            return true;
+        }
+
         if (self::isTypedVectorAccessor($node)) {
             return true;
         }
@@ -765,6 +769,43 @@ final readonly class CallSpecialization
     public static function isTruthyCheck(CallNode $node): bool
     {
         return self::isUnaryCoreCall($node, 'truthy?');
+    }
+
+    /**
+     * `(deref x)` 1-arg / `(reset! v val)` 2-arg — runtime bodies are
+     * single `php/->` method calls. Direct emission saves the registry
+     * lookup + adapter frame. The 3-arg deref overload (timeout) keeps
+     * the runtime dispatch because its body is a cond chain. Returns
+     * the (method, arg-indices-after-target) tuple, or `null`.
+     *
+     * @return array{0: string, 1: list<int>}|null
+     */
+    public static function atomMethodCall(CallNode $node): ?array
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        $argc = count($node->getArguments());
+
+        if ($name === 'deref' && $argc === 1) {
+            return ['deref', []];
+        }
+
+        if ($name === 'reset!' && $argc === 2) {
+            return ['set', [1]];
+        }
+
+        return null;
+    }
+
+    public static function isAtomMethodCall(CallNode $node): bool
+    {
+        return self::atomMethodCall($node) !== null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/CallEmitter.php
@@ -216,6 +216,10 @@ final class CallEmitter implements NodeEmitterInterface
             return;
         }
 
+        if ($this->tryEmitAtomMethodCall($node)) {
+            return;
+        }
+
         if ($this->tryEmitTypedVectorAccessor($node)) {
             return;
         }
@@ -513,6 +517,38 @@ final class CallEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('(($__truthy = ', $loc);
         $this->outputEmitter->emitNode($node->getArguments()[0]);
         $this->outputEmitter->emitStr(') !== null && $__truthy !== false)', $loc);
+        return true;
+    }
+
+    /**
+     * `(deref x)` / `(reset! v val)` — emit the direct method call on
+     * the target, skipping the registry lookup. No tag required: the
+     * runtime body itself is a single `php/-> target (method ...)`, so
+     * the failure mode (method not found) is identical to today.
+     */
+    private function tryEmitAtomMethodCall(CallNode $node): bool
+    {
+        $shape = CallSpecialization::atomMethodCall($node);
+        if ($shape === null) {
+            return false;
+        }
+
+        [$method, $argIndices] = $shape;
+        $args = $node->getArguments();
+        $loc = $node->getStartSourceLocation();
+
+        $this->outputEmitter->emitStr('(', $loc);
+        $this->outputEmitter->emitNode($args[0]);
+        $this->outputEmitter->emitStr('->' . $method . '(', $loc);
+        foreach ($argIndices as $i => $idx) {
+            if ($i > 0) {
+                $this->outputEmitter->emitStr(', ', $loc);
+            }
+
+            $this->outputEmitter->emitNode($args[$idx]);
+        }
+
+        $this->outputEmitter->emitStr('))', $loc);
         return true;
     }
 

--- a/tests/php/Integration/Fixtures/Call/deref-reset-specialised.test
+++ b/tests/php/Integration/Fixtures/Call/deref-reset-specialised.test
@@ -1,0 +1,9 @@
+--PHEL--
+(fn [a] (deref a))
+(fn [a v] (reset! a v))
+--PHP--
+(function($a) {
+  return ($a->deref());
+});(function($a, $v) {
+  return ($a->set($v));
+});


### PR DESCRIPTION
## 🤔 Background

Two atom / var hot paths whose runtime body is a single `(php/-> target (method ...))`:

- 1-arg `(deref x)` → `(php/-> x (deref))`
- `(reset! v val)` → `(php/-> v (set val))`

Both today go through `\Phel::getDefinition(…)->__invoke(…)` plus the `php/->` adapter. The 3-arg deref overload (timeout-aware future/promise path) keeps the runtime dispatch because its body is a cond chain.

Closes #2179

## 🔖 Changes

- `CallSpecialization::atomMethodCall` — returns `(method, arg-indices-after-target)` tuple for eligible shapes, `null` otherwise.
- `CallEmitter::tryEmitAtomMethodCall` — emits `($target->method($args))`.
- Wired into `isSpecialized`.
- Integration fixture `tests/php/Integration/Fixtures/Call/deref-reset-specialised.test`.
- `CHANGELOG.md` — entry.

No tag required for these specialisers: the runtime body itself is a single `php/->` call, so the method-not-found failure mode is identical to today.

## ✅ Verification

- `composer test-compiler` — green
- `composer test-core` — green
- `composer test-quality` — green