### PR TITLE
feat(compiler): infer return types of known php/* scalar functions (closes #2175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Control-flow lowering to PHP `match` (#2091):
 
 - `CallSpecialization`: lower `(deref x)` (1-arg) and `(reset! v val)` to direct method calls (`$x->deref()` and `$v->set($val)`), skipping the registry lookup. The runtime fn body is itself a single `php/->` call, so the failure mode (method not found) is identical. The 3-arg `deref` overload (future / promise timeout) keeps the runtime dispatch (#2179)
 
+- `CallSpecialization`: infer return types of known `php/*` scalar functions (`cos`, `sin`, `sqrt`, `count`, `strlen`, `intval`, `floor`, `is_int`, `sprintf`, etc.) via a private `KnownPhpFunctionReturnTypes` table, plus propagate the result tag of typed-arith calls (`+` / `-` / `*` on `int`/`float`-tagged operands) so nested expressions chain. `(+ ^float angle (php/cos a))` now emits native `($angle + cos($a))` instead of runtime dispatch; `(+ sum (* d (php/cos angle)))` chains all the way to `($sum + ($d * cos($angle)))`. Unlisted PHP functions stay on the runtime dispatch. Path 2 (best-effort propagation through `php/aget` via an `:items-type` meta hint) is deferred (#2175)
+
 ### Fixed
 
 - `phel.cli`: Symfony Console 8.0 compat. `Command::setCode` closure now carries explicit `InputInterface` / `OutputInterface` types; clears the Symfony 7.3 deprecation warning for the same reason (#2094)

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/CallSpecialization.php
@@ -9,6 +9,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LocalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Lang\AbstractFn;
 use Phel\Lang\Collections\HashSet\PersistentHashSetInterface;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
@@ -1135,12 +1136,8 @@ final readonly class CallSpecialization
             return true;
         }
 
-        if (!$arg instanceof LocalVarNode) {
-            return false;
-        }
-
-        $tag = $arg->getInferredType();
-        return $tag !== null && ltrim($tag, '\\') === 'string';
+        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        return $tag !== null && $tag === 'string';
     }
 
     private static function isPersistentMapTag(?string $tag): bool
@@ -1179,11 +1176,7 @@ final readonly class CallSpecialization
         return array_all(
             $args,
             static function (AbstractNode $arg): bool {
-                if (!$arg instanceof LocalVarNode) {
-                    return false;
-                }
-
-                $tag = self::normalisedTag($arg->getInferredType());
+                $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
                 return $tag !== null && in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true);
             },
         );
@@ -1198,12 +1191,112 @@ final readonly class CallSpecialization
             return self::matchesLiteralPrimitive($arg->getValue(), $acceptedTags);
         }
 
-        if (!$arg instanceof LocalVarNode) {
-            return false;
+        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        return $tag !== null && in_array($tag, $acceptedTags, true);
+    }
+
+    /**
+     * Static type the emitter can attribute to `$arg`'s emitted PHP
+     * expression. Handles two shapes:
+     *
+     *  - `LocalVarNode` — analyser-resolved binding tag (`^int` / `^float`
+     *    / a class FQN). The numeric / equality specialiser was built
+     *    around this case in PR #2148.
+     *  - `CallNode` whose `fn` is a `PhpVarNode` listed in
+     *    {@see KnownPhpFunctionReturnTypes}. The fn name resolves to a
+     *    PHP scalar function whose return shape is fixed (`php/cos` →
+     *    `float`, `php/count` → `int`, etc.), so the call site can be
+     *    spliced into a native binary op the same way a tagged local
+     *    can. This is the path closing #2175 — real game / raycaster
+     *    code reads `(+ ^float angle (php/cos a))`, not
+     *    `(+ ^float a ^float b)`.
+     *
+     * Returns `null` when the node carries no usable type, which leaves
+     * the call site on the generic runtime dispatch.
+     */
+    private static function inferredTypeOfNode(AbstractNode $arg): ?string
+    {
+        if ($arg instanceof LocalVarNode) {
+            return $arg->getInferredType();
         }
 
-        $tag = self::normalisedTag($arg->getInferredType());
-        return $tag !== null && in_array($tag, $acceptedTags, true);
+        if (!$arg instanceof CallNode) {
+            return null;
+        }
+
+        $fn = $arg->getFn();
+        if ($fn instanceof PhpVarNode) {
+            return KnownPhpFunctionReturnTypes::returnTypeOf($fn->getName());
+        }
+
+        // Nested typed-arith / typed-equality calls keep their numeric tag so
+        // an outer specialiser fires on the chained shape. `(+ a (* b c))`
+        // with all-numeric operands lowers `(* b c)` to a native PHP product;
+        // the outer `+` must see that product as `float` (when any operand is
+        // float) or `int` so it can emit `($a + ($b * $c))` instead of a
+        // runtime dispatch around the inner native expression.
+        return self::numericTypeOfTypedBinaryCall($arg);
+    }
+
+    /**
+     * Result tag of a numeric typed-arith call (`+`, `-`, `*`) when every
+     * operand carries a known numeric tag. The promotion rule mirrors
+     * PHP's arithmetic operators: any `float` operand yields `float`,
+     * otherwise `int`. Comparison ops return `bool` and aren't covered
+     * here because the caller wants a numeric tag to splice into another
+     * arithmetic op; equality / comparison feed the boolean-expression
+     * detector instead.
+     *
+     * Recursion is bounded by AST depth — each call inspects strictly
+     * smaller subexpressions.
+     */
+    private static function numericTypeOfTypedBinaryCall(CallNode $node): ?string
+    {
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode
+            || $fn->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE
+        ) {
+            return null;
+        }
+
+        $name = $fn->getName()->getName();
+        if (!in_array($name, ['+', '-', '*'], true)) {
+            return null;
+        }
+
+        $args = $node->getArguments();
+        if (count($args) < 2) {
+            return null;
+        }
+
+        $anyFloat = false;
+        foreach ($args as $arg) {
+            $tag = self::operandNumericTag($arg);
+            if ($tag === null) {
+                return null;
+            }
+
+            if ($tag === 'float') {
+                $anyFloat = true;
+            }
+        }
+
+        return $anyFloat ? 'float' : 'int';
+    }
+
+    private static function operandNumericTag(AbstractNode $arg): ?string
+    {
+        if ($arg instanceof LiteralNode) {
+            $value = $arg->getValue();
+            if (is_float($value)) {
+                return 'float';
+            }
+
+            return is_int($value) ? 'int' : null;
+        }
+
+        $tag = self::normalisedTag(self::inferredTypeOfNode($arg));
+        return in_array($tag, self::NUMERIC_PRIMITIVE_TAGS, true) ? $tag : null;
     }
 
     /**

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/KnownPhpFunctionReturnTypes.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/KnownPhpFunctionReturnTypes.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Emitter\OutputEmitter;
+
+/**
+ * Static return-type table for `php/*` interop calls whose signatures the
+ * compiler trusts at face value. The {@see CallSpecialization} numeric /
+ * comparison / equality predicates consult this table so a call site like
+ * `(+ ^float angle (php/cos a))` can fire the native arithmetic emit path
+ * instead of falling back to the runtime dispatch.
+ *
+ * Scope is deliberately narrow:
+ *
+ *  - Only fixed-return-shape functions are listed. Variadic-result
+ *    functions (`abs`, `round`, `min`, `max`) are excluded because their
+ *    return type depends on the caller-supplied argument type; recording
+ *    `int|float` here would let the specialiser fire on the wrong PHP
+ *    operator (the `+` op is fine for both, but `===` against a mixed-tag
+ *    `=` is not).
+ *  - `php/aget` is intentionally NOT covered here; its element type is a
+ *    property of the source array, not the operator, and propagating it
+ *    requires an `:items-type` meta on the binding (deferred). See the
+ *    related issue for details.
+ *
+ * Adding new entries: pick the strictest tag the function guarantees on
+ * every input that does not raise. If the function falls back to `false`
+ * on bad input (e.g. `strpos`), omit it — a mixed `int|false` cannot
+ * splice into a typed-arith expression safely.
+ */
+final readonly class KnownPhpFunctionReturnTypes
+{
+    /**
+     * Map from the `PhpVarNode` name (no `php/` prefix) to the analyser
+     * tag the emitter treats as the call's return type.
+     *
+     * @var array<string, string>
+     */
+    private const array RETURN_TYPES = [
+        // float-returning scalar math
+        'cos' => 'float',
+        'sin' => 'float',
+        'tan' => 'float',
+        'acos' => 'float',
+        'asin' => 'float',
+        'atan' => 'float',
+        'atan2' => 'float',
+        'sqrt' => 'float',
+        'exp' => 'float',
+        'log' => 'float',
+        'log10' => 'float',
+        'log2' => 'float',
+        'pow' => 'float',
+        'fmod' => 'float',
+        'deg2rad' => 'float',
+        'rad2deg' => 'float',
+        'pi' => 'float',
+        'fdiv' => 'float',
+        'hypot' => 'float',
+        'lcg_value' => 'float',
+
+        // int-returning
+        'intval' => 'int',
+        'floor' => 'int',
+        'ceil' => 'int',
+        'intdiv' => 'int',
+        'count' => 'int',
+        'strlen' => 'int',
+        'mb_strlen' => 'int',
+        'ord' => 'int',
+        'crc32' => 'int',
+        'random_int' => 'int',
+        'mt_rand' => 'int',
+        'rand' => 'int',
+
+        // bool-returning
+        'is_int' => 'bool',
+        'is_integer' => 'bool',
+        'is_long' => 'bool',
+        'is_float' => 'bool',
+        'is_double' => 'bool',
+        'is_string' => 'bool',
+        'is_array' => 'bool',
+        'is_bool' => 'bool',
+        'is_callable' => 'bool',
+        'is_null' => 'bool',
+        'is_numeric' => 'bool',
+        'is_object' => 'bool',
+        'is_iterable' => 'bool',
+        'is_countable' => 'bool',
+        'array_key_exists' => 'bool',
+        'in_array' => 'bool',
+        'ctype_alpha' => 'bool',
+        'ctype_digit' => 'bool',
+        'ctype_alnum' => 'bool',
+        'ctype_space' => 'bool',
+
+        // string-returning
+        'strval' => 'string',
+        'str_repeat' => 'string',
+        'str_pad' => 'string',
+        'substr' => 'string',
+        'sprintf' => 'string',
+        'strtolower' => 'string',
+        'strtoupper' => 'string',
+        'mb_strtolower' => 'string',
+        'mb_strtoupper' => 'string',
+        'ucfirst' => 'string',
+        'ucwords' => 'string',
+        'lcfirst' => 'string',
+        'trim' => 'string',
+        'ltrim' => 'string',
+        'rtrim' => 'string',
+        'chr' => 'string',
+        'implode' => 'string',
+        'join' => 'string',
+        'str_replace' => 'string',
+        'bin2hex' => 'string',
+        'hex2bin' => 'string',
+        'base64_encode' => 'string',
+        'json_encode' => 'string',
+    ];
+
+    private function __construct() {}
+
+    public static function returnTypeOf(string $phpVarName): ?string
+    {
+        return self::RETURN_TYPES[$phpVarName] ?? null;
+    }
+
+    public static function knows(string $phpVarName): bool
+    {
+        return isset(self::RETURN_TYPES[$phpVarName]);
+    }
+}

--- a/tests/php/Integration/Fixtures/Let/let-php-aget-still-bails.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-aget-still-bails.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^float angle ^int n offsets] (+ angle (php/aget offsets n)))
+--PHP--
+(function(float $angle, int $n, $offsets) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($angle, (($offsets)[($n)] ?? null));
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-cos-native-add.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-cos-native-add.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^float angle ^float a] (+ angle (php/cos a)))
+--PHP--
+(function(float $angle, float $a) {
+  return ($angle + cos($a));
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-cos-native-mul.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-cos-native-mul.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^float d ^float offset] (* d (php/cos offset)))
+--PHP--
+(function(float $d, float $offset) {
+  return ($d * cos($offset));
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-cos-nested-arith.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-cos-nested-arith.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^float d ^float angle ^float sum] (+ sum (* d (php/cos angle))))
+--PHP--
+(function(float $d, float $angle, float $sum) {
+  return ($sum + ($d * cos($angle)));
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-count-native-lt.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-count-native-lt.test
@@ -1,0 +1,6 @@
+--PHEL--
+(fn [^int i arr] (< i (php/count arr)))
+--PHP--
+(function(int $i, $arr): bool {
+  return ($i < count($arr));
+});

--- a/tests/php/Integration/Fixtures/Let/let-php-unknown-bails.test
+++ b/tests/php/Integration/Fixtures/Let/let-php-unknown-bails.test
@@ -1,0 +1,7 @@
+--PHEL--
+(fn [^float a x] (+ a (php/some_unlisted_fn x)))
+--PHP--
+(function(float $a, $x) {
+  static $__phel_call_0;
+  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, some_unlisted_fn($x));
+});

--- a/tests/php/Integration/Fixtures/Let/loop-php-native-arith-chain.test
+++ b/tests/php/Integration/Fixtures/Let/loop-php-native-arith-chain.test
@@ -1,0 +1,20 @@
+--PHEL--
+(fn [^float d ^float angle] (loop [^int i 0 ^float sum 0.0] (if (< i 10) (recur (+ i 1) (+ sum (* d (php/cos angle)))) sum)))
+--PHP--
+(function(float $d, float $angle) {
+  /** @var int $i_1 */
+  $i_1 = 0;
+  /** @var float $sum_2 */
+  $sum_2 = 0.0;
+  while (true) {
+    if (($__truthy = ($i_1 < 10)) !== null && $__truthy !== false) {
+      $i_1 = ($i_1 + 1);
+      $sum_2 = ($sum_2 + ($d * cos($angle)));
+      continue;
+
+    } else {
+      return $sum_2;
+    }
+    break;
+  }
+});

--- a/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
+++ b/tests/php/Integration/Run/Command/Compile/CompileCommandTest.php
@@ -30,8 +30,11 @@ final class CompileCommandTest extends AbstractTestCommand
     {
         // Pre-fold path: a non-foldable arg keeps the runtime call shape so
         // the compile output still demonstrates the registry-cached form.
+        // `php/getenv` is intentionally NOT in
+        // `KnownPhpFunctionReturnTypes`, so the analyser cannot prove
+        // `int|float` and the typed-arith specialiser bails to dispatch.
         $tester = new CommandTester(new CompileCommand());
-        $tester->execute(['source' => '(+ (php/intval "1") 2)']);
+        $tester->execute(['source' => '(+ (php/getenv "HOME") 2)']);
 
         $tester->assertCommandIsSuccessful();
         self::assertStringContainsString(\Phel::class . '::getDefinition("phel.core", "+"))->__invoke(', $tester->getDisplay());


### PR DESCRIPTION
## Summary

Closes #2175. Path 1 of milestone 2: the typed-arith specialiser now treats `php/cos`, `php/sin`, `php/sqrt`, `php/count`, `php/strlen`, etc. as carrying a known return type, so `(+ ^float angle (php/cos a))` finally lowers to native `($angle + cos($a))` instead of paying a `Phel::getDefinition` dispatch.

Real game / raycaster code reads PHP-native math far more often than it reads tagged-binding chains; a consumer sweep regressed 14x for exactly this gap (issue body has the numbers).

## What changed

- **New** `KnownPhpFunctionReturnTypes` — private static table mapping `php/*` function name to analyser tag. Strict scope: only fixed-return-shape functions (variadic-result functions like `abs` / `round` / `min` / `max` are excluded because their return type depends on the input). `php/aget` is intentionally NOT covered (its element type is a property of the source array, deferred as path 2).
- **`CallSpecialization`** grew `inferredTypeOfNode(AbstractNode)`. Old code only honoured `LocalVarNode->getInferredType()`; the new helper also returns the table's tag for `CallNode` whose `fn` is a listed `PhpVarNode`, and propagates the result type of nested typed-arith calls (`+`/`-`/`*` on numeric operands) using PHP's float-promotion rule. `isPrimitiveOperand` / `allArgsAreTaggedNumericLocals` / `isStringConcatable` all route through it.

## Functions whose return type is now propagated

`float`: `cos` `sin` `tan` `acos` `asin` `atan` `atan2` `sqrt` `exp` `log` `log10` `log2` `pow` `fmod` `deg2rad` `rad2deg` `pi` `fdiv` `hypot` `lcg_value`
`int`: `intval` `floor` `ceil` `intdiv` `count` `strlen` `mb_strlen` `ord` `crc32` `random_int` `mt_rand` `rand`
`bool`: `is_int` `is_integer` `is_long` `is_float` `is_double` `is_string` `is_array` `is_bool` `is_callable` `is_null` `is_numeric` `is_object` `is_iterable` `is_countable` `array_key_exists` `in_array` `ctype_alpha` `ctype_digit` `ctype_alnum` `ctype_space`
`string`: `strval` `str_repeat` `str_pad` `substr` `sprintf` `strtolower` `strtoupper` `mb_strtolower` `mb_strtoupper` `ucfirst` `ucwords` `lcfirst` `trim` `ltrim` `rtrim` `chr` `implode` `join` `str_replace` `bin2hex` `hex2bin` `base64_encode` `json_encode`

Adding new entries: pick the strictest tag the function guarantees on every non-throwing input. Functions that fall back to `false` on bad input (e.g. `strpos`) are omitted because a mixed `int|false` cannot safely splice into typed-arith.

## Before / after

### `(fn [^float angle ^float a] (+ angle (php/cos a)))`

Before:
```php
(function(float $angle, float $a) {
  static $__phel_call_0;
  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($angle, cos($a));
});
```

After:
```php
(function(float $angle, float $a) {
  return ($angle + cos($a));
});
```

### `(fn [^float d ^float angle ^float sum] (+ sum (* d (php/cos angle))))` (nested chain)

Before: two nested runtime dispatches.

After:
```php
(function(float $d, float $angle, float $sum) {
  return ($sum + ($d * cos($angle)));
});
```

### `(fn [^int i arr] (< i (php/count arr)))`

After:
```php
(function(int $i, $arr): bool {
  return ($i < count($arr));
});
```

### Negative case: unlisted `php/*` stays runtime-dispatched

`(fn [^float a x] (+ a (php/some_unlisted_fn x)))`:
```php
(function(float $a, $x) {
  static $__phel_call_0;
  return ($__phel_call_0 ??= \Phel::getDefinition("phel.core", "+"))->__invoke($a, some_unlisted_fn($x));
});
```

### `php/aget` still bails (path 2 deferred)

`(fn [^float angle ^int n offsets] (+ angle (php/aget offsets n)))` keeps the runtime dispatch because the array's element type is unknown. Issue body proposes a `:items-type` meta hint on the binding for path 2; that needs a separate analyser pass and is out of scope here.

## Deferred (milestone 2b)

- `php/aget` items-type inference (a `:phel/items-type` meta hint on `let` / `loop` / `fn` param bindings, read by the analyser, threaded through `PhpArrayGetNode->getInferredType()`).
- Variadic-shape functions whose return type depends on input (`abs`, `round`, `min`, `max`) — would need a per-call analysis instead of a static table.
- User-level extension point so libraries can register their own typed `php/*` calls. The current table is a private const because there's no existing public seam; promote it when a real consumer asks.

## Test plan

- [x] 7 new integration fixtures under `tests/php/Integration/Fixtures/Let/`: `+` with `php/cos`, `*` with `php/cos`, `<` with `php/count`, nested arith chain, loop arith chain, unlisted-php bails, `php/aget` still bails.
- [x] `composer test-compiler`: 3697 tests pass (baseline 3692, +5 new fixtures + carry).
- [x] `composer test`: 5659/5659.
- [x] `composer test-quality`: php-cs-fixer / psalm / phpstan / rector dry-run / validate-config all clean.
- [x] Hand-compiled probe matches consumer regression cases (`bin/phel compile ...`).
- [x] Updated `CompileCommandTest::test_compile_known_core_call_uses_get_definition` to use `php/getenv` (intentionally not in the table) since `php/intval` now folds.