### PR TITLE
fix: seed clojure aliases for file runs

### DIFF
--- a/src/php/Run/Application/BundledNamespaceDetector.php
+++ b/src/php/Run/Application/BundledNamespaceDetector.php
@@ -9,6 +9,7 @@ use function array_values;
 use function file_get_contents;
 use function preg_match_all;
 use function str_replace;
+use function str_starts_with;
 use function substr;
 
 final readonly class BundledNamespaceDetector
@@ -59,5 +60,32 @@ final readonly class BundledNamespaceDetector
         }
 
         return array_values(array_intersect($bundled, array_keys($referenced)));
+    }
+
+    /**
+     * @param list<string> $dependencies
+     *
+     * @return list<string>
+     */
+    public function remapClojureDependencies(array $dependencies): array
+    {
+        $candidates = [];
+        foreach ($dependencies as $dependency) {
+            $normalized = str_replace('\\', '.', $dependency);
+            if (str_starts_with($normalized, 'clojure.')) {
+                $candidates['phel.' . substr($normalized, 8)] = true;
+            }
+        }
+
+        if ($candidates === []) {
+            return [];
+        }
+
+        $bundled = $this->bundledNamespaces->all();
+        if ($bundled === []) {
+            return [];
+        }
+
+        return array_values(array_intersect($bundled, array_keys($candidates)));
     }
 }

--- a/src/php/Run/Application/BundledNamespaceDetector.php
+++ b/src/php/Run/Application/BundledNamespaceDetector.php
@@ -10,16 +10,25 @@ use function file_get_contents;
 use function preg_match_all;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function substr;
 
+/**
+ * Selects bundled `phel.*` namespaces that file runs must seed before
+ * evaluating an ad-hoc script.
+ */
 final readonly class BundledNamespaceDetector
 {
+    private const string CLOJURE_PREFIX = 'clojure.';
+
     /**
      * Matches fully qualified bundled references in the source: `phel.X/sym`
      * or the legacy `phel\X/sym`. The trailing slash anchors the match to
      * actual call/var references rather than comments containing the prefix.
      */
     private const string FQN_PATTERN = '#\bphel[.\\\\][A-Za-z0-9_\-.\\\\]+/#u';
+
+    private const string PHEL_PREFIX = 'phel.';
 
     public function __construct(
         private BundledNamespaces $bundledNamespaces,
@@ -48,21 +57,19 @@ final readonly class BundledNamespaceDetector
             return [];
         }
 
-        $bundled = $this->bundledNamespaces->all();
-        if ($bundled === []) {
-            return [];
-        }
-
         $referenced = [];
         foreach ($matches[0] as $token) {
             $ns = str_replace('\\', '.', substr($token, 0, -1));
             $referenced[$ns] = true;
         }
 
-        return array_values(array_intersect($bundled, array_keys($referenced)));
+        return $this->intersectBundled($referenced);
     }
 
     /**
+     * Returns bundled `phel.*` namespaces matching Clojure-compatible
+     * dependencies such as `clojure.test`.
+     *
      * @param list<string> $dependencies
      *
      * @return list<string>
@@ -72,8 +79,8 @@ final readonly class BundledNamespaceDetector
         $candidates = [];
         foreach ($dependencies as $dependency) {
             $normalized = str_replace('\\', '.', $dependency);
-            if (str_starts_with($normalized, 'clojure.')) {
-                $candidates['phel.' . substr($normalized, 8)] = true;
+            if (str_starts_with($normalized, self::CLOJURE_PREFIX)) {
+                $candidates[self::PHEL_PREFIX . substr($normalized, strlen(self::CLOJURE_PREFIX))] = true;
             }
         }
 
@@ -81,6 +88,16 @@ final readonly class BundledNamespaceDetector
             return [];
         }
 
+        return $this->intersectBundled($candidates);
+    }
+
+    /**
+     * @param array<string, true> $candidates
+     *
+     * @return list<string>
+     */
+    private function intersectBundled(array $candidates): array
+    {
         $bundled = $this->bundledNamespaces->all();
         if ($bundled === []) {
             return [];

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -74,6 +74,8 @@ final readonly class FileRunner
             CompilerConstants::PHEL_CORE_NAMESPACE,
             ...$this->bundledNamespaceDetector->detect($filename),
             ...$this->bundledNamespaceDetector->remapClojureDependencies($dependencies),
+            // Missing seeds are ignored by dependency resolution, so keeping
+            // raw `clojure.*` deps preserves user-defined Clojure namespaces.
             ...$dependencies,
         ]));
     }

--- a/src/php/Run/Application/FileRunner.php
+++ b/src/php/Run/Application/FileRunner.php
@@ -67,11 +67,14 @@ final readonly class FileRunner
      */
     private function primarySeeds(NamespaceInformation $scriptInfo, string $filename): array
     {
+        $dependencies = $scriptInfo->getDependencies();
+
         return array_values(array_unique([
             $scriptInfo->getNamespace(),
             CompilerConstants::PHEL_CORE_NAMESPACE,
             ...$this->bundledNamespaceDetector->detect($filename),
-            ...$scriptInfo->getDependencies(),
+            ...$this->bundledNamespaceDetector->remapClojureDependencies($dependencies),
+            ...$dependencies,
         ]));
     }
 

--- a/src/php/Run/CLAUDE.md
+++ b/src/php/Run/CLAUDE.md
@@ -70,5 +70,5 @@ Run/
 - `ReplHistory` registers `*1`/`*2`/`*3`/`*e` in `phel.core` after REPL boot
 - `ReplErrorFormatter` renders eval-time `Throwable`s with short headline, hints, and filtered trace
 - New `ReplHint` implementations register via `RunFactory::createReplHints()`
-- `BundledNamespaces` lists every `phel.*` module; `NamespaceLoader` (REPL startup) uses it as eager seeds. `FileRunner` instead uses `BundledNamespaceDetector` to seed only the bundles referenced via fully qualified form (`phel.json/encode`) in the script source, avoiding the cold-start penalty for scripts that don't reach into bundled modules
+- `BundledNamespaces` lists every `phel.*` module; `NamespaceLoader` (REPL startup) uses it as eager seeds. `FileRunner` instead uses `BundledNamespaceDetector` to seed only bundles referenced via fully qualified form (`phel.json/encode`) or matching Clojure-compatible requires (`clojure.test` -> `phel.test`) in the script, avoiding the cold-start penalty for scripts that don't reach into bundled modules
 - This is the most connected module: 5 Provider dependencies

--- a/tests/php/Integration/Run/Command/Run/Fixtures/clojure-test-alias-assert-expr-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/clojure-test-alias-assert-expr-script.phel
@@ -1,5 +1,6 @@
 (ns clojure-test-alias-assert-expr-script
-  (:require [clojure.test :as t]))
+  (:require [clojure.test :as t]
+            [clojure.test :as p]))
 
 (defmethod t/assert-expr 'p/thrown?
   [msg form]
@@ -16,3 +17,7 @@
                        :expected '~form
                        :actual e#})
          e#))))
+
+(t/is (p/thrown? (throw (php/new \RuntimeException "boom"))))
+
+(println "clojure-test-alias-ok")

--- a/tests/php/Integration/Run/Command/Run/Fixtures/clojure-test-alias-assert-expr-script.phel
+++ b/tests/php/Integration/Run/Command/Run/Fixtures/clojure-test-alias-assert-expr-script.phel
@@ -1,0 +1,18 @@
+(ns clojure-test-alias-assert-expr-script
+  (:require [clojure.test :as t]))
+
+(defmethod t/assert-expr 'p/thrown?
+  [msg form]
+  (let [body (rest form)]
+    `(try
+       (let [result# (do ~@body)]
+         (t/do-report {:type :fail
+                       :message ~msg
+                       :expected '~form
+                       :actual result#}))
+       (catch ~'Throwable e#
+         (t/do-report {:type :pass
+                       :message ~msg
+                       :expected '~form
+                       :actual e#})
+         e#))))

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -91,7 +91,7 @@ final class RunCommandTest extends AbstractTestCommand
             __DIR__ . '/Fixtures/clojure-test-alias-assert-expr-script.phel',
         );
 
-        self::assertSame('', $output);
+        self::assertStringContainsString('clojure-test-alias-ok', $output);
     }
 
     public function test_pass_flag_arguments_to_script(): void

--- a/tests/php/Integration/Run/Command/Run/RunCommandTest.php
+++ b/tests/php/Integration/Run/Command/Run/RunCommandTest.php
@@ -85,6 +85,15 @@ final class RunCommandTest extends AbstractTestCommand
         self::assertStringContainsString('phel.async/delay resolved', $output);
     }
 
+    public function test_run_by_filename_resolves_clojure_test_alias_before_script_eval(): void
+    {
+        $output = $this->captureRunOutput(
+            __DIR__ . '/Fixtures/clojure-test-alias-assert-expr-script.phel',
+        );
+
+        self::assertSame('', $output);
+    }
+
     public function test_pass_flag_arguments_to_script(): void
     {
         $output = $this->captureRunOutput(

--- a/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
+++ b/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
@@ -106,6 +106,28 @@ final class BundledNamespaceDetectorTest extends TestCase
         self::assertSame([], $detector->detect($this->tmpDir . '/does-not-exist.phel'));
     }
 
+    public function test_remaps_clojure_dependencies_to_existing_bundled_phel_namespaces(): void
+    {
+        $detector = $this->createDetector(['phel.test', 'phel.string']);
+
+        self::assertSame(
+            ['phel.string', 'phel.test'],
+            $detector->remapClojureDependencies(['clojure.test', 'clojure\\string', 'clojure.missing']),
+        );
+    }
+
+    public function test_remap_skips_bundled_discovery_when_no_clojure_dependencies_exist(): void
+    {
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->expects(self::never())->method('getNamespaceFromDirectories');
+
+        $commandFacade = $this->createStub(CommandFacadeInterface::class);
+
+        $detector = new BundledNamespaceDetector(new BundledNamespaces($buildFacade, $commandFacade));
+
+        self::assertSame([], $detector->remapClojureDependencies(['phel.test']));
+    }
+
     /**
      * @param list<string> $bundledNamespaces
      */

--- a/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
+++ b/tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php
@@ -128,6 +128,16 @@ final class BundledNamespaceDetectorTest extends TestCase
         self::assertSame([], $detector->remapClojureDependencies(['phel.test']));
     }
 
+    public function test_remap_deduplicates_equivalent_clojure_dependencies(): void
+    {
+        $detector = $this->createDetector(['phel.test']);
+
+        self::assertSame(
+            ['phel.test'],
+            $detector->remapClojureDependencies(['clojure.test', 'clojure\\test', 'phel.test']),
+        );
+    }
+
     /**
      * @param list<string> $bundledNamespaces
      */

--- a/tests/php/Unit/Run/Application/FileRunnerTest.php
+++ b/tests/php/Unit/Run/Application/FileRunnerTest.php
@@ -201,6 +201,41 @@ final class FileRunnerTest extends TestCase
         );
     }
 
+    public function test_seeds_phel_namespace_for_clojure_alias_dependency(): void
+    {
+        $script = $this->tmpDir . '/demo.phel';
+        file_put_contents($script, "(ns demo (:require [clojure.test :as t]))\n");
+
+        $scriptInfo = new NamespaceInformation($script, 'demo', ['clojure.test'], true);
+        $coreInfo = new NamespaceInformation('/phel/core.phel', 'phel.core', [], true);
+        $testInfo = new NamespaceInformation('/phel/test.phel', 'phel.test', [], true);
+
+        $observedSeeds = [];
+
+        $buildFacade = $this->createMock(BuildFacadeInterface::class);
+        $buildFacade->method('getNamespaceFromFile')->willReturn($scriptInfo);
+        $buildFacade->method('getNamespaceFromDirectories')->willReturn([$testInfo]);
+        $buildFacade->method('getDependenciesForNamespace')->willReturnCallback(
+            static function (array $dirs, array $ns) use (&$observedSeeds, $coreInfo, $testInfo): array {
+                $observedSeeds[] = $ns;
+                return [$coreInfo, $testInfo];
+            },
+        );
+        $buildFacade->method('evalFile')->willReturn(
+            new CompiledFile('', '', '', false),
+        );
+
+        $commandFacade = $this->createMock(CommandFacadeInterface::class);
+        $commandFacade->method('getSourceDirectories')->willReturn([$this->primarySrc]);
+        $commandFacade->method('getVendorSourceDirectories')->willReturn([]);
+
+        $this->createFileRunner($buildFacade, $commandFacade)->run($script);
+
+        self::assertNotSame([], $observedSeeds);
+        self::assertContains('phel.test', $observedSeeds[0]);
+        self::assertContains('clojure.test', $observedSeeds[0]);
+    }
+
     public function test_skips_bundled_seeds_when_script_has_no_fqn_reference(): void
     {
         $script = $this->tmpDir . '/demo.phel';


### PR DESCRIPTION
## Summary

- seed matching bundled phel.* namespaces when file-run scripts depend on clojure.* aliases
- keep the original clojure.* dependency seed so normal resolution semantics stay unchanged
- add a run-command regression for the reported clojure.test assert-expr repro

## Verification

- ./bin/phel run /tmp/issue-demo3.phel
- ./vendor/bin/phpunit tests/php/Unit/Run/Application/BundledNamespaceDetectorTest.php tests/php/Unit/Run/Application/FileRunnerTest.php tests/php/Integration/Run/Command/Run/RunCommandTest.php
- composer test-core
- composer test-compiler
- composer test-quality
- composer validate --strict --quiet --no-interaction --no-check-all --no-check-lock
- composer test-agents
- composer test-tools
- find docs/examples -name "*.phel" -type f | sort | xargs -I {} bash -c './bin/phel run "$1" >/dev/null' _ {}
- vendor/bin/phpbench run --iterations=3 --warmup=1 --report=aggregate --progress=plain

Closes #2129