### PR TITLE
test(bench): keyword emit strategy micro-bench for #2130

### DIFF
--- a/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitDirect.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitDirect.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\Keyword;
+
+/**
+ * No per-call-site cache. Models the bypass-facade alternative (#2131):
+ * `LiteralEmitter::emitKeyword` already emits `Keyword::create(...)`
+ * directly, so this is what the call site degenerates to if the per-fn
+ * cache is removed. `Keyword::create` itself still hits the intern pool
+ * via `self::$internPool[$key] ??= new self(...)`.
+ */
+final class KeywordEmitDirect
+{
+    /**
+     * @return list<Keyword>
+     */
+    public function __invoke(): array
+    {
+        return [
+            Keyword::create('alpha'),
+            Keyword::create('beta'),
+            Keyword::create('gamma'),
+        ];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitNsScope.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitNsScope.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\Keyword;
+
+/**
+ * Hypothetical hoist: a single per-ns cache shared across fns of the
+ * same ns. Models the parent-class static-array variant of issue #2130
+ * (`AbstractFn::$kwCache[$ns][$slot] ??= Keyword::create(...)`). The
+ * `$ns` key is constant-folded into the path to mirror what the emitter
+ * could realistically produce.
+ */
+final class KeywordEmitNsScope
+{
+    /** @var array<string, Keyword> */
+    public static array $cache = [];
+
+    /**
+     * @return list<Keyword>
+     */
+    public function __invoke(): array
+    {
+        return [
+            self::$cache['alpha'] ??= Keyword::create('alpha'),
+            self::$cache['beta'] ??= Keyword::create('beta'),
+            self::$cache['gamma'] ??= Keyword::create('gamma'),
+        ];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitStatusQuo.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/KeywordEmitStatusQuo.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\Keyword;
+
+/**
+ * Mirrors the current emit (per-fn `static $__phel_kw_N` slot reserved by
+ * `BodyConstantScanner`). After warm-up each `??=` short-circuits to the
+ * cached slot, so steady-state cost is one static read per keyword + the
+ * array build.
+ */
+final class KeywordEmitStatusQuo
+{
+    /**
+     * @return list<Keyword>
+     */
+    public function __invoke(): array
+    {
+        static $kw0;
+        static $kw1;
+        static $kw2;
+        $kw0 ??= Keyword::create('alpha');
+        $kw1 ??= Keyword::create('beta');
+        $kw2 ??= Keyword::create('gamma');
+
+        return [$kw0, $kw1, $kw2];
+    }
+}

--- a/tests/php/Benchmark/Compiler/KeywordHoistingBench.php
+++ b/tests/php/Benchmark/Compiler/KeywordHoistingBench.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use Phel\Lang\Keyword;
+use PhelTest\Benchmark\Compiler\Fixtures\KeywordEmitDirect;
+use PhelTest\Benchmark\Compiler\Fixtures\KeywordEmitNsScope;
+use PhelTest\Benchmark\Compiler\Fixtures\KeywordEmitStatusQuo;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Compares the three emission strategies for keyword literals inside a fn body:
+ *
+ *   1. status-quo: per-fn `static $__phel_kw_N; $kw ??= Keyword::create(...);`
+ *      (what `BodyConstantScanner` reserves today).
+ *   2. ns-scope:   shared `self::$cache[$slot] ??= Keyword::create(...);`
+ *      on a parent class (issue #2130 plumbing).
+ *   3. direct:     `Keyword::create(...)` per call (the bypass-facade emit
+ *      shape of issue #2131, sans intermediate cache).
+ *
+ * All three end up returning identity-shared `Keyword` instances via
+ * `Keyword::$internPool`; what differs is the per-call lookup overhead.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class KeywordHoistingBench
+{
+    private KeywordEmitStatusQuo $statusQuoFn;
+
+    private KeywordEmitNsScope $nsScopeFn;
+
+    private KeywordEmitDirect $directFn;
+
+    public function setUp(): void
+    {
+        $this->statusQuoFn = new KeywordEmitStatusQuo();
+        $this->nsScopeFn = new KeywordEmitNsScope();
+        $this->directFn = new KeywordEmitDirect();
+
+        // Pre-warm the intern pool so the very first measured call does
+        // not pay the one-shot `new Keyword(...)` cost.
+        Keyword::create('alpha');
+        Keyword::create('beta');
+        Keyword::create('gamma');
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_status_quo(): void
+    {
+        ($this->statusQuoFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_ns_scope(): void
+    {
+        ($this->nsScopeFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_direct(): void
+    {
+        ($this->directFn)();
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Issue #2130 proposed hoisting per-fn `static $__phel_kw_N` keyword caches to a shared ns-scope table on the parent `AbstractFn`. After investigation I deferred it on the grounds that (a) anon-class fn bodies cannot read a true file-level static without `global`, (b) every workable plumbing alternative adds a per-call array-index hop on a path the per-fn static handles in one read, and (c) keywords are already identity-shared via `Keyword::$internPool` so the proposal's only win is bytecode size, not runtime.

The deferral was based on reasoning; this PR adds the evidence.

## 💡 Goal

Capture the steady-state cost of each candidate keyword-emission strategy so any future re-litigation of issue #2130 (or sibling #2131) starts from numbers, not prose.

## 🔖 Changes

- `tests/php/Benchmark/Compiler/KeywordHoistingBench.php` — PhpBench harness covering three subjects:
  1. **status-quo**: per-fn `static $kw ??= Keyword::create(...)` (today's emit, reserved by `BodyConstantScanner`).
  2. **ns-scope**: shared `self::$cache[$slot] ??= Keyword::create(...)` on a parent class (the issue #2130 hoist shape).
  3. **direct**: `Keyword::create(...)` per call (the bypass-facade emit shape of issue #2131, sans cache).
- `tests/php/Benchmark/Compiler/Fixtures/Keyword{StatusQuo,NsScope,Direct}.php` — minimal `__invoke` classes for each strategy; intern pool pre-warmed in `setUp` so the very first measurement does not pay the one-shot `new Keyword(...)` cost.

### Numbers (PHP 8.5.6, no JIT, 50000 revs × 10 iters)

| Strategy | Mode | vs status-quo |
|---|---|---|
| status-quo | 0.049 - 0.051μs | baseline |
| ns-scope   | 0.052 - 0.059μs | +6% to +15% slower |
| direct     | 0.101 - 0.107μs | +106% slower |

Verdict: status-quo wins steady-state. NS-scope regresses per call site; the hoist would save bytecode but not runtime. `Keyword::create` doubles cost on its own — issue #2131 still needs caching, not just facade bypass.

No production code changes. Bench is opt-in (`./vendor/bin/phpbench run tests/php/Benchmark/Compiler/KeywordHoistingBench.php`).