### PR TITLE
fix(core): defer (repeatedly f) realization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Emit-shape tweaks:
 - Type-tag plumbing: `^int` / `^float` / `^string` annotations on `let` and `loop` bindings now propagate to references in the body, so the typed-arithmetic specialiser fires inside `let` / `loop` the same way it already does for `fn` params. `(loop [^int i 0] (if (< i n) (recur (+ i 1)) i))` now emits native `($i < $n)` / `($i + 1)` instead of runtime `\Phel::getDefinition("phel.core", "+")->__invoke(...)` dispatch (#2146)
 - `phel.test/assert-expr` now follows Clojure's `[message form]` extension signature, so `clojure.test` compatibility shims can register namespaced custom assertions like `p/thrown?` (#2129)
 - Clojure compatibility: global `derive` now rejects invalid tags before mutating hierarchy state, and `some-fn`, `take-last`, and `nthrest` invalid calls can be caught with `phel.test/thrown?` at runtime (#2129)
+- `repeatedly`: arity-1 form no longer invokes `f` at construction time; the returned lazy seq is unrealized until accessed, so `(repeatedly identity)` (or any arity-incompatible fn) constructs without error and `realized?` reports `false` (#2186)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/phel/core/atoms.phel
+++ b/src/phel/core/atoms.phel
@@ -404,4 +404,3 @@
       0 (rf)
       1 (rf (first args))
       2 (step-fn (first args) (second args)))))
-

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -909,7 +909,10 @@
    :see-also ["repeat" "iterate"]}
   [a & rest]
   (case (count rest)
-    0 (lazy-seq-from-generator (php/:: Seq (repeatedly a)))
+    0 (php/:: LazySeq (fromGenerator
+                       (php/new Hasher)
+                       (php/new Equalizer)
+                       (php/:: Seq (repeatedly a))))
     1 (let [n a
             f (get rest 0)]
         (for [i :range [n]] (f)))

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -9,6 +9,21 @@
   (is (= [:x :x :x] (take 3 (repeatedly (fn [] :x))))
       "(take 3 (repeatedly (fn [] :x)))"))
 
+; Regression test for https://github.com/phel-lang/phel-lang/issues/2186.
+; (repeatedly f) must not invoke f at construction; constructing with an
+; arity-incompatible fn (identity) must succeed because the seq is unrealized.
+(deftest test-repeatedly-defers-fn-call
+  (let [call (repeatedly identity)]
+    (is (false? (realized? call))
+        "(repeatedly identity) returns an unrealized lazy seq; identity is not called yet")))
+
+(deftest test-repeatedly-arity-one-yields-lazy-seq
+  (let [call (repeatedly (fn [] :z))]
+    (is (false? (realized? call))
+        "(repeatedly f) with arity-1 returns an unrealized lazy seq")
+    (is (= [:z :z :z :z] (take 4 call))
+        "values from a deferred (repeatedly f) are realized on demand")))
+
 (deftest test-range-infinite
   (is (= [0 1 2 3 4] (take 5 (range)))
       "(take 5 (range)) should return first 5 natural numbers")


### PR DESCRIPTION
## 🤔 Background

`(repeatedly f)` (arity-1, infinite) wrapped its generator in `ChunkedSeq::fromGenerator`, which **eagerly** pulls the first chunk (32 elements) at construction. Two visible consequences:

1. **Construction errors on arity-incompatible fn.** Clojure allows `(repeatedly identity)` to construct without invoking `identity`; Phel raised `ArgumentCountError` immediately because the first-chunk pull called `identity()` with no args.
2. **`realized?` lies.** ChunkedSeq always reports its head chunk as realized, so `(realized? (repeatedly f))` was `true` even though the user never touched it.

Surfaced by `clojure-test-suite` `repeatedly.cljc`.

## 💡 Goal

Make `(repeatedly f)` lazy in the Clojure sense: construct without calling `f`, report `realized?` as `false` until the seq is consumed.

## 🔖 Changes

- `src/phel/core/seq-fns.phel` — the arity-1 branch of `repeatedly` now wraps the generator in `LazySeq::fromGenerator` instead of `lazy-seq-from-generator` (which routes through `ChunkedSeq`). `LazySeq` defers thunk invocation until access, so the generator is not driven at construction
- `tests/phel/core/infinite-seqs.phel` — regression tests: `(repeatedly identity)` constructs without error and reports `(realized? …) => false`; arity-1 `repeatedly` returns an unrealized seq whose elements realize on demand
- `CHANGELOG.md` — Fixed entry under Unreleased

Closes #2186