### PR TITLE
fix(core): make filter/remove lazy on infinite sparse sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Emit-shape tweaks:
 - `phel.test/assert-expr` now follows Clojure's `[message form]` extension signature, so `clojure.test` compatibility shims can register namespaced custom assertions like `p/thrown?` (#2129)
 - Clojure compatibility: global `derive` now rejects invalid tags before mutating hierarchy state, and `some-fn`, `take-last`, and `nthrest` invalid calls can be caught with `phel.test/thrown?` at runtime (#2129)
 - `repeatedly`: arity-1 form no longer invokes `f` at construction time; the returned lazy seq is unrealized until accessed, so `(repeatedly identity)` (or any arity-incompatible fn) constructs without error and `realized?` reports `false` (#2186)
+- `filter` / `remove`: no longer hang on a sparse predicate over an infinite source. The arity-2 form now wraps the underlying generator in `LazySeq::fromGenerator` (instead of `ChunkedSeq`, which pre-pulled 32 elements at construction); `(take 3 (remove (partial < 5) (range)))` returns `(0 1 2)` instead of looping forever. Also fixes a latent `LazySeq` bug where `nil` values were dropped during `getIterator`/`toArray` (#2187)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -522,10 +522,14 @@
     0 (fn [rf]
         (xf-step rf (fn [result input] (if (pred input) (rf result input) result))))
     1 (let [coll   (first args)
-            result (lazy-seq-from-generator (php/:: Seq (filter pred coll)))]
-        (if (nil? result)
-          []
-          (copy-meta coll result)))
+            ;; Use LazySeq (not ChunkedSeq) so the first chunk isn't
+            ;; pre-realized: a sparse predicate over an infinite source
+            ;; would otherwise loop forever trying to fill 32 matches.
+            result (php/:: LazySeq (fromGenerator
+                                    (php/new Hasher)
+                                    (php/new Equalizer)
+                                    (php/:: Seq (filter pred coll))))]
+        (copy-meta coll result))
     (throw (php/new InvalidArgumentException "filter expects 1 or 2 arguments"))))
 
 (defn remove

--- a/src/php/Lang/Collections/LazySeq/LazySeq.php
+++ b/src/php/Lang/Collections/LazySeq/LazySeq.php
@@ -267,10 +267,20 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         /** @psalm-suppress RedundantCondition */
         /** @phpstan-ignore instanceof.alwaysTrue */
         while ($seq instanceof self) {
-            $first = $seq->first();
-            if ($first !== null) {
-                $result[] = $first;
+            // `realize() === null` is the only reliable "empty" signal;
+            // `first() === null` is ambiguous because the user may have
+            // stored `nil` as a legitimate value. Empty `Countable`
+            // collections (e.g. `(lazy-seq [])`) also count as empty.
+            $realized = $seq->realize();
+            if (!$realized instanceof SeqInterface) {
+                break;
             }
+
+            if ($realized instanceof Countable && count($realized) === 0) {
+                break;
+            }
+
+            $result[] = $realized->first();
 
             $next = $seq->cdr();
             if (!$next instanceof LazySeqInterface) {
@@ -301,14 +311,21 @@ final class LazySeq extends AbstractType implements LazySeqInterface, Countable,
         $seq = $this;
 
         while ($seq instanceof self) {
-            $first = $seq->first();
-            if ($first !== null) {
-                yield $first;
+            // See `toArray()`: realize is the only nil-safe empty check.
+            $realized = $seq->realize();
+            if (!$realized instanceof SeqInterface) {
+                return;
             }
+
+            if ($realized instanceof Countable && count($realized) === 0) {
+                return;
+            }
+
+            yield $realized->first();
 
             $next = $seq->cdr();
             if (!$next instanceof LazySeqInterface) {
-                break;
+                return;
             }
 
             $seq = $next instanceof self ? $next : null;

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -147,6 +147,17 @@
   (is (= [0 2 4 6 8] (take 5 (filter even? (iterate inc 0))))
       "filter on infinite sequence should work without hanging"))
 
+; Regression test for https://github.com/phel-lang/phel-lang/issues/2187.
+; A sparse-predicate filter over an infinite source used to hang because the
+; chunked seq tried to pre-realize 32 elements that would never arrive.
+(deftest test-remove-on-infinite-seq-with-bounded-result
+  (is (= '(0 1 2) (take 3 (remove (partial < 5) (range))))
+      "(take 3 (remove (partial < 5) (range))) must not hang"))
+
+(deftest test-filter-on-infinite-seq-with-bounded-result
+  (is (= '(0 1 2) (take 3 (filter (partial >= 5) (range))))
+      "(take 3 (filter (partial >= 5) (range))) must not hang"))
+
 (deftest test-filter-empty-collection
   (is (= [] (filter even? []))
       "filter on empty collection should return empty vector"))


### PR DESCRIPTION
## 🤔 Background

`(remove (partial < 5) (range))` hangs in Phel. `remove` delegates to `filter`, and `filter` wrapped its underlying generator in `ChunkedSeq`. `ChunkedSeq::fromGenerator` **eagerly** pulls the first chunk (32 elements) at construction; with a sparse predicate over an infinite source (only `0..5` match), it spins inside the underlying generator forever waiting for matches that never arrive.

Surfaced by `clojure-test-suite` `remove.cljc`.

## 💡 Goal

Make `filter` / `remove` produce a properly lazy seq: no work at construction, elements realized strictly on demand. `(take 3 (remove (partial < 5) (range)))` returns `(0 1 2)` instead of looping forever.

## 🔖 Changes

- `src/phel/core/seq-fns.phel` — `filter` (arity 2) now constructs `LazySeq::fromGenerator` instead of routing through `ChunkedSeq` via `lazy-seq-from-generator`. `remove` benefits transitively (it delegates to `filter`)
- `src/php/Lang/Collections/LazySeq/LazySeq.php` — `getIterator` and `toArray` previously used `first() !== null` as the empty signal, which silently dropped legitimate `nil` values (e.g. `(into [] (remove identity [nil false]))` returned `[]` instead of `[nil false]`). Switched to `realize() !== null && !(Countable && count === 0)` so `nil` flows through while empty `Countable` containers like `(lazy-seq [])` still terminate the walk
- `tests/phel/core/infinite-seqs.phel` — regression tests for the sparse-predicate-over-infinite-source case (both `remove` and `filter`)
- `CHANGELOG.md` — Fixed entry under Unreleased

Closes #2187