### PR TITLE
fix(core): make concat lazy across all arities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Emit-shape tweaks:
 - Clojure compatibility: global `derive` now rejects invalid tags before mutating hierarchy state, and `some-fn`, `take-last`, and `nthrest` invalid calls can be caught with `phel.test/thrown?` at runtime (#2129)
 - `repeatedly`: arity-1 form no longer invokes `f` at construction time; the returned lazy seq is unrealized until accessed, so `(repeatedly identity)` (or any arity-incompatible fn) constructs without error and `realized?` reports `false` (#2186)
 - `filter` / `remove`: no longer hang on a sparse predicate over an infinite source. The arity-2 form now wraps the underlying generator in `LazySeq::fromGenerator` (instead of `ChunkedSeq`, which pre-pulled 32 elements at construction); `(take 3 (remove (partial < 5) (range)))` returns `(0 1 2)` instead of looping forever. Also fixes a latent `LazySeq` bug where `nil` values were dropped during `getIterator`/`toArray` (#2187)
+- `concat`: the result is no longer pre-realized — `(realized? (concat …))` is `false` until accessed, matching Clojure. Switched the wrapper from `ChunkedSeq` (which eagerly pulls the first 32 elements) to `LazySeq::fromGenerator` (#2191)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -960,13 +960,14 @@
   [& colls]
   (if (php/=== nil colls)
     '()
-    (let [result (lazy-seq-from-generator
-                  (php/call_user_func_array
-                   (php/array "\\Phel\\Lang\\Seq" "concat")
-                   (apply php/array colls)))]
-      (if (php/=== nil result)
-        '()
-        result))))
+    ;; Use LazySeq (not ChunkedSeq) so the head is not pre-realized:
+    ;; the result must not satisfy `realized?` until accessed.
+    (php/:: LazySeq (fromGenerator
+                     (php/new Hasher)
+                     (php/new Equalizer)
+                     (php/call_user_func_array
+                      (php/array "\\Phel\\Lang\\Seq" "concat")
+                      (apply php/array colls))))))
 
 (defn cat
   "A transducer that concatenates the contents of each input into the reduction."

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -158,6 +158,29 @@
   (is (= '(0 1 2) (take 3 (filter (partial >= 5) (range))))
       "(take 3 (filter (partial >= 5) (range))) must not hang"))
 
+; Regression tests for https://github.com/phel-lang/phel-lang/issues/2191.
+; `concat` must return an unrealized lazy seq across all non-zero arities;
+; previously the result was eagerly chunked and `realized?` reported `true`.
+(deftest test-concat-arity-one-defers-realization
+  (is (false? (realized? (concat [1 2 3 4 5])))
+      "(concat coll) should be unrealized until accessed"))
+
+(deftest test-concat-arity-two-defers-realization
+  (is (false? (realized? (concat [1 2 3 4 5] [6 7 8 9 10])))
+      "(concat a b) should be unrealized until accessed"))
+
+(deftest test-concat-arity-many-defers-realization
+  (is (false? (realized? (concat (range 0 5) (range 5 10) (range 10 15))))
+      "(concat …) with 3+ colls should be unrealized until accessed"))
+
+(deftest test-concat-still-realizes-correct-values
+  (is (= [1 2 3 4 5 6] (doall (concat [1 2] [3 4] [5 6])))
+      "lazy concat must still produce the correct concatenated values"))
+
+(deftest test-concat-on-infinite-source-takes-lazily
+  (is (= [0 1 2 3 4] (take 5 (concat (range) (range))))
+      "(take n (concat (range) …)) must not hang"))
+
 (deftest test-filter-empty-collection
   (is (= [] (filter even? []))
       "filter on empty collection should return empty vector"))


### PR DESCRIPTION
## 🤔 Background

`concat` wrapped its underlying generator in `ChunkedSeq::fromGenerator`, which **eagerly** pulls the first chunk (32 elements) at construction. The result satisfied `realized?` before any element was consumed, breaking Clojure-aligned laziness semantics. Surfaced by every non-zero arity in `clojure-test-suite` `concat.cljc`:

\`\`\`
FAIL in (test-concat 'arity 1') (concat.cljc:5)
              Form: s
      evaluated to: @[1 2 3 4 5]
  but does satisfy: realized?  (it shouldn't)
\`\`\`

## 💡 Goal

`(concat …)` returns a properly lazy seq for all non-zero arities: `(realized? (concat …))` is `false` until accessed; elements are produced on demand.

## 🔖 Changes

- `src/phel/core/seq-fns.phel` — `concat` (non-zero arities) now constructs `LazySeq::fromGenerator` directly instead of routing through `ChunkedSeq` via `lazy-seq-from-generator`. The arity-0 branch (\`(concat)\`) still returns `'()` since there's no generator to wrap
- `tests/phel/core/infinite-seqs.phel` — regression tests covering arities 1 / 2 / 3+, value correctness, and `(take n (concat (range) …))` infinite-source case
- `CHANGELOG.md` — Fixed entry under Unreleased

Closes #2191