### PR TITLE
fix(core): three map alignment bugs (laziness, nil, pair entries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ Emit-shape tweaks:
 - `repeatedly`: arity-1 form no longer invokes `f` at construction time; the returned lazy seq is unrealized until accessed, so `(repeatedly identity)` (or any arity-incompatible fn) constructs without error and `realized?` reports `false` (#2186)
 - `filter` / `remove`: no longer hang on a sparse predicate over an infinite source. The arity-2 form now wraps the underlying generator in `LazySeq::fromGenerator` (instead of `ChunkedSeq`, which pre-pulled 32 elements at construction); `(take 3 (remove (partial < 5) (range)))` returns `(0 1 2)` instead of looping forever. Also fixes a latent `LazySeq` bug where `nil` values were dropped during `getIterator`/`toArray` (#2187)
 - `concat`: the result is no longer pre-realized — `(realized? (concat …))` is `false` until accessed, matching Clojure. Switched the wrapper from `ChunkedSeq` (which eagerly pulls the first 32 elements) to `LazySeq::fromGenerator` (#2191)
+- `map`: three Clojure-alignment fixes (#2188):
+  - all non-transducer arities now return an unrealized lazy seq (`realized?` is `false` until accessed); previously the result was pre-chunked
+  - `(map f nil)` and `(map f '())` return a `LazySeq`, not an empty vector, so `lazy-seq?` is `true`
+  - `(map f some-map)` now yields `[k v]` pair vectors instead of values only: `(map identity {:k :v}) ; => [[:k :v]]`. The fix lives in `TransformGenerator::map`, so any other Seq path that hits a `PersistentMap` also sees pair entries
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -65,17 +65,23 @@
   (case (count colls)
     0 (fn [rf]
         (xf-step rf (fn [result input] (rf result (f input)))))
-    1 (let [coll (first colls)]
-        (if (empty? coll)
-          []
-          (copy-meta coll (lazy-seq-from-generator (php/:: Seq (map f coll))))))
-    (let [result (lazy-seq-from-generator
-                  (php/call_user_func_array
-                   (php/array "\\Phel\\Lang\\Seq" "mapMulti")
-                   (php/array_merge (php/array f) (apply php/array colls))))]
-      (if (php/=== nil result)
-        []
-        (copy-meta (first colls) result)))))
+    1 (let [coll   (first colls)
+            ;; LazySeq keeps the seq unrealized until accessed; ChunkedSeq
+            ;; would eagerly materialise the first chunk. `Seq::map`
+            ;; yields `[k v]` pairs when `coll` is a `PersistentMap`
+            ;; (Clojure-aligned), otherwise it yields the elements.
+            result (php/:: LazySeq (fromGenerator
+                                    (php/new Hasher)
+                                    (php/new Equalizer)
+                                    (php/:: Seq (map f coll))))]
+        (copy-meta coll result))
+    (let [result (php/:: LazySeq (fromGenerator
+                                  (php/new Hasher)
+                                  (php/new Equalizer)
+                                  (php/call_user_func_array
+                                   (php/array "\\Phel\\Lang\\Seq" "mapMulti")
+                                   (php/array_merge (php/array f) (apply php/array colls)))))]
+      (copy-meta (first colls) result))))
 
 (defn comp
   "Takes a list of functions and returns a function that is the composition of those functions."

--- a/src/php/Lang/Generators/TransformGenerator.php
+++ b/src/php/Lang/Generators/TransformGenerator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Phel\Lang\Generators;
 
 use Generator;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\TypeFactory;
 
 /**
  * Element-wise transformation generators: map, filter, and their variants.
@@ -22,6 +24,10 @@ final class TransformGenerator
      *   map(fn($x) => $x * 2, [1, 2, 3])      // => [2, 4, 6]
      *   map(fn($c) => strtoupper($c), 'abc')  // => ['A', 'B', 'C']
      *
+     * For `PersistentMap` inputs the iteration yields `[k v]` pair vectors,
+     * matching Clojure's seq-on-a-map semantics: `(map identity {:k :v})`
+     * produces `[[:k :v]]`, not `[:v]`.
+     *
      * @template T
      * @template U
      *
@@ -32,6 +38,16 @@ final class TransformGenerator
      */
     public static function map(callable $f, mixed $iterable): Generator
     {
+        if ($iterable instanceof PersistentMapInterface) {
+            $typeFactory = TypeFactory::getInstance();
+            foreach ($iterable as $k => $v) {
+                /** @psalm-suppress InvalidArgument map entries are pair vectors, not `T` */
+                yield $f($typeFactory->persistentVectorFromArray([$k, $v]));
+            }
+
+            return;
+        }
+
         foreach (SequenceGenerator::toIterable($iterable) as $value) {
             yield $f($value);
         }

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -181,6 +181,43 @@
   (is (= [0 1 2 3 4] (take 5 (concat (range) (range))))
       "(take n (concat (range) …)) must not hang"))
 
+; Regression tests for https://github.com/phel-lang/phel-lang/issues/2188.
+; `map` must (a) defer realization across all non-transducer arities,
+; (b) produce a lazy seq even for nil/empty input, and (c) iterate maps
+; as `[k v]` pair vectors (not values-only).
+(deftest test-map-defers-realization-arity-2
+  (is (false? (realized? (map inc (range 5))))
+      "(map f coll) must be unrealized until accessed"))
+
+(deftest test-map-defers-realization-arity-3
+  (is (false? (realized? (map + (range 5) (range 5))))
+      "(map f a b) must be unrealized until accessed"))
+
+(deftest test-map-defers-realization-arity-many
+  (is (false? (realized? (map + (range 5) (range 5) (range 5))))
+      "(map f a b c …) must be unrealized until accessed"))
+
+(deftest test-map-of-nil-is-lazy-seq
+  (is (true? (lazy-seq? (map identity nil)))
+      "(map f nil) must return a lazy seq, not an empty vector"))
+
+(deftest test-map-of-empty-list-is-lazy-seq
+  (is (true? (lazy-seq? (map identity '())))
+      "(map f '()) must return a lazy seq, not an empty vector"))
+
+(deftest test-map-on-persistent-map-yields-pairs
+  (is (= [[:k :v]] (doall (map identity {:k :v})))
+      "(map identity {:k :v}) must yield [[:k :v]], not [:v]"))
+
+(deftest test-map-on-persistent-map-with-fn
+  (is (= [[:a 1] [:b 2]]
+         (sort-by first (doall (map identity {:a 1 :b 2}))))
+      "(map identity multi-entry-map) yields [k v] pairs for every entry"))
+
+(deftest test-map-on-infinite-source-takes-lazily
+  (is (= [0 1 2 3 4] (take 5 (map identity (range))))
+      "(take n (map f (range))) must not hang"))
+
 (deftest test-filter-empty-collection
   (is (= [] (filter even? []))
       "filter on empty collection should return empty vector"))


### PR DESCRIPTION
## 🤔 Background

\`clojure-test-suite\` \`map.cljc\` surfaced three independent failures in Phel's \`(map …)\`:

1. **Eager realization.** All non-transducer arities wrapped the underlying generator in \`ChunkedSeq::fromGenerator\`, which pre-realizes 32 elements. The result satisfied \`realized?\` immediately.
2. **\`(map f nil)\` and \`(map f '())\` returned an empty vector**, not a \`LazySeq\`, so \`lazy-seq?\` was \`false\` — the test asserts the empty case is still a lazy seq.
3. **\`(map f some-map)\` yielded values, not \`[k v]\` pairs.** \`(map identity {:k :v})\` returned \`[:v]\` instead of \`[[:k :v]]\`.

## 💡 Goal

Bring \`map\` in line with Clojure across all three fronts: deferred realization, lazy-seq empty result, and pair-entry iteration over maps.

## 🔖 Changes

- \`src/phel/core/seq-fns.phel\` — \`map\` (arity 1 and variadic) now constructs \`LazySeq::fromGenerator\` instead of routing through \`ChunkedSeq\`. Dropped the \`empty?\` short-circuit that returned a vector for nil/empty input; \`LazySeq\` already represents the empty case correctly
- \`src/php/Lang/Generators/TransformGenerator.php\` — \`map\` detects \`PersistentMapInterface\` input and yields each entry as a 2-element \`PersistentVector\` (\`[k, v]\`). Other inputs keep the existing values-only iteration. The fix lives at the PHP level so every Seq path that reaches a \`PersistentMap\` gets the same Clojure-aligned shape
- \`tests/phel/core/infinite-seqs.phel\` — regression tests for all three fixes: laziness across arities 2 / 3 / N+, \`(map f nil)\` / \`(map f '())\` returning a lazy seq, map iteration yielding pairs, \`(take n (map f (range)))\` not hanging
- \`CHANGELOG.md\` — Fixed entry under Unreleased

Closes #2188