### PR TITLE
fix(core): defer distinct realization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Emit-shape tweaks:
   - all non-transducer arities now return an unrealized lazy seq (`realized?` is `false` until accessed); previously the result was pre-chunked
   - `(map f nil)` and `(map f '())` return a `LazySeq`, not an empty vector, so `lazy-seq?` is `true`
   - `(map f some-map)` now yields `[k v]` pair vectors instead of values only: `(map identity {:k :v}) ; => [[:k :v]]`. The fix lives in `TransformGenerator::map`, so any other Seq path that hits a `PersistentMap` also sees pair entries
+- `distinct`: the arity-1 result is no longer pre-realized — `(realized? (distinct coll))` is `false` until accessed, matching Clojure. Switched the wrapper from `ChunkedSeq` to `LazySeq::fromGenerator` (#2190)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/phel/core/seq-fns.phel
+++ b/src/phel/core/seq-fns.phel
@@ -637,8 +637,13 @@
     1 (let [coll (first args)]
         (if (nil? coll)
           []
-          (let [result (lazy-seq-from-generator (php/:: Seq (distinct coll)))]
-            (copy-meta coll (or result [])))))
+          ;; LazySeq keeps the seq unrealized until accessed; ChunkedSeq
+          ;; would pre-pull 32 unique elements at construction.
+          (let [result (php/:: LazySeq (fromGenerator
+                                        (php/new Hasher)
+                                        (php/new Equalizer)
+                                        (php/:: Seq (distinct coll))))]
+            (copy-meta coll result))))
     (throw (php/new InvalidArgumentException "distinct expects 0 or 1 arguments"))))
 
 

--- a/tests/phel/core/infinite-seqs.phel
+++ b/tests/phel/core/infinite-seqs.phel
@@ -218,6 +218,17 @@
   (is (= [0 1 2 3 4] (take 5 (map identity (range))))
       "(take n (map f (range))) must not hang"))
 
+; Regression test for https://github.com/phel-lang/phel-lang/issues/2190.
+; `distinct` must produce an unrealized lazy seq; previously the result
+; was pre-chunked and `realized?` was true at construction.
+(deftest test-distinct-defers-realization
+  (let [s (distinct [1 1 1 2 1 2 1 2 3 1 2 3 1 2 3 4 1 2 3 4 5])]
+    (is (false? (realized? s))
+        "(distinct coll) must be unrealized until accessed"))
+  (is (= [1 2 3 4 5]
+         (doall (distinct [1 1 1 2 1 2 1 2 3 1 2 3 1 2 3 4 1 2 3 4 5])))
+      "distinct still removes duplicates when realized"))
+
 (deftest test-filter-empty-collection
   (is (= [] (filter even? []))
       "filter on empty collection should return empty vector"))


### PR DESCRIPTION
## 🤔 Background

\`distinct\` wrapped its underlying generator in \`ChunkedSeq::fromGenerator\`, which eagerly pulls 32 unique elements at construction. The result satisfied \`realized?\` before any element was consumed. Surfaced by \`clojure-test-suite\` \`distinct.cljc\`:

\`\`\`
FAIL in (test-distinct 'arity 1') (distinct.cljc:5)
              Form: s
      evaluated to: @[1 2 3 4 5]
  but does satisfy: realized?  (it shouldn't)
\`\`\`

## 💡 Goal

\`(distinct coll)\` returns a properly lazy seq: \`(realized? s)\` is \`false\` until the seq is consumed; unique elements are produced on demand.

## 🔖 Changes

- \`src/phel/core/seq-fns.phel\` — arity-1 \`distinct\` constructs \`LazySeq::fromGenerator\` instead of routing through \`ChunkedSeq\` via \`lazy-seq-from-generator\`. The \`nil\` short-circuit still returns \`[]\` (no generator to wrap)
- \`tests/phel/core/infinite-seqs.phel\` — regression test for the laziness contract; existing dup-removal tests cover correctness
- \`CHANGELOG.md\` — Fixed entry under Unreleased

Closes #2190