### PR TITLE
fix(compiler): preserve reader meta on vector/map/set literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Emit-shape tweaks:
   - `(map f nil)` and `(map f '())` return a `LazySeq`, not an empty vector, so `lazy-seq?` is `true`
   - `(map f some-map)` now yields `[k v]` pair vectors instead of values only: `(map identity {:k :v}) ; => [[:k :v]]`. The fix lives in `TransformGenerator::map`, so any other Seq path that hits a `PersistentMap` also sees pair entries
 - `distinct`: the arity-1 result is no longer pre-realized — `(realized? (distinct coll))` is `false` until accessed, matching Clojure. Switched the wrapper from `ChunkedSeq` to `LazySeq::fromGenerator` (#2190)
+- Reader-attached metadata on vector / map / set literals now survives the compile pipeline. Previously `^{:k v} […]` parsed correctly but `VectorNode` / `MapNode` / `SetNode` discarded the meta, so the emitted `\Phel::vector(…)` call produced a fresh value with no meta. The three AST nodes now carry the literal meta, their analysers extract it via a shared `LiteralMetaAnalyzer`, and the emitters wrap the literal with `->withMeta(…)`. This fixes the underlying root cause of `group-by` losing element meta (#2189)
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/php/Compiler/Domain/Analyzer/Ast/MapNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/MapNode.php
@@ -16,6 +16,7 @@ final class MapNode extends AbstractNode
         NodeEnvironmentInterface $env,
         private readonly array $keyValues,
         ?SourceLocation $sourceLocation = null,
+        private readonly ?self $meta = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
@@ -26,5 +27,14 @@ final class MapNode extends AbstractNode
     public function getKeyValues(): array
     {
         return $this->keyValues;
+    }
+
+    /**
+     * Reader-attached metadata (`^{:k v} {…}`) for this map literal. Distinct
+     * from a node's `getMeta()` (which doesn't exist on `AbstractNode`).
+     */
+    public function getLiteralMeta(): ?self
+    {
+        return $this->meta;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Ast/SetNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/SetNode.php
@@ -16,6 +16,7 @@ final class SetNode extends AbstractNode
         NodeEnvironmentInterface $env,
         private readonly array $values,
         ?SourceLocation $sourceLocation = null,
+        private readonly ?MapNode $meta = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
@@ -26,5 +27,10 @@ final class SetNode extends AbstractNode
     public function getValues(): array
     {
         return $this->values;
+    }
+
+    public function getMeta(): ?MapNode
+    {
+        return $this->meta;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/Ast/VectorNode.php
+++ b/src/php/Compiler/Domain/Analyzer/Ast/VectorNode.php
@@ -16,6 +16,7 @@ final class VectorNode extends AbstractNode
         NodeEnvironmentInterface $env,
         private readonly array $args,
         ?SourceLocation $sourceLocation = null,
+        private readonly ?MapNode $meta = null,
     ) {
         parent::__construct($env, $sourceLocation);
     }
@@ -26,5 +27,10 @@ final class VectorNode extends AbstractNode
     public function getArgs(): array
     {
         return $this->args;
+    }
+
+    public function getMeta(): ?MapNode
+    {
+        return $this->meta;
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentMap.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentMap.php
@@ -28,6 +28,10 @@ final class AnalyzePersistentMap
             $keyValues[] = $this->analyzer->analyze($value, $kvEnv);
         }
 
-        return new MapNode($env, $keyValues, $map->getStartLocation());
+        // Pass the env (not the kv env) so the meta map is analyzed in
+        // the outer context. `null` if the literal carries no `^{…}` meta.
+        $meta = LiteralMetaAnalyzer::analyze($this->analyzer, $map, $env);
+
+        return new MapNode($env, $keyValues, $map->getStartLocation(), $meta);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentSet.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentSet.php
@@ -26,6 +26,8 @@ final class AnalyzePersistentSet
             $values[] = $this->analyzer->analyze($value, $envDisallowRecur);
         }
 
-        return new SetNode($env, $values, $set->getStartLocation());
+        $meta = LiteralMetaAnalyzer::analyze($this->analyzer, $set, $env);
+
+        return new SetNode($env, $values, $set->getStartLocation(), $meta);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentVector.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentVector.php
@@ -26,6 +26,8 @@ final class AnalyzePersistentVector
             $args[] = $this->analyzer->analyze($arg, $envDisallowRecur);
         }
 
-        return new VectorNode($env, $args, $vector->getStartLocation());
+        $meta = LiteralMetaAnalyzer::analyze($this->analyzer, $vector, $env);
+
+        return new VectorNode($env, $args, $vector->getStartLocation(), $meta);
     }
 }

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralMetaAnalyzer.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralMetaAnalyzer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer;
+
+use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\MetaInterface;
+
+/**
+ * Extracts a `MetaInterface` value's reader-attached metadata map and analyses
+ * it as a `MapNode`. Returns `null` when the host has no meta (or an empty
+ * meta map), which is the common case.
+ *
+ * Used by literal analysers (vector / map / set) so emitters can preserve
+ * `^{:k v} […]` metadata round-trip through the compile pipeline.
+ */
+final class LiteralMetaAnalyzer
+{
+    public static function analyze(
+        AnalyzerInterface $analyzer,
+        MetaInterface $host,
+        NodeEnvironmentInterface $env,
+    ): ?MapNode {
+        $meta = $host->getMeta();
+        if (!$meta instanceof PersistentMapInterface || $meta->count() === 0) {
+            return null;
+        }
+
+        $analyzed = $analyzer->analyze($meta, $env->withExpressionContext());
+        return $analyzed instanceof MapNode ? $analyzed : null;
+    }
+}

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/MapEmitter.php
@@ -39,6 +39,13 @@ final class MapEmitter implements NodeEmitterInterface
             $this->outputEmitter->emitStr(')', $loc);
         }
 
+        $meta = $node->getLiteralMeta();
+        if ($meta instanceof MapNode) {
+            $this->outputEmitter->emitStr('->withMeta(', $loc);
+            $this->outputEmitter->emitNode($meta);
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
         if ($cached) {
             $this->outputEmitter->emitConstantSlotSuffix($loc);
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/SetEmitter.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\SetNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
@@ -25,6 +26,14 @@ final class SetEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('\\' . Phel::class . '::set([', $loc);
         $this->outputEmitter->emitArgList($node->getValues(), $loc);
         $this->outputEmitter->emitStr('])', $loc);
+
+        $meta = $node->getMeta();
+        if ($meta instanceof MapNode) {
+            $this->outputEmitter->emitStr('->withMeta(', $loc);
+            $this->outputEmitter->emitNode($meta);
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
         if ($cached) {
             $this->outputEmitter->emitConstantSlotSuffix($loc);
         }

--- a/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
+++ b/src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/VectorEmitter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitter;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\MapNode;
 use Phel\Compiler\Domain\Analyzer\Ast\VectorNode;
 use Phel\Compiler\Domain\Emitter\OutputEmitter\NodeEmitterInterface;
 
@@ -24,6 +25,14 @@ final class VectorEmitter implements NodeEmitterInterface
         $this->outputEmitter->emitStr('\Phel::vector([', $loc);
         $this->outputEmitter->emitArgList($node->getArgs(), $loc);
         $this->outputEmitter->emitStr('])', $loc);
+
+        $meta = $node->getMeta();
+        if ($meta instanceof MapNode) {
+            $this->outputEmitter->emitStr('->withMeta(', $loc);
+            $this->outputEmitter->emitNode($meta);
+            $this->outputEmitter->emitStr(')', $loc);
+        }
+
         if ($cached) {
             $this->outputEmitter->emitConstantSlotSuffix($loc);
         }

--- a/tests/phel/core/sequence-functions.phel
+++ b/tests/phel/core/sequence-functions.phel
@@ -409,6 +409,43 @@
   (is (= {1 ["a"] 2 ["as" "aa"] 3 ["asd"] 4 ["asdf" "qwer"]}
          (group-by php/strlen ["a" "as" "asd" "aa" "asdf" "qwer"])) "group-by"))
 
+; Regression test for https://github.com/phel-lang/phel-lang/issues/2189.
+; `group-by` must preserve element metadata. The root cause was reader-attached
+; meta `^{:k v} […]` being dropped during emit; group-by itself only proxies
+; the elements through. Both reader meta and `set-meta!` paths must round-trip.
+(deftest test-group-by-retains-element-metadata-via-reader-meta
+  (let [g (group-by first [^{:foo true} [[1] [2]] ^{:bar true} [[1] [3]]])]
+    (is (= {:foo true} (meta (first (get g [1]))))
+        "group-by preserves reader-attached meta on the first bucket element")
+    (is (= {:bar true} (meta (second (get g [1]))))
+        "group-by preserves reader-attached meta on the second bucket element")))
+
+(deftest test-group-by-retains-element-metadata-via-set-meta
+  (let [a (set-meta! [[1] [2]] {:foo true})
+        b (set-meta! [[1] [3]] {:bar true})
+        g (group-by first [a b])]
+    (is (= {:foo true} (meta (first (get g [1]))))
+        "group-by preserves set-meta! meta on the first bucket element")
+    (is (= {:bar true} (meta (second (get g [1]))))
+        "group-by preserves set-meta! meta on the second bucket element")))
+
+; Direct coverage of the underlying reader-meta-on-literal plumbing fix.
+(deftest test-reader-meta-on-vector-literal
+  (is (= {:foo true} (meta ^{:foo true} [1 2]))
+      "reader meta map on a vector literal survives compile/emit"))
+
+(deftest test-reader-meta-on-map-literal
+  (is (= {:tag :env} (meta ^{:tag :env} {:k :v}))
+      "reader meta map on a map literal survives compile/emit"))
+
+(deftest test-reader-meta-on-set-literal
+  (is (= {:tag :seen} (meta ^{:tag :seen} #{1 2 3}))
+      "reader meta map on a set literal survives compile/emit"))
+
+(deftest test-reader-keyword-meta-on-vector-literal
+  (is (= {:foo true} (meta ^:foo [1 2]))
+      "reader keyword shorthand `^:k` on a vector literal survives compile/emit"))
+
 (deftest test-zipcoll
   (is (= {:a 1 :b 2 :c 3} (zipcoll [:a :b :c] [1 2 3])) "zipcoll"))
 


### PR DESCRIPTION
## 🤔 Background

\`(group-by first [^{:foo true} [[1] [2]] ^{:bar true} [[1] [3]]])\` returned a map whose bucket elements had no meta — the test in the issue expects \`{:foo true}\` / \`{:bar true}\` back from \`(meta (first/second …))\`.

Investigation pinned the root cause **not** in \`group-by\` (it only proxies elements through \`for\` / \`assoc\`) but in the literal-emit pipeline:

* The reader parses \`^{…} […]\` correctly, attaching meta to the resulting \`PersistentVector\`.
* The analyser then builds a \`VectorNode\` / \`MapNode\` / \`SetNode\` that **drops** the meta — none of the three AST nodes had a field for it.
* The emitter outputs \`\\Phel::vector([…])\` — a fresh value with no meta.

So reader meta on data literals never made it past compile. \`group-by\` is one downstream consumer; the same gap affected every other path that depended on \`meta\` on a literal collection.

## 💡 Goal

Plumb reader-attached meta through the AST and emitter so \`^{:k v} […]\` round-trips end-to-end. \`group-by\` retains element meta as a natural consequence.

## 🔖 Changes

- \`src/php/Compiler/Domain/Analyzer/Ast/{Vector,Map,Set}Node.php\` — accept an optional \`?MapNode \$meta\` constructor arg and expose it via \`getMeta()\` / \`getLiteralMeta()\` (the \`MapNode\` accessor takes the longer name to avoid colliding with the absent \`AbstractNode::getMeta()\`)
- \`src/php/Compiler/Domain/Analyzer/TypeAnalyzer/LiteralMetaAnalyzer.php\` — new helper that pulls a \`MetaInterface\` host's meta map and analyses it as a \`MapNode\`; returns \`null\` for absent / empty meta. Used by all three literal analysers
- \`src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistent{Vector,Map,Set}.php\` — call \`LiteralMetaAnalyzer\` and pass the result to the node constructor
- \`src/php/Compiler/Domain/Emitter/OutputEmitter/NodeEmitter/{Vector,Map,Set}Emitter.php\` — wrap the literal with \`->withMeta(<map>)\` when the node carries meta, emitted before the constant-slot suffix so the cached value includes the meta
- \`tests/phel/core/sequence-functions.phel\` — regression tests:
  - \`group-by\` retains element meta via reader meta and via \`set-meta!\`
  - direct \`^{:k v} […]\` / \`^{:k v} {…}\` / \`^{:k v} #{…}\` round-trip
  - keyword shorthand \`^:k […]\`
- \`CHANGELOG.md\` — Fixed entry under Unreleased

Closes #2189