### PR TITLE
fix(lang): silence NaN/Inf coerce warning in BigInt/BigDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Emit-shape tweaks:
 - `map` (#2188): `(map f nil)` / `(map f '())` return a `LazySeq` (not an empty vector); `(map identity {:k :v})` yields `[[:k :v]]` (pair vectors, not values-only). The map-of-pairs fix lives in `TransformGenerator::map`, so every Seq path hitting a `PersistentMap` sees pair entries
 - `LazySeq::getIterator` / `toArray` no longer drop `nil` values (latent bug, surfaced by #2187)
 - Reader meta on vector / map / set literals (`^{:k v} […]`, `^:k […]`) now survives compile/emit. `VectorNode` / `MapNode` / `SetNode` carry the literal meta; a shared `LiteralMetaAnalyzer` extracts it; emitters wrap with `->withMeta(…)`. Fixes `group-by` dropping element meta (#2189)
+- `BigInt::fromFloat` / `BigDecimal::fromFloat`: stop coercing `NAN` / `INF` to string when building the rejection message. PHP 8.5 emits a `unexpected NAN value was coerced to string` warning; new private `describeNonFinite` helper renders `NaN` / `Infinity` / `-Infinity` literals, silencing CI noise without changing exception type
 
 ## [0.40.0](https://github.com/phel-lang/phel-lang/compare/v0.39.0...v0.40.0) - 2026-05-25
 

--- a/src/php/Lang/BigDecimal.php
+++ b/src/php/Lang/BigDecimal.php
@@ -106,7 +106,7 @@ final readonly class BigDecimal implements TypeInterface, Stringable
     {
         if (!is_finite($value)) {
             throw new InvalidArgumentException(
-                sprintf("Cannot convert non-finite float '%s' to BigDecimal", $value),
+                sprintf("Cannot convert non-finite float '%s' to BigDecimal", self::describeNonFinite($value)),
             );
         }
 
@@ -366,5 +366,14 @@ final readonly class BigDecimal implements TypeInterface, Stringable
 
         $factor = BigInt::fromInt(10)->pow($other->scale - $this->scale);
         return [$this->mantissa->multiply($factor), $other->mantissa, $other->scale];
+    }
+
+    private static function describeNonFinite(float $value): string
+    {
+        if (is_nan($value)) {
+            return 'NaN';
+        }
+
+        return $value > 0 ? 'Infinity' : '-Infinity';
     }
 }

--- a/src/php/Lang/BigInt.php
+++ b/src/php/Lang/BigInt.php
@@ -154,7 +154,7 @@ final readonly class BigInt implements TypeInterface, Stringable
     {
         if (!is_finite($value)) {
             throw new InvalidArgumentException(
-                sprintf("Cannot convert non-finite float '%s' to BigInt", $value),
+                sprintf("Cannot convert non-finite float '%s' to BigInt", self::describeNonFinite($value)),
             );
         }
 
@@ -734,5 +734,14 @@ final readonly class BigInt implements TypeInterface, Stringable
         }
 
         return sprintf('%.17g', $value);
+    }
+
+    private static function describeNonFinite(float $value): string
+    {
+        if (is_nan($value)) {
+            return 'NaN';
+        }
+
+        return $value > 0 ? 'Infinity' : '-Infinity';
     }
 }


### PR DESCRIPTION
## 🤔 Background

Core tests on PHP 8.5 emit two `PHP Warning: unexpected NAN value was coerced to string in src/php/Lang/BigInt.php on line 157` lines per CI run. The `Tests` workflow on `main` is green, but the warnings clutter the log and obscure real signal. PHP 8.5 added the warning when `NAN` (or `INF`) flows through `(string)` cast / `%s` format.

Source: `BigInt::fromFloat` and `BigDecimal::fromFloat` build the rejection message with `sprintf("...'%s'", $value)`. When the rejected value is `NAN`/`INF`, the format string triggers the coerce warning.

## 💡 Goal

Drop the warning from CI logs without changing the exception class or runtime behaviour. Tests asserting `expectException(InvalidArgumentException::class)` still pass.

## 🔖 Changes

- `BigInt::describeNonFinite(float): string` private helper returns `'NaN'`, `'Infinity'`, `'-Infinity'` — no float→string coerce
- `BigDecimal::describeNonFinite(float): string` mirror of the above
- Both `fromFloat` paths route the rejected value through the helper before `sprintf`
- CHANGELOG `Unreleased / Fixed` updated