### PR TITLE
chore(ci): bump actions/checkout to v6 and actions/cache to v5

### DIFF
--- a/.github/workflows/agnostic-ai.yml
+++ b/.github/workflows/agnostic-ai.yml
@@ -25,7 +25,7 @@ jobs:
     name: Sync drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install agnostic-ai
         run: |

--- a/.github/workflows/announce-release-tests.yml
+++ b/.github/workflows/announce-release-tests.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -16,7 +16,7 @@ jobs:
   draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
     name: Docker quickstart repl
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: docker login
       env:
         DOCKER_USER: ${{secrets.DOCKER_USER}}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validate composer configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     name: Coding Guidelines
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Run friendsofphp/php-cs-fixer
@@ -47,7 +47,7 @@ jobs:
     name: Type Checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Run Psalm on internal code

--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -25,12 +25,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout phel-lang
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: phel
 
       - name: Checkout clojure-test-suite
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: phel-lang/clojure-test-suite
           ref: ${{ github.event.inputs.suite-ref || 'main' }}
@@ -47,7 +47,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-suite-${{ hashFiles('clojure-test-suite/composer.json') }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,7 +19,7 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Run all example scripts
@@ -37,7 +37,7 @@ jobs:
     name: Agent docs validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Validate .agents/ examples and core reference drift
@@ -47,7 +47,7 @@ jobs:
     name: PHAR smoke test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
         with:
           ini-values: phar.readonly=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         php: [ '8.4', '8.5' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
         with:
           php-version: ${{ matrix.php }}
@@ -42,7 +42,7 @@ jobs:
       matrix:
         php: [ '8.4', '8.5' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
         with:
           php-version: ${{ matrix.php }}
@@ -54,7 +54,7 @@ jobs:
     name: Bench tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Run PHPBench
@@ -64,7 +64,7 @@ jobs:
     name: Bash tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Run Bashunit tests
@@ -74,7 +74,7 @@ jobs:
     name: Compat tests on symfony/console ^7.0
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-phel
 
       - name: Pin symfony/console to ^7.0 for this run


### PR DESCRIPTION
## 🤔 Background

Every workflow run on `main` emits:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`, `actions/checkout@v4`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

GitHub forces the cutover on **2026-06-02** (6 days). Removal on **2026-09-16**. Pre-emptive bump avoids day-of breakage.

## 💡 Goal

Move both actions to their Node.js 24 majors so the deprecation warning disappears and the workflows keep running unchanged after the June 2 cutover.

## 🔖 Changes

- `actions/checkout@v4` → `@v6` across all 8 workflow files (17 call sites)
- `actions/cache@v4` → `@v5` in `run-clojure-test-suite.yml`
- No behaviour change expected: both v6 / v5 keep the same input contract; only the runner Node binary version moves