### PR TITLE
ci(clojure-test-suite): nightly cron + fail on errors

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       suite-ref:
@@ -22,7 +24,6 @@ jobs:
   run-clojure-test-suite:
     name: Run clojure-test-suite (PHP 8.4)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout phel-lang
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `schedule: cron '0 6 * * *'` to run the clojure-test-suite workflow nightly, so upstream drift in `phel-lang/clojure-test-suite` is caught even when nobody pushes to `phel-lang`.
- Drop `continue-on-error: true`. The suite is green against the fork's `main` (5494 passed, 0 failed); Phel-side divergences are tracked as `:phel` reader conditionals in the suite, so a red run now signals a real regression in either repo.

## Context
Follow-up to the Slack thread in `#clojure-test-suite` (jasalt + jeaye). Plan: keep Phel CI in this repo (not in the test-suite fork), pull the suite on every Phel run, and add a daily cron so drift surfaces without manual sync.

A companion PR removes the duplicated Phel CI job from the `phel-lang/clojure-test-suite` fork so it stays a clean mirror of `jank-lang/clojure-test-suite` (plus `:phel` reader conditionals).
