### PR TITLE
ci(clojure-test-suite): temp soft-gate while upstream :phel patches land

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -24,6 +24,10 @@ jobs:
   run-clojure-test-suite:
     name: Run clojure-test-suite (PHP 8.4)
     runs-on: ubuntu-latest
+    # Temporary: clojure-test-suite fork now mirrors jank-lang upstream
+    # exactly; the :phel compat patches live in jank-lang/clojure-test-suite#899.
+    # Drop this once that PR is merged.
+    continue-on-error: true
     steps:
       - name: Checkout phel-lang
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Re-add `continue-on-error: true` to the clojure-test-suite job. **Temporary** safety net until [jank-lang/clojure-test-suite#899](https://github.com/jank-lang/clojure-test-suite/pull/899) merges.

## Why
- [phel-lang/clojure-test-suite#15](https://github.com/phel-lang/clojure-test-suite/pull/15) (just merged) plus a follow-up hard-sync made our fork a pure mirror of `jank-lang/clojure-test-suite`.
- This dropped 3 `:phel` reader-conditional patches the suite needs to stay green (class rename, group-by metadata, repeatedly ConstantFolder workaround).
- Those patches are now open at jank-lang/clojure-test-suite#899.
- Until #899 lands, the suite job will go red and would otherwise block every PR here (since #2200 just removed the soft-gate).

## Follow-up
Revert this commit once #899 is merged. The comment in the YAML explicitly points at it.

## Test plan
- [ ] Job runs but does not block the overall workflow on failure.
- [ ] Once #899 merges and the fork is synced, revert PR opened; nightly stays green without the escape hatch.