### PR TITLE
perf(analyzer): defn FnNode side-table (step 1 of #2135)

### DIFF
--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Application;
 
 use Phel\Compiler\Domain\Analyzer\AnalyzerInterface;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
@@ -97,6 +98,16 @@ final class Analyzer implements AnalyzerInterface
     public function setCompileTimeMeta(string $ns, Symbol $symbol, PersistentMapInterface $meta): void
     {
         $this->globalEnvironment->setCompileTimeMeta($ns, $symbol, $meta);
+    }
+
+    public function setDefFnNode(string $ns, Symbol $symbol, FnNode $node): void
+    {
+        $this->globalEnvironment->setDefFnNode($ns, $symbol, $node);
+    }
+
+    public function getDefFnNode(string $ns, Symbol $symbol): ?FnNode
+    {
+        return $this->globalEnvironment->getDefFnNode($ns, $symbol);
     }
 
     public function addInterface(string $ns, Symbol $name): void

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -40,6 +41,10 @@ interface AnalyzerInterface
      * @param PersistentMapInterface<mixed, mixed> $meta
      */
     public function setCompileTimeMeta(string $ns, Symbol $symbol, PersistentMapInterface $meta): void;
+
+    public function setDefFnNode(string $ns, Symbol $symbol, FnNode $node): void;
+
+    public function getDefFnNode(string $ns, Symbol $symbol): ?FnNode;
 
     public function addInterface(string $ns, Symbol $name): void;
 

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironment.php
@@ -6,6 +6,7 @@ namespace Phel\Compiler\Domain\Analyzer\Environment;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Exceptions\DuplicateDefinitionException;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -34,6 +35,17 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
      * @var array<string, array<string, PersistentMapInterface<mixed, mixed>>>
      */
     private array $compileTimeMeta = [];
+
+    /**
+     * Compile-time AST stash for `defn` bodies analyzed in the current
+     * session, keyed by `(namespace, name)`. Populated by `DefSymbol`
+     * whenever the init expression is a single-arity `FnNode`. Consumers
+     * (e.g. a future inliner / constant folder) can read the analysed
+     * body from here without re-analysing the source form.
+     *
+     * @var array<string, array<string, FnNode>>
+     */
+    private array $defFnNodes = [];
 
     /** @var array<string, array<string, Symbol>> */
     private array $refers = [];
@@ -94,6 +106,16 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
     public function setCompileTimeMeta(string $namespace, Symbol $name, PersistentMapInterface $meta): void
     {
         $this->compileTimeMeta[$namespace][$name->getName()] = $meta;
+    }
+
+    public function setDefFnNode(string $namespace, Symbol $name, FnNode $node): void
+    {
+        $this->defFnNodes[$namespace][$name->getName()] = $node;
+    }
+
+    public function getDefFnNode(string $namespace, Symbol $name): ?FnNode
+    {
+        return $this->defFnNodes[$namespace][$name->getName()] ?? null;
     }
 
     public function hasDefinition(string $namespace, Symbol $name): bool

--- a/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/Environment/GlobalEnvironmentInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Domain\Analyzer\Environment;
 
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
 use Phel\Lang\Symbol;
 
@@ -20,6 +21,10 @@ interface GlobalEnvironmentInterface
      * @param PersistentMapInterface<mixed, mixed> $meta
      */
     public function setCompileTimeMeta(string $namespace, Symbol $name, PersistentMapInterface $meta): void;
+
+    public function setDefFnNode(string $namespace, Symbol $name, FnNode $node): void;
+
+    public function getDefFnNode(string $namespace, Symbol $name): ?FnNode;
 
     public function hasDefinition(string $namespace, Symbol $name): bool;
 

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/DefSymbol.php
@@ -88,6 +88,7 @@ final readonly class DefSymbol implements SpecialFormAnalyzerInterface
 
         if ($initNode instanceof FnNode) {
             $initNode->markAsDefinition();
+            $this->analyzer->setDefFnNode($namespace, $nameSymbol, $initNode);
             // Macro args bind to raw Phel forms regardless of how the
             // body manipulates them, so a primitive-op observation in
             // the macro body must not type-narrow the runtime signature.

--- a/tests/php/Integration/Compiler/DefnSideTableTest.php
+++ b/tests/php/Integration/Compiler/DefnSideTableTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+final class DefnSideTableTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_defn_registers_fn_node_on_global_environment(): void
+    {
+        $this->compilerFacade->compile(
+            '(defn identity-fn [x] x)',
+            new CompileOptions(),
+        );
+
+        $node = self::$globalEnv->getDefFnNode('user', Symbol::create('identity-fn'));
+
+        self::assertNotNull($node);
+        self::assertCount(1, $node->getParams());
+        self::assertSame('x', $node->getParams()[0]->getName());
+    }
+
+    public function test_def_with_literal_init_does_not_populate_side_table(): void
+    {
+        $this->compilerFacade->compile(
+            '(def some-const 42)',
+            new CompileOptions(),
+        );
+
+        self::assertNull(self::$globalEnv->getDefFnNode('user', Symbol::create('some-const')));
+    }
+
+    public function test_unknown_symbol_returns_null(): void
+    {
+        self::assertNull(self::$globalEnv->getDefFnNode('user', Symbol::create('never-defined')));
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/Environment/GlobalEnvironmentTest.php
@@ -6,9 +6,11 @@ namespace PhelTest\Unit\Compiler\Analyzer\Environment;
 
 use Phel;
 use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\FnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
 use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
 use Phel\Compiler\Domain\Analyzer\Ast\PhpClassNameNode;
+use Phel\Compiler\Domain\Analyzer\Ast\PhpVarNode;
 use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironment;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -582,5 +584,57 @@ final class GlobalEnvironmentTest extends TestCase
         $this->assertFalse($env->hasDefinition('test-ns', Symbol::create('new-def')));
         $this->assertTrue($env->hasRequireAlias('test-ns', Symbol::create('b')));
         $this->assertFalse($env->hasRequireAlias('test-ns', Symbol::create('c')));
+    }
+
+    public function test_def_fn_node_returns_null_when_unset(): void
+    {
+        $env = new GlobalEnvironment();
+
+        $this->assertNotInstanceOf(FnNode::class, $env->getDefFnNode('user', Symbol::create('missing')));
+    }
+
+    public function test_set_and_get_def_fn_node(): void
+    {
+        $env = new GlobalEnvironment();
+        $fnNode = new FnNode(
+            NodeEnvironment::empty(),
+            params: [Symbol::create('x')],
+            body: PhpVarNode::withReturnContext('$x'),
+            uses: [],
+            isVariadic: false,
+            recurs: false,
+        );
+
+        $env->setDefFnNode('user', Symbol::create('identity'), $fnNode);
+
+        $this->assertSame($fnNode, $env->getDefFnNode('user', Symbol::create('identity')));
+        $this->assertNotInstanceOf(FnNode::class, $env->getDefFnNode('user', Symbol::create('other')));
+        $this->assertNotInstanceOf(FnNode::class, $env->getDefFnNode('other-ns', Symbol::create('identity')));
+    }
+
+    public function test_set_def_fn_node_overwrites_existing(): void
+    {
+        $env = new GlobalEnvironment();
+        $first = new FnNode(
+            NodeEnvironment::empty(),
+            params: [],
+            body: PhpVarNode::withReturnContext('$a'),
+            uses: [],
+            isVariadic: false,
+            recurs: false,
+        );
+        $second = new FnNode(
+            NodeEnvironment::empty(),
+            params: [],
+            body: PhpVarNode::withReturnContext('$b'),
+            uses: [],
+            isVariadic: false,
+            recurs: false,
+        );
+
+        $env->setDefFnNode('user', Symbol::create('f'), $first);
+        $env->setDefFnNode('user', Symbol::create('f'), $second);
+
+        $this->assertSame($second, $env->getDefFnNode('user', Symbol::create('f')));
     }
 }


### PR DESCRIPTION
## 🤔 Background

#2135 proposes inlining single-expression pure `defn` bodies at call
sites to skip the PHP frame + unlock downstream peepholes (e.g. #2140
`(map inc [1 2 3])` folding). The deferral note on that issue called
out the prerequisite plumbing: an analyser-side map from `(ns, name)`
to the analysed `FnNode`, populated when `(defn …)` is analysed and
consulted by a future inliner pass.

This PR ships that foundation slice. No inlining yet, no behaviour
change for compiled output.

## 💡 Goal

Land the side-table + accessors so the inliner work in a follow-up PR
can focus purely on hygiene-safe substitution.

## 🔖 Changes

- `GlobalEnvironment::setDefFnNode()` / `getDefFnNode()` — keyed by
  `(namespace, name)`, stores the analysed `FnNode` body
- `GlobalEnvironmentInterface` + `AnalyzerInterface` + `Analyzer`
  passthroughs for the same pair
- `DefSymbol::analyze()` registers the `FnNode` after
  `markAsDefinition()` for single-arity `defn` forms (multi-arity
  `MultiFnNode` deferred until a consumer needs it)
- Unit tests: setter/getter, missing keys, overwrite semantics
- Integration test: `(defn identity-fn [x] x)` populates the table;
  literal `def` does not

## Test plan

- [x] `composer test-quality` (cs-fixer, psalm, phpstan, rector)
- [x] `./vendor/bin/phpunit --testsuite=unit,integration` — 3718 tests
  pass

Refs #2135.