### PR TITLE
ci(clojure-test-suite): drop PR trigger + soft-gate main/nightly

### DIFF
--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -23,6 +23,11 @@ jobs:
   run-clojure-test-suite:
     name: Run clojure-test-suite (PHP 8.4)
     runs-on: ubuntu-latest
+    # Soft-gate while upstream :phel patches land at
+    # jank-lang/clojure-test-suite#899 and phel-side bugs (ConstantFolder
+    # on (repeatedly identity), group-by metadata) get fixed. Suite is
+    # informational on main/nightly until then. Drop once green.
+    continue-on-error: true
     steps:
       - name: Checkout phel-lang
         uses: actions/checkout@v6

--- a/.github/workflows/run-clojure-test-suite.yml
+++ b/.github/workflows/run-clojure-test-suite.yml
@@ -1,7 +1,6 @@
 name: clojure-test-suite
 
 on:
-  pull_request:
   push:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
## Summary
1. Drop `pull_request:` trigger from `run-clojure-test-suite.yml`. Keep `push: branches: [main]`, `schedule: cron '0 6 * * *'`, `workflow_dispatch`.
2. Re-add `continue-on-error: true` to the job so main/nightly red doesn't paint the branch CI red.

## Why
[#2200](https://github.com/phel-lang/phel-lang/pull/2200) wired the workflow to run on every PR with a hard fail gate. Right after that landed, the [phel-lang/clojure-test-suite](https://github.com/phel-lang/clojure-test-suite) fork was hard-synced to mirror `jank-lang/clojure-test-suite` exactly, which dropped the `:phel` reader-conditional patches the suite needed to stay green.

Those patches are now open at [jank-lang/clojure-test-suite#899](https://github.com/jank-lang/clojure-test-suite/pull/899). Until that merges (and the phel-side `ConstantFolder` bug around `(repeatedly identity)` is fixed), the suite is red — and **every PR runs and fails this job** ([#2202](https://github.com/phel-lang/phel-lang/pull/2202) was the canary).

Per Slack thread `#clojure-test-suite`: gating Phel-suite breakage on per-PR runs is overkill. Drift is still caught by:
- daily nightly cron
- push to main
- on-demand `workflow_dispatch`

The soft-gate is intentionally temporary — drop both `continue-on-error` and (eventually) re-enable `pull_request:` once the suite is reliably green against pure upstream.

## Test plan
- [ ] This PR's CI does **not** show a `clojure-test-suite` job.
- [ ] Push to main still runs the job, but a red suite does not fail the workflow.
- [ ] Nightly cron still runs at 06:00 UTC.
- [ ] `gh workflow run run-clojure-test-suite.yml` still works.

## Follow-ups
- [ ] jank-lang/clojure-test-suite#899 — upstream `:phel` patches.
- [ ] Fix phel-side ConstantFolder evaluating `(repeatedly identity)` at compile time.
- [ ] Once green: drop `continue-on-error`, optionally re-add `pull_request:` trigger.