### PR TITLE
perf(analyzer): rewrite self-recursive defn tail calls to recur loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - CI: `announce-release.yml` + `scripts/announce-release.mjs` build a Twitter/X thread draft from the released tag's CHANGELOG; uploads `thread.md` / `thread.json` as artifacts. Manual posting; `workflow_dispatch` supports back-fills
-- `CompileOptions::setOptimizationLevel(int)` (defaults `0`). Reserved for future auto-inline (`1`) and loop-invariant hoist (`2`); no current consumer (#2092)
+- `CompileOptions::setOptimizationLevel(int)` (defaults `0`). Reserved for future auto-inline (`1`) and the implicit tail-call rewrite (`2`) (#2092, #2141)
 
 ### Performance
+
+Opt-in (`CompileOptions::setOptimizationLevel(2)`):
+- `TailCallRewriter`: detect self-recursive `defn` calls in tail position and rewrite them into an implicit `recur` loop. Eliminates per-iteration PHP stack frames. Variadic and multi-arity defs are skipped. Stack-trace shape inside the loop changes from N frames to one (#2141)
 
 Compile-time folding and simplification:
 - `ConstantFolder`: fold pure `phel.core` calls on literal args (comparisons, boolean predicates, bitwise / `bit-*`, `count` / `first` / `last` / `nth` on literal collections, `str`, `min` / `max` / `mod` / `quot` / `rem` / `abs`). Skipped when runtime would throw or promote (#2088)

--- a/src/php/Compiler/Application/Analyzer.php
+++ b/src/php/Compiler/Application/Analyzer.php
@@ -47,10 +47,26 @@ final class Analyzer implements AnalyzerInterface
 
     private ?AnalyzePersistentMap $mapAnalyzer = null;
 
+    private int $optimizationLevel = 0;
+
     public function __construct(
         private readonly GlobalEnvironmentInterface $globalEnvironment,
         private readonly bool $assertsEnabled = true,
     ) {}
+
+    public function setOptimizationLevel(int $level): void
+    {
+        // Resetting the cached list analyzer ensures the next analyze
+        // call reads the new level when wiring up special-form handlers
+        // (e.g. FnSymbol picks up the level at construction time).
+        $this->optimizationLevel = max(0, $level);
+        $this->listAnalyzer = null;
+    }
+
+    public function getOptimizationLevel(): int
+    {
+        return $this->optimizationLevel;
+    }
 
     public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?AbstractNode
     {

--- a/src/php/Compiler/Application/CodeCompiler.php
+++ b/src/php/Compiler/Application/CodeCompiler.php
@@ -55,6 +55,7 @@ final readonly class CodeCompiler implements CodeCompilerInterface
     {
         $hook = Registry::$profilerHook;
         $source = $compileOptions->getSource();
+        $this->analyzer->setOptimizationLevel($compileOptions->getOptimizationLevel());
 
         $tokenStream = $this->timed($hook, 'lex', $source, fn(): TokenStream => $this->lexer->lexString(
             $phelCode,
@@ -91,6 +92,7 @@ final readonly class CodeCompiler implements CodeCompilerInterface
         float|bool|int|string|TypeInterface|null $form,
         CompileOptions $compileOptions,
     ): EmitterResult {
+        $this->analyzer->setOptimizationLevel($compileOptions->getOptimizationLevel());
         $this->fileEmitter->startFile($compileOptions->getSource());
         $node = $this->analyzer->analyze($form, NodeEnvironment::empty());
         $this->emitNode($node, $compileOptions);

--- a/src/php/Compiler/Application/EvalCompiler.php
+++ b/src/php/Compiler/Application/EvalCompiler.php
@@ -51,6 +51,7 @@ final readonly class EvalCompiler implements EvalCompilerInterface
      */
     public function evalString(string $phelCode, CompileOptions $compileOptions): mixed
     {
+        $this->analyzer->setOptimizationLevel($compileOptions->getOptimizationLevel());
         $tokenStream = $this->lexer->lexString($phelCode, $compileOptions->getSource(), $compileOptions->getStartingLine());
 
         $result = null;
@@ -82,6 +83,7 @@ final readonly class EvalCompiler implements EvalCompilerInterface
             return $form;
         }
 
+        $this->analyzer->setOptimizationLevel($compileOptions->getOptimizationLevel());
         $node = $this->analyzer->analyze($form, NodeEnvironment::empty()->withReturnContext());
         return $this->evalNode($node, $compileOptions);
     }

--- a/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
+++ b/src/php/Compiler/Domain/Analyzer/AnalyzerInterface.php
@@ -46,6 +46,10 @@ interface AnalyzerInterface
 
     public function getDefFnNode(string $ns, Symbol $symbol): ?FnNode;
 
+    public function setOptimizationLevel(int $level): void;
+
+    public function getOptimizationLevel(): int;
+
     public function addInterface(string $ns, Symbol $name): void;
 
     /**

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/AnalyzePersistentList.php
@@ -309,7 +309,11 @@ final class AnalyzePersistentList
             Symbol::NAME_IN_NS => new InNsSymbol($this->analyzer),
             Symbol::NAME_USE => new UseSymbol($this->analyzer),
             Symbol::NAME_LOAD => new LoadSymbol($this->analyzer),
-            Symbol::NAME_FN => new FnSymbol($this->analyzer, $this->assertsEnabled),
+            Symbol::NAME_FN => new FnSymbol(
+                $this->analyzer,
+                $this->assertsEnabled,
+                optimizationLevel: $this->analyzer->getOptimizationLevel(),
+            ),
             Symbol::NAME_QUOTE => new QuoteSymbol(),
             Symbol::NAME_VAR => new VarSymbol($this->analyzer),
             Symbol::NAME_DO => new DoSymbol($this->analyzer),

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/TailCallRewriter.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/Simplification/TailCallRewriter.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+
+use function count;
+
+/**
+ * Rewrites a self-recursive `defn` body so that calls to the surrounding
+ * function in tail position become implicit `recur` jumps. Pairs with
+ * `FnAsClassEmitter` / `MethodEmitter`, which wrap a fn whose
+ * `RecurFrame` is active in a `while (true) { ... break; }` loop.
+ *
+ * Out of scope (kept as ordinary calls):
+ *
+ *  - variadic fns (rest-arg destructuring would change semantics)
+ *  - multi-arity overloads (cross-arity recur is undefined)
+ *  - calls inside `try` / `catch` / `finally` bodies (control-flow
+ *    invariants tightened in a follow-up)
+ *
+ * The rewriter is read-only with respect to user observability except
+ * for stack-trace shape: a recursive descent of N frames becomes a
+ * single frame with a loop. That trade-off is gated behind
+ * `CompileOptions::setOptimizationLevel(2)`.
+ */
+final readonly class TailCallRewriter
+{
+    /**
+     * @return array{0: AbstractNode, 1: bool} the rewritten body and a
+     *                                         flag indicating whether
+     *                                         any tail-call was actually
+     *                                         turned into a `recur`
+     */
+    public function rewrite(
+        AbstractNode $body,
+        RecurFrame $recurFrame,
+        string $selfNs,
+        string $selfName,
+        int $paramCount,
+        bool $isVariadic,
+    ): array {
+        if ($isVariadic) {
+            return [$body, false];
+        }
+
+        $rewrote = false;
+        $rewritten = $this->walk($body, true, $recurFrame, $selfNs, $selfName, $paramCount, $rewrote);
+
+        return [$rewritten, $rewrote];
+    }
+
+    private function walk(
+        AbstractNode $node,
+        bool $tail,
+        RecurFrame $recurFrame,
+        string $selfNs,
+        string $selfName,
+        int $paramCount,
+        bool &$rewrote,
+    ): AbstractNode {
+        if ($node instanceof DoNode) {
+            return new DoNode(
+                $node->getEnv(),
+                $node->getStmts(),
+                $this->walk($node->getRet(), $tail, $recurFrame, $selfNs, $selfName, $paramCount, $rewrote),
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        if ($node instanceof IfNode) {
+            return new IfNode(
+                $node->getEnv(),
+                $node->getTestExpr(),
+                $this->walk($node->getThenExpr(), $tail, $recurFrame, $selfNs, $selfName, $paramCount, $rewrote),
+                $this->walk($node->getElseExpr(), $tail, $recurFrame, $selfNs, $selfName, $paramCount, $rewrote),
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        if ($node instanceof LetNode) {
+            // Skipping `loop` (let with isLoop=true): it owns its own
+            // RecurFrame, so any inner self-call would target the loop's
+            // frame rather than the enclosing fn's.
+            if ($node->isLoop()) {
+                return $node;
+            }
+
+            return new LetNode(
+                $node->getEnv(),
+                $node->getBindings(),
+                $this->walk($node->getBodyExpr(), $tail, $recurFrame, $selfNs, $selfName, $paramCount, $rewrote),
+                $node->isLoop(),
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        if ($tail && $node instanceof CallNode && $this->isSelfCall($node, $selfNs, $selfName, $paramCount)) {
+            $recurFrame->setIsActive(true);
+            $rewrote = true;
+
+            return new RecurNode(
+                $node->getEnv(),
+                $recurFrame,
+                $node->getArguments(),
+                $node->getStartSourceLocation(),
+            );
+        }
+
+        return $node;
+    }
+
+    private function isSelfCall(CallNode $node, string $selfNs, string $selfName, int $paramCount): bool
+    {
+        if (count($node->getArguments()) !== $paramCount) {
+            return false;
+        }
+
+        $fn = $node->getFn();
+        if (!$fn instanceof GlobalVarNode) {
+            return false;
+        }
+
+        return $fn->getNamespace() === $selfNs
+            && $fn->getName()->getName() === $selfName;
+    }
+}

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/SpecialForm/FnSymbol.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Domain\Analyzer\Ast\MultiFnNode;
 use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
 use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironmentInterface;
 use Phel\Compiler\Domain\Analyzer\Exceptions\AnalyzerException;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\TailCallRewriter;
 use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\SpecialForm\ReadModel\FnSymbolTuple;
 use Phel\Lang\Collections\LinkedList\PersistentListInterface;
 use Phel\Lang\Collections\Map\PersistentMapInterface;
@@ -39,6 +40,8 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         private AnalyzerInterface $analyzer,
         private bool $assertsEnabled = true,
         private ReturnTypeInferrer $returnTypeInferrer = new ReturnTypeInferrer(),
+        private int $optimizationLevel = 0,
+        private TailCallRewriter $tailCallRewriter = new TailCallRewriter(),
     ) {}
 
     /**
@@ -166,6 +169,23 @@ final readonly class FnSymbol implements SpecialFormAnalyzerInterface
         }
 
         [$selfNs, $selfNameStr] = $this->splitBoundTo($env->getBoundTo());
+
+        if ($this->optimizationLevel >= 2
+            && $selfNs !== null
+            && $selfNameStr !== null
+            && !$fnSymbolTuple->isVariadic()
+            && !$name instanceof Symbol
+        ) {
+            [$body] = $this->tailCallRewriter->rewrite(
+                $body,
+                $recurFrame,
+                $selfNs,
+                $selfNameStr,
+                count($fnSymbolTuple->params()),
+                $fnSymbolTuple->isVariadic(),
+            );
+        }
+
         $returnType = $declaredReturnType
             ?? $this->returnTypeInferrer->infer(
                 $body,

--- a/src/php/Shared/CompileOptions.php
+++ b/src/php/Shared/CompileOptions.php
@@ -19,7 +19,9 @@ final class CompileOptions
      *
      *  - `0` (default): every experimental optimisation phase is off
      *  - `1`: Phase 5 — auto-inline single-expression private `defn-`
-     *  - `2`: Phase 6 — hoist loop-invariant exprs out of recur loops
+     *  - `2`: Phase 6 — rewrite self-recursive `defn` tail calls into an
+     *    implicit `recur` loop, eliminating per-iteration PHP stack frames
+     *    at the cost of a shorter stack trace inside the loop
      *
      * Phases that ship as default-on (e.g. `ConstantFolder`,
      * `LetSimplifier`) do not consult this flag; only phases whose

--- a/tests/php/Integration/Compiler/TailCallRewriteRuntimeTest.php
+++ b/tests/php/Integration/Compiler/TailCallRewriteRuntimeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end coverage for the implicit-tail-call optimisation gated
+ * behind `CompileOptions::setOptimizationLevel(2)`. The fixtures pick
+ * recursion depths that would blow the default PHP call stack if the
+ * rewrite did not fire.
+ */
+final class TailCallRewriteRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_self_tail_call_runs_at_depth_that_default_stack_blows(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval(
+            '(defn count-down [n] (if (zero? n) :done (count-down (dec n))))',
+            $options,
+        );
+
+        $result = $this->compilerFacade->eval('(count-down 50000)', $options);
+
+        self::assertSame('done', $result->getName());
+    }
+
+    public function test_opt_level_zero_keeps_real_recursion(): void
+    {
+        $options = new CompileOptions();
+        $this->compilerFacade->eval(
+            '(defn count-down-shallow [n] (if (zero? n) :done (count-down-shallow (dec n))))',
+            $options,
+        );
+
+        $result = $this->compilerFacade->eval('(count-down-shallow 50)', $options);
+
+        self::assertSame('done', $result->getName());
+    }
+
+    public function test_tail_call_in_if_else_branch(): void
+    {
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval(
+            '(defn accumulate [n acc] (if (zero? n) acc (accumulate (dec n) (+ acc 1))))',
+            $options,
+        );
+
+        $result = $this->compilerFacade->eval('(accumulate 20000 0)', $options);
+
+        self::assertSame(20000, $result);
+    }
+
+    public function test_non_tail_call_stays_a_real_call(): void
+    {
+        // Non-tail self-reference: the recursive call's result is passed to
+        // `+`, so the rewriter must leave it alone. We pick a small depth
+        // because this *should* use the real stack.
+        $options = new CompileOptions()->setOptimizationLevel(2);
+        $this->compilerFacade->eval(
+            '(defn factorial [n] (if (zero? n) 1 (* n (factorial (dec n)))))',
+            $options,
+        );
+
+        $result = $this->compilerFacade->eval('(factorial 5)', $options);
+
+        self::assertSame(120, $result);
+    }
+}

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/TailCallRewriterTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/Simplification/TailCallRewriterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Unit\Compiler\Analyzer\TypeAnalyzer\Simplification;
+
+use Phel;
+use Phel\Compiler\Domain\Analyzer\Ast\AbstractNode;
+use Phel\Compiler\Domain\Analyzer\Ast\CallNode;
+use Phel\Compiler\Domain\Analyzer\Ast\DoNode;
+use Phel\Compiler\Domain\Analyzer\Ast\GlobalVarNode;
+use Phel\Compiler\Domain\Analyzer\Ast\IfNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LetNode;
+use Phel\Compiler\Domain\Analyzer\Ast\LiteralNode;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurFrame;
+use Phel\Compiler\Domain\Analyzer\Ast\RecurNode;
+use Phel\Compiler\Domain\Analyzer\Environment\NodeEnvironment;
+use Phel\Compiler\Domain\Analyzer\TypeAnalyzer\Simplification\TailCallRewriter;
+use Phel\Lang\Symbol;
+use PHPUnit\Framework\TestCase;
+
+final class TailCallRewriterTest extends TestCase
+{
+    private const string SELF_NS = 'user';
+
+    private const string SELF_NAME = 'count-down';
+
+    public function test_rewrites_direct_tail_self_call_to_recur(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = $this->selfCall($env, [new LiteralNode($env, 5)]);
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertTrue($changed);
+        self::assertTrue($frame->isActive());
+        self::assertInstanceOf(RecurNode::class, $rewritten);
+        self::assertSame($frame, $rewritten->getFrame());
+    }
+
+    public function test_rewrites_self_call_in_if_branches(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = new IfNode(
+            $env,
+            new LiteralNode($env, true),
+            new LiteralNode($env, 'done'),
+            $this->selfCall($env, [new LiteralNode($env, 0)]),
+        );
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertTrue($changed);
+        self::assertInstanceOf(IfNode::class, $rewritten);
+        self::assertInstanceOf(LiteralNode::class, $rewritten->getThenExpr());
+        self::assertInstanceOf(RecurNode::class, $rewritten->getElseExpr());
+    }
+
+    public function test_does_not_rewrite_calls_outside_tail_position(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $inner = $this->selfCall($env, [new LiteralNode($env, 1)]);
+        $body = new DoNode(
+            $env,
+            [$inner],
+            new LiteralNode($env, 'done'),
+        );
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertFalse($changed);
+        self::assertFalse($frame->isActive());
+        self::assertInstanceOf(DoNode::class, $rewritten);
+        self::assertSame($inner, $rewritten->getStmts()[0]);
+    }
+
+    public function test_skips_variadic_fn(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = $this->selfCall($env, [new LiteralNode($env, 1)]);
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            true,
+        );
+
+        self::assertFalse($changed);
+        self::assertSame($body, $rewritten);
+    }
+
+    public function test_skips_arity_mismatch(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = $this->selfCall($env, [new LiteralNode($env, 1), new LiteralNode($env, 2)]);
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertFalse($changed);
+        self::assertSame($body, $rewritten);
+    }
+
+    public function test_skips_call_to_other_global(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = new CallNode(
+            $env,
+            new GlobalVarNode($env, self::SELF_NS, Symbol::create('other'), Phel::map()),
+            [new LiteralNode($env, 1)],
+        );
+
+        [, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertFalse($changed);
+        self::assertFalse($frame->isActive());
+    }
+
+    public function test_skips_loop_let_body(): void
+    {
+        $env = NodeEnvironment::empty()->withReturnContext();
+        $frame = new RecurFrame([Symbol::create('n')]);
+        $body = new LetNode(
+            $env,
+            [],
+            $this->selfCall($env, [new LiteralNode($env, 1)]),
+            isLoop: true,
+        );
+
+        [$rewritten, $changed] = new TailCallRewriter()->rewrite(
+            $body,
+            $frame,
+            self::SELF_NS,
+            self::SELF_NAME,
+            1,
+            false,
+        );
+
+        self::assertFalse($changed);
+        self::assertSame($body, $rewritten);
+    }
+
+    /**
+     * @param list<AbstractNode> $args
+     */
+    private function selfCall(NodeEnvironment $env, array $args): CallNode
+    {
+        return new CallNode(
+            $env,
+            new GlobalVarNode($env, self::SELF_NS, Symbol::create(self::SELF_NAME), Phel::map()),
+            $args,
+        );
+    }
+}


### PR DESCRIPTION
## 🤔 Background

Closes #2141. Self-recursive Phel `defn`s without an explicit `recur`
currently emit a real PHP recursive call: every iteration burns a stack
frame, and naturally Clojure-style recursive loops blow the default PHP
call stack at modest depths.

The deferral note on #2141 called out the prerequisites: analyser-side
tail-position detection, opt-in gating, and a documented stack-trace
shape change. This PR ships all three.

## 💡 Goal

When a `defn`'s body has a self-call in tail position, rewrite it
during analysis into an implicit `recur` against the fn's own
`RecurFrame`. `MethodEmitter` already wraps a fn whose `RecurFrame` is
active in `while (true) { ... break; }`, so the rewrite collapses N
stack frames into one loop with no emitter changes.

Gated behind `CompileOptions::setOptimizationLevel(2)` so the
observable stack-trace shape change stays opt-in.

## 🔖 Changes

- `Simplification/TailCallRewriter`: walks `DoNode` / `IfNode` /
  `LetNode` tail positions and rewrites matching `CallNode`s to
  `RecurNode`s, flipping `RecurFrame::isActive()` so `FnNode::getRecurs()`
  is `true`
- `FnSymbol::analyzeSingle`: invokes the rewriter when bound to a defn
  (non-empty `boundTo`), the fn is not variadic, and there is no inner
  `(fn name ...)` self-binding
- `Analyzer::setOptimizationLevel()` / `getOptimizationLevel()` (added
  to `AnalyzerInterface`); `CodeCompiler` and `EvalCompiler` propagate
  the level from `CompileOptions` before analysis
- `AnalyzePersistentList` reads the analyzer's level when constructing
  `FnSymbol`
- `CompileOptions` docs updated: level `2` is now the implicit tail-call
  rewrite (was previously reserved for loop-invariant hoist)
- `CHANGELOG.md` Unreleased / Performance entry

### Out of scope (kept as ordinary calls)

- Variadic fns (rest-arg destructuring breaks `recur`)
- Multi-arity overloads (cross-arity recur is undefined)
- Self-calls inside `try` / `catch` / `finally`
- `loop` bodies (they own their own `RecurFrame`)

### Stack-trace shape change

A recursive descent of N frames becomes a single frame with a loop. This
is the documented trade-off of opt level 2: keep level 0 for code paths
where the existing trace shape matters for debugging or profiling.

## Test plan

- [x] Unit: `TailCallRewriterTest` (7 cases) — direct tail, `if`
      branches, non-tail rejection, variadic skip, arity mismatch,
      other-global skip, `loop` skip
- [x] Integration: `TailCallRewriteRuntimeTest` (4 cases) —
      `count-down 50000` under opt 2 (would blow the default stack
      otherwise), opt 0 keeps real recursion, `if`-else branch rewrite,
      non-tail `factorial` stays uncoerced
- [x] `composer test-quality` (cs-fixer, psalm, phpstan, rector)
- [x] `composer test-core` (5687 Phel tests pass)
- [x] `./vendor/bin/phpunit --testsuite=unit,integration` — 3729 tests
      pass