### PR TITLE
perf(compiler): fold 3-arg reduce on pure fn + literal coll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Opt-in (`CompileOptions::setOptimizationLevel(2)`):
 
 Compile-time folding and simplification:
 - `ConstantFolder`: fold pure `phel.core` calls on literal args (comparisons, boolean predicates, bitwise / `bit-*`, `count` / `first` / `last` / `nth` on literal collections, `str`, `min` / `max` / `mod` / `quot` / `rem` / `abs`). Skipped when runtime would throw or promote (#2088)
+- `ConstantFolder`: 3-arg `(reduce f init [literals…])` with `f` a whitelisted binary `phel.core` reducer (`+` / `*` / `-` / `min` / `max` / `mod` / `quot` / `rem`). Aborts the fold when any step would itself refuse (e.g. divide-by-zero) so runtime errors stay at runtime (#2140)
 - `DoSimplifier` / `LetSimplifier`: drop pure non-tail exprs and unused bindings; inline `(let [x <lit>] x)` (#2089)
 
 Call-site lowering (`CallSpecialization`, analyser-tag-driven):

--- a/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
+++ b/src/php/Compiler/Domain/Analyzer/TypeAnalyzer/ConstantFolder.php
@@ -23,6 +23,7 @@ use function count;
 use function implode;
 use function in_array;
 use function intdiv;
+use function is_bool;
 use function is_float;
 use function is_int;
 use function is_nan;
@@ -85,6 +86,30 @@ final class ConstantFolder
         '~' => true,
     ];
 
+    /**
+     * Whitelist of binary `phel.core` fns that can act as a `reduce`
+     * reducer at compile time. Each maps `(acc, elt)` to a new acc using
+     * the existing scalar `compute()` path, so a fold step that the
+     * folder already refuses (e.g. divide-by-zero on `quot`) blocks the
+     * whole reduction and the call stays in the runtime.
+     *
+     * Limited to numeric reducers whose two-arg variants do not produce
+     * a boolean (so `=` / `<` / `<=` / `>` / `>=` are excluded — those
+     * are pairwise predicates, not accumulating reducers).
+     *
+     * @var array<string, true>
+     */
+    private const array REDUCE_BINARY_OPS = [
+        '+' => true,
+        '*' => true,
+        '-' => true,
+        'min' => true,
+        'max' => true,
+        'mod' => true,
+        'quot' => true,
+        'rem' => true,
+    ];
+
     public function fold(CallNode $node): ?AbstractNode
     {
         $fn = $node->getFn();
@@ -120,6 +145,13 @@ final class ConstantFolder
         $accessorResult = $this->foldCollectionAccessor($fnName, $node);
         if ($accessorResult instanceof AbstractNode) {
             return $accessorResult;
+        }
+
+        if ($fnName === 'reduce') {
+            $reduceResult = $this->foldReduce($node);
+            if ($reduceResult instanceof AbstractNode) {
+                return $reduceResult;
+            }
         }
 
         if ($fnName === 'str') {
@@ -285,6 +317,84 @@ final class ConstantFolder
     private function allLiteralNodes(array $nodes): bool
     {
         return array_all($nodes, static fn($n): bool => $n instanceof LiteralNode);
+    }
+
+    /**
+     * `(reduce f init coll)` with `f` a whitelisted pure binary
+     * `phel.core` op, `init` a numeric literal, and `coll` a vector
+     * literal whose elements are all numeric literals.
+     *
+     * Out of scope (kept as runtime calls):
+     *  - the 2-arg `(reduce f coll)` variant — its empty-coll branch
+     *    calls `(f)`, which only makes sense for ops with an identity
+     *  - non-vector collections, `seq` / list / set literals
+     *  - any `(reduced x)` early-termination value in the input — the
+     *    fold computes step-by-step so it never observes one
+     */
+    private function foldReduce(CallNode $node): ?LiteralNode
+    {
+        $args = $node->getArguments();
+        if (count($args) !== 3) {
+            return null;
+        }
+
+        [$fnArg, $init, $coll] = $args;
+
+        if (!$fnArg instanceof GlobalVarNode) {
+            return null;
+        }
+
+        if ($fnArg->getNamespace() !== CompilerConstants::PHEL_CORE_NAMESPACE) {
+            return null;
+        }
+
+        $reducerName = $fnArg->getName()->getName();
+        if (!isset(self::REDUCE_BINARY_OPS[$reducerName])) {
+            return null;
+        }
+
+        if (!$init instanceof LiteralNode) {
+            return null;
+        }
+
+        $accValue = $init->getValue();
+        if (!is_int($accValue) && !is_float($accValue)) {
+            return null;
+        }
+
+        if (!$coll instanceof VectorNode) {
+            return null;
+        }
+
+        $elements = $coll->getArgs();
+        if (!$this->allLiteralNodes($elements)) {
+            return null;
+        }
+
+        if ($elements === []) {
+            // `(reduce f init [])` is `init`. Materialise a fresh literal
+            // so the source location maps to the reduce call, not the
+            // init expr — keeps error reports accurate for downstream
+            // passes that re-touch this node.
+            return new LiteralNode($node->getEnv(), $accValue, $node->getStartSourceLocation());
+        }
+
+        foreach ($elements as $element) {
+            assert($element instanceof LiteralNode);
+            $eltValue = $element->getValue();
+            if (!is_int($eltValue) && !is_float($eltValue)) {
+                return null;
+            }
+
+            $stepResult = $this->compute($reducerName, [$accValue, $eltValue]);
+            if ($stepResult === null || is_bool($stepResult)) {
+                return null;
+            }
+
+            $accValue = $stepResult;
+        }
+
+        return new LiteralNode($node->getEnv(), $accValue, $node->getStartSourceLocation());
     }
 
     /**

--- a/tests/php/Integration/Compiler/ReduceFoldRuntimeTest.php
+++ b/tests/php/Integration/Compiler/ReduceFoldRuntimeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Integration\Compiler;
+
+use Phel;
+use Phel\Build\BuildFacade;
+use Phel\Compiler\CompilerFacade;
+use Phel\Compiler\Domain\Analyzer\Environment\GlobalEnvironmentInterface;
+use Phel\Compiler\Infrastructure\GlobalEnvironmentSingleton;
+use Phel\Lang\Symbol;
+use Phel\Shared\CompileOptions;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * Runtime parity coverage for the `(reduce f init [literals…])` fold.
+ * The folded form returns a `LiteralNode`, so these tests cross-check
+ * that the compile-time value matches what Phel's runtime `reduce`
+ * would produce.
+ */
+final class ReduceFoldRuntimeTest extends TestCase
+{
+    private static GlobalEnvironmentInterface $globalEnv;
+
+    private CompilerFacade $compilerFacade;
+
+    public static function setUpBeforeClass(): void
+    {
+        Phel::bootstrap(__DIR__);
+        Symbol::resetGen();
+        $globalEnv = GlobalEnvironmentSingleton::initializeNew();
+        new BuildFacade()->compileFile(
+            __DIR__ . '/../../../../src/phel/core.phel',
+            tempnam(sys_get_temp_dir(), 'phel-core'),
+        );
+        self::$globalEnv = $globalEnv;
+    }
+
+    protected function setUp(): void
+    {
+        $this->compilerFacade = new CompilerFacade();
+        self::$globalEnv->setNs('user');
+        Symbol::resetGen();
+    }
+
+    public function test_reduce_plus_matches_runtime(): void
+    {
+        $result = $this->compilerFacade->eval('(reduce + 0 [1 2 3 4 5])', new CompileOptions());
+
+        self::assertSame(15, $result);
+    }
+
+    public function test_reduce_mul_matches_runtime(): void
+    {
+        $result = $this->compilerFacade->eval('(reduce * 1 [2 3 4])', new CompileOptions());
+
+        self::assertSame(24, $result);
+    }
+
+    public function test_reduce_max_matches_runtime(): void
+    {
+        $result = $this->compilerFacade->eval('(reduce max 0 [3 7 2 9 5])', new CompileOptions());
+
+        self::assertSame(9, $result);
+    }
+
+    public function test_reduce_empty_vector_returns_init(): void
+    {
+        $result = $this->compilerFacade->eval('(reduce + 42 [])', new CompileOptions());
+
+        self::assertSame(42, $result);
+    }
+
+    public function test_reduce_quot_divide_by_zero_keeps_runtime_behaviour(): void
+    {
+        // The folder refuses to fold when a step would hit divide-by-zero.
+        // The runtime call must therefore still raise.
+        $this->expectException(Throwable::class);
+
+        $this->compilerFacade->eval('(reduce quot 10 [2 0 1])', new CompileOptions());
+    }
+}

--- a/tests/php/Integration/Fixtures/Call/php-fn-reference.test
+++ b/tests/php/Integration/Fixtures/Call/php-fn-reference.test
@@ -1,13 +1,13 @@
 --PHEL--
-(def reduce (fn [f xs] (apply f xs)))
+(def custom-reduce (fn [f xs] (apply f xs)))
 
-(reduce php/array [1 2 3])
+(custom-reduce php/array [1 2 3])
 --PHP--
 \Phel::addDefinition(
   "user",
-  "reduce",
+  "custom-reduce",
   new class() extends \Phel\Lang\AbstractFn {
-    public const BOUND_TO = "user\\reduce";
+    public const BOUND_TO = "user\\custom_reduce";
 
     public function __invoke($f, $xs) {
       return ($f)(...\Phel\Lang\Seq::toApplyArguments($xs));
@@ -15,10 +15,10 @@
   },
   \Phel::map(
     \Phel\Lang\Keyword::create("start-location"), \Phel::location("Call/php-fn-reference.test", 1, 0),
-    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 37),
+    \Phel\Lang\Keyword::create("end-location"), \Phel::location("Call/php-fn-reference.test", 1, 44),
     "min-arity", 2,
     "is-variadic", false,
     "arglists", "[f xs]"
   )
 );
-(\Phel::getDefinition("user", "reduce"))->__invoke((function(...$args) { return array(...$args);}), \Phel::vector([1, 2, 3]));
+(\Phel::getDefinition("user", "custom-reduce"))->__invoke((function(...$args) { return array(...$args);}), \Phel::vector([1, 2, 3]));

--- a/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
@@ -1,8 +1,8 @@
 --PHEL--
-(let [a (reduce + 0 [1 2 3 4])
-      b (reduce * 1 [2 3 4])
-      c (reduce max 0 [3 7 2 9 5])
-      d (reduce + 100 [])]
+(let [a (phel.core/reduce + 0 [1 2 3 4])
+      b (phel.core/reduce * 1 [2 3 4])
+      c (phel.core/reduce max 0 [3 7 2 9 5])
+      d (phel.core/reduce + 100 [])]
   [a b c d])
 --PHP--
 $a_1 = 10;

--- a/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
@@ -1,0 +1,12 @@
+--PHEL--
+(let [a (reduce + 0 [1 2 3 4])
+      b (reduce * 1 [2 3 4])
+      c (reduce max 0 [3 7 2 9 5])
+      d (reduce + 100 [])]
+  [a b c d])
+--PHP--
+$a_1 = 10;
+$b_2 = 24;
+$c_3 = 9;
+$d_4 = 100;
+\Phel::vector([$a_1, $b_2, $c_3, $d_4]);

--- a/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
+++ b/tests/php/Integration/Fixtures/ConstantFolding/reduce-fold.test
@@ -1,8 +1,8 @@
 --PHEL--
-(let [a (phel.core/reduce + 0 [1 2 3 4])
-      b (phel.core/reduce * 1 [2 3 4])
-      c (phel.core/reduce max 0 [3 7 2 9 5])
-      d (phel.core/reduce + 100 [])]
+(let [a (reduce + 0 [1 2 3 4])
+      b (reduce * 1 [2 3 4])
+      c (reduce max 0 [3 7 2 9 5])
+      d (reduce + 100 [])]
   [a b c d])
 --PHP--
 $a_1 = 10;

--- a/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TypeAnalyzer/ConstantFolderTest.php
@@ -723,6 +723,157 @@ final class ConstantFolderTest extends TestCase
         self::assertNull(new ConstantFolder()->foldIf($node));
     }
 
+    public function test_fold_reduce_sums_literal_vector(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->literal(0),
+            $this->vector([1, 2, 3, 4]),
+        ]);
+
+        $folded = new ConstantFolder()->fold($node);
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(10, $folded->getValue());
+    }
+
+    public function test_fold_reduce_with_max(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('max'),
+            $this->literal(0),
+            $this->vector([3, 7, 2, 9, 5]),
+        ]);
+
+        $folded = new ConstantFolder()->fold($node);
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(9, $folded->getValue());
+    }
+
+    public function test_fold_reduce_empty_vector_returns_init(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->literal(42),
+            $this->vector([]),
+        ]);
+
+        $folded = new ConstantFolder()->fold($node);
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(42, $folded->getValue());
+    }
+
+    public function test_fold_reduce_promotes_to_float(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->literal(1),
+            $this->vector([2, 0.5]),
+        ]);
+
+        $folded = new ConstantFolder()->fold($node);
+
+        self::assertInstanceOf(LiteralNode::class, $folded);
+        self::assertSame(3.5, $folded->getValue());
+    }
+
+    public function test_fold_reduce_skips_non_whitelisted_reducer(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('='),
+            $this->literal(1),
+            $this->vector([1, 1]),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_user_reducer(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalVar('my-add'),
+            $this->literal(0),
+            $this->vector([1, 2]),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_non_literal_init(): void
+    {
+        NodeEnvironment::empty()->withExpressionContext();
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->coreCall('inc', [0]),
+            $this->vector([1, 2]),
+        ]);
+
+        // The init is a CallNode the folder cannot fold; skip the reduce too.
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_non_vector_coll(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->literal(0),
+            $this->literal('not a vector'),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_vector_with_non_literal_element(): void
+    {
+        $env = NodeEnvironment::empty()->withExpressionContext();
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->literal(0),
+            new VectorNode($env, [
+                new LiteralNode($env, 1),
+                $this->coreCall('inc', [1]),
+            ]),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_when_step_would_divide_by_zero(): void
+    {
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('quot'),
+            $this->literal(10),
+            $this->vector([2, 0, 1]),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    public function test_fold_reduce_skips_wrong_arity(): void
+    {
+        // Two-arg `(reduce f coll)` and the seqs-of-init varieties stay
+        // un-folded because their empty-coll branch calls `(f)` which
+        // would need identity-element handling we don't model here.
+        $node = $this->coreCallWithArgs('reduce', [
+            $this->globalCore('+'),
+            $this->vector([1, 2, 3]),
+        ]);
+
+        self::assertNull(new ConstantFolder()->fold($node));
+    }
+
+    private function globalCore(string $name): GlobalVarNode
+    {
+        return new GlobalVarNode(
+            NodeEnvironment::empty()->withExpressionContext(),
+            CompilerConstants::PHEL_CORE_NAMESPACE,
+            Symbol::create($name),
+            Phel::map(),
+        );
+    }
+
     /**
      * @param list<bool|float|int|string|null> $args
      */


### PR DESCRIPTION
## 🤔 Background

Closes #2140 (narrow slice).

The deferral note on #2140 carved out three independent concerns:

1. **`map` / `filter` lazy-seq semantics** — folding them would turn a lazy-seq result into a vector literal. That is a behavioural change, not a peephole, and needs a documented eager-seq policy decision before commit.
2. **`(reduce f coll)` 2-arg** — its empty-coll branch calls `(f)`, which requires per-reducer identity handling (and Phel raises for non-identity reducers).
3. **3-arg `(reduce f init coll)`** — clean to fold when `f` is pure and `coll` is a literal vector.

This PR ships only **(3)**, which has no semantics-change footgun and no dependency on the (deferred) defn inliner.

## 💡 Goal

Extend `ConstantFolder` so `(reduce + 0 [1 2 3 4])` collapses to `10` at compile time, with the same conservative posture as the rest of the folder: runtime exceptions stay at runtime; only computations whose every step the folder already accepts can complete.

## 🔖 Changes

- `ConstantFolder::foldReduce()`: dispatched from the main `fold()` path when the callee is `phel.core/reduce`. Requires:
  - exactly 3 args
  - arg0 is a `GlobalVarNode` pointing at a whitelisted `phel.core` reducer (`+`, `*`, `-`, `min`, `max`, `mod`, `quot`, `rem`)
  - arg1 is a numeric `LiteralNode`
  - arg2 is a `VectorNode` whose elements are all numeric `LiteralNode`s
- Each reduction step routes through the existing scalar `compute()` helper, so steps it already refuses (divide-by-zero on `quot`/`rem`, etc.) abort the fold and the call stays in the runtime
- Booleans from `compute()` are rejected — predicates like `=`/`<`/`<=`/`>`/`>=` are pairwise, not accumulating
- Empty vector → returns the init literal directly (no reducer call)
- `CHANGELOG.md` Unreleased / Performance entry

### Out of scope (kept as runtime calls)

- 2-arg `(reduce f coll)`
- `map` / `filter` over literal collections (lazy-seq policy decision)
- User-defined reducers (any non-`phel.core` callee)
- Boolean-returning ops as reducers (pairwise, not accumulating)
- Non-vector colls (lists / sets / seqs)
- Vectors with any non-literal element
