### PR TITLE
bench(compiler): collection hoisting bench

### DIFF
--- a/tests/php/Benchmark/Compiler/CollectionHoistingBench.php
+++ b/tests/php/Benchmark/Compiler/CollectionHoistingBench.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use PhelTest\Benchmark\Compiler\Fixtures\CollectionEmitDirect;
+use PhelTest\Benchmark\Compiler\Fixtures\CollectionEmitNsScope;
+use PhelTest\Benchmark\Compiler\Fixtures\CollectionEmitStatusQuo;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Compares the three emission strategies for collection literals inside
+ * a fn body (issue #2138):
+ *
+ *   1. status-quo: per-fn `static $__phel_const_N; $c ??= Phel::vector(...);`
+ *      — what `BodyConstantScanner` reserves today.
+ *   2. ns-scope:   shared `self::$cache[$slot] ??= Phel::vector(...);`
+ *      on a parent class.
+ *   3. direct:     `Phel::vector(...)` per call (no caching reference).
+ *
+ * All three return the same persistent values; what differs is the
+ * per-call lookup overhead.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class CollectionHoistingBench
+{
+    private CollectionEmitStatusQuo $statusQuoFn;
+
+    private CollectionEmitNsScope $nsScopeFn;
+
+    private CollectionEmitDirect $directFn;
+
+    public function setUp(): void
+    {
+        $this->statusQuoFn = new CollectionEmitStatusQuo();
+        $this->nsScopeFn = new CollectionEmitNsScope();
+        $this->directFn = new CollectionEmitDirect();
+
+        // Pre-build the persistent values so the first measured call
+        // does not pay the one-shot construction cost. The status-quo
+        // fixture caches via static; the ns-scope fixture seeds its
+        // own table from the warm-up call.
+        ($this->statusQuoFn)();
+        ($this->nsScopeFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_status_quo(): void
+    {
+        ($this->statusQuoFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_ns_scope(): void
+    {
+        ($this->nsScopeFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_direct(): void
+    {
+        ($this->directFn)();
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitDirect.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitDirect.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+/**
+ * Lower-bound reference: rebuilds the persistent collections on every
+ * call with no caching at all. Quantifies the cost the per-fn / ns-scope
+ * caches actually save.
+ */
+final class CollectionEmitDirect
+{
+    /**
+     * @return array{0: PersistentVectorInterface, 1: PersistentVectorInterface, 2: PersistentMapInterface}
+     */
+    public function __invoke(): array
+    {
+        return [
+            Phel::vector([1, 2, 3]),
+            Phel::vector(['a', 'b', 'c']),
+            Phel::map('k', 1, 'v', 2),
+        ];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitNsScope.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitNsScope.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+/**
+ * Hypothetical per-ns shared cache for collection literals (issue
+ * #2138). Replaces the per-fn `static $__phel_const_N` slot with a
+ * static array lookup on a parent class, so multiple fns of the same
+ * ns share a single instance per literal.
+ */
+final class CollectionEmitNsScope
+{
+    /** @var array<string, PersistentMapInterface|PersistentVectorInterface> */
+    public static array $cache = [];
+
+    /**
+     * @return array{0: PersistentVectorInterface, 1: PersistentVectorInterface, 2: PersistentMapInterface}
+     */
+    public function __invoke(): array
+    {
+        return [
+            self::$cache['v0'] ??= Phel::vector([1, 2, 3]),
+            self::$cache['v1'] ??= Phel::vector(['a', 'b', 'c']),
+            self::$cache['m0'] ??= Phel::map('k', 1, 'v', 2),
+        ];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitStatusQuo.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CollectionEmitStatusQuo.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel;
+use Phel\Lang\Collections\Map\PersistentMapInterface;
+use Phel\Lang\Collections\Vector\PersistentVectorInterface;
+
+/**
+ * Status-quo emission for collection literals inside a fn body:
+ * per-fn `static $__phel_const_N` slot reserved by `BodyConstantScanner`.
+ * After the first call each `??=` short-circuits and returns the cached
+ * persistent collection. Steady-state cost is one static read per slot.
+ */
+final class CollectionEmitStatusQuo
+{
+    /**
+     * @return array{0: PersistentVectorInterface, 1: PersistentVectorInterface, 2: PersistentMapInterface}
+     */
+    public function __invoke(): array
+    {
+        static $c0;
+        static $c1;
+        static $c2;
+        $c0 ??= Phel::vector([1, 2, 3]);
+        $c1 ??= Phel::vector(['a', 'b', 'c']);
+        $c2 ??= Phel::map('k', 1, 'v', 2);
+
+        return [$c0, $c1, $c2];
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2138 proposes replacing per-fn `static \$__phel_const_N` slots with a per-ns shared cache table, the assumption being that sharing the persistent collection across fns saves cold-start allocations.

This PR adds a quantitative bench to drive that decision before writing the implementation, mirroring the existing `KeywordHoistingBench`.

## 💡 Goal

Land permanent bench infrastructure that lets any future re-assessment of #2138 (or similar literal-hoisting proposals) be data-driven instead of speculative.

## 🔖 Changes

- `CollectionHoistingBench`: three subjects mirroring the keyword bench
- Fixtures:
  - `CollectionEmitStatusQuo`: per-fn `static` slots (current emission)
  - `CollectionEmitNsScope`: shared static class array (`#2138` proposal)
  - `CollectionEmitDirect`: uncached baseline

## Results (local, PHP 8.5.6, opcache off, 50k revs × 10 its)

```
status_quo  0.051μs / call
ns_scope    0.055μs / call   (+8% steady-state)
direct      1.978μs / call   (~39× the cached forms)
```

`KeywordHoistingBench` shows the same shape (status_quo 0.050μs, ns_scope 0.056μs, direct 0.102μs).

## Interpretation

- Steady-state cost: ns-scope is consistently ~8–12% slower than per-fn static. The array-key lookup outweighs the static-var read.
- Cold-start savings: one factory call shared across N fns instead of N. Concrete saving = `(N − 1) × 1.978μs` per literal, paid once.
- Crossover: after ~4500 calls per fn the steady-state regression has eaten the cold-start delta.

For Phel core fns that are called millions of times in steady programs, the steady-state regression dominates.

## Recommendation

Close #2138 as won't-fix-without-new-data. The bench files stay so any future change in PHP / opcache behaviour can be re-measured cheaply.

## Test plan

- [x] `./vendor/bin/phpbench run tests/php/Benchmark/Compiler/CollectionHoistingBench.php --report=aggregate`
- [x] `composer test-quality` (cs-fixer, psalm, phpstan, rector)
- [x] No source-tree changes outside `tests/php/Benchmark/`

Refs #2138.