### PR TITLE
bench(compiler): call inlining bench

### DIFF
--- a/tests/php/Benchmark/Compiler/CallInliningBench.php
+++ b/tests/php/Benchmark/Compiler/CallInliningBench.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler;
+
+use PhelTest\Benchmark\Compiler\Fixtures\CallInlineDirect;
+use PhelTest\Benchmark\Compiler\Fixtures\CallInlineInlined;
+use PhelTest\Benchmark\Compiler\Fixtures\CallInlineStatusQuo;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Compares the three emission strategies for a call site to a single
+ * expression pure `defn` (issue #2135):
+ *
+ *   1. status-quo: cached `$__phel_call_N ??= \Phel::getDefinition(...)`
+ *      followed by `->__invoke($arg)` on the resolved `AbstractFn`.
+ *      What `CallEmitter` produces today.
+ *   2. inlined:    callee body spliced at the call site with the
+ *      argument substituted; no dispatch, no PHP frame.
+ *   3. direct:     post-fold lower bound; the literal result that
+ *      const-folding through the inlined args would collapse to.
+ *
+ * Per the `bench-before-perf-refactor` rule, this bench must land
+ * before any inliner implementation PR so the ship decision is
+ * data-driven.
+ *
+ * @BeforeMethods("setUp")
+ */
+final class CallInliningBench
+{
+    private CallInlineStatusQuo $statusQuoFn;
+
+    private CallInlineInlined $inlinedFn;
+
+    private CallInlineDirect $directFn;
+
+    public function setUp(): void
+    {
+        CallInlineStatusQuo::seed();
+
+        $this->statusQuoFn = new CallInlineStatusQuo();
+        $this->inlinedFn = new CallInlineInlined();
+        $this->directFn = new CallInlineDirect();
+
+        // Warm the status-quo fn: the first call would otherwise pay
+        // the one-shot registry-lookup cost the emitter front-loads via
+        // `??=`. The inlined and direct subjects do no such caching.
+        ($this->statusQuoFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_status_quo(): void
+    {
+        ($this->statusQuoFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_inlined(): void
+    {
+        ($this->inlinedFn)();
+    }
+
+    /**
+     * @Revs(50000)
+     *
+     * @Iterations(10)
+     *
+     * @Warmup(2)
+     */
+    public function bench_direct(): void
+    {
+        ($this->directFn)();
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CallInlineDirect.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CallInlineDirect.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+/**
+ * Lower-bound reference: the inliner output after constant folding has
+ * collapsed `(+ 5 1)` etc. to their literal results. Quantifies the
+ * upper ceiling for what inlining + folding could reach, so the delta
+ * between `inlined` and `direct` tells us how much remaining arithmetic
+ * survives the call site after folding cannot fire (non-literal args).
+ */
+final class CallInlineDirect
+{
+    /**
+     * @return array{0: int, 1: int, 2: int}
+     */
+    public function __invoke(): array
+    {
+        return [6, 10, -5];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CallInlineInlined.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CallInlineInlined.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+/**
+ * Hypothetical inliner output for the same three call sites (issue
+ * #2135). Each `defn` body — `(+ x 1)`, `(* x 2)`, `(- x)` — is spliced
+ * directly into the call site with the literal argument substituted.
+ * No `AbstractFn` dispatch, no static-slot read, no PHP frame.
+ *
+ * Still does the arithmetic per call: the constant-folder peephole that
+ * would collapse `(5 + 1)` to `6` is measured separately by the `direct`
+ * subject below.
+ */
+final class CallInlineInlined
+{
+    /**
+     * @return array{0: int, 1: int, 2: int}
+     */
+    public function __invoke(): array
+    {
+        return [
+            (5 + 1),
+            (5 * 2),
+            (-5),
+        ];
+    }
+}

--- a/tests/php/Benchmark/Compiler/Fixtures/CallInlineStatusQuo.php
+++ b/tests/php/Benchmark/Compiler/Fixtures/CallInlineStatusQuo.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Benchmark\Compiler\Fixtures;
+
+use Phel\Lang\AbstractFn;
+
+/**
+ * Status-quo emission for a call site to a single-expression pure `defn`.
+ * Mirrors what `CallEmitter` produces today: a cached
+ * `$__phel_call_N ??= \Phel::getDefinition(...)` lookup followed by a
+ * direct `->__invoke($arg)` on the resolved `AbstractFn`.
+ *
+ * The registry lookup is paid once per fn body (the `??=` short-circuits
+ * after the first call). The per-call cost we are measuring is the static
+ * read + virtual `__invoke` dispatch + body execution.
+ */
+final class CallInlineStatusQuo
+{
+    private static ?AbstractFn $fnInc = null;
+
+    private static ?AbstractFn $fnDouble = null;
+
+    private static ?AbstractFn $fnNeg = null;
+
+    /**
+     * @return array{0: int, 1: int, 2: int}
+     */
+    public function __invoke(): array
+    {
+        return [
+            (self::$fnInc)->__invoke(5),
+            (self::$fnDouble)->__invoke(5),
+            (self::$fnNeg)->__invoke(5),
+        ];
+    }
+
+    public static function seed(): void
+    {
+        self::$fnInc ??= new class() extends AbstractFn {
+            public function __invoke(int $x): int
+            {
+                return $x + 1;
+            }
+        };
+
+        self::$fnDouble ??= new class() extends AbstractFn {
+            public function __invoke(int $x): int
+            {
+                return $x * 2;
+            }
+        };
+
+        self::$fnNeg ??= new class() extends AbstractFn {
+            public function __invoke(int $x): int
+            {
+                return -$x;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🤔 Background

#2135 proposes a `CallInliner` analyser pass that splices the body of single-expression pure `defn`s at the call site, skipping the `AbstractFn->__invoke` dispatch frame and enabling downstream constant folding through inlined args.

Per the `bench-before-perf-refactor` rule, this PR lands the permanent bench infrastructure *before* the implementation, so the ship decision (and any future re-assessment) stays data-driven. Mirrors the shape of `CollectionHoistingBench` (#2208).

## 💡 Goal

Quantify how much an inliner could save at the emitted call site, and how much further constant folding on top of inlined args could push the result. Provide a permanent reference point that future PHP / opcache changes can re-measure cheaply.

## 🔖 Changes

- `CallInliningBench`: three subjects, identical `@Revs(50000) @Iterations(10) @Warmup(2)`.
- Fixtures:
  - `CallInlineStatusQuo`: cached `$__phel_call_N ??= ...` + `->__invoke($arg)` on an `AbstractFn` subclass (mirrors current `CallEmitter` output).
  - `CallInlineInlined`: body spliced at call site with literal arg substituted; no dispatch, no frame.
  - `CallInlineDirect`: post-fold literal result (lower bound).

## Results (local, PHP 8.5.6, opcache off, 50k revs × 10 its)

```
status_quo  0.106μs / call
inlined     0.029μs / call   (-73%)
direct      0.028μs / call   (-74%)
```

## Interpretation

- **Dispatch is the dominant cost** of a Phel defn call site at this scale: removing the `AbstractFn->__invoke` frame saves ~0.077μs per call, ~73%.
- **Folding past inlining is noise** on trivial bodies: `direct` is only ~0.001μs faster than `inlined`. The inliner alone captures essentially all the win the issue describes.
- **Real bodies will be more expensive than `(+ x 1)`**, so the absolute savings scale with body size; the relative shape (most of the gain comes from frame removal) is what generalises.

## Decision support for #2135

Strong signal to ship the inliner — but the impl PR still needs to honour the conditions listed in the issue (callee purity, no `recur`, single arity, no `^:async` / `^:memoize`, caller not in tail-recur frame, hygienic param substitution).

## Test plan

- [x] `./vendor/bin/phpbench run tests/php/Benchmark/Compiler/CallInliningBench.php --report=aggregate`
- [x] `composer test-quality` (cs-fixer, psalm, phpstan, rector)
- [x] No source-tree changes outside `tests/php/Benchmark/`

Refs #2135.